### PR TITLE
Fix/windows system path missing

### DIFF
--- a/src/main/libs/coworkUtil.ts
+++ b/src/main/libs/coworkUtil.ts
@@ -65,6 +65,114 @@ function resolveUserShellPath(): string | null {
 }
 
 /**
+ * Cached Windows registry PATH. Resolved once and reused.
+ */
+let cachedWindowsRegistryPath: string | null | undefined;
+
+/**
+ * Resolve the latest PATH from the Windows registry (Machine + User).
+ *
+ * When a packaged Electron app is launched from the Start Menu, desktop shortcut,
+ * or Explorer, its `process.env.PATH` is inherited from the Explorer shell process.
+ * If the user installed tools (Python, Node.js, npm, etc.) after Explorer started
+ * — or without restarting Explorer — those new PATH entries won't be in
+ * `process.env.PATH`. This causes commands like `python`, `npm`, `pip` to be
+ * missing from the cowork session even though they work fine in a freshly opened
+ * terminal (which reads the latest registry values).
+ *
+ * This function reads the current Machine and User PATH directly from the registry
+ * to get the most up-to-date values, similar to how `resolveUserShellPath()` works
+ * for macOS/Linux.
+ */
+function resolveWindowsRegistryPath(): string | null {
+  if (cachedWindowsRegistryPath !== undefined) return cachedWindowsRegistryPath;
+
+  if (process.platform !== 'win32') {
+    cachedWindowsRegistryPath = null;
+    return null;
+  }
+
+  try {
+    // Use PowerShell to read both Machine and User PATH from registry.
+    // [Environment]::GetEnvironmentVariable reads directly from the registry,
+    // not from the current process environment, so it always returns the latest values.
+    //
+    // Use -EncodedCommand with Base64 to avoid quote-escaping issues.
+    // When Node.js calls execSync, outer double quotes for `-Command "..."` can
+    // conflict with inner double quotes needed by PowerShell string arguments.
+    // -EncodedCommand bypasses all quoting problems entirely.
+    const psScript = [
+      '$machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")',
+      '$userPath = [Environment]::GetEnvironmentVariable("Path", "User")',
+      '[Console]::Write("$machinePath;$userPath")',
+    ].join('; ');
+    // PowerShell -EncodedCommand expects a Base64-encoded UTF-16LE string
+    const encodedCommand = Buffer.from(psScript, 'utf16le').toString('base64');
+
+    const result = execSync(`powershell -NoProfile -NonInteractive -EncodedCommand ${encodedCommand}`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+      windowsHide: true,
+    });
+
+    const registryPath = result.trim();
+    if (registryPath) {
+      // Deduplicate and remove empty entries
+      const entries = registryPath
+        .split(';')
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      const unique = Array.from(new Set(entries));
+      cachedWindowsRegistryPath = unique.join(';');
+      coworkLog('INFO', 'resolveWindowsRegistryPath', `Resolved ${unique.length} PATH entries from Windows registry`);
+    } else {
+      cachedWindowsRegistryPath = null;
+    }
+  } catch (error) {
+    coworkLog('WARN', 'resolveWindowsRegistryPath', `Failed to read PATH from Windows registry: ${error instanceof Error ? error.message : String(error)}`);
+    cachedWindowsRegistryPath = null;
+  }
+
+  return cachedWindowsRegistryPath;
+}
+
+/**
+ * Merge the current process PATH with registry-resolved PATH on Windows.
+ *
+ * This ensures that any PATH entries the user has added (e.g. Python, Node.js,
+ * npm, pip) are available even if the Electron app inherited a stale PATH from
+ * Explorer. The registry PATH entries are appended after the current entries
+ * so that any overrides already in the env (like Git toolchain, shims) take priority.
+ */
+function ensureWindowsRegistryPathEntries(env: Record<string, string | undefined>): void {
+  const registryPath = resolveWindowsRegistryPath();
+  if (!registryPath) return;
+
+  const currentPath = env.PATH || '';
+  const currentEntriesLower = new Set(
+    currentPath.split(delimiter).map((entry) => entry.toLowerCase().replace(/\\$/, ''))
+  );
+
+  const missingEntries: string[] = [];
+  for (const entry of registryPath.split(';')) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    // Normalize: remove trailing backslash for comparison
+    const normalizedLower = trimmed.toLowerCase().replace(/\\$/, '');
+    if (!currentEntriesLower.has(normalizedLower)) {
+      missingEntries.push(trimmed);
+      currentEntriesLower.add(normalizedLower); // prevent duplicates within registry entries
+    }
+  }
+
+  if (missingEntries.length > 0) {
+    // Append registry entries at the END so existing overrides (Git, shims) take priority
+    env.PATH = currentPath ? `${currentPath}${delimiter}${missingEntries.join(delimiter)}` : missingEntries.join(delimiter);
+    coworkLog('INFO', 'ensureWindowsRegistryPathEntries', `Appended ${missingEntries.length} missing PATH entries from Windows registry: ${missingEntries.join(', ')}`);
+  }
+}
+
+/**
  * Cached git-bash path on Windows. Resolved once and reused.
  */
 let cachedGitBashPath: string | null | undefined;
@@ -406,6 +514,70 @@ function ensureWindowsSystemPathEntries(env: Record<string, string | undefined>)
   }
 }
 
+/**
+ * Convert a Windows-format PATH string to MSYS2/POSIX format for git-bash.
+ *
+ * Windows PATH uses semicolons (;) as delimiters and backslash paths (C:\...),
+ * while MSYS2 bash expects colons (:) and forward-slash POSIX paths (/c/...).
+ *
+ * When Node.js passes env vars to a forked process, PATH stays in Windows format.
+ * If the CLI later spawns git-bash, the /etc/profile uses ORIGINAL_PATH="${PATH}"
+ * and appends it to the new PATH with a colon. But since the Windows PATH still
+ * has semicolons inside, it becomes one giant invalid path entry.
+ *
+ * This function converts each semicolon-separated Windows path entry to its
+ * POSIX equivalent so that git-bash can correctly parse all entries.
+ */
+function convertWindowsPathToMsys(windowsPath: string): string {
+  if (!windowsPath) return windowsPath;
+
+  const entries = windowsPath.split(';').filter(Boolean);
+  const converted: string[] = [];
+
+  for (const entry of entries) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+
+    // Convert Windows path to POSIX: C:\foo\bar → /c/foo/bar
+    // Drive letter pattern: X:\ or X:/
+    const driveMatch = trimmed.match(/^([A-Za-z]):[/\\](.*)/);
+    if (driveMatch) {
+      const driveLetter = driveMatch[1].toLowerCase();
+      const rest = driveMatch[2].replace(/\\/g, '/').replace(/\/+$/, '');
+      converted.push(`/${driveLetter}${rest ? '/' + rest : ''}`);
+    } else if (trimmed.startsWith('/')) {
+      // Already POSIX-style
+      converted.push(trimmed);
+    } else {
+      // Relative path or unknown format, convert backslashes
+      converted.push(trimmed.replace(/\\/g, '/'));
+    }
+  }
+
+  return converted.join(':');
+}
+
+/**
+ * Set ORIGINAL_PATH with POSIX-converted PATH for git-bash to inherit.
+ *
+ * Git-bash's /etc/profile (with MSYS2_PATH_TYPE=inherit) reads ORIGINAL_PATH
+ * and appends it to the MSYS2 PATH. However, if ORIGINAL_PATH contains
+ * Windows-format paths (semicolons, backslashes), bash treats them as a single
+ * invalid entry because it uses colons as the PATH delimiter.
+ *
+ * By pre-setting ORIGINAL_PATH to the POSIX-converted version of our PATH,
+ * we ensure that /etc/profile appends properly formatted, colon-separated
+ * paths that bash can actually use.
+ */
+function ensureWindowsOriginalPath(env: Record<string, string | undefined>): void {
+  const currentPath = env.PATH || '';
+  if (!currentPath) return;
+
+  const posixPath = convertWindowsPathToMsys(currentPath);
+  env.ORIGINAL_PATH = posixPath;
+  coworkLog('INFO', 'ensureWindowsOriginalPath', `Set ORIGINAL_PATH with ${posixPath.split(':').length} POSIX-format entries`);
+}
+
 function applyPackagedEnvOverrides(env: Record<string, string | undefined>): void {
   // On Windows, resolve git-bash and ensure Git toolchain directories are available in PATH.
   if (process.platform === 'win32') {
@@ -421,6 +593,13 @@ function applyPackagedEnvOverrides(env: Record<string, string | undefined>): voi
     // The Claude Agent SDK's shell snapshot mechanism captures PATH and may lose
     // system directories if they were missing from the inherited environment.
     ensureWindowsSystemPathEntries(env);
+
+    // Merge the latest PATH entries from the Windows registry (Machine + User).
+    // When the Electron app is launched from Explorer/Start Menu, process.env.PATH
+    // may be stale and missing tools installed after Explorer started (e.g. Python,
+    // Node.js, npm). Reading from the registry ensures we get the latest values,
+    // similar to how a freshly opened terminal would.
+    ensureWindowsRegistryPathEntries(env);
 
     const configuredBashPath = normalizeWindowsPath(env.CLAUDE_CODE_GIT_BASH_PATH);
     const bashPath = configuredBashPath && existsSync(configuredBashPath)
@@ -439,6 +618,31 @@ function applyPackagedEnvOverrides(env: Record<string, string | undefined>): voi
       env.PATH = appendEnvPath(env.PATH, [shimDir]);
       coworkLog('INFO', 'resolveNodeShim', `Injected Electron Node shim PATH entry: ${shimDir}`);
     }
+
+    // Tell git-bash to inherit the PATH from the parent process instead of
+    // rebuilding it from scratch. Without this, git-bash's /etc/profile (login
+    // shell) defaults to constructing a minimal PATH containing only Windows
+    // system directories + MSYS2 tools, discarding user-installed tool paths
+    // like Python, Node.js, npm, pip, etc. Setting MSYS2_PATH_TYPE=inherit
+    // makes git-bash preserve the full PATH we've carefully constructed above.
+    if (!env.MSYS2_PATH_TYPE) {
+      env.MSYS2_PATH_TYPE = 'inherit';
+      coworkLog('INFO', 'applyPackagedEnvOverrides', 'Set MSYS2_PATH_TYPE=inherit to preserve PATH in git-bash');
+    }
+
+    // Pre-set ORIGINAL_PATH in POSIX format so git-bash's /etc/profile can use it.
+    //
+    // ROOT CAUSE: Node.js env PATH on Windows uses semicolons (;) and backslash
+    // paths (C:\...). When the Claude Agent SDK's CLI spawns git-bash with this env,
+    // /etc/profile reads ORIGINAL_PATH="${ORIGINAL_PATH:-${PATH}}" and appends it
+    // with a colon. But the semicolons in the Windows PATH are NOT converted to
+    // colons, so "C:\nodejs;C:\python" becomes one giant invalid entry instead of
+    // two separate paths. This causes `npm`, `python`, `pip` etc. to be unfindable.
+    //
+    // By pre-setting ORIGINAL_PATH to the POSIX-converted version (/c/nodejs:/c/python),
+    // /etc/profile uses it directly and bash can correctly parse all PATH entries.
+    // This MUST be done AFTER all PATH modifications above so the full PATH is captured.
+    ensureWindowsOriginalPath(env);
   }
 
   if (!app.isPackaged) {


### PR DESCRIPTION
## Summary

- Fix Windows built-in commands (ipconfig, systeminfo, netstat, ping) failing in cowork sessions by ensuring System32 directories and critical env vars (SystemRoot, windir, COMSPEC) are always present
- Fix user-installed tools (python, npm, pip) being unfindable in cowork sessions due to Windows PATH format incompatibility with git-bash
- Read latest PATH from Windows registry via PowerShell to handle stale Explorer-inherited PATH

## Root Cause

When the Claude Agent SDK's CLI spawns git-bash to execute shell commands, git-bash's `/etc/profile` rebuilds PATH using `ORIGINAL_PATH`. However, the PATH inherited from Node.js is in Windows format (semicolons as delimiters, backslash paths like `C:\Program Files\nodejs;C:\Users\...`). Bash uses colons as PATH delimiters, so the semicolons are **not** converted — the entire Windows PATH becomes one giant invalid entry, making all user-installed tools unfindable.

## Fix

1. **`ensureWindowsOriginalPath()`** — Pre-set `ORIGINAL_PATH` in POSIX format (`/c/Program Files/nodejs:/c/Users/...`) so git-bash's `/etc/profile` can correctly parse all PATH entries. This is the core fix.
2. **`MSYS2_PATH_TYPE=inherit`** — Tell git-bash to inherit PATH from the parent process instead of rebuilding a minimal one.
3. **`ensureWindowsRegistryPathEntries()`** — Read latest Machine + User PATH from Windows registry via PowerShell (`-EncodedCommand` to avoid quote-escaping issues), ensuring tools installed after Explorer started are available.
4. **`ensureWindowsSystemPathEntries()`** + **`ensureWindowsSystemEnvVars()`** — Ensure System32 directories and critical Windows env vars are always present for built-in commands.

Closes #10
Closes #94
