### PR TITLE
Fix-MiniMax OpenAI Invalid Params

### DIFF
--- a/src/main/libs/coworkOpenAICompatProxy.ts
+++ b/src/main/libs/coworkOpenAICompatProxy.ts
@@ -2284,9 +2284,8 @@ async function handleRequest(
 
   // Some providers (e.g. MiniMax) reject requests with multiple system messages.
   // Merge all system messages into one before sending to these providers.
-  if (upstreamAPIType === 'chat_completions') {
-    mergeSystemMessagesForProvider(openAIRequest);
-  }
+  // This fix applies to both chat_completions and responses API types.
+  mergeSystemMessagesForProvider(openAIRequest);
 
   const upstreamRequest = upstreamAPIType === 'responses'
     ? convertChatCompletionsRequestToResponsesRequest(openAIRequest)


### PR DESCRIPTION
Fixed the invalid params error ERROR code
Current Version:
Issue:
When connecting with MiniMax api key, it looks like it works fine when you press Test Connection
However when you are in the Chat box, input a new task, but get below response:

API Error: 400 {"type":"error","error":{"type":"api_error","message":"invalid params, invalid chat setting (2013)"}}


https://github.com/netease-youdao/LobsterAI/issues/1
```ts

if (upstreamAPIType === 'chat_completions') {
  mergeSystemMessagesForProvider(openAIRequest);
}

```
Originally, when your service provider is OpenAI => It will use responseAPI mode


By removing this, 
It does not matter if it's a OpenAI or Anthropic pattern 


一开始是openai的话，就是会有这个错误。
改完之后就可以用了，本地已经build 测试过了。