### PR TITLE
fix: add Moonshot/Kimi Coding Plan endpoint switch for cowork sessions

### DIFF
--- a/src/main/libs/claudeSettings.ts
+++ b/src/main/libs/claudeSettings.ts
@@ -17,6 +17,9 @@ const QWEN_CODING_PLAN_ANTHROPIC_BASE_URL = 'https://coding.dashscope.aliyuncs.c
 // Volcengine Coding Plan 专属端点 (OpenAI 兼容和 Anthropic 兼容)
 const VOLCENGINE_CODING_PLAN_OPENAI_BASE_URL = 'https://ark.cn-beijing.volces.com/api/coding/v3';
 const VOLCENGINE_CODING_PLAN_ANTHROPIC_BASE_URL = 'https://ark.cn-beijing.volces.com/api/coding';
+// Moonshot/Kimi Coding Plan 专属端点 (OpenAI 兼容和 Anthropic 兼容)
+const MOONSHOT_CODING_PLAN_OPENAI_BASE_URL = 'https://api.kimi.com/coding/v1';
+const MOONSHOT_CODING_PLAN_ANTHROPIC_BASE_URL = 'https://api.kimi.com/coding';
 
 type ProviderModel = {
   id: string;
@@ -156,6 +159,17 @@ function resolveMatchedProvider(appConfig: AppConfig): { matched: MatchedProvide
       baseURL = VOLCENGINE_CODING_PLAN_ANTHROPIC_BASE_URL;
     } else {
       baseURL = VOLCENGINE_CODING_PLAN_OPENAI_BASE_URL;
+      apiFormat = 'openai';
+    }
+  }
+
+  // Handle Moonshot/Kimi Coding Plan endpoint switch
+  // Coding Plan supports both OpenAI and Anthropic compatible formats
+  if (providerName === 'moonshot' && providerConfig.codingPlanEnabled) {
+    if (apiFormat === 'anthropic') {
+      baseURL = MOONSHOT_CODING_PLAN_ANTHROPIC_BASE_URL;
+    } else {
+      baseURL = MOONSHOT_CODING_PLAN_OPENAI_BASE_URL;
       apiFormat = 'openai';
     }
   }


### PR DESCRIPTION
Cowork sessions were stuck in "executing" state when using Moonshot provider with Coding Plan enabled, because claudeSettings.ts was missing the endpoint switch logic for moonshot. The baseURL remained as api.moonshot.cn/anthropic instead of switching to api.kimi.com/coding, causing the Coding Plan API key to be rejected silently.