### PR TITLE
fix: disambiguate model selection by provider key

### DIFF
--- a/src/main/libs/claudeSettings.ts
+++ b/src/main/libs/claudeSettings.ts
@@ -37,6 +37,7 @@ type ProviderConfig = {
 type AppConfig = {
   model?: {
     defaultModel?: string;
+    defaultModelProvider?: string;
   };
   providers?: Record<string, ProviderConfig>;
 };
@@ -120,12 +121,26 @@ function resolveMatchedProvider(appConfig: AppConfig): { matched: MatchedProvide
     return { matched: null, error: 'No available model configured in enabled providers.' };
   }
 
-  const providerEntry = Object.entries(providers).find(([, provider]) => {
-    if (!provider?.enabled || !provider.models) {
-      return false;
+  let providerEntry: [string, ProviderConfig] | undefined;
+  const preferredProviderName = appConfig.model?.defaultModelProvider?.trim();
+  if (preferredProviderName) {
+    const preferredProvider = providers[preferredProviderName];
+    if (
+      preferredProvider?.enabled
+      && preferredProvider.models?.some((model) => model.id === modelId)
+    ) {
+      providerEntry = [preferredProviderName, preferredProvider];
     }
-    return provider.models.some((model) => model.id === modelId);
-  });
+  }
+
+  if (!providerEntry) {
+    providerEntry = Object.entries(providers).find(([, provider]) => {
+      if (!provider?.enabled || !provider.models) {
+        return false;
+      }
+      return provider.models.some((model) => model.id === modelId);
+    });
+  }
 
   if (!providerEntry) {
     return { matched: null, error: `No enabled provider found for model: ${modelId}` };

--- a/src/renderer/components/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../store';
 import { ChevronDownIcon, CheckIcon } from '@heroicons/react/24/outline';
-import { setSelectedModel } from '../store/slices/modelSlice';
+import { setSelectedModel, isSameModelIdentity, getModelIdentityKey } from '../store/slices/modelSlice';
 
 interface ModelSelectorProps {
   dropdownDirection?: 'up' | 'down';
@@ -65,10 +65,10 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ dropdownDirection = 'down
           <div className="max-h-64 overflow-y-auto">
           {availableModels.map((model) => (
             <button
-              key={model.id}
+              key={getModelIdentityKey(model)}
               onClick={() => handleModelSelect(model)}
               className={`w-full px-4 py-2.5 text-left dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover flex items-center justify-between transition-colors ${
-                model.id === selectedModel.id ? 'dark:bg-claude-darkSurfaceHover/50 bg-claude-surfaceHover/50' : ''
+                isSameModelIdentity(model, selectedModel) ? 'dark:bg-claude-darkSurfaceHover/50 bg-claude-surfaceHover/50' : ''
               }`}
             >
               <div className="flex flex-col">
@@ -77,7 +77,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ dropdownDirection = 'down
                   <span className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">{model.provider}</span>
                 )}
               </div>
-              {model.id === selectedModel.id && (
+              {isSameModelIdentity(model, selectedModel) && (
                 <CheckIcon className="h-4 w-4 text-claude-accent" />
               )}
             </button>

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1024,7 +1024,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice }) => {
       });
 
       // 更新 Redux store 中的可用模型列表
-      const allModels: { id: string; name: string; provider?: string; supportsImage?: boolean }[] = [];
+      const allModels: { id: string; name: string; provider?: string; providerKey?: string; supportsImage?: boolean }[] = [];
       Object.entries(normalizedProviders).forEach(([providerName, config]) => {
         if (config.enabled && config.models) {
           config.models.forEach(model => {
@@ -1032,6 +1032,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice }) => {
               id: model.id,
               name: model.name,
               provider: providerName.charAt(0).toUpperCase() + providerName.slice(1),
+              providerKey: providerName,
               supportsImage: model.supportsImage ?? false,
             });
           });

--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -13,6 +13,7 @@ export interface AppConfig {
       supportsImage?: boolean;
     }>;
     defaultModel: string;
+    defaultModelProvider?: string;
   };
   // 多模型提供商配置
   providers?: {
@@ -215,6 +216,7 @@ export const defaultConfig: AppConfig = {
       { id: 'deepseek-reasoner', name: 'DeepSeek Reasoner', supportsImage: false },
     ],
     defaultModel: 'deepseek-chat',
+    defaultModelProvider: 'deepseek',
   },
   providers: {
     openai: {

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -271,7 +271,7 @@ class ApiService {
     const normalizedHint = providerHint?.toLowerCase();
     if (
       normalizedHint
-      && ['openai', 'deepseek', 'moonshot', 'zhipu', 'minimax', 'qwen', 'openrouter', 'gemini', 'anthropic', 'xiaomi', 'volcengine', 'ollama'].includes(normalizedHint)
+      && ['openai', 'deepseek', 'moonshot', 'zhipu', 'minimax', 'qwen', 'openrouter', 'gemini', 'anthropic', 'xiaomi', 'volcengine', 'ollama', 'custom'].includes(normalizedHint)
     ) {
       return normalizedHint;
     }
@@ -376,7 +376,10 @@ class ApiService {
     }
 
     const selectedModel = store.getState().model.selectedModel;
-    const provider = this.detectProvider(selectedModel.id, selectedModel.provider);
+    const provider = this.detectProvider(
+      selectedModel.id,
+      selectedModel.providerKey ?? selectedModel.provider
+    );
     const supportsImages = !!selectedModel.supportsImage;
     const userMessage: ChatUserMessageInput = typeof message === 'string'
       ? { content: message }


### PR DESCRIPTION
When the same model ID exists in multiple providers, the app now uses providerKey to correctly identify and persist the user's choice.