### PR TITLE
fix: Windows 平台 electron-builder 打包 asar 缺失 dist 目录

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,44 @@
+# .npmignore - Used by electron-builder instead of .gitignore
+# This file intentionally does NOT exclude dist/ and dist-electron/
+# so that build outputs are included in the asar archive.
+
+src/
+tests/
+scripts/
+build/*
+!build/entitlements.mac.plist
+!build/icons/
+!build/icons/**
+release/
+.DS_Store
+.env
+.claude/
+__pycache__/
+.codebuddy/
+sandbox/image/out/
+sandbox/image/publish/
+sandbox/image/.work/
+sandbox/runtime/out/
+sandbox/runtime-darwin-*/
+resources/mingit/
+resources/MinGit-*.zip
+resources/PortableGit-*.7z.exe
+resources/python-win/
+resources/python-*.zip
+SKILLs/**/.connection
+SKILLs/**/.server.log
+SKILLs/**/.server.pid
+SKILLs/**/.venv/
+nul
+.work.env
+.playwright-mcp/
+.cowork-temp/
+*.ts
+!*.d.ts
+tsconfig.json
+electron-tsconfig.json
+vite.config.ts
+tailwind.config.js
+postcss.config.js
+.eslintrc.cjs
+CLAUDE.md

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -8,9 +8,17 @@
   "beforePack": "./scripts/electron-builder-hooks.cjs",
   "afterPack": "./scripts/electron-builder-hooks.cjs",
   "files": [
-    "dist/**/*",
-    "dist-electron/**/*",
-    "sandbox/agent-runner/AGENT_SYSTEM_PROMPT.md"
+    "sandbox/agent-runner/AGENT_SYSTEM_PROMPT.md",
+    {
+      "from": "dist",
+      "to": "dist",
+      "filter": ["**/*"]
+    },
+    {
+      "from": "dist-electron",
+      "to": "dist-electron",
+      "filter": ["**/*"]
+    }
   ],
   "extraResources": [
     {


### PR DESCRIPTION
## Summary

- 将 `electron-builder.json` 中 `files` 配置从 glob 字符串格式改为对象格式（`from`/`to`/`filter`），明确指定 `dist` 和 `dist-electron` 目录
- 添加 `.npmignore` 文件，防止 electron-builder 因 `.gitignore` 排除构建产物目录

glob 字符串格式（`"dist/**/*"`、`"dist-electron/**/*"`）在 Windows 上由于路径分隔符差异，minimatch 的 partial matching 无法正确识别目标目录，导致 `dist/` 和 `dist-electron/` 未被打包进 `app.asar`，构建报错：

```
Application entry file "dist-electron\main.js" in the "...\app.asar" does not exist.
```

对象格式为每个目录创建独立的 walker，直接从指定目录开始遍历，绕开了根目录 partial matching 的问题。该改动对 macOS 和 Linux 构建无影响。