### PR TITLE
fix: Windows 打包时 skill 依赖安装失败

### DIFF
--- a/scripts/electron-builder-hooks.cjs
+++ b/scripts/electron-builder-hooks.cjs
@@ -250,11 +250,14 @@ function installSkillDependencies() {
     }
 
     console.log(`[electron-builder-hooks]   ${entry}: installing dependencies...`);
+    // On Windows, use shell: true so cmd.exe resolves npm.cmd correctly
+    const isWin = process.platform === 'win32';
     const result = spawnSync('npm', ['install'], {
       cwd: skillPath,
       encoding: 'utf-8',
       stdio: 'pipe',
       timeout: 5 * 60 * 1000, // 5 minute timeout
+      shell: isWin,
     });
 
     if (result.status === 0) {
@@ -262,6 +265,9 @@ function installSkillDependencies() {
       installedCount++;
     } else {
       console.error(`[electron-builder-hooks]   ${entry}: ✗ failed`);
+      if (result.error) {
+        console.error(`[electron-builder-hooks]     Error: ${result.error.message}`);
+      }
       if (result.stderr) {
         console.error(`[electron-builder-hooks]     ${result.stderr.substring(0, 200)}`);
       }


### PR DESCRIPTION
## Summary

- Windows 上 `electron-builder-hooks.cjs` 中 `spawnSync('npm', ['install'], ...)` 因缺少 `shell: true` 导致 ENOENT 错误，无法解析 `npm.cmd`
- 与 `skillManager.ts` 中已修复的同类问题一致，添加 `shell: isWin` 使 Windows 上通过 `cmd.exe` 正确解析 `npm.cmd`
- 改进错误日志：失败时额外输出 `result.error`，避免 ENOENT 场景下无任何错误信息