### PR TITLE
fix: 修复钉钉网关不必要的重连并增加发送重试机制

### DIFF
--- a/src/main/im/dingtalkGateway.ts
+++ b/src/main/im/dingtalkGateway.ts
@@ -54,11 +54,11 @@ export class DingTalkGateway extends EventEmitter {
   private reconnectDelayMs = 3000; // Reduced to 3 seconds
   private isReconnecting = false;
   private isStopping = false;
-  private lastMessageTime = 0;
+  private lastActivityTime = 0;
 
   // Health check configuration
   private readonly HEALTH_CHECK_INTERVAL = 10000; // 10 seconds
-  private readonly MESSAGE_TIMEOUT = 60000; // 60 seconds - force reconnect if no message
+  private readonly MESSAGE_TIMEOUT = 300000; // 5 minutes - force reconnect if no activity
   private readonly TOKEN_REFRESH_INTERVAL = 3600000; // 1 hour
 
   constructor() {
@@ -100,7 +100,7 @@ export class DingTalkGateway extends EventEmitter {
       this.refreshAccessToken();
     }, this.TOKEN_REFRESH_INTERVAL);
 
-    this.lastMessageTime = Date.now();
+    this.lastActivityTime = Date.now();
   }
 
   /**
@@ -139,12 +139,12 @@ export class DingTalkGateway extends EventEmitter {
     }
 
     const now = Date.now();
-    const timeSinceLastMessage = now - this.lastMessageTime;
+    const timeSinceLastActivity = now - this.lastActivityTime;
 
-    // If no messages for MESSAGE_TIMEOUT, force reconnection
+    // If no activity for MESSAGE_TIMEOUT, force reconnection
     // Don't test token because it might be cached and give false positive
-    if (timeSinceLastMessage > this.MESSAGE_TIMEOUT) {
-      console.log(`[DingTalk Gateway] No messages for ${Math.floor(timeSinceLastMessage / 1000)}s, forcing reconnection...`);
+    if (timeSinceLastActivity > this.MESSAGE_TIMEOUT) {
+      console.log(`[DingTalk Gateway] No activity for ${Math.floor(timeSinceLastActivity / 1000)}s, forcing reconnection...`);
       this.log('[DingTalk Gateway] Long silence detected, SDK connection may be dead, forcing reconnection...');
       await this.reconnect();
     }
@@ -292,8 +292,8 @@ export class DingTalkGateway extends EventEmitter {
           return;
         }
 
-        // Update last message time for health check
-        this.lastMessageTime = Date.now();
+        // Update last activity time for health check
+        this.lastActivityTime = Date.now();
 
         const messageId = res.headers?.messageId;
         try {
@@ -480,6 +480,36 @@ export class DingTalkGateway extends EventEmitter {
     return { text: data.text?.content?.trim() || `[${msgtype}消息]`, messageType: msgtype };
   }
 
+  // Retry configuration
+  private readonly MAX_RETRIES = 3;
+  private readonly RETRY_DELAY = 2000; // 2 seconds
+
+  /**
+   * Execute a request with retry logic
+   */
+  private async retryableRequest(fn: () => Promise<void>, label: string): Promise<void> {
+    for (let attempt = 1; attempt <= this.MAX_RETRIES; attempt++) {
+      try {
+        await fn();
+        return;
+      } catch (error: any) {
+        // Clear token cache on auth errors so next attempt gets a fresh token
+        const status = error.response?.status;
+        if (status === 401 || status === 403) {
+          accessToken = null;
+          accessTokenExpiry = 0;
+          this.log(`[DingTalk Gateway] Token 可能过期，已清除缓存`);
+        }
+        if (attempt === this.MAX_RETRIES) {
+          console.error(`[DingTalk Gateway] ${label} 最终失败 (${this.MAX_RETRIES}次尝试后): ${error.message}`);
+          throw error;
+        }
+        console.warn(`[DingTalk Gateway] ${label} 失败 (${attempt}/${this.MAX_RETRIES}): ${error.message}，${this.RETRY_DELAY / 1000}s 后重试...`);
+        await new Promise(resolve => setTimeout(resolve, this.RETRY_DELAY));
+      }
+    }
+  }
+
   /**
    * Send message via session webhook
    */
@@ -488,8 +518,6 @@ export class DingTalkGateway extends EventEmitter {
     text: string,
     options: { atUserId?: string | null } = {}
   ): Promise<void> {
-    const token = await this.getAccessToken();
-
     // Detect markdown
     const hasMarkdown = /^[#*>-]|[*_`#[\]]/.test(text) || text.includes('\n');
     const useMarkdown = hasMarkdown;
@@ -515,12 +543,15 @@ export class DingTalkGateway extends EventEmitter {
       text,
     }, null, 2));
 
-    await axios({
-      url: sessionWebhook,
-      method: 'POST',
-      data: createUtf8JsonBody(body),
-      headers: { 'x-acs-dingtalk-access-token': token, 'Content-Type': JSON_UTF8_CONTENT_TYPE },
-    });
+    await this.retryableRequest(async () => {
+      const token = await this.getAccessToken();
+      await axios({
+        url: sessionWebhook,
+        method: 'POST',
+        data: createUtf8JsonBody(body),
+        headers: { 'x-acs-dingtalk-access-token': token, 'Content-Type': JSON_UTF8_CONTENT_TYPE },
+      });
+    }, '发送文本消息');
   }
 
   /**
@@ -536,7 +567,6 @@ export class DingTalkGateway extends EventEmitter {
       openConversationId?: string;
     }
   ): Promise<void> {
-    const token = await this.getAccessToken();
     const robotCode = this.config?.robotCode || this.config?.clientId;
 
     // msgParam 需要是 JSON 字符串
@@ -584,18 +614,21 @@ export class DingTalkGateway extends EventEmitter {
       conversationType: options.conversationType,
     }, null, 2));
 
-    const response = await axios({
-      url,
-      method: 'POST',
-      data: createUtf8JsonBody(body),
-      headers: { 'x-acs-dingtalk-access-token': token, 'Content-Type': JSON_UTF8_CONTENT_TYPE },
-      timeout: 30000,
-    });
+    await this.retryableRequest(async () => {
+      const token = await this.getAccessToken();
+      const response = await axios({
+        url,
+        method: 'POST',
+        data: createUtf8JsonBody(body),
+        headers: { 'x-acs-dingtalk-access-token': token, 'Content-Type': JSON_UTF8_CONTENT_TYPE },
+        timeout: 30000,
+      });
 
-    // 检查响应 (新版 API 错误格式可能不同)
-    if (response.data?.code && response.data.code !== '0') {
-      throw new Error(`钉钉API返回错误: ${response.data.message || response.data.code}`);
-    }
+      // 检查响应 (新版 API 错误格式可能不同)
+      if (response.data?.code && response.data.code !== '0') {
+        throw new Error(`钉钉API返回错误: ${response.data.message || response.data.code}`);
+      }
+    }, '发送媒体消息');
   }
 
   /**
@@ -788,6 +821,7 @@ export class DingTalkGateway extends EventEmitter {
         openConversationId: data.conversationId,
       });
       this.status.lastOutboundAt = Date.now();
+      this.lastActivityTime = Date.now();
     };
 
     // Store last conversation for notifications
@@ -835,6 +869,7 @@ export class DingTalkGateway extends EventEmitter {
     }
     await this.sendBySession(this.lastConversation.sessionWebhook, text);
     this.status.lastOutboundAt = Date.now();
+    this.lastActivityTime = Date.now();
   }
 
   /**
@@ -850,5 +885,6 @@ export class DingTalkGateway extends EventEmitter {
       openConversationId: this.lastConversation.openConversationId,
     });
     this.status.lastOutboundAt = Date.now();
+    this.lastActivityTime = Date.now();
   }
 }


### PR DESCRIPTION
- 健康检查从仅跟踪入站消息改为跟踪所有活动(入站+出站)，避免发送通知后立即触发重连
- MESSAGE_TIMEOUT 从 60s 增加到 300s，减少误判
- 新增 retryableRequest 方法，sendBySession 和 sendMediaViaNewApi 支持最多 3 次重试
- Token 过期(401/403)时自动清除缓存并重新获取