### PR TITLE
fix: 修复图片附件文件路径未传递给模型导致 skill 引用路径错误

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -215,9 +215,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       ? activeSkills.map(buildInlinedSkillPrompt).join('\n\n')
       : undefined;
 
-    // Separate image attachments (with base64 data) from regular file attachments
+    // Extract image attachments (with base64 data) for vision-capable models
     const imageAtts: CoworkImageAttachment[] = [];
-    const fileAttachments: CoworkAttachment[] = [];
     for (const attachment of attachments) {
       if (attachment.isImage && attachment.dataUrl) {
         const extracted = extractBase64FromDataUrl(attachment.dataUrl);
@@ -227,14 +226,15 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
             mimeType: extracted.mimeType,
             base64Data: extracted.base64Data,
           });
-          continue;
         }
       }
-      fileAttachments.push(attachment);
     }
 
-    // Build prompt with only non-image file attachments
-    const attachmentLines = fileAttachments
+    // Build prompt with ALL attachments that have real file paths (both regular files and images).
+    // Image attachments also need their file paths in the prompt so the model knows
+    // where the original files are located (e.g., for skills like seedream that need --image <path>).
+    // Note: inline/clipboard images have pseudo-paths starting with 'inline:' and are excluded.
+    const attachmentLines = attachments
       .filter((a) => !a.path.startsWith('inline:'))
       .map((attachment) => `${INPUT_FILE_LABEL}: ${attachment.path}`)
       .join('\n');


### PR DESCRIPTION
## Summary

修复 cowork 中图片附件与 skill（如 seedream/seedance）配合使用时，模型无法获知图片真实文件路径的问题。

### 问题

此前为支持视觉模型，图片附件被单独处理为 base64 内容块直接传递给模型，但在构建 prompt 文本时，图片的原始文件路径被排除在外（仅保留了非图片附件的路径）。

这导致模型在调用需要 `--image <path>` 参数的 skill 时，因不知道文件实际位置而凭空猜测路径，例如：
- 实际路径：`C:\Users\xxx\Desktop\photo.jpg`
- 模型猜测：`D:/cus_sk/1000035689.jpg`

### 修复

将 `attachmentLines` 的数据源从 `fileAttachments`（仅非图片附件）改为 `attachments`（所有附件），使图片附件的文件路径也包含在 prompt 文本中。修改后模型同时获得：

1. **视觉内容** — 通过 base64 内容块（不变）
2. **文件路径** — 通过 prompt 中的 `输入文件: <path>`（新增）

剪贴板粘贴的图片（pseudo-path 以 `inline:` 开头）不受影响，仍被正确过滤。