### PR TITLE
fix: 修复中文路径下 BASH_ENV 编码异常及 Skills 路径不可用

### DIFF
--- a/src/main/libs/coworkUtil.ts
+++ b/src/main/libs/coworkUtil.ts
@@ -619,6 +619,27 @@ function ensureWindowsBashBootstrapPath(env: Record<string, string | undefined>)
 }
 
 /**
+ * Convert a single Windows path to MSYS2/POSIX format.
+ *
+ * When the Windows path contains non-ASCII characters (e.g. Chinese usernames
+ * like C:\Users\中文用户\...), MSYS2's automatic Windows→POSIX conversion may
+ * corrupt the path if it runs before LANG=C.UTF-8 takes effect. Pre-converting
+ * to POSIX format (/c/Users/中文用户/...) bypasses this problematic conversion
+ * because MSYS2 recognises the value as already POSIX and passes it through
+ * directly to its internal wide-char file APIs.
+ */
+function singleWindowsPathToPosix(windowsPath: string): string {
+  if (!windowsPath) return windowsPath;
+  const driveMatch = windowsPath.match(/^([A-Za-z]):[/\\](.*)/);
+  if (driveMatch) {
+    const driveLetter = driveMatch[1].toLowerCase();
+    const rest = driveMatch[2].replace(/\\/g, '/').replace(/\/+$/, '');
+    return `/${driveLetter}${rest ? '/' + rest : ''}`;
+  }
+  return windowsPath.replace(/\\/g, '/');
+}
+
+/**
  * Convert a Windows-format PATH string to MSYS2/POSIX format for git-bash.
  *
  * Windows PATH uses semicolons (;) as delimiters and backslash paths (C:\...),
@@ -770,8 +791,12 @@ function applyPackagedEnvOverrides(env: Record<string, string | undefined>): voi
     if (!env.BASH_ENV) {
       const initScript = ensureWindowsBashUtf8InitScript();
       if (initScript) {
-        env.BASH_ENV = initScript;
-        coworkLog('INFO', 'applyPackagedEnvOverrides', `Set BASH_ENV for UTF-8 console code page: ${initScript}`);
+        // Convert to MSYS2 POSIX format to avoid encoding issues when the
+        // path contains non-ASCII characters (e.g. Chinese Windows username).
+        // MSYS2's automatic Windows→POSIX conversion can corrupt non-ASCII
+        // chars if it runs before LANG=C.UTF-8 takes effect during DLL init.
+        env.BASH_ENV = singleWindowsPathToPosix(initScript);
+        coworkLog('INFO', 'applyPackagedEnvOverrides', `Set BASH_ENV for UTF-8 console code page: ${env.BASH_ENV}`);
       }
     }
 
@@ -947,11 +972,14 @@ export async function getEnhancedEnv(target: OpenAICompatProxyTarget = 'local'):
 
   applyPackagedEnvOverrides(env);
 
-  // Inject SKILLs directory path for skill scripts
-  const skillsRoot = getSkillsRoot();
+  // Inject SKILLs directory path for skill scripts.
+  // On Windows, normalise backslashes to forward slashes so the value is usable
+  // in both Node.js (which accepts forward slashes) and bash (which treats
+  // backslashes as escape characters).
+  const skillsRoot = getSkillsRoot().replace(/\\/g, '/');
   env.SKILLS_ROOT = skillsRoot;
   env.LOBSTERAI_SKILLS_ROOT = skillsRoot; // Alternative name for clarity
-  env.LOBSTERAI_ELECTRON_PATH = process.execPath;
+  env.LOBSTERAI_ELECTRON_PATH = process.execPath.replace(/\\/g, '/');
 
   // Inject internal API base URL for skill scripts (e.g. scheduled-task creation)
   const internalApiBaseURL = getInternalApiBaseURL();


### PR DESCRIPTION
## Summary

Windows 环境下，当用户名或工作路径包含中文等非 ASCII 字符时，Cowork 会话中存在两类路径问题：

1. **BASH_ENV 路径编码损坏**：MSYS2 在 DLL 初始化阶段对 `BASH_ENV` 做 Windows→POSIX 自动转换时，`LANG=C.UTF-8` 尚未生效，导致非 ASCII 字符被损坏，`bash_utf8_init.sh` 无法加载，后续所有 bash 命令输出乱码。
2. **SKILLS_ROOT / LOBSTERAI_ELECTRON_PATH 反斜杠问题**：Windows 风格的反斜杠路径在 bash 环境中被当作转义符，导致 Skill 脚本路径解析失败、无法执行。

### 改动

- 新增 `singleWindowsPathToPosix()` 工具函数，将 `BASH_ENV` 预转换为 MSYS2 POSIX 格式（如 `/c/Users/用户/...`），绕过 MSYS2 的自动转换
- 将 `SKILLS_ROOT` 和 `LOBSTERAI_ELECTRON_PATH` 的反斜杠统一转为正斜杠，确保在 bash 和 Node.js 中均可正确解析

Closes #215
Closes #224