### PR TITLE
feat: IM消息处理时在用户消息上添加 Reaction 状态图标

### DIFF
--- a/src/main/im/discordGateway.ts
+++ b/src/main/im/discordGateway.ts
@@ -430,6 +430,11 @@ export class DiscordGateway extends EventEmitter {
       // Emit message event
       this.emit('message', imMessage);
 
+      // Add processing reaction (fire-and-forget)
+      message.react('👀').catch((err: any) => {
+        this.log(`[Discord Gateway] Failed to add reaction: ${err.message}`);
+      });
+
       // Call message callback if set
       if (this.onMessageCallback) {
         try {

--- a/src/main/im/feishuGateway.ts
+++ b/src/main/im/feishuGateway.ts
@@ -312,6 +312,25 @@ export class FeishuGateway extends EventEmitter {
   }
 
   /**
+   * Add a reaction emoji to a message (best-effort, non-blocking)
+   */
+  private async addReaction(messageId: string, emojiType: string): Promise<void> {
+    if (!this.restClient) return;
+    try {
+      const response: any = await this.restClient.request({
+        method: 'POST',
+        url: `/open-apis/im/v1/messages/${messageId}/reactions`,
+        data: { reaction_type: { emoji_type: emojiType } },
+      });
+      if (response.code !== 0) {
+        this.log(`[Feishu Gateway] Failed to add reaction: ${response.msg || response.code}`);
+      }
+    } catch (err: any) {
+      this.log(`[Feishu Gateway] Failed to add reaction: ${err.message}`);
+    }
+  }
+
+  /**
    * Check if message was already processed (deduplication)
    */
   private isMessageProcessed(messageId: string): boolean {
@@ -862,6 +881,9 @@ export class FeishuGateway extends EventEmitter {
 
     // Emit message event
     this.emit('message', message);
+
+    // Add processing reaction (fire-and-forget)
+    this.addReaction(ctx.messageId, 'OnIt').catch(() => {});
 
     // Call message callback if set
     if (this.onMessageCallback) {

--- a/src/main/im/lark-sdk.d.ts
+++ b/src/main/im/lark-sdk.d.ts
@@ -57,6 +57,7 @@ declare module '@larksuiteoapi/node-sdk' {
     request(params: {
       method: string;
       url: string;
+      data?: any;
     }): Promise<{ code: number; msg?: string; data?: any }>;
   }
 

--- a/src/main/im/telegramGateway.ts
+++ b/src/main/im/telegramGateway.ts
@@ -787,6 +787,14 @@ export class TelegramGateway extends EventEmitter {
     // Emit message event
     this.emit('message', imMessage);
 
+    // Add processing reaction (fire-and-forget)
+    if (ctx.message?.message_id && ctx.chat?.id) {
+      ctx.react('👀').catch((err: any) => {
+        const log = this.config?.debug ? console.log : () => {};
+        log(`[Telegram Gateway] Failed to add reaction: ${err.message}`);
+      });
+    }
+
     // Call message callback if set
     if (this.onMessageCallback) {
       try {


### PR DESCRIPTION
在飞书、Telegram、Discord 三个平台收到用户消息后，立即在用户原始消息上
添加 Reaction emoji 作为"正在处理"的视觉反馈。

- 飞书: 调用 reactions API 添加 "OnIt" emoji
- Telegram: 调用 ctx.react('👀')
- Discord: 调用 message.react('👀')
- 所有操作均为 fire-and-forget，失败不影响消息处理