### PR TITLE
fix: resolve OpenClaw gateway startup failures on Windows

### DIFF
--- a/scripts/sync-openclaw-runtime-current.cjs
+++ b/scripts/sync-openclaw-runtime-current.cjs
@@ -26,3 +26,35 @@ fs.rmSync(currentRuntimeDir, { recursive: true, force: true });
 fs.cpSync(targetRuntimeDir, currentRuntimeDir, { recursive: true, force: true });
 
 console.log(`[sync-openclaw-runtime-current] Synced ${targetId} -> vendor/openclaw-runtime/current`);
+
+// Extract entry files from gateway.asar if bare files are missing.
+// On Windows, Electron's utilityProcess.fork() cannot load ESM from inside .asar archives,
+// so bare files must exist on the real filesystem.
+const gatewayAsarPath = path.join(currentRuntimeDir, 'gateway.asar');
+const bareEntryPath = path.join(currentRuntimeDir, 'openclaw.mjs');
+if (fs.existsSync(gatewayAsarPath) && !fs.existsSync(bareEntryPath)) {
+  try {
+    const asar = require('@electron/asar');
+    const entries = asar.listPackage(gatewayAsarPath);
+    const toExtract = entries.filter(function (e) {
+      const normalized = e.replace(/\\/g, '/');
+      return normalized === '/openclaw.mjs' || normalized.startsWith('/dist/');
+    });
+
+    for (const entry of toExtract) {
+      const normalized = entry.replace(/\\/g, '/').replace(/^\//, '');
+      const destPath = path.join(currentRuntimeDir, normalized);
+      fs.mkdirSync(path.dirname(destPath), { recursive: true });
+      try {
+        const content = asar.extractFile(gatewayAsarPath, normalized);
+        fs.writeFileSync(destPath, content);
+      } catch (_e) {
+        // directory entries, skip
+      }
+    }
+
+    console.log(`[sync-openclaw-runtime-current] Extracted ${toExtract.length} entry files from gateway.asar`);
+  } catch (err) {
+    console.warn(`[sync-openclaw-runtime-current] Could not extract from gateway.asar: ${err.message}`);
+  }
+}

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -306,6 +306,8 @@ export class OpenClawEngineManager extends EventEmitter {
       return this.getStatus();
     }
 
+    this.ensureBareEntryFiles(runtime.root);
+
     const openclawEntry = this.resolveOpenClawEntry(runtime.root);
     if (!openclawEntry) {
       this.setStatus({
@@ -455,13 +457,101 @@ export class OpenClawEngineManager extends EventEmitter {
     return null;
   }
 
+  private ensureBareEntryFiles(runtimeRoot: string): void {
+    const bareEntry = path.join(runtimeRoot, 'openclaw.mjs');
+    const bareDistEntry = path.join(runtimeRoot, 'dist', 'entry.js');
+
+    if (fs.existsSync(bareEntry) && fs.existsSync(bareDistEntry)) {
+      return;
+    }
+
+    const asarRoot = path.join(runtimeRoot, 'gateway.asar');
+    const asarEntry = path.join(asarRoot, 'openclaw.mjs');
+    if (!fs.existsSync(asarEntry)) {
+      return;
+    }
+
+    console.log('[OpenClaw] Bare entry files missing, extracting from gateway.asar...');
+
+    try {
+      if (!fs.existsSync(bareEntry)) {
+        fs.writeFileSync(bareEntry, fs.readFileSync(asarEntry));
+        console.log('[OpenClaw] Extracted openclaw.mjs');
+      }
+
+      const asarDist = path.join(asarRoot, 'dist');
+      const bareDist = path.join(runtimeRoot, 'dist');
+      if (fs.existsSync(asarDist) && !fs.existsSync(bareDistEntry)) {
+        this.copyDirFromAsar(asarDist, bareDist);
+        console.log('[OpenClaw] Extracted dist/');
+      }
+
+      console.log('[OpenClaw] Entry files extracted successfully.');
+    } catch (err) {
+      console.error('[OpenClaw] Failed to extract entry files from gateway.asar:', err);
+    }
+  }
+
+  private copyDirFromAsar(srcDir: string, destDir: string): void {
+    fs.mkdirSync(destDir, { recursive: true });
+    const entries = fs.readdirSync(srcDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const srcPath = path.join(srcDir, entry.name);
+      const destPath = path.join(destDir, entry.name);
+      if (entry.isDirectory()) {
+        this.copyDirFromAsar(srcPath, destPath);
+      } else {
+        fs.writeFileSync(destPath, fs.readFileSync(srcPath));
+      }
+    }
+  }
+
   private resolveOpenClawEntry(runtimeRoot: string): string | null {
-    return findPath([
+    const esmEntry = findPath([
       path.join(runtimeRoot, 'openclaw.mjs'),
       path.join(runtimeRoot, 'dist', 'entry.js'),
       path.join(runtimeRoot, 'dist', 'entry.mjs'),
       path.join(runtimeRoot, 'gateway.asar', 'openclaw.mjs'),
     ]);
+    if (!esmEntry) return null;
+
+    // On Windows, utilityProcess.fork() cannot load ESM modules directly because
+    // the ESM loader misinterprets the drive letter (e.g. "D:") as a URL scheme.
+    // Work around this by generating a CJS wrapper that imports the ESM entry via file:// URL.
+    if (process.platform === 'win32') {
+      return this.ensureGatewayLauncherCjs(runtimeRoot, esmEntry);
+    }
+    return esmEntry;
+  }
+
+  private ensureGatewayLauncherCjs(runtimeRoot: string, esmEntry: string): string {
+    const launcherPath = path.join(runtimeRoot, 'gateway-launcher.cjs');
+    const esmBasename = path.basename(esmEntry);
+    const expectedContent =
+      `// Auto-generated CJS wrapper for Windows ESM compatibility.\n` +
+      `// On Windows, Electron utilityProcess.fork() cannot load ESM modules directly\n` +
+      `// because the drive letter (e.g. "D:") is misinterpreted as a URL scheme.\n` +
+      `const { pathToFileURL } = require('node:url');\n` +
+      `const path = require('node:path');\n` +
+      `const esmEntry = path.join(__dirname, '${esmBasename}');\n` +
+      `// Patch argv[1] so openclaw's isMainModule() recognizes this as the main entry.\n` +
+      `process.argv[1] = esmEntry;\n` +
+      `import(pathToFileURL(esmEntry).href).catch(err => {\n` +
+      `  process.stderr.write('[openclaw-launcher] ' + (err.stack || err) + '\\n');\n` +
+      `  process.exit(1);\n` +
+      `});\n`;
+
+    try {
+      const existing = fs.existsSync(launcherPath) ? fs.readFileSync(launcherPath, 'utf8') : '';
+      if (existing !== expectedContent) {
+        fs.writeFileSync(launcherPath, expectedContent, 'utf8');
+        console.log(`[OpenClaw] Generated gateway-launcher.cjs for Windows ESM compat`);
+      }
+    } catch (err) {
+      console.error('[OpenClaw] Failed to write gateway-launcher.cjs:', err);
+      return esmEntry;
+    }
+    return launcherPath;
   }
 
   private resolveGatewayClientEntry(runtimeRoot: string): string | null {


### PR DESCRIPTION
## Summary

- Auto-extract `openclaw.mjs` and `dist/` from `gateway.asar` when bare files are missing (both at runtime startup and at build-time sync), since `utilityProcess.fork()` cannot load ESM from inside `.asar` archives on Windows
- Generate a CJS wrapper (`gateway-launcher.cjs`) that uses `pathToFileURL()` to load the ESM entry via `file://` URL, avoiding `ERR_UNSUPPORTED_ESM_URL_SCHEME` caused by Windows drive letters being misinterpreted as URL schemes
- Patch `process.argv[1]` in the CJS wrapper so OpenClaw's `isMainModule()` guard recognizes the process as the main entry

## Test plan

- [x] Delete `vendor/openclaw-runtime/current/openclaw.mjs` and `vendor/openclaw-runtime/current/dist/` to simulate a fresh build
- [x] Run `npm run electron:dev` on Windows
- [x] Verify gateway starts successfully (check logs for `[gateway] listening on ws://...`)
- [x] Verify bare files are auto-created in `vendor/openclaw-runtime/current/`
- [ ] Run `node scripts/sync-openclaw-runtime-current.cjs <target-id>` and verify asar extraction log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)