### PR TITLE
fix: sync working directory to OpenClaw config

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -75,7 +75,9 @@ export class OpenClawConfigSync {
     const providerApi = mapApiTypeToOpenClawApi(apiType);
     const sandboxMode = mapExecutionModeToSandboxMode(coworkConfig.executionMode || 'auto');
 
-    const managedConfig = {
+    const workspaceDir = (coworkConfig.workingDirectory || '').trim();
+
+    const managedConfig: Record<string, unknown> = {
       gateway: {
         mode: 'local',
       },
@@ -106,6 +108,7 @@ export class OpenClawConfigSync {
           sandbox: {
             mode: sandboxMode,
           },
+          ...(workspaceDir ? { workspace: workspaceDir } : {}),
         },
       },
     };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1971,7 +1971,8 @@ if (!gotTheLock) {
         && previousConfig.agentEngine !== 'openclaw';
 
       const shouldSyncOpenClawConfig = normalizedExecutionMode !== undefined
-        || normalizedAgentEngine !== undefined;
+        || normalizedAgentEngine !== undefined
+        || (normalizedConfig.workingDirectory !== undefined && normalizedConfig.workingDirectory !== previousWorkingDir);
       if (shouldSyncOpenClawConfig) {
         const syncResult = await syncOpenClawConfig({
           reason: 'cowork-config-change',


### PR DESCRIPTION
## Summary
- OpenClaw engine ignored the user-configured working directory, always using its default `~/.openclaw/workspace` instead
- Added `agents.defaults.workspace` to the managed OpenClaw config in `openclawConfigSync.ts`, syncing the user's working directory
- Extended the config change handler in `main.ts` to trigger OpenClaw config sync (with gateway restart) when `workingDirectory` changes

## Test plan
- [ ] Set a custom working directory (e.g. `D:\cus_sk`) in LobsterAI settings
- [ ] Start a cowork session with OpenClaw engine, verify file operations happen in the configured directory (not `~/.openclaw/workspace`)
- [ ] Change working directory while OpenClaw gateway is running, verify it restarts and picks up the new workspace
- [ ] Verify yd_cowork engine still works correctly with the configured directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)