### PR TITLE
fix: IM 通道消息不实时创建 UI 会话的问题

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -642,6 +642,37 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   /**
+   * Force-reconnect the gateway WebSocket client.
+   * Used after the OpenClaw gateway process has been restarted (e.g. after config sync).
+   * Unlike `connectGatewayIfNeeded`, this always tears down the old client first
+   * to avoid a race where the old client's `onClose` fires after a new client is created.
+   */
+  async reconnectGateway(): Promise<void> {
+    console.log('[ChannelSync] reconnectGateway: tearing down old client and reconnecting...');
+    this.stopGatewayClient();
+    try {
+      await this.ensureGatewayClientReady();
+      console.log('[ChannelSync] reconnectGateway: gateway client ready, starting channel polling');
+      this.startChannelPolling();
+    } catch (error) {
+      console.error('[ChannelSync] reconnectGateway: failed to initialize gateway client:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Explicitly disconnect the gateway WebSocket client.
+   * Called before the OpenClaw gateway process is restarted so that the old
+   * client's async `onClose` handler cannot interfere with a subsequently
+   * created client.
+   */
+  disconnectGatewayClient(): void {
+    console.log('[ChannelSync] disconnectGatewayClient: explicitly tearing down gateway client');
+    this.stopGatewayClient();
+  }
+
+
+  /**
    * Start periodic polling for channel-originated sessions (e.g. Telegram).
    * Uses the gateway `sessions.list` RPC to discover sessions that may not
    * have been delivered via WebSocket events.
@@ -652,7 +683,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       return;
     }
     // Already running
-    if (this.channelPollingTimer) return;
+    if (this.channelPollingTimer) { console.log('[ChannelSync] startChannelPolling: already running, skipping'); return; }
 
     console.log('[ChannelSync] startChannelPolling: starting periodic channel session discovery');
     // Run once immediately, then at interval
@@ -708,7 +739,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           }
         }
       }
-      console.log('[ChannelSync] pollChannelSessions: found', channelCount, 'channel sessions, hasNew=', hasNew);
+      console.log('[ChannelSync] pollChannelSessions: found', channelCount, 'channel sessions, hasNew=', hasNew, 'windowCount=', BrowserWindow.getAllWindows().length);
       if (hasNew) {
         let notified = 0;
         for (const win of BrowserWindow.getAllWindows()) {
@@ -1108,7 +1139,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
 
     this.stopGatewayClient();
+    console.log('[ChannelSync] ensureGatewayClientReady: creating gateway client, url=', connection.url);
     await this.createGatewayClient(connection);
+    console.log('[ChannelSync] ensureGatewayClientReady: createGatewayClient returned, waiting for handshake...');
     if (this.gatewayReadyPromise) {
       await waitWithTimeout(this.gatewayReadyPromise, GATEWAY_READY_TIMEOUT_MS);
     }
@@ -1152,12 +1185,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       role: 'operator',
       scopes: ['operator.admin'],
       onHelloOk: () => {
+        console.log('[ChannelSync] GatewayClient: onHelloOk — handshake succeeded');
         settleResolve();
       },
       onConnectError: (error: Error) => {
+        console.error('[ChannelSync] GatewayClient: onConnectError —', error.message);
         settleReject(error);
       },
       onClose: (_code: number, reason: string) => {
+        console.log('[ChannelSync] GatewayClient: onClose — code:', _code, 'reason:', reason, 'settled:', settled);
         if (!settled) {
           settleReject(new Error(reason || 'OpenClaw gateway disconnected before handshake'));
           return;
@@ -1337,7 +1373,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   private handleGatewayEvent(event: GatewayEventFrame): void {
-    console.log('[Debug:handleGatewayEvent] event:', event.event, 'seq:', event.seq);
+    const sessionKey = isRecord(event.payload) ? (event.payload as Record<string, unknown>).sessionKey : undefined;
+    console.log('[Debug:handleGatewayEvent] event:', event.event, 'seq:', event.seq, 'sessionKey:', sessionKey, 'hasChannelSync:', !!this.channelSessionSync);
     if (event.event === 'chat') {
       this.handleChatEvent(event.payload, event.seq);
       return;
@@ -2146,6 +2183,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     // Try to resolve channel-originated sessions
     if (sessionKey && this.channelSessionSync) {
+      console.log('[Debug:resolveSessionId] attempting channel resolve for sessionKey:', sessionKey);
       const channelSessionId = this.channelSessionSync.resolveOrCreateSession(sessionKey)
         || this.channelSessionSync.resolveOrCreateMainAgentSession(sessionKey);
       console.log('[Debug:resolveSessionId] channel resolve — sessionKey:', sessionKey, '→', channelSessionId);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -819,6 +819,14 @@ const syncOpenClawConfig = async (
     };
   }
 
+  // Tear down the runtime adapter's WebSocket client BEFORE killing the gateway process.
+  // This prevents a race where the old client's async `onClose` fires after a new client
+  // has already been created, destroying the new connection.
+  if (openClawRuntimeAdapter) {
+    console.log('[OpenClaw] syncOpenClawConfig: pre-emptively disconnecting runtime adapter before gateway restart');
+    openClawRuntimeAdapter.disconnectGatewayClient();
+  }
+
   await manager.stopGateway();
   const restarted = await manager.startGateway();
   if (restarted.phase !== 'running') {
@@ -855,6 +863,7 @@ const bindCoworkRuntimeForwarder = (): void => {
   runtime.on('message', (sessionId: string, message: any) => {
     const safeMessage = sanitizeCoworkMessageForIpc(message);
     const windows = BrowserWindow.getAllWindows();
+    console.log('[CoworkForwarder] forwarding message: sessionId=', sessionId, 'type=', message?.type, 'windowCount=', windows.length);
     windows.forEach((win) => {
       if (win.isDestroyed()) return;
       try {
@@ -2646,6 +2655,15 @@ if (!gotTheLock) {
         reason: 'im-config-change',
         restartGatewayIfRunning: true,
       });
+      // After config sync (which may restart the gateway), ensure the runtime
+      // adapter's WebSocket client is connected so channel events are received.
+      if (openClawRuntimeAdapter) {
+        try {
+          await openClawRuntimeAdapter.connectGatewayIfNeeded();
+        } catch (connectError) {
+          console.error('[IM] Failed to connect gateway client after config sync:', connectError);
+        }
+      }
     } catch (error) {
       console.error('[IM] Debounced config sync failed:', error);
     } finally {

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -82,9 +82,14 @@ class CoworkService {
       const state = store.getState().cowork;
       const sessionExists = state.sessions.some(s => s.id === sessionId);
 
+      console.log('[CoworkService] onStreamMessage: sessionId=', sessionId, 'type=', message.type, 'sessionExists=', sessionExists, 'totalSessions=', state.sessions.length);
       if (!sessionExists) {
         // Session was created by IM or another source, refresh the session list
+        console.log('[CoworkService] onStreamMessage: session NOT found in Redux, calling loadSessions...');
         await this.loadSessions();
+        const newState = store.getState().cowork;
+        const nowExists = newState.sessions.some(s => s.id === sessionId);
+        console.log('[CoworkService] onStreamMessage: after loadSessions, sessionExists=', nowExists, 'totalSessions=', newState.sessions.length);
       }
 
       // A new user turn means this session is actively running again
@@ -131,10 +136,13 @@ class CoworkService {
 
     // Sessions changed listener (new channel sessions discovered by polling)
     const sessionsChangedCleanup = cowork.onSessionsChanged(() => {
-      console.log('[CoworkService] onSessionsChanged: received IPC event, refreshing session list...');
+      const beforeState = store.getState().cowork;
+      console.log('[CoworkService] onSessionsChanged: received IPC event, before sessions:', beforeState.sessions.length, 'sessionIds:', beforeState.sessions.map(s => s.id).slice(0, 5));
       void this.loadSessions().then(() => {
         const state = store.getState().cowork;
-        console.log('[CoworkService] onSessionsChanged: loadSessions complete, total sessions:', state.sessions.length);
+        console.log('[CoworkService] onSessionsChanged: loadSessions complete, total sessions:', state.sessions.length, 'sessionIds:', state.sessions.map(s => s.id).slice(0, 5));
+      }).catch((err) => {
+        console.error('[CoworkService] onSessionsChanged: loadSessions FAILED:', err);
       });
     });
     this.streamListenerCleanups.push(sessionsChangedCleanup);


### PR DESCRIPTION
## 问题重现步骤

1. 关闭飞书（或其他 IM 通道）插件并删除对应的会话
2. 退出并重启应用，此时没有任何飞书相关会话
3. 从设置中开启飞书连接
4. 通过飞书发送消息
5. 预期：UI 上应立即出现新的飞书会话
6. 实际：UI 上没有任何变化，需要刷新或重启应用才能看到会话

## 根本原因

问题涉及两个独立的缺陷：

### 缺陷 1（主因）：im:config:set 路径未建立 WebSocket 连接

设置页面切换 IM 通道开关时，调用的是 `im:config:set` IPC handler，
该 handler 通过 `doImConfigSync()` 执行 debounced 配置同步：

  doImConfigSync() → syncOpenClawConfig({ restartGatewayIfRunning: true })

`syncOpenClawConfig` 会正确地重启 OpenClaw gateway 进程（使新的 IM 插件生效），但 `doImConfigSync` **没有**后续调用
`ensureOpenClawGatewayConnected()` 来建立 Electron 主进程到 gateway 的 WebSocket 连接。

对比之下，`im:gateway:start` handler 调用的
`imGatewayManager.startGateway(platform)` 会依次调用
`syncOpenClawConfig` 和 `ensureOpenClawGatewayConnected`，因此不受影响。

结果：gateway 子进程正常接收并处理飞书消息，但 Electron 主进程
的 OpenClawRuntimeAdapter 没有 WebSocket 客户端，无法接收事件，
无法创建本地会话，无法通过 IPC 通知渲染进程。

### 缺陷 2（防御性修复）：gateway 重启时旧 WebSocket 的 onClose 竞态

当 gateway 已连接的情况下 `syncOpenClawConfig` 重启 gateway 时， 旧的 WebSocket 连接的 `onClose` 回调是异步触发的。如果
`ensureOpenClawGatewayConnected` 在 `onClose` 触发前创建了新客户端， 之后 `onClose` 会调用 `stopGatewayClient()` 销毁新建的连接。

## 解决方案

1. 在 `doImConfigSync()` 完成 `syncOpenClawConfig` 后，调用 `openClawRuntimeAdapter.connectGatewayIfNeeded()` 确保 WebSocket 客户端被创建并开始轮询 channel sessions。

2. 在 `syncOpenClawConfig` 重启 gateway 前，主动调用 `openClawRuntimeAdapter.disconnectGatewayClient()` 同步断开旧的 WebSocket 连接，避免旧连接的异步 `onClose` 干扰新连接。

3. 新增 `reconnectGateway()` 和 `disconnectGatewayClient()` 公共方法 用于显式管理 gateway WebSocket 生命周期。

4. 增加关键路径的诊断日志，覆盖 gateway 事件接收、WebSocket 握手、 IPC 消息转发、渲染进程会话刷新等环节。