### PR TITLE
fix: OpenClaw 引擎图片处理修复与非视觉模型兼容性改进

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -927,11 +927,22 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     const client = this.requireGatewayClient();
     try {
+      const attachments = options.imageAttachments?.length
+        ? options.imageAttachments.map((img) => ({
+          type: 'image',
+          mimeType: img.mimeType,
+          content: img.base64Data,
+        }))
+        : undefined;
+      if (attachments) {
+        console.log('[OpenClawRuntime] chat.send with attachments:', attachments.length, 'images,', attachments.map(a => ({ type: a.type, mimeType: a.mimeType, contentLength: a.content?.length ?? 0 })));
+      }
       const sendResult = await client.request<Record<string, unknown>>('chat.send', {
         sessionKey,
         message: outboundMessage,
         deliver: false,
         idempotencyKey: runId,
+        ...(attachments ? { attachments } : {}),
       });
       const returnedRunId = typeof sendResult?.runId === 'string' ? sendResult.runId.trim() : '';
       if (returnedRunId) {
@@ -2061,7 +2072,14 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   private handleChatError(sessionId: string, _turn: ActiveTurn, payload: ChatEventPayload): void {
-    const errorMessage = payload.errorMessage?.trim() || 'OpenClaw run failed';
+    let errorMessage = payload.errorMessage?.trim() || 'OpenClaw run failed';
+
+    // Detect model API errors that are likely caused by unsupported image content
+    // in tool results (e.g., Read tool returning image blocks for non-vision models).
+    if (/^4\d{2}\b/.test(errorMessage)) {
+      errorMessage += '\n\n[Hint: If the model attempted to read an image file, this may be because the model does not support image input. Consider using a vision-capable model or avoid sending image files.]';
+    }
+
     this.store.updateSession(sessionId, { status: 'error' });
     this.emit('error', sessionId, errorMessage);
     this.cleanupSessionTurn(sessionId);

--- a/src/main/libs/claudeSettings.ts
+++ b/src/main/libs/claudeSettings.ts
@@ -23,6 +23,7 @@ const MOONSHOT_CODING_PLAN_ANTHROPIC_BASE_URL = 'https://api.kimi.com/coding';
 
 type ProviderModel = {
   id: string;
+  supportsImage?: boolean;
 };
 
 type ProviderConfig = {
@@ -48,6 +49,7 @@ export type ApiConfigResolution = {
   providerMetadata?: {
     providerName: string;
     codingPlanEnabled: boolean;
+    supportsImage?: boolean;
   };
 };
 
@@ -91,6 +93,7 @@ type MatchedProvider = {
   modelId: string;
   apiFormat: AnthropicApiFormat;
   baseURL: string;
+  supportsImage?: boolean;
 };
 
 function getEffectiveProviderApiFormat(providerName: string, apiFormat: unknown): AnthropicApiFormat {
@@ -224,6 +227,8 @@ function resolveMatchedProvider(appConfig: AppConfig): { matched: MatchedProvide
     return { matched: null, error: `Provider ${providerName} requires API key for Anthropic-compatible mode.` };
   }
 
+  const matchedModel = providerConfig.models?.find((m) => m.id === modelId);
+
   return {
     matched: {
       providerName,
@@ -231,6 +236,7 @@ function resolveMatchedProvider(appConfig: AppConfig): { matched: MatchedProvide
       modelId,
       apiFormat,
       baseURL,
+      supportsImage: matchedModel?.supportsImage,
     },
   };
 }
@@ -279,6 +285,7 @@ export function resolveCurrentApiConfig(target: OpenAICompatProxyTarget = 'local
       providerMetadata: {
         providerName: matched.providerName,
         codingPlanEnabled: !!matched.providerConfig.codingPlanEnabled,
+        supportsImage: matched.supportsImage,
       },
     };
   }
@@ -355,6 +362,7 @@ export function resolveRawApiConfig(): ApiConfigResolution {
     providerMetadata: {
       providerName: matched.providerName,
       codingPlanEnabled: !!matched.providerConfig.codingPlanEnabled,
+      supportsImage: matched.supportsImage,
     },
   };
 }

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -266,9 +266,11 @@ const buildProviderSelection = (options: {
   apiType: 'anthropic' | 'openai' | undefined;
   providerName?: string;
   codingPlanEnabled?: boolean;
+  supportsImage?: boolean;
 }): OpenClawProviderSelection => {
   const providerModelName = normalizeModelName(options.modelId);
   const providerApi = mapApiTypeToOpenClawApi(options.apiType);
+  const modelInput: string[] = options.supportsImage ? ['text', 'image'] : ['text'];
   const providerName = options.providerName ?? '';
   const codingPlanEnabled = !!options.codingPlanEnabled;
 
@@ -288,7 +290,7 @@ const buildProviderSelection = (options: {
             id: 'k2p5',
             name: 'Kimi K2.5',
             api: 'anthropic-messages',
-            input: ['text', 'image'],
+            input: modelInput,
             reasoning: true,
             cost: {
               input: 0,
@@ -321,7 +323,7 @@ const buildProviderSelection = (options: {
             id: options.modelId,
             name: providerModelName,
             api: 'openai-completions',
-            input: ['text', 'image'],
+            input: modelInput,
             reasoning: supportsThinking,
             cost: {
               input: 0,
@@ -352,7 +354,7 @@ const buildProviderSelection = (options: {
           id: options.modelId,
           name: providerModelName,
           api: providerApi,
-          input: ['text'],
+          input: modelInput,
         },
       ],
     },
@@ -460,6 +462,7 @@ export class OpenClawConfigSync {
       apiType,
       providerName: apiResolution.providerMetadata?.providerName,
       codingPlanEnabled: apiResolution.providerMetadata?.codingPlanEnabled,
+      supportsImage: apiResolution.providerMetadata?.supportsImage,
     });
     const sandboxMode = mapExecutionModeToSandboxMode(coworkConfig.executionMode || 'auto');
 

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { PaperAirplaneIcon, StopIcon, FolderIcon } from '@heroicons/react/24/solid';
-import { PhotoIcon } from '@heroicons/react/24/outline';
+import { PhotoIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import PaperClipIcon from '../icons/PaperClipIcon';
 import XMarkIcon from '../icons/XMarkIcon';
 import ModelSelector from '../ModelSelector';
@@ -115,6 +115,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const [showFolderRequiredWarning, setShowFolderRequiredWarning] = useState(false);
     const [isDraggingFiles, setIsDraggingFiles] = useState(false);
     const [isAddingFile, setIsAddingFile] = useState(false);
+    const [imageVisionHint, setImageVisionHint] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const folderButtonRef = useRef<HTMLButtonElement>(null);
     const dragDepthRef = useRef(0);
@@ -261,6 +262,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     setValue('');
     dispatch(setDraftPrompt(''));
     setAttachments([]);
+    setImageVisionHint(false);
   }, [value, isStreaming, disabled, onSubmit, activeSkillIds, skills, attachments, showFolderSelector, workingDirectory, dispatch]);
 
   const handleSelectSkill = useCallback((skill: Skill) => {
@@ -406,6 +408,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const files = Array.from(fileList ?? []);
     if (files.length === 0) return;
 
+    let hasImageWithoutVision = false;
     for (const file of files) {
       const nativePath = getNativeFilePath(file);
 
@@ -414,34 +417,38 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         ? isImagePath(nativePath)
         : isImageMimeType(file.type);
 
-      if (fileIsImage && modelSupportsImage) {
-        // For images on vision-capable models, read as data URL
-        if (nativePath) {
-          try {
-            const result = await window.electron.dialog.readFileAsDataUrl(nativePath);
-            if (result.success && result.dataUrl) {
-              addAttachment(nativePath, { isImage: true, dataUrl: result.dataUrl });
-              continue;
+      if (fileIsImage) {
+        if (modelSupportsImage) {
+          // For images on vision-capable models, read as data URL
+          if (nativePath) {
+            try {
+              const result = await window.electron.dialog.readFileAsDataUrl(nativePath);
+              if (result.success && result.dataUrl) {
+                addAttachment(nativePath, { isImage: true, dataUrl: result.dataUrl });
+                continue;
+              }
+            } catch (error) {
+              console.error('Failed to read image as data URL:', error);
             }
-          } catch (error) {
-            console.error('Failed to read image as data URL:', error);
-          }
-          // Fallback: add as regular file attachment
-          addAttachment(nativePath);
-        } else {
-          // No native path (clipboard/drag from browser) - read via FileReader
-          try {
-            const dataUrl = await fileToDataUrl(file);
-            addImageAttachmentFromDataUrl(file.name, dataUrl);
-          } catch (error) {
-            console.error('Failed to read image from clipboard:', error);
-            const stagedPath = await saveInlineFile(file);
-            if (stagedPath) {
-              addAttachment(stagedPath);
+            // Fallback: add as regular file attachment
+            addAttachment(nativePath);
+          } else {
+            // No native path (clipboard/drag from browser) - read via FileReader
+            try {
+              const dataUrl = await fileToDataUrl(file);
+              addImageAttachmentFromDataUrl(file.name, dataUrl);
+            } catch (error) {
+              console.error('Failed to read image from clipboard:', error);
+              const stagedPath = await saveInlineFile(file);
+              if (stagedPath) {
+                addAttachment(stagedPath);
+              }
             }
           }
+          continue;
         }
-        continue;
+        // Model doesn't support image input — add as file path and show hint
+        hasImageWithoutVision = true;
       }
 
       // Non-image file or model doesn't support images: use original flow
@@ -455,6 +462,9 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         addAttachment(stagedPath);
       }
     }
+    if (hasImageWithoutVision) {
+      setImageVisionHint(true);
+    }
   }, [addAttachment, addImageAttachmentFromDataUrl, disabled, fileToDataUrl, getNativeFilePath, isStreaming, modelSupportsImage, saveInlineFile]);
 
   const handleAddFile = useCallback(async () => {
@@ -465,19 +475,27 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         title: i18nService.t('coworkAddFile'),
       });
       if (!result.success || result.paths.length === 0) return;
+      let hasImageWithoutVision = false;
       for (const filePath of result.paths) {
-        if (isImagePath(filePath) && modelSupportsImage) {
-          try {
-            const readResult = await window.electron.dialog.readFileAsDataUrl(filePath);
-            if (readResult.success && readResult.dataUrl) {
-              addAttachment(filePath, { isImage: true, dataUrl: readResult.dataUrl });
-              continue;
+        if (isImagePath(filePath)) {
+          if (modelSupportsImage) {
+            try {
+              const readResult = await window.electron.dialog.readFileAsDataUrl(filePath);
+              if (readResult.success && readResult.dataUrl) {
+                addAttachment(filePath, { isImage: true, dataUrl: readResult.dataUrl });
+                continue;
+              }
+            } catch (error) {
+              console.error('Failed to read image as data URL:', error);
             }
-          } catch (error) {
-            console.error('Failed to read image as data URL:', error);
+          } else {
+            hasImageWithoutVision = true;
           }
         }
         addAttachment(filePath);
+      }
+      if (hasImageWithoutVision) {
+        setImageVisionHint(true);
       }
     } catch (error) {
       console.error('Failed to select file:', error);
@@ -573,6 +591,23 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                 </button>
               </div>
           ))}
+        </div>
+      )}
+      {imageVisionHint && (
+        <div className="mb-2 flex items-start gap-1.5 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 px-2.5 py-1.5 text-xs text-amber-700 dark:text-amber-400">
+          <ExclamationTriangleIcon className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
+          <span>
+            {i18nService.getLanguage() === 'zh'
+              ? '当前模型未启用图片输入，图片将以文件路径形式发送。若该模型本身支持图片理解，可在模型配置中开启图片输入选项。'
+              : 'Image input is not enabled for the current model. Images will be sent as file paths. If the model supports vision, you can enable image input in the model configuration.'}
+          </span>
+          <button
+            type="button"
+            onClick={() => setImageVisionHint(false)}
+            className="ml-auto flex-shrink-0 rounded-full p-0.5 hover:bg-amber-200/50 dark:hover:bg-amber-800/50"
+          >
+            <XMarkIcon className="h-3 w-3" />
+          </button>
         </div>
       )}
       <div


### PR DESCRIPTION
## Summary
- 修复 `chat.send` 未传递图片附件到 OpenClaw gateway 的问题，支持视觉模型正确接收用户图片
- 根据模型 `supportsImage` 配置动态设置 OpenClaw `input` 能力声明（`['text', 'image']` vs `['text']`），避免非视觉模型收到不支持的图片内容
- 非视觉模型添加图片时显示引导性提示（而非静默丢弃），图片以文件路径形式发送
- 模型 API 4xx 错误时增加图片相关的提示信息，改善错误体验

## Test plan
- [x] 视觉模型（如 Claude）发送图片附件，验证图片正确传递到 LLM
- [x] 非视觉模型（如 GLM 4.7）添加图片，验证显示amber提示条
- [x] 非视觉模型发送含图片路径的消息，验证不会因图片导致 chat 中断
- [ ] 切换模型后添加图片，验证提示条根据模型能力正确显示/隐藏

🤖 Generated with [Claude Code](https://claude.com/claude-code)