### PR TITLE
fix: 防止设置中快速切换 IM 机器人开关导致的 UI 状态不一致

### DIFF
--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -431,57 +431,72 @@ const IMSettings: React.FC = () => {
       // All OpenClaw platforms: im:config:set handler already calls
       // syncOpenClawConfig({ restartGatewayIfRunning: true }), so no startGateway/stopGateway needed.
       // Only updateConfig + loadStatus is required.
+      // Pessimistic UI update: wait for IPC to complete before updating Redux state.
+      // This prevents UI/backend state divergence when rapidly toggling, since the
+      // backend debounces syncOpenClawConfig calls with a 600ms window.
       if (platform === 'telegram') {
         const newEnabled = !tgOpenClawConfig.enabled;
-        dispatch(setTelegramOpenClawConfig({ enabled: newEnabled }));
-        if (newEnabled) dispatch(clearError());
-        await imService.updateConfig({ telegram: { ...tgOpenClawConfig, enabled: newEnabled } });
-        await imService.loadStatus();
+        const success = await imService.updateConfig({ telegram: { ...tgOpenClawConfig, enabled: newEnabled } });
+        if (success) {
+          dispatch(setTelegramOpenClawConfig({ enabled: newEnabled }));
+          if (newEnabled) dispatch(clearError());
+          await imService.loadStatus();
+        }
         return;
       }
 
       if (platform === 'dingtalk') {
         const newEnabled = !dtOpenClawConfig.enabled;
-        dispatch(setDingTalkConfig({ enabled: newEnabled }));
-        if (newEnabled) dispatch(clearError());
-        await imService.updateConfig({ dingtalk: { ...dtOpenClawConfig, enabled: newEnabled } });
-        await imService.loadStatus();
+        const success = await imService.updateConfig({ dingtalk: { ...dtOpenClawConfig, enabled: newEnabled } });
+        if (success) {
+          dispatch(setDingTalkConfig({ enabled: newEnabled }));
+          if (newEnabled) dispatch(clearError());
+          await imService.loadStatus();
+        }
         return;
       }
 
       if (platform === 'feishu') {
         const newEnabled = !fsOpenClawConfig.enabled;
-        dispatch(setFeishuConfig({ enabled: newEnabled }));
-        if (newEnabled) dispatch(clearError());
-        await imService.updateConfig({ feishu: { ...fsOpenClawConfig, enabled: newEnabled } });
-        await imService.loadStatus();
+        const success = await imService.updateConfig({ feishu: { ...fsOpenClawConfig, enabled: newEnabled } });
+        if (success) {
+          dispatch(setFeishuConfig({ enabled: newEnabled }));
+          if (newEnabled) dispatch(clearError());
+          await imService.loadStatus();
+        }
         return;
       }
 
       if (platform === 'discord') {
         const newEnabled = !dcOpenClawConfig.enabled;
-        dispatch(setDiscordConfig({ enabled: newEnabled }));
-        if (newEnabled) dispatch(clearError());
-        await imService.updateConfig({ discord: { ...dcOpenClawConfig, enabled: newEnabled } });
-        await imService.loadStatus();
+        const success = await imService.updateConfig({ discord: { ...dcOpenClawConfig, enabled: newEnabled } });
+        if (success) {
+          dispatch(setDiscordConfig({ enabled: newEnabled }));
+          if (newEnabled) dispatch(clearError());
+          await imService.loadStatus();
+        }
         return;
       }
 
       if (platform === 'qq') {
         const newEnabled = !qqOpenClawConfig.enabled;
-        dispatch(setQQConfig({ enabled: newEnabled }));
-        if (newEnabled) dispatch(clearError());
-        await imService.updateConfig({ qq: { ...qqOpenClawConfig, enabled: newEnabled } });
-        await imService.loadStatus();
+        const success = await imService.updateConfig({ qq: { ...qqOpenClawConfig, enabled: newEnabled } });
+        if (success) {
+          dispatch(setQQConfig({ enabled: newEnabled }));
+          if (newEnabled) dispatch(clearError());
+          await imService.loadStatus();
+        }
         return;
       }
 
       if (platform === 'wecom') {
         const newEnabled = !wecomOpenClawConfig.enabled;
-        dispatch(setWecomConfig({ enabled: newEnabled }));
-        if (newEnabled) dispatch(clearError());
-        await imService.updateConfig({ wecom: { ...wecomOpenClawConfig, enabled: newEnabled } });
-        await imService.loadStatus();
+        const success = await imService.updateConfig({ wecom: { ...wecomOpenClawConfig, enabled: newEnabled } });
+        if (success) {
+          dispatch(setWecomConfig({ enabled: newEnabled }));
+          if (newEnabled) dispatch(clearError());
+          await imService.loadStatus();
+        }
         return;
       }
 


### PR DESCRIPTION
## 问题背景
在设置面板中如果快速连续点击 IM 机器人开关（例如在约 600ms 内进行“开 -> 关 -> 开”的操作），会导致即使用户最终在界面上看到是“关闭”状态，机器人在后台仍然继续运行并回复消息的 Bug。

## 根本原因
代码中的 [toggleGateway](cci:1://file:///Users/zhangxiaochang/workspace/projects/github/LobsterAI/src/renderer/components/im/IMSettings.tsx:422:2-533:4) 函数采用了**乐观 UI 更新（Optimistic UI Updates）**的策略：在调用 IPC 发送配置前，会直接通过 `dispatch(setXxxConfig({ enabled }))` 更新界面状态。然而在主进程中，配置同步到引擎（[syncOpenClawConfig](cci:1://file:///Users/zhangxiaochang/workspace/projects/github/LobsterAI/src/main/main.ts:1116:8-1121:9)）的逻辑带有 600ms 的防抖机制（debounce）。
如果在这 600ms 内发生了多次开关切换，会产生以下情况：

1. 每次点击都会立刻通过 `dispatch()` 更新 UI 变为当前状态；
2. 防重复点击的锁（`togglingPlatform`）在 IPC 返回（同步成功落盘数据库，且未等到底层加载完成）后马上释放；
3. 后端主进程的防抖机制会把期间攒起的配置更新调用合并执行，最终 OpenClaw 引擎只认最后一次落盘的配置；
4. 如果引擎最后认定配置为 `enabled: true`，但前端 UI 上最新的派发状态刚好又变成了“关闭”，两者就会产生差异，导致机器人关不掉。

```
时间线：
0ms    点击 OFF -> 触发 dispatch(enabled=false) -> IPC 数据库更新完毕马上返回
10ms   togglingPlatform 锁被释放
50ms   点击 ON  -> 触发 dispatch(enabled=true)  -> IPC 数据库更新完毕马上返回
60ms   togglingPlatform 锁被释放
600ms  触发 600ms 防抖 -> 向引擎执行最后一次记录在案的配置 syncOpenClawConfig(enabled=true) -> 机器人实质仍开启 
```

## 修复方案
将全部平台在点击开关操作后的更新策略由**乐观 UI 更新**改为**悲观 UI 更新**：

- **修复前**：先派发 `dispatch()` UI 事件 -> 后 `await IPC` 将配置传向后台
- **修复后**：先 `await IPC` 确认成功应用配置传向后台 -> 后派发 `dispatch()` UI 事件

通过这种强同步依赖的方式，确保 `togglingPlatform` 交互锁会在整个向主进程通信并同步配置的操作期间持续加锁，从而阻止发生快速的连续点击。最终前端界面只会在后端主进程彻底落盘成功后，再更新 UI 展现的状态。