### PR TITLE
fix: optimize toggleJob to return updated task directly

### DIFF
--- a/src/main/libs/cronJobService.ts
+++ b/src/main/libs/cronJobService.ts
@@ -359,9 +359,10 @@ export class CronJobService {
     }
   }
 
-  async toggleJob(id: string, enabled: boolean): Promise<void> {
+  async toggleJob(id: string, enabled: boolean): Promise<ScheduledTask> {
     const client = await this.client();
-    await client.request('cron.update', { id, patch: { enabled } });
+    const job = await client.request<GatewayJob>('cron.update', { id, patch: { enabled } });
+    return mapGatewayJob(job);
   }
 
   async runJob(id: string): Promise<void> {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2500,8 +2500,7 @@ if (!gotTheLock) {
 
   ipcMain.handle('scheduledTask:toggle', async (_event, id: string, enabled: boolean) => {
     try {
-      await getCronJobService().toggleJob(id, enabled);
-      const task = await getCronJobService().getJob(id);
+      const task = await getCronJobService().toggleJob(id, enabled);
       return { success: true, task };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Failed to toggle task' };


### PR DESCRIPTION
  问题背景                                                                                                                                                                                                         
                                                                                                                                                                                                                   
  定时任务切换开关时，scheduledTask:toggle IPC handler 在调用 toggleJob 后还需要额外调用一次 getJob 获取更新后的任务数据返回给前端，造成一次冗余的 gateway 请求。                                                  


  根本原因

  1. CronJobService.toggleJob 原本返回 Promise<void>，丢弃了 cron.update 接口返回的任务数据。调用方（scheduledTask:toggle handler）不得不再发一次 getJob 请求来获取更新后的任务状态。

  修复方案
  将 toggleJob 返回类型从 Promise<void> 改为 Promise<ScheduledTask>，直接捕获并映射 cron.update 的响应：

  - 修复前：toggleJob 返回 void → 调用方额外调用 getJob 获取任务数据
  - 修复后：toggleJob 直接返回更新后的 ScheduledTask → 调用方省去一次冗余请求
