### PR TITLE
fix: improve scheduled task history title display by extracting name …

### DIFF
--- a/src/main/libs/cronJobService.ts
+++ b/src/main/libs/cronJobService.ts
@@ -98,6 +98,7 @@ interface GatewayRunLogEntry {
   runAtMs?: number;
   durationMs?: number;
   jobName?: string;
+  summary?: string;
 }
 
 interface CronJobServiceDeps {
@@ -258,6 +259,14 @@ export function mapGatewayRun(entry: GatewayRunLogEntry): ScheduledTaskRun {
   };
 }
 
+/** Extract a short title from a run's summary (first line, trimmed to 30 chars). */
+function extractRunTitle(summary?: string): string | undefined {
+  if (!summary) return undefined;
+  const firstLine = summary.split('\n')[0].trim();
+  if (!firstLine) return undefined;
+  return firstLine.length > 30 ? firstLine.slice(0, 30) + '…' : firstLine;
+}
+
 export class CronJobService {
   private readonly getGatewayClient: () => GatewayClientLike | null;
   private readonly ensureGatewayReady: () => Promise<void>;
@@ -400,12 +409,33 @@ export class CronJobService {
       offset,
       sortDir: 'desc',
     });
-    return Array.isArray(result.entries)
-      ? result.entries.map((entry) => ({
-          ...mapGatewayRun(entry),
-          taskName: entry.jobName || entry.jobId,
-        }))
-      : [];
+    if (!Array.isArray(result.entries) || result.entries.length === 0) return [];
+
+    // Build a jobId→name map for entries missing jobName
+    const missingIds = new Set(
+      result.entries.filter((e) => !e.jobName && !e.summary).map((e) => e.jobId),
+    );
+    const nameMap = new Map<string, string>();
+    if (missingIds.size > 0) {
+      try {
+        const jobs = await this.listJobs();
+        for (const job of jobs) {
+          if (missingIds.has(job.id)) {
+            nameMap.set(job.id, job.name);
+          }
+        }
+      } catch {
+        // fall through
+      }
+    }
+
+    return result.entries.map((entry) => ({
+      ...mapGatewayRun(entry),
+      taskName: entry.jobName
+        || nameMap.get(entry.jobId)
+        || extractRunTitle(entry.summary)
+        || entry.jobId,
+    }));
   }
 
   startPolling(): void {


### PR DESCRIPTION
 问题背景

  定时任务历史记录页面中，大部分条目的标题列显示的是 UUID（jobId）而非任务名称，用户无法辨识每条记录对应哪个定时任务。

  根本原因

  CronJobService.listAllRuns 中通过 entry.jobName || entry.jobId 获取标题。然而 gateway 的 cron.runs 接口在大多数 run log 条目中不返回 jobName 字段，且由于定时任务会被系统重建（分配新的 jobId），通过当前 job
  列表也无法匹配到历史 run 对应的 jobId，最终 fallback 到显示原始 UUID。

  修复方案

  为 listAllRuns 增加多级 fallback 策略来解析任务标题：

  1. entry.jobName — gateway 返回的任务名（部分条目有值）
  2. nameMap(jobId) — 从现存 job 列表构建 id→name 映射匹配
  3. extractRunTitle(entry.summary) — 从 run 的 summary 字段提取首行文本（截断 30 字符）作为标题
  4. entry.jobId — 最终 fallback

  具体改动（src/main/libs/cronJobService.ts）：
  - GatewayRunLogEntry 新增 summary 可选字段
  - 新增 extractRunTitle() 工具函数，提取 summary 首行并截断
  - listAllRuns 对缺少 jobName 且无 summary 的条目，批量查询现存 job 列表补全名称