### PR TITLE
fix: 钉钉定时任务触发后消息不发送到钉钉

### DIFF
--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -12,7 +12,7 @@ import type { CoworkStore, CoworkMessage } from '../coworkStore';
 import type { IMStore } from './imStore';
 import type { IMMessage, IMPlatform, IMMediaAttachment, IMSessionMapping } from './types';
 import { buildIMMediaInstruction } from './imMediaInstruction';
-import { analyzeIMReply } from './imReplyGuard';
+import { analyzeIMReply, DEFAULT_IM_EMPTY_REPLY } from './imReplyGuard';
 import {
   isReminderSystemTurn,
   type IMScheduledTaskCreationResult,
@@ -821,7 +821,12 @@ export class IMCoworkHandler extends EventEmitter {
       return;
     }
 
-    const replyText = this.formatReply(sessionId, accumulator.messages);
+    // For cron-triggered background deliveries (scheduled task executions),
+    // skip the reminder guard — the assistant text IS the scheduled reminder
+    // itself, not a promise to create one.
+    const replyText = accumulator.backgroundDelivery
+      ? this.formatReplyRaw(accumulator.messages)
+      : this.formatReply(sessionId, accumulator.messages);
 
     console.log(`[IMCoworkHandler] 会话完成:`, JSON.stringify({
       sessionId,
@@ -885,6 +890,22 @@ export class IMCoworkHandler extends EventEmitter {
       clearTimeout(accumulator.timeoutId);
     }
     this.messageAccumulators.delete(sessionId);
+  }
+
+  /**
+   * Extract raw assistant text from accumulated messages, bypassing the
+   * reminder-commitment guard.  Used for cron-triggered background deliveries
+   * where the reply IS the scheduled reminder, not a promise to create one.
+   */
+  private formatReplyRaw(messages: CoworkMessage[]): string {
+    const parts: string[] = [];
+    for (const message of messages) {
+      if (message.type === 'assistant' && message.content && !message.metadata?.isThinking) {
+        const text = message.content.trim();
+        if (text) parts.push(text);
+      }
+    }
+    return parts.join('\n\n') || DEFAULT_IM_EMPTY_REPLY;
   }
 
   /**

--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -113,6 +113,10 @@ export class IMGatewayManager extends EventEmitter {
   // NIM probe mutex: serializes concurrent connectivity tests
   private nimProbePromise: Promise<void> | null = null;
 
+  // DingTalk direct HTTP API token cache
+  private dingTalkAccessToken: string | null = null;
+  private dingTalkAccessTokenExpiry = 0;
+
   constructor(db: Database, saveDb: () => void, options?: IMGatewayManagerOptions) {
     super();
 
@@ -1646,22 +1650,19 @@ export class IMGatewayManager extends EventEmitter {
           const target = await this.resolveDingTalkConversationReplyTarget(conversationId)
             ?? this.parseDingTalkConversationTarget(conversationId);
           if (!target) {
-            console.warn(`[IMGatewayManager] Cannot resolve DingTalk target from conversationId: ${conversationId}`);
-            return false;
+            // Fallback: try to extract userId directly from conversationId (raw peerId).
+            const fallbackUserId = conversationId.trim();
+            if (!fallbackUserId) {
+              console.warn(`[IMGatewayManager] Cannot resolve DingTalk target from conversationId: ${conversationId}`);
+              return false;
+            }
+            return this.sendDingTalkDirectHttp(fallbackUserId, text);
           }
-          await this.requestOpenClawGateway('dingtalk-connector.send', {
-            ...(target.accountId ? { accountId: target.accountId } : {}),
-            target: target.target,
-            content: text,
-            useAICard: false,
-            fallbackToNormal: true,
-          });
-          this.cacheConversationReplyRoute('dingtalk', conversationId, {
-            channel: 'dingtalk-connector',
-            to: target.target,
-            ...(target.accountId ? { accountId: target.accountId } : {}),
-          });
-          return true;
+          // Extract userId from target string like "user:0146552636218419"
+          const userId = target.target.startsWith('user:')
+            ? target.target.slice(5)
+            : target.target;
+          return this.sendDingTalkDirectHttp(userId, text);
         }
         case 'nim':
           await this.nimGateway.sendConversationNotification(conversationId, text);
@@ -1678,6 +1679,88 @@ export class IMGatewayManager extends EventEmitter {
     }
   }
 
+  // ─── DingTalk direct HTTP API ──────────────────────────────────────────────
+
+  /**
+   * Obtain a DingTalk access token (v2.0 API), caching it for its lifetime.
+   */
+  private async getDingTalkAccessToken(clientId: string, clientSecret: string): Promise<string> {
+    const now = Date.now();
+    if (this.dingTalkAccessToken && this.dingTalkAccessTokenExpiry > now + 60_000) {
+      return this.dingTalkAccessToken;
+    }
+
+    const resp = await fetchJsonWithTimeout<{
+      accessToken?: string;
+      expireIn?: number;
+    }>('https://api.dingtalk.com/v1.0/oauth2/accessToken', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ appKey: clientId, appSecret: clientSecret }),
+    }, 10_000);
+
+    if (!resp.accessToken) {
+      throw new Error('DingTalk accessToken response missing token');
+    }
+
+    this.dingTalkAccessToken = resp.accessToken;
+    this.dingTalkAccessTokenExpiry = now + ((resp.expireIn ?? 7200) * 1000);
+    return this.dingTalkAccessToken;
+  }
+
+  /**
+   * Send a text/markdown message to a DingTalk user via the proactive messaging
+   * HTTP API, bypassing the OpenClaw gateway plugin (which lacks `cfg` context).
+   */
+  private async sendDingTalkDirectHttp(userId: string, text: string): Promise<boolean> {
+    const dtConfig = this.imStore.getDingTalkOpenClawConfig();
+    if (!dtConfig.clientId || !dtConfig.clientSecret) {
+      console.warn('[IMGatewayManager] DingTalk direct send skipped: missing clientId/clientSecret');
+      return false;
+    }
+
+    const token = await this.getDingTalkAccessToken(dtConfig.clientId, dtConfig.clientSecret);
+
+    // Auto-detect markdown vs plain text.
+    const hasMarkdown = /^[#*>\-]|[*_`#\[\]]/.test(text) || text.includes('\n');
+    const msgKey = hasMarkdown ? 'sampleMarkdown' : 'sampleText';
+    const msgParam = hasMarkdown
+      ? { title: text.split('\n')[0].replace(/^[#*\s\->]+/, '').slice(0, 20) || 'Message', text }
+      : { content: text };
+
+    const body = {
+      robotCode: dtConfig.clientId,
+      userIds: [userId],
+      msgKey,
+      msgParam: JSON.stringify(msgParam),
+    };
+
+    console.log('[IMGatewayManager] DingTalk direct HTTP send', JSON.stringify({
+      userId,
+      msgKey,
+      textLength: text.length,
+    }));
+
+    const resp = await fetchJsonWithTimeout<{
+      processQueryKey?: string;
+      message?: string;
+    }>('https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend', {
+      method: 'POST',
+      headers: {
+        'x-acs-dingtalk-access-token': token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    }, 10_000);
+
+    if (resp.processQueryKey) {
+      console.log(`[IMGatewayManager] DingTalk direct send success: processQueryKey=${resp.processQueryKey}`);
+      return true;
+    }
+
+    console.warn('[IMGatewayManager] DingTalk direct send unexpected response:', JSON.stringify(resp));
+    return false;
+  }
   async primeConversationReplyRoute(
     platform: IMPlatform,
     conversationId: string,
@@ -1690,20 +1773,37 @@ export class IMGatewayManager extends EventEmitter {
     try {
       const lookup = await this.lookupDingTalkConversationReplyRoute(conversationId, coworkSessionId);
       const resolved = lookup?.resolved;
-      if (!resolved) {
+      if (resolved) {
+        this.cacheConversationReplyRoute('dingtalk', conversationId, resolved.route);
+        const sendParams = buildDingTalkSendParamsFromRoute(resolved.route);
+        console.log('[IMGatewayManager] Primed DingTalk reply route', JSON.stringify({
+          conversationId,
+          coworkSessionId: lookup.coworkSessionId,
+          sessionKey: resolved.sessionKey,
+          channel: resolved.route.channel,
+          target: sendParams?.target ?? resolved.route.to,
+          accountId: sendParams?.accountId ?? resolved.route.accountId ?? null,
+        }));
         return;
       }
 
-      this.cacheConversationReplyRoute('dingtalk', conversationId, resolved.route);
-      const sendParams = buildDingTalkSendParamsFromRoute(resolved.route);
-      console.log('[IMGatewayManager] Primed DingTalk reply route', JSON.stringify({
-        conversationId,
-        coworkSessionId: lookup.coworkSessionId,
-        sessionKey: resolved.sessionKey,
-        channel: resolved.route.channel,
-        target: sendParams?.target ?? resolved.route.to,
-        accountId: sendParams?.accountId ?? resolved.route.accountId ?? null,
-      }));
+      // Fallback: construct route from session key JSON context.
+      // When the OpenClaw session lacks deliveryContext (e.g. cron-triggered runs),
+      // the session key itself may embed a JSON SessionContext with all needed info.
+      const fallbackRoute = this.buildDingTalkRouteFromSessionKeys(
+        lookup?.candidateSessionKeys ?? [],
+      );
+      if (fallbackRoute) {
+        this.cacheConversationReplyRoute('dingtalk', conversationId, fallbackRoute.route);
+        console.log('[IMGatewayManager] Primed DingTalk reply route from session key context', JSON.stringify({
+          conversationId,
+          coworkSessionId,
+          sessionKey: fallbackRoute.sessionKey,
+          channel: fallbackRoute.route.channel,
+          target: fallbackRoute.route.to,
+          accountId: fallbackRoute.route.accountId ?? null,
+        }));
+      }
     } catch (error: any) {
       console.warn(
         `[IMGatewayManager] Failed to prime DingTalk reply route for ${conversationId}:`,
@@ -1748,6 +1848,26 @@ export class IMGatewayManager extends EventEmitter {
             accountId: cachedSendParams.accountId ?? null,
           }));
           return cachedSendParams;
+        }
+      }
+
+      // Fallback: construct route from session key JSON context when OpenClaw
+      // session lacks deliveryContext (common for cron-triggered runs).
+      const fallbackRoute = this.buildDingTalkRouteFromSessionKeys(
+        lookup?.candidateSessionKeys ?? [],
+      );
+      if (fallbackRoute) {
+        this.cacheConversationReplyRoute('dingtalk', conversationId, fallbackRoute.route);
+        const fallbackSendParams = buildDingTalkSendParamsFromRoute(fallbackRoute.route);
+        if (fallbackSendParams) {
+          console.log('[IMGatewayManager] Resolved DingTalk reply route from session key context', JSON.stringify({
+            conversationId,
+            sessionKey: fallbackRoute.sessionKey,
+            channel: fallbackRoute.route.channel,
+            target: fallbackSendParams.target,
+            accountId: fallbackSendParams.accountId ?? null,
+          }));
+          return fallbackSendParams;
         }
       }
 
@@ -1859,24 +1979,19 @@ export class IMGatewayManager extends EventEmitter {
       return null;
     }
 
-    let accountId = parts[0]?.trim();
+    const accountId = parts[0]?.trim();
     if (!accountId) {
       return null;
     }
 
-    // The dingtalk-connector plugin uses "__default__" as the internal account
-    // alias in conversationIds.  The send API expects the actual clientId, so
-    // resolve the alias from the persisted DingTalk config.
-    if (accountId === '__default__') {
-      const dtConfig = this.imStore.getDingTalkOpenClawConfig();
-      if (dtConfig.clientId) {
-        accountId = dtConfig.clientId;
-      }
-    }
+    // The dingtalk-connector plugin uses "__default__" as an internal account
+    // lookup key.  The send API expects this key (or undefined for default),
+    // NOT the actual clientId.  Omit it so the plugin uses its default account.
+    const resolvedAccountId = accountId === '__default__' ? undefined : accountId;
 
     if ((parts[1] === 'user' || parts[1] === 'group') && parts[2]) {
       return {
-        accountId,
+        accountId: resolvedAccountId,
         target: `${parts[1]}:${parts.slice(2).join(':')}`,
       };
     }
@@ -1887,9 +2002,73 @@ export class IMGatewayManager extends EventEmitter {
     }
 
     return {
-      accountId,
+      accountId: resolvedAccountId,
       target: `user:${senderId}`,
     };
+  }
+
+  /**
+   * Attempt to construct a DingTalk delivery route by parsing JSON SessionContext
+   * embedded in OpenClaw session keys.  This covers the case where the OpenClaw
+   * session entry itself lacks a deliveryContext (e.g. cron-triggered runs that
+   * reuse an existing session without full delivery metadata).
+   *
+   * Session key format (since dingtalk-connector v0.7.5):
+   *   agent:{agentId}:openai-user:{"channel":"dingtalk-connector","accountid":"...","chattype":"direct","peerid":"...","sendername":"..."}
+   */
+  private buildDingTalkRouteFromSessionKeys(
+    sessionKeys: string[],
+  ): { sessionKey: string; route: OpenClawDeliveryRoute } | null {
+    for (const sessionKey of sessionKeys) {
+      const jsonIdx = sessionKey.indexOf(':{');
+      if (jsonIdx < 0) {
+        continue;
+      }
+      const jsonStr = sessionKey.slice(jsonIdx + 1);
+      let ctx: Record<string, unknown>;
+      try {
+        ctx = JSON.parse(jsonStr);
+      } catch {
+        continue;
+      }
+      if (!ctx || typeof ctx.channel !== 'string') {
+        continue;
+      }
+      const channel = (ctx.channel as string).trim().toLowerCase();
+      if (channel !== 'dingtalk-connector' && channel !== 'dingtalk') {
+        continue;
+      }
+
+      // Determine the target address from the session context.
+      const chatType = typeof ctx.chattype === 'string' ? ctx.chattype : 'direct';
+      const peerId = typeof ctx.peerid === 'string' ? (ctx.peerid as string).trim() : '';
+      const ctxConversationId = typeof ctx.conversationid === 'string' ? (ctx.conversationid as string).trim() : '';
+      if (!peerId && !ctxConversationId) {
+        continue;
+      }
+
+      const to = chatType === 'group'
+        ? `group:${ctxConversationId || peerId}`
+        : `user:${peerId || ctxConversationId}`;
+
+      // Keep the original accountId from the session context (e.g. '__default__').
+      // The dingtalk-connector plugin uses this as an account lookup key, NOT the clientId.
+      // When accountId is '__default__', omit it so the plugin uses its default account.
+      let accountId = typeof ctx.accountid === 'string' ? (ctx.accountid as string).trim() : undefined;
+      if (!accountId || accountId === '__default__') {
+        accountId = undefined;
+      }
+
+      return {
+        sessionKey,
+        route: {
+          channel: 'dingtalk-connector',
+          to,
+          ...(accountId ? { accountId } : {}),
+        },
+      };
+    }
+    return null;
   }
 
   private async requestOpenClawGateway<T = Record<string, unknown>>(

--- a/src/main/im/imScheduledTaskHandler.ts
+++ b/src/main/im/imScheduledTaskHandler.ts
@@ -275,6 +275,12 @@ export function createIMScheduledTaskRequestDetector(options: {
 export function isReminderSystemTurn(messages: Array<{ type: string; content: string }>): boolean {
   return messages.some((message) => {
     const content = typeof message.content === 'string' ? message.content : '';
+    // Only consider user and system messages — tool_use/tool_result/assistant
+    // messages may contain reminder text from cron.add payloads which would
+    // cause false positives on user-initiated task creation turns.
+    if (message.type !== 'user' && message.type !== 'system') {
+      return false;
+    }
     if (message.type === 'system') {
       return parseSimpleScheduledReminderText(content) !== null
         || parseLegacyScheduledReminderSystemMessage(content) !== null;


### PR DESCRIPTION
## 问题重现

1. 通过钉钉给 AI 机器人发消息创建定时任务（如"30秒后提醒我起来活动"）
2. AI 回复"已设置"并成功创建 cron job
3. 定时任务到期触发后，AI 生成了提醒内容并在 LobsterAI UI 中正常显示
4. **但提醒消息未发送到钉钉**，日志报错：
   - `No OpenClaw delivery route found for DingTalk session`
   - `Cannot resolve DingTalk target from conversationId`
   - `Failed to relay async IM reminder reply`

## 历史原因

存在三个层级的问题，按发现顺序：

### 1. 路由解析失败

`primeConversationReplyRoute` 在创建定时任务时尝试缓存钉钉投递路由，
但 OpenClaw session 的 `deliveryContext` 字段缺少 `to` 信息（cron 触发 的 run 不经过 connector 入站流程），导致 `extractOpenClawDeliveryRoute` 返回 null。回退解析 `parseDingTalkConversationTarget` 也失败，因为 conversationId 是纯 peerId（如 `0146552636218419`），不含冒号分隔的 accountId。

### 2. Gateway 插件 `cfg` 为空（根因）

即使路由解析成功，`dingtalk-connector.send` gateway method 也无法工作。 OpenClaw gateway 框架调用 plugin handler 时传入
`{ req, params, client, respond, context }`，**不传 `cfg`**。 钉钉插件依赖 `cfg` 获取 `channels['dingtalk-connector']` 配置 （clientId/clientSecret），`cfg` 为 undefined 导致
`getConfig(undefined)` 返回空对象 → `"DingTalk not configured"`。 此错误被 gateway wire protocol 丢失为 `"unknown error"`。

### 3. 重复发送与 Guard 误判

修复发送后暴露了两个额外问题：
- `isReminderSystemTurn` 对所有消息类型做匹配，用户创建定时任务时 tool_use/tool_result 中的 reminder payload 文本触发误判，导致 `sendAsyncReply` 重复发送（connector 已自动回复了一次）
- `analyzeIMReply` 的 reminder guard 将 cron 触发的提醒回复误判为 "承诺创建提醒但未成功"，替换为 `UNSCHEDULED_REMINDER_FAILURE_REPLY`

## 修复方案

### imGatewayManager.ts

- **新增 `sendDingTalkDirectHttp`**：绕过 OpenClaw gateway 插件， 直接调用钉钉 HTTP API (`/v1.0/oauth2/accessToken` + `/v1.0/robot/oToMessages/batchSend`) 发送消息，带 token 缓存
- **新增 `buildDingTalkRouteFromSessionKeys`**：从 OpenClaw session key 中嵌入的 JSON SessionContext 构造投递路由（fallback）
- **修改 `sendConversationReply`**：DingTalk case 改用直接 HTTP API
- **修改 `primeConversationReplyRoute`**：增加 session key fallback
- **修改 `parseDingTalkConversationTarget`**：不再将 `__default__` 替换为 clientId（插件期望的是账号标识，不是 clientId 值）

### imCoworkHandler.ts

- **新增 `formatReplyRaw`**：直接提取 assistant 原始文本，跳过 reminder guard
- **修改 `handleComplete`**：`backgroundDelivery` 存在时使用 `formatReplyRaw`，避免 cron 触发的提醒被 guard 错误替换

### imScheduledTaskHandler.ts

- **修改 `isReminderSystemTurn`**：只检查 `user` 和 `system` 类型消息， 忽略 `tool_use`/`tool_result`/`assistant`，避免 cron.add payload 中的 reminder 文本导致误判

## 影响范围

- 仅影响钉钉渠道的定时任务触发后消息投递
- 不影响用户主动消息的正常回复（仍由 OpenClaw connector 处理）
- 不影响 NIM、小蜜蜂等其他 IM 渠道
- 不影响 LobsterAI UI 中的消息显示

## 未来规划

- OpenClaw gateway 应在调用 plugin handler 时传入 `cfg` 参数， 使 `dingtalk-connector.send` 等 gateway method 正常工作， 届时可切回 gateway method 调用以支持 AI Card 等高级消息格式
- `isReminderSystemTurn` 的判断逻辑可进一步优化，引入显式的 `messageChannel` 标记来区分 cron 触发和用户触发