### PR TITLE
fix: only inject system prompt on first turn of OpenClaw session

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -3080,7 +3080,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       });
     }
     this.activeTurns.delete(sessionId);
-    this.lastSystemPromptBySession.delete(sessionId);
+    // NOTE: Do NOT clear lastSystemPromptBySession here — it must persist
+    // across turns so that the system prompt is only injected on the first
+    // turn of a session (or when it actually changes).  Cleanup happens in
+    // onSessionDeleted() when the session is removed entirely.
     this.reCreatedChannelSessionIds.delete(sessionId);
   }
 


### PR DESCRIPTION
## Summary
- `lastSystemPromptBySession` was cleared after every turn in `cleanupSessionTurn()`, causing the full system prompt to be re-injected into the user message on each subsequent turn
- Persist the cache across turns so the prompt is only sent on the first message of a session (or when the content actually changes)
- Cleanup still happens in `onSessionDeleted()` when the session is removed entirely

Closes #453

## Test plan
- [ ] New OpenClaw session: first message should contain `[LobsterAI system instructions]` block
- [ ] Same session follow-up messages should NOT contain the system instructions block
- [ ] If skill config changes mid-session (systemPrompt content differs), it should re-inject
- [ ] Deleting and recreating a session should inject system prompt on the new first message