### PR TITLE
fix: prevent GB18030 false positive causing garbled session titles

### DIFF
--- a/src/main/libs/coworkOpenAICompatProxy.ts
+++ b/src/main/libs/coworkOpenAICompatProxy.ts
@@ -978,8 +978,14 @@ function readRequestBody(req: http.IncomingMessage): Promise<string> {
         if (utf8Decoded && gbDecoded) {
           const utf8Score = scoreDecodedJsonText(utf8Decoded);
           const gbScore = scoreDecodedJsonText(gbDecoded);
-          if (gbScore > utf8Score) {
-            console.warn(`[CoworkProxy] Decoded request body using gb18030 (score ${gbScore} > utf8 ${utf8Score})`);
+          // Require GB18030 to score significantly higher than UTF-8 to avoid
+          // false positives on short CJK strings (e.g. "你好" scores UTF-8=10
+          // vs GB18030=11 due to one extra non-ASCII char from misaligned
+          // multi-byte boundaries).  UTF-8 is the overwhelmingly expected
+          // encoding, so give it a comfortable margin.
+          const GB18030_SCORE_MARGIN = 5;
+          if (gbScore > utf8Score + GB18030_SCORE_MARGIN) {
+            console.warn(`[CoworkProxy] Decoded request body using gb18030 (score ${gbScore} > utf8 ${utf8Score} + ${GB18030_SCORE_MARGIN})`);
             return gbDecoded;
           }
           return utf8Decoded;

--- a/src/main/libs/coworkUtil.ts
+++ b/src/main/libs/coworkUtil.ts
@@ -1597,6 +1597,7 @@ export async function generateSessionTitle(userIntent: string | null): Promise<s
   try {
     const url = buildAnthropicMessagesUrl(config.baseURL);
     const prompt = `Generate a short title from this input, keep the same language, return plain text only (no markdown), and keep it within ${SESSION_TITLE_MAX_CHARS} characters: ${normalizedInput}`;
+    console.log(`[cowork-title] Generating title: apiType=${config.apiType}, baseURL=${config.baseURL}, requestUrl=${url}, model=${config.model}`);
 
     const response = await fetch(url, {
       method: 'POST',
@@ -1625,7 +1626,9 @@ export async function generateSessionTitle(userIntent: string | null): Promise<s
     }
 
     const payload = await response.json();
+    console.log(`[cowork-title] Title response payload:`, JSON.stringify(payload).slice(0, 500));
     const llmTitle = extractTextFromAnthropicResponse(payload);
+    console.log(`[cowork-title] Extracted title text: "${llmTitle}"`);
     return normalizeTitleToPlainText(llmTitle, fallbackTitle);
   } catch (error) {
     console.error('Failed to generate session title:', error);

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -403,6 +403,7 @@ class ApiService {
     // - openai: OpenAI 兼容协议 (OpenAI provider uses /v1/responses)
     const normalizedApiFormat = this.normalizeApiFormat(effectiveConfig.apiFormat);
     const useOpenAIFormat = normalizedApiFormat === 'openai';
+    console.log(`[api-chat] provider=${provider}, model=${selectedModel.id}, apiFormat=${normalizedApiFormat}, useOpenAI=${useOpenAIFormat}, baseUrl=${effectiveConfig.baseUrl}`);
 
     if (!useOpenAIFormat) {
       return this.chatWithAnthropic(userMessage, onProgress, history, selectedModel.id, effectiveConfig, supportsImages);
@@ -533,6 +534,7 @@ class ApiService {
         this.cleanupFunctions = [removeDataListener, removeDoneListener, removeErrorListener, removeAbortListener];
 
         // 发起流式请求
+        console.log(`[api-chat] Anthropic request: baseUrl=${config.baseUrl}, finalUrl=${config.baseUrl}/v1/messages, model=${modelId}, apiFormat=${config.apiFormat}`);
         window.electron.api.stream({
           url: `${config.baseUrl}/v1/messages`,
           method: 'POST',
@@ -741,6 +743,7 @@ class ApiService {
         const requestUrl = useResponsesApi
           ? this.buildOpenAIResponsesUrl(config.baseUrl)
           : this.buildOpenAICompatibleChatCompletionsUrl(config.baseUrl, provider);
+        console.log(`[api-chat] OpenAI-compat request: provider=${provider}, baseUrl=${config.baseUrl}, finalUrl=${requestUrl}, model=${modelId}, apiFormat=${config.apiFormat}`);
         const requestBody: Record<string, unknown> = useResponsesApi
           ? {
               model: modelId,


### PR DESCRIPTION
## Summary
- The proxy's `readRequestBody` encoding heuristic incorrectly chose GB18030 over UTF-8 for short CJK strings like "你好" (score 11 vs 10), causing garbled session titles (e.g. "浣犲ソ")
- Added a score margin of 5 so GB18030 only wins when the evidence is strong
- Added diagnostic logging for API request URLs and title generation payload

## Test plan
- [ ] Send "你好" in cowork mode, verify session title is correct Chinese (not garbled)
- [ ] Send English text, verify title generation still works
- [ ] Check `main.log` for `[cowork-title]` diagnostic logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)