### PR TITLE
fix: strip endpoint suffix from base URL in OpenClaw config

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -252,6 +252,26 @@ const normalizeMoonshotBaseUrl = (rawBaseUrl: string): string => {
   return normalizeBaseUrlPath(trimmed, '/v1');
 };
 
+/**
+ * Strip well-known API endpoint suffixes from a base URL so that the
+ * OpenClaw gateway can append its own path without duplication.
+ *
+ * e.g. "https://gw.example.com/v1/chat/completions" → "https://gw.example.com/v1"
+ *      "https://gw.example.com/v1/messages"          → "https://gw.example.com/v1"
+ *      "https://gw.example.com/v1"                   → "https://gw.example.com/v1"  (unchanged)
+ */
+const stripEndpointSuffix = (rawBaseUrl: string): string => {
+  let normalized = rawBaseUrl.trim().replace(/\/+$/, '');
+  const endpointSuffixes = ['/chat/completions', '/messages', '/completions', '/responses'];
+  for (const suffix of endpointSuffixes) {
+    if (normalized.endsWith(suffix)) {
+      normalized = normalized.slice(0, -suffix.length).replace(/\/+$/, '');
+      break;
+    }
+  }
+  return normalized;
+};
+
 const normalizeKimiCodingBaseUrl = (rawBaseUrl: string): string => {
   const trimmed = rawBaseUrl.trim();
   if (!trimmed) {
@@ -346,7 +366,7 @@ const buildProviderSelection = (options: {
     sessionModelId: options.modelId,
     primaryModel: `lobster/${options.modelId}`,
     providerConfig: {
-      baseUrl: options.baseURL,
+      baseUrl: stripEndpointSuffix(options.baseURL),
       api: providerApi,
       apiKey: options.apiKey,
       auth: 'api-key',


### PR DESCRIPTION
## Summary
- When users configure a Custom provider with a full endpoint URL like `https://gw.example.com/v1/chat/completions`, the OpenClaw gateway appends `/chat/completions` again, producing `https://gw.example.com/v1/chat/completions/chat/completions` → HTTP 404
- Strip well-known endpoint suffixes (`/chat/completions`, `/messages`, `/completions`, `/responses`) from the base URL before writing to `openclaw.json`
- This also explains why "test connection" passed but actual chat failed: test connection goes renderer → upstream directly, while actual chat goes OpenClaw gateway → upstream (different URL construction paths)

## Test plan
- [ ] Configure Custom provider with `https://example.com/v1/chat/completions` as base URL
- [ ] Verify cowork session no longer returns HTTP 404
- [ ] Configure with `https://example.com/v1` — verify still works
- [ ] Run `node --test tests/openclawConfigSync.test.mjs` — all 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)