### PR TITLE
fix: provide placeholder API key for providers that don't require auth

### DIFF
--- a/src/main/libs/claudeSettings.ts
+++ b/src/main/libs/claudeSettings.ts
@@ -268,11 +268,11 @@ export function resolveCurrentApiConfig(target: OpenAICompatProxyTarget = 'local
 
   const resolvedBaseURL = matched.baseURL;
   const resolvedApiKey = matched.providerConfig.apiKey?.trim() || '';
-  const effectiveApiKey = matched.providerName === 'ollama'
-    && matched.apiFormat === 'anthropic'
-    && !resolvedApiKey
-    ? 'sk-ollama-local'
-    : resolvedApiKey;
+  // Providers that don't require auth (e.g. Ollama) still need a non-empty
+  // placeholder so downstream components (OpenClaw gateway, compat proxy)
+  // don't reject the request with "No API key found for provider".
+  const effectiveApiKey = resolvedApiKey
+    || (!providerRequiresApiKey(matched.providerName) ? 'sk-lobsterai-local' : '');
 
   if (matched.apiFormat === 'anthropic') {
     return {
@@ -350,11 +350,15 @@ export function resolveRawApiConfig(): ApiConfigResolution {
     return { config: null, error };
   }
   const apiKey = matched.providerConfig.apiKey?.trim() || '';
+  // OpenClaw's gateway requires a non-empty apiKey for every provider — even
+  // local servers (Ollama, vLLM, etc.) that don't enforce auth.  When the user
+  // leaves the key blank we supply a placeholder so the gateway doesn't reject
+  // the request with "No API key found for provider".
+  const effectiveApiKey = apiKey
+    || (!providerRequiresApiKey(matched.providerName) ? 'sk-lobsterai-local' : '');
   return {
     config: {
-      apiKey: matched.providerName === 'ollama' && matched.apiFormat === 'anthropic' && !apiKey
-        ? 'sk-ollama-local'
-        : apiKey,
+      apiKey: effectiveApiKey,
       baseURL: matched.baseURL,
       model: matched.modelId,
       apiType: matched.apiFormat === 'anthropic' ? 'anthropic' : 'openai',

--- a/tests/openclawConfigSync.test.mjs
+++ b/tests/openclawConfigSync.test.mjs
@@ -396,3 +396,39 @@ test('sync disables legacy reminder skills so native IM sessions use built-in cr
   assert.equal(config.skills.entries['qqbot-cron'].enabled, false);
   assert.equal(config.skills.entries['feishu-cron-reminder'].enabled, false);
 });
+
+test('sync writes non-empty placeholder apiKey for providers that do not require auth (e.g. Ollama)', (t) => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-config-sync-empty-key-'));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  setElectronPaths(tmpDir);
+
+  const ollamaAppConfig = {
+    model: {
+      defaultModel: 'llama3',
+      defaultModelProvider: 'ollama',
+    },
+    providers: {
+      ollama: {
+        enabled: true,
+        apiKey: '',
+        baseUrl: 'http://localhost:11434/v1',
+        apiFormat: 'openai',
+        models: [
+          { id: 'llama3' },
+        ],
+      },
+    },
+  };
+
+  const sync = createSync(tmpDir, ollamaAppConfig);
+  const result = sync.sync('test-empty-key');
+
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, true);
+
+  const config = JSON.parse(fs.readFileSync(path.join(tmpDir, 'state', 'openclaw.json'), 'utf8'));
+  const providerConfig = config.models.providers.lobster;
+  assert.ok(providerConfig, 'lobster provider should exist in config');
+  assert.ok(providerConfig.apiKey, 'apiKey must be a non-empty string');
+  assert.equal(providerConfig.apiKey, 'sk-lobsterai-local');
+});


### PR DESCRIPTION
## Summary

- Fix "No API key found for provider 'lobster'" error for providers that don't require authentication (e.g. Ollama, vLLM)
- Previously only Ollama + Anthropic format got a dummy key; Ollama + OpenAI format and other no-auth providers got an empty string, which OpenClaw's gateway rejects
- Now both `resolveCurrentApiConfig` and `resolveRawApiConfig` supply `'sk-lobsterai-local'` as a placeholder whenever the provider does not require an API key

## Root Cause

OpenClaw's gateway requires a non-empty `apiKey` for every provider. Its `normalizeOptionalSecretInput('')` treats empty strings as `undefined`, triggering the error. The old code only handled the Ollama + Anthropic format special case, missing Ollama + OpenAI format entirely.

## Test plan

- [x] Added test case: Ollama with OpenAI format and empty API key → verifies `'sk-lobsterai-local'` is written to `openclaw.json`
- [x] All existing tests pass (2 pre-existing failures unrelated to this change)
- [ ] Manual test: configure Ollama provider without API key, verify no "No API key found" error

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)