### PR TITLE
refactor: migrate NIM gateway from direct SDK to OpenClaw plugin arch…

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
         "version": "1.0.62",
         "registry": "https://npm.nie.netease.com",
         "optional": true
+      },
+      {
+        "id": "nim",
+        "npm": "openclaw-nim",
+        "version": "0.3.0"
       }
     ]
   },

--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -6,8 +6,6 @@
 
 import { EventEmitter } from 'events';
 import * as path from 'path';
-import * as os from 'os';
-import * as fs from 'fs';
 import { NimGateway } from './nimGateway';
 import { XiaomifengGateway } from './xiaomifengGateway';
 import { IMChatHandler } from './imChatHandler';
@@ -110,8 +108,6 @@ export class IMGatewayManager extends EventEmitter {
   private coworkRuntime: CoworkRuntime | null = null;
   private coworkStore: CoworkStore | null = null;
 
-  // NIM probe mutex: serializes concurrent connectivity tests
-  private nimProbePromise: Promise<void> | null = null;
 
   // DingTalk direct HTTP API token cache
   private dingTalkAccessToken: string | null = null;
@@ -148,23 +144,7 @@ export class IMGatewayManager extends EventEmitter {
   private setupGatewayEventForwarding(): void {
     // DingTalk runs via OpenClaw; no direct gateway events to forward
 
-    // NIM events
-    this.nimGateway.on('status', () => {
-      this.emit('statusChange', this.getStatus());
-    });
-    this.nimGateway.on('connected', () => {
-      this.emit('statusChange', this.getStatus());
-    });
-    this.nimGateway.on('disconnected', () => {
-      this.emit('statusChange', this.getStatus());
-    });
-    this.nimGateway.on('error', (error) => {
-      this.emit('error', { platform: 'nim', error });
-      this.emit('statusChange', this.getStatus());
-    });
-    this.nimGateway.on('message', (message: IMMessage) => {
-      this.emit('message', message);
-    });
+    // NIM runs via OpenClaw; no direct gateway events to forward
 
     // Xiaomifeng events
     this.xiaomifengGateway.on('status', () => {
@@ -200,10 +180,7 @@ export class IMGatewayManager extends EventEmitter {
 
     // DingTalk runs via OpenClaw; no direct reconnect needed
 
-    if (this.nimGateway && !this.nimGateway.isConnected()) {
-      console.log('[IMGatewayManager] Reconnecting NIM...');
-      this.nimGateway.reconnectIfNeeded();
-    }
+    // NIM runs via OpenClaw; no direct reconnect needed
 
     if (this.xiaomifengGateway && !this.xiaomifengGateway.isConnected()) {
       console.log('[IMGatewayManager] Reconnecting Xiaomifeng...');
@@ -372,24 +349,14 @@ export class IMGatewayManager extends EventEmitter {
   }
 
   // ==================== Configuration ====================
-
-  /**
-   * Get current configuration
-   */
   getConfig(): IMGatewayConfig {
     return this.imStore.getConfig();
   }
 
-  /**
-   * Get the underlying IMStore instance (for session mapping operations)
-   */
   getIMStore(): IMStore {
     return this.imStore;
   }
 
-  /**
-   * Update configuration
-   */
   setConfig(config: Partial<IMGatewayConfig>): void {
     const previousConfig = this.imStore.getConfig();
     this.imStore.setConfig(config);
@@ -400,40 +367,7 @@ export class IMGatewayManager extends EventEmitter {
     }
 
 
-    // Hot-update NIM config: if credential fields changed while gateway is connected,
-    // restart the gateway transparently so the SDK re-logs in with new credentials.
-    if (config.nim && this.nimGateway) {
-      const oldNim = previousConfig.nim;
-      const newNim = { ...oldNim, ...config.nim };
-      const credentialsChanged =
-        newNim.appKey !== oldNim.appKey ||
-        newNim.account !== oldNim.account ||
-        newNim.token !== oldNim.token;
-      const gatewayShouldBeActive =
-        Boolean(newNim.enabled && newNim.appKey && newNim.account && newNim.token);
-
-      if (credentialsChanged && gatewayShouldBeActive) {
-        if (this.nimGateway.isRunning() || this.nimGateway.isReconnecting()) {
-          console.log('[IMGatewayManager] NIM credentials changed, restarting gateway...');
-          this.restartGateway('nim').catch((err) => {
-            console.error('[IMGatewayManager] Failed to restart NIM after config change:', err.message);
-          });
-        } else {
-          console.log('[IMGatewayManager] NIM credentials changed, starting gateway...');
-          this.startGateway('nim').catch((err) => {
-            console.error('[IMGatewayManager] Failed to start NIM after config change:', err.message);
-          });
-        }
-      } else {
-        // Hot-update non-credential fields (e.g. accountWhitelist) without restart
-        const nonCredentialChanged =
-          newNim.accountWhitelist !== oldNim.accountWhitelist;
-        if (nonCredentialChanged) {
-          console.log('[IMGatewayManager] NIM non-credential config changed, hot-updating...');
-          this.nimGateway.updateConfig(config.nim);
-        }
-      }
-    }
+    // NIM now runs via OpenClaw; config sync is handled by IPC handler
 
     // DingTalk now runs via OpenClaw; config sync is handled by IPC handler
 
@@ -475,10 +409,6 @@ export class IMGatewayManager extends EventEmitter {
 
   }
 
-  /**
-   * Restart a specific gateway (stop then start with latest config)
-   * Used for hot-reloading when credentials change at runtime.
-   */
   private async restartGateway(platform: IMPlatform): Promise<void> {
     console.log(`[IMGatewayManager] Restarting ${platform} gateway...`);
     await this.stopGateway(platform);
@@ -487,10 +417,6 @@ export class IMGatewayManager extends EventEmitter {
   }
 
   // ==================== Status ====================
-
-  /**
-   * Get current status of all gateways
-   */
   getStatus(): IMGatewayStatus {
     const config = this.getConfig();
     // Telegram runs via OpenClaw; reflect enabled+configured state as connected
@@ -545,7 +471,17 @@ export class IMGatewayManager extends EventEmitter {
         lastOutboundAt: null as number | null,
       },
       discord: discordStatus,
-      nim: this.nimGateway.getStatus(),
+      nim: (() => {
+        const nmConfig = config.nim;
+        return {
+          connected: Boolean(nmConfig?.enabled && nmConfig.appKey && nmConfig.account && nmConfig.token),
+          startedAt: null as number | null,
+          lastError: null as string | null,
+          botAccount: nmConfig?.account || null,
+          lastInboundAt: null as number | null,
+          lastOutboundAt: null as number | null,
+        };
+      })(),
       xiaomifeng: this.xiaomifengGateway.getStatus(),
       wecom: {
         connected: Boolean(config.wecom?.enabled && config.wecom.botId && config.wecom.secret),
@@ -565,9 +501,6 @@ export class IMGatewayManager extends EventEmitter {
     };
   }
 
-  /**
-   * Test platform connectivity and readiness for conversation.
-   */
   async testGateway(
     platform: IMPlatform,
     configOverride?: Partial<IMGatewayConfig>
@@ -590,6 +523,10 @@ export class IMGatewayManager extends EventEmitter {
     // DingTalk always uses OpenClaw mode
     if (platform === 'dingtalk') {
       return this.testDingTalkOpenClawConnectivity(configOverride);
+    }
+
+    if (platform === 'nim') {
+      return this.testNimOpenClawConnectivity(configOverride);
     }
 
     // WeCom always uses OpenClaw mode
@@ -735,14 +672,7 @@ export class IMGatewayManager extends EventEmitter {
       });
     }
 
-    if (platform === 'nim') {
-      addCheck({
-        code: 'nim_p2p_only_hint',
-        level: 'info',
-        message: '云信 IM 当前仅支持 P2P（私聊）消息。',
-        suggestion: '请通过私聊方式向机器人账号发送消息触发对话。',
-      });
-    } else if (platform === 'qq') {
+    if (platform === 'qq') {
       addCheck({
         code: 'qq_guild_mention_hint',
         level: 'info',
@@ -760,10 +690,6 @@ export class IMGatewayManager extends EventEmitter {
   }
 
   // ==================== Gateway Control ====================
-
-  /**
-   * Start a specific gateway
-   */
   async startGateway(platform: IMPlatform): Promise<void> {
     const config = this.getConfig();
 
@@ -796,7 +722,11 @@ export class IMGatewayManager extends EventEmitter {
       await this.ensureOpenClawGatewayConnected?.();
       return;
     } else if (platform === 'nim') {
-      await this.nimGateway.start(config.nim);
+      // NIM runs via OpenClaw gateway (openclaw-nim plugin)
+      console.log('[IMGatewayManager] NIM in OpenClaw mode, syncing config instead of starting direct gateway');
+      await this.syncOpenClawConfig?.();
+      await this.ensureOpenClawGatewayConnected?.();
+      return;
     } else if (platform === 'xiaomifeng') {
       await this.xiaomifengGateway.start(config.xiaomifeng);
     } else if (platform === 'qq') {
@@ -823,9 +753,6 @@ export class IMGatewayManager extends EventEmitter {
     this.restoreNotificationTarget(platform);
   }
 
-  /**
-   * Stop a specific gateway
-   */
   async stopGateway(platform: IMPlatform): Promise<void> {
     if (platform === 'dingtalk') {
       // DingTalk runs via OpenClaw gateway
@@ -848,7 +775,10 @@ export class IMGatewayManager extends EventEmitter {
       await this.syncOpenClawConfig?.();
       return;
     } else if (platform === 'nim') {
-      await this.nimGateway.stop();
+      // NIM runs via OpenClaw gateway
+      console.log('[IMGatewayManager] NIM in OpenClaw mode, syncing disabled config');
+      await this.syncOpenClawConfig?.();
+      return;
     } else if (platform === 'xiaomifeng') {
       await this.xiaomifengGateway.stop();
     } else if (platform === 'qq') {
@@ -872,7 +802,7 @@ export class IMGatewayManager extends EventEmitter {
   /**
    * Start all enabled gateways.
    *
-   * OpenClaw platforms (dingtalk/feishu/telegram/discord/qq/wecom/popo) are batched
+   * OpenClaw platforms (dingtalk/feishu/telegram/discord/qq/wecom/popo/nim) are batched
    * so that `syncOpenClawConfig` + `ensureOpenClawGatewayConnected` are called
    * only **once** regardless of how many OpenClaw platforms are enabled.
    * This avoids N serial gateway restarts which cause message loss, Telegram
@@ -885,14 +815,6 @@ export class IMGatewayManager extends EventEmitter {
     this.updateChatHandler();
 
     // --- Non-OpenClaw platforms: start independently ---
-
-    if (config.nim.enabled && config.nim.appKey && config.nim.account && config.nim.token) {
-      try {
-        await this.startGateway('nim');
-      } catch (error: any) {
-        console.error(`[IMGatewayManager] Failed to start NIM: ${error.message}`);
-      }
-    }
 
     if (config.xiaomifeng?.enabled && config.xiaomifeng?.clientId && config.xiaomifeng?.secret) {
       try {
@@ -927,6 +849,9 @@ export class IMGatewayManager extends EventEmitter {
     if (config.popo?.enabled && config.popo?.appKey && config.popo?.appSecret && config.popo?.token && config.popo?.aesKey) {
       openClawPlatformsToStart.push('popo');
     }
+    if (config.nim?.enabled && config.nim.appKey && config.nim.account && config.nim.token) {
+      openClawPlatformsToStart.push('nim');
+    }
 
     if (openClawPlatformsToStart.length > 0) {
       console.log(`[IMGatewayManager] Starting OpenClaw platforms in batch: ${openClawPlatformsToStart.join(', ')}`);
@@ -939,26 +864,16 @@ export class IMGatewayManager extends EventEmitter {
     }
   }
 
-  /**
-   * Stop all gateways
-   */
   async stopAll(): Promise<void> {
     await Promise.all([
-      this.nimGateway.stop(),
       this.xiaomifengGateway.stop(),
     ]);
   }
 
-  /**
-   * Check if any gateway is connected
-   */
   isAnyConnected(): boolean {
-    return this.nimGateway.isConnected() || this.xiaomifengGateway.isConnected();
+    return this.xiaomifengGateway.isConnected();
   }
 
-  /**
-   * Check if a specific gateway is connected
-   */
   isConnected(platform: IMPlatform): boolean {
     if (platform === 'dingtalk') {
       // DingTalk runs via OpenClaw; consider it connected when enabled and configured
@@ -976,7 +891,9 @@ export class IMGatewayManager extends EventEmitter {
       return Boolean(config.discord?.enabled && config.discord.botToken);
     }
     if (platform === 'nim') {
-      return this.nimGateway.isConnected();
+      // NIM runs via OpenClaw; consider it connected when enabled and configured
+      const config = this.getConfig();
+      return Boolean(config.nim?.enabled && config.nim.appKey && config.nim.account && config.nim.token);
     }
     if (platform === 'xiaomifeng') {
       return this.xiaomifengGateway.isConnected();
@@ -999,11 +916,6 @@ export class IMGatewayManager extends EventEmitter {
     return false;
   }
 
-  /**
-   * Send a notification message through a specific platform.
-   * Uses platform-specific broadcast mechanisms.
-   * Returns true if successfully sent, false if platform not connected.
-   */
   async sendNotification(platform: IMPlatform, text: string): Promise<boolean> {
     if (!this.isConnected(platform)) {
       console.warn(`[IMGatewayManager] Cannot send notification: ${platform} is not connected`);
@@ -1012,7 +924,8 @@ export class IMGatewayManager extends EventEmitter {
 
     try {
       if (platform === 'nim') {
-        await this.nimGateway.sendNotification(text);
+        // NIM runs via OpenClaw; notifications not yet supported via plugin
+        console.log('[IMGatewayManager] NIM notification via OpenClaw not yet supported');
       } else if (platform === 'qq') {
         // QQ runs via OpenClaw; notifications are handled by the qqbot plugin
         console.log('[IMGatewayManager] QQ notification via OpenClaw not yet supported');
@@ -1040,7 +953,8 @@ export class IMGatewayManager extends EventEmitter {
 
     try {
       if (platform === 'nim') {
-        await this.nimGateway.sendNotificationWithMedia(text);
+        // NIM runs via OpenClaw; notifications not yet supported via plugin
+        console.log('[IMGatewayManager] NIM notification with media via OpenClaw not yet supported');
       } else if (platform === 'qq') {
         // QQ runs via OpenClaw; notifications are handled by the qqbot plugin
         console.log('[IMGatewayManager] QQ notification with media via OpenClaw not yet supported');
@@ -1060,10 +974,6 @@ export class IMGatewayManager extends EventEmitter {
     }
   }
 
-  /**
-   * Test Telegram connectivity when running via OpenClaw runtime.
-   * Validates bot token via Telegram API (same auth probe as direct mode).
-   */
   private async testTelegramOpenClawConnectivity(
     configOverride?: Partial<IMGatewayConfig>
   ): Promise<IMConnectivityTestResult> {
@@ -1139,10 +1049,6 @@ export class IMGatewayManager extends EventEmitter {
     return { platform, testedAt, verdict, checks };
   }
 
-  /**
-   * Test Discord connectivity when running via OpenClaw runtime.
-   * Validates bot token via Discord API (/users/@me).
-   */
   private async testDiscordOpenClawConnectivity(
     configOverride?: Partial<IMGatewayConfig>
   ): Promise<IMConnectivityTestResult> {
@@ -1217,10 +1123,6 @@ export class IMGatewayManager extends EventEmitter {
     return { platform, testedAt, verdict, checks };
   }
 
-  /**
-   * Test Feishu connectivity when running via OpenClaw runtime (feishu-openclaw-plugin).
-   * Validates credentials via Feishu API (/open-apis/bot/v3/info).
-   */
   private async testFeishuOpenClawConnectivity(
     configOverride?: Partial<IMGatewayConfig>
   ): Promise<IMConnectivityTestResult> {
@@ -1310,10 +1212,6 @@ export class IMGatewayManager extends EventEmitter {
     return { platform, testedAt, verdict, checks };
   }
 
-  /**
-   * Test DingTalk connectivity when running via OpenClaw runtime.
-   * Validates credentials via DingTalk API.
-   */
   private async testDingTalkOpenClawConnectivity(
     configOverride?: Partial<IMGatewayConfig>
   ): Promise<IMConnectivityTestResult> {
@@ -1388,10 +1286,6 @@ export class IMGatewayManager extends EventEmitter {
     return { platform, testedAt, verdict, checks };
   }
 
-  /**
-   * Test WeCom connectivity when running via OpenClaw runtime.
-   * Validates config completeness; actual connection is handled by OpenClaw.
-   */
   private async testWecomOpenClawConnectivity(
     configOverride?: Partial<IMGatewayConfig>
   ): Promise<IMConnectivityTestResult> {
@@ -1428,6 +1322,58 @@ export class IMGatewayManager extends EventEmitter {
       code: 'gateway_running',
       level: 'info',
       message: '企业微信通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
+    });
+
+    const verdict: IMConnectivityVerdict = checks.some(c => c.level === 'fail')
+      ? 'fail'
+      : checks.some(c => c.level === 'warn')
+        ? 'warn'
+        : 'pass';
+
+    return { platform, testedAt, verdict, checks };
+  }
+
+  private async testNimOpenClawConnectivity(
+    configOverride?: Partial<IMGatewayConfig>
+  ): Promise<IMConnectivityTestResult> {
+    const checks: IMConnectivityCheck[] = [];
+    const testedAt = Date.now();
+    const platform: IMPlatform = 'nim';
+
+    const mergedConfig = this.buildMergedConfig(configOverride);
+    const nimConfig = mergedConfig.nim;
+
+    if (!nimConfig?.appKey || !nimConfig?.account || !nimConfig?.token) {
+      const missing: string[] = [];
+      if (!nimConfig?.appKey) missing.push('appKey');
+      if (!nimConfig?.account) missing.push('account');
+      if (!nimConfig?.token) missing.push('token');
+      checks.push({
+        code: 'missing_credentials',
+        level: 'fail',
+        message: `缺少必要配置项: ${missing.join(', ')}`,
+        suggestion: '请补全 AppKey、Account 和 Token 后重新测试连通性。',
+      });
+      return { platform, testedAt, verdict: 'fail', checks };
+    }
+
+    checks.push({
+      code: 'auth_check',
+      level: 'pass',
+      message: `云信配置已就绪（Account: ${nimConfig.account}）。`,
+    });
+
+    checks.push({
+      code: 'gateway_running',
+      level: 'info',
+      message: '云信通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
+    });
+
+    checks.push({
+      code: 'nim_p2p_only_hint',
+      level: 'info',
+      message: '云信 IM 当前仅支持 P2P（私聊）消息。',
+      suggestion: '请通过私聊方式向机器人账号发送消息触发对话。',
     });
 
     const verdict: IMConnectivityVerdict = checks.some(c => c.level === 'fail')
@@ -1491,6 +1437,8 @@ export class IMGatewayManager extends EventEmitter {
 
     return { platform, testedAt, verdict, checks };
   }
+
+
 
   private buildMergedConfig(configOverride?: Partial<IMGatewayConfig>): IMGatewayConfig {
     const current = this.getConfig();
@@ -1596,10 +1544,11 @@ export class IMGatewayManager extends EventEmitter {
     }
 
     if (platform === 'nim') {
-      // Use an isolated temporary NimGateway instance so the probe never
-      // touches the main gateway's state and never fires onMessageCallback.
-      await this.testNimConnectivity(config.nim);
-      return `云信鉴权通过（Account: ${config.nim.account}，SDK 登录成功）。`;
+      const { appKey, account, token } = config.nim;
+      if (!appKey || !account || !token) {
+        throw new Error('配置不完整');
+      }
+      return `云信配置已就绪（Account: ${account}）。`;
     }
 
     if (platform === 'xiaomifeng') {
@@ -1654,131 +1603,6 @@ export class IMGatewayManager extends EventEmitter {
     return '未知平台。';
   }
 
-  /**
-   * Test NIM connectivity.
-   *
-   * NIM enforces single-device login per account: if a second client logs in
-   * with the same account, the first one is kicked offline. Therefore we CANNOT
-   * create a temporary NimGateway alongside the main one.
-   *
-   * Strategy:
-   * 1. If the main nimGateway is already connected → credentials are valid,
-   *    return immediately.
-   * 2. Otherwise, **stop the main gateway first** (if it has a stale SDK
-   *    instance), then create a temporary probe instance with its own data
-   *    path. After the probe completes, fully stop it, then **restart the
-   *    main gateway** so normal message reception resumes.
-   */
-  private async testNimConnectivity(nimConfig: IMGatewayConfig['nim']): Promise<void> {
-    // Fast path: if the main gateway is already connected, credentials are valid.
-    if (this.nimGateway.isConnected()) {
-      return;
-    }
-
-    // Mutex: if a previous probe is still running, wait for it to finish first
-    // to avoid concurrent NIM SDK instances causing native crashes.
-    if (this.nimProbePromise) {
-      try {
-        await this.nimProbePromise;
-      } catch (_) { /* ignore previous probe errors */ }
-    }
-
-    // Wrap the actual probe in a tracked promise for mutex
-    this.nimProbePromise = this.executeNimProbe(nimConfig);
-    try {
-      await this.nimProbePromise;
-    } finally {
-      this.nimProbePromise = null;
-    }
-  }
-
-  /**
-   * Internal NIM probe execution (called under mutex protection).
-   */
-  private async executeNimProbe(nimConfig: IMGatewayConfig['nim']): Promise<void> {
-    // Stop the main gateway before probing to avoid kick-offline conflicts.
-    // This is a no-op if it's not running.
-    try {
-      await this.nimGateway.stop();
-    } catch (_) { /* ignore */ }
-
-    // Wait for native SDK resources to be fully released before creating a new instance.
-    await new Promise(resolve => setTimeout(resolve, 500));
-
-    const NIM_TEST_TIMEOUT_MS = 9_000;
-    let tmpGateway: NimGateway | null = new NimGateway();
-
-    // Use a unique temporary data path to avoid file-lock conflicts.
-    const tmpDataPath = path.join(
-      os.tmpdir(),
-      `lobsterai-nim-probe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-    );
-    fs.mkdirSync(tmpDataPath, { recursive: true });
-
-    try {
-      await new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(() => {
-          reject(new Error('NIM 登录超时（9s），请检查网络或凭据'));
-        }, NIM_TEST_TIMEOUT_MS);
-
-        tmpGateway!.once('connected', () => {
-          clearTimeout(timer);
-          resolve();
-        });
-
-        tmpGateway!.once('error', (err: Error) => {
-          clearTimeout(timer);
-          reject(err);
-        });
-
-        // Also listen for loginFailed which may not always emit 'error'
-        tmpGateway!.once('loginFailed', (err: any) => {
-          clearTimeout(timer);
-          const desc = err?.desc || err?.message || JSON.stringify(err);
-          reject(new Error(`NIM 登录失败: ${desc}`));
-        });
-
-        tmpGateway!.start(
-          { ...nimConfig, enabled: true },
-          { appDataPathOverride: tmpDataPath }
-        ).catch(reject);
-      });
-    } finally {
-      // Fully stop the temporary instance before doing anything else.
-      if (tmpGateway) {
-        const gw = tmpGateway;
-        tmpGateway = null;
-        try {
-          await gw.stop();
-        } catch (stopErr: any) {
-          // Ensure uninit failures never propagate as uncaught exceptions
-          console.warn('[IMGatewayManager] NIM probe tmpGateway.stop() error (ignored):', stopErr?.message || stopErr);
-        }
-      }
-
-      // Wait for native cleanup before restarting the main gateway.
-      await new Promise(resolve => setTimeout(resolve, 500));
-
-      // Clean up the temporary data directory after a short delay.
-      setTimeout(() => {
-        try {
-          fs.rmSync(tmpDataPath, { recursive: true, force: true });
-        } catch (_) { /* ignore */ }
-      }, 2000);
-
-      // Restart the main gateway if the NIM config says it should be enabled
-      // so that normal message reception resumes.
-      // We restart regardless of probe success: even if the probe failed,
-      // the main gateway was stopped and needs to be restarted if enabled.
-      if (nimConfig.enabled) {
-        try {
-          await this.startGateway('nim');
-        } catch (err: any) {
-          console.error('[IMGatewayManager] Failed to restart main NIM gateway after probe:', err.message);
-        }
-      }
-    }
-  }
 
   async sendConversationReply(platform: IMPlatform, conversationId: string, text: string): Promise<boolean> {
     try {
@@ -1802,8 +1626,8 @@ export class IMGatewayManager extends EventEmitter {
           return this.sendDingTalkDirectHttp(userId, text);
         }
         case 'nim':
-          await this.nimGateway.sendConversationNotification(conversationId, text);
-          return true;
+          console.log('[IMGatewayManager] NIM conversation reply via OpenClaw not yet supported');
+          return false;
         case 'xiaomifeng':
           await this.xiaomifengGateway.sendConversationNotification(conversationId, text);
           return true;
@@ -1818,9 +1642,6 @@ export class IMGatewayManager extends EventEmitter {
 
   // ─── DingTalk direct HTTP API ──────────────────────────────────────────────
 
-  /**
-   * Obtain a DingTalk access token (v2.0 API), caching it for its lifetime.
-   */
   private async getDingTalkAccessToken(clientId: string, clientSecret: string): Promise<string> {
     const now = Date.now();
     if (this.dingTalkAccessToken && this.dingTalkAccessTokenExpiry > now + 60_000) {
@@ -1845,10 +1666,6 @@ export class IMGatewayManager extends EventEmitter {
     return this.dingTalkAccessToken;
   }
 
-  /**
-   * Send a text/markdown message to a DingTalk user via the proactive messaging
-   * HTTP API, bypassing the OpenClaw gateway plugin (which lacks `cfg` context).
-   */
   private async sendDingTalkDirectHttp(userId: string, text: string): Promise<boolean> {
     const dtConfig = this.imStore.getDingTalkOpenClawConfig();
     if (!dtConfig.clientId || !dtConfig.clientSecret) {
@@ -2144,15 +1961,6 @@ export class IMGatewayManager extends EventEmitter {
     };
   }
 
-  /**
-   * Attempt to construct a DingTalk delivery route by parsing JSON SessionContext
-   * embedded in OpenClaw session keys.  This covers the case where the OpenClaw
-   * session entry itself lacks a deliveryContext (e.g. cron-triggered runs that
-   * reuse an existing session without full delivery metadata).
-   *
-   * Session key format (since dingtalk-connector v0.7.5):
-   *   agent:{agentId}:openai-user:{"channel":"dingtalk-connector","accountid":"...","chattype":"direct","peerid":"...","sendername":"..."}
-   */
   private buildDingTalkRouteFromSessionKeys(
     sessionKeys: string[],
   ): { sessionKey: string; route: OpenClawDeliveryRoute } | null {
@@ -2206,6 +2014,19 @@ export class IMGatewayManager extends EventEmitter {
       };
     }
     return null;
+  }
+
+  /**
+   * Fetch the OpenClaw config schema (JSON Schema + uiHints) from the gateway.
+   * Returns { schema, uiHints } or null if the gateway is unavailable.
+   */
+  async getOpenClawConfigSchema(): Promise<{ schema: Record<string, unknown>; uiHints: Record<string, Record<string, unknown>> } | null> {
+    try {
+      return await this.requestOpenClawGateway<{ schema: Record<string, unknown>; uiHints: Record<string, Record<string, unknown>> }>('config.schema', {});
+    } catch (err: any) {
+      console.warn('[IMGatewayManager] Failed to fetch config.schema from OpenClaw gateway:', err.message);
+      return null;
+    }
   }
 
   private async requestOpenClawGateway<T = Record<string, unknown>>(

--- a/src/main/im/nimGateway.ts
+++ b/src/main/im/nimGateway.ts
@@ -254,7 +254,7 @@ export class NimGateway extends EventEmitter {
 
   /**
    * Update runtime config without restarting the gateway.
-   * Used for hot-updating non-credential fields like accountWhitelist.
+   * Used for hot-updating non-credential fields.
    */
   updateConfig(partial: Partial<NimConfig>): void {
     if (this.config) {
@@ -378,7 +378,7 @@ export class NimGateway extends EventEmitter {
     }
 
     this.config = config;
-    this.log = config.debug ? console.log.bind(console) : () => {};
+    this.log = config.advanced?.debug ? console.log.bind(console) : () => {};
 
     this.log('[NIM Gateway] Starting NIM gateway...');
 
@@ -434,7 +434,7 @@ export class NimGateway extends EventEmitter {
           }
 
           // Activate QChat if enabled
-          if (this.config?.qchatEnabled) {
+          if (this.config?.qchat?.policy && this.config.qchat.policy !== 'disabled') {
             this.activateQChat();
           }
         } else if (loginStatus === 0) {
@@ -782,19 +782,12 @@ export class NimGateway extends EventEmitter {
         return;
       }
 
-      // Whitelist filtering: if accountWhitelist is set, only process messages from whitelisted accounts
-      if (this.config?.accountWhitelist) {
-        const whitelist = this.config.accountWhitelist
-          .split(',')
-          .map(s => s.trim())
-          .filter(Boolean);
-
-        if (whitelist.length > 0) {
-          const whitelistSet = new Set(whitelist);
-          if (!whitelistSet.has(senderId)) {
-            this.log(`[NIM Gateway] Ignoring message from non-whitelisted account: ${senderId}`);
-            return;
-          }
+      // P2P allowlist filtering: if p2p.policy is "allowlist", check p2p.allowFrom
+      if (this.config?.p2p?.policy === 'allowlist' && this.config.p2p.allowFrom?.length) {
+        const whitelistSet = new Set(this.config.p2p.allowFrom.map(String));
+        if (!whitelistSet.has(senderId)) {
+          this.log(`[NIM Gateway] Ignoring message from non-whitelisted account: ${senderId}`);
+          return;
         }
       }
 
@@ -825,9 +818,8 @@ export class NimGateway extends EventEmitter {
       if (isTeam) {
         const botAccount = this.config?.account || '';
         const forcePushIds: string[] = msg.pushConfig?.forcePushAccountIds ?? [];
-        const teamPolicy: NimTeamPolicy = this.config?.teamPolicy || 'disabled';
-        const teamAllowlistStr = this.config?.teamAllowlist || '';
-        const teamAllowlist = teamAllowlistStr.split(',').map(s => s.trim()).filter(Boolean);
+        const teamPolicy: NimTeamPolicy = (this.config?.team?.policy as NimTeamPolicy) || 'disabled';
+        const teamAllowlist = (this.config?.team?.allowFrom ?? []).map(String);
 
         // Always log team message details (not gated by debug) for easier diagnostics
         console.log('[NIM Gateway] Team message check:', JSON.stringify({
@@ -1348,8 +1340,8 @@ export class NimGateway extends EventEmitter {
   private async activateQChat(): Promise<void> {
     if (!this.v2Client || !this.config) return;
 
-    const serverIdsStr = this.config.qchatServerIds || '';
-    const serverIds = serverIdsStr.split(',').map(s => s.trim()).filter(Boolean);
+    const qchatAllowFrom = this.config.qchat?.allowFrom ?? [];
+    const serverIds = qchatAllowFrom.map(String).filter(Boolean);
 
     this.log('[NIM Gateway] Activating QChat...');
 
@@ -1389,11 +1381,11 @@ export class NimGateway extends EventEmitter {
         return;
       }
 
-      // Apply whitelist if configured
-      if (this.config?.accountWhitelist) {
-        const whitelist = this.config.accountWhitelist.split(',').map(s => s.trim()).filter(Boolean);
-        if (whitelist.length > 0 && !whitelist.includes(msg.senderAccid)) {
-          this.log(`[NIM QChat] Sender ${msg.senderAccid} not in whitelist`);
+      // Apply QChat allowlist if configured
+      if (this.config?.qchat?.policy === 'allowlist' && this.config.qchat.allowFrom?.length) {
+        const allowSet = new Set(this.config.qchat.allowFrom.map(String));
+        if (!allowSet.has(msg.senderAccid)) {
+          this.log(`[NIM QChat] Sender ${msg.senderAccid} not in allowlist`);
           return;
         }
       }

--- a/src/main/im/types.ts
+++ b/src/main/im/types.ts
@@ -136,19 +136,36 @@ export interface DiscordGatewayStatus {
 export type NimTeamPolicy = 'open' | 'allowlist' | 'disabled';
 export type NimSessionType = 'p2p' | 'team' | 'superTeam';
 
+export interface NimP2pConfig {
+  policy: 'open' | 'allowlist' | 'disabled';
+  allowFrom?: (string | number)[];
+}
+
+export interface NimTeamConfig {
+  policy: 'open' | 'allowlist' | 'disabled';
+  allowFrom?: (string | number)[];
+}
+
+export interface NimQChatConfig {
+  policy: 'open' | 'allowlist' | 'disabled';
+  allowFrom?: (string | number)[];
+}
+
+export interface NimAdvancedConfig {
+  mediaMaxMb?: number;
+  textChunkLimit?: number;
+  debug?: boolean;
+}
+
 export interface NimConfig {
   enabled: boolean;
   appKey: string;
   account: string;
   token: string;
-  accountWhitelist: string;
-  debug?: boolean;
-  // 群组消息配置
-  teamPolicy?: NimTeamPolicy;      // 群消息策略，默认 'disabled'
-  teamAllowlist?: string;          // 逗号分隔的群 ID 白名单
-  // QChat 圈组配置
-  qchatEnabled?: boolean;          // 是否启用圈组
-  qchatServerIds?: string;         // 逗号分隔的服务器 ID，空则自动发现
+  p2p?: NimP2pConfig;
+  team?: NimTeamConfig;
+  qchat?: NimQChatConfig;
+  advanced?: NimAdvancedConfig;
 }
 
 export interface NimGatewayStatus {
@@ -458,12 +475,6 @@ export const DEFAULT_NIM_CONFIG: NimConfig = {
   appKey: '',
   account: '',
   token: '',
-  accountWhitelist: '',
-  debug: true,
-  teamPolicy: 'disabled',
-  teamAllowlist: '',
-  qchatEnabled: false,
-  qchatServerIds: '',
 };
 
 export const DEFAULT_XIAOMIFENG_CONFIG: XiaomifengConfig = {

--- a/src/main/libs/openclawChannelSessionSync.ts
+++ b/src/main/libs/openclawChannelSessionSync.ts
@@ -67,6 +67,7 @@ export const CHANNEL_PLATFORM_MAP: Record<string, IMPlatform> = {
   wecom: 'wecom',
   'wecom-openclaw-plugin': 'wecom',
   'moltbot-popo': 'popo',
+  nim: 'nim',
 };
 
 /** Parse a channel sessionKey into platform + conversationId.
@@ -163,6 +164,7 @@ const CHANNEL_TITLE_PREFIX: Record<string, string> = {
   wecom: '[企微]',
   'wecom-openclaw-plugin': '[企微]',
   popo: '[POPO]',
+  nim: '[云信]',
 };
 
 export interface ChannelSessionSyncDeps {

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import type { CoworkConfig, CoworkExecutionMode } from '../coworkStore';
 import type { TelegramOpenClawConfig, DiscordOpenClawConfig } from '../im/types';
-import type { DingTalkOpenClawConfig, FeishuOpenClawConfig, QQOpenClawConfig, WecomOpenClawConfig, PopoOpenClawConfig } from '../im/types';
+import type { DingTalkOpenClawConfig, FeishuOpenClawConfig, QQOpenClawConfig, WecomOpenClawConfig, PopoOpenClawConfig, NimConfig } from '../im/types';
 import { resolveRawApiConfig } from './claudeSettings';
 import type { OpenClawEngineManager } from './openclawEngineManager';
 import { parseChannelSessionKey } from './openclawChannelSessionSync';
@@ -421,6 +421,7 @@ type OpenClawConfigSyncDeps = {
   getQQConfig: () => QQOpenClawConfig | null;
   getWecomConfig: () => WecomOpenClawConfig | null;
   getPopoConfig: () => PopoOpenClawConfig | null;
+  getNimConfig: () => NimConfig | null;
   getMcpBridgeConfig?: () => McpBridgeConfig | null;
   getSkillsList?: () => Array<{ id: string; enabled: boolean }>;
 };
@@ -435,6 +436,7 @@ export class OpenClawConfigSync {
   private readonly getQQConfig: () => QQOpenClawConfig | null;
   private readonly getWecomConfig: () => WecomOpenClawConfig | null;
   private readonly getPopoConfig: () => PopoOpenClawConfig | null;
+  private readonly getNimConfig: () => NimConfig | null;
   private readonly getMcpBridgeConfig?: () => McpBridgeConfig | null;
   private readonly getSkillsList?: () => Array<{ id: string; enabled: boolean }>;
 
@@ -448,6 +450,7 @@ export class OpenClawConfigSync {
     this.getQQConfig = deps.getQQConfig;
     this.getWecomConfig = deps.getWecomConfig;
     this.getPopoConfig = deps.getPopoConfig;
+    this.getNimConfig = deps.getNimConfig;
     this.getMcpBridgeConfig = deps.getMcpBridgeConfig;
     this.getSkillsList = deps.getSkillsList;
   }
@@ -511,6 +514,8 @@ export class OpenClawConfigSync {
     const wecomConfig = this.getWecomConfig();
 
     const popoConfig = this.getPopoConfig();
+    
+    const nimConfig = this.getNimConfig();
 
     const hasAnyChannel = hasDingTalkOpenClaw;
 
@@ -587,6 +592,7 @@ export class OpenClawConfigSync {
                 if (id === 'qqbot') return !!(qqConfig?.enabled && qqConfig.appId);
                 if (id === 'wecom-openclaw-plugin') return !!(wecomConfig?.enabled && wecomConfig.botId);
                 if (id === 'moltbot-popo') return !!(popoConfig?.enabled && popoConfig.appKey);
+                if (id === 'nim') return !!(nimConfig?.enabled && nimConfig.appKey && nimConfig.account && nimConfig.token);
                 return true; // other plugins stay enabled
               })();
               return [id, { enabled: pluginEnabled }];
@@ -851,6 +857,21 @@ export class OpenClawConfigSync {
         popoChannel.webhookPath = popoConfig.webhookPath;
       }
       managedConfig.channels = { ...(managedConfig.channels as Record<string, unknown> || {}), 'moltbot-popo': popoChannel };
+    }
+    // Sync NIM OpenClaw channel config (via openclaw-nim plugin)
+    if (nimConfig?.enabled && nimConfig.appKey && nimConfig.account && nimConfig.token) {
+      const nimChannel: Record<string, unknown> = {
+        enabled: true,
+        appKey: nimConfig.appKey,
+        account: nimConfig.account,
+        token: nimConfig.token,
+      };
+      // Pass structured sub-configs directly — the plugin's Zod schema validates them
+      if (nimConfig.p2p) nimChannel.p2p = nimConfig.p2p;
+      if (nimConfig.team) nimChannel.team = nimConfig.team;
+      if (nimConfig.qchat) nimChannel.qchat = nimConfig.qchat;
+      if (nimConfig.advanced) nimChannel.advanced = nimConfig.advanced;
+      managedConfig.channels = { ...(managedConfig.channels as Record<string, unknown> || {}), 'nim': nimChannel };
     }
 
     const nextContent = `${JSON.stringify(managedConfig, null, 2)}\n`;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -769,6 +769,13 @@ const getOpenClawConfigSync = (): OpenClawConfigSync => {
       getPopoConfig: () => {
         try {
           return getIMGatewayManager().getConfig().popo;
+          } catch {
+          return null;
+        }
+      },
+      getNimConfig: () => {
+        try {
+          return getIMGatewayManager().getConfig().nim;
         } catch {
           return null;
         }
@@ -2770,6 +2777,17 @@ if (!gotTheLock) {
       }
     }
     return '127.0.0.1';
+  });
+  ipcMain.handle('im:openclaw:config-schema', async () => {
+    try {
+      const result = await getIMGatewayManager().getOpenClawConfigSchema();
+      return { success: true, result };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to get OpenClaw config schema',
+      };
+    }
   });
 
   // ---- Pairing IPC handlers ----

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -292,6 +292,9 @@ contextBridge.exposeInMainWorld('electron', {
     // Status
     getStatus: () => ipcRenderer.invoke('im:status:get'),
     getLocalIp: () => ipcRenderer.invoke('im:getLocalIp') as Promise<string>,
+    // OpenClaw config schema
+    getOpenClawConfigSchema: () => ipcRenderer.invoke('im:openclaw:config-schema'),
+
 
     // Pairing
     listPairingRequests: (platform: string) => ipcRenderer.invoke('im:pairing:list', platform),

--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -14,6 +14,8 @@ import { i18nService } from '../../services/i18n';
 import type { IMPlatform, IMConnectivityCheck, IMConnectivityTestResult, IMGatewayConfig, TelegramOpenClawConfig, DiscordOpenClawConfig, FeishuOpenClawConfig, DingTalkOpenClawConfig, QQOpenClawConfig, WecomOpenClawConfig, PopoOpenClawConfig } from '../../types/im';
 import { getVisibleIMPlatforms } from '../../utils/regionFilter';
 import WecomAIBotSDK from '@wecom/wecom-aibot-sdk';
+import { SchemaForm } from './SchemaForm';
+import type { UiHint } from './SchemaForm';
 
 // Platform metadata - logos only, labels use i18n
 const platformLogos: Record<IMPlatform, string> = {
@@ -99,6 +101,19 @@ function translateIMError(error: string | null): string {
   return error;
 }
 
+// Helper function to deep-set a value in nested object by dot path
+function deepSet(obj: Record<string, unknown>, path: string, value: unknown): Record<string, unknown> {
+  const keys = path.split('.');
+  const result = { ...obj };
+  let current: Record<string, unknown> = result;
+  for (let i = 0; i < keys.length - 1; i++) {
+    current[keys[i]] = { ...(current[keys[i]] as Record<string, unknown> || {}) };
+    current = current[keys[i]] as Record<string, unknown>;
+  }
+  current[keys[keys.length - 1]] = value;
+  return result;
+}
+
 const IMSettings: React.FC = () => {
   const dispatch = useDispatch();
   const { config, status, isLoading } = useSelector((state: RootState) => state.im);
@@ -118,12 +133,9 @@ const IMSettings: React.FC = () => {
   const [wecomQuickSetupError, setWecomQuickSetupError] = useState<string>('');
   const [localIp, setLocalIp] = useState<string>('');
   const isMountedRef = useRef(true);
-  // Track the last-persisted NIM credentials so we can detect real changes on save
-  const savedNimConfigRef = useRef<{ appKey: string; account: string; token: string }>({
-    appKey: config.nim.appKey,
-    account: config.nim.account,
-    token: config.nim.token,
-  });
+
+  // OpenClaw config schema for schema-driven forms
+  const [openclawSchema, setOpenclawSchema] = useState<{ schema: Record<string, unknown>; uiHints: Record<string, Record<string, unknown>> } | null>(null);
 
   // Subscribe to language changes
   useEffect(() => {
@@ -165,6 +177,10 @@ const IMSettings: React.FC = () => {
     void imService.init().then(() => {
       if (!cancelled) {
         setConfigLoaded(true);
+        // Fetch OpenClaw config schema for schema-driven rendering
+        imService.getOpenClawConfigSchema().then(schema => {
+          if (schema && isMountedRef.current) setOpenclawSchema(schema);
+        });
       }
     });
     return () => {
@@ -173,6 +189,31 @@ const IMSettings: React.FC = () => {
       imService.destroy();
     };
   }, []);
+
+  // Extract NIM channel schema and hints from the full OpenClaw config schema
+  const nimSchemaData = useMemo(() => {
+    if (!openclawSchema) return null;
+    const { schema, uiHints } = openclawSchema;
+
+    // Find the NIM channel key — could be 'nim' or 'openclaw-nim'
+    const channelsProps = (schema as any)?.properties?.channels?.properties ?? {};
+    const channelKey = channelsProps['openclaw-nim'] ? 'openclaw-nim' : channelsProps['nim'] ? 'nim' : null;
+    if (!channelKey) return null;
+
+    const channelSchema = channelsProps[channelKey] as Record<string, unknown>;
+    if (!channelSchema) return null;
+
+    // Filter and strip prefix from uiHints
+    const prefix = `channels.${channelKey}.`;
+    const hints: Record<string, UiHint> = {};
+    for (const [key, value] of Object.entries(uiHints)) {
+      if (key.startsWith(prefix)) {
+        hints[key.slice(prefix.length)] = value as unknown as UiHint;
+      }
+    }
+
+    return { schema: channelSchema, hints };
+  }, [openclawSchema]);
 
   // Handle DingTalk OpenClaw config change
   const dtOpenClawConfig = config.dingtalk;
@@ -265,14 +306,6 @@ const IMSettings: React.FC = () => {
   const [popoAllowedUserIdInput, setPopoAllowedUserIdInput] = useState('');
   const [popoGroupAllowIdInput, setPopoGroupAllowIdInput] = useState('');
 
-  // Handle NIM config change
-  const handleNimChange = (
-    field: 'appKey' | 'account' | 'token' | 'accountWhitelist' | 'teamPolicy' | 'teamAllowlist' | 'qchatEnabled' | 'qchatServerIds',
-    value: string | boolean
-  ) => {
-    dispatch(setNimConfig({ [field]: value }));
-  };
-
   // Handle Xiaomifeng config change
   const handleXiaomifengChange = (field: 'clientId' | 'secret', value: string) => {
     dispatch(setXiaomifengConfig({ [field]: value }));
@@ -342,8 +375,6 @@ const IMSettings: React.FC = () => {
     }
   };
 
-  // Save config on blur — also auto-triggers NIM connectivity test when
-  // the NIM toggle is ON and credential fields have changed.
   const handleSaveConfig = async () => {
     if (!configLoaded) return;
 
@@ -384,35 +415,9 @@ const IMSettings: React.FC = () => {
     }
 
     await imService.updateConfig({ [activePlatform]: config[activePlatform] });
-
-    // Detect NIM credential changes while the gateway is enabled (only for NIM platform)
-    if (activePlatform === 'nim') {
-      const prev = savedNimConfigRef.current;
-      const cur = config.nim;
-      const nimCredentialsChanged =
-        cur.appKey !== prev.appKey ||
-        cur.account !== prev.account ||
-        cur.token !== prev.token;
-
-      // Update the snapshot regardless
-      savedNimConfigRef.current = { appKey: cur.appKey, account: cur.account, token: cur.token };
-
-      if (nimCredentialsChanged && cur.enabled && cur.appKey && cur.account && cur.token) {
-        // Auto-run connectivity test: stop → start → test (silently, no modal)
-        await imService.stopGateway('nim');
-        await imService.startGateway('nim');
-        await runConnectivityTest('nim', { nim: cur } as Partial<IMGatewayConfig>);
-      }
-    }
   };
 
-  // Save NIM config with explicit updated fields (for select/toggle that need immediate save)
-  // This avoids the race condition where Redux state hasn't updated yet
-  const saveNimConfigWithUpdate = async (updates: Partial<typeof config.nim>) => {
-    if (!configLoaded) return;
-    const updatedNimConfig = { ...config.nim, ...updates };
-    await imService.updateConfig({ nim: updatedNimConfig });
-  };
+
 
   const getCheckTitle = (code: IMConnectivityCheck['code']): string => {
     return i18nService.t(`imConnectivityCheckTitle_${code}`);
@@ -543,8 +548,17 @@ const IMSettings: React.FC = () => {
         }
         return;
       }
+      if (platform === 'nim') {
+        const newEnabled = !config.nim.enabled;
+        const success = await imService.updateConfig({ nim: { ...config.nim, enabled: newEnabled } });
+        if (success) {
+          dispatch(setNimConfig({ enabled: newEnabled }));
+          if (newEnabled) dispatch(clearError());
+          await imService.loadStatus();
+        }
+        return;
+      }
 
-      // Non-OpenClaw platforms (nim, xiaomifeng): use startGateway/stopGateway
       const isEnabled = config[platform].enabled;
       const newEnabled = !isEnabled;
 
@@ -731,14 +745,9 @@ const IMSettings: React.FC = () => {
     // The backend's testNimConnectivity already manages the SDK lifecycle
     // (stop main → probe with temp instance → restart main) under a mutex,
     // so doing stop/start here would cause a race condition and potential crash.
-    if (isEnabled && platform !== 'nim') {
-      // For non-OpenClaw platforms (xiaomifeng), restart gateway to pick up latest credentials.
-      // OpenClaw platforms (dingtalk, discord, etc.) are already restarted by im:config:set handler
-      // via syncOpenClawConfig({ restartGatewayIfRunning: true }), so stop/start is redundant.
-      if (platform === 'xiaomifeng') {
-        await imService.stopGateway(platform);
-        await imService.startGateway(platform);
-      }
+    if (isEnabled && platform === 'xiaomifeng') {
+      await imService.stopGateway(platform);
+      await imService.startGateway(platform);
     }
     // When the gateway is OFF we skip stop/start entirely.
     // The main process testGateway → runAuthProbe will spawn an isolated
@@ -2539,7 +2548,6 @@ const IMSettings: React.FC = () => {
         {/* NIM (NetEase IM) Settings */}
         {activePlatform === 'nim' && (
           <div className="space-y-3">
-            {/* How to get NIM credentials */}
             <PlatformGuide
               title={i18nService.t('nimCredentialsGuide')}
               steps={[
@@ -2550,230 +2558,55 @@ const IMSettings: React.FC = () => {
               ]}
             />
 
-            {/* App Key */}
-            <div className="space-y-1.5">
-              <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-                App Key
-              </label>
-              <div className="relative">
-                <input
-                  type="text"
-                  value={config.nim.appKey}
-                  onChange={(e) => handleNimChange('appKey', e.target.value)}
-                  onBlur={handleSaveConfig}
-                  className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-8 text-sm transition-colors"
-                  placeholder="your_app_key"
-                />
-                {config.nim.appKey && (
-                  <div className="absolute right-2 inset-y-0 flex items-center">
-                    <button
-                      type="button"
-                      onClick={() => { handleNimChange('appKey', ''); void imService.updateConfig({ nim: { ...config.nim, appKey: '' } }); }}
-                      className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                      title={i18nService.t('clear') || 'Clear'}
-                    >
-                      <XCircleIconSolid className="h-4 w-4" />
-                    </button>
-                  </div>
-                )}
-              </div>
-              <p className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
-                {i18nService.t('nimAppKeyHint') || '从云信控制台应用信息中获取'}
-              </p>
-            </div>
-
-            {/* Account */}
-            <div className="space-y-1.5">
-              <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-                Account (accid)
-              </label>
-              <div className="relative">
-                <input
-                  type="text"
-                  value={config.nim.account}
-                  onChange={(e) => handleNimChange('account', e.target.value)}
-                  onBlur={handleSaveConfig}
-                  className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-8 text-sm transition-colors"
-                  placeholder={i18nService.t('nimAccountPlaceholder') || 'bot_account_id'}
-                />
-                {config.nim.account && (
-                  <div className="absolute right-2 inset-y-0 flex items-center">
-                    <button
-                      type="button"
-                      onClick={() => { handleNimChange('account', ''); void imService.updateConfig({ nim: { ...config.nim, account: '' } }); }}
-                      className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                      title={i18nService.t('clear') || 'Clear'}
-                    >
-                      <XCircleIconSolid className="h-4 w-4" />
-                    </button>
-                  </div>
-                )}
-              </div>
-              <p className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
-                {i18nService.t('nimAccountHint') || '在云信控制台"账号管理"中创建的 IM 账号 ID'}
-              </p>
-            </div>
-
-            {/* Token */}
-            <div className="space-y-1.5">
-              <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-                Token
-              </label>
-              <div className="relative">
-                <input
-                  type={showSecrets['nim.token'] ? 'text' : 'password'}
-                  value={config.nim.token}
-                  onChange={(e) => handleNimChange('token', e.target.value)}
-                  onBlur={handleSaveConfig}
-                  className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-16 text-sm transition-colors"
-                  placeholder="••••••••••••"
-                />
-                <div className="absolute right-2 inset-y-0 flex items-center gap-1">
-                  {config.nim.token && (
-                    <button
-                      type="button"
-                      onClick={() => { handleNimChange('token', ''); void imService.updateConfig({ nim: { ...config.nim, token: '' } }); }}
-                      className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                      title={i18nService.t('clear') || 'Clear'}
-                    >
-                      <XCircleIconSolid className="h-4 w-4" />
-                    </button>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => setShowSecrets(prev => ({ ...prev, 'nim.token': !prev['nim.token'] }))}
-                    className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                    title={showSecrets['nim.token'] ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
-                  >
-                    {showSecrets['nim.token'] ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
-                  </button>
+            {nimSchemaData ? (
+              <SchemaForm
+                schema={nimSchemaData.schema}
+                hints={nimSchemaData.hints}
+                value={config.nim as unknown as Record<string, unknown>}
+                onChange={(path, value) => {
+                  const updated = deepSet({ ...config.nim } as unknown as Record<string, unknown>, path, value);
+                  dispatch(setNimConfig(updated as any));
+                }}
+                onBlur={handleSaveConfig}
+                showSecrets={showSecrets}
+                onToggleSecret={(path) => setShowSecrets(prev => ({ ...prev, [path]: !prev[path] }))}
+              />
+            ) : (
+              /* Fallback: minimal credential inputs when schema not yet loaded */
+              <div className="space-y-3">
+                <div className="space-y-1.5">
+                  <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">App Key</label>
+                  <input
+                    type="text"
+                    value={config.nim.appKey}
+                    onChange={(e) => dispatch(setNimConfig({ appKey: e.target.value }))}
+                    onBlur={handleSaveConfig}
+                    className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-sm transition-colors"
+                    placeholder="your_app_key"
+                  />
                 </div>
-              </div>
-              <p className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
-                {i18nService.t('nimTokenHint') || '为该账号生成的访问凭证（建议设置为长期有效）'}
-              </p>
-            </div>
-
-            {/* Account Whitelist */}
-            <div className="space-y-1.5">
-              <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-                {i18nService.t('nimAccountWhitelist') || '白名单账号'}
-              </label>
-              <div className="relative">
-                <input
-                  type="text"
-                  value={config.nim.accountWhitelist}
-                  onChange={(e) => handleNimChange('accountWhitelist', e.target.value)}
-                  onBlur={handleSaveConfig}
-                  className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-8 text-sm transition-colors"
-                  placeholder="account1,account2"
-                />
-                {config.nim.accountWhitelist && (
-                  <div className="absolute right-2 inset-y-0 flex items-center">
-                    <button
-                      type="button"
-                      onClick={() => { handleNimChange('accountWhitelist', ''); void imService.updateConfig({ nim: { ...config.nim, accountWhitelist: '' } }); }}
-                      className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                      title={i18nService.t('clear') || 'Clear'}
-                    >
-                      <XCircleIconSolid className="h-4 w-4" />
-                    </button>
-                  </div>
-                )}
-              </div>
-              <p className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
-                {i18nService.t('nimAccountWhitelistHint') || '填写允许与机器人对话的云信账号，多个账号用逗号分隔。留空则不限制，响应所有账号的消息。'}
-              </p>
-            </div>
-
-            {/* Team Policy (群消息策略) */}
-            <div className="space-y-1.5">
-              <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-                {i18nService.t('nimTeamPolicy') || '群消息策略'}
-              </label>
-              <select
-                value={config.nim.teamPolicy || 'disabled'}
-                onChange={(e) => {
-                  const newValue = e.target.value as 'disabled' | 'open' | 'allowlist';
-                  handleNimChange('teamPolicy', newValue);
-                  saveNimConfigWithUpdate({ teamPolicy: newValue });
-                }}
-                className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-sm transition-colors"
-              >
-                <option value="disabled">{i18nService.t('nimTeamPolicyDisabled') || '禁用 - 不响应群消息'}</option>
-                <option value="open">{i18nService.t('nimTeamPolicyOpen') || '开放 - 响应所有群的@消息'}</option>
-                <option value="allowlist">{i18nService.t('nimTeamPolicyAllowlist') || '白名单 - 仅响应指定群的@消息'}</option>
-              </select>
-              <p className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
-                {i18nService.t('nimTeamPolicyHint') || '群消息仅响应@机器人的消息'}
-              </p>
-            </div>
-
-            {/* Team Allowlist - only show when policy is 'allowlist' */}
-            {config.nim.teamPolicy === 'allowlist' && (
-              <div className="space-y-1.5">
-                <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-                  {i18nService.t('nimTeamAllowlist') || '群白名单'}
-                </label>
-                <input
-                  type="text"
-                  value={config.nim.teamAllowlist || ''}
-                  onChange={(e) => handleNimChange('teamAllowlist', e.target.value)}
-                  onBlur={handleSaveConfig}
-                  className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-sm transition-colors"
-                  placeholder="team_id_1,team_id_2"
-                />
-                <p className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
-                  {i18nService.t('nimTeamAllowlistHint') || '填写允许响应的群ID，多个用逗号分隔'}
-                </p>
-              </div>
-            )}
-
-            {/* QChat Enable Toggle */}
-            <div className="flex items-center justify-between py-2">
-              <div>
-                <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-                  {i18nService.t('nimQChatEnabled') || '启用圈组 (QChat)'}
-                </label>
-                <p className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary mt-0.5">
-                  {i18nService.t('nimQChatEnabledHint') || '订阅圈组消息，仅响应@机器人的消息'}
-                </p>
-              </div>
-              <div
-                className={`w-10 h-5 rounded-full flex items-center transition-colors cursor-pointer ${
-                  config.nim.qchatEnabled ? 'bg-green-500' : 'dark:bg-claude-darkBorder bg-claude-border'
-                }`}
-                onClick={() => {
-                  const newValue = !config.nim.qchatEnabled;
-                  handleNimChange('qchatEnabled', newValue);
-                  saveNimConfigWithUpdate({ qchatEnabled: newValue });
-                }}
-              >
-                <div
-                  className={`w-4 h-4 rounded-full bg-white shadow-md transform transition-transform ${
-                    config.nim.qchatEnabled ? 'translate-x-5' : 'translate-x-0.5'
-                  }`}
-                />
-              </div>
-            </div>
-
-            {/* QChat Server IDs - only show when QChat is enabled */}
-            {config.nim.qchatEnabled && (
-              <div className="space-y-1.5">
-                <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-                  {i18nService.t('nimQChatServerIds') || '圈组服务器 ID'}
-                </label>
-                <input
-                  type="text"
-                  value={config.nim.qchatServerIds || ''}
-                  onChange={(e) => handleNimChange('qchatServerIds', e.target.value)}
-                  onBlur={handleSaveConfig}
-                  className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-sm transition-colors"
-                  placeholder={i18nService.t('nimQChatServerIdsPlaceholder') || '留空自动发现所有已加入的服务器'}
-                />
-                <p className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
-                  {i18nService.t('nimQChatServerIdsHint') || '指定要订阅的服务器 ID，多个用逗号分隔。留空则自动订阅所有已加入的服务器。'}
-                </p>
+                <div className="space-y-1.5">
+                  <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">Account</label>
+                  <input
+                    type="text"
+                    value={config.nim.account}
+                    onChange={(e) => dispatch(setNimConfig({ account: e.target.value }))}
+                    onBlur={handleSaveConfig}
+                    className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-sm transition-colors"
+                    placeholder="bot_account_id"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">Token</label>
+                  <input
+                    type="password"
+                    value={config.nim.token}
+                    onChange={(e) => dispatch(setNimConfig({ token: e.target.value }))}
+                    onBlur={handleSaveConfig}
+                    className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-sm transition-colors"
+                    placeholder="••••••••••••"
+                  />
+                </div>
               </div>
             )}
 
@@ -2781,17 +2614,15 @@ const IMSettings: React.FC = () => {
               {renderConnectivityTestButton('nim')}
             </div>
 
-            {/* Bot account display */}
             {status.nim.botAccount && (
               <div className="text-xs text-green-600 dark:text-green-400 bg-green-500/10 px-3 py-2 rounded-lg">
                 Account: {status.nim.botAccount}
               </div>
             )}
 
-            {/* Error display */}
             {status.nim.lastError && (
               <div className="text-xs text-red-500 bg-red-500/10 px-3 py-2 rounded-lg">
-                {status.nim.lastError}
+                {translateIMError(status.nim.lastError)}
               </div>
             )}
           </div>

--- a/src/renderer/components/im/SchemaForm.tsx
+++ b/src/renderer/components/im/SchemaForm.tsx
@@ -1,0 +1,303 @@
+/**
+ * Schema-driven form component
+ * Renders form fields dynamically from JSON Schema + uiHints
+ */
+
+import React from 'react';
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
+import { XCircleIcon as XCircleIconSolid, ChevronRightIcon } from '@heroicons/react/20/solid';
+
+/** A single uiHint entry from the gateway */
+export interface UiHint {
+  order: number;
+  label: string;
+  sensitive?: boolean;
+  advanced?: boolean;
+}
+
+/** Props for SchemaForm */
+export interface SchemaFormProps {
+  /** JSON Schema for this channel (the `properties` object from `schema.properties.channels.properties.<channel>`) */
+  schema: Record<string, unknown>;
+  /** uiHints entries, already stripped of the `channels.<id>.` prefix. Keys are relative dot paths like 'appKey', 'p2p.policy', etc. */
+  hints: Record<string, UiHint>;
+  /** Current config value (nested object matching the schema) */
+  value: Record<string, unknown>;
+  /** Called when any field changes. Path is dot-notation ('p2p.policy'), value is the new value. */
+  onChange: (path: string, value: unknown) => void;
+  /** Called on field blur (for save-on-blur) */
+  onBlur?: () => void;
+  /** Map of dot-paths to show/hide state for sensitive fields */
+  showSecrets?: Record<string, boolean>;
+  /** Toggle secret field visibility */
+  onToggleSecret?: (path: string) => void;
+}
+
+/** Deep-get a value from nested object by dot path */
+function deepGet(obj: Record<string, unknown>, path: string): unknown {
+  return path.split('.').reduce((o, k) => (o && typeof o === 'object' ? (o as Record<string, unknown>)[k] : undefined), obj as unknown);
+}
+
+
+
+/** Get JSON Schema property descriptor at a dot path */
+function getSchemaProperty(schema: Record<string, unknown>, path: string): Record<string, unknown> | null {
+  const keys = path.split('.');
+  let current = schema;
+  for (const key of keys) {
+    const props = (current.properties || current) as Record<string, unknown>;
+    const next = props[key] as Record<string, unknown> | undefined;
+    if (!next) return null;
+    current = next;
+  }
+  return current;
+}
+
+export const SchemaForm: React.FC<SchemaFormProps> = ({
+  schema,
+  hints,
+  value,
+  onChange,
+  onBlur,
+  showSecrets = {},
+  onToggleSecret,
+}) => {
+  // Identify groups and fields
+  const groups: string[] = [];
+  const topLevelFields: string[] = [];
+
+  // Sort all hint keys by order
+  const sortedKeys = Object.keys(hints).sort((a, b) => hints[a].order - hints[b].order);
+
+  for (const key of sortedKeys) {
+    // Skip 'enabled' field
+    if (key === 'enabled') continue;
+
+    // Check if it's a group (no dot + type: "object")
+    if (!key.includes('.')) {
+      const schemaProp = getSchemaProperty(schema, key);
+      if (schemaProp && schemaProp.type === 'object') {
+        groups.push(key);
+      } else {
+        topLevelFields.push(key);
+      }
+    }
+  }
+
+  // Render a single field
+  const renderField = (path: string, hint: UiHint): React.ReactNode => {
+    const schemaProp = getSchemaProperty(schema, path);
+    if (!schemaProp) return null;
+
+    const fieldValue = deepGet(value, path);
+    const handleChange = (newValue: unknown) => {
+      onChange(path, newValue);
+    };
+
+    const type = schemaProp.type as string;
+    const enumValues = schemaProp.enum as string[] | undefined;
+    const isBoolean = type === 'boolean';
+
+    // Conditional visibility for allowFrom fields
+    if (path.endsWith('.allowFrom')) {
+      const policyPath = path.replace('.allowFrom', '.policy');
+      const policyValue = deepGet(value, policyPath);
+      if (policyValue !== 'allowlist') return null;
+    }
+
+    // Boolean toggle
+    if (isBoolean) {
+      const boolValue = Boolean(fieldValue);
+      return (
+        <div key={path} className="flex items-center justify-between py-1">
+          <label className="text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
+            {hint.label}
+          </label>
+          <div
+            className={`w-10 h-5 rounded-full flex items-center transition-colors cursor-pointer ${
+              boolValue ? 'bg-green-500' : 'dark:bg-claude-darkBorder bg-claude-border'
+            }`}
+            onClick={() => handleChange(!boolValue)}
+          >
+            <div
+              className={`w-4 h-4 rounded-full bg-white shadow-md transform transition-transform ${
+                boolValue ? 'translate-x-5' : 'translate-x-0.5'
+              }`}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    // String with enum → select
+    if (type === 'string' && enumValues) {
+      return (
+        <div key={path} className="space-y-1.5">
+          <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
+            {hint.label}
+          </label>
+          <select
+            value={String(fieldValue || '')}
+            onChange={(e) => handleChange(e.target.value)}
+            onBlur={onBlur}
+            className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-sm transition-colors"
+          >
+            {enumValues.map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </div>
+      );
+    }
+
+    // String with sensitive → password with show/hide
+    if (type === 'string' && hint.sensitive) {
+      const shown = showSecrets[path] || false;
+      const strValue = String(fieldValue || '');
+      return (
+        <div key={path} className="space-y-1.5">
+          <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
+            {hint.label}
+          </label>
+          <div className="relative">
+            <input
+              type={shown ? 'text' : 'password'}
+              value={strValue}
+              onChange={(e) => handleChange(e.target.value)}
+              onBlur={onBlur}
+              className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-16 text-sm transition-colors"
+              placeholder="••••••••••••"
+            />
+            <div className="absolute right-2 inset-y-0 flex items-center gap-1">
+              {strValue && (
+                <button
+                  type="button"
+                  onClick={() => handleChange('')}
+                  className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
+                  title="Clear"
+                >
+                  <XCircleIconSolid className="h-4 w-4" />
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => onToggleSecret?.(path)}
+                className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
+              >
+                {shown ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // String → text input
+    if (type === 'string') {
+      const strValue = String(fieldValue || '');
+      return (
+        <div key={path} className="space-y-1.5">
+          <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
+            {hint.label}
+          </label>
+          <div className="relative">
+            <input
+              type="text"
+              value={strValue}
+              onChange={(e) => handleChange(e.target.value)}
+              onBlur={onBlur}
+              className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-8 text-sm transition-colors"
+            />
+            {strValue && (
+              <div className="absolute right-2 inset-y-0 flex items-center">
+                <button
+                  type="button"
+                  onClick={() => handleChange('')}
+                  className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
+                  title="Clear"
+                >
+                  <XCircleIconSolid className="h-4 w-4" />
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    // Array → textarea (one line per entry)
+    if (type === 'array') {
+      const arrValue = Array.isArray(fieldValue) ? fieldValue.map(String).join('\n') : '';
+      return (
+        <div key={path} className="space-y-1.5">
+          <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
+            {hint.label}
+          </label>
+          <textarea
+            value={arrValue}
+            onChange={(e) => {
+              const lines = e.target.value.split('\n').map((s) => s.trim()).filter(Boolean);
+              handleChange(lines);
+            }}
+            onBlur={onBlur}
+            className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-sm transition-colors min-h-[60px] resize-y"
+          />
+        </div>
+      );
+    }
+
+    // Number / integer → number input
+    if (type === 'number' || type === 'integer') {
+      const numValue = typeof fieldValue === 'number' ? fieldValue : '';
+      return (
+        <div key={path} className="space-y-1.5">
+          <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
+            {hint.label}
+          </label>
+          <input
+            type="number"
+            value={numValue}
+            onChange={(e) => handleChange(e.target.value ? Number(e.target.value) : undefined)}
+            onBlur={onBlur}
+            className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-sm transition-colors"
+          />
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  // Render a group (collapsible section)
+  const renderGroup = (groupKey: string): React.ReactNode => {
+    const groupHint = hints[groupKey];
+    if (!groupHint) return null;
+
+    // Find all child fields
+    const childFields = sortedKeys.filter((key) => key.startsWith(`${groupKey}.`) && key.split('.').length === 2);
+
+    return (
+      <details key={groupKey} className="group">
+        <summary className="flex items-center gap-1.5 cursor-pointer text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary select-none py-1">
+          <ChevronRightIcon className="h-3.5 w-3.5 transition-transform group-open:rotate-90" />
+          {groupHint.label}
+        </summary>
+        <div className="space-y-3 mt-2 ml-1 pl-3 border-l-2 border-claude-border/30 dark:border-claude-darkBorder/30">
+          {childFields.map((field) => renderField(field, hints[field]))}
+        </div>
+      </details>
+    );
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Top-level fields */}
+      {topLevelFields.map((field) => renderField(field, hints[field]))}
+
+      {/* Groups */}
+      {groups.map((group) => renderGroup(group))}
+    </div>
+  );
+};

--- a/src/renderer/services/im.ts
+++ b/src/renderer/services/im.ts
@@ -243,6 +243,21 @@ class IMService {
   async rejectPairingRequest(platform: string, code: string) {
     return window.electron.im.rejectPairingRequest(platform, code);
   }
+
+  /**
+   * Fetch the OpenClaw config schema (JSON Schema + uiHints) from the gateway.
+   */
+  async getOpenClawConfigSchema(): Promise<{ schema: Record<string, unknown>; uiHints: Record<string, Record<string, unknown>> } | null> {
+    try {
+      const result = await window.electron.im.getOpenClawConfigSchema();
+      if (result.success && result.result) {
+        return result.result;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
 }
 
 export const imService = new IMService();

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -386,6 +386,7 @@ interface IElectronAPI {
     ) => Promise<{ success: boolean; result?: IMConnectivityTestResult; error?: string }>;
     getStatus: () => Promise<{ success: boolean; status?: IMGatewayStatus; error?: string }>;
     getLocalIp: () => Promise<string>;
+    getOpenClawConfigSchema: () => Promise<{ success: boolean; result?: { schema: Record<string, unknown>; uiHints: Record<string, Record<string, unknown>> }; error?: string }>;
     listPairingRequests: (platform: string) => Promise<{
       success: boolean;
       requests: Array<{ id: string; code: string; createdAt: string; lastSeenAt: string; meta?: Record<string, string> }>;
@@ -529,19 +530,36 @@ interface DiscordOpenClawConfig {
   debug: boolean;
 }
 
+interface NimP2pConfig {
+  policy: 'open' | 'allowlist' | 'disabled';
+  allowFrom?: (string | number)[];
+}
+
+interface NimTeamConfig {
+  policy: 'open' | 'allowlist' | 'disabled';
+  allowFrom?: (string | number)[];
+}
+
+interface NimQChatConfig {
+  policy: 'open' | 'allowlist' | 'disabled';
+  allowFrom?: (string | number)[];
+}
+
+interface NimAdvancedConfig {
+  mediaMaxMb?: number;
+  textChunkLimit?: number;
+  debug?: boolean;
+}
+
 interface NimConfig {
   enabled: boolean;
   appKey: string;
   account: string;
   token: string;
-  accountWhitelist: string;
-  debug?: boolean;
-  // 群组消息配置
-  teamPolicy?: 'open' | 'allowlist' | 'disabled';
-  teamAllowlist?: string;
-  // QChat 圈组配置
-  qchatEnabled?: boolean;
-  qchatServerIds?: string;
+  p2p?: NimP2pConfig;
+  team?: NimTeamConfig;
+  qchat?: NimQChatConfig;
+  advanced?: NimAdvancedConfig;
 }
 
 interface XiaomifengConfig {

--- a/src/renderer/types/im.ts
+++ b/src/renderer/types/im.ts
@@ -137,19 +137,36 @@ export interface DiscordGatewayStatus {
 
 export type NimTeamPolicy = 'open' | 'allowlist' | 'disabled';
 
+export interface NimP2pConfig {
+  policy: 'open' | 'allowlist' | 'disabled';
+  allowFrom?: (string | number)[];
+}
+
+export interface NimTeamConfig {
+  policy: 'open' | 'allowlist' | 'disabled';
+  allowFrom?: (string | number)[];
+}
+
+export interface NimQChatConfig {
+  policy: 'open' | 'allowlist' | 'disabled';
+  allowFrom?: (string | number)[];
+}
+
+export interface NimAdvancedConfig {
+  mediaMaxMb?: number;
+  textChunkLimit?: number;
+  debug?: boolean;
+}
+
 export interface NimConfig {
   enabled: boolean;
   appKey: string;
   account: string;
   token: string;
-  accountWhitelist: string;
-  debug?: boolean;
-  // 群组消息配置
-  teamPolicy?: NimTeamPolicy;      // 群消息策略，默认 'disabled'
-  teamAllowlist?: string;          // 逗号分隔的群 ID 白名单
-  // QChat 圈组配置
-  qchatEnabled?: boolean;          // 是否启用圈组
-  qchatServerIds?: string;         // 逗号分隔的服务器 ID，空则自动发现
+  p2p?: NimP2pConfig;
+  team?: NimTeamConfig;
+  qchat?: NimQChatConfig;
+  advanced?: NimAdvancedConfig;
 }
 
 export interface NimGatewayStatus {
@@ -453,8 +470,6 @@ export const DEFAULT_NIM_CONFIG: NimConfig = {
   appKey: '',
   account: '',
   token: '',
-  accountWhitelist: '',
-  debug: true,
 };
 
 export const DEFAULT_XIAOMIFENG_CONFIG: XiaomifengConfig = {


### PR DESCRIPTION
…itecture

Migrate the NIM (NetEase IM) channel from a locally-managed native SDK gateway to running through the OpenClaw runtime plugin (`openclaw-nim`), aligning it with the existing pattern used by DingTalk, Feishu, Telegram, Discord, QQ, and WeCom channels.

Key changes:
- **OpenClaw plugin registration**: Add `openclaw-nim@0.3.0` to `package.json` channel plugins; register `nim` in channel-platform maps and config sync.
- **Gateway manager**: Remove direct NIM SDK lifecycle management (start/stop, reconnect, event forwarding, credential hot-reload, probe mutex). NIM now delegates to OpenClaw gateway via `syncOpenClawConfig` / `ensureOpenClawGatewayConnected`, matching other OpenClaw channels. Add `testNimOpenClawConnectivity()` for config-level validation. Expose `getOpenClawConfigSchema()` to retrieve JSON Schema + uiHints from gateway.
- **NimConfig restructuring**: Replace flat config fields (`accountWhitelist`, `teamPolicy`, `teamAllowlist`, `qchatEnabled`, `qchatServerIds`, `debug`) with structured sub-objects (`p2p`, `team`, `qchat`, `advanced`), each using `{ policy, allowFrom }` pattern. Update `nimGateway.ts` to consume the new shape.
- **Schema-driven settings UI**: Add `SchemaForm.tsx` — a generic component that dynamically renders form fields from JSON Schema + uiHints. Replace the ~230 lines of hardcoded NIM settings fields in `IMSettings.tsx` with a `SchemaForm` instance driven by the OpenClaw config schema at runtime.
- **IPC + service plumbing**: Add `im:openclaw:config-schema` IPC channel, preload binding, renderer service method, and TypeScript declarations for the new schema API and restructured NIM types.