### PR TITLE
fix: 修复打包 Python 运行 pip 失败

### DIFF
--- a/scripts/setup-python-runtime.js
+++ b/scripts/setup-python-runtime.js
@@ -283,8 +283,15 @@ async function ensurePipPayload(rootDir, options = {}) {
     "pip_pyz = root / 'tools' / 'pip.pyz'",
     'if not pip_pyz.exists():',
     "    raise SystemExit(f'pip runtime archive missing: {pip_pyz}')",
+    '',
+    '# Ensure pip imports resolve to the zipapp payload, not this shim package.',
+    'sys.path.insert(0, str(pip_pyz))',
+    'for name in list(sys.modules):',
+    "    if name == 'pip' or name.startswith('pip.'):",
+    '        del sys.modules[name]',
+    '',
     "sys.argv[0] = 'pip'",
-    "runpy.run_path(str(pip_pyz), run_name='__main__')",
+    "runpy.run_module('pip', run_name='__main__', alter_sys=True)",
     '',
   ].join('\n');
 


### PR DESCRIPTION
在 Windows 环境下通过setup-python-runtime构建的 Python 包，通过 pip 安装库时会出现递归错误：RecursionError: maximum recursion depth exceeded，导致某些技能（SKILLs）无法正常调用。