### PR TITLE
fix: disable Vite usePolling to reduce dev-mode CPU usage

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
       port: devPort,
     },
     watch: {
-      usePolling: true,
+      usePolling: false,
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- Disable `usePolling` in Vite dev server config (`vite.config.ts`) to reduce CPU usage during development
- Polling-based file watching causes unnecessary CPU overhead; native filesystem watchers are sufficient for most environments

## Test plan
- [ ] Run `npm run dev` and verify hot-reload still works correctly
- [ ] Confirm CPU usage is lower compared to the polling-based approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)