### PR TITLE
fix: resolve gateway PATH case-sensitivity issue on Windows

### DIFF
--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -388,7 +388,10 @@ export class OpenClawEngineManager extends EventEmitter {
       LOBSTERAI_OPENCLAW_ENTRY: openclawEntry.replace(/\\/g, '/'),
     };
     if (cliShimDir) {
-      env.PATH = [cliShimDir, env.PATH].filter(Boolean).join(path.delimiter);
+      // Plain object is case-sensitive: the spread key from process.env on Windows is "Path",
+      // not "PATH". We must read the actual key to avoid creating a PATH with only cliShimDir.
+      const currentPath = env.PATH || env.Path || '';
+      env.PATH = [cliShimDir, currentPath].filter(Boolean).join(path.delimiter);
     }
 
     if (isSystemProxyEnabled()) {


### PR DESCRIPTION
## Summary
- Fix PATH environment variable case-sensitivity issue when spawning the gateway process on Windows
- On Windows, `process.env` uses `Path` (not `PATH`). The spread into a plain object loses case-insensitive lookup, so `env.PATH` was `undefined`, causing `cliShimDir` to be the only entry and breaking tool resolution
- Now reads from both `env.PATH` and `env.Path` to handle Windows correctly

## Test plan
- [ ] Verify gateway process starts correctly on Windows with all expected PATH entries
- [ ] Confirm CLI shim tools are still resolved properly on both Windows and macOS/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)