### PR TITLE
feat: add dedicated webchat agent with trimmed tool set

### DIFF
--- a/src/main/im/imDeliveryRoute.ts
+++ b/src/main/im/imDeliveryRoute.ts
@@ -2,6 +2,7 @@ import {
   buildManagedSessionKey,
   DEFAULT_MANAGED_AGENT_ID,
 } from '../libs/openclawChannelSessionSync';
+import { WEBCHAT_AGENT_ID } from '../libs/openclawConfigSync';
 
 export interface OpenClawDeliveryRoute {
   channel: string;
@@ -102,7 +103,16 @@ export function resolveManagedSessionDeliveryRoute(
   coworkSessionId: string,
   sessions: unknown[],
 ): { sessionKey: string; route: OpenClawDeliveryRoute } | null {
-  return resolveOpenClawDeliveryRouteForSessionKeys([buildManagedSessionKey(coworkSessionId)], sessions);
+  // Try the webchat agent first (current default), then fall back to the
+  // legacy "main" agent so that older sessions created before the webchat
+  // agent migration still resolve correctly.
+  return resolveOpenClawDeliveryRouteForSessionKeys(
+    [
+      buildManagedSessionKey(coworkSessionId, WEBCHAT_AGENT_ID),
+      buildManagedSessionKey(coworkSessionId, DEFAULT_MANAGED_AGENT_ID),
+    ],
+    sessions,
+  );
 }
 
 export function buildDingTalkSendParamsFromRoute(

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -22,6 +22,7 @@ import {
   isManagedSessionKey,
   parseManagedSessionKey,
 } from '../openclawChannelSessionSync';
+import { WEBCHAT_AGENT_ID } from '../openclawConfigSync';
 import {
   extractGatewayHistoryEntries,
   extractGatewayMessageText,
@@ -3392,7 +3393,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   private toSessionKey(sessionId: string): string {
-    return buildManagedSessionKey(sessionId);
+    return buildManagedSessionKey(sessionId, WEBCHAT_AGENT_ID);
   }
 
   private requireGatewayClient(): GatewayClientLike {

--- a/src/main/libs/coworkOpenAICompatProxy.ts
+++ b/src/main/libs/coworkOpenAICompatProxy.ts
@@ -909,43 +909,6 @@ function readRequestBody(req: http.IncomingMessage): Promise<string> {
         return '';
       }
 
-      const collectStringValues = (input: unknown, out: string[]): void => {
-        if (typeof input === 'string') {
-          out.push(input);
-          return;
-        }
-        if (Array.isArray(input)) {
-          for (const item of input) collectStringValues(item, out);
-          return;
-        }
-        if (input && typeof input === 'object') {
-          for (const value of Object.values(input as Record<string, unknown>)) {
-            collectStringValues(value, out);
-          }
-        }
-      };
-
-      const scoreDecodedJsonText = (text: string): number => {
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(text);
-        } catch {
-          return -10000;
-        }
-
-        const values: string[] = [];
-        collectStringValues(parsed, values);
-        const joined = values.join('\n');
-        if (!joined) return 0;
-
-        const cjkCount = (joined.match(/[\u3400-\u9FFF]/g) || []).length;
-        const replacementCount = (joined.match(/\uFFFD/g) || []).length;
-        const mojibakeCount = (joined.match(/[ÃÂÐÑØÙÞæçèéêëìíîïðñòóôõöøùúûüýþÿ]/g) || []).length;
-        const nonAsciiCount = (joined.match(/[^\x00-\x7F]/g) || []).length;
-
-        return cjkCount * 4 + nonAsciiCount - replacementCount * 8 - mojibakeCount * 3;
-      };
-
       // BOM-aware decoding first.
       if (raw.length >= 3 && raw[0] === 0xef && raw[1] === 0xbb && raw[2] === 0xbf) {
         return new TextDecoder('utf-8', { fatal: false }).decode(raw.subarray(3));
@@ -976,18 +939,13 @@ function readRequestBody(req: http.IncomingMessage): Promise<string> {
         }
 
         if (utf8Decoded && gbDecoded) {
-          const utf8Score = scoreDecodedJsonText(utf8Decoded);
-          const gbScore = scoreDecodedJsonText(gbDecoded);
-          // Require GB18030 to score significantly higher than UTF-8 to avoid
-          // false positives on short CJK strings (e.g. "你好" scores UTF-8=10
-          // vs GB18030=11 due to one extra non-ASCII char from misaligned
-          // multi-byte boundaries).  UTF-8 is the overwhelmingly expected
-          // encoding, so give it a comfortable margin.
-          const GB18030_SCORE_MARGIN = 5;
-          if (gbScore > utf8Score + GB18030_SCORE_MARGIN) {
-            console.warn(`[CoworkProxy] Decoded request body using gb18030 (score ${gbScore} > utf8 ${utf8Score} + ${GB18030_SCORE_MARGIN})`);
-            return gbDecoded;
-          }
+          // UTF-8 strict decode succeeded → the bytes ARE valid UTF-8.
+          // Genuine GB18030 CJK byte sequences (first byte 0xB0-0xF7,
+          // second byte 0xA1-0xFE) are almost never valid UTF-8, so if
+          // strict UTF-8 passes the body is overwhelmingly UTF-8.
+          // The previous scoring heuristic could false-positive on longer
+          // CJK strings where GB18030 reinterpretation also yields CJK
+          // characters with comparable scores.
           return utf8Decoded;
         }
 

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -6,7 +6,7 @@ import type { TelegramOpenClawConfig, DiscordOpenClawConfig } from '../im/types'
 import type { DingTalkOpenClawConfig, FeishuOpenClawConfig, QQOpenClawConfig, WecomOpenClawConfig, PopoOpenClawConfig } from '../im/types';
 import { resolveRawApiConfig } from './claudeSettings';
 import type { OpenClawEngineManager } from './openclawEngineManager';
-import { parseChannelSessionKey } from './openclawChannelSessionSync';
+import { isManagedSessionKey, parseChannelSessionKey } from './openclawChannelSessionSync';
 import type { McpToolManifestEntry } from './mcpServerManager';
 import { hasBundledOpenClawExtension } from './openclawLocalExtensions';
 import { buildScheduledTaskEnginePrompt } from './scheduledTaskEnginePrompt';
@@ -49,6 +49,14 @@ const MANAGED_OWNER_ALLOW_FROM = [
 ];
 
 const MANAGED_TOOL_DENY = ['web_search'] as const;
+
+/**
+ * Agent ID used for webchat sessions originating from the LobsterAI UI.
+ * Webchat sessions use a dedicated agent with a trimmed tool set so that
+ * IM-specific plugin tools (Feishu, MCP bridge, etc.) are not loaded,
+ * significantly reducing system prompt token consumption.
+ */
+export const WEBCHAT_AGENT_ID = 'webchat';
 
 const MANAGED_SKILL_ENTRY_OVERRIDES: Record<string, { enabled: boolean }> = {
   // QQ plugin ships a legacy reminder skill that steers the model toward a
@@ -541,6 +549,31 @@ export class OpenClawConfigSync {
           },
           ...(workspaceDir ? { workspace: workspaceDir } : {}),
         },
+        list: [
+          {
+            id: 'main',
+            default: true,
+            // IM channel sessions keep the full tool set.
+          },
+          {
+            id: WEBCHAT_AGENT_ID,
+            // Share the same workspace as main so AGENTS.md, MEMORY.md, etc.
+            // are discovered correctly. Without this, non-default agents fall
+            // back to {STATE_DIR}/workspace-{agentId}/ which is empty.
+            ...(workspaceDir ? { workspace: workspaceDir } : {}),
+            // Webchat sessions deny IM plugin tools that register actual tools,
+            // saving ~11K tokens from the system prompt.
+            // Only feishu (33 tools) and wecom (1 tool) register tools;
+            // other IM plugins (dingtalk, qqbot, popo) are channel-only adapters.
+            // MCP bridge tools are kept available for desktop use.
+            tools: {
+              deny: [
+                'feishu-openclaw-plugin',
+                'wecom-openclaw-plugin',
+              ],
+            },
+          },
+        ],
       },
       session: {
         dmScope: 'per-channel-peer',
@@ -941,7 +974,7 @@ export class OpenClawConfigSync {
         }
       }
 
-      if (!shouldMigrateManagedModelRefs || !sessionKey.startsWith('agent:main:lobsterai:')) {
+      if (!shouldMigrateManagedModelRefs || !isManagedSessionKey(sessionKey)) {
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Add a dedicated `webchat` agent ID for LobsterAI UI sessions with a trimmed tool set, denying IM-specific plugin tools (feishu, wecom) that are unnecessary for webchat, saving ~11K system prompt tokens
- Simplify proxy encoding detection by always preferring UTF-8 when strict decode succeeds, removing the scoring heuristic that could false-positive on longer CJK strings
- Update managed session routing to try webchat agent first, then fall back to legacy main agent for backward compatibility

## Test plan
- [ ] Verify webchat sessions use the new `webchat` agent and do not load feishu/wecom plugin tools
- [ ] Verify existing IM channel sessions still use the `main` agent with full tool set
- [ ] Verify older sessions created before the webchat agent migration still resolve correctly
- [ ] Test proxy request body decoding with UTF-8 and GB18030 encoded CJK content

🤖 Generated with [Claude Code](https://claude.com/claude-code)