### PR TITLE
fix: prevent channel sync loop and history burst from forward-match false positives

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -2727,14 +2727,23 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       }
     }
 
-    // When cursor >= historyEntries.length, the gateway hasn't produced new entries
-    // since our last sync.  tail-overlap and last-user-anchor (above) are the correct
-    // strategies for detecting a sliding history window; if both failed the mismatch
-    // is caused by duplicates in the local store, not by genuinely new messages.
-    // Trust the cursor here to prevent forward-match from producing false positives
-    // that would create an infinite re-sync loop.
-    if (cursor >= historyEntries.length) {
-      return { firstNewIdx: historyEntries.length, strategy: 'cursor-stable' };
+    // When cursor > 0, tail-overlap and last-user-anchor (above) are the correct
+    // content-based strategies for detecting a sliding history window.  If both
+    // failed the mismatch is caused by duplicates in the local store, not by
+    // genuinely new gateway messages.  Trust the cursor — it was set to
+    // historyEntries.length at the end of the previous sync — instead of falling
+    // through to forward-match, which can produce wildly wrong firstNewIdx values
+    // when local entries are polluted (causing either an infinite re-sync loop
+    // when cursor == historyEntries.length, or a burst of old messages being
+    // re-synced when cursor < historyEntries.length).
+    //
+    // forward-match is still used when cursor == 0 (initial sync / after restart)
+    // because there is no cursor history to rely on.
+    if (cursor > 0) {
+      if (cursor >= historyEntries.length) {
+        return { firstNewIdx: historyEntries.length, strategy: 'cursor-stable' };
+      }
+      return { firstNewIdx: cursor, strategy: 'cursor-fallback' };
     }
 
     let localIdx = 0;


### PR DESCRIPTION
## Summary

Fixes two related bugs in DingTalk (and other channel) message sync, both caused by `forward-match` producing incorrect `firstNewIdx` when the local store contains duplicate entries:

- **Bug 1 — Infinite sync loop**: When `cursor >= historyEntries.length` (no new gateway messages), `forward-match` still found a lower `firstNewIdx`, causing the same user message to be re-synced every 10-second poll cycle. Visible as the same message repeating endlessly in the UI.

- **Bug 2 — History message burst**: When a genuinely new message arrived (`cursor < historyEntries.length`), `forward-match` returned a very low `firstNewIdx` (e.g. 12 instead of 38), causing up to 15 old user messages to be re-synced in a single burst.

**Root cause**: `forward-match` sequentially compares `localEntries[0..N]` against `historyEntries[0..M]`. When the local store has been polluted with duplicate entries (from Bug 1 or from streaming/history format mismatches), the sequential matching breaks early, producing a falsely low continuation point.

## Fix

When `cursor > 0` (i.e., not the initial sync), prefer the cursor over `forward-match` as the continuation point. The cursor is reliably set to `historyEntries.length` at the end of each sync cycle. Content-based strategies (`tail-overlap`, `last-user-anchor`) remain the primary methods for detecting sliding history windows and are tried first.

`forward-match` is now only used when `cursor == 0` (initial sync or after app restart).

## Test plan

- [ ] Connect DingTalk bot, alternate sending messages from mobile and desktop
- [ ] Verify no repeated messages appear in the desktop UI
- [ ] Verify sending a new message from mobile after extended idle doesn't cause old messages to burst
- [ ] Check logs: expect `cursor-stable` (no new messages) or `cursor-fallback` (new messages), no `forward-match` during normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)