### PR TITLE
fix(cowork): prevent EPERM on Windows drive root workspace and surfac…

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -33,7 +33,9 @@ const mapApiTypeToOpenClawApi = (apiType: 'anthropic' | 'openai' | undefined): '
 };
 
 const ensureDir = (dirPath: string): void => {
-  fs.mkdirSync(dirPath, { recursive: true });
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
 };
 
 const normalizeModelName = (modelId: string): string => {
@@ -551,7 +553,7 @@ export class OpenClawConfigSync {
           sandbox: {
             mode: sandboxMode,
           },
-          ...(workspaceDir ? { workspace: workspaceDir } : {}),
+          ...(workspaceDir ? { workspace: path.resolve(workspaceDir) } : {}),
         },
       },
       session: {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -268,7 +268,14 @@ const normalizeCaptureRect = (rect?: Partial<CaptureRect> | null): CaptureRect |
 
 const resolveTaskWorkingDirectory = (workspaceRoot: string): string => {
   const resolvedWorkspaceRoot = path.resolve(workspaceRoot);
-  fs.mkdirSync(resolvedWorkspaceRoot, { recursive: true });
+  // Reject bare Windows drive roots (e.g. "D:\") — mkdir on drive roots causes EPERM,
+  // and some agent engines (OpenClaw) also fail when given a drive root as workspace.
+  if (process.platform === 'win32' && /^[a-zA-Z]:\\?$/.test(resolvedWorkspaceRoot)) {
+    throw new Error(`Cannot use a drive root as the working directory (${resolvedWorkspaceRoot}). Please select a subfolder instead, for example: ${resolvedWorkspaceRoot}Projects`);
+  }
+  if (!fs.existsSync(resolvedWorkspaceRoot)) {
+    fs.mkdirSync(resolvedWorkspaceRoot, { recursive: true });
+  }
   if (!fs.statSync(resolvedWorkspaceRoot).isDirectory()) {
     throw new Error(`Selected workspace is not a directory: ${resolvedWorkspaceRoot}`);
   }
@@ -2574,6 +2581,12 @@ if (!gotTheLock) {
 
   ipcMain.handle('scheduledTask:list', async () => {
     try {
+      // If OpenClaw gateway is not connected yet, return empty list immediately
+      // to avoid blocking the renderer init. Tasks will be loaded later via the
+      // onRefresh listener when the gateway becomes available.
+      if (!openClawRuntimeAdapter?.getGatewayClient()) {
+        return { success: true, tasks: [] };
+      }
       const tasks = await getCronJobService().listJobs();
       return { success: true, tasks };
     } catch (error) {
@@ -3772,7 +3785,14 @@ if (!gotTheLock) {
       console.error('[OpenClaw] Startup config sync failed:', startupSync.error);
     }
     if (resolveCoworkAgentEngine() === 'openclaw') {
-      void ensureOpenClawRunningForCowork().catch((error) => {
+      void ensureOpenClawRunningForCowork().then(() => {
+        // Start cron polling once the gateway is confirmed running.
+        try {
+          getCronJobService().startPolling();
+        } catch (err) {
+          console.warn('[Main] CronJobService not available after OpenClaw startup:', err);
+        }
+      }).catch((error) => {
         console.error('[OpenClaw] Failed to auto-start gateway on app startup:', error);
       });
     }

--- a/src/renderer/components/Toast.tsx
+++ b/src/renderer/components/Toast.tsx
@@ -9,12 +9,12 @@ interface ToastProps {
 const Toast: React.FC<ToastProps> = ({ message, onClose }) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop">
-      <div className="w-full max-w-sm mx-4 rounded-2xl border border-claude-border/60 dark:border-claude-darkBorder/60 bg-white/95 dark:bg-claude-darkSurface/95 text-claude-text dark:text-claude-darkText px-6 py-4 shadow-xl backdrop-blur-md animate-scale-in">
-        <div className="flex items-center gap-4">
+      <div className="w-full max-w-md mx-4 rounded-2xl border border-claude-border/60 dark:border-claude-darkBorder/60 bg-white/95 dark:bg-claude-darkSurface/95 text-claude-text dark:text-claude-darkText px-6 py-4 shadow-xl backdrop-blur-md animate-scale-in">
+        <div className="flex items-start gap-4">
           <div className="shrink-0 rounded-full bg-claude-accent/10 p-2.5">
             <InformationCircleIcon className="h-5 w-5 text-claude-accent" />
           </div>
-          <div className="flex-1 text-base font-semibold leading-none">
+          <div className="flex-1 text-base font-medium leading-snug">
             {message}
           </div>
           {onClose && (

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../store';
-import { clearCurrentSession, setCurrentSession, setStreaming } from '../../store/slices/coworkSlice';
+import { addMessage, clearCurrentSession, setCurrentSession, setStreaming, updateSessionStatus } from '../../store/slices/coworkSlice';
 import { clearActiveSkills, setActiveSkillIds } from '../../store/slices/skillSlice';
 import { setActions, selectAction, clearSelection } from '../../store/slices/quickActionSlice';
 import { coworkService } from '../../services/cowork';
@@ -239,7 +239,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         .join('\n\n') || undefined;
 
       // Start the actual session immediately with fallback title
-      const startedSession = await coworkService.startSession({
+      const { session: startedSession, error: startError } = await coworkService.startSession({
         prompt,
         title: fallbackTitle,
         cwd: config.workingDirectory || undefined,
@@ -247,6 +247,21 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         activeSkillIds: sessionSkillIds,
         imageAttachments,
       });
+
+      if (!startedSession && startError) {
+        // Show the error as a system message in the temp session
+        dispatch(addMessage({
+          sessionId: tempSessionId,
+          message: {
+            id: `error-${Date.now()}`,
+            type: 'system',
+            content: i18nService.t('coworkErrorSessionStartFailed').replace('{error}', startError),
+            timestamp: Date.now(),
+          },
+        }));
+        dispatch(updateSessionStatus({ sessionId: tempSessionId, status: 'error' }));
+        return;
+      }
 
       // Generate title in the background and update when ready
       if (startedSession) {

--- a/src/renderer/components/cowork/FolderSelectorPopover.tsx
+++ b/src/renderer/components/cowork/FolderSelectorPopover.tsx
@@ -152,12 +152,21 @@ const FolderSelectorPopover: React.FC<FolderSelectorPopoverProps> = ({
     }
   }, [showRecentSubmenu]);
 
+  const isWindowsDriveRoot = (dirPath: string): boolean => {
+    if (window.electron.platform !== 'win32') return false;
+    return /^[a-zA-Z]:[/\\]?$/.test(dirPath.trim());
+  };
+
   const handleAddFolder = async () => {
+    onClose();
     try {
       const result = await window.electron.dialog.selectDirectory();
       if (result.success && result.path) {
+        if (isWindowsDriveRoot(result.path)) {
+          window.dispatchEvent(new CustomEvent('app:showToast', { detail: i18nService.t('folderDriveRootNotAllowed') }));
+          return;
+        }
         onSelectFolder(result.path);
-        onClose();
       }
     } catch (error) {
       console.error('Failed to select directory:', error);
@@ -165,6 +174,10 @@ const FolderSelectorPopover: React.FC<FolderSelectorPopoverProps> = ({
   };
 
   const handleSelectRecentFolder = (path: string) => {
+    if (isWindowsDriveRoot(path)) {
+      window.dispatchEvent(new CustomEvent('app:showToast', { detail: i18nService.t('folderDriveRootNotAllowed') }));
+      return;
+    }
     onSelectFolder(path);
     onClose();
   };

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -253,11 +253,11 @@ class CoworkService {
     return this.openClawStatus;
   }
 
-  async startSession(options: CoworkStartOptions): Promise<CoworkSession | null> {
+  async startSession(options: CoworkStartOptions): Promise<{ session: CoworkSession | null; error?: string }> {
     const cowork = window.electron?.cowork;
     if (!cowork) {
       console.error('Cowork API not available');
-      return null;
+      return { session: null, error: 'Cowork API not available' };
     }
 
     store.dispatch(setStreaming(true));
@@ -268,7 +268,7 @@ class CoworkService {
       if (result.session.status !== 'running') {
         store.dispatch(setStreaming(false));
       }
-      return result.session;
+      return { session: result.session };
     }
 
     if (result.engineStatus) {
@@ -277,7 +277,7 @@ class CoworkService {
 
     store.dispatch(setStreaming(false));
     console.error('Failed to start session:', result.error);
-    return null;
+    return { session: null, error: result.error };
   }
 
   async continueSession(options: CoworkContinueOptions): Promise<boolean> {
@@ -304,6 +304,17 @@ class CoworkService {
       }
       if (result.code !== 'ENGINE_NOT_READY') {
         store.dispatch(updateSessionStatus({ sessionId: options.sessionId, status: 'error' }));
+        if (result.error) {
+          store.dispatch(addMessage({
+            sessionId: options.sessionId,
+            message: {
+              id: `error-${Date.now()}`,
+              type: 'system',
+              content: i18nService.t('coworkErrorSessionContinueFailed').replace('{error}', result.error),
+              timestamp: Date.now(),
+            },
+          }));
+        }
       }
       console.error('Failed to continue session:', result.error);
       return false;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -427,6 +427,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noFolderSelected: '未选择文件夹',
     coworkSelectFolderFirst: '请选择任务目录后再提交',
     noRecentFolders: '暂无最近文件夹',
+    folderDriveRootNotAllowed: '不支持使用磁盘根目录作为工作目录，请选择一个子文件夹（例如 D:\\Projects）。',
     coworkOpenFolder: '打开文件夹',
 
     // Cowork 错误消息
@@ -442,6 +443,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorRateLimit: '请求过于频繁，请稍后再试。',
     coworkErrorContentFiltered: '内容未通过安全审核，请修改后重试。',
     coworkErrorServerError: '服务端出现错误，请稍后重试。',
+    coworkErrorSessionStartFailed: '会话启动失败：{error}',
+    coworkErrorSessionContinueFailed: '发送消息失败：{error}',
 
     // Skills
     skills: '技能',
@@ -1367,6 +1370,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noFolderSelected: 'No folder selected',
     coworkSelectFolderFirst: 'Please select a task folder before submitting',
     noRecentFolders: 'No recent folders',
+    folderDriveRootNotAllowed: 'Drive root directories are not supported as working directories. Please select a subfolder (e.g. D:\\Projects).',
     coworkOpenFolder: 'Open folder',
 
     // Cowork error messages
@@ -1382,6 +1386,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorRateLimit: 'Too many requests. Please try again later.',
     coworkErrorContentFiltered: 'Content did not pass the safety review. Please modify and try again.',
     coworkErrorServerError: 'Server error occurred. Please try again later.',
+    coworkErrorSessionStartFailed: 'Failed to start session: {error}',
+    coworkErrorSessionContinueFailed: 'Failed to send message: {error}',
 
     // Skills
     skills: 'Skills',


### PR DESCRIPTION
…e session errors to user

When the user sets the working directory to a bare drive letter (e.g. D:), multiple code paths called fs.mkdirSync on the drive root, causing EPERM. This change:

- Guard resolveTaskWorkingDirectory and ensureDir with fs.existsSync before mkdir, and reject bare drive roots early with a clear message
- Normalize workspace path with path.resolve before passing to OpenClaw
- Validate folder selection in FolderSelectorPopover: block drive roots with a toast and close the popover immediately on Add Folder click
- Surface session start/continue errors as visible system messages instead of only logging to console
- Improve Toast component for long multi-line messages
- Fix scheduledTaskService.init 5s timeout by returning empty task list when OpenClaw gateway is not yet connected, and start cron polling after the gateway is confirmed running