### PR TITLE
fix(api): 为 OpenAI 官方 provider 统一使用 max_completion_tokens

### DIFF
--- a/src/main/im/imChatHandler.ts
+++ b/src/main/im/imChatHandler.ts
@@ -144,18 +144,10 @@ export class IMChatHandler {
   }
 
   private shouldUseMaxCompletionTokens(config: LLMConfig): boolean {
-    const provider = config.provider?.toLowerCase();
-    if (provider !== 'openai') {
-      return false;
-    }
-    const normalizedModel = config.model?.toLowerCase() || '';
-    const resolvedModel = normalizedModel.includes('/')
-      ? normalizedModel.slice(normalizedModel.lastIndexOf('/') + 1)
-      : normalizedModel;
-    return resolvedModel.startsWith('gpt-5')
-      || resolvedModel.startsWith('o1')
-      || resolvedModel.startsWith('o3')
-      || resolvedModel.startsWith('o4');
+    // OpenAI's newer models reject `max_tokens` and require `max_completion_tokens`.
+    // Since all current OpenAI models accept `max_completion_tokens`, always use it
+    // for the official OpenAI provider.
+    return config.provider?.toLowerCase() === 'openai';
   }
 
   /**

--- a/src/main/libs/coworkOpenAICompatProxy.ts
+++ b/src/main/libs/coworkOpenAICompatProxy.ts
@@ -767,20 +767,6 @@ function clampMaxTokensFromError(
   return { changed: true, clampedTo: nextValue };
 }
 
-function shouldUseMaxCompletionTokensForModel(model: unknown): boolean {
-  if (typeof model !== 'string') {
-    return false;
-  }
-  const normalizedModel = model.toLowerCase();
-  const resolvedModel = normalizedModel.includes('/')
-    ? normalizedModel.slice(normalizedModel.lastIndexOf('/') + 1)
-    : normalizedModel;
-  return resolvedModel.startsWith('gpt-5')
-    || resolvedModel.startsWith('o1')
-    || resolvedModel.startsWith('o3')
-    || resolvedModel.startsWith('o4');
-}
-
 function normalizeMaxTokensFieldForOpenAIProvider(
   openAIRequest: Record<string, unknown>,
   provider?: string
@@ -788,9 +774,10 @@ function normalizeMaxTokensFieldForOpenAIProvider(
   if (provider !== 'openai') {
     return;
   }
-  if (!shouldUseMaxCompletionTokensForModel(openAIRequest.model)) {
-    return;
-  }
+  // OpenAI's newer models (o-series, gpt-4.1+, gpt-5, etc.) reject `max_tokens`
+  // and require `max_completion_tokens`. Since all current OpenAI models accept
+  // `max_completion_tokens`, always use it for the official OpenAI provider to
+  // avoid fragile per-model checks.
   const maxTokens = openAIRequest.max_tokens;
   if (typeof maxTokens !== 'number' || !Number.isFinite(maxTokens)) {
     return;

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -326,18 +326,11 @@ const buildOpenAIResponsesUrl = (baseUrl: string): string => {
 const shouldUseOpenAIResponsesForProvider = (provider: string): boolean => (
   provider === 'openai'
 );
-const shouldUseMaxCompletionTokensForOpenAI = (provider: string, modelId?: string): boolean => {
-  if (provider !== 'openai') {
-    return false;
-  }
-  const normalizedModel = (modelId ?? '').toLowerCase();
-  const resolvedModel = normalizedModel.includes('/')
-    ? normalizedModel.slice(normalizedModel.lastIndexOf('/') + 1)
-    : normalizedModel;
-  return resolvedModel.startsWith('gpt-5')
-    || resolvedModel.startsWith('o1')
-    || resolvedModel.startsWith('o3')
-    || resolvedModel.startsWith('o4');
+const shouldUseMaxCompletionTokensForOpenAI = (provider: string): boolean => {
+  // OpenAI's newer models reject `max_tokens` and require `max_completion_tokens`.
+  // Since all current OpenAI models accept `max_completion_tokens`, always use it
+  // for the official OpenAI provider.
+  return provider === 'openai';
 };
 const CONNECTIVITY_TEST_TOKEN_BUDGET = 64;
 
@@ -1509,7 +1502,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
               model: firstModel.id,
               messages: [{ role: 'user', content: 'Hi' }],
             };
-        if (!useResponsesApi && shouldUseMaxCompletionTokensForOpenAI(testingProvider, firstModel.id)) {
+        if (!useResponsesApi && shouldUseMaxCompletionTokensForOpenAI(testingProvider)) {
           openAIRequestBody.max_completion_tokens = CONNECTIVITY_TEST_TOKEN_BUDGET;
         } else {
           if (!useResponsesApi) {


### PR DESCRIPTION
## 概述

修复 #501 — OpenAI 最新模型拒绝已弃用的 `max_tokens` 参数，要求使用 `max_completion_tokens`。

### 根因分析

原有逻辑通过模型名前缀白名单（`gpt-5`/`o1`/`o3`/`o4`）判断是否使用 `max_completion_tokens`，新模型不在名单中则仍发送 `max_tokens`，导致报错。

### 修改内容

- **`src/main/libs/coworkOpenAICompatProxy.ts`**：移除 `shouldUseMaxCompletionTokensForModel()` 白名单函数，对 `openai` provider 统一转换 `max_tokens` → `max_completion_tokens`
- **`src/renderer/components/Settings.tsx`**：简化 `shouldUseMaxCompletionTokensForOpenAI()`，对 `openai` provider 始终返回 true
- **`src/main/im/imChatHandler.ts`**：IM 聊天路径同步简化

第三方 OpenAI 兼容 API 继续使用 `max_tokens`，保持向后兼容。

## 测试计划

- [ ] 配置 OpenAI 官方 provider，使用 gpt-4.1/o 系列模型，验证无 `max_tokens` 报错
- [ ] 配置第三方 OpenAI 兼容 provider，验证向后兼容
- [ ] 验证 IM 通道聊天在 OpenAI 模型下正常工作