### PR TITLE
fix(cowork): 增强非 Anthropic 模型的错误信息提取能力

### DIFF
--- a/src/main/libs/coworkRunner.ts
+++ b/src/main/libs/coworkRunner.ts
@@ -2460,17 +2460,34 @@ export class CoworkRunner extends EventEmitter {
   }
 
   private normalizeSdkError(value: unknown): string | null {
-    if (typeof value !== 'string') {
-      return null;
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed || trimmed.toLowerCase() === 'unknown') {
+        return null;
+      }
+      return trimmed;
     }
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return null;
+    // Handle object-type errors (e.g. OpenAI-compatible API error format:
+    // { message: "...", type: "...", code: "..." })
+    if (value && typeof value === 'object') {
+      const errObj = value as Record<string, unknown>;
+      const message = errObj.message ?? errObj.msg;
+      if (typeof message === 'string' && message.trim()) {
+        const parts: string[] = [message.trim()];
+        if (typeof errObj.type === 'string' && errObj.type.trim()) {
+          parts.push(`(type: ${errObj.type.trim()})`);
+        }
+        if (errObj.code != null && String(errObj.code).trim()) {
+          parts.push(`(code: ${String(errObj.code).trim()})`);
+        }
+        return parts.join(' ');
+      }
+      // Try nested error.message (some APIs wrap: { error: { message: "..." } })
+      if (errObj.error && typeof errObj.error === 'object') {
+        return this.normalizeSdkError(errObj.error);
+      }
     }
-    if (trimmed.toLowerCase() === 'unknown') {
-      return null;
-    }
-    return trimmed;
+    return null;
   }
 
   private handleClaudeEvent(sessionId: string, event: unknown): void {
@@ -2543,17 +2560,19 @@ export class CoworkRunner extends EventEmitter {
       if (subtype !== 'success') {
         const errors = Array.isArray(payload.errors)
           ? payload.errors
-            .filter((error) => typeof error === 'string')
-            .map((error) => (error as string).trim())
-            .filter((error) => error && error.toLowerCase() !== 'unknown')
+            .map((error) => typeof error === 'string' ? error.trim() : this.normalizeSdkError(error))
+            .filter((error): error is string => !!error && error.toLowerCase() !== 'unknown')
           : [];
         const payloadError = this.normalizeSdkError(payload.error);
+        const resultError = this.normalizeSdkError(payload.result);
         const errorMessage =
           errors.length > 0
             ? errors.join('\n')
             : payloadError
               ? payloadError
-              : 'Claude run failed';
+              : resultError
+                ? resultError
+                : `Agent run failed (subtype: ${subtype})`;
         this.handleError(sessionId, errorMessage);
         return;
       }


### PR DESCRIPTION
## 概述

修复 #399 — 使用阿里云百炼的 GLM 4.5 模型时，错误消息只显示通用的 "Claude run failed"，无法看到实际错误详情。

### 根因分析

`normalizeSdkError()` 仅处理字符串类型错误。非 Anthropic 模型返回的 OpenAI 格式错误对象 `{ message, type, code }` 被静默丢弃，回退到通用消息。

### 修改内容

- **`src/main/libs/coworkRunner.ts`**：
  - 扩展 `normalizeSdkError()` 支持 object 类型错误（`{ message, type, code }` 及嵌套 `{ error: { message } }`）
  - `payload.errors` 数组中的 object 项也通过 `normalizeSdkError` 处理
  - 新增 `payload.result` 作为备用错误来源
  - 将 fallback 从 `"Claude run failed"` 改为 `"Agent run failed (subtype: ${subtype})"`，包含诊断信息

## 测试计划

- [ ] 配置阿里云百炼 GLM 4.5，触发错误，验证显示实际错误信息
- [ ] 验证 Anthropic 模型错误仍正确显示
- [ ] 验证其他 OpenAI 兼容 provider 能正确提取错误详情