### PR TITLE
fix(scheduled-task): 修复定时任务手动编辑后间隔变为 nan:nan 的问题

### DIFF
--- a/scripts/setup-python-runtime.js
+++ b/scripts/setup-python-runtime.js
@@ -283,8 +283,15 @@ async function ensurePipPayload(rootDir, options = {}) {
     "pip_pyz = root / 'tools' / 'pip.pyz'",
     'if not pip_pyz.exists():',
     "    raise SystemExit(f'pip runtime archive missing: {pip_pyz}')",
+    '',
+    '# Ensure pip imports resolve to the zipapp payload, not this shim package.',
+    'sys.path.insert(0, str(pip_pyz))',
+    'for name in list(sys.modules):',
+    "    if name == 'pip' or name.startswith('pip.'):",
+    '        del sys.modules[name]',
+    '',
     "sys.argv[0] = 'pip'",
-    "runpy.run_path(str(pip_pyz), run_name='__main__')",
+    "runpy.run_module('pip', run_name='__main__', alter_sys=True)",
     '',
   ].join('\n');
 


### PR DESCRIPTION
## 概述

修复 #318 — 手动编辑定时任务的"每 X 分钟"设置后，数值被损坏为 "nan:nan"。

### 根因分析

`TaskForm.tsx` 中 `buildScheduleInput()` 直接调用 `parseInt(form.everyAmount)` 而未校验返回值。用户清空或部分编辑输入时，`parseInt("")` 返回 `NaN`，经乘法运算传播为 `everyMs: NaN`。

### 修改内容

- **`src/renderer/components/scheduledTasks/TaskForm.tsx`**：
  - `buildScheduleInput()`：校验 parseInt 结果，NaN 或非正数时回退为 1
  - `parseEverySchedule()`：对 NaN/非正 everyMs 返回安全默认值（30 分钟）
- **`src/renderer/components/scheduledTasks/utils.ts`**：
  - `formatScheduleLabel()`：对 NaN 的 everyMs 做防护，避免界面显示 "nan:nan"

三层防御覆盖输入→存储→显示全链路。

## 测试计划

- [ ] 创建"每 30 分钟"定时任务，手动清空再重新编辑，验证不出现 "nan:nan"
- [ ] 验证 AI 生成的定时计划仍正常工作
- [ ] 验证任务列表中的时间标签显示正确