### PR TITLE
fix(scheduled-task): 修复 API 创建任务时中文路径乱码问题

### DIFF
--- a/src/main/libs/coworkOpenAICompatProxy.ts
+++ b/src/main/libs/coworkOpenAICompatProxy.ts
@@ -892,10 +892,21 @@ function writeJSON(
 ): void {
   const payload = JSON.stringify(body);
   res.writeHead(statusCode, {
-    'Content-Type': 'application/json',
+    'Content-Type': 'application/json; charset=utf-8',
     'Content-Length': Buffer.byteLength(payload),
   });
   res.end(payload);
+}
+
+/**
+ * Extract charset from Content-Type header (e.g. "application/json; charset=utf-8").
+ * Returns the normalised charset string or null when absent / unparseable.
+ */
+function extractContentTypeCharset(req: http.IncomingMessage): string | null {
+  const ct = req.headers['content-type'];
+  if (!ct) return null;
+  const match = ct.match(/charset\s*=\s*"?([^";,\s]+)"?/i);
+  return match ? match[1].toLowerCase().replace(/^utf8$/i, 'utf-8') : null;
 }
 
 function readRequestBody(req: http.IncomingMessage): Promise<string> {
@@ -904,9 +915,26 @@ function readRequestBody(req: http.IncomingMessage): Promise<string> {
     let totalBytes = 0;
     let settled = false;
 
+    // When the Content-Type header declares a charset, honour it directly
+    // instead of running heuristic detection. This prevents CJK characters
+    // (e.g. Chinese paths in workingDirectory) from being misinterpreted
+    // as Latin-1 / Windows-1252 when the client already tells us the encoding.
+    const declaredCharset = extractContentTypeCharset(req);
+
     const decodeBody = (raw: Buffer): string => {
       if (raw.length === 0) {
         return '';
+      }
+
+      // If the request explicitly declares a charset, trust it.
+      // JSON APIs (including the OpenClaw gateway) always use UTF-8,
+      // so this path avoids any ambiguity for CJK characters.
+      if (declaredCharset) {
+        try {
+          return new TextDecoder(declaredCharset, { fatal: false }).decode(raw);
+        } catch {
+          // Unknown charset label — fall through to auto-detection.
+        }
       }
 
       // BOM-aware decoding first.

--- a/src/main/libs/mcpBridgeServer.ts
+++ b/src/main/libs/mcpBridgeServer.ts
@@ -83,7 +83,7 @@ export class McpBridgeServer {
   private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
     // Only accept POST /mcp/execute
     if (req.method !== 'POST' || !req.url?.startsWith('/mcp/execute')) {
-      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
       res.end(JSON.stringify({ error: 'Not found' }));
       return;
     }
@@ -91,7 +91,7 @@ export class McpBridgeServer {
     // Verify secret token
     const authHeader = req.headers['x-mcp-bridge-secret'];
     if (authHeader !== this.secret) {
-      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.writeHead(401, { 'Content-Type': 'application/json; charset=utf-8' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
       return;
     }
@@ -105,19 +105,19 @@ export class McpBridgeServer {
       };
 
       if (!server || !tool) {
-        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' });
         res.end(JSON.stringify({ error: 'Missing "server" or "tool" field' }));
         return;
       }
 
       const result = await this.mcpManager.callTool(server, tool, args || {});
 
-      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
       res.end(JSON.stringify(result));
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
       log('ERROR', `Request handling error: ${errMsg}`);
-      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.writeHead(500, { 'Content-Type': 'application/json; charset=utf-8' });
       res.end(JSON.stringify({
         content: [{ type: 'text', text: `Bridge error: ${errMsg}` }],
         isError: true,


### PR DESCRIPTION
## 概述

修复 #310 — 通过 API 创建定时任务时，`workingDirectory` 字段中的中文字符被损坏（如 "营销" → "钀ラ攢"）。

### 根因分析

`coworkOpenAICompatProxy.ts` 中的 `readRequestBody()` 使用启发式编码检测，当客户端已在 Content-Type 头中声明 `charset=utf-8` 时，仍走启发式逻辑，可能将 UTF-8 CJK 字节误判为 Latin-1/GB18030。

### 修改内容

- **`src/main/libs/coworkOpenAICompatProxy.ts`**：
  - 新增 `extractContentTypeCharset()` 辅助函数，从 Content-Type 头提取 charset 声明
  - 有显式 charset 声明时，直接使用 `TextDecoder(charset)` 解码，跳过启发式检测
  - 无声明时回退到原有启发式逻辑
- **`src/main/libs/mcpBridgeServer.ts`**：
  - 所有 JSON 响应的 Content-Type 头统一添加 `charset=utf-8`

## 测试计划

- [ ] 通过 API 创建包含中文 workingDirectory 的定时任务，验证字符正确保留
- [ ] 验证通过 UI 创建的含 CJK 字符任务仍正常工作
- [ ] 验证无 charset 头的请求仍使用启发式检测作为兜底