### PR TITLE
fix(scheduled-task): guard against NaN in scheduled task data from gateway

### DIFF
--- a/src/main/libs/cronJobService.ts
+++ b/src/main/libs/cronJobService.ts
@@ -106,6 +106,25 @@ interface CronJobServiceDeps {
   ensureGatewayReady: () => Promise<void>;
 }
 
+/**
+ * Coerce a value to a finite number, returning `fallback` when the value is
+ * undefined, null, NaN, Infinity, or not a number at all.
+ * Used to guard against malformed Gateway responses that could surface NaN in the UI.
+ */
+function safeFiniteNumber(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return fallback;
+}
+
+/**
+ * Same as {@link safeFiniteNumber} but returns `null` when the value is absent
+ * instead of a numeric fallback.  Suitable for optional timestamp fields.
+ */
+function safeFiniteNumberOrNull(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return null;
+}
+
 function mapGatewayResultStatus(
   status?: 'ok' | 'error' | 'skipped',
 ): 'success' | 'error' | 'skipped' | null {
@@ -119,19 +138,24 @@ export function mapGatewaySchedule(schedule: GatewaySchedule): Schedule {
   switch (schedule.kind) {
     case 'at':
       return { kind: 'at', at: schedule.at };
-    case 'every':
+    case 'every': {
+      const everyMs = safeFiniteNumber(schedule.everyMs, 60_000);
+      const anchorMs = safeFiniteNumberOrNull(schedule.anchorMs);
       return {
         kind: 'every',
-        everyMs: schedule.everyMs,
-        ...(typeof schedule.anchorMs === 'number' ? { anchorMs: schedule.anchorMs } : {}),
+        everyMs,
+        ...(anchorMs !== null ? { anchorMs } : {}),
       };
-    case 'cron':
+    }
+    case 'cron': {
+      const staggerMs = safeFiniteNumberOrNull(schedule.staggerMs);
       return {
         kind: 'cron',
         expr: schedule.expr,
         ...(schedule.tz ? { tz: schedule.tz } : {}),
-        ...(typeof schedule.staggerMs === 'number' ? { staggerMs: schedule.staggerMs } : {}),
+        ...(staggerMs !== null ? { staggerMs } : {}),
       };
+    }
   }
 }
 
@@ -194,13 +218,13 @@ export function mapGatewayTaskState(state: GatewayJobState): TaskState {
     : mapGatewayResultStatus(state.lastRunStatus ?? state.lastStatus);
 
   return {
-    nextRunAtMs: state.nextRunAtMs ?? null,
-    lastRunAtMs: state.lastRunAtMs ?? null,
+    nextRunAtMs: safeFiniteNumberOrNull(state.nextRunAtMs),
+    lastRunAtMs: safeFiniteNumberOrNull(state.lastRunAtMs),
     lastStatus,
     lastError: state.lastError ?? null,
-    lastDurationMs: state.lastDurationMs ?? null,
-    runningAtMs: state.runningAtMs ?? null,
-    consecutiveErrors: state.consecutiveErrors ?? 0,
+    lastDurationMs: safeFiniteNumberOrNull(state.lastDurationMs),
+    runningAtMs: safeFiniteNumberOrNull(state.runningAtMs),
+    consecutiveErrors: safeFiniteNumber(state.consecutiveErrors ?? 0, 0),
   };
 }
 
@@ -236,8 +260,8 @@ export function mapGatewayJob(job: GatewayJob): ScheduledTask {
     agentId: job.agentId ?? null,
     sessionKey: job.sessionKey ?? null,
     state: mapGatewayTaskState(job.state),
-    createdAt: new Date(job.createdAtMs).toISOString(),
-    updatedAt: new Date(job.updatedAtMs).toISOString(),
+    createdAt: new Date(safeFiniteNumber(job.createdAtMs, Date.now())).toISOString(),
+    updatedAt: new Date(safeFiniteNumber(job.updatedAtMs, Date.now())).toISOString(),
   };
 }
 
@@ -246,15 +270,17 @@ export function mapGatewayRun(entry: GatewayRunLogEntry): ScheduledTaskRun {
     ? 'running'
     : (mapGatewayResultStatus(entry.status) ?? 'error');
 
+  const tsMs = safeFiniteNumber(entry.runAtMs ?? entry.ts, Date.now());
+
   return {
     id: `${entry.jobId}-${entry.ts}`,
     taskId: entry.jobId,
     sessionId: entry.sessionId ?? null,
     sessionKey: entry.sessionKey ?? null,
     status,
-    startedAt: new Date(entry.runAtMs ?? entry.ts).toISOString(),
-    finishedAt: status === 'running' ? null : new Date(entry.ts).toISOString(),
-    durationMs: entry.durationMs ?? null,
+    startedAt: new Date(tsMs).toISOString(),
+    finishedAt: status === 'running' ? null : new Date(safeFiniteNumber(entry.ts, tsMs)).toISOString(),
+    durationMs: safeFiniteNumberOrNull(entry.durationMs),
     error: entry.error ?? null,
   };
 }

--- a/src/renderer/components/scheduledTasks/utils.ts
+++ b/src/renderer/components/scheduledTasks/utils.ts
@@ -152,6 +152,9 @@ export function formatScheduleLabel(schedule: Schedule): string {
 
   if (schedule.kind === 'every') {
     const everyMs = schedule.everyMs;
+    if (!Number.isFinite(everyMs) || everyMs <= 0) {
+      return `${i18nService.t('scheduledTasksScheduleEvery')} -`;
+    }
     if (everyMs % 86_400_000 === 0) {
       return `${i18nService.t('scheduledTasksScheduleEvery')} ${everyMs / 86_400_000} ${i18nService.t('scheduledTasksFormIntervalDays')}`;
     }
@@ -165,7 +168,7 @@ export function formatScheduleLabel(schedule: Schedule): string {
 }
 
 export function formatDuration(ms: number | null): string {
-  if (ms === null) return '-';
+  if (ms === null || !Number.isFinite(ms)) return '-';
   if (ms < 1000) return `${ms}ms`;
   if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
   return `${Math.round(ms / 60_000)}m`;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -947,6 +947,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksSessionKey: '会话键',
     scheduledTasksToggleWarningAtPast: '该任务的执行时间已过，启用后将不会运行',
     scheduledTasksToggleWarningExpired: '该任务已过期，启用后将不会运行',
+    scheduledTasksDataAnomalyWarning: '定时任务「{name}」存在异常数据，已自动修正显示，建议重新编辑该任务',
   },
   en: {
     // Common
@@ -1890,6 +1891,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksSessionKey: 'Session Key',
     scheduledTasksToggleWarningAtPast: 'The execution time of this task has passed. It will not run after enabling',
     scheduledTasksToggleWarningExpired: 'This task has expired. It will not run after enabling',
+    scheduledTasksDataAnomalyWarning: 'Scheduled task "{name}" has abnormal data. Display has been auto-corrected. Consider re-editing this task',
   }
 };
 

--- a/src/renderer/services/scheduledTask.ts
+++ b/src/renderer/services/scheduledTask.ts
@@ -14,11 +14,43 @@ import {
   appendAllRuns,
 } from '../store/slices/scheduledTaskSlice';
 import type {
+  ScheduledTask,
   ScheduledTaskChannelOption,
   ScheduledTaskInput,
   ScheduledTaskStatusEvent,
   ScheduledTaskRunEvent,
 } from '../types/scheduledTask';
+import { i18nService } from './i18n';
+
+function showToast(message: string): void {
+  window.dispatchEvent(new CustomEvent('app:showToast', { detail: message }));
+}
+
+function hasTaskDataAnomaly(task: ScheduledTask): boolean {
+  if (task.schedule.kind === 'every') {
+    const ms = task.schedule.everyMs;
+    if (!Number.isFinite(ms) || ms <= 0) return true;
+  }
+  if (task.schedule.kind === 'at') {
+    const d = new Date(task.schedule.at);
+    if (!Number.isFinite(d.getTime())) return true;
+  }
+  const ts = task.state;
+  const nums = [ts.nextRunAtMs, ts.lastRunAtMs, ts.lastDurationMs, ts.runningAtMs];
+  for (const v of nums) {
+    if (v !== null && !Number.isFinite(v)) return true;
+  }
+  return false;
+}
+
+function checkTasksForAnomalies(tasks: ScheduledTask[]): void {
+  const anomalous = tasks.filter(hasTaskDataAnomaly);
+  if (anomalous.length === 0) return;
+
+  const name = anomalous[0].name;
+  const msg = i18nService.t('scheduledTasksDataAnomalyWarning').replace('{name}', name);
+  showToast(msg);
+}
 
 class ScheduledTaskService {
   private cleanupFns: (() => void)[] = [];
@@ -76,6 +108,7 @@ class ScheduledTaskService {
     try {
       const result = await api.list();
       if (result.success && result.tasks) {
+        checkTasksForAnomalies(result.tasks);
         store.dispatch(setTasks(result.tasks));
       }
     } catch (err: unknown) {
@@ -92,6 +125,10 @@ class ScheduledTaskService {
     try {
       const result = await api.create(input);
       if (result.success && result.task) {
+        if (hasTaskDataAnomaly(result.task)) {
+          const msg = i18nService.t('scheduledTasksDataAnomalyWarning').replace('{name}', result.task.name);
+          showToast(msg);
+        }
         store.dispatch(addTask(result.task));
       } else {
         throw new Error(result.error || 'Failed to create task');


### PR DESCRIPTION
[问题]
通过大模型/Agent 创建的定时任务，在 UI 中偶现 NaN 显示（如调度间隔、运行时间等字段）。 

[根因]
Agent 通过 OpenClaw cron.add API 创建任务时不经过 TaskForm 的前端校验， Gateway 返回的数值字段（everyMs、createdAtMs、lastRunAtMs 等）可能为 undefined/null/非数字类型。这些值经 mapGatewayJob 等映射函数直接透传到前端后， Math.max(1, NaN) 仍返回 NaN，new Date(undefined).toISOString() 直接抛异常。 

[修复]
三层防御：
1. cronJobService.ts（主进程入口）：新增 safeFiniteNumber/safeFiniteNumberOrNull， 在 mapGatewaySchedule、mapGatewayTaskState、mapGatewayJob、mapGatewayRun 中对所有数值字段做 Number.isFinite 校验，非法值 fallback 为安全默认值或 null
2. scheduledTask.ts（渲染进程 service）：新增 hasTaskDataAnomaly 检测， loadTasks/createTask 收到数据后检查异常并通过 toast 提示用户重新编辑
3. utils.ts（UI 最后防线）：formatScheduleLabel 和 formatDuration 增加 Number.isFinite 守卫，非法值显示为 "-" 而非 NaN

Closes #407