### PR TITLE
feat: 添加 OpenClaw 网关状态国际化支持

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -26,6 +26,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Timeout hint
     taskTimedOut: '[任务超时] 任务因超过最大允许时长而被自动停止。你可以继续对话以从中断处继续。',
+
+    // OpenClaw gateway status
+    coworkOpenClawGateway: '正在启动 OpenClaw 网关...',
+    coworkOpenClawRuntimeReady: 'OpenClaw runtime 已就绪。',
+    coworkOpenClawRuntimeMissing: '未检测到内置 OpenClaw runtime（cfmind）。预期路径：',
+    coworkOpenClawGatewayRunning: 'OpenClaw gateway 正在运行',
+    coworkOpenClawEntryMissing: 'OpenClaw runtime 中缺少入口文件',
+    coworkOpenClawGatewayTimeout: 'OpenClaw gateway 未能在规定时间内启动成功。',
+    coworkOpenClawGatewayError: 'OpenClaw gateway 进程错误',
+    coworkOpenClawGatewayExitedUnexpectedly: 'OpenClaw gateway 意外退出',
+    coworkOpenClawWarmingUp: '首次启动：正在预热编译缓存...',
   },
   en: {
     // Tray menu
@@ -39,6 +50,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Timeout hint
     taskTimedOut: '[Task timed out] The task was automatically stopped because it exceeded the maximum allowed duration. You can continue the conversation to pick up where it left off.',
+
+    // OpenClaw gateway status
+    coworkOpenClawGateway: 'Starting OpenClaw gateway...',
+    coworkOpenClawRuntimeReady: 'OpenClaw runtime is ready.',
+    coworkOpenClawRuntimeMissing: 'Bundled OpenClaw runtime is missing. Expected:',
+    coworkOpenClawGatewayRunning: 'OpenClaw gateway is running on',
+    coworkOpenClawEntryMissing: 'OpenClaw entry file is missing in runtime',
+    coworkOpenClawGatewayTimeout: 'OpenClaw gateway failed to become healthy in time.',
+    coworkOpenClawGatewayError: 'OpenClaw gateway process error',
+    coworkOpenClawGatewayExitedUnexpectedly: 'OpenClaw gateway exited unexpectedly',
+    coworkOpenClawWarmingUp: 'First start: warming up compile cache...',
   },
 };
 

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -5,6 +5,7 @@ import { EventEmitter } from 'events';
 import fs from 'fs';
 import net from 'net';
 import path from 'path';
+import { t } from '../i18n';
 import { getElectronNodeRuntimePath } from './coworkUtil';
 import { syncLocalOpenClawExtensionsIntoRuntime } from './openclawLocalExtensions';
 import { applyBundledOpenClawRuntimeHotfixes } from './openclawRuntimeHotfix';
@@ -182,13 +183,13 @@ export class OpenClawEngineManager extends EventEmitter {
       ? {
           phase: 'ready',
           version: this.desiredVersion,
-          message: 'OpenClaw runtime is ready.',
+          message: t('coworkOpenClawRuntimeReady'),
           canRetry: false,
         }
       : {
           phase: 'not_installed',
           version: null,
-          message: `Bundled OpenClaw runtime is missing. Expected: ${runtime.expectedPathHint}`,
+          message: `${t('coworkOpenClawRuntimeMissing')} ${runtime.expectedPathHint}`,
           canRetry: true,
         };
   }
@@ -261,7 +262,7 @@ export class OpenClawEngineManager extends EventEmitter {
       this.setStatus({
         phase: 'not_installed',
         version: null,
-        message: `Bundled OpenClaw runtime is missing. Expected: ${runtime.expectedPathHint}`,
+        message: `${t('coworkOpenClawRuntimeMissing')} ${runtime.expectedPathHint}`,
         canRetry: true,
       });
       return this.getStatus();
@@ -279,7 +280,7 @@ export class OpenClawEngineManager extends EventEmitter {
     this.setStatus({
       phase: 'ready',
       version: this.desiredVersion,
-      message: 'OpenClaw runtime is ready.',
+      message: t('coworkOpenClawRuntimeReady'),
       canRetry: false,
     });
     return this.getStatus();
@@ -317,7 +318,7 @@ export class OpenClawEngineManager extends EventEmitter {
             this.setStatus({
               phase: 'running',
               version: this.desiredVersion,
-              message: `OpenClaw gateway is running on loopback:${port}.`,
+              message: `${t('coworkOpenClawGatewayRunning')}（loopback:${port}）。`,
               canRetry: false,
             });
           }
@@ -335,7 +336,7 @@ export class OpenClawEngineManager extends EventEmitter {
       this.setStatus({
         phase: 'not_installed',
         version: null,
-        message: `Bundled OpenClaw runtime is missing. Expected: ${runtime.expectedPathHint}`,
+        message: `${t('coworkOpenClawRuntimeMissing')} ${runtime.expectedPathHint}`,
         canRetry: true,
       });
       return this.getStatus();
@@ -351,7 +352,7 @@ export class OpenClawEngineManager extends EventEmitter {
       this.setStatus({
         phase: 'error',
         version: runtime.version,
-        message: `OpenClaw entry file is missing in runtime: ${runtime.root}.`,
+        message: `${t('coworkOpenClawEntryMissing')}：${runtime.root}。`,
         canRetry: true,
       });
       return this.getStatus();
@@ -370,7 +371,7 @@ export class OpenClawEngineManager extends EventEmitter {
       phase: 'starting',
       version: runtime.version,
       progressPercent: 10,
-      message: 'Starting OpenClaw gateway...',
+      message: t('coworkOpenClawGateway'),
       canRetry: false,
     });
 
@@ -462,7 +463,7 @@ export class OpenClawEngineManager extends EventEmitter {
       this.setStatus({
         phase: 'error',
         version: runtime.version,
-        message: 'OpenClaw gateway failed to become healthy in time.',
+        message: t('coworkOpenClawGatewayTimeout'),
         canRetry: true,
       });
       this.stopGatewayProcess(child);
@@ -474,7 +475,7 @@ export class OpenClawEngineManager extends EventEmitter {
       phase: 'running',
       version: runtime.version,
       progressPercent: 100,
-      message: `OpenClaw gateway is running on loopback:${port}.`,
+      message: `${t('coworkOpenClawGatewayRunning')}（loopback:${port}）。`,
       canRetry: false,
     });
 
@@ -706,7 +707,7 @@ export class OpenClawEngineManager extends EventEmitter {
       phase: 'starting',
       version: this.status.version,
       progressPercent: 5,
-      message: 'First start: warming up compile cache...',
+      message: t('coworkOpenClawWarmingUp'),
       canRetry: false,
     });
 
@@ -1084,7 +1085,7 @@ export class OpenClawEngineManager extends EventEmitter {
           phase: 'starting',
           version: this.status.version,
           progressPercent: progress,
-          message: `Starting OpenClaw gateway... (${Math.round(elapsedMs / 1000)}s)`,
+          message: `${t('coworkOpenClawGateway')} (${Math.round(elapsedMs / 1000)}s)`,
           canRetry: false,
         });
 
@@ -1157,7 +1158,7 @@ export class OpenClawEngineManager extends EventEmitter {
       this.setStatus({
         phase: 'error',
         version: this.status.version,
-        message: `OpenClaw gateway process error: ${errorMsg}`,
+        message: `${t('coworkOpenClawGatewayError')}：${errorMsg}`,
         canRetry: true,
       });
     });
@@ -1176,7 +1177,7 @@ export class OpenClawEngineManager extends EventEmitter {
       this.setStatus({
         phase: 'error',
         version: this.status.version,
-        message: `OpenClaw gateway exited unexpectedly (code=${code ?? 'null'}).`,
+        message: `${t('coworkOpenClawGatewayExitedUnexpectedly')}（code=${code ?? 'null'}）。`,
         canRetry: true,
       });
       this.scheduleGatewayRestart();


### PR DESCRIPTION
- 在 i18n 配置中添加 OpenClaw 相关的状态消息翻译
- 将 OpenClawEngineManager 中的硬编码字符串替换为国际化函数调用
- 实现 OpenClaw 网关启动、运行、错误等状态的多语言显示
- 统一 OpenClaw 相关提示信息的格式和内容
- 保持现有功能逻辑不变，仅优化消息展示的国际化支持