### PR TITLE
fix(cowork): clear streaming state when deleting active session

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2126,6 +2126,7 @@ if (!gotTheLock) {
 
   ipcMain.handle('cowork:session:delete', async (_event, sessionId: string) => {
     try {
+      getCoworkEngineRouter().stopSession(sessionId);
       const coworkStoreInstance = getCoworkStore();
       coworkStoreInstance.deleteSession(sessionId);
       // Clean up IM session mapping so that new channel messages
@@ -2153,6 +2154,10 @@ if (!gotTheLock) {
 
   ipcMain.handle('cowork:session:deleteBatch', async (_event, sessionIds: string[]) => {
     try {
+      const runtime = getCoworkEngineRouter();
+      sessionIds.forEach((sessionId) => {
+        runtime.stopSession(sessionId);
+      });
       const coworkStoreInstance = getCoworkStore();
       coworkStoreInstance.deleteSessions(sessionIds);
       return { success: true };

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -30,6 +30,7 @@ interface CoworkSessionDetailProps {
   onManageSkills?: () => void;
   onContinue: (prompt: string, skillPrompt?: string, imageAttachments?: CoworkImageAttachment[]) => void;
   onStop: () => void;
+  onDeleteSession?: (sessionId: string) => Promise<void>;
   onNavigateHome?: () => void;
   isSidebarCollapsed?: boolean;
   onToggleSidebar?: () => void;
@@ -1280,6 +1281,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   onManageSkills,
   onContinue,
   onStop,
+  onDeleteSession,
   onNavigateHome,
   isSidebarCollapsed,
   onToggleSidebar,
@@ -1649,7 +1651,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
   const handleConfirmDelete = async () => {
     if (!currentSession) return;
-    await coworkService.deleteSession(currentSession.id);
+    if (onDeleteSession) {
+      await onDeleteSession(currentSession.id);
+    } else {
+      await coworkService.deleteSession(currentSession.id);
+    }
     setShowConfirmDelete(false);
     if (onNavigateHome) {
       onNavigateHome();

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -37,7 +37,11 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   // Track if we're starting a session to prevent duplicate submissions
   const isStartingRef = useRef(false);
   // Track pending start request so stop can cancel delayed startup.
-  const pendingStartRef = useRef<{ requestId: number; cancelled: boolean } | null>(null);
+  const pendingStartRef = useRef<{
+    requestId: number;
+    cancelled: boolean;
+    cancellationAction: 'stop' | 'delete' | null;
+  } | null>(null);
   const startRequestIdRef = useRef(0);
   // Ref for CoworkPromptInput
   const promptInputRef = useRef<CoworkPromptInputRef>(null);
@@ -162,10 +166,17 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     if (isStartingRef.current) return;
     isStartingRef.current = true;
     const requestId = ++startRequestIdRef.current;
-    pendingStartRef.current = { requestId, cancelled: false };
+    pendingStartRef.current = { requestId, cancelled: false, cancellationAction: null };
     const isPendingStartCancelled = () => {
       const pending = pendingStartRef.current;
       return !pending || pending.requestId !== requestId || pending.cancelled;
+    };
+    const getPendingCancellationAction = () => {
+      const pending = pendingStartRef.current;
+      if (!pending || pending.requestId !== requestId || !pending.cancelled) {
+        return null;
+      }
+      return pending.cancellationAction;
     };
 
     try {
@@ -278,6 +289,9 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       // Stop immediately if user cancelled while startup request was in flight.
       if (isPendingStartCancelled() && startedSession) {
         await coworkService.stopSession(startedSession.id);
+        if (getPendingCancellationAction() === 'delete') {
+          await coworkService.deleteSession(startedSession.id);
+        }
       }
     } finally {
       if (pendingStartRef.current?.requestId === requestId) {
@@ -329,8 +343,17 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     if (!currentSession) return;
     if (currentSession.id.startsWith('temp-') && pendingStartRef.current) {
       pendingStartRef.current.cancelled = true;
+      pendingStartRef.current.cancellationAction = 'stop';
     }
     await coworkService.stopSession(currentSession.id);
+  };
+
+  const handleDeleteSession = async (sessionId: string) => {
+    if (sessionId.startsWith('temp-') && pendingStartRef.current) {
+      pendingStartRef.current.cancelled = true;
+      pendingStartRef.current.cancellationAction = 'delete';
+    }
+    await coworkService.deleteSession(sessionId);
   };
 
   // Get selected quick action
@@ -458,6 +481,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
           onManageSkills={() => onShowSkills?.()}
           onContinue={handleContinueSession}
           onStop={handleStopSession}
+          onDeleteSession={handleDeleteSession}
           onNavigateHome={() => dispatch(clearCurrentSession())}
           isSidebarCollapsed={isSidebarCollapsed}
           onToggleSidebar={onToggleSidebar}

--- a/src/renderer/store/slices/coworkDeleteState.ts
+++ b/src/renderer/store/slices/coworkDeleteState.ts
@@ -1,0 +1,40 @@
+type SessionLike = {
+  id: string;
+};
+
+type CoworkDeleteStateShape = {
+  sessions: SessionLike[];
+  unreadSessionIds: string[];
+  currentSessionId: string | null;
+  currentSession: SessionLike | null;
+  isStreaming: boolean;
+};
+
+export const removeSessionFromState = (
+  state: CoworkDeleteStateShape,
+  sessionId: string,
+): void => {
+  state.sessions = state.sessions.filter((session) => session.id !== sessionId);
+  state.unreadSessionIds = state.unreadSessionIds.filter((id) => id !== sessionId);
+
+  if (state.currentSessionId === sessionId) {
+    state.currentSessionId = null;
+    state.currentSession = null;
+    state.isStreaming = false;
+  }
+};
+
+export const removeSessionsFromState = (
+  state: CoworkDeleteStateShape,
+  sessionIds: string[],
+): void => {
+  const sessionIdSet = new Set(sessionIds);
+  state.sessions = state.sessions.filter((session) => !sessionIdSet.has(session.id));
+  state.unreadSessionIds = state.unreadSessionIds.filter((id) => !sessionIdSet.has(id));
+
+  if (state.currentSessionId && sessionIdSet.has(state.currentSessionId)) {
+    state.currentSessionId = null;
+    state.currentSession = null;
+    state.isStreaming = false;
+  }
+};

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -7,6 +7,7 @@ import type {
   CoworkPermissionRequest,
   CoworkSessionStatus,
 } from '../../types/cowork';
+import { removeSessionFromState, removeSessionsFromState } from './coworkDeleteState';
 
 interface CoworkState {
   sessions: CoworkSessionSummary[];
@@ -180,25 +181,11 @@ const coworkSlice = createSlice({
     },
 
     deleteSession(state, action: PayloadAction<string>) {
-      const sessionId = action.payload;
-      state.sessions = state.sessions.filter(s => s.id !== sessionId);
-      state.unreadSessionIds = state.unreadSessionIds.filter((id) => id !== sessionId);
-
-      if (state.currentSessionId === sessionId) {
-        state.currentSessionId = null;
-        state.currentSession = null;
-      }
+      removeSessionFromState(state, action.payload);
     },
 
     deleteSessions(state, action: PayloadAction<string[]>) {
-      const sessionIds = new Set(action.payload);
-      state.sessions = state.sessions.filter(s => !sessionIds.has(s.id));
-      state.unreadSessionIds = state.unreadSessionIds.filter((id) => !sessionIds.has(id));
-
-      if (state.currentSessionId && sessionIds.has(state.currentSessionId)) {
-        state.currentSessionId = null;
-        state.currentSession = null;
-      }
+      removeSessionsFromState(state, action.payload);
     },
 
     addMessage(state, action: PayloadAction<{ sessionId: string; message: CoworkMessage }>) {

--- a/tests/coworkDeleteState.test.mjs
+++ b/tests/coworkDeleteState.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  removeSessionFromState,
+  removeSessionsFromState,
+} from '../src/renderer/store/slices/coworkDeleteState.ts';
+
+test('removeSessionFromState clears streaming when deleting the current session', () => {
+  const state = {
+    sessions: [{ id: 's1' }, { id: 's2' }],
+    unreadSessionIds: ['s1', 's2'],
+    currentSessionId: 's1',
+    currentSession: { id: 's1' },
+    isStreaming: true,
+  };
+
+  removeSessionFromState(state, 's1');
+
+  assert.equal(state.currentSessionId, null);
+  assert.equal(state.currentSession, null);
+  assert.equal(state.isStreaming, false);
+  assert.deepEqual(state.sessions, [{ id: 's2' }]);
+  assert.deepEqual(state.unreadSessionIds, ['s2']);
+});
+
+test('removeSessionFromState keeps streaming when deleting a non-current session', () => {
+  const state = {
+    sessions: [{ id: 's1' }, { id: 's2' }],
+    unreadSessionIds: ['s2'],
+    currentSessionId: 's1',
+    currentSession: { id: 's1' },
+    isStreaming: true,
+  };
+
+  removeSessionFromState(state, 's2');
+
+  assert.equal(state.currentSessionId, 's1');
+  assert.deepEqual(state.currentSession, { id: 's1' });
+  assert.equal(state.isStreaming, true);
+  assert.deepEqual(state.sessions, [{ id: 's1' }]);
+  assert.deepEqual(state.unreadSessionIds, []);
+});
+
+test('removeSessionsFromState clears streaming when deleting the current session in batch', () => {
+  const state = {
+    sessions: [{ id: 's1' }, { id: 's2' }, { id: 's3' }],
+    unreadSessionIds: ['s2', 's3'],
+    currentSessionId: 's2',
+    currentSession: { id: 's2' },
+    isStreaming: true,
+  };
+
+  removeSessionsFromState(state, ['s1', 's2']);
+
+  assert.equal(state.currentSessionId, null);
+  assert.equal(state.currentSession, null);
+  assert.equal(state.isStreaming, false);
+  assert.deepEqual(state.sessions, [{ id: 's3' }]);
+  assert.deepEqual(state.unreadSessionIds, ['s3']);
+});


### PR DESCRIPTION
[问题]
删除正在生成中的会话后，首页输入框仍然保持发送中状态，停止按钮无法继续生效。
临时会话在真实 session 异步创建完成后还有可能被重新加回列表，出现“删掉又复活”的现象。

[根因]
删除会话时只清除了 currentSession/currentSessionId，没有同步重置全局 isStreaming 状态，导致首页输入框继续读取到错误的 streaming 标记。 同时，删除流程没有先停止正在运行的 session，也没有处理 pending start 的删除意图，导致后台任务仍可能继续执行并在创建完成后重新写回状态。

[修复]
抽出删除会话的状态更新逻辑，在删除当前会话和批量删除包含当前会话时统一清除 isStreaming。 主进程在删除会话前先停止对应运行中的 session，避免后台继续流式输出。
前端为临时会话补充 pending start 删除标记，在真实 session 创建完成后立即 stop + delete，防止会话复活。 新增回归测试覆盖删除当前会话后 streaming 状态清理的场景。

[复现路径]
1. 新建一个 cowork 会话并发送消息。
2. 在回复仍在流式生成时删除当前会话。
3. 删除后返回首页，输入框仍显示发送中状态，停止按钮无效。

Closes #545