### PR TITLE
fix: stop stubbing playwright-core and pdfjs-dist in OpenClaw runtime…

### DIFF
--- a/scripts/prune-openclaw-runtime.cjs
+++ b/scripts/prune-openclaw-runtime.cjs
@@ -64,8 +64,6 @@ const DIRS_TO_DELETE = new Set([
 
 const PACKAGES_TO_STUB = [
   'koffi',            // Windows FFI for terminal PTY — not needed in gateway mode
-  'pdfjs-dist',       // Browser-side PDF rendering — gateway is a backend process
-  'playwright-core',  // Browser automation — gateway doesn't launch browsers
 ];
 
 const GENERIC_STUB_INDEX_CJS = `// Stub (CJS): this package is not needed for headless gateway operation.


### PR DESCRIPTION
  ## Summary

  - Remove `playwright-core` and `pdfjs-dist` from the `PACKAGES_TO_STUB` list in the OpenClaw runtime pruning script

  ## Background

  The prune script (`scripts/prune-openclaw-runtime.cjs`) replaces large packages with lightweight stubs to reduce package size. However, two of the three stubbed packages are actively used by OpenClaw at
  runtime:

  - **`playwright-core` (9.6MB)**: Used by OpenClaw's browser tool (`pw-session.ts`) for web page screenshots, content extraction, and browser automation. It's imported via top-level static `import` with no
  try-catch protection — stubbing it causes the browser tool to fail completely. This is the root cause of customer reports about being unable to open browsers.

  - **`pdfjs-dist` (40MB)**: Used by OpenClaw's `extractPdfContent` for reading and analyzing PDF file contents. Stubbing it prevents the AI from reading PDF files sent by users.

  Only `koffi` remains stubbed, as it is solely used for Windows terminal VT input mode in `@mariozechner/pi-tui`, is protected by try-catch, and has no impact on gateway mode operation.

  ## Test plan

  - [x] Run `node scripts/prune-openclaw-runtime.cjs` and verify only `koffi` is listed as stubbed
  - [ ] Start OpenClaw gateway and verify browser tool works (e.g. take a screenshot of a webpage)
  - [ ] Verify PDF reading works (e.g. send a PDF file and ask AI to analyze it)
