### PR TITLE
feat:  IM机器人配置， POPO机器人配置内，高级配置模块，添加 一键复制 “Webhook Base URL” 的能力

### DIFF
--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { SignalIcon, XMarkIcon, CheckCircleIcon, XCircleIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { SignalIcon, XMarkIcon, CheckCircleIcon, XCircleIcon, ExclamationTriangleIcon, ClipboardDocumentIcon, CheckIcon } from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
 import { RootState } from '../../store';
 import { imService } from '../../services/im';
@@ -132,6 +132,7 @@ const IMSettings: React.FC = () => {
   const [wecomQuickSetupStatus, setWecomQuickSetupStatus] = useState<'idle' | 'pending' | 'success' | 'error'>('idle');
   const [wecomQuickSetupError, setWecomQuickSetupError] = useState<string>('');
   const [localIp, setLocalIp] = useState<string>('');
+  const [webhookBaseUrlCopied, setWebhookBaseUrlCopied] = useState(false);
   const isMountedRef = useRef(true);
 
   // OpenClaw config schema for schema-driven forms
@@ -3171,14 +3172,40 @@ const IMSettings: React.FC = () => {
                 {/* Webhook Base URL */}
                 <div className="space-y-1.5">
                   <label className="block text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">Webhook Base URL</label>
-                  <input
-                    type="text"
-                    value={popoConfig.webhookBaseUrl}
-                    onChange={(e) => handlePopoChange({ webhookBaseUrl: e.target.value })}
-                    onBlur={() => void handleSavePopoConfig()}
-                    placeholder={localIp ? `http://${localIp}` : (i18nService.t('lang') === 'zh' ? '外部域名（可选，不填则自动检测本机 IP）' : 'External domain (optional, auto-detects local IP)')}
-                    className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-sm transition-colors"
-                  />
+                  <div className="relative">
+                    <input
+                      type="text"
+                      value={popoConfig.webhookBaseUrl}
+                      onChange={(e) => handlePopoChange({ webhookBaseUrl: e.target.value })}
+                      onBlur={() => void handleSavePopoConfig()}
+                      placeholder={localIp ? `http://${localIp}` : (i18nService.t('lang') === 'zh' ? '外部域名（可选，不填则自动检测本机 IP）' : 'External domain (optional, auto-detects local IP)')}
+                      className="block w-full rounded-lg dark:bg-claude-darkSurface/80 bg-claude-surface/80 dark:border-claude-darkBorder/60 border-claude-border/60 border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-10 text-sm transition-colors"
+                    />
+                    <div className="absolute right-2 inset-y-0 flex items-center">
+                      <button
+                        type="button"
+                        onClick={async () => {
+                          const text = popoConfig.webhookBaseUrl || (localIp ? `http://${localIp}` : '');
+                          try {
+                            await navigator.clipboard.writeText(text);
+                            setWebhookBaseUrlCopied(true);
+                            setTimeout(() => setWebhookBaseUrlCopied(false), 1500);
+                          } catch (err) {
+                            console.error('Failed to copy webhook base URL:', err);
+                          }
+                        }}
+                        className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
+                        title={i18nService.t('copyToClipboard')}
+                        aria-label={i18nService.t('copyToClipboard')}
+                      >
+                        {webhookBaseUrlCopied ? (
+                          <CheckIcon className="h-4 w-4 text-green-500" />
+                        ) : (
+                          <ClipboardDocumentIcon className="h-4 w-4" />
+                        )}
+                      </button>
+                    </div>
+                  </div>
                 </div>
 
                 {/* Webhook Path */}


### PR DESCRIPTION
### **现状截图：**

<img width="2360" height="1530" alt="image" src="https://github.com/user-attachments/assets/7eb7f3f5-908d-4588-9921-339ab994a24a" />

### 优化后功能
<img width="2134" height="1720" alt="image" src="https://github.com/user-attachments/assets/511e15c0-f339-470a-b868-c63e5b9853a4" />




### **POPO Webhook Base URL 复制按钮**

**需求**

路径: 设置 > IM机器人 > POPO > 高级设置 > Webhook Base URL

功能: 在 Webhook Base URL 输入框右侧增加复制按钮，点击一键复制该字段的值

实现方案

1. 修改文件

[src/renderer/components/im/IMSettings.tsx](https://github.com/netease-youdao/LobsterAI/compare/main...shaqihe:feature/src/renderer/components/im/IMSettings.tsx)

2. 具体改动

2.1 导入图标

在现有 @heroicons/react 导入中增加 ClipboardDocumentIcon 和 CheckIcon（若尚未导入）：

import { ..., ClipboardDocumentIcon, CheckIcon } from '@heroicons/react/24/outline';

2.2 复制逻辑与 UI 布局

参考同文件中 AES Key 的布局（约 3126–3158 行）：使用 relative 容器包裹输入框，右侧用 absolute 放置按钮。

将 Webhook Base URL 的 <input> 放入 div.relative

为输入框添加 pr-10 预留复制按钮空间

在右侧添加复制按钮，使用 ClipboardDocumentIcon / CheckIcon 做复制前后状态切换

复制内容：优先使用 popoConfig.webhookBaseUrl；若为空且存在 localIp，则复制 http://${localIp}（与 placeholder 一致，便于用户粘贴有效 Base URL）

2.3 复制实现

沿用 [CoworkSessionDetail.tsx](https://github.com/netease-youdao/LobsterAI/compare/main...shaqihe:feature/src/renderer/components/cowork/CoworkSessionDetail.tsx) 的 CopyButton 模式：

使用 navigator.clipboard.writeText(text) 执行复制

使用 useState 管理 copied 状态，复制成功后约 1.5–2 秒后重置

复制成功时显示 CheckIcon，否则显示 ClipboardDocumentIcon

按钮 title 使用已有 i18n 键 copyToClipboard（复制到剪贴板）

3. 布局示意

┌─────────────────────────────────────────────────────┬────┐
│ Webhook Base URL                                     │    │
├─────────────────────────────────────────────────────┼────┤
│ http://192.168.1.100/                                 │ 📋 │  <- 复制按钮
└─────────────────────────────────────────────────────┴────┘

4. i18n

无需新增 i18n 键，直接使用已有的 copyToClipboard（zh: 复制到剪贴板，en: Copy to Clipboard）。

5. 边界情况

当 webhookBaseUrl 为空且 localIp 存在时：复制 http://${localIp}

当两者都为空时：复制空字符串（或可考虑禁用按钮，按实现复杂度选择）




