### PR TITLE
feat(cowork): 优化图片附件预览体验

### DIFF
--- a/src/renderer/components/cowork/CoworkImageLightbox.tsx
+++ b/src/renderer/components/cowork/CoworkImageLightbox.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect } from 'react';
+
+interface CoworkImageLightboxProps {
+  imageSrc: string | null;
+  imageAlt?: string;
+  onClose: () => void;
+}
+
+const CoworkImageLightbox: React.FC<CoworkImageLightboxProps> = ({
+  imageSrc,
+  imageAlt = 'Preview',
+  onClose,
+}) => {
+  useEffect(() => {
+    if (!imageSrc) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [imageSrc, onClose]);
+
+  if (!imageSrc) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 cursor-pointer"
+      onClick={onClose}
+    >
+      <img
+        src={imageSrc}
+        alt={imageAlt}
+        className="max-h-[90vh] max-w-[90vw] object-contain rounded-lg shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      />
+    </div>
+  );
+};
+
+export default CoworkImageLightbox;

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -6,6 +6,7 @@ import PaperClipIcon from '../icons/PaperClipIcon';
 import XMarkIcon from '../icons/XMarkIcon';
 import ModelSelector from '../ModelSelector';
 import FolderSelectorPopover from './FolderSelectorPopover';
+import CoworkImageLightbox from './CoworkImageLightbox';
 import { SkillsButton, ActiveSkillBadge } from '../skills';
 import { i18nService } from '../../services/i18n';
 import { skillService } from '../../services/skill';
@@ -116,6 +117,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const [isDraggingFiles, setIsDraggingFiles] = useState(false);
     const [isAddingFile, setIsAddingFile] = useState(false);
     const [imageVisionHint, setImageVisionHint] = useState(false);
+    const [expandedImage, setExpandedImage] = useState<{ src: string; alt: string } | null>(null);
 
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const folderButtonRef = useRef<HTMLButtonElement>(null);
@@ -145,6 +147,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   const isLarge = size === 'large';
   const minHeight = isLarge ? 60 : 24;
   const maxHeight = isLarge ? 200 : 200;
+  const selectedModel = useSelector((state: RootState) => state.model.selectedModel);
+  const modelSupportsImage = !!selectedModel?.supportsImage;
 
   // Load skills on mount
   useEffect(() => {
@@ -181,6 +185,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       if (shouldClear) {
         setValue('');
         setAttachments([]);
+        setExpandedImage(null);
       }
       requestAnimationFrame(() => {
         textareaRef.current?.focus();
@@ -228,7 +233,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     // Extract image attachments (with base64 data) for vision-capable models
     const imageAtts: CoworkImageAttachment[] = [];
     for (const attachment of attachments) {
-      if (attachment.isImage && attachment.dataUrl) {
+      if (modelSupportsImage && attachment.isImage && attachment.dataUrl) {
         const extracted = extractBase64FromDataUrl(attachment.dataUrl);
         if (extracted) {
           imageAtts.push({
@@ -264,7 +269,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     dispatch(setDraftPrompt(''));
     setAttachments([]);
     setImageVisionHint(false);
-  }, [value, isStreaming, disabled, onSubmit, activeSkillIds, skills, attachments, showFolderSelector, workingDirectory, dispatch]);
+    setExpandedImage(null);
+  }, [value, isStreaming, disabled, onSubmit, activeSkillIds, skills, attachments, showFolderSelector, workingDirectory, dispatch, modelSupportsImage]);
 
   const handleSelectSkill = useCallback((skill: Skill) => {
     dispatch(toggleActiveSkill(skill.id));
@@ -309,9 +315,6 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       onWorkingDirectoryChange(path);
     }
   };
-
-  const selectedModel = useSelector((state: RootState) => state.model.selectedModel);
-  const modelSupportsImage = !!selectedModel?.supportsImage;
 
   const addAttachment = useCallback((filePath: string, imageInfo?: { isImage: boolean; dataUrl?: string }) => {
     if (!filePath) return;
@@ -419,27 +422,31 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         : isImageMimeType(file.type);
 
       if (fileIsImage) {
-        if (modelSupportsImage) {
-          // For images on vision-capable models, read as data URL
-          if (nativePath) {
-            try {
-              const result = await window.electron.dialog.readFileAsDataUrl(nativePath);
-              if (result.success && result.dataUrl) {
-                addAttachment(nativePath, { isImage: true, dataUrl: result.dataUrl });
-                continue;
-              }
-            } catch (error) {
-              console.error('Failed to read image as data URL:', error);
+        let imageDataUrl: string | undefined;
+        if (nativePath) {
+          try {
+            const result = await window.electron.dialog.readFileAsDataUrl(nativePath);
+            if (result.success && result.dataUrl) {
+              imageDataUrl = result.dataUrl;
             }
-            // Fallback: add as regular file attachment
-            addAttachment(nativePath);
+          } catch (error) {
+            console.error('Failed to read image as data URL:', error);
+          }
+        } else {
+          try {
+            imageDataUrl = await fileToDataUrl(file);
+          } catch (error) {
+            console.error('Failed to read image from clipboard:', error);
+          }
+        }
+
+        if (modelSupportsImage) {
+          if (nativePath) {
+            addAttachment(nativePath, { isImage: true, dataUrl: imageDataUrl });
           } else {
-            // No native path (clipboard/drag from browser) - read via FileReader
-            try {
-              const dataUrl = await fileToDataUrl(file);
-              addImageAttachmentFromDataUrl(file.name, dataUrl);
-            } catch (error) {
-              console.error('Failed to read image from clipboard:', error);
+            if (imageDataUrl) {
+              addImageAttachmentFromDataUrl(file.name, imageDataUrl);
+            } else {
               const stagedPath = await saveInlineFile(file);
               if (stagedPath) {
                 addAttachment(stagedPath);
@@ -448,8 +455,18 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
           }
           continue;
         }
-        // Model doesn't support image input — add as file path and show hint
+
         hasImageWithoutVision = true;
+        if (nativePath) {
+          addAttachment(nativePath, { isImage: true, dataUrl: imageDataUrl });
+          continue;
+        }
+
+        const stagedPath = await saveInlineFile(file);
+        if (stagedPath) {
+          addAttachment(stagedPath, { isImage: true, dataUrl: imageDataUrl });
+        }
+        continue;
       }
 
       // Non-image file or model doesn't support images: use original flow
@@ -479,20 +496,24 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       let hasImageWithoutVision = false;
       for (const filePath of result.paths) {
         if (isImagePath(filePath)) {
-          if (modelSupportsImage) {
-            try {
-              const readResult = await window.electron.dialog.readFileAsDataUrl(filePath);
-              if (readResult.success && readResult.dataUrl) {
-                addAttachment(filePath, { isImage: true, dataUrl: readResult.dataUrl });
-                continue;
-              }
-            } catch (error) {
-              console.error('Failed to read image as data URL:', error);
-
+          let imageDataUrl: string | undefined;
+          try {
+            const readResult = await window.electron.dialog.readFileAsDataUrl(filePath);
+            if (readResult.success && readResult.dataUrl) {
+              imageDataUrl = readResult.dataUrl;
             }
+          } catch (error) {
+            console.error('Failed to read image as data URL:', error);
+          }
+
+          if (modelSupportsImage) {
+            addAttachment(filePath, { isImage: true, dataUrl: imageDataUrl });
+            continue;
           } else {
             hasImageWithoutVision = true;
           }
+          addAttachment(filePath, { isImage: true, dataUrl: imageDataUrl });
+          continue;
         }
         addAttachment(filePath);
       }
@@ -572,27 +593,61 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       {attachments.length > 0 && (
         <div className="mb-2 flex flex-wrap gap-2">
           {attachments.map((attachment) => (
-              <div
-                key={attachment.path}
-                className="inline-flex items-center gap-1.5 rounded-full border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface bg-claude-surface px-2.5 py-1 text-xs dark:text-claude-darkText text-claude-text max-w-full"
-                title={attachment.path}
-              >
+            <div
+              key={attachment.path}
+              className={`group inline-flex max-w-full items-center gap-1 rounded-full border py-1 text-xs dark:text-claude-darkText text-claude-text transition-colors ${
+                attachment.isImage
+                  ? 'px-1.5 dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface bg-claude-surface hover:border-claude-accent/50 dark:hover:border-claude-accent/50'
+                  : 'gap-1.5 px-2.5 dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface bg-claude-surface'
+              }`}
+              title={attachment.path}
+            >
                 {attachment.isImage ? (
-                  <PhotoIcon className="h-3.5 w-3.5 flex-shrink-0 text-blue-500" />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (!attachment.dataUrl) return;
+                      setExpandedImage({ src: attachment.dataUrl, alt: attachment.name });
+                    }}
+                    className={`inline-flex min-w-0 items-center gap-2 rounded-full pr-1 transition-all ${
+                      attachment.dataUrl
+                        ? 'cursor-pointer hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover'
+                        : 'cursor-default'
+                    }`}
+                    disabled={!attachment.dataUrl}
+                  >
+                    {attachment.dataUrl ? (
+                      <span className="flex h-8 w-10 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-black/5 transition-transform transition-colors group-hover:border-claude-accent/50 dark:border-claude-darkBorder/50 border-claude-border/50 dark:bg-white/5 group-hover:scale-[1.02]">
+                        <img
+                          src={attachment.dataUrl}
+                          alt={attachment.name}
+                          className="h-full w-full object-contain"
+                        />
+                      </span>
+                    ) : (
+                      <PhotoIcon className="h-3.5 w-3.5 flex-shrink-0 text-blue-500" />
+                    )}
+                    <span className="truncate max-w-[180px]">{attachment.name}</span>
+                  </button>
                 ) : (
-                  <PaperClipIcon className="h-3.5 w-3.5 flex-shrink-0" />
+                  <>
+                    <PaperClipIcon className="h-3.5 w-3.5 flex-shrink-0" />
+                    <span className="truncate max-w-[180px]">{attachment.name}</span>
+                  </>
                 )}
-                <span className="truncate max-w-[180px]">{attachment.name}</span>
                 <button
                   type="button"
-                  onClick={() => handleRemoveAttachment(attachment.path)}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleRemoveAttachment(attachment.path);
+                  }}
                   className="ml-0.5 rounded-full p-0.5 hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover"
                   aria-label={i18nService.t('coworkAttachmentRemove')}
                   title={i18nService.t('coworkAttachmentRemove')}
                 >
                   <XMarkIcon className="h-3 w-3" />
                 </button>
-              </div>
+            </div>
           ))}
         </div>
       )}
@@ -766,6 +821,11 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
           {i18nService.t('coworkSelectFolderFirst')}
         </div>
       )}
+      <CoworkImageLightbox
+        imageSrc={expandedImage?.src ?? null}
+        imageAlt={expandedImage?.alt}
+        onClose={() => setExpandedImage(null)}
+      />
     </div>
   );
   }

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -22,6 +22,7 @@ import PuzzleIcon from '../icons/PuzzleIcon';
 import EllipsisHorizontalIcon from '../icons/EllipsisHorizontalIcon';
 import PencilSquareIcon from '../icons/PencilSquareIcon';
 import TrashIcon from '../icons/TrashIcon';
+import CoworkImageLightbox from './CoworkImageLightbox';
 import WindowTitleBar from '../window/WindowTitleBar';
 import { getCompactFolderName } from '../../utils/path';
 import { getScheduledReminderDisplayText } from '../../../common/scheduledReminderText';
@@ -894,7 +895,7 @@ const CopyButton: React.FC<{
 
 export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[] }> = React.memo(({ message, skills }) => {
   const [isHovered, setIsHovered] = useState(false);
-  const [expandedImage, setExpandedImage] = useState<string | null>(null);
+  const [expandedImage, setExpandedImage] = useState<{ src: string; alt: string } | null>(null);
 
   // Get skills used for this message
   const messageSkillIds = (message.metadata as CoworkMessageMetadata)?.skillIds || [];
@@ -924,21 +925,24 @@ export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[]
                 )}
                 {imageAttachments.length > 0 && (
                   <div className={`flex flex-wrap gap-2 ${message.content?.trim() ? 'mt-2' : ''}`}>
-                    {imageAttachments.map((img, idx) => (
-                      <div key={idx} className="relative group">
-                        <img
-                          src={`data:${img.mimeType};base64,${img.base64Data}`}
-                          alt={img.name}
-                          className="max-h-48 max-w-[16rem] rounded-lg object-contain cursor-pointer border dark:border-claude-darkBorder/50 border-claude-border/50 hover:border-claude-accent/50 transition-colors"
-                          title={img.name}
-                          onClick={() => setExpandedImage(`data:${img.mimeType};base64,${img.base64Data}`)}
-                        />
-                        <div className="absolute bottom-1 left-1 right-1 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/50 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity truncate pointer-events-none">
-                          <PhotoIcon className="h-3 w-3 flex-shrink-0" />
-                          <span className="truncate">{img.name}</span>
+                    {imageAttachments.map((img, idx) => {
+                      const imageSrc = `data:${img.mimeType};base64,${img.base64Data}`;
+                      return (
+                        <div key={idx} className="relative group">
+                          <img
+                            src={imageSrc}
+                            alt={img.name}
+                            className="max-h-48 max-w-[16rem] rounded-lg object-contain cursor-pointer border dark:border-claude-darkBorder/50 border-claude-border/50 hover:border-claude-accent/50 transition-colors"
+                            title={img.name}
+                            onClick={() => setExpandedImage({ src: imageSrc, alt: img.name })}
+                          />
+                          <div className="absolute bottom-1 left-1 right-1 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/50 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity truncate pointer-events-none">
+                            <PhotoIcon className="h-3 w-3 flex-shrink-0" />
+                            <span className="truncate">{img.name}</span>
+                          </div>
                         </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </div>
@@ -964,20 +968,11 @@ export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[]
           </div>
         </div>
       </div>
-      {/* Image lightbox overlay */}
-      {expandedImage && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 cursor-pointer"
-          onClick={() => setExpandedImage(null)}
-        >
-          <img
-            src={expandedImage}
-            alt="Preview"
-            className="max-h-[90vh] max-w-[90vw] object-contain rounded-lg shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-          />
-        </div>
-      )}
+      <CoworkImageLightbox
+        imageSrc={expandedImage?.src ?? null}
+        imageAlt={expandedImage?.alt}
+        onClose={() => setExpandedImage(null)}
+      />
     </div>
   );
 });


### PR DESCRIPTION
## 变更摘要
本次 PR 优化了 Cowork 场景下的图片附件预览体验，让用户在发送前和发送后都能更直观地查看图片内容，减少误传和重复确认成本。

## 为什么要做这次优化
此前输入框中的图片附件主要以文件名或图标形式展示，用户在发送前无法快速确认具体图片内容；发送后的图片预览逻辑也和输入区不一致，整体体验不够连贯。对于图片较多或文件名不直观的场景，这会增加确认成本，也更容易误传错误图片。

## 改动内容
### 1. 抽离统一的大图预览组件
新增 `src/renderer/components/cowork/CoworkImageLightbox.tsx`，用于统一处理图片大图预览：
- 支持点击图片后放大查看
- 支持点击遮罩关闭
- 支持按 `Esc` 快捷关闭

### 2. 优化输入区图片附件展示
修改 `src/renderer/components/cowork/CoworkPromptInput.tsx`：
- 图片附件从“普通文件样式”优化为“缩略图 + 文件名”的展示方式
- 点击缩略图可以直接预览大图
- 在提交消息或清空输入框时同步重置预览状态
- 即使当前模型未开启图片理解能力，也尽量保留图片预览所需的数据，保证本地确认体验

### 3. 统一消息区图片预览行为
修改 `src/renderer/components/cowork/CoworkSessionDetail.tsx`：
- 将原本内联的图片放大预览逻辑替换为统一的 `CoworkImageLightbox`
- 让发送后的图片消息与输入区使用一致的预览交互
- 补充图片 `alt` / 预览状态结构，减少重复实现

## 效果
- 发送前可以更直观地确认附加的是否是目标图片
- 发送后查看大图的方式更统一，交互更自然
- 降低误传图片的概率
- 减少为确认图片内容而反复打开外部查看器的成本

## 关联 issue
无

## UI 截图
<img width="762" height="97" alt="image" src="https://github.com/user-attachments/assets/9fc37be0-c41d-48d9-8da2-9accdbb466e5" />

<img width="820" height="458" alt="image" src="https://github.com/user-attachments/assets/0af08dc6-5b0c-4d91-a46f-9765bf5e7dfa" />

## Electron 行为变更说明
本次改动仅涉及 Renderer 侧的交互与展示逻辑优化，没有新增 IPC，也没有修改主进程行为。
