### PR TITLE
fix: suppress timeout hint when task is manually stopped

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -3292,6 +3292,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
    */
   private ensureActiveTurn(sessionId: string, sessionKey: string, runId: string): void {
     if (this.activeTurns.has(sessionId)) return;
+    if (this.manuallyStoppedSessions.has(sessionId)) {
+      console.warn('[OpenClawRuntime] ensureActiveTurn called after manual stop — sessionId:', sessionId, 'runId:', runId, 'sessionKey:', sessionKey);
+    }
     const turnRunId = runId || randomUUID();
     const turnToken = this.nextTurnToken(sessionId);
     const isChannel = this.channelSessionSync


### PR DESCRIPTION
## Summary
- 修复手动停止任务时错误显示 `[任务超时]` 提示的问题
- 根因：`stopSession()` 清理 turn 后，gateway 回送的 late `aborted` 事件经 `resolveSessionIdFromChatPayload` → `ensureActiveTurn` 重建了一个 `stopRequested=false` 的新 turn，导致 `handleChatAborted` 误判为超时
- 方案：新增 `manuallyStoppedSessions` 集合，在 `stopSession` 时记录，`handleChatAborted` 中额外检查，避免对手动停止的 session 显示超时提示

## Test plan
- [ ] 发送一个耗时任务，等 AI 开始输出后手动停止 → 不应出现超时提示
- [ ] 连续多次发送并手动停止 → 均不出现超时提示
- [ ] 发送简短任务等其正常完成 → 无异常提示
- [ ] 临时调短 `OPENCLAW_AGENT_TIMEOUT_SECONDS`，发送长任务等待真正超时 → 应正常显示超时提示
- [ ] 手动停止后再发新消息 → 新任务正常完成，无残留影响