### PR TITLE
fix(scheduled-task): skip future-date validation when editing an existing task

### DIFF
--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -235,7 +235,11 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
     }
     if (form.scheduleKind === 'at') {
       const runAtMs = Date.parse(form.scheduleAt);
-      if (!Number.isFinite(runAtMs) || runAtMs <= Date.now()) {
+      if (!Number.isFinite(runAtMs)) {
+        nextErrors.schedule = i18nService.t('scheduledTasksFormValidationDatetimeFuture');
+      } else if (mode === 'create' && runAtMs <= Date.now()) {
+        // Only enforce future-date constraint when creating a new task;
+        // editing an already-fired task should still allow saving other fields.
         nextErrors.schedule = i18nService.t('scheduledTasksFormValidationDatetimeFuture');
       }
     }


### PR DESCRIPTION
## Summary

- Fix: editing a scheduled task with schedule kind `at` whose time has already passed was blocked by the "datetime must be in the future" validation error, even when the user only changed non-schedule fields (e.g. task name or description).

## Problem

`TaskForm.validate()` unconditionally enforces `runAtMs <= Date.now()` for `at`-type tasks regardless of whether the form is in `create` or `edit` mode. When a user edits a previously fired one-time task (e.g. to rename it), the form is pre-filled with the original past datetime and validation always rejects the save.

**Steps to reproduce:**
1. Create a scheduled task → Schedule kind: "At" → set time to 1 minute from now
2. Wait for the time to pass
3. Edit the task → only change the task name
4. Click Save → ❌ blocked by "执行时间必须在未来" error

## Fix

Split the validation into two checks:
- **Format validity** (`Number.isFinite`) — always enforced in both create and edit modes
- **Future-date constraint** (`runAtMs <= Date.now()`) — only enforced in `create` mode

The `mode` prop (`'create' | 'edit'`) was already available on the component but unused by `validate()`.

## Screenshots

**Before (edit mode blocked):**

The validation error appears even when only the task name is changed:

![scheduled-task-edit-blocked](https://github.com/user-attachments/assets/placeholder)

## Changed Files

- `src/renderer/components/scheduledTasks/TaskForm.tsx` — 5 lines added, 1 removed