### PR TITLE
fix(im): 切换模型后 IM 通道立即生效

### DIFF
--- a/src/main/im/imChatHandler.ts
+++ b/src/main/im/imChatHandler.ts
@@ -21,7 +21,7 @@ interface LLMConfig {
 export interface IMChatHandlerOptions {
   getLLMConfig: () => Promise<LLMConfig | null>;
   getSkillsPrompt?: () => Promise<string | null>;
-  imSettings: IMSettings;
+  imSettings: IMSettings | (() => IMSettings);
 }
 
 export class IMChatHandler {
@@ -29,6 +29,14 @@ export class IMChatHandler {
 
   constructor(options: IMChatHandlerOptions) {
     this.options = options;
+  }
+
+  /**
+   * Resolve imSettings, supporting both static object and getter function.
+   */
+  private resolveIMSettings(): IMSettings {
+    const s = this.options.imSettings;
+    return typeof s === 'function' ? s() : s;
   }
 
   /**
@@ -40,10 +48,12 @@ export class IMChatHandler {
       throw new Error('LLM configuration not found');
     }
 
-    // Build system prompt with optional skills
-    let systemPrompt = this.options.imSettings.systemPrompt || '';
+    const imSettings = this.resolveIMSettings();
 
-    if (this.options.imSettings.skillsEnabled && this.options.getSkillsPrompt) {
+    // Build system prompt with optional skills
+    let systemPrompt = imSettings.systemPrompt || '';
+
+    if (imSettings.skillsEnabled && this.options.getSkillsPrompt) {
       const skillsPrompt = await this.options.getSkillsPrompt();
       if (skillsPrompt) {
         systemPrompt = systemPrompt
@@ -53,7 +63,7 @@ export class IMChatHandler {
     }
 
     // Append IM media sending instruction
-    const mediaInstruction = buildIMMediaInstruction(this.options.imSettings);
+    const mediaInstruction = buildIMMediaInstruction(imSettings);
     if (mediaInstruction) {
       systemPrompt = systemPrompt
         ? `${systemPrompt}\n\n${mediaInstruction}`
@@ -287,9 +297,10 @@ export class IMChatHandler {
     }
 
     // Build system prompt
-    let systemPrompt = this.options.imSettings.systemPrompt || '';
+    const imSettings = this.resolveIMSettings();
+    let systemPrompt = imSettings.systemPrompt || '';
 
-    if (this.options.imSettings.skillsEnabled && this.options.getSkillsPrompt) {
+    if (imSettings.skillsEnabled && this.options.getSkillsPrompt) {
       const skillsPrompt = await this.options.getSkillsPrompt();
       if (skillsPrompt) {
         systemPrompt = systemPrompt

--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -310,12 +310,10 @@ export class IMGatewayManager extends EventEmitter {
       return;
     }
 
-    const imSettings = this.imStore.getIMSettings();
-
     this.chatHandler = new IMChatHandler({
       getLLMConfig: this.getLLMConfig,
       getSkillsPrompt: this.getSkillsPrompt || undefined,
-      imSettings,
+      imSettings: () => this.imStore.getIMSettings(),
     });
 
     // Update or create Cowork handler if dependencies are available

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1572,7 +1572,7 @@ if (!gotTheLock) {
     if (key === 'app_config') {
       const syncResult = await syncOpenClawConfig({
         reason: 'app-config-change',
-        restartGatewayIfRunning: false,
+        restartGatewayIfRunning: true,
       });
       if (!syncResult.success) {
         console.error('[OpenClaw] Failed to sync config after app_config update:', syncResult.error);


### PR DESCRIPTION
复现了 #585 说的问题：设置里把模型从通义千问切到智谱之后，飞书那边发消息返回的还是通义的错误。

查了下发现 `imChatHandler` 初始化的时候把配置存成了静态对象，后面改了它感知不到。另外 `main.ts` 里 app_config 变更也没触发网关重启，所以 OpenClaw 那边一直用的旧配置。

改了三个地方：
1. imChatHandler 的 imSettings 改成 getter，每条消息进来实时读
2. imGatewayManager 传 getter 函数进去而不是一次性的值
3. app_config 改了之后触发网关重启

飞书上来回切了几次模型，消息都能正确走到新模型。