### PR TITLE
fix(cowork): 修复侧边栏折叠时新建按钮图标容易误认为重命名

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -13,11 +13,11 @@ import {
   ExclamationTriangleIcon,
   ChevronRightIcon,
   PhotoIcon,
+  PlusIcon,
 } from '@heroicons/react/24/outline';
 import { FolderIcon } from '@heroicons/react/24/solid';
 import { coworkService } from '../../services/cowork';
 import SidebarToggleIcon from '../icons/SidebarToggleIcon';
-import ComposeIcon from '../icons/ComposeIcon';
 import PuzzleIcon from '../icons/PuzzleIcon';
 import EllipsisHorizontalIcon from '../icons/EllipsisHorizontalIcon';
 import PencilSquareIcon from '../icons/PencilSquareIcon';
@@ -1877,8 +1877,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 type="button"
                 onClick={onNewChat}
                 className="h-8 w-8 inline-flex items-center justify-center rounded-lg dark:text-claude-darkTextSecondary text-claude-textSecondary hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors"
+                title={i18nService.t('newChat')}
               >
-                <ComposeIcon className="h-4 w-4" />
+                <PlusIcon className="h-4 w-4" />
               </button>
               {updateBadge}
             </div>


### PR DESCRIPTION
#552 说的这个我自己也碰到过——侧边栏收起来之后顶上有个铅笔图标，下意识以为是重命名，点完才发现新建了个会话。

看了下代码，这个按钮功能其实没错，就是图标用的 ComposeIcon（铅笔+文档）跟菜单里的重命名图标太像了。换成 PlusIcon 加号就清楚了，顺便加了个 hover 提示。