### PR TITLE
fix(settings): 修复部分模型连接测试误报失败的问题

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1485,6 +1485,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
           body: JSON.stringify({
             model: firstModel.id,
             max_tokens: CONNECTIVITY_TEST_TOKEN_BUDGET,
+            stream: false,
             messages: [{ role: 'user', content: 'Hi' }],
           }),
         });
@@ -1508,6 +1509,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
           : {
               model: firstModel.id,
               messages: [{ role: 'user', content: 'Hi' }],
+              stream: false,
             };
         if (!useResponsesApi && shouldUseMaxCompletionTokensForOpenAI(testingProvider, firstModel.id)) {
           openAIRequestBody.max_completion_tokens = CONNECTIVITY_TEST_TOKEN_BUDGET;
@@ -1528,10 +1530,37 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
         enableProvider(testingProvider);
         showTestResultModal({ success: true, message: i18nService.t('connectionSuccess') }, testingProvider);
       } else {
+        // HTTP 429 means rate-limited — the connection and auth are working
+        if (response.status === 429) {
+          enableProvider(testingProvider);
+          showTestResultModal({ success: true, message: i18nService.t('connectionSuccess') }, testingProvider);
+          return;
+        }
         const data = response.data || {};
-        // 提取错误信息
-        const errorMessage = data.error?.message || data.message || `${i18nService.t('connectionFailed')}: ${response.status}`;
-        if (typeof errorMessage === 'string' && errorMessage.toLowerCase().includes('model output limit was reached')) {
+        // Extract error info — data may be a string (e.g. SSE text) or an object
+        const errorMsg = typeof data === 'object'
+          ? (data as Record<string, unknown> & { error?: { message?: string }; message?: string }).error?.message
+            || (data as Record<string, unknown> & { message?: string }).message
+            || ''
+          : String(data);
+        const errorMessage = errorMsg || `${i18nService.t('connectionFailed')}: ${response.status}`;
+        // Certain error messages indicate the model actually processed the request,
+        // which means the connection and API key are valid.
+        const lowerError = typeof errorMessage === 'string' ? errorMessage.toLowerCase() : '';
+        const errorCode = typeof data === 'object'
+          ? (data as Record<string, unknown> & { error?: { code?: string; type?: string } }).error?.code
+            || (data as Record<string, unknown> & { error?: { code?: string; type?: string } }).error?.type
+            || ''
+          : '';
+        const connectionWorking = lowerError.includes('model output limit was reached')
+          || lowerError.includes('maximum context length')
+          || lowerError.includes('max_tokens')
+          || lowerError.includes('context_length_exceeded')
+          || lowerError.includes('reduce the length')
+          || (/\btokens?\b/.test(lowerError) && (lowerError.includes('limit') || lowerError.includes('exceed') || lowerError.includes('max')))
+          || errorCode === 'context_length_exceeded'
+          || errorCode === 'rate_limit_exceeded';
+        if (connectionWorking) {
           enableProvider(testingProvider);
           showTestResultModal({ success: true, message: i18nService.t('connectionSuccess') }, testingProvider);
           return;


### PR DESCRIPTION
帮同事配 GLM-4.7 的时候碰到 #592 的问题，测试连接显示失败但实际聊天没问题。抓了下请求，发现几个原因：

1. 没加 stream: false，智谱默认返回 SSE 流式响应，解析格式对不上就直接判失败了
2. 有时候返回 429 限频，说明认证连接都没问题，但是被当成失败了
3. 错误消息匹配写死了只认一种，context_length_exceeded 这种其实也说明模型跑起来了

改了 Settings.tsx 里测试连接的判断逻辑，加了 stream: false，429 当成功，然后多匹配了几种 "虽然报错但说明连上了" 的情况。

改完之后 GLM-4.7 和 GLM-5 测试都能正确显示状态了，填个错误 key 还是会报失败。