### PR TITLE
fix(openclaw): 停止网关时清理进程监听器防止 fd 泄漏

### DIFF
--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -1121,21 +1121,31 @@ export class OpenClawEngineManager extends EventEmitter {
   private stopGatewayProcess(child: GatewayProcess): void {
     this.expectedGatewayExits.add(child);
 
+    // Remove all listeners on stdout/stderr/child to prevent fd handle leaks.
+    // These were attached by attachGatewayProcessLogs() and attachGatewayExitHandlers().
+    child.stdout?.removeAllListeners();
+    child.stderr?.removeAllListeners();
+    child.removeAllListeners();
+
     try {
       child.kill();
     } catch {
       // ignore
     }
 
-    setTimeout(() => {
+    const forceKillTimer = setTimeout(() => {
       try {
         if ('pid' in child && typeof child.pid === 'number') {
-          child.kill();
+          process.kill(child.pid, 'SIGKILL');
         }
       } catch {
-        // ignore
+        // ignore — process may have already exited
       }
     }, 1200);
+
+    child.once('exit', () => {
+      clearTimeout(forceKillTimer);
+    });
   }
 
   private attachGatewayProcessLogs(child: GatewayProcess): void {


### PR DESCRIPTION
看 #601 的时候顺手翻了下 stopGatewayProcess()，发现 attachGatewayProcessLogs() 往 stdout/stderr 上挂了 on('data')，但 stop 的时候直接 kill 没摘掉这些监听。

写了个脚本反复 restart 网关 20 次，lsof 看 fd 数在涨，虽然涨得不快但是长期跑肯定有问题。

改动很小：kill 之前先 removeAllListeners 把监听摘干净，然后加了个 once('exit') 在进程正常退出时清掉强杀定时器，省得白等 1.2 秒。另外强杀从 child.kill() 改成 process.kill(pid, 'SIGKILL')，Windows 上更靠谱。

改完再跑那个脚本，fd 数稳定了。