### PR TITLE
fix(openclaw): 防止网关并发启动产生多个进程

### DIFF
--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -1203,10 +1203,18 @@ export class OpenClawEngineManager extends EventEmitter {
   private scheduleGatewayRestart(): void {
     if (this.shutdownRequested) return;
     if (this.gatewayRestartTimer) return;
+    if (this.startGatewayPromise) {
+      console.log('[OpenClaw] scheduleGatewayRestart: startGateway already in progress, skipping');
+      return;
+    }
 
     this.gatewayRestartTimer = setTimeout(() => {
       this.gatewayRestartTimer = null;
       if (this.shutdownRequested) return;
+      if (this.startGatewayPromise) {
+        console.log('[OpenClaw] scheduleGatewayRestart: startGateway already in progress at timer fire, skipping');
+        return;
+      }
       void this.startGateway();
     }, GATEWAY_RESTART_DELAY_MS);
   }


### PR DESCRIPTION
排查 #490 反复重启的问题，看 scheduleGatewayRestart() 的时候发现定时器触发时没检查有没有启动流程已经在跑了。

场景是这样的：网关挂了触发了 restart 调度，但是这时候用户正好改了个配置也触发了 startGateway()，两边都去 fork 进程，第二个起来发现端口被占了直接报错挂掉，然后又触发 restart……循环了。

跑的时候确实在日志里看到过两行 "Gateway process started"。

改了 scheduleGatewayRestart()，调度入口和定时器回调里都加了 startGatewayPromise 的检查，有启动在跑就跳过。