### PR TITLE
fix(openclaw): WebSocket 事件流增加空闲超时防止会话卡死

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -120,6 +120,8 @@ type ActiveTurn = {
   bufferedAgentPayloads: BufferedAgentEvent[];
   /** Client-side timeout watchdog timer (fallback for missing gateway abort events). */
   timeoutTimer?: ReturnType<typeof setTimeout>;
+  /** Event idle timer — fires when no chat/agent events arrive within the idle window. */
+  idleTimer?: ReturnType<typeof setTimeout>;
 };
 
 type BufferedChatEvent = {
@@ -568,6 +570,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
    */
   agentTimeoutSeconds = OPENCLAW_AGENT_TIMEOUT_SECONDS;
   private static readonly CLIENT_TIMEOUT_GRACE_MS = 30_000;
+  /** Idle timeout for WebSocket event stream — fires when no chat/agent events arrive for 5 minutes. */
+  private static readonly EVENT_IDLE_TIMEOUT_MS = 300_000;
 
   constructor(store: CoworkStore, engineManager: OpenClawEngineManager) {
     super();
@@ -1010,6 +1014,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     // lifecycle event fires). This timer fires slightly after the server-side
     // timeout to recover the UI from a stuck "running" state.
     this.startTurnTimeoutWatchdog(sessionId);
+    // Start event idle timer — recovers from stuck upstream agent that produces
+    // no events at all (complements the server-side timeout watchdog above).
+    this.resetEventIdleTimer(sessionId);
 
     const client = this.requireGatewayClient();
     try {
@@ -1695,6 +1702,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       this.lastAgentSeqByRunId.set(runId, seq);
     }
 
+    // Reset event idle timer on every non-buffered agent event
+    this.resetEventIdleTimer(sessionId);
+
     // Fast-path: skip assistant-stream events — they carry the same text as
     // chat deltas and dispatchAgentEvent() has no handler for stream=assistant.
     if (stream === 'assistant') {
@@ -2037,6 +2047,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       }
       this.lastChatSeqByRunId.set(runId, seq);
     }
+
+    // Reset event idle timer on every non-buffered chat event
+    this.resetEventIdleTimer(sessionId);
 
     if (state === 'delta') {
       this.handleChatDelta(sessionId, turn, chatPayload);
@@ -3199,6 +3212,11 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         clearTimeout(turn.timeoutTimer);
         turn.timeoutTimer = undefined;
       }
+      // Clear event idle timer
+      if (turn.idleTimer) {
+        clearTimeout(turn.idleTimer);
+        turn.idleTimer = undefined;
+      }
       // Cancel any pending throttled messageUpdate timer for this turn
       if (turn.assistantMessageId) {
         this.clearPendingMessageUpdate(turn.assistantMessageId);
@@ -3238,6 +3256,30 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       );
       this.handleChatAborted(sessionId, currentTurn);
     }, timeoutMs);
+  }
+
+  /**
+   * Reset the event idle timer for a turn.
+   * Called on every incoming chat or agent event. If no events arrive
+   * within EVENT_IDLE_TIMEOUT_MS the turn is treated as timed-out,
+   * recovering the UI from a stuck "running" state when the upstream
+   * agent hangs without producing any WS events.
+   */
+  private resetEventIdleTimer(sessionId: string): void {
+    const turn = this.activeTurns.get(sessionId);
+    if (!turn) return;
+    if (turn.idleTimer) {
+      clearTimeout(turn.idleTimer);
+    }
+    turn.idleTimer = setTimeout(() => {
+      const currentTurn = this.activeTurns.get(sessionId);
+      if (!currentTurn || currentTurn.turnToken !== turn.turnToken) return;
+      console.warn(
+        `[OpenClawRuntime] Event idle timeout fired for session ${sessionId}, `
+        + `runId=${currentTurn.runId} — no events received for ${OpenClawRuntimeAdapter.EVENT_IDLE_TIMEOUT_MS}ms`,
+      );
+      this.handleChatAborted(sessionId, currentTurn);
+    }, OpenClawRuntimeAdapter.EVENT_IDLE_TIMEOUT_MS);
   }
 
   /**
@@ -3328,6 +3370,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
     this.store.updateSession(sessionId, { status: 'running' });
     this.startTurnTimeoutWatchdog(sessionId);
+    this.resetEventIdleTimer(sessionId);
 
     // For channel sessions, prefetch user messages before streaming starts
     if (isChannel) {


### PR DESCRIPTION
之前给内置引擎加空闲超时（#512）的时候就想到 OpenClaw 这边也缺这个。

看了下 #509 加的 watchdog，它要求知道服务端的 agentTimeoutSeconds 才能算超时时间，但如果上游 API 直接不响应（连错误都不返回），这个值拿不到，watchdog 就不起作用。

加了个独立的 idleTimer，逻辑跟内置引擎一样：每收到一个事件重置 5 分钟倒计时，超时了就 abort 会话。跟已有的 timeoutTimer 不冲突，一个管总时长一个管事件间隔。

startSession/continueSession 的时候启动，cleanupSessionTurn 的时候清掉。