### PR TITLE
fix(openclaw): 修复助手消息在 tool_use 后被分片的问题

### DIFF
--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -38,7 +38,6 @@ import type { Database } from 'sql.js';
 import type { CoworkRuntime } from '../libs/agentEngine/types';
 import type { CoworkStore } from '../coworkStore';
 import { classifyErrorKey } from '../../common/coworkErrorClassify';
-import { t } from '../i18n';
 const CONNECTIVITY_TIMEOUT_MS = 10_000;
 const INBOUND_ACTIVITY_WARN_AFTER_MS = 2 * 60 * 1000;
 

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -2144,6 +2144,13 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       return;
     }
 
+    console.debug('[Debug:splitBeforeTool] assistantMessageId:', turn.assistantMessageId,
+      'currentText.length:', turn.currentText.length,
+      'committedAssistantText.length:', turn.committedAssistantText.length,
+      'currentAssistantSegmentText.length:', turn.currentAssistantSegmentText.length,
+      'currentText:', turn.currentText.slice(0, 100),
+      'pendingTimer:', this.pendingMessageUpdateTimer.has(turn.assistantMessageId));
+
     const segmentText = turn.currentAssistantSegmentText.trim();
     if (segmentText) {
       const committedCandidate = `${turn.committedAssistantText}${segmentText}`;
@@ -2160,7 +2167,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       }
     }
 
-    turn.assistantMessageId = null;
+    // Keep assistantMessageId so subsequent text appends to the same message
+    // instead of creating a new fragmented message after each tool_use block
     turn.currentAssistantSegmentText = '';
   }
 
@@ -2202,6 +2210,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (segmentText === previousSegmentText && streamedText === previousText) return;
 
     if (!turn.assistantMessageId) {
+      console.debug('[Debug:handleChatDelta] CREATE assistant msg, segmentText.length:', segmentText.length, 'text:', segmentText.slice(0, 60));
       const assistantMessage = this.store.addMessage(sessionId, {
         type: 'assistant',
         content: segmentText,
@@ -2217,15 +2226,23 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
 
     if (turn.assistantMessageId && segmentText !== previousSegmentText) {
+      // Send full accumulated text so the message contains the complete assistant
+      // response, not just the latest fragment after the last tool_use block.
+      // streamedText is the raw full text from OpenClaw; committed + segment
+      // reconstructs the same thing, so we use streamedText directly.
+      const fullContent = turn.committedAssistantText
+        ? streamedText.trim()
+        : segmentText;
+      console.debug('[Debug:handleChatDelta] UPDATE assistant msg, fullContent.length:', fullContent.length, 'committed.length:', turn.committedAssistantText.length, 'text:', fullContent.slice(0, 60));
       this.store.updateMessage(sessionId, turn.assistantMessageId, {
-        content: segmentText,
+        content: fullContent,
         metadata: {
           isStreaming: true,
           isFinal: false,
         },
       });
       turn.currentAssistantSegmentText = segmentText;
-      this.throttledEmitMessageUpdate(sessionId, turn.assistantMessageId, segmentText);
+      this.throttledEmitMessageUpdate(sessionId, turn.assistantMessageId, fullContent);
     }
   }
 
@@ -2244,15 +2261,21 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (turn.assistantMessageId) {
       const persistedSegmentText = finalSegmentText || previousSegmentText;
       if (persistedSegmentText) {
+        // Send full accumulated text for the final message.
+        // Fall back to persistedSegmentText when finalText is empty (e.g. final
+        // event contains only tool_use blocks with no text).
+        const fullContent = turn.committedAssistantText
+          ? ((finalText || '').trim() || persistedSegmentText)
+          : persistedSegmentText;
         this.store.updateMessage(sessionId, turn.assistantMessageId, {
-          content: persistedSegmentText,
+          content: fullContent,
           metadata: {
             isStreaming: false,
             isFinal: true,
           },
         });
         if (persistedSegmentText !== previousSegmentText) {
-          this.emit('messageUpdate', sessionId, turn.assistantMessageId, persistedSegmentText);
+          this.emit('messageUpdate', sessionId, turn.assistantMessageId, fullContent);
         }
       }
     } else if (finalSegmentText) {
@@ -2642,18 +2665,24 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       const session = this.store.getSession(sessionId);
       const currentMessage = session?.messages.find((message) => message.id === turn.assistantMessageId);
       const currentText = currentMessage?.content.trim() ?? '';
-      if (canonicalSegmentText === currentText) {
+      // Use full accumulated text (canonicalText) when committed text exists,
+      // to stay consistent with handleChatDelta/handleChatFinal which store
+      // the complete assistant response in a single message.
+      const persistContent = turn.committedAssistantText
+        ? (canonicalText.trim() || canonicalSegmentText)
+        : canonicalSegmentText;
+      if (persistContent === currentText) {
         return;
       }
 
       this.store.updateMessage(sessionId, turn.assistantMessageId, {
-        content: canonicalSegmentText,
+        content: persistContent,
         metadata: {
           isStreaming: false,
           isFinal: true,
         },
       });
-      this.emit('messageUpdate', sessionId, turn.assistantMessageId, canonicalSegmentText);
+      this.emit('messageUpdate', sessionId, turn.assistantMessageId, persistContent);
     } catch (error) {
       console.warn('[OpenClawRuntime] chat.history sync after final failed:', error);
     }


### PR DESCRIPTION
[问题]
OpenClaw 引擎在连续的文本-工具-文本流中，每次遇到 tool_use 块后会创建
一条新的助手消息，导致一轮对话中的助手回复被分割成多条独立消息显示。

[根因]
splitBeforeTool() 在遇到 tool_use 时会将 assistantMessageId 置为 null，
导致后续 handleChatDelta() 判定没有现有消息，从而创建新消息。同时
handleChatDelta/handleChatFinal 只存储当前 segment 的文本而非完整累积文本，
造成消息内容不完整。

[修复]
- splitBeforeTool() 不再清空 assistantMessageId，后续文本追加到同一消息
- handleChatDelta/handleChatFinal/chat.history 同步时使用完整累积文本
  （committedAssistantText + segmentText）而非仅当前 segment
- 添加调试日志辅助排查消息流转
- 移除 imGatewayManager.ts 中未使用的 t import

[复现路径]
1. 使用 OpenClaw 引擎发起 cowork 会话
2. 发送需要多次工具调用的提示
3. 观察助手回复是否被分割成多条消息