### PR TITLE
feat(renderer): 添加首次启动隐私协议弹窗

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -28,6 +28,7 @@ import { i18nService } from './services/i18n';
 import { matchesShortcut } from './services/shortcuts';
 import AppUpdateBadge from './components/update/AppUpdateBadge';
 import AppUpdateModal from './components/update/AppUpdateModal';
+import PrivacyDialog from './components/PrivacyDialog';
 
 const App: React.FC = () => {
   const [showSettings, setShowSettings] = useState(false);
@@ -43,6 +44,7 @@ const App: React.FC = () => {
   const [updateModalState, setUpdateModalState] = useState<'info' | 'downloading' | 'installing' | 'error'>('info');
   const [downloadProgress, setDownloadProgress] = useState<AppUpdateDownloadProgress | null>(null);
   const [updateError, setUpdateError] = useState<string | null>(null);
+  const [privacyAgreed, setPrivacyAgreed] = useState<boolean | null>(null);
   const toastTimerRef = useRef<number | null>(null);
   const hasInitialized = useRef(false);
   const dispatch = useDispatch();
@@ -140,6 +142,10 @@ const App: React.FC = () => {
           ) ?? resolvedModels[0];
           dispatch(setSelectedModel(preferredModel));
         }
+
+        // 检查隐私协议是否已同意（必须在 setIsInitialized 之前）
+        const agreed = await window.electron.store.get('privacy_agreed');
+        setPrivacyAgreed(agreed === true);
 
         setIsInitialized(true);
         console.info('[App] initializeApp: shell ready');
@@ -363,6 +369,16 @@ const App: React.FC = () => {
     setUpdateModalState('info');
     setUpdateError(null);
     setDownloadProgress(null);
+  }, []);
+
+  const handlePrivacyAccept = useCallback(async () => {
+    await window.electron.store.set('privacy_agreed', true);
+    setPrivacyAgreed(true);
+  }, []);
+
+  const handlePrivacyReject = useCallback(() => {
+    // 立刻隐藏窗口，让用户感觉立即关闭
+    window.electron.window.close();
   }, []);
 
   const handlePermissionResponse = useCallback(async (result: CoworkPermissionResult) => {
@@ -685,6 +701,12 @@ const App: React.FC = () => {
         />
       )}
       {permissionModal}
+      {privacyAgreed === false && (
+        <PrivacyDialog
+          onAccept={handlePrivacyAccept}
+          onReject={handlePrivacyReject}
+        />
+      )}
     </div>
   );
 };

--- a/src/renderer/components/PrivacyDialog.tsx
+++ b/src/renderer/components/PrivacyDialog.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { i18nService } from '@/services/i18n';
+
+const PRIVACY_URL = 'https://c.youdao.com/dict/hardware/lobsterai/lobsterai_service.html';
+
+interface PrivacyDialogProps {
+  onAccept: () => void;
+  onReject: () => void;
+}
+
+const PrivacyDialog: React.FC<PrivacyDialogProps> = ({ onAccept, onReject }) => {
+  const handleLinkClick = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    await window.electron.shell.openExternal(PRIVACY_URL);
+  };
+
+  const desc = i18nService.t('privacyDialogDesc');
+  const linkText = i18nService.t('privacyDialogLinkText');
+  const parts = desc.split('{link}');
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop">
+      <div className="modal-content w-full max-w-md mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal overflow-hidden">
+        {/* Header */}
+        <div className="px-6 pt-6 pb-2">
+          <h2 className="text-lg font-semibold dark:text-claude-darkText text-claude-text text-center">
+            {i18nService.t('privacyDialogTitle')}
+          </h2>
+        </div>
+
+        {/* Content */}
+        <div className="px-6 py-4">
+          <p className="text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary text-center leading-relaxed">
+            {parts[0]}
+            <a
+              href={PRIVACY_URL}
+              onClick={handleLinkClick}
+              className="text-claude-accent hover:text-claude-accentHover underline"
+            >
+              {linkText}
+            </a>
+            {parts[1]}
+          </p>
+        </div>
+
+        {/* Buttons */}
+        <div className="px-6 pb-6 pt-2 flex gap-3">
+          <button
+            onClick={onReject}
+            className="flex-1 px-4 py-2.5 rounded-xl text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary dark:bg-claude-darkSurfaceHover bg-claude-surfaceHover hover:opacity-80 transition-opacity"
+          >
+            {i18nService.t('privacyDialogReject')}
+          </button>
+          <button
+            onClick={onAccept}
+            className="flex-1 px-4 py-2.5 rounded-xl text-sm font-medium text-white bg-claude-accent hover:bg-claude-accentHover transition-colors"
+          >
+            {i18nService.t('privacyDialogAccept')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PrivacyDialog;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1040,6 +1040,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksSessionKey: '会话键',
     scheduledTasksToggleWarningAtPast: '该任务的执行时间已过，启用后将不会运行',
     scheduledTasksToggleWarningExpired: '该任务已过期，启用后将不会运行',
+
+    // 隐私协议弹窗
+    privacyDialogTitle: '网易有道LobsterAI服务协议',
+    privacyDialogDesc: '在使用网易有道LobsterAI之前，请您仔细阅读{link}内容，并进行确认。',
+    privacyDialogLinkText: '网易有道LobsterAI服务协议',
+    privacyDialogAccept: '我已阅读并同意',
+    privacyDialogReject: '拒绝',
   },
   en: {
     // Common
@@ -2076,6 +2083,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksSessionKey: 'Session Key',
     scheduledTasksToggleWarningAtPast: 'The execution time of this task has passed. It will not run after enabling',
     scheduledTasksToggleWarningExpired: 'This task has expired. It will not run after enabling',
+
+    // Privacy dialog
+    privacyDialogTitle: 'NetEase Youdao LobsterAI Terms of Service',
+    privacyDialogDesc: 'Before using NetEase Youdao LobsterAI, please carefully read the {link} and confirm.',
+    privacyDialogLinkText: 'NetEase Youdao LobsterAI Terms of Service',
+    privacyDialogAccept: 'I have read and agree',
+    privacyDialogReject: 'Decline',
   }
 };
 


### PR DESCRIPTION
[问题]
用户首次使用 LobsterAI 时，没有隐私协议确认流程，不符合合规要求

[修复]
- 新增 PrivacyDialog 组件，展示服务协议链接，提供同意/拒绝按钮
- App 初始化时检查 store 中 privacy_agreed 状态，未同意则显示弹窗
- 同意后写入 store，后续启动不再弹出
- 拒绝则立即关闭窗口
- 隐私检查在 setIsInitialized 之前执行，避免主界面闪现
- 支持中英文国际化