### PR TITLE
feat(cowork): 添加 unknown error 友好提示

### DIFF
--- a/src/common/coworkErrorClassify.ts
+++ b/src/common/coworkErrorClassify.ts
@@ -27,6 +27,8 @@ const ERROR_RULES: Array<[RegExp, string]> = [
   [/ECONNREFUSED|ENOTFOUND|ETIMEDOUT|could not connect|connection.*refused|network.*error/i, 'coworkErrorNetworkError'],
   // Server errors: HTTP 500/502/503
   [/internal.server.error|bad.gateway|service.unavailable|\b50[023]\b/i, 'coworkErrorServerError'],
+  // Unknown / unclassified errors from upstream (OpenClaw wraps unrecognized errors)
+  [/unknown error|an unknown error occurred/i, 'coworkErrorUnknown'],
 ];
 
 /**

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -45,6 +45,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorContentFiltered: '内容未通过安全审核，请修改后重试。',
     coworkErrorServerError: '服务端出现错误，请稍后重试。',
     coworkErrorEngineNotReady: 'AI 引擎正在启动中，请稍等几秒后重试。',
+    coworkErrorUnknown: '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
     imErrorPrefix: '处理消息时出错',
 
     // Skill manager errors
@@ -81,6 +82,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorContentFiltered: 'Content did not pass the safety review. Please modify and try again.',
     coworkErrorServerError: 'Server error occurred. Please try again later.',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
+    coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
     imErrorPrefix: 'Error processing message',
 
     // Skill manager errors

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -446,6 +446,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionStartFailed: '会话启动失败：{error}',
     coworkErrorSessionContinueFailed: '发送消息失败：{error}',
     coworkErrorEngineNotReady: 'AI 引擎正在启动中，请稍等几秒后重试。',
+    coworkErrorUnknown: '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
 
     // Skills
     skills: '技能',
@@ -1489,6 +1490,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionStartFailed: 'Failed to start session: {error}',
     coworkErrorSessionContinueFailed: 'Failed to send message: {error}',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
+    coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
 
     // Skills
     skills: 'Skills',


### PR DESCRIPTION
[问题]
OpenClaw 调用上游模型 API 失败时，会返回 "An unknown error occurred" 原始英文错误信息， 用户看到后无法理解也不知道如何处理

[修复]
- 在 coworkErrorClassify.ts 的 ERROR_RULES 末尾新增兜底规则，匹配 unknown error
- 在 main/renderer 两侧 i18n 中新增 coworkErrorUnknown 中英文翻译
- 用户现在会看到「任务执行出错，请重试。如果问题持续出现，请检查模型配置。」

<img width="1662" height="1154" alt="image" src="https://github.com/user-attachments/assets/a9ca98a7-9fc3-4818-9be1-81cd73172601" />
