### PR TITLE
fix(cowork): clean up in-memory state when sessions are deleted

### DIFF
--- a/src/main/libs/coworkRunner.ts
+++ b/src/main/libs/coworkRunner.ts
@@ -1602,6 +1602,27 @@ export class CoworkRunner extends EventEmitter {
     this.store.updateSession(sessionId, { status: 'idle' });
   }
 
+  onSessionDeleted(sessionId: string): void {
+    try {
+      this.stopSession(sessionId);
+    } catch {
+      // stopSession may fail if the DB row is already gone; proceed with cleanup.
+    }
+    // Remove from stoppedSessions so it doesn't linger after deletion.
+    this.stoppedSessions.delete(sessionId);
+    this.lastTurnMemoryKeyBySession.delete(sessionId);
+    // Purge any queued memory updates for the deleted session.
+    const remaining: QueuedTurnMemoryUpdate[] = [];
+    for (const job of this.turnMemoryQueue) {
+      if (job.sessionId === sessionId) {
+        this.turnMemoryQueueKeys.delete(job.key);
+      } else {
+        remaining.push(job);
+      }
+    }
+    this.turnMemoryQueue = remaining;
+  }
+
   respondToPermission(requestId: string, result: PermissionResult): void {
     const pending = this.pendingPermissions.get(requestId);
     if (!pending) return;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2179,6 +2179,19 @@ if (!gotTheLock) {
     try {
       const coworkStoreInstance = getCoworkStore();
       coworkStoreInstance.deleteSessions(sessionIds);
+      const router = getCoworkEngineRouter();
+      for (const sessionId of sessionIds) {
+        try {
+          getIMGatewayManager()?.getIMStore()?.deleteSessionMappingByCoworkSessionId(sessionId);
+        } catch {
+          // IM store may not be initialised yet; safe to ignore.
+        }
+        try {
+          router.onSessionDeleted(sessionId);
+        } catch {
+          // Router may not be initialised yet; safe to ignore.
+        }
+      }
       return { success: true };
     } catch (error) {
       return {


### PR DESCRIPTION
Add onSessionDeleted() to CoworkRunner that purges stoppedSessions, lastTurnMemoryKeyBySession, turnMemoryQueue, and turnMemoryQueueKeys for the deleted session. Wrap stopSession in try/catch so cleanup always completes even if the DB row is already gone.

Also fix deleteBatch IPC handler to clean up IM gateway session mappings per session, matching the single-delete handler behavior.