### PR TITLE
Fix/openclaw exec host gateway

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -10,7 +10,6 @@ import { parseChannelSessionKey } from './openclawChannelSessionSync';
 import type { McpToolManifestEntry } from './mcpServerManager';
 import { hasBundledOpenClawExtension } from './openclawLocalExtensions';
 import { buildScheduledTaskEnginePrompt } from './scheduledTaskEnginePrompt';
-import { getBundledPythonRoot, getUserPythonRoot } from './pythonRuntime';
 
 export type McpBridgeConfig = {
   callbackUrl: string;
@@ -565,20 +564,6 @@ export class OpenClawConfigSync {
       },
       tools: {
         deny: [...MANAGED_TOOL_DENY],
-        exec: {
-          host: 'gateway',
-          ...(process.platform === 'win32' ? (() => {
-            const userRoot = getUserPythonRoot();
-            const bundledRoot = getBundledPythonRoot();
-            const entries: string[] = [];
-            for (const root of [userRoot, bundledRoot]) {
-              if (root && fs.existsSync(root)) {
-                entries.push(root, path.join(root, 'Scripts'));
-              }
-            }
-            return entries.length > 0 ? { pathPrepend: entries } : {};
-          })() : {}),
-        },
         web: {
           search: {
             enabled: false,

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import { getElectronNodeRuntimePath } from './coworkUtil';
 import { syncLocalOpenClawExtensionsIntoRuntime } from './openclawLocalExtensions';
 import { applyBundledOpenClawRuntimeHotfixes } from './openclawRuntimeHotfix';
+import { appendPythonRuntimeToEnv } from './pythonRuntime';
 import { isSystemProxyEnabled, resolveSystemProxyUrl } from './systemProxy';
 
 type GatewayProcess = UtilityProcess | ChildProcess;
@@ -419,6 +420,10 @@ export class OpenClawEngineManager extends EventEmitter {
       const currentPath = env.PATH || env.Path || '';
       env.PATH = [cliShimDir, currentPath].filter(Boolean).join(path.delimiter);
     }
+
+    // Prepend bundled/user Python runtime paths so gateway exec commands
+    // find the LobsterAI-managed Python instead of the Windows Store stub.
+    appendPythonRuntimeToEnv(env as Record<string, string | undefined>);
 
     if (isSystemProxyEnabled()) {
       const proxyUrl = await resolveSystemProxyUrl('https://openrouter.ai');


### PR DESCRIPTION
## Summary                                                                          
                                               
  - Fix Python runtime not found on Windows in OpenClaw mode                          
  - Call `appendPythonRuntimeToEnv` when starting the gateway process to prepend the  
  bundled/user Python runtime paths into the gateway's PATH environment variable      
  - Ensures `exec` commands find the LobsterAI-managed Python instead of the Windows
  Store `python.exe` stub                                                             
                                                                  
  ## Background                                                                       
                                                                  
  Some Windows users reported that Python-related commands fail with "Python not      
  found" errors in OpenClaw mode. The root cause is that the gateway process's PATH
  did not include the LobsterAI bundled Python runtime paths, so `exec` commands could
   only find the Windows Store Python stub (`WindowsApps\python.exe`), which is not a
  real Python interpreter.

  ## Test plan                                                                        
   
  - [ ] Start OpenClaw mode on Windows                                                
  - [ ] Ask for the current Python path in a cowork session; verify it returns the
  LobsterAI bundled path instead of the WindowsApps path                              
  - [ ] Execute a Python script and confirm it runs successfully 