### PR TITLE
fix(openclaw): inject node shims into gateway PATH and guard env var

### DIFF
--- a/src/main/libs/coworkUtil.ts
+++ b/src/main/libs/coworkUtil.ts
@@ -439,7 +439,7 @@ function getWindowsGitToolDirs(bashPath: string): string[] {
   return candidates.filter((dir) => existsSync(dir));
 }
 
-function ensureElectronNodeShim(electronPath: string, npmBinDir?: string): string | null {
+export function ensureElectronNodeShim(electronPath: string, npmBinDir?: string): string | null {
   try {
     const shimDir = join(app.getPath('userData'), 'cowork', 'bin');
     mkdirSync(shimDir, { recursive: true });

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -944,9 +944,9 @@ export class OpenClawConfigSync {
 
     // Provider API Key
     const apiResolution = resolveRawApiConfig();
-    if (apiResolution.config?.apiKey) {
-      env.LOBSTER_PROVIDER_API_KEY = apiResolution.config.apiKey;
-    }
+    // Provider API Key — always set so stale openclaw.json with
+    // ${LOBSTER_PROVIDER_API_KEY} placeholder doesn't crash the gateway.
+    env.LOBSTER_PROVIDER_API_KEY = apiResolution.config?.apiKey || '';
 
     // MCP Bridge Secret
     const mcpBridgeCfg = this.getMcpBridgeConfig?.();
@@ -1004,6 +1004,11 @@ export class OpenClawConfigSync {
     }
     if (popoConfig?.enabled && popoConfig.token) {
       env.LOBSTER_POPO_TOKEN = popoConfig.token;
+    } else if (popoConfig?.enabled) {
+      // Provide empty fallback so stale openclaw.json files that still
+      // contain ${LOBSTER_POPO_TOKEN} from a previous webhook config
+      // don't crash the gateway with MissingEnvVarError.
+      env.LOBSTER_POPO_TOKEN = '';
     }
 
     // NIM

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from 'events';
 import fs from 'fs';
 import net from 'net';
 import path from 'path';
-import { getElectronNodeRuntimePath } from './coworkUtil';
+import { getElectronNodeRuntimePath, ensureElectronNodeShim } from './coworkUtil';
 import { syncLocalOpenClawExtensionsIntoRuntime } from './openclawLocalExtensions';
 import { applyBundledOpenClawRuntimeHotfixes } from './openclawRuntimeHotfix';
 import { appendPythonRuntimeToEnv } from './pythonRuntime';
@@ -424,6 +424,18 @@ export class OpenClawEngineManager extends EventEmitter {
     // Prepend bundled/user Python runtime paths so gateway exec commands
     // find the LobsterAI-managed Python instead of the Windows Store stub.
     appendPythonRuntimeToEnv(env as Record<string, string | undefined>);
+
+    // Inject node/npm/npx shims so gateway exec commands can use them.
+    // The shims wrap Electron as a Node.js runtime via ELECTRON_RUN_AS_NODE=1.
+    const npmBinDir = app.isPackaged
+      ? path.join(process.resourcesPath, 'app.asar.unpacked', 'node_modules', 'npm', 'bin')
+      : undefined;
+    const nodeShimDir = ensureElectronNodeShim(electronNodeRuntimePath, npmBinDir);
+    if (nodeShimDir) {
+      const curPath = env.PATH || env.Path || '';
+      env.PATH = [nodeShimDir, curPath].filter(Boolean).join(path.delimiter);
+      env.LOBSTERAI_NPM_BIN_DIR = npmBinDir || '';
+    }
 
     if (isSystemProxyEnabled()) {
       const proxyUrl = await resolveSystemProxyUrl('https://openrouter.ai');


### PR DESCRIPTION
## Summary

  - Inject bundled Python runtime paths into the gateway process PATH so
  exec commands find the LobsterAI-managed Python instead of the Windows
  Store stub
  - Inject node/npm/npx shims into the gateway process PATH so exec
  commands can use the bundled Electron Node.js runtime
  - Guard all `${VAR}` env var placeholders in openclaw.json with empty
  string fallbacks to prevent `MissingEnvVarError` crashes on stale
  configs or unconfigured keys

  ## Background

  **Python PATH**: Some Windows users reported "Python not found" errors
  in OpenClaw mode. The gateway process PATH did not include the bundled
  Python runtime paths, so exec commands could only find the Windows
  Store `python.exe` stub.

  **Node shims**: The gateway process only had `openclaw`/`claw` CLI
  shims in PATH but lacked `node`/`npm`/`npx`. Exec commands requiring
  Node.js would fail.

  **Env var guards**: When users upgrade versions or switch
  configurations (e.g. Popo webhook → websocket, or fresh install without
   API key), the `openclaw.json` on disk may still contain
  `${LOBSTER_PROVIDER_API_KEY}` or `${LOBSTER_POPO_TOKEN}` placeholders
  from a previous config. If the corresponding env vars are not injected,
   OpenClaw crashes with `MissingEnvVarError` during config resolution.

  ## Changes

  - **`openclawEngineManager.ts`**: Call `appendPythonRuntimeToEnv` and
  `ensureElectronNodeShim` when starting the gateway process to prepend
  Python and Node paths into the gateway's PATH
  - **`coworkUtil.ts`**: Export `ensureElectronNodeShim` so it can be
  reused by the engine manager
  - **`openclawConfigSync.ts`**: Always set `LOBSTER_PROVIDER_API_KEY`
  (empty fallback when not configured); set `LOBSTER_POPO_TOKEN` to empty
   string in websocket mode; remove unused `exec.host`/`pathPrepend`
  config and `pythonRuntime` import

  ## Test plan

  - [ ] Windows: start OpenClaw mode, ask for Python path → should return
   LobsterAI bundled path
  - [ ] Windows: run `node --version` via exec → should use bundled
  Electron Node runtime
  - [ ] Fresh install without API key configured → gateway should start
  without `MissingEnvVarError`
  - [ ] Popo websocket mode → gateway should start without
  `LOBSTER_POPO_TOKEN` error
  - [ ] Existing Popo webhook users upgrading → gateway should start
  normally with token injected