### PR TITLE
fix(cowork): remove duplicate error messages in continueSession

### DIFF
--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -284,7 +284,21 @@ class CoworkService {
       if (result.engineStatus) {
         this.notifyOpenClawStatus(result.engineStatus);
       }
-      if (result.code !== 'ENGINE_NOT_READY') {
+      if (result.code === 'ENGINE_NOT_READY') {
+        // Engine not ready: show a dedicated hint without changing session status,
+        // so the user can retry once the engine finishes starting.
+        if (result.error) {
+          store.dispatch(addMessage({
+            sessionId: options.sessionId,
+            message: {
+              id: `error-${Date.now()}`,
+              type: 'system',
+              content: i18nService.t('coworkErrorEngineNotReady'),
+              timestamp: Date.now(),
+            },
+          }));
+        }
+      } else {
         store.dispatch(updateSessionStatus({ sessionId: options.sessionId, status: 'error' }));
         if (result.error) {
           store.dispatch(addMessage({
@@ -292,26 +306,11 @@ class CoworkService {
             message: {
               id: `error-${Date.now()}`,
               type: 'system',
-              content: i18nService.t('coworkErrorSessionContinueFailed').replace('{error}', result.error),
+              content: classifyError(result.error),
               timestamp: Date.now(),
             },
           }));
         }
-      }
-      // Show a user-visible error message in the session
-      if (result.error) {
-        const errorContent = result.code === 'ENGINE_NOT_READY'
-          ? i18nService.t('coworkErrorEngineNotReady')
-          : classifyError(result.error);
-        store.dispatch(addMessage({
-          sessionId: options.sessionId,
-          message: {
-            id: `error-${Date.now()}`,
-            type: 'system',
-            content: errorContent,
-            timestamp: Date.now(),
-          },
-        }));
       }
       console.error('Failed to continue session:', result.error);
       return false;


### PR DESCRIPTION
## Problem

When `continueSession` fails with a non-`ENGINE_NOT_READY` error, the user sees **two duplicate system error messages** in the chat session.

### Root Cause

The error handling block in `CoworkService.continueSession()` had two separate `addMessage` dispatches that both triggered on the same error path:

1. **Lines 289-299**: Added a message using `coworkErrorSessionContinueFailed` template
2. **Lines 302-315**: Added another message using `classifyError()`

When `result.code !== 'ENGINE_NOT_READY'` and `result.error` was present, both blocks executed, resulting in duplicate messages.

| Error type | Block 1 (L289-299) | Block 2 (L302-315) | Messages shown |
|---|:---:|:---:|---|
| `ENGINE_NOT_READY` | ❌ skip | ✅ run | 1 ✅ |
| Other errors | ✅ run | ✅ run | **2** 🐛 |

## Fix

Merged the two blocks into a single `if/else` branch:

- **`ENGINE_NOT_READY`**: Show dedicated hint (`coworkErrorEngineNotReady`) without changing session status, so the user can retry once the engine finishes starting.
- **Other errors**: Set session status to `error` and show a single classified error message via `classifyError()`.

## How to reproduce (before fix)

1. Configure an invalid API key
2. Continue an existing session by sending a new message
3. Observe two system error messages appear in the chat

## Screenshot

N/A (logic-only change, no UI layout changes)
