### PR TITLE
fix(cowork): fix deleteUserMemory returning false for valid deletions

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -1230,13 +1230,17 @@ export class CoworkStore {
       SET status = 'deleted', updated_at = ?
       WHERE id = ?
     `, [now, id]);
+    // Capture the result of the memory update before running the next
+    // statement, because getRowsModified() always returns the count for
+    // the most recently executed db.run() call.
+    const memoryUpdated = (this.db.getRowsModified?.() || 0) > 0;
     this.db.run(`
       UPDATE user_memory_sources
       SET is_active = 0
       WHERE memory_id = ?
     `, [id]);
     this.saveDb();
-    return (this.db.getRowsModified?.() || 0) > 0;
+    return memoryUpdated;
   }
 
   getUserMemoryStats(): CoworkUserMemoryStats {


### PR DESCRIPTION
## Problem

`CoworkStore.deleteUserMemory()` returns `false` even when the memory is successfully marked as deleted, causing callers to incorrectly report "memory not found".

### Root Cause

`sql.js`'s `getRowsModified()` returns the affected row count of **only the most recently executed** `db.run()` call.

`deleteUserMemory()` runs two UPDATE statements sequentially:

```typescript
// ① Mark the memory as deleted
this.db.run('UPDATE user_memories SET status = \'deleted\' ...', [now, id]);

// ② Deactivate associated source records  
this.db.run('UPDATE user_memory_sources SET is_active = 0 ...', [id]);

this.saveDb();
// ❌ This checks the result of statement ②, NOT statement ①
return (this.db.getRowsModified?.() || 0) > 0;
```

When a memory has **no associated source records** (e.g. manually created, or sources already deactivated), statement ② affects 0 rows, so the method returns `false` despite the memory being successfully deleted.

### Impact

Two callers depend on this return value:

| Caller | Effect |
|--------|--------|
| `CoworkRunner.runMemoryUserEditsTool()` | AI tool reports `failed=1, reason="memory not found"` to the model even though deletion succeeded |
| `CoworkStore.applyTurnMemoryUpdates()` | Deletion is counted as `skipped` instead of `deleted` in memory update stats |

## Fix

Capture `getRowsModified()` immediately after the first UPDATE (the one that actually deletes the memory) and use that value as the return:

```diff
  this.db.run('UPDATE user_memories ...', [now, id]);
+ const memoryUpdated = (this.db.getRowsModified?.() || 0) > 0;
  this.db.run('UPDATE user_memory_sources ...', [id]);
  this.saveDb();
- return (this.db.getRowsModified?.() || 0) > 0;
+ return memoryUpdated;
```
