### PR TITLE
refactor(cowork): use matchAll to avoid regex lastIndex mutation

### DIFF
--- a/src/main/libs/coworkMemoryExtractor.ts
+++ b/src/main/libs/coworkMemoryExtractor.ts
@@ -86,9 +86,7 @@ function extractExplicit(
 ): ExtractedMemoryChange[] {
   const result: ExtractedMemoryChange[] = [];
   const seen = new Set<string>();
-  pattern.lastIndex = 0;
-  let match: RegExpExecArray | null = null;
-  while ((match = pattern.exec(text)) !== null) {
+  for (const match of text.matchAll(pattern)) {
     const raw = normalizeText(match[1] || '');
     if (!shouldKeepCandidate(raw)) continue;
     const key = raw.toLowerCase();


### PR DESCRIPTION
## Summary

Replace the manual `while + exec` loop in `extractExplicit()` with `String.prototype.matchAll()` to prevent potential regex state pollution on shared module-level constants.

## Problem

`EXPLICIT_ADD_RE` and `EXPLICIT_DELETE_RE` are defined as module-level constants with the `g` (global) flag. Regex objects with the `g` flag maintain a mutable `lastIndex` property that advances after each `.exec()` or `.test()` call:

```javascript
const RE = /hello/g;
RE.test('hello world');  // true,  lastIndex = 5
RE.test('hello world');  // false, lastIndex = 0  ← unexpected!
```

The current code in `extractExplicit()` mitigates this with a manual `pattern.lastIndex = 0` reset before the `while + exec` loop. While this works today, it's fragile — if anyone else uses these regexes with `.test()` or `.exec()` in the future without resetting `lastIndex`, they'll encounter intermittent match failures.

## Fix

```diff
- pattern.lastIndex = 0;
- let match: RegExpExecArray | null = null;
- while ((match = pattern.exec(text)) !== null) {
+ for (const match of text.matchAll(pattern)) {
```

`matchAll()` internally clones the regex, so it **never mutates `lastIndex`** on the original object. This:
- Eliminates the defensive `lastIndex = 0` reset
- Prevents state pollution if these regexes are reused elsewhere
- Is more idiomatic modern JavaScript

## Compatibility

`String.prototype.matchAll()` is stable since **Node.js 12** (ES2020), well within the project's `>=24 <25` engine requirement.

## Change size

`+1 / -3` lines — behavior-preserving refactor, no logic changes.