### PR TITLE
fix(im): restart gateway after weixin QR login and adjust settings guide

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2972,6 +2972,12 @@ if (!gotTheLock) {
   ipcMain.handle('im:weixin:qr-login-wait', async (_event, accountId?: string) => {
     try {
       const result = await getIMGatewayManager().weixinQrLoginWait(accountId);
+      if (result.connected) {
+        // Restart gateway so the plugin picks up the new token and starts
+        // a fresh monitor loop (the old one may be stuck in a session pause).
+        console.log('[IMGatewayManager] Weixin login succeeded, restarting OpenClaw gateway');
+        await getOpenClawEngineManager().restartGateway();
+      }
       return { success: true, ...result };
     } catch (error) {
       return { success: false, connected: false, message: error instanceof Error ? error.message : 'Weixin QR login failed' };

--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -2970,6 +2970,15 @@ const IMSettings: React.FC = () => {
         {/* Weixin (微信) Settings */}
         {activePlatform === 'weixin' && (
           <div className="space-y-3">
+            {/* Platform Guide */}
+            <PlatformGuide
+              steps={[
+                i18nService.t('imWeixinGuideStep2'),
+                i18nService.t('imWeixinGuideStep3'),
+              ]}
+              guideUrl={IM_GUIDE_URLS.weixin}
+            />
+
             {/* Scan QR code section */}
             <div className="rounded-lg border border-dashed dark:border-claude-darkBorder/60 border-claude-border/60 p-4 text-center space-y-3">
               {(weixinQrStatus === 'idle' || weixinQrStatus === 'error') && (
@@ -3019,16 +3028,6 @@ const IMSettings: React.FC = () => {
                 </div>
               )}
             </div>
-
-            {/* Platform Guide */}
-            <PlatformGuide
-              steps={[
-                i18nService.t('imWeixinGuideStep1'),
-                i18nService.t('imWeixinGuideStep2'),
-                i18nService.t('imWeixinGuideStep3'),
-              ]}
-              guideUrl={IM_GUIDE_URLS.weixin}
-            />
 
             {/* Connectivity test */}
             <div className="pt-1">


### PR DESCRIPTION

- Restart OpenClaw gateway after successful WeChat QR login so the plugin picks up the new token and starts a fresh monitor loop
- Move PlatformGuide above the scan button in WeChat settings to match other IM platforms layout
- Remove redundant guide step "点击下方按钮启用微信接入"