### PR TITLE
fix(openclaw): use non-empty placeholder for env var fallbacks

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -965,13 +965,13 @@ export class OpenClawConfigSync {
     const apiResolution = resolveRawApiConfig();
     // Provider API Key — always set so stale openclaw.json with
     // ${LOBSTER_PROVIDER_API_KEY} placeholder doesn't crash the gateway.
-    env.LOBSTER_PROVIDER_API_KEY = apiResolution.config?.apiKey || '';
+    // OpenClaw treats empty string as "missing", so use a non-empty placeholder.
+    env.LOBSTER_PROVIDER_API_KEY = apiResolution.config?.apiKey || 'unconfigured';
 
-    // MCP Bridge Secret
+    // MCP Bridge Secret — always set so stale openclaw.json with
+    // ${LOBSTER_MCP_BRIDGE_SECRET} placeholder doesn't crash the gateway.
     const mcpBridgeCfg = this.getMcpBridgeConfig?.();
-    if (mcpBridgeCfg?.secret) {
-      env.LOBSTER_MCP_BRIDGE_SECRET = mcpBridgeCfg.secret;
-    }
+    env.LOBSTER_MCP_BRIDGE_SECRET = mcpBridgeCfg?.secret || 'unconfigured';
 
     // Telegram
     const tgConfig = this.getTelegramOpenClawConfig?.();
@@ -1024,10 +1024,10 @@ export class OpenClawConfigSync {
     if (popoConfig?.enabled && popoConfig.token) {
       env.LOBSTER_POPO_TOKEN = popoConfig.token;
     } else if (popoConfig?.enabled) {
-      // Provide empty fallback so stale openclaw.json files that still
+      // Provide non-empty fallback so stale openclaw.json files that still
       // contain ${LOBSTER_POPO_TOKEN} from a previous webhook config
       // don't crash the gateway with MissingEnvVarError.
-      env.LOBSTER_POPO_TOKEN = '';
+      env.LOBSTER_POPO_TOKEN = 'unconfigured';
     }
 
     // NIM


### PR DESCRIPTION
OpenClaw treats empty string env vars as "missing", causing MissingEnvVarError when the gateway hot-reloads config before secrets are available (e.g. MCP bridge not yet started, API key not configured, Popo in websocket mode).

Use 'unconfigured' as the fallback value instead of empty string for LOBSTER_PROVIDER_API_KEY, LOBSTER_MCP_BRIDGE_SECRET, and LOBSTER_POPO_TOKEN.