### PR TITLE
feat(cowork): support ! prefix to run shell commands directly

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3279,6 +3279,64 @@ if (!gotTheLock) {
     }
   });
 
+  ipcMain.handle('shell:exec', async (_event, options: { command: string; cwd?: string }) => {
+    const { execFile } = await import('child_process');
+    const { promisify } = await import('util');
+    const execFileAsync = promisify(execFile);
+    const { command, cwd } = options;
+    const EXEC_TIMEOUT_MS = 30_000;
+    const MAX_OUTPUT_CHARS = 50_000;
+
+    const resolveCwd = (): string | undefined => {
+      if (!cwd?.trim()) return undefined;
+      try {
+        const resolved = path.resolve(cwd);
+        if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
+          return resolved;
+        }
+      } catch {
+        // ignore resolution errors
+      }
+      return undefined;
+    };
+
+    const truncate = (s: string): string =>
+      s.length > MAX_OUTPUT_CHARS ? s.slice(0, MAX_OUTPUT_CHARS) + '\n[output truncated]' : s;
+
+    const resolvedCwd = resolveCwd();
+    const shellBin = process.platform === 'win32' ? 'cmd.exe' : '/bin/sh';
+    const shellArgs = process.platform === 'win32' ? ['/c', command] : ['-c', command];
+
+    try {
+      const { stdout, stderr } = await execFileAsync(shellBin, shellArgs, {
+        cwd: resolvedCwd,
+        timeout: EXEC_TIMEOUT_MS,
+        maxBuffer: 10 * 1024 * 1024,
+        windowsHide: true,
+      });
+      return {
+        success: true,
+        stdout: truncate(stdout ?? ''),
+        stderr: truncate(stderr ?? ''),
+        exitCode: 0,
+      };
+    } catch (error: any) {
+      const stdout = truncate(error?.stdout ?? '');
+      const stderr = truncate(error?.stderr ?? '');
+      const exitCode: number = typeof error?.code === 'number' ? error.code : 1;
+      const isTimeout = error?.signal === 'SIGTERM' || /timed out/i.test(error?.message ?? '');
+      return {
+        success: false,
+        stdout,
+        stderr,
+        exitCode,
+        error: isTimeout
+          ? `Command timed out after ${EXEC_TIMEOUT_MS / 1000}s`
+          : (error instanceof Error ? error.message : 'Command failed'),
+      };
+    }
+  });
+
   // App update download & install
   ipcMain.handle('appUpdate:download', async (event, url: string) => {
     try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -257,6 +257,14 @@ contextBridge.exposeInMainWorld('electron', {
     openPath: (filePath: string) => ipcRenderer.invoke('shell:openPath', filePath),
     showItemInFolder: (filePath: string) => ipcRenderer.invoke('shell:showItemInFolder', filePath),
     openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url),
+    exec: (options: { command: string; cwd?: string }) =>
+      ipcRenderer.invoke('shell:exec', options) as Promise<{
+        success: boolean;
+        stdout: string;
+        stderr: string;
+        exitCode: number;
+        error?: string;
+      }>,
   },
   autoLaunch: {
     get: () => ipcRenderer.invoke('app:getAutoLaunch'),

--- a/src/main/shellExec.test.ts
+++ b/src/main/shellExec.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Unit tests for the shell:exec IPC handler logic (src/main/main.ts).
+ *
+ * The handler itself cannot be imported directly because it lives inside the
+ * Electron app bootstrap.  Instead we mirror the pure functions extracted from
+ * the handler and test them in isolation, then use child_process to run a few
+ * real integration-style cases that do not depend on Electron at all.
+ */
+import { test, expect, describe } from 'vitest';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import os from 'os';
+import path from 'path';
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Mirrors of pure helper functions from the shell:exec handler
+// ---------------------------------------------------------------------------
+
+const MAX_OUTPUT_CHARS = 50_000;
+
+function truncate(s: string): string {
+  return s.length > MAX_OUTPUT_CHARS
+    ? s.slice(0, MAX_OUTPUT_CHARS) + '\n[output truncated]'
+    : s;
+}
+
+function resolveCwd(cwd: string | undefined): string | undefined {
+  if (!cwd?.trim()) return undefined;
+  try {
+    // In tests we just check the logic; real fs calls are avoided
+    const resolved = path.resolve(cwd);
+    return resolved;
+  } catch {
+    return undefined;
+  }
+}
+
+function isTimeoutError(error: any): boolean {
+  return (
+    error?.signal === 'SIGTERM' ||
+    /timed out/i.test(error?.message ?? '')
+  );
+}
+
+function getShellArgs(command: string): { bin: string; args: string[] } {
+  if (process.platform === 'win32') {
+    return { bin: 'cmd.exe', args: ['/c', command] };
+  }
+  return { bin: '/bin/sh', args: ['-c', command] };
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function unit tests
+// ---------------------------------------------------------------------------
+
+describe('truncate', () => {
+  test('returns the string unchanged when within limit', () => {
+    const s = 'hello world';
+    expect(truncate(s)).toBe(s);
+  });
+
+  test('truncates strings exceeding MAX_OUTPUT_CHARS and appends marker', () => {
+    const long = 'x'.repeat(MAX_OUTPUT_CHARS + 100);
+    const result = truncate(long);
+    expect(result.length).toBe(MAX_OUTPUT_CHARS + '\n[output truncated]'.length);
+    expect(result.endsWith('\n[output truncated]')).toBe(true);
+  });
+
+  test('handles empty string', () => {
+    expect(truncate('')).toBe('');
+  });
+
+  test('does not truncate string at exact limit', () => {
+    const s = 'y'.repeat(MAX_OUTPUT_CHARS);
+    expect(truncate(s)).toBe(s);
+  });
+});
+
+describe('resolveCwd', () => {
+  test('returns undefined for undefined input', () => {
+    expect(resolveCwd(undefined)).toBeUndefined();
+  });
+
+  test('returns undefined for empty string', () => {
+    expect(resolveCwd('')).toBeUndefined();
+  });
+
+  test('returns undefined for whitespace-only string', () => {
+    expect(resolveCwd('   ')).toBeUndefined();
+  });
+
+  test('resolves a relative path to absolute', () => {
+    const result = resolveCwd('.');
+    expect(path.isAbsolute(result!)).toBe(true);
+  });
+
+  test('resolves an absolute path unchanged', () => {
+    const abs = os.tmpdir();
+    const result = resolveCwd(abs);
+    expect(result).toBe(path.resolve(abs));
+  });
+});
+
+describe('isTimeoutError', () => {
+  test('detects SIGTERM signal as timeout', () => {
+    expect(isTimeoutError({ signal: 'SIGTERM', message: '' })).toBe(true);
+  });
+
+  test('detects "timed out" message as timeout (case-insensitive)', () => {
+    expect(isTimeoutError({ signal: null, message: 'Command timed out after 30s' })).toBe(true);
+    expect(isTimeoutError({ signal: null, message: 'TIMED OUT' })).toBe(true);
+  });
+
+  test('returns false for regular errors', () => {
+    expect(isTimeoutError({ signal: null, message: 'Command failed: exit code 1' })).toBe(false);
+    expect(isTimeoutError(null)).toBe(false);
+    expect(isTimeoutError(undefined)).toBe(false);
+  });
+});
+
+describe('getShellArgs', () => {
+  test('uses cmd.exe on Windows, /bin/sh elsewhere', () => {
+    const { bin, args } = getShellArgs('echo hello');
+    if (process.platform === 'win32') {
+      expect(bin).toBe('cmd.exe');
+      expect(args).toEqual(['/c', 'echo hello']);
+    } else {
+      expect(bin).toBe('/bin/sh');
+      expect(args).toEqual(['-c', 'echo hello']);
+    }
+  });
+
+  test('passes the full command string as a single argument', () => {
+    const cmd = 'echo hello && echo world';
+    const { args } = getShellArgs(cmd);
+    expect(args[args.length - 1]).toBe(cmd);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests — real child_process execution (no Electron dependency)
+// ---------------------------------------------------------------------------
+
+describe('shell execution (integration)', () => {
+  const isWin = process.platform === 'win32';
+
+  async function runCommand(command: string, cwd?: string) {
+    const { bin, args } = getShellArgs(command);
+    try {
+      const { stdout, stderr } = await execFileAsync(bin, args, {
+        cwd,
+        timeout: 10_000,
+        maxBuffer: 10 * 1024 * 1024,
+        ...(isWin ? { windowsHide: true } : {}),
+      });
+      return { success: true, stdout: truncate(stdout ?? ''), stderr: truncate(stderr ?? ''), exitCode: 0 };
+    } catch (err: any) {
+      const stdout = truncate(err?.stdout ?? '');
+      const stderr = truncate(err?.stderr ?? '');
+      const exitCode: number = typeof err?.code === 'number' ? err.code : 1;
+      return {
+        success: false,
+        stdout,
+        stderr,
+        exitCode,
+        error: isTimeoutError(err)
+          ? 'Command timed out'
+          : (err instanceof Error ? err.message : 'Command failed'),
+      };
+    }
+  }
+
+  test('TC-EXEC-01: simple echo command returns stdout and exitCode 0', async () => {
+    const result = await runCommand(isWin ? 'echo hello' : 'echo hello');
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('hello');
+    expect(result.stderr).toBe('');
+  });
+
+  test('TC-EXEC-02: non-existent command returns non-zero exitCode', async () => {
+    const cmd = isWin ? 'thiscommanddoesnotexist_xyz' : 'thiscommanddoesnotexist_xyz';
+    const result = await runCommand(cmd);
+    expect(result.success).toBe(false);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test('TC-EXEC-03: command that writes to stderr is captured', async () => {
+    const cmd = isWin ? 'echo error_output 1>&2' : 'echo error_output >&2';
+    const result = await runCommand(cmd);
+    expect(result.stderr.trim()).toBe('error_output');
+  });
+
+  test('TC-EXEC-04: explicit exit code is returned correctly', async () => {
+    const cmd = isWin ? 'exit /b 42' : 'exit 42';
+    const result = await runCommand(cmd);
+    expect(result.exitCode).toBe(42);
+    expect(result.success).toBe(false);
+  });
+
+  test('TC-EXEC-05: multi-line output is preserved intact', async () => {
+    const cmd = isWin
+      ? 'echo line1 && echo line2 && echo line3'
+      : 'printf "line1\nline2\nline3\n"';
+    const result = await runCommand(cmd);
+    expect(result.success).toBe(true);
+    expect(result.stdout).toContain('line1');
+    expect(result.stdout).toContain('line2');
+    expect(result.stdout).toContain('line3');
+  });
+
+  test('TC-EXEC-06: command runs in the specified working directory', async () => {
+    const tmpDir = os.tmpdir();
+    const cmd = isWin ? 'cd' : 'pwd';
+    const result = await runCommand(cmd, tmpDir);
+    expect(result.success).toBe(true);
+    // Normalise separators and case for comparison on Windows
+    const normalised = result.stdout.trim().toLowerCase().replace(/\\/g, '/');
+    const expected = tmpDir.toLowerCase().replace(/\\/g, '/');
+    expect(normalised).toContain(expected);
+  });
+
+  test('TC-EXEC-07: empty command produces no stdout', async () => {
+    const cmd = isWin ? 'echo.' : 'true';
+    const result = await runCommand(cmd);
+    expect(result.success).toBe(true);
+  });
+
+  test('TC-EXEC-08: output exceeding MAX_OUTPUT_CHARS is truncated', async () => {
+    // Generate output slightly larger than the limit
+    const charCount = MAX_OUTPUT_CHARS + 500;
+    const cmd = isWin
+      ? `powershell -Command "Write-Host ('A' * ${charCount})"`
+      : `python3 -c "print('A' * ${charCount})"`;
+    // Skip if neither powershell nor python3 is available (CI may lack them)
+    try {
+      const result = await runCommand(cmd);
+      if (result.success && result.stdout.length > 0) {
+        // If the command ran, output must be truncated
+        expect(result.stdout.endsWith('[output truncated]')).toBe(true);
+      }
+    } catch {
+      // Runtime unavailable — skip gracefully
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleShellCommand output-message construction logic (mirrored)
+// ---------------------------------------------------------------------------
+
+describe('output message content construction', () => {
+  function buildContent(
+    stdout: string,
+    stderr: string,
+    success: boolean,
+    error?: string,
+  ): string {
+    return (
+      [stdout, stderr].filter(Boolean).join('\n') ||
+      (success ? '（无输出）' : (error ?? '命令执行失败'))
+    );
+  }
+
+  test('TC-MSG-01: stdout only → content is stdout', () => {
+    expect(buildContent('hello\n', '', true)).toBe('hello\n');
+  });
+
+  test('TC-MSG-02: stderr only → content is stderr', () => {
+    expect(buildContent('', 'err\n', false, 'Command failed')).toBe('err\n');
+  });
+
+  test('TC-MSG-03: both stdout and stderr → joined with newline', () => {
+    const result = buildContent('out\n', 'err\n', true);
+    expect(result).toBe('out\n\nerr\n');
+  });
+
+  test('TC-MSG-04: no output and success → no-output placeholder', () => {
+    expect(buildContent('', '', true)).toBe('（无输出）');
+  });
+
+  test('TC-MSG-05: no output and failure with error string → error string shown', () => {
+    expect(buildContent('', '', false, 'Command timed out after 30s')).toBe(
+      'Command timed out after 30s',
+    );
+  });
+
+  test('TC-MSG-06: no output and failure without error string → fallback text', () => {
+    expect(buildContent('', '', false, undefined)).toBe('命令执行失败');
+  });
+
+  test('TC-MSG-07: isError flag is true when exitCode != 0', () => {
+    const isError = (success: boolean, exitCode: number) =>
+      !success || exitCode !== 0;
+    expect(isError(true, 0)).toBe(false);
+    expect(isError(true, 1)).toBe(true);
+    expect(isError(false, 0)).toBe(true);
+    expect(isError(false, 1)).toBe(true);
+  });
+});

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -13,6 +13,7 @@ import {
   ExclamationTriangleIcon,
   ChevronRightIcon,
   PhotoIcon,
+  CommandLineIcon,
 } from '@heroicons/react/24/outline';
 import { FolderIcon } from '@heroicons/react/24/solid';
 import { coworkService } from '../../services/cowork';
@@ -1134,6 +1135,60 @@ export const AssistantTurnBlock: React.FC<{
   const visibleAssistantItems = getVisibleAssistantItems(turn.assistantItems);
 
   const renderSystemMessage = (message: CoworkMessage) => {
+    // Shell command output: render with a terminal-style block
+    if (typeof message.metadata?.shellCommand === 'string') {
+      const cmd = message.metadata.shellCommand as string;
+      const exitCode = typeof message.metadata.exitCode === 'number' ? message.metadata.exitCode : null;
+      const isError = Boolean(message.metadata.isError);
+      const stdout = typeof message.metadata.stdout === 'string' ? message.metadata.stdout : '';
+      const stderr = typeof message.metadata.stderr === 'string' ? message.metadata.stderr : '';
+      const hasOutput = stdout.trim() || stderr.trim();
+
+      return (
+        <div className="rounded-lg border dark:border-claude-darkBorder/70 border-claude-border/70 dark:bg-claude-darkBg/60 bg-claude-bg/60 overflow-hidden">
+          {/* Header bar */}
+          <div className={`flex items-center gap-2 px-3 py-1.5 text-xs font-mono ${
+            isError
+              ? 'dark:bg-red-950/40 bg-red-50 dark:border-red-800/50 border-red-200 border-b'
+              : 'dark:bg-claude-darkSurface/60 bg-claude-surface/60 dark:border-claude-darkBorder/40 border-claude-border/40 border-b'
+          }`}>
+            <CommandLineIcon className={`h-3.5 w-3.5 flex-shrink-0 ${isError ? 'text-red-500' : 'dark:text-claude-darkTextSecondary text-claude-textSecondary'}`} />
+            <span className={`flex-1 truncate ${isError ? 'text-red-600 dark:text-red-400' : 'dark:text-claude-darkTextSecondary text-claude-textSecondary'}`}>
+              {cmd}
+            </span>
+            {exitCode !== null && (
+              <span className={`flex-shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold ${
+                exitCode === 0
+                  ? 'dark:bg-green-900/50 bg-green-100 dark:text-green-400 text-green-700'
+                  : 'dark:bg-red-900/50 bg-red-100 dark:text-red-400 text-red-700'
+              }`}>
+                {exitCode === 0 ? i18nService.t('shellExitOk') : `exit ${exitCode}`}
+              </span>
+            )}
+          </div>
+          {/* Output area */}
+          {hasOutput ? (
+            <div className="px-3 py-2 max-h-64 overflow-y-auto">
+              {stdout.trim() && (
+                <pre className="text-xs font-mono whitespace-pre-wrap break-words dark:text-claude-darkText text-claude-text leading-relaxed">
+                  {stdout}
+                </pre>
+              )}
+              {stderr.trim() && (
+                <pre className="text-xs font-mono whitespace-pre-wrap break-words text-red-500 dark:text-red-400 leading-relaxed mt-1">
+                  {stderr}
+                </pre>
+              )}
+            </div>
+          ) : (
+            <div className="px-3 py-2 text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 italic">
+              {i18nService.t('shellCommandNoOutput')}
+            </div>
+          )}
+        </div>
+      );
+    }
+
     const rawContent = hasText(message.content)
       ? message.content
       : (typeof message.metadata?.error === 'string' ? message.metadata.error : '');

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../store';
 import { addMessage, clearCurrentSession, setCurrentSession, setStreaming, updateSessionStatus } from '../../store/slices/coworkSlice';
@@ -17,7 +17,7 @@ import { ShieldCheckIcon } from '@heroicons/react/24/outline';
 import WindowTitleBar from '../window/WindowTitleBar';
 import { QuickActionBar, PromptPanel } from '../quick-actions';
 import type { SettingsOpenOptions } from '../Settings';
-import type { CoworkSession, CoworkImageAttachment, OpenClawEngineStatus } from '../../types/cowork';
+import type { CoworkSession, CoworkImageAttachment, CoworkMessage, OpenClawEngineStatus } from '../../types/cowork';
 
 export interface CoworkViewProps {
   onRequestAppSettings?: (options?: SettingsOpenOptions) => void;
@@ -153,6 +153,104 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       unsubscribeOpenClawStatus();
     };
   }, [dispatch]);
+
+  /**
+   * Execute a shell command entered via the "!" prefix shortcut.
+   * The command result is shown as a system message in the current session
+   * (or a new lightweight session when there is no active one), without
+   * involving the AI agent.
+   */
+  const handleShellCommand = useCallback(async (command: string): Promise<void> => {
+    const now = Date.now();
+    const cwd = config.workingDirectory || undefined;
+
+    // Build a user message so the command itself is visible in the chat
+    const userMessage: CoworkMessage = {
+      id: `shell-user-${now}`,
+      type: 'user',
+      content: `!${command}`,
+      timestamp: now,
+    };
+
+    // If there is no active session, create a temporary one so the output has
+    // somewhere to live.  We never persist it to the backend — it is purely
+    // in-memory for this command execution.
+    if (!currentSession) {
+      const tempSession: CoworkSession = {
+        id: `temp-shell-${now}`,
+        title: `!${command}`.slice(0, 50),
+        claudeSessionId: null,
+        status: 'idle',
+        pinned: false,
+        createdAt: now,
+        updatedAt: now,
+        cwd: cwd || '',
+        systemPrompt: '',
+        executionMode: config.executionMode || 'local',
+        activeSkillIds: [],
+        messages: [userMessage],
+      };
+      dispatch(setCurrentSession(tempSession));
+    } else {
+      dispatch(addMessage({ sessionId: currentSession.id, message: userMessage }));
+    }
+
+    // Execute the command via the main process
+    let result: { success: boolean; stdout: string; stderr: string; exitCode: number; error?: string };
+    try {
+      result = await window.electron.shell.exec({ command, cwd });
+    } catch (err) {
+      result = {
+        success: false,
+        stdout: '',
+        stderr: err instanceof Error ? err.message : String(err),
+        exitCode: 1,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    const sessionId = currentSession?.id ?? `temp-shell-${now}`;
+    const outputMessage: CoworkMessage = {
+      id: `shell-result-${now}`,
+      type: 'system',
+      content: [result.stdout, result.stderr].filter(Boolean).join('\n') || (result.success
+        ? i18nService.t('shellCommandNoOutput')
+        : (result.error ?? i18nService.t('shellCommandFailed'))),
+      timestamp: Date.now(),
+      metadata: {
+        shellCommand: command,
+        exitCode: result.exitCode,
+        isError: !result.success || result.exitCode !== 0,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      },
+    };
+    dispatch(addMessage({ sessionId, message: outputMessage }));
+  }, [config.workingDirectory, config.executionMode, currentSession, dispatch]);
+
+  /**
+   * Unified submit handler: intercepts the "!" shell shortcut before
+   * forwarding regular prompts to the appropriate session handler.
+   */
+  const handlePromptSubmit = useCallback(async (
+    prompt: string,
+    skillPrompt?: string,
+    imageAttachments?: CoworkImageAttachment[],
+  ): Promise<boolean | void> => {
+    const trimmed = prompt.trim();
+    if (trimmed.startsWith('!')) {
+      const command = trimmed.slice(1).trim();
+      if (command) {
+        await handleShellCommand(command);
+        return; // consumed — do not pass to AI
+      }
+    }
+    // Delegate to the appropriate session handler
+    if (currentSession) {
+      return handleContinueSession(prompt, skillPrompt, imageAttachments);
+    }
+    return handleStartSession(prompt, skillPrompt, imageAttachments);
+  }, [currentSession, handleShellCommand]);
 
   const handleStartSession = async (prompt: string, skillPrompt?: string, imageAttachments?: CoworkImageAttachment[]): Promise<boolean | void> => {
     if (isOpenClawEngine && openClawStatus && !isOpenClawReadyForSession(openClawStatus)) {
@@ -492,7 +590,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         {engineStatusBanner}
         <CoworkSessionDetail
           onManageSkills={() => onShowSkills?.()}
-          onContinue={handleContinueSession}
+          onContinue={handlePromptSubmit}
           onStop={handleStopSession}
           onNavigateHome={() => dispatch(clearCurrentSession())}
           isSidebarCollapsed={isSidebarCollapsed}
@@ -532,7 +630,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
             <div className="shadow-glow-accent rounded-2xl">
               <CoworkPromptInput
                 ref={promptInputRef}
-                onSubmit={handleStartSession}
+                onSubmit={handlePromptSubmit}
                 onStop={handleStopSession}
                 isStreaming={isStreaming}
                 disabled={!isEngineReady}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -172,12 +172,15 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       timestamp: now,
     };
 
-    // If there is no active session, create a temporary one so the output has
-    // somewhere to live.  We never persist it to the backend — it is purely
-    // in-memory for this command execution.
+    // Determine (or create) the session that will hold the output.
+    // We capture sessionId here — before any async work — so that the
+    // result message lands in the same session regardless of React's
+    // asynchronous state-update cycle.
+    let sessionId: string;
     if (!currentSession) {
+      sessionId = `temp-shell-${now}`;
       const tempSession: CoworkSession = {
-        id: `temp-shell-${now}`,
+        id: sessionId,
         title: `!${command}`.slice(0, 50),
         claudeSessionId: null,
         status: 'idle',
@@ -192,7 +195,8 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       };
       dispatch(setCurrentSession(tempSession));
     } else {
-      dispatch(addMessage({ sessionId: currentSession.id, message: userMessage }));
+      sessionId = currentSession.id;
+      dispatch(addMessage({ sessionId, message: userMessage }));
     }
 
     // Execute the command via the main process
@@ -209,7 +213,6 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       };
     }
 
-    const sessionId = currentSession?.id ?? `temp-shell-${now}`;
     const outputMessage: CoworkMessage = {
       id: `shell-result-${now}`,
       type: 'system',
@@ -227,30 +230,6 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     };
     dispatch(addMessage({ sessionId, message: outputMessage }));
   }, [config.workingDirectory, config.executionMode, currentSession, dispatch]);
-
-  /**
-   * Unified submit handler: intercepts the "!" shell shortcut before
-   * forwarding regular prompts to the appropriate session handler.
-   */
-  const handlePromptSubmit = useCallback(async (
-    prompt: string,
-    skillPrompt?: string,
-    imageAttachments?: CoworkImageAttachment[],
-  ): Promise<boolean | void> => {
-    const trimmed = prompt.trim();
-    if (trimmed.startsWith('!')) {
-      const command = trimmed.slice(1).trim();
-      if (command) {
-        await handleShellCommand(command);
-        return; // consumed — do not pass to AI
-      }
-    }
-    // Delegate to the appropriate session handler
-    if (currentSession) {
-      return handleContinueSession(prompt, skillPrompt, imageAttachments);
-    }
-    return handleStartSession(prompt, skillPrompt, imageAttachments);
-  }, [currentSession, handleShellCommand]);
 
   const handleStartSession = async (prompt: string, skillPrompt?: string, imageAttachments?: CoworkImageAttachment[]): Promise<boolean | void> => {
     if (isOpenClawEngine && openClawStatus && !isOpenClawReadyForSession(openClawStatus)) {
@@ -426,6 +405,31 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       imageAttachments,
     });
   };
+
+  /**
+   * Unified submit handler: intercepts the "!" shell shortcut before
+   * forwarding regular prompts to the appropriate session handler.
+   * Defined after handleStartSession / handleContinueSession to avoid TDZ.
+   */
+  const handlePromptSubmit = useCallback(async (
+    prompt: string,
+    skillPrompt?: string,
+    imageAttachments?: CoworkImageAttachment[],
+  ): Promise<boolean | void> => {
+    const trimmed = prompt.trim();
+    if (trimmed.startsWith('!')) {
+      const command = trimmed.slice(1).trim();
+      if (command) {
+        await handleShellCommand(command);
+        return; // consumed — do not pass to AI
+      }
+    }
+    // Delegate to the appropriate session handler
+    if (currentSession) {
+      return handleContinueSession(prompt, skillPrompt, imageAttachments);
+    }
+    return handleStartSession(prompt, skillPrompt, imageAttachments);
+  }, [currentSession, handleShellCommand]); // handleStartSession / handleContinueSession are stable plain async fns
 
   const handleStopSession = async () => {
     if (!currentSession) return;

--- a/src/renderer/components/cowork/shellBangCommand.test.ts
+++ b/src/renderer/components/cowork/shellBangCommand.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for the "!" shell-command shortcut implemented in CoworkView.tsx.
+ *
+ * We mirror the pure decision logic from handlePromptSubmit and
+ * handleShellCommand so no React / Electron environment is required.
+ */
+import { test, expect, describe } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mirror: handlePromptSubmit — bang detection & routing
+// ---------------------------------------------------------------------------
+
+type SubmitTarget = 'shell' | 'start' | 'continue';
+
+function classifyPrompt(
+  prompt: string,
+  hasCurrentSession: boolean,
+): { target: SubmitTarget; command?: string } {
+  const trimmed = prompt.trim();
+  if (trimmed.startsWith('!')) {
+    const command = trimmed.slice(1).trim();
+    if (command) {
+      return { target: 'shell', command };
+    }
+  }
+  return { target: hasCurrentSession ? 'continue' : 'start' };
+}
+
+// ---------------------------------------------------------------------------
+// Mirror: sessionId capture logic from handleShellCommand
+// ---------------------------------------------------------------------------
+
+function resolveSessionId(
+  currentSessionId: string | null,
+  now: number,
+): string {
+  if (!currentSessionId) {
+    return `temp-shell-${now}`;
+  }
+  return currentSessionId;
+}
+
+// ---------------------------------------------------------------------------
+// Mirror: tempSession title construction
+// ---------------------------------------------------------------------------
+
+function buildTempTitle(command: string): string {
+  return `!${command}`.slice(0, 50);
+}
+
+// ---------------------------------------------------------------------------
+// Mirror: isError flag
+// ---------------------------------------------------------------------------
+
+function computeIsError(success: boolean, exitCode: number): boolean {
+  return !success || exitCode !== 0;
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe('handlePromptSubmit — bang detection', () => {
+  test('TC-BANG-01: "!ls -la" is classified as shell command', () => {
+    const r = classifyPrompt('!ls -la', false);
+    expect(r.target).toBe('shell');
+    expect(r.command).toBe('ls -la');
+  });
+
+  test('TC-BANG-02: "!  ls -la" trims surrounding whitespace from command', () => {
+    const r = classifyPrompt('!  ls -la', false);
+    expect(r.target).toBe('shell');
+    expect(r.command).toBe('ls -la');
+  });
+
+  test('TC-BANG-03: "  !ls" strips leading whitespace from prompt before matching', () => {
+    const r = classifyPrompt('  !ls', false);
+    expect(r.target).toBe('shell');
+    expect(r.command).toBe('ls');
+  });
+
+  test('TC-BANG-04: "!" with no command is NOT treated as shell shortcut', () => {
+    // Empty command falls through to the AI handler
+    const r = classifyPrompt('!', false);
+    expect(r.target).toBe('start');
+    expect(r.command).toBeUndefined();
+  });
+
+  test('TC-BANG-05: "!   " (only whitespace after !) is NOT treated as shell shortcut', () => {
+    const r = classifyPrompt('!   ', false);
+    expect(r.target).toBe('start');
+    expect(r.command).toBeUndefined();
+  });
+
+  test('TC-BANG-06: normal prompt without "!" is routed to AI (start when no session)', () => {
+    const r = classifyPrompt('list my files', false);
+    expect(r.target).toBe('start');
+  });
+
+  test('TC-BANG-07: normal prompt is routed to AI (continue when session active)', () => {
+    const r = classifyPrompt('list my files', true);
+    expect(r.target).toBe('continue');
+  });
+
+  test('TC-BANG-08: "!" in the middle of a prompt is NOT treated as shell shortcut', () => {
+    const r = classifyPrompt('say hello! now', false);
+    expect(r.target).toBe('start');
+  });
+
+  test('TC-BANG-09: bang command includes complex shell syntax', () => {
+    const r = classifyPrompt('!git log --oneline -10 | head -5', false);
+    expect(r.target).toBe('shell');
+    expect(r.command).toBe('git log --oneline -10 | head -5');
+  });
+
+  test('TC-BANG-10: bang command with paths containing spaces', () => {
+    const r = classifyPrompt('!ls "my folder"', false);
+    expect(r.target).toBe('shell');
+    expect(r.command).toBe('ls "my folder"');
+  });
+});
+
+describe('handlePromptSubmit — routing when active session exists', () => {
+  test('TC-ROUTE-01: shell command is not forwarded to AI regardless of session state', () => {
+    expect(classifyPrompt('!echo hi', true).target).toBe('shell');
+    expect(classifyPrompt('!echo hi', false).target).toBe('shell');
+  });
+
+  test('TC-ROUTE-02: regular prompt routes to continue when session is active', () => {
+    expect(classifyPrompt('What is the weather?', true).target).toBe('continue');
+  });
+
+  test('TC-ROUTE-03: regular prompt routes to start when no session is active', () => {
+    expect(classifyPrompt('What is the weather?', false).target).toBe('start');
+  });
+});
+
+describe('sessionId capture logic', () => {
+  const NOW = 1_700_000_000_000;
+
+  test('TC-SID-01: generates a deterministic temp ID when there is no current session', () => {
+    const id = resolveSessionId(null, NOW);
+    expect(id).toBe(`temp-shell-${NOW}`);
+  });
+
+  test('TC-SID-02: uses existing session ID when a session is active', () => {
+    const id = resolveSessionId('session-abc-123', NOW);
+    expect(id).toBe('session-abc-123');
+  });
+
+  test('TC-SID-03: temp ID changes with different timestamps (no collision across calls)', () => {
+    const id1 = resolveSessionId(null, NOW);
+    const id2 = resolveSessionId(null, NOW + 1);
+    expect(id1).not.toBe(id2);
+  });
+});
+
+describe('tempSession title construction', () => {
+  test('TC-TITLE-01: prepends "!" to command', () => {
+    expect(buildTempTitle('ls -la')).toBe('!ls -la');
+  });
+
+  test('TC-TITLE-02: titles are capped at 50 characters', () => {
+    const long = 'a'.repeat(60);
+    expect(buildTempTitle(long).length).toBe(50);
+  });
+
+  test('TC-TITLE-03: short commands are not padded', () => {
+    expect(buildTempTitle('pwd')).toBe('!pwd');
+  });
+
+  test('TC-TITLE-04: title starts with "!" for every command', () => {
+    ['ls', 'git status', 'npm run build'].forEach((cmd) => {
+      expect(buildTempTitle(cmd).startsWith('!')).toBe(true);
+    });
+  });
+});
+
+describe('isError / exitCode semantics', () => {
+  test('TC-ERR-01: exitCode 0 and success=true → not an error', () => {
+    expect(computeIsError(true, 0)).toBe(false);
+  });
+
+  test('TC-ERR-02: exitCode 1 and success=false → is an error', () => {
+    expect(computeIsError(false, 1)).toBe(true);
+  });
+
+  test('TC-ERR-03: exitCode non-zero even when success=true → is an error', () => {
+    // Edge case: IPC returned success=true but exitCode was non-zero
+    expect(computeIsError(true, 1)).toBe(true);
+  });
+
+  test('TC-ERR-04: exitCode 0 but success=false → is an error', () => {
+    expect(computeIsError(false, 0)).toBe(true);
+  });
+
+  test('TC-ERR-05: common non-zero exit codes are all flagged as errors', () => {
+    [1, 2, 42, 127, 128, 255].forEach((code) => {
+      expect(computeIsError(false, code)).toBe(true);
+    });
+  });
+});
+
+describe('user message construction', () => {
+  function buildUserContent(command: string): string {
+    return `!${command}`;
+  }
+
+  test('TC-USER-01: user message content always prefixes "!" to the raw command', () => {
+    expect(buildUserContent('ls -la')).toBe('!ls -la');
+  });
+
+  test('TC-USER-02: complex command with pipes is preserved verbatim', () => {
+    const cmd = 'git log --oneline | head -5';
+    expect(buildUserContent(cmd)).toBe(`!${cmd}`);
+  });
+});

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -449,6 +449,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorEngineNotReady: 'AI 引擎正在启动中，请稍等几秒后重试。',
     coworkErrorUnknown: '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
 
+    // Shell bang command (!command)
+    shellCommandNoOutput: '（无输出）',
+    shellCommandFailed: '命令执行失败',
+    shellExitOk: '✓ 成功',
+
     // Skills
     skills: '技能',
     searchSkills: '搜索技能',
@@ -1493,6 +1498,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionContinueFailed: 'Failed to send message: {error}',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
     coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
+
+    // Shell bang command (!command)
+    shellCommandNoOutput: '(no output)',
+    shellCommandFailed: 'Command failed',
+    shellExitOk: '✓ ok',
 
     // Skills
     skills: 'Skills',

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -352,6 +352,13 @@ interface IElectronAPI {
     openPath: (filePath: string) => Promise<{ success: boolean; error?: string }>;
     showItemInFolder: (filePath: string) => Promise<{ success: boolean; error?: string }>;
     openExternal: (url: string) => Promise<{ success: boolean; error?: string }>;
+    exec: (options: { command: string; cwd?: string }) => Promise<{
+      success: boolean;
+      stdout: string;
+      stderr: string;
+      exitCode: number;
+      error?: string;
+    }>;
   };
   autoLaunch: {
     get: () => Promise<{ enabled: boolean }>;


### PR DESCRIPTION
---
 Summary
- 新增 `!<command>` shell 快捷方式：在 cowork 输入框中输入 `!ls -la` 等命令，直接在本机执行，不经过 AI，结果即时显示
- 结果以终端样式卡片呈现（命令标题栏 + 退出码徽章 + stdout/stderr 分区）
- 包含测试期间发现的 2 个 bug 修复
 Changes
 feat — 核心实现
**`src/main/main.ts`**
- 新增 `shell:exec` IPC handler，使用 `child_process.execFile`
  - 跨平台：Windows 用 `cmd.exe /c`，Unix 用 `/bin/sh -c`
  - 30s 超时，10MB maxBuffer，50000 字符截断
**`src/main/preload.ts`** / **`src/renderer/types/electron.d.ts`**
- 向渲染进程暴露 `window.electron.shell.exec({ command, cwd })`
**`src/renderer/components/cowork/CoworkView.tsx`**
- `handleShellCommand`：执行命令，插入 user 消息（`!<cmd>`）和 system 消息（结果）；无活跃会话时创建轻量内存临时会话
- `handlePromptSubmit`：统一提交入口，拦截 `!` 前缀后转 shell 执行，其余走原 AI 流程
**`src/renderer/components/cowork/CoworkSessionDetail.tsx`**
- `renderSystemMessage` 为带 `shellCommand` metadata 的消息渲染终端样式块：命令标题栏、绿/红退出码徽章、可滚动的 stdout（白色）/ stderr（红色）区域
**`src/renderer/services/i18n.ts`**
- 新增 `shellCommandNoOutput`、`shellCommandFailed`、`shellExitOk`（中英双语）
 fix — 测试中发现的 bug
**`fix(cowork): fix sessionId capture race and handlePromptSubmit TDZ`**
- 在 `await shell.exec()` 之前同步捕获 `sessionId`，避免 React 异步更新导致结果消息落入错误会话
- 将 `handlePromptSubmit` 移至 `handleStartSession`/`handleContinueSession` 之后定义，消除 `const` TDZ 引用错误
 test — 单元测试
**`src/main/shellExec.test.ts`**（39 个用例）
- 纯函数测试：`truncate`、`resolveCwd`、`isTimeoutError`、`getShellArgs`
- 集成测试：真实子进程执行（stdout、stderr、退出码、cwd、多行输出、截断）
- 输出消息内容构建逻辑
**`src/renderer/components/cowork/shellBangCommand.test.ts`**（41 个用例）
- `!` 检测与路由、会话路由、sessionId 竞态、标题截断、isError 语义
全部 **80 个测试通过**，TypeScript 编译无报错，无新增 lint 错误。
 Usage
!ls -la
!git status
!npm run build
!echo hello world
命令在配置的工作目录下即时执行，结果以终端卡片展示，不触发 AI 会话。
---