### PR TITLE
fix(sqlite): handle corrupted metadata JSON in getSessionMessages

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -744,13 +744,23 @@ export class CoworkStore {
         ROWID ASC
     `, [sessionId]);
 
-    return rows.map(row => ({
-      id: row.id,
-      type: row.type as CoworkMessageType,
-      content: row.content,
-      timestamp: row.created_at,
-      metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
-    }));
+    return rows.map(row => {
+      let metadata: CoworkMessageMetadata | undefined;
+      if (row.metadata) {
+        try {
+          metadata = JSON.parse(row.metadata);
+        } catch {
+          console.warn(`[CoworkStore] message ${row.id} has corrupted metadata, treating as empty`);
+        }
+      }
+      return {
+        id: row.id,
+        type: row.type as CoworkMessageType,
+        content: row.content,
+        timestamp: row.created_at,
+        metadata,
+      };
+    });
   }
 
   addMessage(sessionId: string, message: Omit<CoworkMessage, 'id' | 'timestamp'>): CoworkMessage {


### PR DESCRIPTION
[问题]
cowork_messages 表中任意一条消息的 metadata 字段损坏时，
整个 session 无法加载，UI 显示失败，且用户无法自行恢复。

[根因]
getSessionMessages() 对 metadata 字段直接调用 JSON.parse() 而没有 try-catch 保护。该方法使用 Array.map() 遍历所有消息行，
单行抛出 SyntaxError 会导致整个 map() 中断并向上穿透，
最终使 getSession() 抛出异常，致使该 session 永久无法打开。

同文件 L576 的 active_skill_ids 字段已有 try-catch 容错，
但 metadata 字段遗漏了相同的保护。

[修复]
在 getSessionMessages() 中对 metadata 的 JSON.parse 增加 try-catch 容错，解析失败时降级返回 undefined，同时输出
warn 日志便于排查。消息的 content/type 等核心字段不受影响。

[复现路径]
1. 在 Cowork 中发起需要大量工具调用的任务
2. AI 流式输出期间通过 Activity Monitor 强制终止进程
3. 重启后尝试打开该 session，session 无法加载