### PR TITLE
fix(cowork): CoworkSessionItem menuItems useMemo 因依赖不稳定而完全失效

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionItem.tsx
+++ b/src/renderer/components/cowork/CoworkSessionItem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CoworkSessionSummary, CoworkSessionStatus } from '../../types/cowork';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import EllipsisHorizontalIcon from '../icons/EllipsisHorizontalIcon';
@@ -149,20 +149,20 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
     setShowConfirmDelete(false);
   };
 
-  const handleTogglePin = (e: React.MouseEvent) => {
+  const handleTogglePin = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     onTogglePin(!session.pinned);
     closeMenu();
-  };
+  }, [onTogglePin, session.pinned]);
 
-  const handleRenameClick = (e: React.MouseEvent) => {
+  const handleRenameClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     ignoreNextBlurRef.current = false;
     setIsRenaming(true);
     setShowConfirmDelete(false);
     setRenameValue(session.title);
     setMenuPosition(null);
-  };
+  }, [session.title]);
 
   const handleRenameSave = (e?: React.SyntheticEvent) => {
     e?.stopPropagation();
@@ -189,11 +189,11 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
     handleRenameSave(event);
   };
 
-  const handleDeleteClick = (e: React.MouseEvent) => {
+  const handleDeleteClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     setShowConfirmDelete(true);
     setMenuPosition(null);
-  };
+  }, []);
 
   const handleConfirmDelete = () => {
     onDelete();
@@ -205,11 +205,11 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
     setShowConfirmDelete(false);
   };
 
-  const handleBatchClick = (e: React.MouseEvent) => {
+  const handleBatchClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     closeMenu();
     onEnterBatchMode();
-  };
+  }, [onEnterBatchMode]);
 
   useEffect(() => {
     if (!menuPosition) return;


### PR DESCRIPTION
## Summary
- `CoworkSessionItem` 的 `menuItems` `useMemo` 依赖了 4 个未用 `useCallback` 包裹的内联函数，每次渲染都是新引用，导致 memoization 完全失效
- 将 `handleBatchClick`、`handleDeleteClick`、`handleRenameClick`、`handleTogglePin` 用 `useCallback` 包裹，使 `useMemo` 真正生效

## Changes
- 仅修改 `src/renderer/components/cowork/CoworkSessionItem.tsx`
- `import` 新增 `useCallback`
- 4 个 handler 从普通函数改为 `useCallback` 包裹，声明正确依赖
- TypeScript 编译零错误，无功能变更，纯性能优化