### PR TITLE
feat(cowork): add message rollback and edit-regenerate support

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -869,6 +869,58 @@ export class CoworkStore {
     this.saveDb();
   }
 
+  /**
+   * Delete all messages after a specific message (for rollback functionality).
+   * Returns the number of messages deleted.
+   */
+  deleteMessagesAfter(sessionId: string, messageId: string): number {
+    // First, get the sequence number of the target message
+    const targetRow = this.db.exec(
+      'SELECT sequence FROM cowork_messages WHERE id = ? AND session_id = ?',
+      [messageId, sessionId],
+    );
+
+    if (!targetRow[0]?.values[0]) {
+      return 0;
+    }
+
+    const targetSequence = targetRow[0].values[0][0] as number;
+
+    // Delete all messages with sequence >= targetSequence (including the target message itself)
+    this.db.run(
+      'DELETE FROM cowork_messages WHERE session_id = ? AND sequence >= ?',
+      [sessionId, targetSequence]
+    );
+
+    // Read rowsModified before saveDb to avoid potential overwrite by saveDb internals
+    const changes = this.db.getRowsModified?.() || 0;
+    this.saveDb();
+
+    return changes;
+  }
+
+  /**
+   * Get a user message by ID for edit & regenerate functionality.
+   */
+  getMessage(sessionId: string, messageId: string): CoworkMessage | null {
+    const rows = this.getAll<CoworkMessageRow>(`
+      SELECT id, type, content, metadata, created_at, sequence
+      FROM cowork_messages
+      WHERE session_id = ? AND id = ?
+    `, [sessionId, messageId]);
+
+    if (rows.length === 0) return null;
+
+    const row = rows[0];
+    return {
+      id: row.id,
+      type: row.type as CoworkMessageType,
+      content: row.content,
+      timestamp: row.created_at,
+      metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
+    };
+  }
+
   // Config operations
   getConfig(): CoworkConfig {
     interface ConfigRow {

--- a/src/main/libs/agentEngine/coworkEngineRouter.ts
+++ b/src/main/libs/agentEngine/coworkEngineRouter.ts
@@ -135,6 +135,16 @@ export class CoworkEngineRouter extends EventEmitter implements CoworkRuntime {
     }
   }
 
+  async clearSessionHistory(sessionId: string): Promise<void> {
+    const engine = this.safeResolveEngine();
+    try {
+      await this.runtimeByEngine[engine].clearSessionHistory?.(sessionId);
+    } catch (error) {
+      console.warn('[CoworkEngineRouter] clearSessionHistory failed for session:', sessionId, 'error:', error);
+      throw error;
+    }
+  }
+
   handleEngineConfigChanged(nextEngine: CoworkAgentEngine): void {
     if (nextEngine === this.currentEngine) {
       return;

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -515,6 +515,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private readonly lastSystemPromptBySession = new Map<string, string>();
   private readonly gatewayHistoryCountBySession = new Map<string, number>();
   private readonly latestTurnTokenBySession = new Map<string, number>();
+  private readonly rolledBackSessionSuffixes = new Map<string, string>();
 
   private gatewayClient: GatewayClientLike | null = null;
   private gatewayClientVersion: string | null = null;
@@ -3253,6 +3254,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     this.gatewayHistoryCountBySession.delete(sessionId);
     this.latestTurnTokenBySession.delete(sessionId);
 
+    // Clean up rollback suffix
+    this.rolledBackSessionSuffixes.delete(sessionId);
+
     // Clean up active turn and related run-id mappings
     this.cleanupSessionTurn(sessionId);
 
@@ -3266,6 +3270,51 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (this.channelSessionSync) {
       this.channelSessionSync.onSessionDeleted(sessionId);
     }
+  }
+
+  /**
+   * Clear OpenClaw gateway history for a session.
+   * This should be called when messages are rolled back to ensure the gateway
+   * doesn't retain stale conversation history.
+   *
+   * This clears:
+   * 1. Gateway history (via chat.clear)
+   * 2. Local tracking state (bridgedSessions, fullySyncedSessions, etc.)
+   *
+   * After calling this method, the next turn will re-bridge from the local store's
+   * current messages (which should be the post-rollback state).
+   */
+  async clearSessionHistory(sessionId: string): Promise<void> {
+    const sessionKey = this.toSessionKey(sessionId);
+    const client = this.gatewayClient;
+
+    // Since OpenClaw doesn't support chat.clear, we use a different strategy:
+    // Generate a new sessionKey suffix to force OpenClaw to create a fresh session
+    const newSuffix = `rollback-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    this.rolledBackSessionSuffixes.set(sessionId, newSuffix);
+
+    // Try to abort any active run for this session
+    const activeTurn = this.activeTurns.get(sessionId);
+    if (activeTurn && activeTurn.runId && client) {
+      try {
+        await client.request('chat.abort', {
+          sessionKey,
+          runId: activeTurn.runId,
+        });
+      } catch (error) {
+        // Abort might fail if run already completed, which is fine
+      }
+    }
+
+    // Clear local tracking for this session (similar to onSessionDeleted but without full deletion)
+    this.latestTurnTokenBySession.delete(sessionId);
+    this.lastSystemPromptBySession.delete(sessionId);
+    this.gatewayHistoryCountBySession.delete(sessionId);
+    this.fullySyncedSessions.delete(sessionId);
+    this.bridgedSessions.delete(sessionId);
+
+    // Also clear the session-to-sessionKey mapping to force a fresh session
+    this.sessionIdBySessionKey.delete(sessionKey);
   }
 
   /**
@@ -3460,7 +3509,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   private toSessionKey(sessionId: string): string {
-    return buildManagedSessionKey(sessionId);
+    const baseKey = buildManagedSessionKey(sessionId);
+    const suffix = this.rolledBackSessionSuffixes.get(sessionId);
+    if (suffix) {
+      return `${baseKey}:${suffix}`;
+    }
+    return baseKey;
   }
 
   private requireGatewayClient(): GatewayClientLike {

--- a/src/main/libs/agentEngine/types.ts
+++ b/src/main/libs/agentEngine/types.ts
@@ -59,4 +59,5 @@ export interface CoworkRuntime {
   isSessionActive(sessionId: string): boolean;
   getSessionConfirmationMode(sessionId: string): 'modal' | 'text' | null;
   onSessionDeleted?(sessionId: string): void;
+  clearSessionHistory?(sessionId: string): Promise<void>;
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2256,6 +2256,96 @@ if (!gotTheLock) {
     }
   });
 
+  ipcMain.handle('cowork:message:rollback', async (_event, options: { sessionId: string; messageId: string }) => {
+    try {
+      const { sessionId, messageId } = options;
+      const deletedCount = getCoworkStore().deleteMessagesAfter(sessionId, messageId);
+
+      // Stop the running session to clear AI runtime context
+      try {
+        getCoworkEngineRouter().stopSession(sessionId);
+      } catch (error) {
+        // Session might not be running, which is fine
+      }
+
+      // Clear the OpenClaw gateway history to prevent it from remembering rolled-back messages
+      try {
+        await getCoworkEngineRouter().clearSessionHistory(sessionId);
+      } catch (error) {
+        // Continue anyway - the database deletion is more important
+      }
+
+      // Clear the OpenClaw claudeSessionId to force a new session creation
+      getCoworkStore().updateSession(sessionId, { claudeSessionId: null });
+
+      return { success: true, deletedCount };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to rollback message',
+      };
+    }
+  });
+
+  ipcMain.handle('cowork:message:editAndRegenerate', async (_event, options: { sessionId: string; messageId: string; newContent?: string }) => {
+    try {
+      const { sessionId, messageId, newContent } = options;
+
+      // Get the message to edit BEFORE deleting it
+      const message = getCoworkStore().getMessage(sessionId, messageId);
+      if (!message) {
+        return { success: false, error: 'Message not found' };
+      }
+
+      if (message.type !== 'user') {
+        return { success: false, error: 'Only user messages can be edited and regenerated' };
+      }
+
+      // Extract message content and attachments BEFORE deleting
+      const contentToUse = newContent || message.content;
+      const metadata = message.metadata as Record<string, unknown> | undefined;
+      const imageAttachments = (metadata?.imageAttachments ?? []) as Array<{
+        name: string;
+        mimeType: string;
+        base64Data: string;
+      }>;
+
+      // Delete the target message and all messages after it
+      getCoworkStore().deleteMessagesAfter(sessionId, messageId);
+
+      // Stop the running session to clear AI runtime context (similar to rollback)
+      try {
+        getCoworkEngineRouter().stopSession(sessionId);
+      } catch (error) {
+        // Session might not be running, which is fine
+      }
+
+      // Clear the OpenClaw gateway history to prevent it from remembering old messages
+      try {
+        await getCoworkEngineRouter().clearSessionHistory(sessionId);
+      } catch (error) {
+        // Continue anyway
+      }
+
+      // Clear the OpenClaw claudeSessionId to force a new session creation
+      getCoworkStore().updateSession(sessionId, { claudeSessionId: null });
+
+      // Continue the session with the edited content (or original if no new content provided)
+      const runtime = getCoworkEngineRouter();
+      await runtime.continueSession(sessionId, contentToUse, {
+        imageAttachments,
+      });
+
+      const session = getCoworkStore().getSession(sessionId);
+      return { success: true, session };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to edit and regenerate message',
+      };
+    }
+  });
+
   ipcMain.handle('cowork:session:list', async () => {
     try {
       const sessions = getCoworkStore().listSessions();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -149,6 +149,10 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.invoke('cowork:session:pin', options),
     renameSession: (options: { sessionId: string; title: string }) =>
       ipcRenderer.invoke('cowork:session:rename', options),
+    rollbackMessage: (options: { sessionId: string; messageId: string }) =>
+      ipcRenderer.invoke('cowork:message:rollback', options),
+    editAndRegenerateMessage: (options: { sessionId: string; messageId: string; newContent?: string }) =>
+      ipcRenderer.invoke('cowork:message:editAndRegenerate', options),
     getSession: (sessionId: string) =>
       ipcRenderer.invoke('cowork:session:get', sessionId),
     remoteManaged: (sessionId: string) =>

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../store';
+import { setCurrentSession } from '../../store/slices/coworkSlice';
 import { i18nService } from '../../services/i18n';
 import type { CoworkMessage, CoworkMessageMetadata, CoworkImageAttachment } from '../../types/cowork';
 import type { Skill } from '../../types/skill';
@@ -892,9 +893,41 @@ const CopyButton: React.FC<{
   );
 };
 
-export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[] }> = React.memo(({ message, skills }) => {
+export const UserMessageItem: React.FC<{
+  message: CoworkMessage;
+  skills: Skill[];
+  onRollback?: (messageId: string) => void;
+  onEdit?: (messageId: string, content: string) => void;
+  onStartEdit?: (messageId: string | null) => void;
+  editingMessageId?: string | null;
+  isFirstMessage?: boolean;
+}> = React.memo(({ message, skills, onRollback, onEdit, onStartEdit, editingMessageId, isFirstMessage = false }) => {
   const [isHovered, setIsHovered] = useState(false);
   const [expandedImage, setExpandedImage] = useState<string | null>(null);
+  const isEditing = editingMessageId === message.id;
+  const [editContent, setEditContent] = useState(message.content);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-focus textarea when entering edit mode
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+      // Small delay to ensure DOM is fully updated
+      setTimeout(() => {
+        if (textareaRef.current) {
+          const len = textareaRef.current.value.length;
+          textareaRef.current.focus();
+          textareaRef.current.setSelectionRange(len, len);
+        }
+      }, 0);
+    }
+  }, [isEditing]);
+
+  // Reset edit content when message changes or when editing another message
+  useEffect(() => {
+    if (!isEditing) {
+      setEditContent(message.content);
+    }
+  }, [message.content, isEditing]);
 
   // Get skills used for this message
   const messageSkillIds = (message.metadata as CoworkMessageMetadata)?.skillIds || [];
@@ -904,6 +937,36 @@ export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[]
 
   // Get image attachments from metadata
   const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ?? []) as CoworkImageAttachment[];
+
+  const handleStartEdit = useCallback(() => {
+    // Request parent to set editingMessageId
+    if (onStartEdit) {
+      onStartEdit(message.id);
+    }
+  }, [message.id, onStartEdit]);
+
+  const handleCancelEdit = useCallback(() => {
+    // Request parent to clear editingMessageId
+    if (onStartEdit) {
+      onStartEdit(null); // Passing null should clear the editing state
+    }
+  }, [onStartEdit]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const isComposing = event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229;
+    if (event.key === 'Enter' && !event.shiftKey && !isComposing) {
+      event.preventDefault();
+      if (onEdit) {
+        onEdit(message.id, editContent);
+      }
+    }
+  };
+
+  const handleConfirmEdit = useCallback(() => {
+    if (onEdit) {
+      onEdit(message.id, editContent);
+    }
+  }, [message.id, editContent, onEdit]);
 
   return (
     <div
@@ -915,30 +978,59 @@ export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[]
         <div className="pl-4 sm:pl-8 md:pl-12">
           <div className="flex items-start gap-3 flex-row-reverse">
             <div className="w-full min-w-0 flex flex-col items-end">
-              <div className="w-fit max-w-[42rem] rounded-2xl px-4 py-2.5 dark:bg-claude-darkSurface bg-claude-surface dark:text-claude-darkText text-claude-text shadow-subtle">
-                {message.content?.trim() && (
-                  <MarkdownContent
-                    content={message.content}
-                    className="max-w-none whitespace-pre-wrap break-words"
-                  />
-                )}
-                {imageAttachments.length > 0 && (
-                  <div className={`flex flex-wrap gap-2 ${message.content?.trim() ? 'mt-2' : ''}`}>
-                    {imageAttachments.map((img, idx) => (
-                      <div key={idx} className="relative group">
-                        <img
-                          src={`data:${img.mimeType};base64,${img.base64Data}`}
-                          alt={img.name}
-                          className="max-h-48 max-w-[16rem] rounded-lg object-contain cursor-pointer border dark:border-claude-darkBorder/50 border-claude-border/50 hover:border-claude-accent/50 transition-colors"
-                          title={img.name}
-                          onClick={() => setExpandedImage(`data:${img.mimeType};base64,${img.base64Data}`)}
-                        />
-                        <div className="absolute bottom-1 left-1 right-1 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/50 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity truncate pointer-events-none">
-                          <PhotoIcon className="h-3 w-3 flex-shrink-0" />
-                          <span className="truncate">{img.name}</span>
-                        </div>
+              <div className={isEditing ? "w-full" : "w-fit max-w-[42rem]"}>
+                {isEditing ? (
+                  <div className="rounded-2xl border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface bg-claude-surface shadow-subtle p-3">
+                    <textarea
+                      ref={textareaRef}
+                      value={editContent}
+                      onChange={(e) => setEditContent(e.target.value)}
+                      onKeyDown={handleKeyDown}
+                      className="w-full bg-transparent dark:text-claude-darkText text-claude-text resize-none outline-none whitespace-pre-wrap break-words min-h-[40px]"
+                      rows={2}
+                    />
+                    <div className="flex items-center justify-end gap-2 mt-2">
+                      <button
+                        onClick={handleCancelEdit}
+                        className="px-3 py-1.5 rounded-md dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-all duration-200 text-sm dark:text-claude-darkText text-claude-text"
+                      >
+                        {i18nService.t('cancel')}
+                      </button>
+                      <button
+                        onClick={handleConfirmEdit}
+                        className="px-3 py-1.5 rounded-md bg-claude-accent hover:bg-claude-accentHover text-white transition-all duration-200 text-sm"
+                      >
+                        {i18nService.t('send')}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="rounded-2xl px-4 py-2.5 dark:bg-claude-darkSurface bg-claude-surface dark:text-claude-darkText text-claude-text shadow-subtle">
+                    {message.content?.trim() && (
+                      <MarkdownContent
+                        content={message.content}
+                        className="max-w-none whitespace-pre-wrap break-words"
+                      />
+                    )}
+                    {imageAttachments.length > 0 && (
+                      <div className={`flex flex-wrap gap-2 ${message.content?.trim() ? 'mt-2' : ''}`}>
+                        {imageAttachments.map((img, idx) => (
+                          <div key={idx} className="relative group">
+                            <img
+                              src={`data:${img.mimeType};base64,${img.base64Data}`}
+                              alt={img.name}
+                              className="max-h-48 max-w-[16rem] rounded-lg object-contain cursor-pointer border dark:border-claude-darkBorder/50 border-claude-border/50 hover:border-claude-accent/50 transition-colors"
+                              title={img.name}
+                              onClick={() => setExpandedImage(`data:${img.mimeType};base64,${img.base64Data}`)}
+                            />
+                            <div className="absolute bottom-1 left-1 right-1 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/50 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity truncate pointer-events-none">
+                              <PhotoIcon className="h-3 w-3 flex-shrink-0" />
+                              <span className="truncate">{img.name}</span>
+                            </div>
+                          </div>
+                        ))}
                       </div>
-                    ))}
+                    )}
                   </div>
                 )}
               </div>
@@ -955,10 +1047,38 @@ export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[]
                     </span>
                   </div>
                 ))}
-                <CopyButton
-                  content={message.content}
-                  visible={isHovered}
-                />
+                {!isEditing && (
+                  <>
+                    <CopyButton
+                      content={message.content}
+                      visible={isHovered}
+                    />
+                    {!isFirstMessage && onRollback && (
+                      <button
+                        onClick={() => onRollback(message.id)}
+                        className={`p-1.5 rounded-md dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-all duration-200 ${
+                          isHovered ? 'opacity-100' : 'opacity-0 pointer-events-none'
+                        }`}
+                        title={i18nService.t('coworkMessageRollback')}
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-4 h-4 text-[var(--icon-secondary)]">
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3" />
+                        </svg>
+                      </button>
+                    )}
+                    {!isFirstMessage && onEdit && (
+                      <button
+                        onClick={handleStartEdit}
+                        className={`p-1.5 rounded-md dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-all duration-200 ${
+                          isHovered ? 'opacity-100' : 'opacity-0 pointer-events-none'
+                        }`}
+                        title={i18nService.t('coworkMessageEdit')}
+                      >
+                        <PencilSquareIcon className="w-4 h-4 text-[var(--icon-secondary)]" />
+                      </button>
+                    )}
+                  </>
+                )}
               </div>
             </div>
           </div>
@@ -1286,6 +1406,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   onNewChat,
   updateBadge,
 }) => {
+  const dispatch = useDispatch();
   const isMac = window.electron.platform === 'darwin';
   const currentSession = useSelector((state: RootState) => state.cowork.currentSession);
   const isStreaming = useSelector((state: RootState) => state.cowork.isStreaming);
@@ -1313,12 +1434,19 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const actionButtonRef = useRef<HTMLButtonElement>(null);
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
   const [isExportingImage, setIsExportingImage] = useState(false);
+  const [showRollbackConfirm, setShowRollbackConfirm] = useState(false);
+  const [pendingRollbackMessageId, setPendingRollbackMessageId] = useState<string | null>(null);
 
   // Rename states
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState('');
   const renameInputRef = useRef<HTMLInputElement>(null);
   const ignoreNextBlurRef = useRef(false);
+
+  // Edit message state
+  const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
+  const [showEditConfirm, setShowEditConfirm] = useState(false);
+  const [pendingEditMessage, setPendingEditMessage] = useState<{ messageId: string; newContent: string } | null>(null);
 
   // Reset rename value when session changes
   useEffect(() => {
@@ -1483,6 +1611,80 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     if (!currentSession) return;
     await coworkService.setSessionPinned(currentSession.id, !currentSession.pinned);
     closeMenu();
+  };
+
+  // Message rollback handler
+  const handleRollbackMessage = (messageId: string) => {
+    if (!currentSession) return;
+    setPendingRollbackMessageId(messageId);
+    setShowRollbackConfirm(true);
+  };
+
+  const handleConfirmRollback = async () => {
+    if (!pendingRollbackMessageId || !currentSession) return;
+    const result = await coworkService.rollbackMessage(currentSession.id, pendingRollbackMessageId);
+    if (result.success) {
+      // Reload session to update UI
+      await coworkService.loadSession(currentSession.id);
+    } else {
+      console.error('Failed to rollback message:', result.error);
+    }
+    setShowRollbackConfirm(false);
+    setPendingRollbackMessageId(null);
+  };
+
+  const handleCancelRollback = () => {
+    setShowRollbackConfirm(false);
+    setPendingRollbackMessageId(null);
+  };
+
+  // Message edit handler
+  const handleStartEditMessage = (messageId: string | null) => {
+    setEditingMessageId(messageId);
+  };
+
+  const handleEditMessageConfirm = async (messageId: string, newContent: string) => {
+    if (!currentSession) return;
+    // Show confirmation dialog instead of directly editing
+    setPendingEditMessage({ messageId, newContent });
+    setShowEditConfirm(true);
+  };
+
+  const handleConfirmEditMessage = async () => {
+    if (!pendingEditMessage || !currentSession) return;
+    const { messageId, newContent } = pendingEditMessage;
+
+    // Immediately hide edit box and confirmation dialog
+    setEditingMessageId(null);
+    setShowEditConfirm(false);
+
+    // Optimistic update: Remove the message and all messages after it from UI immediately
+    const messageIndex = currentSession.messages.findIndex(m => m.id === messageId);
+    if (messageIndex !== -1) {
+      // Get the messages to keep (before the target message)
+      const messagesToKeep = currentSession.messages.slice(0, messageIndex);
+
+      // Dispatch using the imported action creator for type safety
+      dispatch(setCurrentSession({
+        ...currentSession,
+        messages: messagesToKeep,
+        updatedAt: Date.now(),
+      }));
+    }
+
+    const result = await coworkService.editAndRegenerateMessage(currentSession.id, messageId, newContent);
+    if (!result.success) {
+      console.error('Failed to edit and regenerate message:', result.error);
+      // If failed, reload to restore the original state before optimistic update
+      await coworkService.loadSession(currentSession.id);
+    }
+
+    setPendingEditMessage(null);
+  };
+
+  const handleCancelEditMessage = () => {
+    setShowEditConfirm(false);
+    setPendingEditMessage(null);
   };
 
   // Delete handlers
@@ -1840,7 +2042,15 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         <div key={turn.id} data-turn-index={index}>
           {turn.userMessage && (
             <div data-export-role="user-message">
-              <UserMessageItem message={turn.userMessage} skills={skills} />
+              <UserMessageItem
+                message={turn.userMessage}
+                skills={skills}
+                onRollback={handleRollbackMessage}
+                onEdit={handleEditMessageConfirm}
+                onStartEdit={handleStartEditMessage}
+                editingMessageId={editingMessageId}
+                isFirstMessage={index === 0}
+              />
             </div>
           )}
           {showAssistantBlock && (
@@ -2024,6 +2234,104 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 className="px-4 py-2 text-sm font-medium rounded-lg bg-red-500 hover:bg-red-600 text-white transition-colors"
               >
                 {i18nService.t('deleteSession')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Rollback Confirmation Modal */}
+      {showRollbackConfirm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
+          onClick={handleCancelRollback}
+        >
+          <div
+            className="w-full max-w-sm mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal overflow-hidden modal-content"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Header */}
+            <div className="flex items-center gap-3 px-5 py-4">
+              <div className="p-2 rounded-full bg-orange-100 dark:bg-orange-900/30">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="h-5 w-5 text-orange-600 dark:text-orange-500">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3" />
+                </svg>
+              </div>
+              <h2 className="text-base font-semibold dark:text-claude-darkText text-claude-text">
+                {i18nService.t('coworkMessageRollbackConfirmTitle')}
+              </h2>
+            </div>
+
+            {/* Content */}
+            <div className="px-5 pb-4">
+              <p className="text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                {i18nService.t('coworkMessageRollbackConfirmLine1')}
+                <br />
+                {i18nService.t('coworkMessageRollbackConfirmLine2')}
+              </p>
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-end gap-3 px-5 py-4 border-t dark:border-claude-darkBorder border-claude-border">
+              <button
+                onClick={handleCancelRollback}
+                className="px-4 py-2 text-sm font-medium rounded-lg dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-colors"
+              >
+                {i18nService.t('cancel')}
+              </button>
+              <button
+                onClick={handleConfirmRollback}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-orange-500 hover:bg-orange-600 text-white transition-colors"
+              >
+                {i18nService.t('confirmRollback')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Edit Message Confirmation Modal */}
+      {showEditConfirm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
+          onClick={handleCancelEditMessage}
+        >
+          <div
+            className="w-full max-w-sm mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal overflow-hidden modal-content"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Header */}
+            <div className="flex items-center gap-3 px-5 py-4">
+              <div className="p-2 rounded-full bg-blue-100 dark:bg-blue-900/30">
+                <PencilSquareIcon className="h-5 w-5 text-blue-600 dark:text-blue-500" />
+              </div>
+              <h2 className="text-base font-semibold dark:text-claude-darkText text-claude-text">
+                {i18nService.t('coworkMessageEditConfirmTitle')}
+              </h2>
+            </div>
+
+            {/* Content */}
+            <div className="px-5 pb-4">
+              <p className="text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                {i18nService.t('coworkMessageEditConfirmLine1')}
+                <br />
+                {i18nService.t('coworkMessageEditConfirmLine2')}
+              </p>
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-end gap-3 px-5 py-4 border-t dark:border-claude-darkBorder border-claude-border">
+              <button
+                onClick={handleCancelEditMessage}
+                className="px-4 py-2 text-sm font-medium rounded-lg dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-colors"
+              >
+                {i18nService.t('cancel')}
+              </button>
+              <button
+                onClick={handleConfirmEditMessage}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-blue-500 hover:bg-blue-600 text-white transition-colors"
+              >
+                {i18nService.t('confirmEdit')}
               </button>
             </div>
           </div>

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -394,6 +394,36 @@ class CoworkService {
     return false;
   }
 
+  async rollbackMessage(sessionId: string, messageId: string): Promise<{ success: boolean; error?: string }> {
+    const cowork = window.electron?.cowork;
+    if (!cowork?.rollbackMessage) {
+      return { success: false, error: 'Rollback API not available' };
+    }
+
+    const result = await cowork.rollbackMessage({ sessionId, messageId });
+    if (result.success) {
+      return { success: true };
+    }
+
+    console.error('Failed to rollback message:', result.error);
+    return { success: false, error: result.error };
+  }
+
+  async editAndRegenerateMessage(sessionId: string, messageId: string, newContent?: string): Promise<{ success: boolean; error?: string }> {
+    const cowork = window.electron?.cowork;
+    if (!cowork?.editAndRegenerateMessage) {
+      return { success: false, error: 'Edit & regenerate API not available' };
+    }
+
+    const result = await cowork.editAndRegenerateMessage({ sessionId, messageId, newContent });
+    if (result.success) {
+      return { success: true };
+    }
+
+    console.error('Failed to edit and regenerate message:', result.error);
+    return { success: false, error: result.error };
+  }
+
   async exportSessionResultImage(options: {
     rect: { x: number; y: number; width: number; height: number };
     defaultFileName?: string;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -8,6 +8,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
   zh: {
     // 通用
     save: '保存',
+    send: '发送',
     cancel: '取消',
     saving: '保存中...',
     create: '创建',
@@ -448,6 +449,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionContinueFailed: '发送消息失败：{error}',
     coworkErrorEngineNotReady: 'AI 引擎正在启动中，请稍等几秒后重试。',
     coworkErrorUnknown: '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
+    coworkMessageRollback: '回滚消息',
+    coworkMessageEdit: '重新编辑',
+    coworkEditMessagePlaceholder: '编辑您的消息...',
+    confirmRollback: '确认回滚',
+    coworkMessageRollbackConfirmTitle: '回滚消息',
+    coworkMessageRollbackConfirmLine1: '将对话回滚到此处。',
+    coworkMessageRollbackConfirmLine2: '这将删除此处之后的所有消息，且无法撤销。',
+    coworkMessageEditConfirmTitle: '重新编辑',
+    coworkMessageEditConfirmLine1: '确认要编辑此消息吗？',
+    coworkMessageEditConfirmLine2: '这将从此处重新生成对话，可能会改变后续回复内容。',
+    confirmEdit: '确认编辑',
 
     // Skills
     skills: '技能',
@@ -1053,6 +1065,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
   en: {
     // Common
     save: 'Save',
+    send: 'Send',
     cancel: 'Cancel',
     saving: 'Saving...',
     create: 'Create',
@@ -1493,6 +1506,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionContinueFailed: 'Failed to send message: {error}',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
     coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
+    coworkMessageRollback: 'Rollback',
+    coworkMessageEdit: 'Edit & Regenerate',
+    coworkEditMessagePlaceholder: 'Edit your message...',
+    confirmRollback: 'Confirm Rollback',
+    coworkMessageRollbackConfirmTitle: 'Rollback Message',
+    coworkMessageRollbackConfirmLine1: 'Rollback the conversation to this point.',
+    coworkMessageRollbackConfirmLine2: 'This will delete all messages after this point and cannot be undone.',
+    coworkMessageEditConfirmTitle: 'Edit & Regenerate',
+    coworkMessageEditConfirmLine1: 'Confirm to edit this message?',
+    coworkMessageEditConfirmLine2: 'This will regenerate the conversation from this point and may change subsequent replies.',
+    confirmEdit: 'Confirm Edit',
 
     // Skills
     skills: 'Skills',

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -301,6 +301,8 @@ interface IElectronAPI {
     deleteSessions: (sessionIds: string[]) => Promise<{ success: boolean; error?: string }>;
     setSessionPinned: (options: { sessionId: string; pinned: boolean }) => Promise<{ success: boolean; error?: string }>;
     renameSession: (options: { sessionId: string; title: string }) => Promise<{ success: boolean; error?: string }>;
+    rollbackMessage: (options: { sessionId: string; messageId: string }) => Promise<{ success: boolean; deletedCount?: number; error?: string }>;
+    editAndRegenerateMessage: (options: { sessionId: string; messageId: string; newContent?: string }) => Promise<{ success: boolean; error?: string }>;
     getSession: (sessionId: string) => Promise<{ success: boolean; session?: CoworkSession; error?: string }>;
     remoteManaged: (sessionId: string) => Promise<{ success: boolean; remoteManaged: boolean; error?: string }>;
     listSessions: () => Promise<{ success: boolean; sessions?: CoworkSessionSummary[]; error?: string }>;


### PR DESCRIPTION
## Summary

Add message rollback and edit & regenerate functionality to Cowork conversations, allowing users to rewind conversations to any previous user message or edit a sent message and regenerate the AI response from that point.

## Motivation

Currently, if a user sends an unsatisfactory prompt in a Cowork session, the only option is to start a new session entirely. This PR improves conversation controllability and fault tolerance by enabling mid-conversation corrections.

## Changes

### Data Layer (`coworkStore.ts`)
- Add `deleteMessagesAfter()` — deletes a target message and all subsequent messages by sequence number
- Add `getMessage()` — retrieves a single message by ID for edit & regenerate

### Engine Layer (`types.ts` / `coworkEngineRouter.ts` / `openclawRuntimeAdapter.ts`)
- Add optional `clearSessionHistory()` to `CoworkRuntime` interface
- Implement in `CoworkEngineRouter` with engine delegation
- Implement in `OpenClawRuntimeAdapter` using a sessionKey suffix strategy to force fresh gateway sessions (since OpenClaw doesn't support `chat.clear`)

### IPC Layer (`main.ts` / `preload.ts` / `electron.d.ts`)
- Add `cowork:message:rollback` — stops session, clears gateway history, deletes messages from DB
- Add `cowork:message:editAndRegenerate` — rollback + re-submit with edited content

### UI Layer (`CoworkSessionDetail.tsx`)
- Add rollback and edit buttons on hover for user messages (hidden for first message)
- Inline edit mode with textarea, Enter to submit, Shift+Enter for newline
- Confirmation modals for both rollback and edit actions
- Optimistic UI update on edit (immediate message removal, restore on failure)

### Service & i18n (`cowork.ts` / `i18n.ts`)
- Add `rollbackMessage()` and `editAndRegenerateMessage()` to CoworkService
- Add all i18n keys for both Chinese and English

## Testing

- Verified rollback correctly removes target message and all subsequent messages
- Verified edit & regenerate re-submits with edited content and streams new response
- Verified first message cannot be rolled back or edited (buttons hidden)
- Verified confirmation modals work correctly for both operations
- TypeScript: `tsc --noEmit` passes on both tsconfig files with zero errors
- ESLint: no new lint errors introduced