### PR TITLE
feat(im): 微信扫码登录优化二维码生成速度：绕过 OpenClaw Gateway 直接调用 ilink API

### DIFF
--- a/src/main/im/weixinLogin.ts
+++ b/src/main/im/weixinLogin.ts
@@ -1,0 +1,132 @@
+/**
+ * Direct HTTP calls to WeChat ilink API for QR code login.
+ * Bypasses OpenClaw Gateway — works independently.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ILINK_BASE_URL = 'https://ilinkai.weixin.qq.com';
+const BOT_TYPE = '3';
+const POLL_TIMEOUT_MS = 35_000;
+
+interface IlinkQrCodeResponse {
+  qrcode: string;
+  qrcode_img_content: string;
+}
+
+interface IlinkStatusResponse {
+  status: 'wait' | 'scaned' | 'confirmed' | 'expired';
+  bot_token?: string;
+  ilink_bot_id?: string;
+  baseurl?: string;
+  ilink_user_id?: string;
+}
+
+export interface WeixinQrCodeResult {
+  qrcode: string;
+  qrcodeUrl: string;
+}
+
+export interface WeixinPollResult {
+  status: 'wait' | 'scaned' | 'confirmed' | 'expired';
+  botToken?: string;
+  accountId?: string;
+  baseUrl?: string;
+  userId?: string;
+}
+
+export async function fetchWeixinQrCode(): Promise<WeixinQrCodeResult> {
+  const url = `${ILINK_BASE_URL}/ilink/bot/get_bot_qrcode?bot_type=${encodeURIComponent(BOT_TYPE)}`;
+  console.log('[WeixinLogin] fetching QR code from ilink API');
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    const body = await response.text().catch(() => '(unreadable)');
+    throw new Error(`Failed to fetch QR code: ${response.status} ${response.statusText} body=${body}`);
+  }
+
+  const data = await response.json() as IlinkQrCodeResponse;
+  console.log('[WeixinLogin] QR code received, url length:', data.qrcode_img_content?.length ?? 0);
+
+  return {
+    qrcode: data.qrcode,
+    qrcodeUrl: data.qrcode_img_content,
+  };
+}
+
+export async function pollWeixinQrStatus(qrcode: string): Promise<WeixinPollResult> {
+  const url = `${ILINK_BASE_URL}/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), POLL_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      headers: { 'iLink-App-ClientVersion': '1' },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '(unreadable)');
+      throw new Error(`Failed to poll QR status: ${response.status} ${response.statusText} body=${body}`);
+    }
+
+    const data = await response.json() as IlinkStatusResponse;
+    return {
+      status: data.status,
+      botToken: data.bot_token,
+      accountId: data.ilink_bot_id,
+      baseUrl: data.baseurl,
+      userId: data.ilink_user_id,
+    };
+  } catch (err) {
+    clearTimeout(timer);
+    if (err instanceof Error && err.name === 'AbortError') {
+      return { status: 'wait' };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Save weixin account credentials to OpenClaw state directory.
+ * Mirrors openclaw-weixin plugin's saveWeixinAccount + registerWeixinAccountId.
+ */
+export function saveWeixinAccountToOpenClaw(
+  stateDir: string,
+  accountId: string,
+  data: { token?: string; baseUrl?: string; userId?: string },
+): void {
+  const weixinDir = path.join(stateDir, 'openclaw-weixin');
+  const accountsDir = path.join(weixinDir, 'accounts');
+  fs.mkdirSync(accountsDir, { recursive: true });
+
+  // Save account data (merge with existing)
+  const accountPath = path.join(accountsDir, `${accountId}.json`);
+  const existing = (() => {
+    try { return JSON.parse(fs.readFileSync(accountPath, 'utf-8')); } catch { return {}; }
+  })();
+
+  const merged = {
+    ...(data.token ? { token: data.token, savedAt: new Date().toISOString() } : existing.token ? { token: existing.token, savedAt: existing.savedAt } : {}),
+    ...(data.baseUrl ? { baseUrl: data.baseUrl } : existing.baseUrl ? { baseUrl: existing.baseUrl } : {}),
+    ...(data.userId ? { userId: data.userId } : existing.userId ? { userId: existing.userId } : {}),
+  };
+
+  fs.writeFileSync(accountPath, JSON.stringify(merged, null, 2), 'utf-8');
+  try { fs.chmodSync(accountPath, 0o600); } catch { /* best-effort */ }
+
+  // Register account ID in index
+  const indexPath = path.join(weixinDir, 'accounts.json');
+  const ids: string[] = (() => {
+    try { const arr = JSON.parse(fs.readFileSync(indexPath, 'utf-8')); return Array.isArray(arr) ? arr : []; } catch { return []; }
+  })();
+  if (!ids.includes(accountId)) {
+    ids.push(accountId);
+    fs.writeFileSync(indexPath, JSON.stringify(ids, null, 2), 'utf-8');
+  }
+
+  console.log(`[WeixinLogin] saved account ${accountId} to ${accountPath}`);
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -25,6 +25,7 @@ import {
   rejectPairingRequest,
   readAllowFromStore,
 } from './im/imPairingStore';
+import { fetchWeixinQrCode, pollWeixinQrStatus, saveWeixinAccountToOpenClaw } from './im/weixinLogin';
 import { OpenClawConfigSync } from './libs/openclawConfigSync';
 import {
   resolveMemoryFilePath,
@@ -2959,28 +2960,39 @@ if (!gotTheLock) {
     }
   });
 
-  // Weixin QR login
-  ipcMain.handle('im:weixin:qr-login-start', async () => {
+  // Weixin QR login (direct ilink API, no OpenClaw Gateway dependency)
+  ipcMain.handle('im:weixin:login:start', async () => {
     try {
-      const result = await getIMGatewayManager().weixinQrLoginStart();
-      return { success: true, ...result };
+      const result = await fetchWeixinQrCode();
+      return { success: true, qrcode: result.qrcode, qrcodeUrl: result.qrcodeUrl };
     } catch (error) {
-      return { success: false, message: error instanceof Error ? error.message : 'Failed to start Weixin QR login' };
+      return { success: false, message: error instanceof Error ? error.message : 'Failed to fetch WeChat QR code' };
     }
   });
 
-  ipcMain.handle('im:weixin:qr-login-wait', async (_event, accountId?: string) => {
+  ipcMain.handle('im:weixin:login:poll', async (_event, qrcode: string) => {
     try {
-      const result = await getIMGatewayManager().weixinQrLoginWait(accountId);
-      if (result.connected) {
+      const result = await pollWeixinQrStatus(qrcode);
+      if (result.status === 'confirmed' && result.accountId) {
+        // Save account credentials to OpenClaw state directory so the weixin
+        // plugin can authenticate after gateway restart.
+        const stateDir = getOpenClawEngineManager().getStateDir();
+        saveWeixinAccountToOpenClaw(stateDir, result.accountId, {
+          token: result.botToken,
+          baseUrl: result.baseUrl,
+          userId: result.userId,
+        });
+
         // Restart gateway so the plugin picks up the new token and starts
         // a fresh monitor loop (the old one may be stuck in a session pause).
-        console.log('[IMGatewayManager] Weixin login succeeded, restarting OpenClaw gateway');
-        await getOpenClawEngineManager().restartGateway();
+        console.log('[WeixinLogin] login confirmed, restarting OpenClaw gateway');
+        getOpenClawEngineManager().restartGateway().catch((err: unknown) => {
+          console.error('[WeixinLogin] failed to restart gateway after login:', err);
+        });
       }
       return { success: true, ...result };
     } catch (error) {
-      return { success: false, connected: false, message: error instanceof Error ? error.message : 'Weixin QR login failed' };
+      return { success: false, status: 'wait' as const, message: error instanceof Error ? error.message : 'Failed to poll QR status' };
     }
   });
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -302,9 +302,9 @@ contextBridge.exposeInMainWorld('electron', {
     getOpenClawConfigSchema: () => ipcRenderer.invoke('im:openclaw:config-schema'),
 
 
-    // Weixin QR login
-    weixinQrLoginStart: () => ipcRenderer.invoke('im:weixin:qr-login-start'),
-    weixinQrLoginWait: (accountId?: string) => ipcRenderer.invoke('im:weixin:qr-login-wait', accountId),
+    // Weixin QR login (direct ilink API)
+    weixinLoginStart: () => ipcRenderer.invoke('im:weixin:login:start'),
+    weixinLoginPoll: (qrcode: string) => ipcRenderer.invoke('im:weixin:login:poll', qrcode),
 
     // Pairing
     listPairingRequests: (platform: string) => ipcRenderer.invoke('im:pairing:list', platform),

--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -136,9 +136,13 @@ const IMSettings: React.FC = () => {
   const [wecomQuickSetupStatus, setWecomQuickSetupStatus] = useState<'idle' | 'pending' | 'success' | 'error'>('idle');
   const [wecomQuickSetupError, setWecomQuickSetupError] = useState<string>('');
   // Weixin QR login state
-  const [weixinQrStatus, setWeixinQrStatus] = useState<'idle' | 'loading' | 'showing' | 'waiting' | 'success' | 'error'>('idle');
-  const [weixinQrUrl, setWeixinQrUrl] = useState<string>('');
+  const [weixinQrStatus, setWeixinQrStatus] = useState<'idle' | 'loading' | 'showing' | 'scaned' | 'success' | 'error'>('idle');
+  const [weixinQrcodeUrl, setWeixinQrcodeUrl] = useState<string>('');
+  const [weixinQrcode, setWeixinQrcode] = useState<string>('');
   const [weixinQrError, setWeixinQrError] = useState<string>('');
+  const [weixinQrTimeLeft, setWeixinQrTimeLeft] = useState<number>(0);
+  const weixinPollingRef = useRef(false);
+  const weixinCountdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [localIp, setLocalIp] = useState<string>('');
   const isMountedRef = useRef(true);
 
@@ -253,9 +257,13 @@ const IMSettings: React.FC = () => {
   // Reset weixin QR login state when switching away from weixin
   useEffect(() => {
     if (activePlatform !== 'weixin') {
+      weixinPollingRef.current = false;
+      if (weixinCountdownRef.current) { clearInterval(weixinCountdownRef.current); weixinCountdownRef.current = null; }
       setWeixinQrStatus('idle');
-      setWeixinQrUrl('');
+      setWeixinQrcodeUrl('');
+      setWeixinQrcode('');
       setWeixinQrError('');
+      setWeixinQrTimeLeft(0);
     }
   }, [activePlatform]);
 
@@ -481,42 +489,120 @@ const IMSettings: React.FC = () => {
     }
   };
 
-  const handleWeixinQrLogin = async () => {
+  const QR_EXPIRE_SECONDS = 300; // 5 minutes, matches ilink server TTL
+
+  const startWeixinCountdown = () => {
+    if (weixinCountdownRef.current) { clearInterval(weixinCountdownRef.current); }
+    setWeixinQrTimeLeft(QR_EXPIRE_SECONDS);
+    weixinCountdownRef.current = setInterval(() => {
+      setWeixinQrTimeLeft((prev) => {
+        if (prev <= 1) {
+          if (weixinCountdownRef.current) { clearInterval(weixinCountdownRef.current); weixinCountdownRef.current = null; }
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  const stopWeixinCountdown = () => {
+    if (weixinCountdownRef.current) { clearInterval(weixinCountdownRef.current); weixinCountdownRef.current = null; }
+    setWeixinQrTimeLeft(0);
+  };
+
+  const handleWeixinLogin = async () => {
     setWeixinQrStatus('loading');
     setWeixinQrError('');
+    weixinPollingRef.current = false;
+    stopWeixinCountdown();
+
     try {
-      const startResult = await window.electron.im.weixinQrLoginStart();
+      const startResult = await window.electron.im.weixinLoginStart();
       if (!isMountedRef.current) return;
 
-      if (!startResult.success || !startResult.qrDataUrl) {
+      if (!startResult.success || !startResult.qrcodeUrl || !startResult.qrcode) {
         setWeixinQrStatus('error');
         setWeixinQrError(startResult.message || i18nService.t('imWeixinQrFailed'));
         return;
       }
 
-      setWeixinQrUrl(startResult.qrDataUrl);
+      setWeixinQrcodeUrl(startResult.qrcodeUrl);
+      setWeixinQrcode(startResult.qrcode);
       setWeixinQrStatus('showing');
+      startWeixinCountdown();
 
-      // Start polling for scan result
-      setWeixinQrStatus('waiting');
-      const waitResult = await window.electron.im.weixinQrLoginWait(startResult.sessionKey);
-      if (!isMountedRef.current) return;
+      // Start polling
+      weixinPollingRef.current = true;
+      let currentQrcode = startResult.qrcode;
+      let refreshCount = 0;
+      const maxRefresh = 3;
 
-      if (waitResult.success && waitResult.connected) {
-        setWeixinQrStatus('success');
-        // Enable weixin and save config with accountId
-        const accountId = waitResult.accountId || '';
-        const fullConfig = { ...weixinOpenClawConfig, enabled: true, accountId };
-        dispatch(setWeixinConfig({ enabled: true, accountId }));
-        dispatch(clearError());
-        await imService.updateConfig({ weixin: fullConfig });
-        await imService.loadStatus();
-      } else {
-        setWeixinQrStatus('error');
-        setWeixinQrError(waitResult.message || i18nService.t('imWeixinQrFailed'));
+      while (weixinPollingRef.current && isMountedRef.current) {
+        const pollResult = await window.electron.im.weixinLoginPoll(currentQrcode);
+        if (!isMountedRef.current || !weixinPollingRef.current) return;
+
+        if (!pollResult.success) {
+          stopWeixinCountdown();
+          setWeixinQrStatus('error');
+          setWeixinQrError(pollResult.message || i18nService.t('imWeixinQrFailed'));
+          return;
+        }
+
+        switch (pollResult.status) {
+          case 'wait':
+            break;
+          case 'scaned':
+            setWeixinQrStatus('scaned');
+            stopWeixinCountdown();
+            break;
+          case 'expired': {
+            refreshCount++;
+            if (refreshCount > maxRefresh) {
+              stopWeixinCountdown();
+              setWeixinQrStatus('error');
+              setWeixinQrError(i18nService.t('imWeixinQrExpired'));
+              weixinPollingRef.current = false;
+              return;
+            }
+            // Auto-refresh QR code
+            stopWeixinCountdown();
+            setWeixinQrStatus('loading');
+            const refreshResult = await window.electron.im.weixinLoginStart();
+            if (!isMountedRef.current || !weixinPollingRef.current) return;
+            if (!refreshResult.success || !refreshResult.qrcodeUrl || !refreshResult.qrcode) {
+              setWeixinQrStatus('error');
+              setWeixinQrError(refreshResult.message || i18nService.t('imWeixinQrFailed'));
+              weixinPollingRef.current = false;
+              return;
+            }
+            currentQrcode = refreshResult.qrcode;
+            setWeixinQrcodeUrl(refreshResult.qrcodeUrl);
+            setWeixinQrcode(refreshResult.qrcode);
+            setWeixinQrStatus('showing');
+            startWeixinCountdown();
+            break;
+          }
+          case 'confirmed': {
+            weixinPollingRef.current = false;
+            stopWeixinCountdown();
+            setWeixinQrStatus('success');
+            const accountId = pollResult.accountId || '';
+            const fullConfig = { ...weixinOpenClawConfig, enabled: true, accountId };
+            dispatch(setWeixinConfig({ enabled: true, accountId }));
+            dispatch(clearError());
+            await imService.updateConfig({ weixin: fullConfig });
+            await imService.loadStatus();
+            return;
+          }
+        }
+
+        // Wait 2 seconds before next poll
+        await new Promise((r) => setTimeout(r, 2000));
       }
     } catch (err) {
       if (!isMountedRef.current) return;
+      weixinPollingRef.current = false;
+      stopWeixinCountdown();
       setWeixinQrStatus('error');
       setWeixinQrError(String(err));
     }
@@ -2976,7 +3062,7 @@ const IMSettings: React.FC = () => {
                 <>
                   <button
                     type="button"
-                    onClick={() => void handleWeixinQrLogin()}
+                    onClick={() => void handleWeixinLogin()}
                     className="px-4 py-2.5 rounded-lg text-sm font-medium bg-claude-accent text-white hover:bg-claude-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                   >
                     {i18nService.t('imWeixinScanBtn')}
@@ -3000,16 +3086,23 @@ const IMSettings: React.FC = () => {
                   </span>
                 </div>
               )}
-              {(weixinQrStatus === 'showing' || weixinQrStatus === 'waiting') && weixinQrUrl && (
+              {(weixinQrStatus === 'showing' || weixinQrStatus === 'scaned') && weixinQrcodeUrl && (
                 <div className="space-y-3">
                   <p className="text-sm font-medium dark:text-claude-darkText text-claude-text">
-                    {i18nService.t('imWeixinQrScanPrompt')}
+                    {weixinQrStatus === 'scaned'
+                      ? i18nService.t('imWeixinQrWaiting')
+                      : i18nService.t('imWeixinQrScanPrompt')}
                   </p>
                   <div className="flex justify-center">
                     <div className="p-3 bg-white rounded-lg border dark:border-claude-darkBorder/40 border-claude-border/40">
-                      <QRCodeSVG value={weixinQrUrl} size={192} />
+                      <QRCodeSVG value={weixinQrcodeUrl} size={192} />
                     </div>
                   </div>
+                  {weixinQrStatus === 'showing' && weixinQrTimeLeft > 0 && (
+                    <p className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
+                      {weixinQrTimeLeft}s
+                    </p>
+                  )}
                 </div>
               )}
               {weixinQrStatus === 'success' && (

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -391,8 +391,8 @@ interface IElectronAPI {
     getStatus: () => Promise<{ success: boolean; status?: IMGatewayStatus; error?: string }>;
     getLocalIp: () => Promise<string>;
     getOpenClawConfigSchema: () => Promise<{ success: boolean; result?: { schema: Record<string, unknown>; uiHints: Record<string, Record<string, unknown>> }; error?: string }>;
-    weixinQrLoginStart: () => Promise<{ success: boolean; qrDataUrl?: string; message: string; sessionKey?: string }>;
-    weixinQrLoginWait: (accountId?: string) => Promise<{ success: boolean; connected: boolean; message: string; accountId?: string }>;
+    weixinLoginStart: () => Promise<{ success: boolean; qrcode?: string; qrcodeUrl?: string; message?: string }>;
+    weixinLoginPoll: (qrcode: string) => Promise<{ success: boolean; status: 'wait' | 'scaned' | 'confirmed' | 'expired'; botToken?: string; accountId?: string; baseUrl?: string; userId?: string; message?: string }>;
     listPairingRequests: (platform: string) => Promise<{
       success: boolean;
       requests: Array<{ id: string; code: string; createdAt: string; lastSeenAt: string; meta?: Record<string, string> }>;


### PR DESCRIPTION
## Summary

- 新增 `weixinLogin.ts`，直接调用微信 ilink HTTP API（`get_bot_qrcode` / `get_qrcode_status`），不依赖 OpenClaw Gateway
- IPC handler 改为 `im:weixin:login:start` + `im:weixin:login:poll`
- 前端 2s 轮询替代阻塞等待，支持 QR 过期自动刷新（最多 3 次）
- 新增"已扫码"中间状态提示和 300 秒倒计时显示
- 登录成功后将 botToken 写入 OpenClaw state 目录，再异步重启 gateway

## Test plan

- [ ] 编译通过（`npm run compile:electron`）
- [ ] 点击扫码按钮，QR 码正常显示
- [ ] 不扫码等待过期，QR 码自动刷新
- [ ] 扫码后 UI 提示"已扫码"，手机确认后连接成功
- [ ] 连接成功后发送微信消息，AI 正常回复