### PR TITLE
fix(cowork): keep full input box for IM channel   sessions

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -91,6 +91,8 @@ interface CoworkPromptInputProps {
   showModelSelector?: boolean;
   onManageSkills?: () => void;
   sessionId?: string;
+  /** When true, hides attachment/skill buttons but keeps the input box visible (disabled) */
+  remoteManaged?: boolean;
 }
 
 const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInputProps>(
@@ -108,6 +110,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       showModelSelector = false,
       onManageSkills,
       sessionId,
+      remoteManaged = false,
     } = props;
     const dispatch = useDispatch();
     const draftKey = sessionId || '__home__';
@@ -679,22 +682,28 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                     />
                   </>
                 )}
-                {showModelSelector && <ModelSelector dropdownDirection="up" />}
-                <button
-                  type="button"
-                  onClick={handleAddFile}
-                  className="flex items-center justify-center p-1.5 rounded-lg text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover dark:hover:text-claude-darkText hover:text-claude-text transition-colors"
-                  title={i18nService.t('coworkAddFile')}
-                  aria-label={i18nService.t('coworkAddFile')}
-                  disabled={disabled || isStreaming || isAddingFile}
-                >
-                  <PaperClipIcon className="h-4 w-4" />
-                </button>
-                <SkillsButton
-                  onSelectSkill={handleSelectSkill}
-                  onManageSkills={handleManageSkills}
-                />
-                <ActiveSkillBadge />
+                {showModelSelector && !remoteManaged && <ModelSelector dropdownDirection="up" />}
+                {!remoteManaged && (
+                  <button
+                    type="button"
+                    onClick={handleAddFile}
+                    className="flex items-center justify-center p-1.5 rounded-lg text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover dark:hover:text-claude-darkText hover:text-claude-text transition-colors"
+                    title={i18nService.t('coworkAddFile')}
+                    aria-label={i18nService.t('coworkAddFile')}
+                    disabled={disabled || isStreaming || isAddingFile}
+                  >
+                    <PaperClipIcon className="h-4 w-4" />
+                  </button>
+                )}
+                {!remoteManaged && (
+                  <>
+                    <SkillsButton
+                      onSelectSkill={handleSelectSkill}
+                      onManageSkills={handleManageSkills}
+                    />
+                    <ActiveSkillBadge />
+                  </>
+                )}
               </div>
               <div className="flex items-center gap-2">
                 {isStreaming ? (
@@ -734,18 +743,20 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
               className={textareaClass}
             />
 
-            <div className="flex items-center gap-1">
-              <button
-                type="button"
-                onClick={handleAddFile}
-                className="flex-shrink-0 p-1.5 rounded-lg dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover dark:hover:text-claude-darkText hover:text-claude-text transition-colors"
-                title={i18nService.t('coworkAddFile')}
-                aria-label={i18nService.t('coworkAddFile')}
-                disabled={disabled || isStreaming || isAddingFile}
-              >
-                <PaperClipIcon className="h-4 w-4" />
-              </button>
-            </div>
+            {!remoteManaged && (
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={handleAddFile}
+                  className="flex-shrink-0 p-1.5 rounded-lg dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover dark:hover:text-claude-darkText hover:text-claude-text transition-colors"
+                  title={i18nService.t('coworkAddFile')}
+                  aria-label={i18nService.t('coworkAddFile')}
+                  disabled={disabled || isStreaming || isAddingFile}
+                >
+                  <PaperClipIcon className="h-4 w-4" />
+                </button>
+              </div>
+            )}
 
             {isStreaming ? (
               <button

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -2085,26 +2085,18 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       {/* Input Area */}
       <div className="p-4 shrink-0">
         <div className="max-w-3xl mx-auto">
-          {remoteManaged ? (
-            <div className="flex items-center gap-2 rounded-xl border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface bg-claude-surface px-4 py-3">
-              <InformationCircleIcon className="h-5 w-5 shrink-0 dark:text-claude-darkTextSecondary text-claude-textSecondary" />
-              <span className="text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary">
-                {i18nService.t('coworkRemoteManagedPlaceholder')}
-              </span>
-            </div>
-          ) : (
-            <CoworkPromptInput
-              onSubmit={onContinue}
-              onStop={onStop}
-              isStreaming={isStreaming}
-              placeholder={i18nService.t('coworkContinuePlaceholder')}
-              disabled={false}
-              onManageSkills={onManageSkills}
-              size="large"
-              showModelSelector={true}
-              sessionId={currentSession?.id}
-            />
-          )}
+          <CoworkPromptInput
+            onSubmit={onContinue}
+            onStop={onStop}
+            isStreaming={isStreaming}
+            placeholder={i18nService.t(remoteManaged ? 'coworkRemoteManagedPlaceholder' : 'coworkContinuePlaceholder')}
+            disabled={remoteManaged}
+            size="large"
+            remoteManaged={remoteManaged}
+            onManageSkills={remoteManaged ? undefined : onManageSkills}
+            showModelSelector={!remoteManaged}
+            sessionId={currentSession?.id}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
 Summary

  - Replace the collapsed info bar with the standard
  CoworkPromptInput component for remote-managed (IM channel)
  sessions
  - Input box retains its original size and styling but is
  disabled, with a placeholder hint for IM sessions
  - Hide attachment button (PaperClipIcon), skills button
  (SkillsButton), and model selector (ModelSelector)
  - Send button is visible but non-clickable; stop button
  remains available during streaming
  - Merge the remoteManaged and normal branches in
  CoworkSessionDetail into a single CoworkPromptInput call,
  eliminating duplicate code

  Test plan

  - Open an IM channel session, verify the input box retains
  its original size
  - Verify the input is disabled with the IM placeholder text
  shown
  - Verify attachment, skills, and model selector buttons are
  hidden
  - Verify the send button is greyed out and non-clickable
  - Open a normal (non-IM) session, verify all input features
  work as expected (attachment, skills, send, etc.)