### PR TITLE
refactor: 💡 提取重复定义的共享常量和工具函数

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared constants and utility functions used by both main and renderer processes.
+ * Centralised here to avoid duplication across modules.
+ */
+
+// ─── File name sanitisation ──────────────────────────────────────────────────
+
+/** Characters that are invalid in file names across major operating systems. */
+export const INVALID_FILE_NAME_PATTERN = /[<>:"/\\|?*\u0000-\u001F]/g;
+
+/**
+ * Sanitise a string for use as a file name by replacing invalid characters
+ * with spaces and collapsing consecutive whitespace.
+ */
+export const sanitizeExportFileName = (value: string): string => {
+  const sanitized = value.replace(INVALID_FILE_NAME_PATTERN, ' ').replace(/\s+/g, ' ').trim();
+  return sanitized || 'cowork-session';
+};
+
+// ─── Memory configuration bounds ────────────────────────────────────────────
+
+/** Minimum allowed value for the user-memories-max-items setting. */
+export const MIN_MEMORY_USER_MEMORIES_MAX_ITEMS = 1;
+
+/** Maximum allowed value for the user-memories-max-items setting. */
+export const MAX_MEMORY_USER_MEMORIES_MAX_ITEMS = 60;
+
+// ─── Memory text filters ────────────────────────────────────────────────────
+
+/**
+ * Matches text that looks like procedural / command-line content rather than a
+ * durable personal fact, used to auto-reject memory candidates.
+ */
+export const MEMORY_PROCEDURAL_TEXT_RE = /(执行以下命令|run\s+(?:the\s+)?following\s+command|\b(?:cd|npm|pnpm|yarn|node|python|bash|sh|git|curl|wget)\b|\$[A-Z_][A-Z0-9_]*|&&|--[a-z0-9-]+|\/tmp\/|\.sh\b|\.bat\b|\.ps1\b)/i;
+
+/**
+ * Matches text that describes an assistant's own workflow instruction (e.g.
+ * "使用 xxx 技能" / "use xxx skill"), which should not be stored as user memory.
+ */
+export const MEMORY_ASSISTANT_STYLE_TEXT_RE = /^(?:使用|use)\s+[A-Za-z0-9._-]+\s*(?:技能|skill)/i;

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -29,16 +29,19 @@ const normalizeRecentWorkspacePath = (cwd: string): string => {
   return resolved;
 };
 
+import {
+  MIN_MEMORY_USER_MEMORIES_MAX_ITEMS,
+  MAX_MEMORY_USER_MEMORIES_MAX_ITEMS,
+  MEMORY_PROCEDURAL_TEXT_RE,
+  MEMORY_ASSISTANT_STYLE_TEXT_RE,
+} from '../common/constants';
+
 const DEFAULT_MEMORY_ENABLED = true;
 const DEFAULT_MEMORY_IMPLICIT_UPDATE_ENABLED = true;
 const DEFAULT_MEMORY_LLM_JUDGE_ENABLED = false;
 const DEFAULT_MEMORY_GUARD_LEVEL: CoworkMemoryGuardLevel = 'strict';
 const DEFAULT_MEMORY_USER_MEMORIES_MAX_ITEMS = 12;
-const MIN_MEMORY_USER_MEMORIES_MAX_ITEMS = 1;
-const MAX_MEMORY_USER_MEMORIES_MAX_ITEMS = 60;
 const MEMORY_NEAR_DUPLICATE_MIN_SCORE = 0.82;
-const MEMORY_PROCEDURAL_TEXT_RE = /(执行以下命令|run\s+(?:the\s+)?following\s+command|\b(?:cd|npm|pnpm|yarn|node|python|bash|sh|git|curl|wget)\b|\$[A-Z_][A-Z0-9_]*|&&|--[a-z0-9-]+|\/tmp\/|\.sh\b|\.bat\b|\.ps1\b)/i;
-const MEMORY_ASSISTANT_STYLE_TEXT_RE = /^(?:使用|use)\s+[A-Za-z0-9._-]+\s*(?:技能|skill)/i;
 
 function normalizeMemoryGuardLevel(value: string | undefined): CoworkMemoryGuardLevel {
   if (value === 'strict' || value === 'standard' || value === 'relaxed') return value;

--- a/src/main/libs/coworkRunner.ts
+++ b/src/main/libs/coworkRunner.ts
@@ -61,8 +61,10 @@ const GIT_CLEAN_COMMAND_RE = /\bgit\s+clean\b/i;
 const PYTHON_BASH_COMMAND_RE = /(?:^|[^\w.-])(?:python(?:3)?|py(?:\.exe)?|pip(?:3)?)(?:\s+-3)?(?:\s|$)|\.py(?:\s|$)/i;
 const PYTHON_PIP_BASH_COMMAND_RE = /(?:^|[^\w.-])(?:pip(?:3)?|python(?:3)?\s+-m\s+pip|py(?:\.exe)?\s+-m\s+pip)(?:\s|$)/i;
 const MEMORY_REQUEST_TAIL_SPLIT_RE = /[,，。]\s*(?:请|麻烦)?你(?:帮我|帮忙|给我|为我|看下|看一下|查下|查一下)|[,，。]\s*帮我|[,，。]\s*请帮我|[,，。]\s*(?:能|可以)不能?\s*帮我|[,，。]\s*你看|[,，。]\s*请你/i;
-const MEMORY_PROCEDURAL_TEXT_RE = /(执行以下命令|run\s+(?:the\s+)?following\s+command|\b(?:cd|npm|pnpm|yarn|node|python|bash|sh|git|curl|wget)\b|\$[A-Z_][A-Z0-9_]*|&&|--[a-z0-9-]+|\/tmp\/|\.sh\b|\.bat\b|\.ps1\b)/i;
-const MEMORY_ASSISTANT_STYLE_TEXT_RE = /^(?:使用|use)\s+[A-Za-z0-9._-]+\s*(?:技能|skill)/i;
+import {
+  MEMORY_PROCEDURAL_TEXT_RE,
+  MEMORY_ASSISTANT_STYLE_TEXT_RE,
+} from '../../common/constants';
 const WINDOWS_HIDE_INIT_SCRIPT_NAME = 'windows_hide_init.cjs';
 const WINDOWS_HIDE_INIT_SCRIPT_CONTENT = [
   '\'use strict\';',

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -68,14 +68,17 @@ import {
   restoreOriginalProxyEnv,
   setSystemProxyEnabled,
 } from './libs/systemProxy';
+import {
+  INVALID_FILE_NAME_PATTERN,
+  sanitizeExportFileName,
+  MIN_MEMORY_USER_MEMORIES_MAX_ITEMS,
+  MAX_MEMORY_USER_MEMORIES_MAX_ITEMS,
+} from '../common/constants';
 
 // 设置应用程序名称
 app.name = APP_NAME;
 app.setName(APP_NAME);
 
-const INVALID_FILE_NAME_PATTERN = /[<>:"/\\|?*\u0000-\u001F]/g;
-const MIN_MEMORY_USER_MEMORIES_MAX_ITEMS = 1;
-const MAX_MEMORY_USER_MEMORIES_MAX_ITEMS = 60;
 const IPC_MESSAGE_CONTENT_MAX_CHARS = 120_000;
 const IPC_UPDATE_CONTENT_MAX_CHARS = 120_000;
 const IPC_STRING_MAX_CHARS = 4_000;
@@ -106,11 +109,6 @@ const MIME_EXTENSION_MAP: Record<string, string> = {
   'text/markdown': '.md',
   'application/json': '.json',
   'text/csv': '.csv',
-};
-
-const sanitizeExportFileName = (value: string): string => {
-  const sanitized = value.replace(INVALID_FILE_NAME_PATTERN, ' ').replace(/\s+/g, ' ').trim();
-  return sanitized || 'cowork-session';
 };
 
 const sanitizeAttachmentFileName = (value?: string): string => {

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -41,12 +41,7 @@ const AUTO_SCROLL_THRESHOLD = 120;
 const NAV_HIDE_DELAY = 3000;
 const NAV_SCROLL_LOCK_DURATION = 500;
 const NAV_BOTTOM_SNAP_THRESHOLD = 20;
-const INVALID_FILE_NAME_PATTERN = /[<>:"/\\|?*\u0000-\u001F]/g;
-
-const sanitizeExportFileName = (value: string): string => {
-  const sanitized = value.replace(INVALID_FILE_NAME_PATTERN, ' ').replace(/\s+/g, ' ').trim();
-  return sanitized || 'cowork-session';
-};
+import { sanitizeExportFileName } from '../../../common/constants';
 
 const formatExportTimestamp = (value: Date): string => {
   const pad = (num: number): string => String(num).padStart(2, '0');


### PR DESCRIPTION
PR 标题
refactor: 提取重复定义的共享常量和工具函数到 src/common/constants.ts

描述
多个文件中独立定义了完全相同的常量和工具函数。这种重复会带来维护风险——当逻辑需要修改时，必须同步更新每一份副本，容易遗漏导致不一致。本 PR 将这些重复项提取到统一的共享模块 src/common/constants.ts 中，并将所有重复定义替换为导入引用。

背景
在代码审查中发现以下重复定义：

常量 / 函数	重复所在文件
INVALID_FILE_NAME_PATTERN	src/main/main.ts、src/renderer/components/cowork/CoworkSessionDetail.tsx
sanitizeExportFileName()	src/main/main.ts、src/renderer/components/cowork/CoworkSessionDetail.tsx
MIN_MEMORY_USER_MEMORIES_MAX_ITEMS	src/main/main.ts、src/main/coworkStore.ts
MAX_MEMORY_USER_MEMORIES_MAX_ITEMS	src/main/main.ts、src/main/coworkStore.ts
MEMORY_PROCEDURAL_TEXT_RE	src/main/coworkStore.ts、src/main/libs/coworkRunner.ts
MEMORY_ASSISTANT_STYLE_TEXT_RE	src/main/coworkStore.ts、src/main/libs/coworkRunner.ts
改动内容
新增文件： src/common/constants.ts — 上述所有共享常量和工具函数的唯一定义，附带 JSDoc 注释。
修改文件：
src/main/main.ts — 移除 3 个常量定义和 1 个函数定义，改为从 common/constants 导入。
src/renderer/components/cowork/CoworkSessionDetail.tsx — 移除 1 个常量定义和 1 个函数定义，改为从 common/constants 导入。
src/main/coworkStore.ts — 移除 4 个常量定义，改为从 common/constants 导入。
src/main/libs/coworkRunner.ts — 移除 2 个常量定义，改为从 common/constants 导入。