### PR TITLE
feat(model): 为模型提供商添加官网链接和 API Key 获取引导

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -9,7 +9,7 @@ import { decryptSecret, encryptWithPassword, decryptWithPassword, EncryptedPaylo
 import { coworkService } from '../services/cowork';
 import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
 import ErrorMessage from './ErrorMessage';
-import { XMarkIcon, Cog6ToothIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, EnvelopeIcon, CpuChipIcon, InformationCircleIcon, UserCircleIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, Cog6ToothIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, EnvelopeIcon, CpuChipIcon, InformationCircleIcon, UserCircleIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
 import PlusCircleIcon from './icons/PlusCircleIcon';
 import TrashIcon from './icons/TrashIcon';
@@ -146,6 +146,40 @@ const providerMeta: Record<ProviderType, { label: string; icon: React.ReactNode 
   openrouter: { label: 'OpenRouter', icon: <OpenRouterIcon /> },
   ollama: { label: 'Ollama', icon: <OllamaIcon /> },
   custom: { label: 'Custom', icon: <CustomProviderIcon /> },
+};
+
+const providerApiKeyUrl: Partial<Record<ProviderType, string>> = {
+  openai: 'https://platform.openai.com/api-keys',
+  gemini: 'https://aistudio.google.com/apikey',
+  anthropic: 'https://console.anthropic.com/settings/keys',
+  deepseek: 'https://platform.deepseek.com/api_keys',
+  moonshot: 'https://platform.moonshot.cn/console/api-keys',
+  zhipu: 'https://open.bigmodel.cn/usercenter/apikeys',
+  minimax: 'https://platform.minimaxi.com/user-center/basic-information/interface-key',
+  volcengine: 'https://console.volcengine.com/ark',
+  qwen: 'https://dashscope.console.aliyun.com/apiKey',
+  youdaozhiyun: 'https://ai.youdao.com/console',
+  stepfun: 'https://platform.stepfun.com/interface-key',
+  xiaomi: 'https://dev.mi.com/platform',
+  openrouter: 'https://openrouter.ai/keys',
+  ollama: 'https://ollama.com',
+};
+
+const providerWebsiteUrl: Partial<Record<ProviderType, string>> = {
+  openai: 'https://platform.openai.com',
+  gemini: 'https://aistudio.google.com',
+  anthropic: 'https://console.anthropic.com',
+  deepseek: 'https://platform.deepseek.com',
+  moonshot: 'https://platform.moonshot.cn',
+  zhipu: 'https://open.bigmodel.cn',
+  minimax: 'https://platform.minimaxi.com',
+  volcengine: 'https://console.volcengine.com/ark',
+  qwen: 'https://dashscope.console.aliyun.com',
+  youdaozhiyun: 'https://ai.youdao.com',
+  stepfun: 'https://platform.stepfun.com',
+  xiaomi: 'https://dev.mi.com/platform',
+  openrouter: 'https://openrouter.ai',
+  ollama: 'https://ollama.com',
 };
 
 const providerSwitchableDefaultBaseUrls: Partial<Record<ProviderType, { anthropic: string; openai: string }>> = {
@@ -2589,9 +2623,21 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
             {/* Provider Settings - Right Side */}
             <div className="w-3/5 pl-4 pr-2 space-y-4 overflow-y-auto [scrollbar-gutter:stable]">
               <div className="flex items-center justify-between pb-2 border-b dark:border-claude-darkBorder border-claude-border">
-                <h3 className="text-base font-medium dark:text-claude-darkText text-claude-text">
-                  {(providerMeta[activeProvider]?.label ?? activeProvider.charAt(0).toUpperCase() + activeProvider.slice(1))} {i18nService.t('providerSettings')}
-                </h3>
+                <div className="flex items-center gap-1.5">
+                  <h3 className="text-base font-medium dark:text-claude-darkText text-claude-text">
+                    {(providerMeta[activeProvider]?.label ?? activeProvider.charAt(0).toUpperCase() + activeProvider.slice(1))} {i18nService.t('providerSettings')}
+                  </h3>
+                  {providerWebsiteUrl[activeProvider] && (
+                    <button
+                      type="button"
+                      onClick={() => void window.electron.shell.openExternal(providerWebsiteUrl[activeProvider]!)}
+                      className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
+                      title={i18nService.t('visitOfficialSite')}
+                    >
+                      <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
                 <div
                   className={`px-2 py-0.5 rounded-lg text-xs font-medium ${
                     providers[activeProvider].enabled
@@ -2631,7 +2677,22 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
 
                   {/* API Key mode */}
                   {providers.minimax.authType !== 'oauth' && (
-                    <div className="relative">
+                    <div>
+                      <div className="flex items-center justify-between mb-1">
+                        <label htmlFor="minimax-apiKey" className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
+                          {i18nService.t('apiKey')}
+                        </label>
+                        {providerApiKeyUrl.minimax && (
+                          <button
+                            type="button"
+                            onClick={() => void window.electron.shell.openExternal(providerApiKeyUrl.minimax!)}
+                            className="text-[11px] text-claude-accent hover:underline transition-colors"
+                          >
+                            {i18nService.t('getApiKey')} &rarr;
+                          </button>
+                        )}
+                      </div>
+                      <div className="relative">
                       <input
                         type={showApiKey ? 'text' : 'password'}
                         id="minimax-apiKey"
@@ -2659,6 +2720,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
                         >
                           {showApiKey ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
                         </button>
+                      </div>
                       </div>
                     </div>
                   )}
@@ -2815,9 +2877,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
               {/* Standard API key section for non-MiniMax providers */}
               {providerRequiresApiKey(activeProvider) && activeProvider !== 'minimax' && (
                 <div>
-                  <label htmlFor={`${activeProvider}-apiKey`} className="block text-xs font-medium dark:text-claude-darkText text-claude-text mb-1">
-                    {i18nService.t('apiKey')}
-                  </label>
+                  <div className="flex items-center justify-between mb-1">
+                    <label htmlFor={`${activeProvider}-apiKey`} className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
+                      {i18nService.t('apiKey')}
+                    </label>
+                    {providerApiKeyUrl[activeProvider] && (
+                      <button
+                        type="button"
+                        onClick={() => void window.electron.shell.openExternal(providerApiKeyUrl[activeProvider]!)}
+                        className="text-[11px] text-claude-accent hover:underline transition-colors"
+                      >
+                        {i18nService.t('getApiKey')} &rarr;
+                      </button>
+                    )}
+                  </div>
                   <div className="relative">
                     <input
                       type={showApiKey ? 'text' : 'password'}

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -47,6 +47,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // API设置
     apiKey: 'API Key',
     apiKeyPlaceholder: '输入你的 API Key',
+    getApiKey: '获取 API Key',
+    visitOfficialSite: '访问官网',
     baseUrl: 'API Base URL',
     baseUrlPlaceholder: '输入 API 基础 URL',
     baseUrlHint1: 'Anthropic 兼容（以硅基流动为例）：',
@@ -1124,6 +1126,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // API Settings
     apiKey: 'API Key',
     apiKeyPlaceholder: 'Enter your API Key',
+    getApiKey: 'Get API Key',
+    visitOfficialSite: 'Visit official site',
     baseUrl: 'API Base URL',
     baseUrlPlaceholder: 'Enter API Base URL',
     baseUrlHint1: 'Anthropic compatible (e.g. SiliconFlow):',


### PR DESCRIPTION
## 概述

- 在每个模型提供商标题旁添加可点击的外链图标，跳转到对应提供商的官方平台
- 在 API Key 输入框标签旁添加"获取 API Key"快捷链接，直接跳转到对应提供商的密钥管理页面
- 新增中英文 i18n 支持

## 背景

当前模型设置页面只有一个空的 API Key 输入框，没有任何引导信息。新用户往往不知道去哪里获取各家提供商的 API Key。本次改动通过直接提供官网和 API Key 管理页面的链接，降低用户的配置门槛。

## 改动文件

| 文件 | 改动内容 |
|------|---------|
| `src/renderer/components/Settings.tsx` | 新增 `providerApiKeyUrl`、`providerWebsiteUrl` 数据映射；提供商标题旁添加外链图标；API Key 标签旁添加"获取 API Key"链接（标准提供商和 MiniMax 均已适配） |
| `src/renderer/services/i18n.ts` | 新增 `getApiKey`（获取 API Key / Get API Key）和 `visitOfficialSite`（访问官网 / Visit official site）两个 i18n key |

## 各提供商链接一览

以下为本次新增的所有内置提供商链接（不含 Custom）：

| 提供商 | 官网地址 | API Key 管理页面 |
|--------|---------|-----------------|
| OpenAI | https://platform.openai.com | https://platform.openai.com/api-keys |
| Gemini | https://aistudio.google.com | https://aistudio.google.com/apikey |
| Anthropic | https://console.anthropic.com | https://console.anthropic.com/settings/keys |
| DeepSeek | https://platform.deepseek.com | https://platform.deepseek.com/api_keys |
| Moonshot | https://platform.moonshot.cn | https://platform.moonshot.cn/console/api-keys |
| Zhipu (智谱) | https://open.bigmodel.cn | https://open.bigmodel.cn/usercenter/apikeys |
| MiniMax | https://platform.minimaxi.com | https://platform.minimaxi.com/user-center/basic-information/interface-key |
| Volcengine (火山引擎) | https://console.volcengine.com/ark | https://console.volcengine.com/ark |
| Qwen (通义千问) | https://dashscope.console.aliyun.com | https://dashscope.console.aliyun.com/apiKey |
| Youdao (有道智云) | https://ai.youdao.com | https://ai.youdao.com/console |
| StepFun (阶跃星辰) | https://platform.stepfun.com | https://platform.stepfun.com/interface-key |
| Xiaomi (小米) | https://dev.mi.com/platform | https://dev.mi.com/platform |
| OpenRouter | https://openrouter.ai | https://openrouter.ai/keys |
| Ollama | https://ollama.com | https://ollama.com（本地运行，无需 API Key） |

> **说明**：Custom 提供商不显示任何链接。Ollama 不需要 API Key，仅通过标题旁的图标提供官网下载链接。

## UI 交互说明

- **提供商标题区域**：名称右侧显示一个 `ArrowTopRightOnSquareIcon` 外链图标，点击通过 `shell.openExternal()` 在系统浏览器中打开官网
- **API Key 标签区域**：标签右侧显示"获取 API Key →"文字链接，点击在系统浏览器中打开对应的密钥管理页面
- **MiniMax 特殊处理**：在 API Key 认证模式（非 OAuth）下，同样显示"获取 API Key"链接

## 截图
<img width="841" height="639" alt="image" src="https://github.com/user-attachments/assets/3f8dcbc1-9323-4c57-a8ea-d4fea628cf49" />


## 测试

- [x] TypeScript 编译通过（`npx tsc --noEmit`）
- [x] ESLint 检查通过（无新增 warning/error）
- [x] 手动测试：通过 `npm run electron:dev` 验证各提供商链接跳转正常