### PR TITLE
perf(cowork): 为 MarkdownContent 添加 React.memo 避免流式输出时历史消息重复解析

### DIFF
--- a/src/renderer/components/MarkdownContent.tsx
+++ b/src/renderer/components/MarkdownContent.tsx
@@ -598,7 +598,7 @@ interface MarkdownContentProps {
   resolveLocalFilePath?: (href: string, text: string) => string | null;
 }
 
-const MarkdownContent: React.FC<MarkdownContentProps> = ({
+const MarkdownContent: React.FC<MarkdownContentProps> = React.memo(({
   content,
   className = '',
   resolveLocalFilePath,
@@ -617,6 +617,8 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
       </ReactMarkdown>
     </div>
   );
-};
+});
+
+MarkdownContent.displayName = 'MarkdownContent';
 
 export default MarkdownContent;


### PR DESCRIPTION
## 改动内容

为 `MarkdownContent` 组件包裹 `React.memo`，使其在 props 未变化时跳过渲染。

## 背景

Cowork 流式输出时，每个 streaming chunk 会触发 Redux 状态更新，导致 `CoworkSessionDetail` 整个组件树重渲染。由于 `AssistantMessageItem` 没有 `React.memo`，**所有历史 assistant 消息**的 `MarkdownContent` 都会被重新执行，触发完整的 markdown AST 解析 + remark-gfm + remark-math + rehype-katex 插件链。

## 效果

加上 `React.memo` 后，历史消息的 `content`、`className`、`resolveLocalFilePath` 三个 prop 在流式期间均保持引用稳定（`resolveLocalFilePath` 由 `useCallback([currentSession?.cwd])` 保证），浅比较通过即跳过渲染。

- 20 条历史消息的会话中，每个 streaming chunk 的 markdown 解析次数从 20 次降为 1 次（仅当前流式消息）
- 会话中历史消息越多，优化效果越明显
- 改动极小（3 行），零风险