### PR TITLE
fix: abort OpenClaw sessions before deleting them

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2188,6 +2188,8 @@ if (!gotTheLock) {
 
   ipcMain.handle('cowork:session:delete', async (_event, sessionId: string) => {
     try {
+      const router = getCoworkEngineRouter();
+      router.stopSession(sessionId);
       const coworkStoreInstance = getCoworkStore();
       coworkStoreInstance.deleteSession(sessionId);
       // Clean up IM session mapping so that new channel messages
@@ -2200,7 +2202,7 @@ if (!gotTheLock) {
       // Notify runtime to purge in-memory caches for this session
       // so that channel messages can create a fresh session.
       try {
-        getCoworkEngineRouter().onSessionDeleted(sessionId);
+        router.onSessionDeleted(sessionId);
       } catch {
         // Router may not be initialised yet; safe to ignore.
       }
@@ -2215,9 +2217,12 @@ if (!gotTheLock) {
 
   ipcMain.handle('cowork:session:deleteBatch', async (_event, sessionIds: string[]) => {
     try {
+      const router = getCoworkEngineRouter();
+      for (const sessionId of sessionIds) {
+        router.stopSession(sessionId);
+      }
       const coworkStoreInstance = getCoworkStore();
       coworkStoreInstance.deleteSessions(sessionIds);
-      const router = getCoworkEngineRouter();
       for (const sessionId of sessionIds) {
         try {
           getIMGatewayManager()?.getIMStore()?.deleteSessionMappingByCoworkSessionId(sessionId);


### PR DESCRIPTION
## Summary

- stop sessions before deleting them from the Cowork session handlers
- apply the same abort-before-delete flow to batch deletion
- keep the existing `onSessionDeleted()` cleanup after the stop path runs

## Testing

- not run: repo dependencies are not installed in this workspace

Closes #734
