### PR TITLE
fix: honor configured execution mode

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -11,6 +11,7 @@ import {
   type CoworkMemoryGuardLevel,
 } from './libs/coworkMemoryExtractor';
 import { judgeMemoryCandidate } from './libs/coworkMemoryJudge';
+import { normalizeCoworkExecutionMode } from './libs/coworkExecutionMode';
 
 // Default working directory for new users
 const getDefaultWorkingDirectory = (): string => {
@@ -876,6 +877,7 @@ export class CoworkStore {
     }
 
     const workingDirRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['workingDirectory']);
+    const executionModeRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['executionMode']);
     const agentEngineRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['agentEngine']);
     const memoryEnabledRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['memoryEnabled']);
     const memoryImplicitUpdateEnabledRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['memoryImplicitUpdateEnabled']);
@@ -888,7 +890,7 @@ export class CoworkStore {
     return {
       workingDirectory: workingDirRow?.value || getDefaultWorkingDirectory(),
       systemPrompt: getDefaultSystemPrompt(),
-      executionMode: 'local' as CoworkExecutionMode,
+      executionMode: normalizeCoworkExecutionMode(executionModeRow?.value),
       agentEngine: normalizedAgentEngine,
       memoryEnabled: parseBooleanConfig(memoryEnabledRow?.value, DEFAULT_MEMORY_ENABLED),
       memoryImplicitUpdateEnabled: parseBooleanConfig(

--- a/src/main/libs/coworkExecutionMode.test.ts
+++ b/src/main/libs/coworkExecutionMode.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest';
+import { mapExecutionModeToSandboxMode, normalizeCoworkExecutionMode } from './coworkExecutionMode';
+
+test('normalizeCoworkExecutionMode returns persisted values unchanged', () => {
+  expect(normalizeCoworkExecutionMode('local')).toBe('local');
+  expect(normalizeCoworkExecutionMode('auto')).toBe('auto');
+  expect(normalizeCoworkExecutionMode('sandbox')).toBe('sandbox');
+});
+
+test('normalizeCoworkExecutionMode falls back to local for invalid values', () => {
+  expect(normalizeCoworkExecutionMode(undefined)).toBe('local');
+  expect(normalizeCoworkExecutionMode(null)).toBe('local');
+  expect(normalizeCoworkExecutionMode('container')).toBe('local');
+});
+
+test('mapExecutionModeToSandboxMode preserves the documented sandbox mapping', () => {
+  expect(mapExecutionModeToSandboxMode('local')).toBe('off');
+  expect(mapExecutionModeToSandboxMode('auto')).toBe('non-main');
+  expect(mapExecutionModeToSandboxMode('sandbox')).toBe('all');
+});

--- a/src/main/libs/coworkExecutionMode.ts
+++ b/src/main/libs/coworkExecutionMode.ts
@@ -1,0 +1,20 @@
+import type { CoworkExecutionMode } from '../coworkStore';
+
+export const normalizeCoworkExecutionMode = (value?: string | null): CoworkExecutionMode => {
+  if (value === 'auto' || value === 'local' || value === 'sandbox') {
+    return value;
+  }
+  return 'local';
+};
+
+export const mapExecutionModeToSandboxMode = (
+  mode: CoworkExecutionMode,
+): 'off' | 'non-main' | 'all' => {
+  if (mode === 'auto') {
+    return 'non-main';
+  }
+  if (mode === 'sandbox') {
+    return 'all';
+  }
+  return 'off';
+};

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
-import type { CoworkConfig, CoworkExecutionMode } from '../coworkStore';
+import type { CoworkConfig } from '../coworkStore';
 import type { TelegramOpenClawConfig, DiscordOpenClawConfig } from '../im/types';
 import type { DingTalkOpenClawConfig, FeishuOpenClawConfig, QQOpenClawConfig, WecomOpenClawConfig, PopoOpenClawConfig, NimConfig, WeixinOpenClawConfig } from '../im/types';
 import { resolveRawApiConfig } from './claudeSettings';
@@ -9,17 +9,13 @@ import type { OpenClawEngineManager } from './openclawEngineManager';
 import { parseChannelSessionKey } from './openclawChannelSessionSync';
 import type { McpToolManifestEntry } from './mcpServerManager';
 import { hasBundledOpenClawExtension } from './openclawLocalExtensions';
+import { mapExecutionModeToSandboxMode } from './coworkExecutionMode';
 import { buildScheduledTaskEnginePrompt } from './scheduledTaskEnginePrompt';
 
 export type McpBridgeConfig = {
   callbackUrl: string;
   secret: string;
   tools: McpToolManifestEntry[];
-};
-
-const mapExecutionModeToSandboxMode = (_mode: CoworkExecutionMode): 'off' | 'non-main' | 'all' => {
-  // Sandbox mode disabled — always run locally
-  return 'off';
 };
 
 /**


### PR DESCRIPTION
## Summary

- read `executionMode` from `cowork_config` instead of hardcoding `local`
- restore the documented OpenClaw sandbox mapping for `local/auto/sandbox`
- add a focused unit test for execution mode normalization and sandbox mapping

## Testing

- not run: repo dependencies are not installed in this workspace

Closes #735
