### PR TITLE
fix(im): update gateway status on startup/restart failure

### DIFF
--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -402,11 +402,13 @@ export class IMGatewayManager extends EventEmitter {
           console.log('[IMGatewayManager] Xiaomifeng credentials changed, restarting gateway...');
           this.restartGateway('xiaomifeng').catch((err) => {
             console.error('[IMGatewayManager] Failed to restart Xiaomifeng after config change:', err.message);
+            this.emit('statusChange', this.getStatus());
           });
         } else {
           console.log('[IMGatewayManager] Xiaomifeng credentials changed, starting gateway...');
           this.startGateway('xiaomifeng').catch((err) => {
             console.error('[IMGatewayManager] Failed to start Xiaomifeng after config change:', err.message);
+            this.emit('statusChange', this.getStatus());
           });
         }
       }


### PR DESCRIPTION
## Summary

- Emit `statusChange` in the `.catch()` handlers of `startGateway()` and `restartGateway()` so the renderer receives the updated (error) status when the gateway fails to start.

## Problem

In `src/main/im/imGatewayManager.ts`, both `startGateway()` and `restartGateway()` have `.catch()` blocks that log the error but never emit a status update. The renderer continues to show the previous status (e.g., "starting") indefinitely, leaving the user unaware that the gateway failed.

## Solution

Add `this.emit('statusChange', this.getStatus())` in both `.catch()` handlers, matching the pattern already used elsewhere in the class (e.g., after successful start, after stop).

## Electron-specific behavior

This affects the IM gateway status IPC flow. The `statusChange` event propagates from the main process to the renderer via IPC listeners. Without this fix, the renderer's gateway status indicator becomes stale after a startup failure, requiring an app restart to recover.

## Changed files

- `src/main/im/imGatewayManager.ts`

## Verification

- `npx tsc --noEmit` — zero errors
- `npx tsc -p electron-tsconfig.json --noEmit` — zero errors