### PR TITLE
fix(cowork): add secondary try-catch in session error handlers

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2096,18 +2096,22 @@ if (!gotTheLock) {
         confirmationMode: 'modal',
         imageAttachments: options.imageAttachments,
       }).catch(error => {
-        console.error('Cowork session error:', error);
-        // The engine router already emits an 'error' event (handled at line ~990)
-        // which sends cowork:stream:error to the renderer. Only send here if the
-        // session hasn't been marked as error yet, to avoid duplicate messages.
-        const existing = coworkStoreInstance.getSession(session.id);
-        if (existing?.status === 'error') return;
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        const windows = BrowserWindow.getAllWindows();
-        windows.forEach((win) => {
-          if (win.isDestroyed()) return;
-          win.webContents.send('cowork:stream:error', { sessionId: session.id, error: errorMessage });
-        });
+        console.error('[Cowork] session error:', error);
+        try {
+          // The engine router already emits an 'error' event (handled at line ~990)
+          // which sends cowork:stream:error to the renderer. Only send here if the
+          // session hasn't been marked as error yet, to avoid duplicate messages.
+          const existing = coworkStoreInstance.getSession(session.id);
+          if (existing?.status === 'error') return;
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          const windows = BrowserWindow.getAllWindows();
+          windows.forEach((win) => {
+            if (win.isDestroyed()) return;
+            win.webContents.send('cowork:stream:error', { sessionId: session.id, error: errorMessage });
+          });
+        } catch (handlerError) {
+          console.error('[Cowork] failed to send error notification to renderer:', handlerError);
+        }
       });
 
       const sessionWithMessages = coworkStoreInstance.getSession(session.id) || {
@@ -2149,18 +2153,22 @@ if (!gotTheLock) {
         skillIds: options.activeSkillIds,
         imageAttachments: options.imageAttachments,
       }).catch(error => {
-        console.error('Cowork continue error:', error);
-        // The engine router already emits an 'error' event (handled at line ~990)
-        // which sends cowork:stream:error to the renderer. Only send here if the
-        // session hasn't been marked as error yet, to avoid duplicate messages.
-        const existing = getCoworkStore().getSession(options.sessionId);
-        if (existing?.status === 'error') return;
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        const windows = BrowserWindow.getAllWindows();
-        windows.forEach((win) => {
-          if (win.isDestroyed()) return;
-          win.webContents.send('cowork:stream:error', { sessionId: options.sessionId, error: errorMessage });
-        });
+        console.error('[Cowork] continue error:', error);
+        try {
+          // The engine router already emits an 'error' event (handled at line ~990)
+          // which sends cowork:stream:error to the renderer. Only send here if the
+          // session hasn't been marked as error yet, to avoid duplicate messages.
+          const existing = getCoworkStore().getSession(options.sessionId);
+          if (existing?.status === 'error') return;
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          const windows = BrowserWindow.getAllWindows();
+          windows.forEach((win) => {
+            if (win.isDestroyed()) return;
+            win.webContents.send('cowork:stream:error', { sessionId: options.sessionId, error: errorMessage });
+          });
+        } catch (handlerError) {
+          console.error('[Cowork] failed to send error notification to renderer:', handlerError);
+        }
       });
 
       const session = getCoworkStore().getSession(options.sessionId);


### PR DESCRIPTION
## Summary

- Wrap the error-handling logic inside `startSession` and `continueSession` `.catch()` blocks with a secondary `try-catch` to prevent unhandled exceptions from crashing the main process.

## Problem

In `src/main/main.ts`, the `.catch()` handlers for `startSession` and `continueSession` perform non-trivial operations (updating session store, sending IPC messages). If any of these operations throw (e.g., SQLite write failure, window already destroyed), the exception propagates as an unhandled promise rejection, which can crash the Electron main process.

## Solution

Add a secondary `try-catch` inside each `.catch()` block. The inner catch logs the error with `console.error` using the project's `[tag] message` log format, ensuring the main process remains stable even when error handling itself fails.

## Electron-specific behavior

Unhandled exceptions in the main process cause the entire Electron app to crash. These `.catch()` blocks interact with `coworkStore` (SQLite) and `BrowserWindow.webContents.send()` (IPC), both of which can throw if the database is locked or the window has been destroyed. The secondary try-catch prevents these edge cases from taking down the app.

## Changed files

- `src/main/main.ts`

## Verification

- `npx tsc --noEmit` — zero errors
- `npx tsc -p electron-tsconfig.json --noEmit` — zero errors