### PR TITLE
refactor(im): extract platform config handlers into makePlatformHandlers factory

### DIFF
--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -283,7 +283,6 @@ const IMSettings: React.FC = () => {
     };
   }, []);
 
-  // Extract NIM channel schema and hints from the full OpenClaw config schema
   const nimSchemaData = useMemo(() => {
     if (!openclawSchema) return null;
     const { schema, uiHints } = openclawSchema;
@@ -308,32 +307,76 @@ const IMSettings: React.FC = () => {
     return { schema: channelSchema, hints };
   }, [openclawSchema]);
 
-  // Handle DingTalk OpenClaw config change
-  const dtOpenClawConfig = config.dingtalk;
-  const handleDingTalkOpenClawChange = (update: Partial<DingTalkOpenClawConfig>) => {
-    dispatch(setDingTalkConfig(update));
-  };
-  const handleSaveDingTalkOpenClawConfig = async (override?: Partial<DingTalkOpenClawConfig>) => {
-    if (!configLoaded) return;
-    const configToSave = override
-      ? { ...dtOpenClawConfig, ...override }
-      : dtOpenClawConfig;
-    await imService.persistConfig({ dingtalk: configToSave });
-  };
-  const [dingtalkAllowedUserIdInput, setDingtalkAllowedUserIdInput] = useState('');
+  const platformDispatchMap: Record<string, (update: Record<string, unknown>) => void> = useMemo(() => ({
+    dingtalk: (u) => dispatch(setDingTalkConfig(u as Partial<DingTalkOpenClawConfig>)),
+    feishu: (u) => dispatch(setFeishuConfig(u as Partial<FeishuOpenClawConfig>)),
+    telegram: (u) => dispatch(setTelegramOpenClawConfig(u as Partial<TelegramOpenClawConfig>)),
+    qq: (u) => dispatch(setQQConfig(u as Partial<QQOpenClawConfig>)),
+    discord: (u) => dispatch(setDiscordConfig(u as Partial<DiscordOpenClawConfig>)),
+    wecom: (u) => dispatch(setWecomConfig(u as Partial<WecomOpenClawConfig>)),
+    popo: (u) => dispatch(setPopoConfig(u as Partial<PopoOpenClawConfig>)),
+  }), [dispatch]);
 
-  // Handle Feishu OpenClaw config change
-  const fsOpenClawConfig = config.feishu;
-  const handleFeishuOpenClawChange = (update: Partial<FeishuOpenClawConfig>) => {
-    dispatch(setFeishuConfig(update));
-  };
-  const handleSaveFeishuOpenClawConfig = async (override?: Partial<FeishuOpenClawConfig>) => {
-    if (!configLoaded) return;
-    const configToSave = override
-      ? { ...fsOpenClawConfig, ...override }
-      : fsOpenClawConfig;
-    await imService.persistConfig({ feishu: configToSave });
-  };
+  function makePlatformHandlers<K extends keyof IMGatewayConfig>(platform: K) {
+    const currentConfig = config[platform];
+    const handleChange = (update: Partial<IMGatewayConfig[K]>) => {
+      platformDispatchMap[platform]?.(update as Record<string, unknown>);
+    };
+    const handleSave = async (override?: Partial<IMGatewayConfig[K]>) => {
+      if (!configLoaded) return;
+      const configToSave = override
+        ? { ...currentConfig, ...override }
+        : currentConfig;
+      await imService.persistConfig({ [platform]: configToSave } as Partial<IMGatewayConfig>);
+    };
+    return { config: currentConfig, handleChange, handleSave };
+  }
+
+  const {
+    config: dtOpenClawConfig,
+    handleChange: handleDingTalkOpenClawChange,
+    handleSave: handleSaveDingTalkOpenClawConfig,
+  } = makePlatformHandlers('dingtalk');
+
+  const {
+    config: fsOpenClawConfig,
+    handleChange: handleFeishuOpenClawChange,
+    handleSave: handleSaveFeishuOpenClawConfig,
+  } = makePlatformHandlers('feishu');
+
+  const {
+    config: tgOpenClawConfig,
+    handleChange: handleTelegramOpenClawChange,
+    handleSave: handleSaveTelegramOpenClawConfig,
+  } = makePlatformHandlers('telegram');
+
+  const {
+    config: qqOpenClawConfig,
+    handleChange: handleQQOpenClawChange,
+    handleSave: handleSaveQQOpenClawConfig,
+  } = makePlatformHandlers('qq');
+
+  const {
+    config: dcOpenClawConfig,
+    handleChange: handleDiscordOpenClawChange,
+    handleSave: handleSaveDiscordOpenClawConfig,
+  } = makePlatformHandlers('discord');
+
+  const {
+    config: wecomOpenClawConfig,
+    handleChange: handleWecomOpenClawChange,
+    handleSave: handleSaveWecomOpenClawConfig,
+  } = makePlatformHandlers('wecom');
+
+  const weixinOpenClawConfig = config.weixin;
+
+  const {
+    config: popoConfig,
+    handleChange: handlePopoChange,
+    handleSave: handleSavePopoConfig,
+  } = makePlatformHandlers('popo');
+
+  const [dingtalkAllowedUserIdInput, setDingtalkAllowedUserIdInput] = useState('');
 
   // State for Feishu allow-from inputs
   const [feishuAllowedUserIdInput, setFeishuAllowedUserIdInput] = useState('');
@@ -361,44 +404,6 @@ const IMSettings: React.FC = () => {
       setPairingStatus((prev) => ({ ...prev, [platform]: { type: 'error', message: result.error || i18nService.t('imPairingCodeInvalid') } }));
     }
   };
-  // Handle Telegram OpenClaw config change
-  const tgOpenClawConfig = config.telegram;
-  const handleTelegramOpenClawChange = (update: Partial<TelegramOpenClawConfig>) => {
-    dispatch(setTelegramOpenClawConfig(update));
-  };
-  const handleSaveTelegramOpenClawConfig = async (override?: Partial<TelegramOpenClawConfig>) => {
-    if (!configLoaded) return;
-    const configToSave = override
-      ? { ...tgOpenClawConfig, ...override }
-      : tgOpenClawConfig;
-    await imService.persistConfig({ telegram: configToSave });
-  };
-
-  // Handle QQ OpenClaw config change
-  const qqOpenClawConfig = config.qq;
-  const handleQQOpenClawChange = (update: Partial<QQOpenClawConfig>) => {
-    dispatch(setQQConfig(update));
-  };
-  const handleSaveQQOpenClawConfig = async (override?: Partial<QQOpenClawConfig>) => {
-    if (!configLoaded) return;
-    const configToSave = override
-      ? { ...qqOpenClawConfig, ...override }
-      : qqOpenClawConfig;
-    await imService.persistConfig({ qq: configToSave });
-  };
-
-  // Handle Discord OpenClaw config change
-  const dcOpenClawConfig = config.discord;
-  const handleDiscordOpenClawChange = (update: Partial<DiscordOpenClawConfig>) => {
-    dispatch(setDiscordConfig(update));
-  };
-  const handleSaveDiscordOpenClawConfig = async (override?: Partial<DiscordOpenClawConfig>) => {
-    if (!configLoaded) return;
-    const configToSave = override
-      ? { ...dcOpenClawConfig, ...override }
-      : dcOpenClawConfig;
-    await imService.persistConfig({ discord: configToSave });
-  };
 
   // State for Discord allow-from inputs
   const [discordAllowedUserIdInput, setDiscordAllowedUserIdInput] = useState('');
@@ -412,35 +417,6 @@ const IMSettings: React.FC = () => {
   // Handle Xiaomifeng config change
   const handleXiaomifengChange = (field: 'clientId' | 'secret', value: string) => {
     dispatch(setXiaomifengConfig({ [field]: value }));
-  };
-
-  // Handle WeCom OpenClaw config change
-  const wecomOpenClawConfig = config.wecom;
-  const handleWecomOpenClawChange = (update: Partial<WecomOpenClawConfig>) => {
-    dispatch(setWecomConfig(update));
-  };
-  const handleSaveWecomOpenClawConfig = async (override?: Partial<WecomOpenClawConfig>) => {
-    if (!configLoaded) return;
-    const configToSave = override
-      ? { ...wecomOpenClawConfig, ...override }
-      : wecomOpenClawConfig;
-    await imService.persistConfig({ wecom: configToSave });
-  };
-
-  // Handle Weixin OpenClaw config
-  const weixinOpenClawConfig = config.weixin;
-
-  // Handle POPO OpenClaw config change
-  const popoConfig = config.popo;
-  const handlePopoChange = (update: Partial<PopoOpenClawConfig>) => {
-    dispatch(setPopoConfig(update));
-  };
-  const handleSavePopoConfig = async (override?: Partial<PopoOpenClawConfig>) => {
-    if (!configLoaded) return;
-    const configToSave = override
-      ? { ...popoConfig, ...override }
-      : popoConfig;
-    await imService.persistConfig({ popo: configToSave });
   };
 
   const handleWecomQuickSetup = async () => {


### PR DESCRIPTION
## Summary

- Replace 7 repetitive platform-specific handler triplets (`config`, `handleChange`, `handleSave`) with a generic `makePlatformHandlers<K>()` factory function and a `platformDispatchMap` lookup table.
- Each platform now destructures its handlers from a single factory call, keeping all existing variable names so downstream JSX (~3800 lines) is untouched.

## Problem

`IMSettings.tsx` contained 7 near-identical blocks of code — one per IM platform (DingTalk, Feishu, Telegram, QQ, Discord, WeCom, POPO). Each block:
1. Read config from Redux: `const xxxConfig = config.platform`
2. Created a change handler that dispatches to the platform-specific Redux action
3. Created a save handler that persists config via `imService.persistConfig()`

This ~90 lines of boilerplate made maintenance error-prone (a fix in one platform's handler could be missed in others) and inflated the already large file.

## Solution

1. **`platformDispatchMap`** — A `useMemo`-wrapped `Record<string, (update) => void>` mapping platform keys to their Redux dispatch calls. This is needed because platform dispatch actions have inconsistent naming (e.g., `setTelegramOpenClawConfig` vs `setFeishuConfig`).

2. **`makePlatformHandlers<K>(platform)`** — A generic factory that returns `{ config, handleChange, handleSave }` for any platform key. Type-safe via `K extends keyof IMGatewayConfig`.

3. **Destructuring aliases** — Each platform destructures with its original variable names (`dtOpenClawConfig`, `handleDingTalkOpenClawChange`, etc.) so no downstream JSX changes are needed.

## Changed files

- `src/renderer/components/im/IMSettings.tsx` — 69 insertions, 93 deletions (net -24 lines)

## Verification

- `npx tsc --noEmit` — zero errors
- `npx tsc -p electron-tsconfig.json --noEmit` — zero errors
- All variable names preserved; JSX below line ~380 is completely unchanged