### PR TITLE
perf(cowork): memoize ToolCallGroup, AssistantMessageItem and ThinkingBlock

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -666,7 +666,7 @@ const ToolCallGroup: React.FC<{
   group: ToolGroupItem;
   isLastInSequence?: boolean;
   mapDisplayText?: (value: string) => string;
-}> = ({
+}> = React.memo(({
   group,
   isLastInSequence = true,
   mapDisplayText,
@@ -826,7 +826,7 @@ const ToolCallGroup: React.FC<{
       )}
     </div>
   );
-};
+});
 
 // Copy button component
 const CopyButton: React.FC<{
@@ -987,7 +987,7 @@ const AssistantMessageItem: React.FC<{
   resolveLocalFilePath?: (href: string, text: string) => string | null;
   mapDisplayText?: (value: string) => string;
   showCopyButton?: boolean;
-}> = ({
+}> = React.memo(({
   message,
   resolveLocalFilePath,
   mapDisplayText,
@@ -1019,7 +1019,7 @@ const AssistantMessageItem: React.FC<{
       )}
     </div>
   );
-};
+});
 
 // Streaming activity bar shown between messages and input
 const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ messages }) => {
@@ -1075,7 +1075,7 @@ const TypingDots: React.FC = () => (
 const ThinkingBlock: React.FC<{
   message: CoworkMessage;
   mapDisplayText?: (value: string) => string;
-}> = ({ message, mapDisplayText }) => {
+}> = React.memo(({ message, mapDisplayText }) => {
   const isCurrentlyStreaming = Boolean(message.metadata?.isStreaming);
   const [isExpanded, setIsExpanded] = useState(isCurrentlyStreaming);
   const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content;
@@ -1116,7 +1116,7 @@ const ThinkingBlock: React.FC<{
       )}
     </div>
   );
-};
+});
 
 export const AssistantTurnBlock: React.FC<{
   turn: ConversationTurn;


### PR DESCRIPTION
## Summary

- Wrap `ToolCallGroup`, `AssistantMessageItem`, and `ThinkingBlock` components with `React.memo()` to prevent unnecessary re-renders during cowork session streaming.

## Problem

`CoworkSessionDetail.tsx` renders a potentially long list of messages. During streaming, every `messageUpdate` event triggers a re-render of the parent, which cascades to all child message components — even those whose props haven't changed. With long sessions (50+ messages), this causes noticeable UI jank.

## Solution

Wrap three frequently-rendered child components with `React.memo()`:

1. **`ToolCallGroup`** — Renders tool call/result pairs. Props are stable once the tool call completes.
2. **`AssistantMessageItem`** — Renders assistant message content. Only the actively-streaming message changes; all previous messages have stable props.
3. **`ThinkingBlock`** — Renders thinking/reasoning blocks. Props stabilize once thinking completes.

These components already receive `useCallback`-wrapped handlers (`mapDisplayText`, `resolveLocalFilePath`) as props, so `React.memo` can effectively short-circuit re-renders.

## Why not `useCallback` on inline handlers?

The initial analysis considered memoizing ~9 inline `onClick` handlers, but most are passed to native HTML elements (`<button>`, `<div>`), where `useCallback` provides no benefit. `React.memo` on the component level is the correct optimization here — it prevents the entire subtree from re-rendering, not just individual prop comparisons.

## Changed files

- `src/renderer/components/cowork/CoworkSessionDetail.tsx`

## Verification

- `npx tsc --noEmit` — zero errors
- `npx tsc -p electron-tsconfig.json --noEmit` — zero errors