### PR TITLE
fix(renderer): preserve MEMORY.md structure when appending new memory

### DIFF
--- a/src/main/libs/openclawMemoryFile.ts
+++ b/src/main/libs/openclawMemoryFile.ts
@@ -117,14 +117,18 @@ export function serializeMemoryMd(entries: OpenClawMemoryEntry[]): string {
 }
 
 /**
- * Build updated MEMORY.md content by surgically replacing bullet lines
- * while preserving all non-bullet content (headings, prose, sections).
+ * Build updated MEMORY.md content by surgically patching bullet lines
+ * while preserving the original document structure exactly.
  *
  * Strategy:
- *   1. Walk original lines; collect non-bullet lines verbatim.
- *   2. Replace the first contiguous bullet block with the new entries.
- *   3. Remove all other bullet lines (to avoid duplicates).
- *   4. If no bullet block existed, append entries at the end.
+ *   1. Walk original lines in order.
+ *   2. For each bullet line, look up its ID in the new entries map:
+ *      - If found → emit the (possibly updated) text and mark as handled.
+ *      - If not found → the entry was deleted, skip the line.
+ *   3. Non-bullet content (headings, prose, blank lines) is always kept verbatim.
+ *   4. After the full pass, any entries that were NOT matched to an existing
+ *      bullet (i.e. genuinely new additions) are appended at the end so the
+ *      original structure is never disturbed.
  */
 function rebuildMemoryMd(
   originalContent: string,
@@ -134,14 +138,17 @@ function rebuildMemoryMd(
     return serializeMemoryMd(entries);
   }
 
+  // Build a map of id → entry for O(1) lookup, and a set to track which
+  // entries have been placed (matched an existing bullet in the document).
+  const entryMap = new Map<string, OpenClawMemoryEntry>(entries.map((e) => [e.id, e]));
+  const placed = new Set<string>();
+
   const lines = originalContent.split(/\r?\n/);
   const result: string[] = [];
-  let bulletBlockInserted = false;
-  // Track whether we are inside a fenced code block
   let inCodeBlock = false;
 
   for (const line of lines) {
-    // Toggle code-block state
+    // Toggle fenced-code-block state (never treat bullets inside as entries)
     if (line.trimStart().startsWith('```')) {
       inCodeBlock = !inCodeBlock;
       result.push(line);
@@ -153,24 +160,32 @@ function rebuildMemoryMd(
     }
 
     if (isBulletLine(line)) {
-      // First bullet block → insert all new entries here
-      if (!bulletBlockInserted) {
-        bulletBlockInserted = true;
-        for (const e of entries) {
-          result.push(`- ${e.text}`);
-        }
+      const match = line.trim().match(BULLET_RE);
+      const originalText = match?.[1]?.replace(/\s+/g, ' ').trim() ?? '';
+      const originalId = fingerprint(originalText);
+
+      const updated = entryMap.get(originalId);
+      if (updated) {
+        // Entry still exists (possibly with updated text) → emit it in place
+        result.push(`- ${updated.text}`);
+        placed.add(originalId);
       }
-      // Skip original bullet line (already replaced by new entries)
+      // else: entry was deleted from the list → drop the line (don't emit)
       continue;
     }
 
     result.push(line);
   }
 
-  // No bullet block in original → append entries at the end
-  if (!bulletBlockInserted && entries.length > 0) {
-    result.push('');
-    for (const e of entries) {
+  // Append genuinely new entries (those not matched to any existing bullet)
+  const newEntries = entries.filter((e) => !placed.has(e.id));
+  if (newEntries.length > 0) {
+    // Add a blank separator only if the last non-empty line isn't already blank
+    const trimmed = result[result.length - 1]?.trim();
+    if (trimmed !== undefined && trimmed !== '') {
+      result.push('');
+    }
+    for (const e of newEntries) {
       result.push(`- ${e.text}`);
     }
   }


### PR DESCRIPTION
## 问题
#754 记忆条目管理，新增单字长度的记忆内容后，保存成功未报错，但无法在记忆条目管理中展示。
#753 记忆条目管理，任意增删改操作后，MEMORY.md文件里'-'开头的文案会被抽离到一起

## 根因
/Users/huahaoze/projects/LobsterAI/src/main/libs/openclawMemoryFile.ts
1. parseMemoryMd 和 migrateSqliteToMemoryMd 方法过滤了单字长度的entity
2. rebuildMemoryMd 方法追加方式实现较简易，导致原始文档结构被破坏

## 修复
1. 支持单字memory的编辑和删除管理操作，添加完成后正回现到列表中。
2.  重写 rebuildMemoryMd() 函数，追加 memory 时保留原文件结构
                                                                                                                        
  - 问题：旧的实现会把整个文件的 bullet 列表合并替换，导致其他 section（如 Silent Replies、Heartbeats）中的 bullet      
  被错误处理，破坏文件语义结构                                                                                          
  - 新策略：                                                                                                            
    a. 遍历原文件的每一行，非 bullet 内容（标题、段落、空行）完全保留                                                   
    b. 对于 bullet 行，检查是否是已知 memory：                                                                          
        - 存在 → 原地更新（可能文本有修改）                                                                             
      - 不存在 → 删除该条目（跳过不输出）                                                                               
    c. 遍历完成后，将真正新增的 memory 追加到文件末尾                                                                   
  - 效果：新增 memory 不会破坏原文件结构，其他 section 的 bullet 列表保持原样

## Origin

<img width="1338" height="772" alt="image" src="https://github.com/user-attachments/assets/496c8f41-f22e-45b1-91d6-f7a1d8407386" />

## After edit

<img width="617" height="546" alt="image" src="https://github.com/user-attachments/assets/867a09b8-64f4-4e6f-a5ec-5bcf7a52b9fb" />

<img width="858" height="798" alt="image" src="https://github.com/user-attachments/assets/d22464f4-2925-49cb-8c65-cad414d3faf3" />
