### PR TITLE
fix(cowork): remove duplicate session status update on start

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2082,10 +2082,6 @@ if (!gotTheLock) {
 
       const runner = getCoworkRunner();
 
-      // Update session status to 'running' before starting async task
-      // This ensures the frontend receives the correct status immediately
-      coworkStoreInstance.updateSession(session.id, { status: 'running' });
-
       // Start the session asynchronously (skip initial user message since we already added it)
       const runtime = getCoworkEngineRouter();
       runtime.startSession(session.id, options.prompt, {


### PR DESCRIPTION
## Summary
- 删除 `cowork:startSession` 处理函数中第二次冗余的 `updateSession(session.id, { status: 'running' })` 调用
- 第一次调用（添加用户消息之前）已足够，第二次是复制粘贴遗留
- 每次创建会话减少一次不必要的 SQLite 序列化 + 同步磁盘写入

## 改动文件
- `src/main/main.ts`

Closes #758