### PR TITLE
perf(cowork): 优化聊天区域消息过多导致的卡顿、白屏问题

### DIFF
--- a/scripts/test-inject-messages.js
+++ b/scripts/test-inject-messages.js
@@ -1,0 +1,138 @@
+/**
+ * 在 DevTools Console 中粘贴运行此脚本
+ * 向当前 Cowork 会话注入 200 条模拟消息用于性能测试
+ *
+ * 使用方法:
+ *   1. 先打开一个 Cowork 会话
+ *   2. 打开 DevTools (Cmd+Shift+I)
+ *   3. 粘贴此脚本到 Console 并回车
+ */
+
+(function injectTestMessages() {
+  // Try multiple methods to find Redux store
+  let store = null;
+
+  // Method 1: window.__REDUX_STORE__ (if exposed)
+  if (window.__REDUX_STORE__) {
+    store = window.__REDUX_STORE__;
+  }
+
+  // Method 2: Walk React fiber tree
+  if (!store) {
+    const rootEl = document.getElementById('root');
+    if (rootEl) {
+      const fiberKey = Object.keys(rootEl).find(k => k.startsWith('__reactFiber') || k.startsWith('__reactInternalInstance'));
+      if (fiberKey) {
+        let fiber = rootEl[fiberKey];
+        while (fiber) {
+          const s = fiber.memoizedProps?.store || fiber.stateNode?.store;
+          if (s?.dispatch && s?.getState) {
+            store = s;
+            break;
+          }
+          fiber = fiber.return;
+        }
+      }
+    }
+  }
+
+  // Method 3: Scan all DOM elements for React Provider
+  if (!store) {
+    const allEls = document.querySelectorAll('*');
+    for (const el of allEls) {
+      const key = Object.keys(el).find(k => k.startsWith('__reactFiber') || k.startsWith('__reactInternalInstance'));
+      if (!key) continue;
+      let fiber = el[key];
+      let depth = 0;
+      while (fiber && depth < 50) {
+        const s = fiber.memoizedProps?.store;
+        if (s?.dispatch && s?.getState) {
+          store = s;
+          break;
+        }
+        fiber = fiber.return;
+        depth++;
+      }
+      if (store) break;
+    }
+  }
+
+  if (!store) {
+    console.error('Cannot find Redux store. Try running this in the renderer process DevTools.');
+    console.log('Tip: In Electron, use View > Toggle Developer Tools, or press Cmd+Option+I while the main window is focused.');
+    return;
+  }
+
+  const state = store.getState();
+  console.log('Found Redux store. State keys:', Object.keys(state));
+  const sessionId = state.cowork?.currentSessionId;
+  if (!sessionId) {
+    console.error('No active cowork session. Please open a session first.');
+    return;
+  }
+
+  console.log(`Injecting 200 messages into session: ${sessionId}`);
+
+  const sampleContents = [
+    '你好，请帮我分析一下这段代码的性能问题。',
+    '当然可以。让我看看你的代码...\n\n```typescript\nfunction fibonacci(n: number): number {\n  if (n <= 1) return n;\n  return fibonacci(n - 1) + fibonacci(n - 2);\n}\n```\n\n这个递归实现的时间复杂度是 O(2^n)，建议使用动态规划优化。',
+    '能给个优化后的版本吗？',
+    '好的，这是使用动态规划优化后的版本：\n\n```typescript\nfunction fibonacci(n: number): number {\n  if (n <= 1) return n;\n  let prev = 0, curr = 1;\n  for (let i = 2; i <= n; i++) {\n    [prev, curr] = [curr, prev + curr];\n  }\n  return curr;\n}\n```\n\n时间复杂度从 O(2^n) 降到了 O(n)，空间复杂度 O(1)。',
+    '这个方案不错！还有别的优化思路吗？',
+    '还可以使用**矩阵快速幂**，将时间复杂度进一步降到 O(log n)：\n\n$$\\begin{pmatrix} F(n+1) \\\\ F(n) \\end{pmatrix} = \\begin{pmatrix} 1 & 1 \\\\ 1 & 0 \\end{pmatrix}^n \\begin{pmatrix} 1 \\\\ 0 \\end{pmatrix}$$\n\n不过对于大多数应用场景，O(n) 的方案已经足够了。',
+    '帮我写一个 React 组件，显示一个可以拖拽排序的列表。',
+    '我来帮你实现。这里使用 `@dnd-kit/core` 库：\n\n```tsx\nimport { DndContext, closestCenter } from \'@dnd-kit/core\';\nimport { SortableContext, verticalListSortingStrategy } from \'@dnd-kit/sortable\';\n\nfunction SortableList({ items, onReorder }) {\n  return (\n    <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>\n      <SortableContext items={items} strategy={verticalListSortingStrategy}>\n        {items.map(item => <SortableItem key={item.id} item={item} />)}\n      </SortableContext>\n    </DndContext>\n  );\n}\n```',
+    '谢谢！能帮我看看为什么 TypeScript 报错了吗？',
+    '请把报错信息发给我看看。',
+    '```\nTS2345: Argument of type \'string\' is not assignable to parameter of type \'number\'.\n```',
+    '这是类型不匹配的错误。你传入了一个字符串，但函数期望的是数字类型。可以使用 `parseInt()` 或 `Number()` 进行转换。',
+    '这个项目的目录结构能帮我梳理一下吗？',
+    '好的，我来看一下当前项目结构...\n\n```\nsrc/\n├── main/          # Electron 主进程\n├── renderer/      # React 渲染进程\n│   ├── components/\n│   ├── services/\n│   ├── store/\n│   └── types/\n└── shared/        # 共享类型和工具\n```',
+    '帮我写一个单元测试。',
+    '```typescript\nimport { describe, it, expect } from \'vitest\';\nimport { fibonacci } from \'./fibonacci\';\n\ndescribe(\'fibonacci\', () => {\n  it(\'should return 0 for n=0\', () => {\n    expect(fibonacci(0)).toBe(0);\n  });\n  it(\'should return 1 for n=1\', () => {\n    expect(fibonacci(1)).toBe(1);\n  });\n  it(\'should return 55 for n=10\', () => {\n    expect(fibonacci(10)).toBe(55);\n  });\n});\n```',
+    '运行结果全部通过了 ✅',
+    '太好了！测试覆盖了边界情况和正常情况，代码质量有保障。',
+    '还有什么需要优化的地方吗？',
+    '建议再加几个方面的测试：\n\n1. **负数输入** - 测试 `fibonacci(-1)` 的行为\n2. **大数输入** - 测试 `fibonacci(50)` 确保不会溢出\n3. **性能测试** - 确保大数计算在合理时间内完成',
+    '好的，我加上这些测试用例。',
+  ];
+
+  const now = Date.now();
+  const messages = [];
+
+  for (let i = 0; i < 200; i++) {
+    const isUser = i % 2 === 0;
+    const contentIndex = i % sampleContents.length;
+    messages.push({
+      sessionId,
+      message: {
+        id: `test-msg-${i}-${Date.now()}`,
+        type: isUser ? 'user' : 'assistant',
+        content: sampleContents[contentIndex],
+        timestamp: now - (200 - i) * 1000,
+        metadata: isUser ? {} : { isFinal: true },
+      },
+    });
+  }
+
+  // Batch dispatch
+  const batchSize = 10;
+  let injected = 0;
+
+  function injectBatch() {
+    const batch = messages.slice(injected, injected + batchSize);
+    batch.forEach(msg => {
+      store.dispatch({ type: 'cowork/addMessage', payload: msg });
+    });
+    injected += batch.length;
+    console.log(`Injected ${injected}/${messages.length} messages...`);
+
+    if (injected < messages.length) {
+      requestAnimationFrame(injectBatch);
+    } else {
+      console.log('✅ Done! 200 messages injected. Scroll the chat to test performance.');
+    }
+  }
+
+  injectBatch();
+})();

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -18,6 +18,7 @@ import { FolderIcon } from '@heroicons/react/24/solid';
 import { coworkService } from '../../services/cowork';
 import SidebarToggleIcon from '../icons/SidebarToggleIcon';
 import ComposeIcon from '../icons/ComposeIcon';
+import LazyRenderTurn, { clearHeightCache } from './LazyRenderTurn';
 import PuzzleIcon from '../icons/PuzzleIcon';
 import EllipsisHorizontalIcon from '../icons/EllipsisHorizontalIcon';
 import PencilSquareIcon from '../icons/PencilSquareIcon';
@@ -1295,6 +1296,12 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [shouldAutoScroll, setShouldAutoScroll] = useState(true);
 
+  // Clear lazy-render height cache when session changes
+  const sessionId = currentSession?.id;
+  useEffect(() => {
+    clearHeightCache();
+  }, [sessionId]);
+
   // Turn navigation states
   // currentTurnIndex (state) drives UI rendering; currentTurnIndexRef (ref) provides
   // up-to-date value inside callbacks (avoids stale closure). Both must be updated together.
@@ -1835,9 +1842,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       const isLastTurn = index === turns.length - 1;
       const showTypingIndicator = isStreaming && isLastTurn && !hasRenderableAssistantContent(turn);
       const showAssistantBlock = turn.assistantItems.length > 0 || showTypingIndicator;
+      // Always render last 3 turns (needed for streaming, auto-scroll, and smooth UX)
+      const alwaysRender = index >= turns.length - 3;
 
       return (
-        <div key={turn.id} data-turn-index={index}>
+        <LazyRenderTurn key={turn.id} turnId={turn.id} alwaysRender={alwaysRender} data-turn-index={index}>
           {turn.userMessage && (
             <div data-export-role="user-message">
               <UserMessageItem message={turn.userMessage} skills={skills} />
@@ -1854,7 +1863,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               />
             </div>
           )}
-        </div>
+        </LazyRenderTurn>
       );
     });
   };

--- a/src/renderer/components/cowork/LazyRenderTurn.tsx
+++ b/src/renderer/components/cowork/LazyRenderTurn.tsx
@@ -1,0 +1,109 @@
+import React, { useRef, useState, useEffect } from 'react';
+
+/**
+ * LazyRenderTurn — Viewport-based lazy rendering wrapper for conversation turns.
+ *
+ * Renders a lightweight placeholder when the turn is far from the viewport,
+ * and renders the actual content when it enters (or is near) the viewport.
+ * Once rendered, keeps a cached height so the placeholder matches the real size.
+ *
+ * This dramatically reduces DOM node count and React reconciliation work
+ * for long conversations (200+ turns).
+ */
+
+interface LazyRenderTurnProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Unique key for height cache */
+  turnId: string;
+  /** Vertical margin around viewport to pre-render (px) */
+  rootMargin?: number;
+  /** Whether this turn should always be rendered (e.g. last turn during streaming) */
+  alwaysRender?: boolean;
+  children: React.ReactNode;
+}
+
+// Global height cache survives re-renders — keyed by turnId
+const heightCache = new Map<string, number>();
+
+const LazyRenderTurn: React.FC<LazyRenderTurnProps> = ({
+  turnId,
+  rootMargin = 600,
+  alwaysRender = false,
+  children,
+  style,
+  ...restProps
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(alwaysRender);
+  const hasRenderedRef = useRef(false);
+
+  // Observe intersection
+  useEffect(() => {
+    if (alwaysRender) {
+      setIsVisible(true);
+      return;
+    }
+
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const nowVisible = entry.isIntersecting;
+        setIsVisible(nowVisible);
+        if (nowVisible) {
+          hasRenderedRef.current = true;
+        }
+      },
+      {
+        rootMargin: `${rootMargin}px 0px ${rootMargin}px 0px`,
+      },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [alwaysRender, rootMargin]);
+
+  // Cache height when visible content is rendered
+  useEffect(() => {
+    if (!isVisible) return;
+    const el = containerRef.current;
+    if (!el) return;
+
+    const ro = new ResizeObserver(([entry]) => {
+      const h = entry.contentRect.height;
+      if (h > 0) {
+        heightCache.set(turnId, h);
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [isVisible, turnId]);
+
+  const shouldRender = isVisible || alwaysRender;
+  const cachedHeight = heightCache.get(turnId);
+
+  return (
+    <div
+      ref={containerRef}
+      {...restProps}
+      style={{
+        ...style,
+        ...(!shouldRender && cachedHeight
+          ? { height: cachedHeight, minHeight: cachedHeight }
+          : undefined),
+      }}
+    >
+      {shouldRender ? children : (
+        <div
+          style={{ height: cachedHeight || 80 }}
+          className="dark:bg-claude-darkBg bg-claude-bg"
+        />
+      )}
+    </div>
+  );
+};
+
+export default LazyRenderTurn;
+
+/** Clear all cached heights (e.g. when switching sessions) */
+export const clearHeightCache = () => heightCache.clear();


### PR DESCRIPTION
当消息比较多的时候，会导致滚动卡顿、上下按钮点击无响应、页面甚至白屏，可参考以下视频

优化前后视频对比：
https://docs.popo.netease.com/team/pc/c5jcjsth/pageDetail/b56a0f3f5158455a9abeee479398d546

本地测试方式：
拷贝 test-inject-messages.js 里的内容，在控制台粘贴，会自动插入200条消息，然后就可以测试了（需要注意如果控制台禁止粘贴，请先手打：allow paste 命令）

新增功能点：
- 新增 LazyRenderTurn 组件，基于 IntersectionObserver + ResizeObserver 实现按需渲染
- 仅当对话轮次进入视口 600px 范围内时渲染真实内容，其余用占位符替代
- 缓存已渲染内容的高度，确保占位符尺寸准确，滚动条不跳动
- 最后 3 个对话轮次始终渲染，保障流式输出和自动滚动体验
- 切换会话时自动清空高度缓存
- 将 data-turn-index 属性透传到 LazyRenderTurn 根元素，兼容上下导航按钮
- 新增测试脚本，支持注入 200 条消息验证性能