### PR TITLE
feat: 优化文件夹选择器组件交互体验

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -5,6 +5,7 @@ import { PhotoIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import PaperClipIcon from '../icons/PaperClipIcon';
 import XMarkIcon from '../icons/XMarkIcon';
 import ModelSelector from '../ModelSelector';
+import Tooltip from '../ui/Tooltip';
 import FolderSelectorPopover from './FolderSelectorPopover';
 import { SkillsButton, ActiveSkillBadge } from '../skills';
 import { i18nService } from '../../services/i18n';
@@ -662,25 +663,38 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
               <div className="flex items-center gap-2 relative">
                 {showFolderSelector && (
                   <>
-                    <div className="relative group">
-                      <button
-                        ref={folderButtonRef as React.RefObject<HTMLButtonElement>}
-                        type="button"
-                        onClick={() => setShowFolderMenu(!showFolderMenu)}
-                        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover dark:hover:text-claude-darkText hover:text-claude-text transition-colors"
-                      >
-                        <FolderIcon className="h-4 w-4" />
-                        <span className="max-w-[150px] truncate text-xs">
-                          {truncatePath(workingDirectory)}
-                        </span>
-                      </button>
-                      {/* Tooltip - hidden when folder menu is open */}
-                      {!showFolderMenu && (
-                        <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3.5 py-2.5 text-[13px] leading-relaxed rounded-xl shadow-xl dark:bg-claude-darkBg bg-claude-bg dark:text-claude-darkText text-claude-text dark:border-claude-darkBorder border-claude-border border opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 pointer-events-none z-50 max-w-[400px] break-all whitespace-nowrap">
-                          {truncatePath(workingDirectory, 120)}
-                        </div>
-                      )}
-                    </div>
+                    <Tooltip
+                      content={truncatePath(workingDirectory, 120)}
+                      disabled={showFolderMenu || !workingDirectory}
+                      maxWidth="min(400px, 90vw)"
+                    >
+                      <div className="flex items-center">
+                        <button
+                          ref={folderButtonRef as React.RefObject<HTMLButtonElement>}
+                          type="button"
+                          onClick={() => setShowFolderMenu(!showFolderMenu)}
+                          className="flex items-center gap-1.5 pl-2.5 pr-1.5 py-1.5 rounded-lg text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover dark:hover:text-claude-darkText hover:text-claude-text transition-colors"
+                        >
+                          <FolderIcon className="h-4 w-4 flex-shrink-0" />
+                          <span className="max-w-[150px] truncate text-xs">
+                            {truncatePath(workingDirectory)}
+                          </span>
+                          {workingDirectory && (
+                            <span
+                              role="button"
+                              tabIndex={-1}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleFolderSelect('');
+                              }}
+                              className="flex-shrink-0 ml-0.5 p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+                            >
+                              <XMarkIcon className="h-3 w-3" />
+                            </span>
+                          )}
+                        </button>
+                      </div>
+                    </Tooltip>
                     <FolderSelectorPopover
                       isOpen={showFolderMenu}
                       onClose={() => setShowFolderMenu(false)}


### PR DESCRIPTION
## 问题

文件夹选择器存在三个交互体验问题：

1. 添加文件夹后，无法手动移除关联，只能通过选择新文件夹替换
2. 添加文件夹后，hover 提示气泡中的文件夹路径超长时溢出显示
3. hover 提示气泡 z-index 过低，在小窗口下被左侧会话列表菜单遮挡
<img width="546" height="199" alt="截屏2026-03-24 15 35 24" src="https://github.com/user-attachments/assets/32d2f5f1-7503-4480-87a0-69d56b2cada3" />
<img width="760" height="140" alt="截屏2026-03-24 16 06 53" src="https://github.com/user-attachments/assets/bf64cd7d-8185-48e0-8789-0b4bfe01774c" />

## 根因

1. 文件夹按钮区域没有提供"移除/清除"操作入口
2. 自定义 tooltip 使用 `whitespace-nowrap` + `max-w-[400px]`，超长路径无法换行且不适应窄窗口
3. 自定义 tooltip 使用 `absolute` 定位 + `z-50`，被父容器 `overflow-y-auto` 裁剪，且 z-index 低于侧边栏的 stacking context

## 修复

1. **增加文件夹移除按钮**：在文件夹按钮内部右侧增加 `×` 关闭图标，点击调用 `handleFolderSelect('')` 清除工作目录，`e.stopPropagation()` 阻止冒泡避免触发文件夹菜单

2. **替换为统一 Tooltip 组件**：移除自定义 inline tooltip 实现（`absolute` + `group-hover` + CSS 控制显隐），改用项目内已有的 `<Tooltip>` 组件（`src/renderer/components/ui/Tooltip.tsx`）。该组件内部使用 `position: fixed` + 智能方向选择 + viewport 边界检测，自动处理溢出和层级问题

3. **Tooltip 自适应宽度**：设置 `maxWidth="min(400px, 90vw)"` 确保窄窗口不溢出；菜单打开时或无文件夹时通过 `disabled` 禁用 tooltip

<img width="671" height="523" alt="image" src="https://github.com/user-attachments/assets/cdf967ed-ad4c-4a21-9f74-5b6767ad936c" />


## 复现路径

1. 启动应用，在 Cowork 输入区域点击文件夹图标选择一个文件夹
2. **移除按钮**：观察文件夹名称右侧出现 `×` 按钮，点击后文件夹关联被清除
3. **Tooltip 溢出**：选择一个深层嵌套路径的文件夹（如 `/Users/xxx/very/deep/nested/project/path/name`），缩小窗口到较窄宽度，hover 文件夹按钮查看 tooltip 是否正常显示不溢出
5. **Tooltip 层级**：保持窗口较小使侧边栏可见，hover 文件夹按钮确认 tooltip 不被侧边栏遮挡