### PR TITLE
feat(observability): add Opik observability integration via OpenClaw plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
         "id": "nim",
         "npm": "openclaw-nim",
         "version": "0.3.0"
+      },
+      {
+        "id": "opik-openclaw",
+        "npm": "@opik/opik-openclaw",
+        "version": "0.2.9"
       }
     ]
   },

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -399,6 +399,15 @@ export interface CoworkConversationSearchRecord {
   assistant: string;
 }
 
+export type ObservabilityProvider = 'opik';
+
+export interface ObservabilityOpikConfig {
+  url: string;
+  workspace: string;
+  apiKey: string;
+  project: string;
+}
+
 export interface CoworkConfig {
   workingDirectory: string;
   systemPrompt: string;
@@ -409,6 +418,8 @@ export interface CoworkConfig {
   memoryLlmJudgeEnabled: boolean;
   memoryGuardLevel: CoworkMemoryGuardLevel;
   memoryUserMemoriesMaxItems: number;
+  observabilityProviders: ObservabilityProvider[];
+  observabilityOpik: ObservabilityOpikConfig;
 }
 
 export type CoworkConfigUpdate = Partial<Pick<
@@ -421,6 +432,8 @@ export type CoworkConfigUpdate = Partial<Pick<
   | 'memoryLlmJudgeEnabled'
   | 'memoryGuardLevel'
   | 'memoryUserMemoriesMaxItems'
+  | 'observabilityProviders'
+  | 'observabilityOpik'
 >>;
 
 export interface ApplyTurnMemoryUpdatesOptions {
@@ -882,8 +895,27 @@ export class CoworkStore {
     const memoryLlmJudgeEnabledRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['memoryLlmJudgeEnabled']);
     const memoryGuardLevelRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['memoryGuardLevel']);
     const memoryUserMemoriesMaxItemsRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['memoryUserMemoriesMaxItems']);
+    const observabilityProvidersRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['observabilityProviders']);
+    const observabilityOpikRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['observabilityOpik']);
 
     const normalizedAgentEngine = normalizeCoworkAgentEngineValue(agentEngineRow?.value);
+
+    let observabilityProviders: ObservabilityProvider[] = [];
+    try {
+      const parsed = observabilityProvidersRow?.value ? JSON.parse(observabilityProvidersRow.value) : [];
+      if (Array.isArray(parsed)) {
+        observabilityProviders = parsed.filter((p: unknown) => p === 'opik');
+      }
+    } catch { /* ignore */ }
+
+    const defaultOpikConfig: ObservabilityOpikConfig = { url: '', workspace: 'default', apiKey: '', project: 'LobsterAI' };
+    let observabilityOpik = defaultOpikConfig;
+    try {
+      if (observabilityOpikRow?.value) {
+        const parsed = JSON.parse(observabilityOpikRow.value);
+        observabilityOpik = { ...defaultOpikConfig, ...parsed };
+      }
+    } catch { /* ignore */ }
 
     return {
       workingDirectory: workingDirRow?.value || getDefaultWorkingDirectory(),
@@ -901,6 +933,8 @@ export class CoworkStore {
       ),
       memoryGuardLevel: normalizeMemoryGuardLevel(memoryGuardLevelRow?.value),
       memoryUserMemoriesMaxItems: clampMemoryUserMemoriesMaxItems(Number(memoryUserMemoriesMaxItemsRow?.value)),
+      observabilityProviders,
+      observabilityOpik,
     };
   }
 
@@ -986,6 +1020,26 @@ export class CoworkStore {
           value = excluded.value,
           updated_at = excluded.updated_at
       `, [String(clampMemoryUserMemoriesMaxItems(config.memoryUserMemoriesMaxItems)), now]);
+    }
+
+    if (config.observabilityProviders !== undefined) {
+      this.db.run(`
+        INSERT INTO cowork_config (key, value, updated_at)
+        VALUES ('observabilityProviders', ?, ?)
+        ON CONFLICT(key) DO UPDATE SET
+          value = excluded.value,
+          updated_at = excluded.updated_at
+      `, [JSON.stringify(config.observabilityProviders), now]);
+    }
+
+    if (config.observabilityOpik !== undefined) {
+      this.db.run(`
+        INSERT INTO cowork_config (key, value, updated_at)
+        VALUES ('observabilityOpik', ?, ?)
+        ON CONFLICT(key) DO UPDATE SET
+          value = excluded.value,
+          updated_at = excluded.updated_at
+      `, [JSON.stringify(config.observabilityOpik), now]);
     }
 
     this.saveDb();

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -650,6 +650,35 @@ export class OpenClawConfigSync {
       };
     }
 
+    // Sync Opik observability plugin config
+    const opikEnabled = coworkConfig.observabilityProviders?.includes('opik');
+    const opikCfg = coworkConfig.observabilityOpik;
+    if (isBundledPluginAvailable('opik-openclaw')) {
+      if (!managedConfig.plugins) {
+        managedConfig.plugins = { entries: {} };
+      }
+      const plugins = managedConfig.plugins as Record<string, unknown>;
+      if (!plugins.entries) {
+        plugins.entries = {};
+      }
+      const entries = plugins.entries as Record<string, Record<string, unknown>>;
+      if (opikEnabled && opikCfg?.url) {
+        entries['opik-openclaw'] = {
+          enabled: true,
+          config: {
+            enabled: true,
+            apiUrl: opikCfg.url,
+            workspaceName: opikCfg.workspace || 'default',
+            ...(opikCfg.apiKey ? { apiKey: opikCfg.apiKey } : {}),
+            projectName: opikCfg.project || 'LobsterAI',
+            tags: ['lobsterai'],
+          },
+        };
+      } else {
+        entries['opik-openclaw'] = { enabled: false };
+      }
+    }
+
     // Sync Telegram OpenClaw channel config
     const tgConfig = this.getTelegramOpenClawConfig?.();
     if (tgConfig?.enabled && tgConfig.botToken) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2570,6 +2570,8 @@ if (!gotTheLock) {
     memoryLlmJudgeEnabled?: boolean;
     memoryGuardLevel?: 'strict' | 'standard' | 'relaxed';
     memoryUserMemoriesMaxItems?: number;
+    observabilityProviders?: ('opik')[];
+    observabilityOpik?: { url: string; workspace: string; apiKey: string; project: string };
   }) => {
     try {
       const normalizedExecutionMode =
@@ -2639,7 +2641,9 @@ if (!gotTheLock) {
 
       const shouldSyncOpenClawConfig = normalizedExecutionMode !== undefined
         || normalizedAgentEngine !== undefined
-        || (normalizedConfig.workingDirectory !== undefined && normalizedConfig.workingDirectory !== previousWorkingDir);
+        || (normalizedConfig.workingDirectory !== undefined && normalizedConfig.workingDirectory !== previousWorkingDir)
+        || config.observabilityProviders !== undefined
+        || config.observabilityOpik !== undefined;
       if (shouldSyncOpenClawConfig) {
         const syncResult = await syncOpenClawConfig({
           reason: 'cowork-config-change',

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -178,6 +178,8 @@ contextBridge.exposeInMainWorld('electron', {
       memoryLlmJudgeEnabled?: boolean;
       memoryGuardLevel?: 'strict' | 'standard' | 'relaxed';
       memoryUserMemoriesMaxItems?: number;
+      observabilityProviders?: string[];
+      observabilityOpik?: { url: string; workspace: string; apiKey: string; project: string };
     }) =>
       ipcRenderer.invoke('cowork:config:set', config),
     listMemoryEntries: (input: {

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -9,7 +9,7 @@ import { decryptSecret, encryptWithPassword, decryptWithPassword, EncryptedPaylo
 import { coworkService } from '../services/cowork';
 import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
 import ErrorMessage from './ErrorMessage';
-import { XMarkIcon, Cog6ToothIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, EnvelopeIcon, CpuChipIcon, InformationCircleIcon, UserCircleIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, Cog6ToothIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, EnvelopeIcon, CpuChipIcon, InformationCircleIcon, UserCircleIcon, ChartBarIcon } from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
 import PlusCircleIcon from './icons/PlusCircleIcon';
 import TrashIcon from './icons/TrashIcon';
@@ -24,6 +24,8 @@ import type {
   OpenClawEngineStatus,
   CoworkUserMemoryEntry,
   CoworkMemoryStats,
+  ObservabilityProvider,
+  ObservabilityOpikConfig,
 } from '../types/cowork';
 import IMSettings from './im/IMSettings';
 import { imService } from '../services/im';
@@ -47,7 +49,7 @@ import {
   CustomProviderIcon,
 } from './icons/providers';
 
-type TabType = 'general'| 'coworkAgentEngine' | 'model' | 'coworkMemory' | 'coworkAgent' | 'shortcuts' | 'im' | 'email' | 'about';
+type TabType = 'general'| 'coworkAgentEngine' | 'model' | 'coworkMemory' | 'coworkAgent' | 'observability' | 'shortcuts' | 'im' | 'email' | 'about';
 
 export type SettingsOpenOptions = {
   initialTab?: TabType;
@@ -590,14 +592,23 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
   const [bootstrapLoaded, setBootstrapLoaded] = useState<boolean>(false);
   const [openClawEngineStatus, setOpenClawEngineStatus] = useState<OpenClawEngineStatus | null>(null);
 
+  const [observabilityProviders, setObservabilityProviders] = useState<ObservabilityProvider[]>(coworkConfig.observabilityProviders ?? []);
+  const [opikConfig, setOpikConfig] = useState<ObservabilityOpikConfig>(coworkConfig.observabilityOpik ?? { url: '', workspace: '', apiKey: '', project: '' });
+  const [observabilitySaving, setObservabilitySaving] = useState(false);
+  const [observabilitySaved, setObservabilitySaved] = useState(false);
+
   useEffect(() => {
     setCoworkAgentEngine(coworkConfig.agentEngine || 'openclaw');
     setCoworkMemoryEnabled(coworkConfig.memoryEnabled ?? true);
     setCoworkMemoryLlmJudgeEnabled(coworkConfig.memoryLlmJudgeEnabled ?? false);
+    setObservabilityProviders(coworkConfig.observabilityProviders ?? []);
+    setOpikConfig(coworkConfig.observabilityOpik ?? { url: '', workspace: '', apiKey: '', project: '' });
   }, [
     coworkConfig.agentEngine,
     coworkConfig.memoryEnabled,
     coworkConfig.memoryLlmJudgeEnabled,
+    coworkConfig.observabilityProviders,
+    coworkConfig.observabilityOpik,
   ]);
 
   useEffect(() => () => {
@@ -2052,6 +2063,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
     { key: 'email',          label: i18nService.t('emailTab'),       icon: <EnvelopeIcon className="h-5 w-5" /> },
     { key: 'coworkMemory',   label: i18nService.t('coworkMemoryTitle'), icon: <BrainIcon className="h-5 w-5" /> },
     { key: 'coworkAgent',    label: i18nService.t('coworkAgentTab'),    icon: <UserCircleIcon className="h-5 w-5" /> },
+    { key: 'observability',  label: i18nService.t('observability'),    icon: <ChartBarIcon className="h-5 w-5" /> },
     { key: 'shortcuts',      label: i18nService.t('shortcuts'),      icon: <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-5 w-5"><rect x="2" y="4" width="20" height="14" rx="2" /><line x1="6" y1="8" x2="8" y2="8" /><line x1="10" y1="8" x2="12" y2="8" /><line x1="14" y1="8" x2="16" y2="8" /><line x1="6" y1="12" x2="8" y2="12" /><line x1="10" y1="12" x2="14" y2="12" /><line x1="16" y1="12" x2="18" y2="12" /><line x1="8" y1="15.5" x2="16" y2="15.5" /></svg> },
     { key: 'about',          label: i18nService.t('about'),          icon: <InformationCircleIcon className="h-5 w-5" /> },
   ], [language]);
@@ -3413,6 +3425,124 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
                 Copyright &copy; {new Date().getFullYear()} NetEase Youdao. All Rights Reserved.
               </p>
             </div>
+          </div>
+        );
+
+      case 'observability':
+        return (
+          <div className="space-y-6">
+            <p className="text-sm dark:text-claude-darkSecondaryText text-claude-secondaryText">
+              {i18nService.t('observabilityDescription')}
+            </p>
+
+            <div>
+              <h4 className="text-sm font-medium dark:text-claude-darkText text-claude-text mb-3">
+                {i18nService.t('observabilityProviders')}
+              </h4>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={observabilityProviders.includes('opik')}
+                  onChange={(e) => {
+                    setObservabilityProviders(
+                      e.target.checked
+                        ? [...observabilityProviders, 'opik']
+                        : observabilityProviders.filter(p => p !== 'opik')
+                    );
+                  }}
+                  className="rounded border-gray-300 dark:border-gray-600"
+                />
+                <span className="text-sm dark:text-claude-darkText text-claude-text">Opik</span>
+              </label>
+            </div>
+
+            {observabilityProviders.includes('opik') && (
+              <div className="space-y-4 pl-1 border-l-2 border-claude-border dark:border-claude-darkBorder ml-1 pl-4">
+                <div>
+                  <label className="block text-sm font-medium dark:text-claude-darkText text-claude-text mb-1">
+                    {i18nService.t('observabilityOpikUrl')}
+                  </label>
+                  <input
+                    type="text"
+                    value={opikConfig.url}
+                    onChange={(e) => setOpikConfig({ ...opikConfig, url: e.target.value })}
+                    placeholder={i18nService.t('observabilityOpikUrlPlaceholder')}
+                    className="w-full rounded-lg border border-claude-border dark:border-claude-darkBorder bg-white dark:bg-claude-darkBg px-3 py-2 text-sm dark:text-claude-darkText text-claude-text focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium dark:text-claude-darkText text-claude-text mb-1">
+                    {i18nService.t('observabilityOpikWorkspace')}
+                  </label>
+                  <input
+                    type="text"
+                    value={opikConfig.workspace}
+                    onChange={(e) => setOpikConfig({ ...opikConfig, workspace: e.target.value })}
+                    placeholder={i18nService.t('observabilityOpikWorkspacePlaceholder')}
+                    className="w-full rounded-lg border border-claude-border dark:border-claude-darkBorder bg-white dark:bg-claude-darkBg px-3 py-2 text-sm dark:text-claude-darkText text-claude-text focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium dark:text-claude-darkText text-claude-text mb-1">
+                    {i18nService.t('observabilityOpikApiKey')}
+                  </label>
+                  <input
+                    type="password"
+                    value={opikConfig.apiKey}
+                    onChange={(e) => setOpikConfig({ ...opikConfig, apiKey: e.target.value })}
+                    placeholder={i18nService.t('observabilityOpikApiKeyPlaceholder')}
+                    className="w-full rounded-lg border border-claude-border dark:border-claude-darkBorder bg-white dark:bg-claude-darkBg px-3 py-2 text-sm dark:text-claude-darkText text-claude-text focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium dark:text-claude-darkText text-claude-text mb-1">
+                    {i18nService.t('observabilityOpikProject')}
+                  </label>
+                  <input
+                    type="text"
+                    value={opikConfig.project}
+                    onChange={(e) => setOpikConfig({ ...opikConfig, project: e.target.value })}
+                    placeholder={i18nService.t('observabilityOpikProjectPlaceholder')}
+                    className="w-full rounded-lg border border-claude-border dark:border-claude-darkBorder bg-white dark:bg-claude-darkBg px-3 py-2 text-sm dark:text-claude-darkText text-claude-text focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+              </div>
+            )}
+
+            <button
+              onClick={async () => {
+                setObservabilitySaving(true);
+                setObservabilitySaved(false);
+                try {
+                  const ok = await coworkService.updateConfig({
+                    observabilityProviders,
+                    observabilityOpik: opikConfig,
+                  });
+                  if (ok) {
+                    setObservabilitySaved(true);
+                    setTimeout(() => setObservabilitySaved(false), 2000);
+                  } else {
+                    setError(i18nService.t('failedToSaveSettings'));
+                  }
+                } catch (err) {
+                  setError(err instanceof Error ? err.message : String(err));
+                } finally {
+                  setObservabilitySaving(false);
+                }
+              }}
+              disabled={observabilitySaving}
+              className={`px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors ${
+                observabilitySaved
+                  ? 'bg-green-600'
+                  : 'bg-blue-600 hover:bg-blue-700 disabled:opacity-50'
+              }`}
+            >
+              {observabilitySaving
+                ? i18nService.t('saving')
+                : observabilitySaved
+                  ? '✓'
+                  : i18nService.t('save')}
+            </button>
           </div>
         );
 

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1081,6 +1081,20 @@ const translations: Record<LanguageType, Record<string, string>> = {
     privacyDialogLinkText: '网易有道LobsterAI服务协议',
     privacyDialogAccept: '我已阅读并同意',
     privacyDialogReject: '拒绝',
+
+    // 可观测性
+    observability: '可观测性',
+    observabilityDescription: '启用可观测性平台以追踪 LLM 调用的 prompt、response、token 用量和耗时。',
+    observabilityProviders: '可观测性平台',
+    observabilityOpikUrl: 'Opik 服务地址',
+    observabilityOpikUrlPlaceholder: '例如 http://localhost:5173/api',
+    observabilityOpikWorkspace: '工作区',
+    observabilityOpikWorkspacePlaceholder: '默认 default',
+    observabilityOpikApiKey: 'API Key',
+    observabilityOpikApiKeyPlaceholder: '自部署可留空',
+    observabilityOpikProject: '项目名称',
+    observabilityOpikProjectPlaceholder: '默认 LobsterAI',
+    observabilityConfigSaved: '可观测性配置已保存',
   },
   en: {
     // Common
@@ -2157,6 +2171,20 @@ const translations: Record<LanguageType, Record<string, string>> = {
     privacyDialogLinkText: 'NetEase Youdao LobsterAI Terms of Service',
     privacyDialogAccept: 'I have read and agree',
     privacyDialogReject: 'Decline',
+
+    // Observability
+    observability: 'Observability',
+    observabilityDescription: 'Enable observability platforms to trace LLM calls including prompts, responses, token usage, and latency.',
+    observabilityProviders: 'Observability Platforms',
+    observabilityOpikUrl: 'Opik Server URL',
+    observabilityOpikUrlPlaceholder: 'e.g. http://localhost:5173/api',
+    observabilityOpikWorkspace: 'Workspace',
+    observabilityOpikWorkspacePlaceholder: 'Default: default',
+    observabilityOpikApiKey: 'API Key',
+    observabilityOpikApiKeyPlaceholder: 'Optional for self-hosted',
+    observabilityOpikProject: 'Project Name',
+    observabilityOpikProjectPlaceholder: 'Default: LobsterAI',
+    observabilityConfigSaved: 'Observability configuration saved',
   }
 };
 

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -55,6 +55,16 @@ export interface CoworkSession {
   updatedAt: number;
 }
 
+// Observability provider types
+export type ObservabilityProvider = 'opik';
+
+export interface ObservabilityOpikConfig {
+  url: string;
+  workspace: string;
+  apiKey: string;
+  project: string;
+}
+
 // Cowork configuration
 export interface CoworkConfig {
   workingDirectory: string;
@@ -66,6 +76,8 @@ export interface CoworkConfig {
   memoryLlmJudgeEnabled: boolean;
   memoryGuardLevel: 'strict' | 'standard' | 'relaxed';
   memoryUserMemoriesMaxItems: number;
+  observabilityProviders: ObservabilityProvider[];
+  observabilityOpik: ObservabilityOpikConfig;
 }
 
 export type CoworkConfigUpdate = Partial<Pick<
@@ -78,6 +90,8 @@ export type CoworkConfigUpdate = Partial<Pick<
   | 'memoryLlmJudgeEnabled'
   | 'memoryGuardLevel'
   | 'memoryUserMemoriesMaxItems'
+  | 'observabilityProviders'
+  | 'observabilityOpik'
 >>;
 
 export interface CoworkApiConfig {


### PR DESCRIPTION
## Summary

- Add an extensible **Observability** tab in Settings with multi-provider checkbox UI (Opik as the first provider, easy to add LangFuse/LangSmith in the future)
- Integrate [`@opik/opik-openclaw`](https://www.npmjs.com/package/@opik/opik-openclaw) v0.2.9 official plugin to capture full LLM traces (prompts, responses, tool calls, token usage, latency) in the OpenClaw gateway — **zero instrumentation in LobsterAI application code**
- Sync Opik configuration (URL, workspace, API key, project) from Settings UI to OpenClaw gateway config, with automatic gateway restart on config changes
- Add zh/en i18n translations for all observability UI strings

## Changes

| File | Description |
|------|-------------|
| `package.json` | Declare `opik-openclaw` in `openclaw.plugins` for automatic installation |
| `src/main/coworkStore.ts` | Add `ObservabilityProvider`, `ObservabilityOpikConfig` types; read/write observability config from SQLite |
| `src/main/libs/openclawConfigSync.ts` | Sync Opik plugin config (`apiUrl`, `workspaceName`, `apiKey`, `projectName`, `tags`) to gateway `plugins.entries['opik-openclaw']` |
| `src/main/main.ts` | Add observability config changes to `shouldSyncOpenClawConfig` trigger; extend IPC handler type |
| `src/main/preload.ts` | Extend `setConfig` IPC type signature with observability fields |
| `src/renderer/types/cowork.ts` | Add `ObservabilityProvider` and `ObservabilityOpikConfig` type definitions |
| `src/renderer/components/Settings.tsx` | Add Observability tab with Opik checkbox + config form (URL/Workspace/API Key/Project) |
| `src/renderer/services/i18n.ts` | Add 14 zh/en translation keys for observability UI |

## How it works

1. User configures Opik in **Settings → Observability** (URL, workspace, API key, project name)
2. On save → `coworkStore.setConfig()` persists to SQLite → triggers `openclawConfigSync`
3. Config sync writes `plugins.entries['opik-openclaw']` into OpenClaw gateway config
4. Gateway restarts → `@opik/opik-openclaw` plugin loads and hooks into the gateway's native tracing
5. All subsequent LLM calls are automatically traced and exported to Opik dashboard

## Screenshots

### Settings UI — Observability Tab
<img width="2060" height="994" alt="lobsterai-setting-opik" src="https://github.com/user-attachments/assets/335d3b0e-cac0-4d47-bec8-3f9cb7e518a2" />


### Chat with Agent
<img width="2082" height="710" alt="talk-with-agent" src="https://github.com/user-attachments/assets/1cec3cb5-fb52-4d83-a5d2-1c951311827a" />


### Opik Dashboard — Trace with Prompt Details
<img width="3040" height="1118" alt="opik-trace-prompt" src="https://github.com/user-attachments/assets/a7d9052b-7e0a-46e9-9b92-ca8be89b72ff" />


### Opik Dashboard — Tool Call Span
<img width="3068" height="1448" alt="opik-span-tool" src="https://github.com/user-attachments/assets/7a9a9596-3414-4d42-8dad-1da5e1de2f68" />


### Gateway Log — Opik Plugin Loaded
<img width="3134" height="506" alt="log-pure-text" src="https://github.com/user-attachments/assets/965da15a-8717-4338-b15d-52953d8da9fe" />


## Test plan

- [x] Settings > Observability tab displays correctly with Opik checkbox
- [x] Opik checkbox toggles config form visibility
- [x] Save button persists config to SQLite and shows success indicator
- [x] Config change triggers OpenClaw gateway restart
- [x] Gateway log shows `opik: exporting traces to project "..."` after restart
- [x] Send a message via Cowork and verify trace appears in Opik dashboard
- [x] TypeScript compilation passes (`tsc --project electron-tsconfig.json`)
- [x] Vite build passes for all 3 targets (renderer, main, preload)