### PR TITLE
feat(cowork): 新增消息删除功能，支持多选批量删除（参考豆包交互设计）

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -869,6 +869,21 @@ export class CoworkStore {
     this.saveDb();
   }
 
+  deleteMessage(sessionId: string, messageId: string): void {
+    this.db.run('DELETE FROM cowork_messages WHERE id = ? AND session_id = ?', [messageId, sessionId]);
+    this.saveDb();
+  }
+
+  deleteMessages(sessionId: string, messageIds: string[]): void {
+    if (messageIds.length === 0) return;
+    const placeholders = messageIds.map(() => '?').join(',');
+    this.db.run(
+      `DELETE FROM cowork_messages WHERE id IN (${placeholders}) AND session_id = ?`,
+      [...messageIds, sessionId]
+    );
+    this.saveDb();
+  }
+
   // Config operations
   getConfig(): CoworkConfig {
     interface ConfigRow {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2561,6 +2561,24 @@ if (!gotTheLock) {
     }
   });
 
+  ipcMain.handle('cowork:message:delete', async (_event, sessionId: string, messageId: string) => {
+    try {
+      getCoworkStore().deleteMessage(sessionId, messageId);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Failed to delete message' };
+    }
+  });
+
+  ipcMain.handle('cowork:message:deleteBatch', async (_event, sessionId: string, messageIds: string[]) => {
+    try {
+      getCoworkStore().deleteMessages(sessionId, messageIds);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Failed to batch delete messages' };
+    }
+  });
+
   ipcMain.handle('cowork:session:pin', async (_event, options: { sessionId: string; pinned: boolean }) => {
     try {
       const coworkStoreInstance = getCoworkStore();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -145,6 +145,10 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.invoke('cowork:session:delete', sessionId),
     deleteSessions: (sessionIds: string[]) =>
       ipcRenderer.invoke('cowork:session:deleteBatch', sessionIds),
+    deleteMessage: (sessionId: string, messageId: string) =>
+      ipcRenderer.invoke('cowork:message:delete', sessionId, messageId),
+    deleteMessages: (sessionId: string, messageIds: string[]) =>
+      ipcRenderer.invoke('cowork:message:deleteBatch', sessionId, messageIds),
     setSessionPinned: (options: { sessionId: string; pinned: boolean }) =>
       ipcRenderer.invoke('cowork:session:pin', options),
     renameSession: (options: { sessionId: string; title: string }) =>

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -16,6 +16,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { FolderIcon } from '@heroicons/react/24/solid';
 import { coworkService } from '../../services/cowork';
+import { expandMessageIdsForDeletion } from '../../utils/coworkDeleteUtils';
 import SidebarToggleIcon from '../icons/SidebarToggleIcon';
 import ComposeIcon from '../icons/ComposeIcon';
 import PuzzleIcon from '../icons/PuzzleIcon';
@@ -648,11 +649,10 @@ const TodoWriteInputView: React.FC<{ items: ParsedTodoItem[] }> = ({ items }) =>
             {item.status === 'completed' && <CheckIcon className="h-3 w-3 stroke-[2.5]" />}
           </span>
           <div className="min-w-0 flex-1">
-            <div className={`text-xs whitespace-pre-wrap break-words leading-5 ${
-              item.status === 'completed'
-                ? 'dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/80'
-                : 'dark:text-claude-darkText text-claude-text'
-            }`}>
+            <div className={`text-xs whitespace-pre-wrap break-words leading-5 ${item.status === 'completed'
+              ? 'dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/80'
+              : 'dark:text-claude-darkText text-claude-text'
+              }`}>
               {item.primaryText}
             </div>
           </div>
@@ -671,162 +671,158 @@ const ToolCallGroup: React.FC<{
   isLastInSequence = true,
   mapDisplayText,
 }) => {
-  const { toolUse, toolResult } = group;
-  const rawToolName = typeof toolUse.metadata?.toolName === 'string' ? toolUse.metadata.toolName : 'Tool';
-  const toolName = getToolDisplayName(rawToolName);
-  const toolInput = toolUse.metadata?.toolInput;
-  const isCronTool = isCronToolName(rawToolName);
-  const isTodoWriteTool = isTodoWriteToolName(rawToolName);
-  const todoItems = isTodoWriteTool ? parseTodoWriteItems(toolInput) : null;
-  const mapText = mapDisplayText ?? ((value: string) => value);
-  const toolInputDisplayRaw = formatToolInput(rawToolName, toolInput);
-  const toolInputDisplay = toolInputDisplayRaw ? mapText(toolInputDisplayRaw) : null;
-  const toolInputSummaryRaw = getToolInputSummary(rawToolName, toolInput) ?? toolInputDisplayRaw;
-  const toolInputSummary = toolInputSummaryRaw ? mapText(toolInputSummaryRaw) : null;
-  const toolResultDisplayRaw = toolResult ? getToolResultDisplay(toolResult) : '';
-  const toolResultDisplay = mapText(toolResultDisplayRaw);
-  const hasToolResultText = hasText(toolResultDisplay);
-  const isToolError = Boolean(toolResult?.metadata?.isError || toolResult?.metadata?.error);
-  const showNoDetailError = isToolError && !hasToolResultText;
-  const toolResultFallback = showNoDetailError ? i18nService.t('coworkToolNoErrorDetail') : '';
-  const displayToolResult = hasToolResultText ? toolResultDisplay : toolResultFallback;
-  const [isExpanded, setIsExpanded] = useState(false);
-  const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0;
-  const toolResultSummary = isCronTool && hasToolResultText
-    ? truncatePreview(toolResultDisplay.replace(/\s+/g, ' '))
-    : null;
+    const { toolUse, toolResult } = group;
+    const rawToolName = typeof toolUse.metadata?.toolName === 'string' ? toolUse.metadata.toolName : 'Tool';
+    const toolName = getToolDisplayName(rawToolName);
+    const toolInput = toolUse.metadata?.toolInput;
+    const isCronTool = isCronToolName(rawToolName);
+    const isTodoWriteTool = isTodoWriteToolName(rawToolName);
+    const todoItems = isTodoWriteTool ? parseTodoWriteItems(toolInput) : null;
+    const mapText = mapDisplayText ?? ((value: string) => value);
+    const toolInputDisplayRaw = formatToolInput(rawToolName, toolInput);
+    const toolInputDisplay = toolInputDisplayRaw ? mapText(toolInputDisplayRaw) : null;
+    const toolInputSummaryRaw = getToolInputSummary(rawToolName, toolInput) ?? toolInputDisplayRaw;
+    const toolInputSummary = toolInputSummaryRaw ? mapText(toolInputSummaryRaw) : null;
+    const toolResultDisplayRaw = toolResult ? getToolResultDisplay(toolResult) : '';
+    const toolResultDisplay = mapText(toolResultDisplayRaw);
+    const hasToolResultText = hasText(toolResultDisplay);
+    const isToolError = Boolean(toolResult?.metadata?.isError || toolResult?.metadata?.error);
+    const showNoDetailError = isToolError && !hasToolResultText;
+    const toolResultFallback = showNoDetailError ? i18nService.t('coworkToolNoErrorDetail') : '';
+    const displayToolResult = hasToolResultText ? toolResultDisplay : toolResultFallback;
+    const [isExpanded, setIsExpanded] = useState(false);
+    const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0;
+    const toolResultSummary = isCronTool && hasToolResultText
+      ? truncatePreview(toolResultDisplay.replace(/\s+/g, ' '))
+      : null;
 
-  // Check if this is a Bash-like tool that should show terminal style
-  const isBashTool = isBashLikeToolName(rawToolName);
+    // Check if this is a Bash-like tool that should show terminal style
+    const isBashTool = isBashLikeToolName(rawToolName);
 
-  return (
-    <div className="relative py-1">
-      {/* Vertical connecting line to next tool group */}
-      {!isLastInSequence && (
-        <div className="absolute left-[3.5px] top-[14px] bottom-[-8px] w-px dark:bg-claude-darkTextSecondary/30 bg-claude-textSecondary/30" />
-      )}
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-start gap-2 text-left group relative z-10"
-      >
-        <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
-          !toolResult
+    return (
+      <div className="relative py-1">
+        {/* Vertical connecting line to next tool group */}
+        {!isLastInSequence && (
+          <div className="absolute left-[3.5px] top-[14px] bottom-[-8px] w-px dark:bg-claude-darkTextSecondary/30 bg-claude-textSecondary/30" />
+        )}
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="w-full flex items-start gap-2 text-left group relative z-10"
+        >
+          <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${!toolResult
             ? 'bg-blue-500 animate-pulse'
             : isToolError
               ? 'bg-red-500'
               : 'bg-green-500'
-        }`} />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-              {toolName}
-            </span>
-            {toolInputSummary && (
-              <code className="text-xs dark:text-claude-darkTextSecondary/80 text-claude-textSecondary/80 font-mono truncate max-w-[400px]">
-                {toolInputSummary}
-              </code>
-            )}
-          </div>
-          {toolResult && !isTodoWriteTool && (hasToolResultText || showNoDetailError) && (
-            <div className={`text-xs mt-0.5 ${
-              hasToolResultText
+            }`} />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                {toolName}
+              </span>
+              {toolInputSummary && (
+                <code className="text-xs dark:text-claude-darkTextSecondary/80 text-claude-textSecondary/80 font-mono truncate max-w-[400px]">
+                  {toolInputSummary}
+                </code>
+              )}
+            </div>
+            {toolResult && !isTodoWriteTool && (hasToolResultText || showNoDetailError) && (
+              <div className={`text-xs mt-0.5 ${hasToolResultText
                 ? 'dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60'
                 : showNoDetailError
                   ? 'text-red-500/80'
                   : 'dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60'
-            }`}>
-              {hasToolResultText
-                ? (toolResultSummary ?? `${resultLineCount} ${resultLineCount === 1 ? 'line' : 'lines'} of output`)
-                : toolResultFallback}
-            </div>
-          )}
-          {!toolResult && (
-            <div className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-0.5">
-              {i18nService.t('coworkToolRunning')}
-            </div>
-          )}
-        </div>
-      </button>
-      {isExpanded && (
-        <div className="ml-4 mt-2">
-          {isBashTool ? (
-            // Terminal-style display for Bash commands
-            <div className="rounded-lg overflow-hidden border dark:border-claude-darkBorder border-claude-border">
-              {/* Terminal header */}
-              <div className="flex items-center gap-1.5 px-3 py-1.5 dark:bg-claude-darkSurface bg-claude-surfaceInset">
-                <div className="w-2.5 h-2.5 rounded-full bg-red-500" />
-                <div className="w-2.5 h-2.5 rounded-full bg-yellow-500" />
-                <div className="w-2.5 h-2.5 rounded-full bg-green-500" />
-                <span className="ml-2 text-[10px] dark:text-claude-darkTextSecondary text-claude-textSecondary font-medium">Terminal</span>
+                }`}>
+                {hasToolResultText
+                  ? (toolResultSummary ?? `${resultLineCount} ${resultLineCount === 1 ? 'line' : 'lines'} of output`)
+                  : toolResultFallback}
               </div>
-              {/* Terminal content */}
-              <div className="dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset px-3 py-3 max-h-72 overflow-y-auto font-mono text-xs">
-                {toolInputDisplay && (
-                  <div className="dark:text-claude-darkText text-claude-text">
-                    <span className="text-claude-accent select-none">$ </span>
-                    <span className="whitespace-pre-wrap break-words">{toolInputDisplay}</span>
-                  </div>
-                )}
-                {toolResult && (hasToolResultText || showNoDetailError) && (
-                  <div className={`mt-1.5 whitespace-pre-wrap break-words ${
-                    isToolError
+            )}
+            {!toolResult && (
+              <div className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-0.5">
+                {i18nService.t('coworkToolRunning')}
+              </div>
+            )}
+          </div>
+        </button>
+        {isExpanded && (
+          <div className="ml-4 mt-2">
+            {isBashTool ? (
+              // Terminal-style display for Bash commands
+              <div className="rounded-lg overflow-hidden border dark:border-claude-darkBorder border-claude-border">
+                {/* Terminal header */}
+                <div className="flex items-center gap-1.5 px-3 py-1.5 dark:bg-claude-darkSurface bg-claude-surfaceInset">
+                  <div className="w-2.5 h-2.5 rounded-full bg-red-500" />
+                  <div className="w-2.5 h-2.5 rounded-full bg-yellow-500" />
+                  <div className="w-2.5 h-2.5 rounded-full bg-green-500" />
+                  <span className="ml-2 text-[10px] dark:text-claude-darkTextSecondary text-claude-textSecondary font-medium">Terminal</span>
+                </div>
+                {/* Terminal content */}
+                <div className="dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset px-3 py-3 max-h-72 overflow-y-auto font-mono text-xs">
+                  {toolInputDisplay && (
+                    <div className="dark:text-claude-darkText text-claude-text">
+                      <span className="text-claude-accent select-none">$ </span>
+                      <span className="whitespace-pre-wrap break-words">{toolInputDisplay}</span>
+                    </div>
+                  )}
+                  {toolResult && (hasToolResultText || showNoDetailError) && (
+                    <div className={`mt-1.5 whitespace-pre-wrap break-words ${isToolError
                       ? 'text-red-400'
                       : hasToolResultText
                         ? 'dark:text-claude-darkTextSecondary text-claude-textSecondary'
                         : 'dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/70 italic'
-                  }`}>
-                    {displayToolResult}
-                  </div>
-                )}
-                {!toolResult && (
-                  <div className="dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-1.5 italic">
-                    {i18nService.t('coworkToolRunning')}
-                  </div>
-                )}
-              </div>
-            </div>
-          ) : isTodoWriteTool && todoItems ? (
-            <TodoWriteInputView items={todoItems} />
-          ) : (
-            // Standard display for other tools with input/output labels
-            <div className="space-y-2">
-              {toolInputDisplay && (
-                <div>
-                  <div className="text-[10px] font-medium dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/70 uppercase tracking-wider mb-1">
-                    {i18nService.t('coworkToolInput')}
-                  </div>
-                  <div className="max-h-48 overflow-y-auto">
-                    <pre className="text-xs dark:text-claude-darkText text-claude-text whitespace-pre-wrap break-words font-mono">
-                      {toolInputDisplay}
-                    </pre>
-                  </div>
+                      }`}>
+                      {displayToolResult}
+                    </div>
+                  )}
+                  {!toolResult && (
+                    <div className="dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-1.5 italic">
+                      {i18nService.t('coworkToolRunning')}
+                    </div>
+                  )}
                 </div>
-              )}
-              {toolResult && (hasToolResultText || showNoDetailError) && (
-                <div>
-                  <div className="text-[10px] font-medium dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/70 uppercase tracking-wider mb-1">
-                    {i18nService.t('coworkToolResult')}
+              </div>
+            ) : isTodoWriteTool && todoItems ? (
+              <TodoWriteInputView items={todoItems} />
+            ) : (
+              // Standard display for other tools with input/output labels
+              <div className="space-y-2">
+                {toolInputDisplay && (
+                  <div>
+                    <div className="text-[10px] font-medium dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/70 uppercase tracking-wider mb-1">
+                      {i18nService.t('coworkToolInput')}
+                    </div>
+                    <div className="max-h-48 overflow-y-auto">
+                      <pre className="text-xs dark:text-claude-darkText text-claude-text whitespace-pre-wrap break-words font-mono">
+                        {toolInputDisplay}
+                      </pre>
+                    </div>
                   </div>
-                  <div className="max-h-64 overflow-y-auto">
-                    <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${
-                      isToolError
+                )}
+                {toolResult && (hasToolResultText || showNoDetailError) && (
+                  <div>
+                    <div className="text-[10px] font-medium dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/70 uppercase tracking-wider mb-1">
+                      {i18nService.t('coworkToolResult')}
+                    </div>
+                    <div className="max-h-64 overflow-y-auto">
+                      <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${isToolError
                         ? 'text-red-500'
                         : hasToolResultText
                           ? 'dark:text-claude-darkText text-claude-text'
                           : 'dark:text-claude-darkTextSecondary text-claude-textSecondary italic'
-                    }`}>
-                      {displayToolResult}
-                    </pre>
+                        }`}>
+                        {displayToolResult}
+                      </pre>
+                    </div>
                   </div>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
 
 // Copy button component
 const CopyButton: React.FC<{
@@ -849,9 +845,8 @@ const CopyButton: React.FC<{
   return (
     <button
       onClick={handleCopy}
-      className={`p-1.5 rounded-md dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-all duration-200 ${
-        visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
-      }`}
+      className={`p-1.5 rounded-md dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-all duration-200 ${visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
       title={i18nService.t('copyToClipboard')}
     >
       {copied ? (
@@ -892,7 +887,53 @@ const CopyButton: React.FC<{
   );
 };
 
-export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[] }> = React.memo(({ message, skills }) => {
+// Delete button component
+const DeleteButton: React.FC<{
+  visible: boolean;
+  onDelete: (e: React.MouseEvent) => void;
+}> = ({ visible, onDelete }) => {
+  return (
+    <button
+      onClick={onDelete}
+      className={`p-1.5 rounded-md dark:hover:bg-red-500/20 hover:bg-red-100 transition-all duration-200 ${visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+      title={i18nService.t('deleteMessage')}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="w-4 h-4 text-red-500"
+        aria-hidden="true"
+      >
+        <polyline points="3 6 5 6 21 6"></polyline>
+        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+      </svg>
+    </button>
+  );
+};
+
+export const UserMessageItem: React.FC<{
+  message: CoworkMessage;
+  skills: Skill[];
+  isMultiSelectMode?: boolean;
+  isSelected?: boolean;
+  onToggleSelect?: (messageId: string) => void;
+  onDelete?: (messageId: string) => void;
+}> = React.memo(({
+  message,
+  skills,
+  isMultiSelectMode = false,
+  isSelected = false,
+  onToggleSelect,
+  onDelete,
+}) => {
   const [isHovered, setIsHovered] = useState(false);
   const [expandedImage, setExpandedImage] = useState<string | null>(null);
 
@@ -905,43 +946,72 @@ export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[]
   // Get image attachments from metadata
   const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ?? []) as CoworkImageAttachment[];
 
+  const handleClick = () => {
+    if (isMultiSelectMode && onToggleSelect) {
+      onToggleSelect(message.id);
+    }
+  };
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onDelete) {
+      onDelete(message.id);
+    }
+  };
+
   return (
     <div
-      className="py-2 px-4"
+      className={`py-2 px-4 ${isMultiSelectMode && isSelected ? 'dark:bg-claude-accent/15 bg-claude-accent/10' : ''}`}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      onClick={handleClick}
     >
       <div className="max-w-3xl mx-auto">
-        <div className="pl-4 sm:pl-8 md:pl-12">
-          <div className="flex items-start gap-3 flex-row-reverse">
-            <div className="w-full min-w-0 flex flex-col items-end">
-              <div className="w-fit max-w-[42rem] rounded-2xl px-4 py-2.5 dark:bg-claude-darkSurface bg-claude-surface dark:text-claude-darkText text-claude-text shadow-subtle">
-                {message.content?.trim() && (
-                  <MarkdownContent
-                    content={message.content}
-                    className="max-w-none whitespace-pre-wrap break-words"
-                  />
-                )}
-                {imageAttachments.length > 0 && (
-                  <div className={`flex flex-wrap gap-2 ${message.content?.trim() ? 'mt-2' : ''}`}>
-                    {imageAttachments.map((img, idx) => (
-                      <div key={idx} className="relative group">
-                        <img
-                          src={`data:${img.mimeType};base64,${img.base64Data}`}
-                          alt={img.name}
-                          className="max-h-48 max-w-[16rem] rounded-lg object-contain cursor-pointer border dark:border-claude-darkBorder/50 border-claude-border/50 hover:border-claude-accent/50 transition-colors"
-                          title={img.name}
-                          onClick={() => setExpandedImage(`data:${img.mimeType};base64,${img.base64Data}`)}
-                        />
-                        <div className="absolute bottom-1 left-1 right-1 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/50 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity truncate pointer-events-none">
-                          <PhotoIcon className="h-3 w-3 flex-shrink-0" />
-                          <span className="truncate">{img.name}</span>
-                        </div>
+        {/* Row: checkbox on left, bubble on right */}
+        <div className="flex items-start gap-3">
+          {/* Checkbox at far left */}
+          {isMultiSelectMode && (
+            <div
+              className={`w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 mt-2 transition-colors ${isSelected ? 'bg-claude-accent border-claude-accent' : 'border-[var(--icon-secondary)]'
+                }`}
+            >
+              {isSelected && (
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" className="w-3 h-3">
+                  <polyline points="20 6 9 17 4 12"></polyline>
+                </svg>
+              )}
+            </div>
+          )}
+          {/* Right side: bubble + buttons stacked */}
+          <div className="flex-1 min-w-0 flex flex-col items-end">
+            <div className="w-fit max-w-[42rem] rounded-2xl px-4 py-2.5 dark:bg-claude-darkSurface bg-claude-surface dark:text-claude-darkText text-claude-text shadow-subtle">
+              {message.content?.trim() && (
+                <MarkdownContent
+                  content={message.content}
+                  className="max-w-none whitespace-pre-wrap break-words"
+                />
+              )}
+              {imageAttachments.length > 0 && (
+                <div className={`flex flex-wrap gap-2 ${message.content?.trim() ? 'mt-2' : ''}`}>
+                  {imageAttachments.map((img, idx) => (
+                    <div key={idx} className="relative group">
+                      <img
+                        src={`data:${img.mimeType};base64,${img.base64Data}`}
+                        alt={img.name}
+                        className="max-h-48 max-w-[16rem] rounded-lg object-contain cursor-pointer border dark:border-claude-darkBorder/50 border-claude-border/50 hover:border-claude-accent/50 transition-colors"
+                        title={img.name}
+                        onClick={() => setExpandedImage(`data:${img.mimeType};base64,${img.base64Data}`)}
+                      />
+                      <div className="absolute bottom-1 left-1 right-1 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/50 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity truncate pointer-events-none">
+                        <PhotoIcon className="h-3 w-3 flex-shrink-0" />
+                        <span className="truncate">{img.name}</span>
                       </div>
-                    ))}
-                  </div>
-                )}
-              </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+            {!isMultiSelectMode && (
               <div className="flex items-center justify-end gap-1.5 mt-1">
                 {messageSkills.map(skill => (
                   <div
@@ -955,16 +1025,13 @@ export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[]
                     </span>
                   </div>
                 ))}
-                <CopyButton
-                  content={message.content}
-                  visible={isHovered}
-                />
+                <CopyButton content={message.content} visible={isHovered} />
+                <DeleteButton visible={isHovered} onDelete={handleDelete} />
               </div>
-            </div>
+            )}
           </div>
         </div>
       </div>
-      {/* Image lightbox overlay */}
       {expandedImage && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 cursor-pointer"
@@ -987,39 +1054,48 @@ const AssistantMessageItem: React.FC<{
   resolveLocalFilePath?: (href: string, text: string) => string | null;
   mapDisplayText?: (value: string) => string;
   showCopyButton?: boolean;
+  isMultiSelectMode?: boolean;
+  onDelete?: (messageId: string) => void;
 }> = ({
   message,
   resolveLocalFilePath,
   mapDisplayText,
   showCopyButton = false,
+  isMultiSelectMode = false,
+  onDelete,
 }) => {
-  const [isHovered, setIsHovered] = useState(false);
-  const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content;
+    const [isHovered, setIsHovered] = useState(false);
+    const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content;
 
-  return (
-    <div
-      className="relative"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <div className="dark:text-claude-darkText text-claude-text">
-        <MarkdownContent
-          content={displayContent}
-          className="prose dark:prose-invert max-w-none"
-          resolveLocalFilePath={resolveLocalFilePath}
-        />
-      </div>
-      {showCopyButton && (
-        <div className="flex items-center gap-1.5 mt-1">
-          <CopyButton
+    const handleDelete = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onDelete) {
+        onDelete(message.id);
+      }
+    };
+
+    return (
+      <div
+        className="relative"
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <div className="dark:text-claude-darkText text-claude-text">
+          <MarkdownContent
             content={displayContent}
-            visible={isHovered}
+            className="prose dark:prose-invert max-w-none"
+            resolveLocalFilePath={resolveLocalFilePath}
           />
         </div>
-      )}
-    </div>
-  );
-};
+        {(showCopyButton || onDelete) && !isMultiSelectMode && (
+          <div className="flex items-center gap-1.5 mt-1">
+            {showCopyButton && <CopyButton content={displayContent} visible={isHovered} />}
+            {onDelete && <DeleteButton visible={isHovered} onDelete={handleDelete} />}
+          </div>
+        )}
+      </div>
+    );
+  };
 
 // Streaming activity bar shown between messages and input
 const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ messages }) => {
@@ -1096,9 +1172,8 @@ const ThinkingBlock: React.FC<{
         className="w-full flex items-center gap-2 px-3 py-2 text-left dark:hover:bg-claude-darkSurfaceHover/50 hover:bg-claude-surfaceHover/50 transition-colors"
       >
         <ChevronRightIcon
-          className={`h-3.5 w-3.5 dark:text-claude-darkTextSecondary text-claude-textSecondary flex-shrink-0 transition-transform duration-200 ${
-            isExpanded ? 'rotate-90' : ''
-          }`}
+          className={`h-3.5 w-3.5 dark:text-claude-darkTextSecondary text-claude-textSecondary flex-shrink-0 transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''
+            }`}
         />
         <span className="text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
           {i18nService.t('reasoning')}
@@ -1124,157 +1199,195 @@ export const AssistantTurnBlock: React.FC<{
   mapDisplayText?: (value: string) => string;
   showTypingIndicator?: boolean;
   showCopyButtons?: boolean;
+  isMultiSelectMode?: boolean;
+  selectedMessageIds?: Set<string>;
+  onToggleSelect?: (messageId: string) => void;
+  onDeleteMessage?: (messageId: string) => void;
 }> = ({
   turn,
   resolveLocalFilePath,
   mapDisplayText,
   showTypingIndicator = false,
   showCopyButtons = true,
+  isMultiSelectMode = false,
+  selectedMessageIds = new Set(),
+  onToggleSelect,
+  onDeleteMessage,
 }) => {
-  const visibleAssistantItems = getVisibleAssistantItems(turn.assistantItems);
+    const visibleAssistantItems = getVisibleAssistantItems(turn.assistantItems);
 
-  const renderSystemMessage = (message: CoworkMessage) => {
-    const rawContent = hasText(message.content)
-      ? message.content
-      : (typeof message.metadata?.error === 'string' ? message.metadata.error : '');
-    const normalizedContent = getScheduledReminderDisplayText(rawContent) ?? rawContent;
-    const content = mapDisplayText ? mapDisplayText(normalizedContent) : normalizedContent;
-    if (!content.trim()) return null;
+    const renderSystemMessage = (message: CoworkMessage) => {
+      const rawContent = hasText(message.content)
+        ? message.content
+        : (typeof message.metadata?.error === 'string' ? message.metadata.error : '');
+      const normalizedContent = getScheduledReminderDisplayText(rawContent) ?? rawContent;
+      const content = mapDisplayText ? mapDisplayText(normalizedContent) : normalizedContent;
+      if (!content.trim()) return null;
 
-    return (
-      <div className="rounded-lg border dark:border-claude-darkBorder/70 border-claude-border/70 dark:bg-claude-darkBg/40 bg-claude-bg/60 px-3 py-2">
-        <div className="flex items-start gap-2">
-          <InformationCircleIcon className="h-4 w-4 mt-0.5 dark:text-claude-darkTextSecondary text-claude-textSecondary flex-shrink-0" />
-          <div className="text-xs whitespace-pre-wrap dark:text-claude-darkTextSecondary text-claude-textSecondary">
-            {content}
+      return (
+        <div className="rounded-lg border dark:border-claude-darkBorder/70 border-claude-border/70 dark:bg-claude-darkBg/40 bg-claude-bg/60 px-3 py-2">
+          <div className="flex items-start gap-2">
+            <InformationCircleIcon className="h-4 w-4 mt-0.5 dark:text-claude-darkTextSecondary text-claude-textSecondary flex-shrink-0" />
+            <div className="text-xs whitespace-pre-wrap dark:text-claude-darkTextSecondary text-claude-textSecondary">
+              {content}
+            </div>
           </div>
         </div>
-      </div>
-    );
-  };
+      );
+    };
 
-  const renderOrphanToolResult = (message: CoworkMessage) => {
-    const toolResultDisplayRaw = getToolResultDisplay(message);
-    const toolResultDisplay = mapDisplayText ? mapDisplayText(toolResultDisplayRaw) : toolResultDisplayRaw;
-    const isToolError = Boolean(message.metadata?.isError || message.metadata?.error);
-    const hasToolResultText = hasText(toolResultDisplay);
-    const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0;
-    const showNoDetailError = isToolError && !hasToolResultText;
-    const fallbackText = showNoDetailError ? i18nService.t('coworkToolNoErrorDetail') : '';
-    const displayText = hasToolResultText ? toolResultDisplay : fallbackText;
-    return (
-      <div className="py-1">
-        <div className="flex items-start gap-2">
-          <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
-            isToolError ? 'bg-red-500' : 'bg-claude-darkTextSecondary/50'
-          }`} />
-          <div className="flex-1 min-w-0">
-            <div className="text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-              {i18nService.t('coworkToolResult')}
-            </div>
-            {resultLineCount > 0 && (
-              <div className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-0.5">
-                {resultLineCount} {resultLineCount === 1 ? 'line' : 'lines'} of output
+    const renderOrphanToolResult = (message: CoworkMessage) => {
+      const toolResultDisplayRaw = getToolResultDisplay(message);
+      const toolResultDisplay = mapDisplayText ? mapDisplayText(toolResultDisplayRaw) : toolResultDisplayRaw;
+      const isToolError = Boolean(message.metadata?.isError || message.metadata?.error);
+      const hasToolResultText = hasText(toolResultDisplay);
+      const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0;
+      const showNoDetailError = isToolError && !hasToolResultText;
+      const fallbackText = showNoDetailError ? i18nService.t('coworkToolNoErrorDetail') : '';
+      const displayText = hasToolResultText ? toolResultDisplay : fallbackText;
+      return (
+        <div className="py-1">
+          <div className="flex items-start gap-2">
+            <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${isToolError ? 'bg-red-500' : 'bg-claude-darkTextSecondary/50'
+              }`} />
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                {i18nService.t('coworkToolResult')}
               </div>
-            )}
-            {resultLineCount === 0 && showNoDetailError && (
-              <div className={`text-xs mt-0.5 ${
-                isToolError
+              {resultLineCount > 0 && (
+                <div className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-0.5">
+                  {resultLineCount} {resultLineCount === 1 ? 'line' : 'lines'} of output
+                </div>
+              )}
+              {resultLineCount === 0 && showNoDetailError && (
+                <div className={`text-xs mt-0.5 ${isToolError
                   ? 'text-red-500/80'
                   : 'dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60'
-              }`}>
-                {fallbackText}
-              </div>
-            )}
-            {(hasToolResultText || showNoDetailError) && (
-              <div className="mt-2 px-3 py-2 rounded-lg dark:bg-claude-darkSurface/50 bg-claude-surface/50 max-h-64 overflow-y-auto">
-                <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${
-                  isToolError
+                  }`}>
+                  {fallbackText}
+                </div>
+              )}
+              {(hasToolResultText || showNoDetailError) && (
+                <div className="mt-2 px-3 py-2 rounded-lg dark:bg-claude-darkSurface/50 bg-claude-surface/50 max-h-64 overflow-y-auto">
+                  <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${isToolError
                     ? 'text-red-500'
                     : hasToolResultText
                       ? 'dark:text-claude-darkText text-claude-text'
                       : 'dark:text-claude-darkTextSecondary text-claude-textSecondary italic'
-                }`}>
-                  {displayText}
-                </pre>
+                    }`}>
+                    {displayText}
+                  </pre>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      );
+    };
+
+    // Check if any assistant message in this turn is selected
+    // Note: selectedMessageIds only contains user + assistant IDs for display purposes
+    const hasSelectedAssistantMessage = isMultiSelectMode && visibleAssistantItems.some((item) => {
+      if (item.type === 'assistant') {
+        return selectedMessageIds.has(item.message.id);
+      }
+      return false;
+    });
+
+    return (
+      <div className={`px-4 py-2 ${hasSelectedAssistantMessage ? 'dark:bg-claude-accent/15 bg-claude-accent/10' : ''}`}>
+        <div className="max-w-3xl mx-auto">
+          <div className="flex items-start gap-3">
+            {/* Checkbox for multi-select mode */}
+            {isMultiSelectMode && visibleAssistantItems.some(item => item.type === 'assistant') && (
+              <div className="flex flex-col gap-3 py-3">
+                {visibleAssistantItems.map((item) => {
+                  if (item.type !== 'assistant') return null;
+                  const isSelected = selectedMessageIds.has(item.message.id);
+                  return (
+                    <div
+                      key={item.message.id}
+                      className={`w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 transition-colors ${isSelected ? 'bg-claude-accent border-claude-accent' : 'border-[var(--icon-secondary)]'}`}
+                      onClick={() => onToggleSelect?.(item.message.id)}
+                    >
+                      {isSelected && (
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" className="w-3 h-3">
+                          <polyline points="20 6 9 17 4 12"></polyline>
+                        </svg>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             )}
+            <div className="flex-1 min-w-0 px-4 py-3 space-y-3">
+              {visibleAssistantItems.map((item, index) => {
+                if (item.type === 'assistant') {
+                  if (item.message.metadata?.isThinking) {
+                    return (
+                      <ThinkingBlock
+                        key={item.message.id}
+                        message={item.message}
+                        mapDisplayText={mapDisplayText}
+                      />
+                    );
+                  }
+                  // Check if there are any tool_group items after this assistant message
+                  const hasToolGroupAfter = visibleAssistantItems
+                    .slice(index + 1)
+                    .some(laterItem => laterItem.type === 'tool_group');
+
+                  return (
+                    <AssistantMessageItem
+                      key={item.message.id}
+                      message={item.message}
+                      resolveLocalFilePath={resolveLocalFilePath}
+                      mapDisplayText={mapDisplayText}
+                      showCopyButton={showCopyButtons && !hasToolGroupAfter}
+                      isMultiSelectMode={isMultiSelectMode}
+                      onDelete={onDeleteMessage}
+                    />
+                  );
+                }
+
+                if (item.type === 'tool_group') {
+                  const nextItem = visibleAssistantItems[index + 1];
+                  const isLastInSequence = !nextItem || nextItem.type !== 'tool_group';
+                  return (
+                    <ToolCallGroup
+                      key={`tool-${item.group.toolUse.id}`}
+                      group={item.group}
+                      isLastInSequence={isLastInSequence}
+                      mapDisplayText={mapDisplayText}
+                    />
+                  );
+                }
+
+                if (item.type === 'system') {
+                  const systemMessage = renderSystemMessage(item.message);
+                  if (!systemMessage) {
+                    return null;
+                  }
+                  return (
+                    <div key={item.message.id}>
+                      {systemMessage}
+                    </div>
+                  );
+                }
+
+                return (
+                  <div key={item.message.id}>
+                    {renderOrphanToolResult(item.message)}
+                  </div>
+                );
+              })}
+              {showTypingIndicator && <TypingDots />}
+            </div>
           </div>
         </div>
       </div>
     );
   };
-
-  return (
-    <div className="px-4 py-2">
-      <div className="max-w-3xl mx-auto">
-        <div className="flex items-start gap-3">
-          <div className="flex-1 min-w-0 px-4 py-3 space-y-3">
-            {visibleAssistantItems.map((item, index) => {
-              if (item.type === 'assistant') {
-                if (item.message.metadata?.isThinking) {
-                  return (
-                    <ThinkingBlock
-                      key={item.message.id}
-                      message={item.message}
-                      mapDisplayText={mapDisplayText}
-                    />
-                  );
-                }
-                // Check if there are any tool_group items after this assistant message
-                const hasToolGroupAfter = visibleAssistantItems
-                  .slice(index + 1)
-                  .some(laterItem => laterItem.type === 'tool_group');
-
-                return (
-                  <AssistantMessageItem
-                    key={item.message.id}
-                    message={item.message}
-                    resolveLocalFilePath={resolveLocalFilePath}
-                    mapDisplayText={mapDisplayText}
-                    showCopyButton={showCopyButtons && !hasToolGroupAfter}
-                  />
-                );
-              }
-
-              if (item.type === 'tool_group') {
-                const nextItem = visibleAssistantItems[index + 1];
-                const isLastInSequence = !nextItem || nextItem.type !== 'tool_group';
-                return (
-                  <ToolCallGroup
-                    key={`tool-${item.group.toolUse.id}`}
-                    group={item.group}
-                    isLastInSequence={isLastInSequence}
-                    mapDisplayText={mapDisplayText}
-                  />
-                );
-              }
-
-              if (item.type === 'system') {
-                const systemMessage = renderSystemMessage(item.message);
-                if (!systemMessage) {
-                  return null;
-                }
-                return (
-                  <div key={item.message.id}>
-                    {systemMessage}
-                  </div>
-                );
-              }
-
-              return (
-                <div key={item.message.id}>
-                  {renderOrphanToolResult(item.message)}
-                </div>
-              );
-            })}
-            {showTypingIndicator && <TypingDots />}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
 
 const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   onManageSkills,
@@ -1320,6 +1433,12 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const renameInputRef = useRef<HTMLInputElement>(null);
   const ignoreNextBlurRef = useRef(false);
 
+  // Multi-select states
+  const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
+  const [selectedMessageIds, setSelectedMessageIds] = useState<Set<string>>(new Set());
+  const [pendingDeleteMessageIds, setPendingDeleteMessageIds] = useState<string[]>([]);
+  const [showDeleteMessageConfirm, setShowDeleteMessageConfirm] = useState(false);
+
   // Reset rename value when session changes
   useEffect(() => {
     if (!isRenaming && currentSession) {
@@ -1330,6 +1449,12 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
   useEffect(() => {
     setShouldAutoScroll(true);
+  }, [currentSession?.id]);
+
+  // Reset multi-select when session changes
+  useEffect(() => {
+    setIsMultiSelectMode(false);
+    setSelectedMessageIds(new Set());
   }, [currentSession?.id]);
 
   // Focus rename input when entering rename mode
@@ -1662,6 +1787,32 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     setShowConfirmDelete(false);
   };
 
+  const handleCancelMultiSelect = () => {
+    setIsMultiSelectMode(false);
+    setSelectedMessageIds(new Set());
+  };
+
+  const handleBatchDeleteClick = () => {
+    if (selectedMessageIds.size === 0) return;
+    setPendingDeleteMessageIds(Array.from(selectedMessageIds));
+    setShowDeleteMessageConfirm(true);
+  };
+
+  const handleConfirmDeleteMessages = async () => {
+    if (!currentSession || pendingDeleteMessageIds.length === 0) return;
+
+    const allIdsToDelete = expandMessageIdsForDeletion(pendingDeleteMessageIds, turns);
+    await coworkService.deleteMessages(currentSession.id, allIdsToDelete);
+    setShowDeleteMessageConfirm(false);
+    setPendingDeleteMessageIds([]);
+    handleCancelMultiSelect();
+  };
+
+  const handleCancelDeleteMessage = () => {
+    setShowDeleteMessageConfirm(false);
+    setPendingDeleteMessageIds([]);
+  };
+
   const handleMessagesScroll = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
@@ -1779,6 +1930,89 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const displayItems = useMemo(() => messages ? buildDisplayItems(messages) : [], [messages]);
   const turns = useMemo(() => buildConversationTurns(displayItems), [displayItems]);
 
+  // Helper function to collect visible message IDs (user + assistant only)
+  // Used for UI selection display
+  const collectVisibleMessageIds = useCallback((turn: ConversationTurn): string[] => {
+    return turn.assistantItems
+      .filter(item => item.type === 'assistant')
+      .map(item => item.message.id);
+  }, []);
+
+  // Multi-select handlers (must be after turns definition)
+  const handleToggleSelect = useCallback((messageId: string) => {
+    // Find if this is a user message and collect related IDs
+    let isUserMessage = false;
+    let pairedVisibleIds: string[] = [];
+    for (const turn of turns) {
+      if (turn.userMessage?.id === messageId) {
+        isUserMessage = true;
+        // Collect visible message IDs for UI display (user + assistant only)
+        pairedVisibleIds = collectVisibleMessageIds(turn);
+        break;
+      }
+    }
+
+    if (!isMultiSelectMode) {
+      // First selection - enter multi-select mode
+      const initialIds = new Set([messageId]);
+      // If selecting a user message, also select paired messages
+      if (isUserMessage) {
+        pairedVisibleIds.forEach(id => initialIds.add(id));
+      }
+      setIsMultiSelectMode(true);
+      setSelectedMessageIds(initialIds);
+    } else {
+      // Compute next state directly to avoid calling setState inside a state updater (React anti-pattern)
+      const next = new Set(selectedMessageIds);
+      const wasSelected = selectedMessageIds.has(messageId);
+
+      if (wasSelected) {
+        // Unselecting - just remove this message (no cascade)
+        next.delete(messageId);
+      } else {
+        // Selecting - add this message
+        next.add(messageId);
+        // If selecting a user message, also select paired messages
+        if (isUserMessage) {
+          pairedVisibleIds.forEach(id => next.add(id));
+        }
+      }
+      setSelectedMessageIds(next);
+      if (next.size === 0) {
+        setIsMultiSelectMode(false);
+      }
+    }
+  }, [isMultiSelectMode, selectedMessageIds, turns, collectVisibleMessageIds]);
+
+  // Click delete button → enter multi-select with paired messages pre-selected
+  const handleDeleteMessage = useCallback((messageId: string) => {
+    const pairedVisibleIds: string[] = [messageId];
+    let found = false;
+    for (const turn of turns) {
+      if (found) break;
+      if (turn.userMessage?.id === messageId) {
+        // Collect visible message IDs for UI display
+        pairedVisibleIds.push(...collectVisibleMessageIds(turn));
+        found = true;
+        break;
+      }
+      // Check if clicking delete on an assistant message
+      for (const item of turn.assistantItems) {
+        if (item.type === 'assistant' && item.message.id === messageId) {
+          if (turn.userMessage) {
+            pairedVisibleIds.push(turn.userMessage.id);
+          }
+          // Collect visible message IDs for UI display
+          pairedVisibleIds.push(...collectVisibleMessageIds(turn));
+          found = true;
+          break;
+        }
+      }
+    }
+    setIsMultiSelectMode(true);
+    setSelectedMessageIds(new Set(pairedVisibleIds));
+  }, [turns, collectVisibleMessageIds]);
+
   // Cache turn DOM elements when turns change
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -1840,7 +2074,14 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         <div key={turn.id} data-turn-index={index}>
           {turn.userMessage && (
             <div data-export-role="user-message">
-              <UserMessageItem message={turn.userMessage} skills={skills} />
+              <UserMessageItem
+                message={turn.userMessage}
+                skills={skills}
+                isMultiSelectMode={isMultiSelectMode}
+                isSelected={selectedMessageIds.has(turn.userMessage.id)}
+                onToggleSelect={handleToggleSelect}
+                onDelete={!isStreaming ? handleDeleteMessage : undefined}
+              />
             </div>
           )}
           {showAssistantBlock && (
@@ -1851,6 +2092,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 mapDisplayText={mapDisplayText}
                 showTypingIndicator={showTypingIndicator}
                 showCopyButtons={!isStreaming}
+                isMultiSelectMode={isMultiSelectMode}
+                selectedMessageIds={selectedMessageIds}
+                onToggleSelect={handleToggleSelect}
+                onDeleteMessage={!isStreaming ? handleDeleteMessage : undefined}
               />
             </div>
           )}
@@ -2030,6 +2275,47 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         </div>
       )}
 
+      {/* Delete Message Confirmation Modal */}
+      {showDeleteMessageConfirm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
+          onClick={handleCancelDeleteMessage}
+        >
+          <div
+            className="w-full max-w-sm mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal overflow-hidden modal-content"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-3 px-5 py-4">
+              <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
+                <ExclamationTriangleIcon className="h-5 w-5 text-red-600 dark:text-red-500" />
+              </div>
+              <h2 className="text-base font-semibold dark:text-claude-darkText text-claude-text">
+                {i18nService.t('deleteMessagesConfirmTitle')}
+              </h2>
+            </div>
+            <div className="px-5 pb-4">
+              <p className="text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                {i18nService.t('deleteMessagesConfirmMessage').replace('{count}', String(pendingDeleteMessageIds.length))}
+              </p>
+            </div>
+            <div className="flex items-center justify-end gap-3 px-5 py-4 border-t dark:border-claude-darkBorder border-claude-border">
+              <button
+                onClick={handleCancelDeleteMessage}
+                className="px-4 py-2 text-sm font-medium rounded-lg dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-colors"
+              >
+                {i18nService.t('cancel')}
+              </button>
+              <button
+                onClick={handleConfirmDeleteMessages}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-red-500 hover:bg-red-600 text-white transition-colors"
+              >
+                {i18nService.t('batchDelete')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Messages */}
       <div className="relative flex-1 min-h-0">
         <div
@@ -2040,6 +2326,29 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
           {renderConversationTurns()}
           <div className="h-20" />
         </div>
+
+        {/* Multi-Select Floating Bar */}
+        {isMultiSelectMode && (
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-4 px-4 py-3 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface shadow-popover border dark:border-claude-darkBorder border-claude-border z-20">
+            <span className="text-sm font-medium dark:text-claude-darkText text-claude-text">
+              {i18nService.t('selectedNMessages').replace('{count}', String(selectedMessageIds.size))}
+            </span>
+            <button
+              onClick={handleBatchDeleteClick}
+              disabled={selectedMessageIds.size === 0}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-red-500 hover:bg-red-600 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <TrashIcon className="h-4 w-4" />
+              {i18nService.t('batchDelete')}
+            </button>
+            <button
+              onClick={handleCancelMultiSelect}
+              className="px-3 py-1.5 text-sm font-medium rounded-lg dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-colors"
+            >
+              {i18nService.t('cancel')}
+            </button>
+          </div>
+        )}
 
         {/* Turn Navigation Buttons */}
         {turns.length > 1 && isScrollable && (

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -6,6 +6,8 @@ import {
   updateSessionStatus,
   deleteSession as deleteSessionAction,
   deleteSessions as deleteSessionsAction,
+  deleteMessage as deleteMessageAction,
+  deleteMessages as deleteMessagesAction,
   addMessage,
   updateMessageContent,
   setStreaming,
@@ -360,6 +362,34 @@ class CoworkService {
     }
 
     console.error('Failed to batch delete sessions:', result.error);
+    return false;
+  }
+
+  async deleteMessage(sessionId: string, messageId: string): Promise<boolean> {
+    const cowork = window.electron?.cowork;
+    if (!cowork) return false;
+
+    const result = await cowork.deleteMessage(sessionId, messageId);
+    if (result.success) {
+      store.dispatch(deleteMessageAction({ sessionId, messageId }));
+      return true;
+    }
+
+    console.error('Failed to delete message:', result.error);
+    return false;
+  }
+
+  async deleteMessages(sessionId: string, messageIds: string[]): Promise<boolean> {
+    const cowork = window.electron?.cowork;
+    if (!cowork) return false;
+
+    const result = await cowork.deleteMessages(sessionId, messageIds);
+    if (result.success) {
+      store.dispatch(deleteMessagesAction({ sessionId, messageIds }));
+      return true;
+    }
+
+    console.error('Failed to batch delete messages:', result.error);
     return false;
   }
 

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -18,7 +18,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: '用户',
     login: '登录',
     inDevelopment: '正在开发中',
-    
+
     // 设置
     settings: '设置',
     general: '通用',
@@ -43,7 +43,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     system: '跟随系统',
     chinese: '中文',
     english: 'English',
-    
+
     // API设置
     apiKey: 'API Key',
     apiKeyPlaceholder: '输入你的 API Key',
@@ -56,7 +56,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: '当前模型',
     availableModels: '可用模型列表',
     modelSwitchHint: '在聊天界面可以切换使用的模型',
-    
+
     // 模型提供商设置
     enabled: '已启用',
     disabled: '已禁用',
@@ -138,7 +138,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: '两次输入的密码不一致',
     passwordTooShort: '密码长度至少为4位',
     wrongPassword: '密码错误，请检查后重试',
-    
+
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
     newChat: '新建任务',
@@ -174,14 +174,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     planStandard: '标准',
     planAdvanced: '进阶',
     planPro: '专业',
-    
     // 错误信息
     failedToLoadSettings: '加载设置失败',
     failedToSaveSettings: '保存设置失败',
-    
+
     // 加载状态
     loading: '加载中...',
-    
+
     // 侧边栏
     conversations: '对话',
     noConversations: '暂无对话',
@@ -219,7 +218,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: '工作',
     folderIconCode: '代码',
     folderIconIdea: '灵感',
-    
+
     // 聊天窗口
     sendMessage: '发送消息',
     typeMessage: '询问任何问题...',
@@ -248,17 +247,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: '最多上传 10 张图片',
     imageReadError: '读取图片失败',
     imageInputNotSupported: '当前模型不支持图像输入',
-    
+
     // 模型选择
     selectModel: '选择模型',
-    
+
     // 错误提示
     errorOccurred: '发生错误',
     tryAgain: '请重试',
     networkError: '网络错误',
     apiKeyRequired: '需要设置API密钥',
     configureApiKey: '请在设置中配置您的API密钥',
-    
+
     // 初始化
     initializationError: '初始化应用程序失败。请检查您的配置。',
     apiKeyNotConfigured: 'API密钥未配置。请在设置中设置您的API密钥。',
@@ -460,6 +459,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     deleteSession: '删除任务',
     deleteTaskConfirmTitle: '确认删除任务',
     deleteTaskConfirmMessage: '此操作无法撤销，任务的所有消息记录将被永久删除。',
+    deleteMessagesConfirmTitle: '确认批量删除消息',
+    deleteMessagesConfirmMessage: '确定要删除选中的 {count} 条消息吗？此操作不可撤销。',
+    selectedNMessages: '已选中 {count} 条消息',
+    deleteMessage: '删除消息',
     batchOperations: '批量操作',
     batchSelectAll: '全选',
     batchDelete: '删除',
@@ -1123,7 +1126,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: 'User',
     login: 'Login',
     inDevelopment: 'In development',
-    
+
     // Settings
     settings: 'Settings',
     general: 'General',
@@ -1148,7 +1151,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     system: 'System',
     chinese: 'Chinese',
     english: 'English',
-    
+
     // API Settings
     apiKey: 'API Key',
     apiKeyPlaceholder: 'Enter your API Key',
@@ -1161,7 +1164,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: 'Current Model',
     availableModels: 'Available Models',
     modelSwitchHint: 'You can switch models in the chat interface',
-    
+
     // Model Provider Settings
     enabled: 'Enabled',
     disabled: 'Disabled',
@@ -1243,7 +1246,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: 'Passwords do not match',
     passwordTooShort: 'Password must be at least 4 characters',
     wrongPassword: 'Wrong password, please try again',
-    
+
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
     newChat: 'New Task',
@@ -1278,14 +1281,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     planFree: 'Free',
     planAdvanced: 'Advanced',
     planPro: 'Pro',
-    
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',
-    
+
     // Loading State
     loading: 'Loading...',
-    
+
     // Sidebar
     conversations: 'Conversations',
     noConversations: 'No conversations',
@@ -1323,7 +1325,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: 'Work',
     folderIconCode: 'Code',
     folderIconIdea: 'Ideas',
-    
+
     // Chat Window
     sendMessage: 'Send Message',
     typeMessage: 'Type a message...',
@@ -1352,17 +1354,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: 'Up to 10 images',
     imageReadError: 'Failed to read image',
     imageInputNotSupported: 'Current model does not support images',
-    
+
     // Model Selection
     selectModel: 'Select Model',
-    
+
     // Error Messages
     errorOccurred: 'An error occurred',
     tryAgain: 'Please try again',
     networkError: 'Network error',
     apiKeyRequired: 'API Key Required',
     configureApiKey: 'Please configure your API key in settings',
-    
+
     // Initialization
     initializationError: 'Failed to initialize application. Please check your configuration.',
     apiKeyNotConfigured: 'API key not configured. Please set up your API key in settings.',
@@ -1564,6 +1566,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     deleteSession: 'Delete Task',
     deleteTaskConfirmTitle: 'Confirm Deletion',
     deleteTaskConfirmMessage: 'This action cannot be undone. All messages in this task will be permanently deleted.',
+    deleteMessagesConfirmTitle: 'Confirm Delete Messages',
+    deleteMessagesConfirmMessage: 'Are you sure you want to delete {count} selected messages? This action cannot be undone.',
+    selectedNMessages: '{count} messages selected',
+    deleteMessage: 'Delete Message',
     batchOperations: 'Batch Operations',
     batchSelectAll: 'Select All',
     batchDelete: 'Delete',
@@ -1826,7 +1832,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nim: 'NetEase IM',
     xiaomifeng: 'Netease Bee',
     weixin: 'WeChat',
-    wecom: 'WeCom',    popo: 'POPO',
+    wecom: 'WeCom', popo: 'POPO',
     connected: 'Connected',
     disconnected: 'Disconnected',
     kickedByOtherClient: 'Account logged in elsewhere',
@@ -2218,12 +2224,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
 class I18nService {
   private currentLanguage: LanguageType = 'zh';
   private listeners = new Set<() => void>();
-  
+
   constructor() {
     // 默认使用中文
     this.currentLanguage = 'zh';
   }
-  
+
   // 初始化语言设置
   async initialize(): Promise<void> {
     try {
@@ -2300,7 +2306,7 @@ class I18nService {
     }
     return 'en'; // 默认英文 (包括 zh-TW, zh-HK, en-*, 以及其他所有语言)
   }
-  
+
   // 设置语言
   setLanguage(language: LanguageType, options: { persist?: boolean } = {}): void {
     const { persist = true } = options;
@@ -2326,12 +2332,12 @@ class I18nService {
       console.error('Failed to save language setting:', error);
     }
   }
-  
+
   // 获取当前语言
   getLanguage(): LanguageType {
     return this.currentLanguage;
   }
-  
+
   // 获取翻译文本
   t(key: string): string {
     const translation = translations[this.currentLanguage][key];

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -208,6 +208,21 @@ const coworkSlice = createSlice({
       }
     },
 
+    deleteMessage(state, action: PayloadAction<{ sessionId: string; messageId: string }>) {
+      const { sessionId, messageId } = action.payload;
+      if (state.currentSession?.id === sessionId && state.currentSession.messages) {
+        state.currentSession.messages = state.currentSession.messages.filter(m => m.id !== messageId);
+      }
+    },
+
+    deleteMessages(state, action: PayloadAction<{ sessionId: string; messageIds: string[] }>) {
+      const { sessionId, messageIds } = action.payload;
+      const idsToDelete = new Set(messageIds);
+      if (state.currentSession?.id === sessionId && state.currentSession.messages) {
+        state.currentSession.messages = state.currentSession.messages.filter(m => !idsToDelete.has(m.id));
+      }
+    },
+
     addMessage(state, action: PayloadAction<{ sessionId: string; message: CoworkMessage }>) {
       const { sessionId, message } = action.payload;
 
@@ -328,6 +343,8 @@ export const {
   updateSessionStatus,
   deleteSession,
   deleteSessions,
+  deleteMessage,
+  deleteMessages,
   addMessage,
   updateMessageContent,
   setStreaming,

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -315,6 +315,8 @@ interface IElectronAPI {
     stopSession: (sessionId: string) => Promise<{ success: boolean; error?: string }>;
     deleteSession: (sessionId: string) => Promise<{ success: boolean; error?: string }>;
     deleteSessions: (sessionIds: string[]) => Promise<{ success: boolean; error?: string }>;
+    deleteMessage: (sessionId: string, messageId: string) => Promise<{ success: boolean; error?: string }>;
+    deleteMessages: (sessionId: string, messageIds: string[]) => Promise<{ success: boolean; error?: string }>;
     setSessionPinned: (options: { sessionId: string; pinned: boolean }) => Promise<{ success: boolean; error?: string }>;
     renameSession: (options: { sessionId: string; title: string }) => Promise<{ success: boolean; error?: string }>;
     getSession: (sessionId: string) => Promise<{ success: boolean; session?: CoworkSession; error?: string }>;

--- a/src/renderer/utils/coworkDeleteUtils.ts
+++ b/src/renderer/utils/coworkDeleteUtils.ts
@@ -1,0 +1,60 @@
+import type { AssistantTurnItem, ConversationTurn } from '../components/cowork/CoworkSessionDetail';
+
+/**
+ * Expands a set of explicitly selected message IDs to include all related
+ * messages that must be deleted together for data consistency:
+ *
+ * - If any assistant item in a turn is selected, all other assistant items
+ *   in the same turn are also included (tool_use/tool_result must stay paired).
+ * - User messages are NEVER force-added — they are only deleted if explicitly selected.
+ *
+ * @param selectedIds  The IDs explicitly chosen by the user in the UI.
+ * @param turns        The full conversation turn list (used for pairing context).
+ * @returns            A deduplicated array of all message IDs to delete.
+ */
+export function expandMessageIdsForDeletion(
+    selectedIds: string[],
+    turns: ConversationTurn[],
+): string[] {
+    const allIdsToDelete = new Set<string>(selectedIds);
+
+    for (const turn of turns) {
+        const hasSelectedInTurn =
+            (turn.userMessage != null && allIdsToDelete.has(turn.userMessage.id)) ||
+            turn.assistantItems.some((item) => isAssistantItemSelected(item, allIdsToDelete));
+
+        if (hasSelectedInTurn) {
+            // Expand to all assistant items in this turn for data consistency.
+            // Do NOT force-add turn.userMessage — only delete it if explicitly selected.
+            for (const item of turn.assistantItems) {
+                addAssistantItemIds(item, allIdsToDelete);
+            }
+        }
+    }
+
+    return Array.from(allIdsToDelete);
+}
+
+function isAssistantItemSelected(item: AssistantTurnItem, ids: Set<string>): boolean {
+    if (item.type === 'assistant' || item.type === 'tool_result') {
+        return ids.has(item.message.id);
+    }
+    if (item.type === 'tool_group') {
+        return (
+            ids.has(item.group.toolUse.id) ||
+            (item.group.toolResult != null && ids.has(item.group.toolResult.id))
+        );
+    }
+    return false;
+}
+
+function addAssistantItemIds(item: AssistantTurnItem, ids: Set<string>): void {
+    if (item.type === 'assistant' || item.type === 'tool_result') {
+        ids.add(item.message.id);
+    } else if (item.type === 'tool_group') {
+        ids.add(item.group.toolUse.id);
+        if (item.group.toolResult) {
+            ids.add(item.group.toolResult.id);
+        }
+    }
+}

--- a/tests/coworkDeleteUtils.test.ts
+++ b/tests/coworkDeleteUtils.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'vitest';
+import type { ConversationTurn } from '../src/renderer/components/cowork/CoworkSessionDetail';
+import { expandMessageIdsForDeletion } from '../src/renderer/utils/coworkDeleteUtils';
+
+// ---------------------------------------------------------------------------
+// Helpers — build lightweight fake messages and turns
+// ---------------------------------------------------------------------------
+
+let _idSeq = 0;
+function msg(id: string) {
+    return { id, type: 'user' as const, role: 'user' as const, content: '', sessionId: 'session1', createdAt: ++_idSeq };
+}
+
+function turn(
+    userMsgId: string | null,
+    assistantItems: ConversationTurn['assistantItems'],
+): ConversationTurn {
+    return {
+        id: `turn-${++_idSeq}`,
+        userMessage: userMsgId ? msg(userMsgId) : null,
+        assistantItems,
+    };
+}
+
+function assistantItem(id: string): ConversationTurn['assistantItems'][number] {
+    return { type: 'assistant', message: msg(id) };
+}
+
+function toolGroupItem(
+    toolUseId: string,
+    toolResultId?: string,
+): ConversationTurn['assistantItems'][number] {
+    return {
+        type: 'tool_group',
+        group: {
+            type: 'tool_group',
+            toolUse: msg(toolUseId),
+            toolResult: toolResultId ? msg(toolResultId) : null,
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('expandMessageIdsForDeletion', () => {
+
+    // ── 1. 基础：空输入 ────────────────────────────────────────────────────────
+    test('空选择 → 返回空数组', () => {
+        const turns = [turn('u1', [assistantItem('a1')])];
+        expect(expandMessageIdsForDeletion([], turns)).toEqual([]);
+    });
+
+    // ── 2. 只选 user 消息 ───────────────────────────────────────────────────────
+    test('只选 user 消息 → user + 同轮所有 assistant 消息一并删除', () => {
+        const turns_ = [turn('u1', [assistantItem('a1'), assistantItem('a2')])];
+        const result = expandMessageIdsForDeletion(['u1'], turns_);
+        expect(result.sort()).toEqual(['a1', 'a2', 'u1'].sort());
+    });
+
+    // ── 3. 只选 assistant 消息 → 不扩展 user 消息 ─────────────────────────────
+    test('只选 assistant 消息 → user 消息不被强制加入', () => {
+        const turns_ = [turn('u1', [assistantItem('a1'), assistantItem('a2')])];
+        const result = expandMessageIdsForDeletion(['a1'], turns_);
+        expect(result).not.toContain('u1');
+    });
+
+    // ── 4. 只选 assistant 消息 → 同轮其他 assistant 一起扩展 ──────────────────
+    test('选中 assistant 消息 → 同轮所有 assistant 消息都被扩展', () => {
+        const turns_ = [turn('u1', [assistantItem('a1'), assistantItem('a2'), assistantItem('a3')])];
+        const result = expandMessageIdsForDeletion(['a1'], turns_);
+        expect(result.sort()).toEqual(['a1', 'a2', 'a3'].sort());
+        expect(result).not.toContain('u1');
+    });
+
+    // ── 5. tool_group：选中 tool_use → tool_result 一起被扩展 ─────────────────
+    test('选中 tool_use → 配对的 tool_result 一起扩展', () => {
+        const turns_ = [turn('u1', [toolGroupItem('tu1', 'tr1')])];
+        const result = expandMessageIdsForDeletion(['tu1'], turns_);
+        expect(result.sort()).toEqual(['tr1', 'tu1'].sort());
+        expect(result).not.toContain('u1');
+    });
+
+    // ── 6. tool_group：选中 tool_result → tool_use 一起被扩展 ─────────────────
+    test('选中 tool_result → 配对的 tool_use 一起扩展', () => {
+        const turns_ = [turn('u1', [toolGroupItem('tu1', 'tr1')])];
+        const result = expandMessageIdsForDeletion(['tr1'], turns_);
+        expect(result.sort()).toEqual(['tr1', 'tu1'].sort());
+        expect(result).not.toContain('u1');
+    });
+
+    // ── 7. tool_group 无 tool_result ───────────────────────────────────────────
+    test('tool_group 没有 tool_result 时，只删 tool_use', () => {
+        const turns_ = [turn('u1', [toolGroupItem('tu1')])];
+        const result = expandMessageIdsForDeletion(['tu1'], turns_);
+        expect(result).toEqual(['tu1']);
+    });
+
+    // ── 8. 混合：assistant + tool_group 在同一轮 ──────────────────────────────
+    test('选中 assistant 消息 → 同轮 tool_group 也被扩展（含 tool_use/tool_result）', () => {
+        const turns_ = [
+            turn('u1', [
+                assistantItem('a1'),
+                toolGroupItem('tu1', 'tr1'),
+                assistantItem('a2'),
+            ]),
+        ];
+        const result = expandMessageIdsForDeletion(['a1'], turns_);
+        expect(result.sort()).toEqual(['a1', 'a2', 'tr1', 'tu1'].sort());
+        expect(result).not.toContain('u1');
+    });
+
+    // ── 9. 跨轮：只扩展被选中的那一轮 ────────────────────────────────────────
+    test('只扩展被选中消息所在的轮次，其他轮次不受影响', () => {
+        const turns_ = [
+            turn('u1', [assistantItem('a1'), assistantItem('a2')]),
+            turn('u2', [assistantItem('b1'), assistantItem('b2')]),
+        ];
+        const result = expandMessageIdsForDeletion(['a1'], turns_);
+        expect(result.sort()).toEqual(['a1', 'a2'].sort());
+        expect(result).not.toContain('u1');
+        expect(result).not.toContain('b1');
+        expect(result).not.toContain('b2');
+    });
+
+    // ── 10. 同时选中两轮的消息 ─────────────────────────────────────────────────
+    test('同时选中两轮的消息 → 各自扩展各自轮次', () => {
+        const turns_ = [
+            turn('u1', [assistantItem('a1'), assistantItem('a2')]),
+            turn('u2', [assistantItem('b1'), toolGroupItem('tu1', 'tr1')]),
+        ];
+        const result = expandMessageIdsForDeletion(['a1', 'b1'], turns_);
+        expect(result.sort()).toEqual(['a1', 'a2', 'b1', 'tr1', 'tu1'].sort());
+        expect(result).not.toContain('u1');
+        expect(result).not.toContain('u2');
+    });
+
+    // ── 11. 同时选中 user 和 assistant ────────────────────────────────────────
+    test('同时选中 user 和 assistant 消息 → 两者都删，同轮其他 assistant 也扩展', () => {
+        const turns_ = [turn('u1', [assistantItem('a1'), assistantItem('a2')])];
+        const result = expandMessageIdsForDeletion(['u1', 'a1'], turns_);
+        expect(result.sort()).toEqual(['a1', 'a2', 'u1'].sort());
+    });
+
+    // ── 12. 无 userMessage 的轮次（孤立 assistant） ────────────────────────────
+    test('没有 userMessage 的轮次中选中 assistant → 正常扩展，不崩溃', () => {
+        const turns_ = [turn(null, [assistantItem('a1'), assistantItem('a2')])];
+        const result = expandMessageIdsForDeletion(['a1'], turns_);
+        expect(result.sort()).toEqual(['a1', 'a2'].sort());
+    });
+
+    // ── 13. 去重：同一 ID 被多次传入 ──────────────────────────────────────────
+    test('selectedIds 中有重复 ID → 结果不重复', () => {
+        const turns_ = [turn('u1', [assistantItem('a1')])];
+        const result = expandMessageIdsForDeletion(['a1', 'a1', 'a1'], turns_);
+        const unique = new Set(result);
+        expect(unique.size).toBe(result.length);
+    });
+
+});

--- a/tests/coworkSlice.deleteMessages.test.ts
+++ b/tests/coworkSlice.deleteMessages.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'vitest';
+import { createSlice, configureStore } from '@reduxjs/toolkit';
+import type { CoworkMessage, CoworkSession } from '../src/renderer/types/cowork';
+
+// Import the slice actions and reducer
+// We import the whole slice module to access the reducer and actions
+import coworkReducer, { deleteMessages } from '../src/renderer/store/slices/coworkSlice';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMessage(id: string, type: CoworkMessage['type'] = 'user'): CoworkMessage {
+    return {
+        id,
+        type,
+        role: type === 'user' ? 'user' : 'assistant',
+        content: `content-${id}`,
+        sessionId: 'session-1',
+        timestamp: Date.now(),
+        metadata: {},
+    };
+}
+
+function makeSession(id: string, messages: CoworkMessage[]): CoworkSession {
+    return {
+        id,
+        title: 'Test Session',
+        status: 'idle',
+        messages,
+        pinned: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('coworkSlice — deleteMessages reducer', () => {
+
+    // ── 1. 基础删除 ─────────────────────────────────────────────────────────
+    test('删除指定 ID 的消息', () => {
+        const messages = [makeMessage('a'), makeMessage('b'), makeMessage('c')];
+        const state = { currentSession: makeSession('session-1', messages) } as any;
+
+        const next = coworkReducer(state, deleteMessages({ sessionId: 'session-1', messageIds: ['a', 'c'] }));
+
+        expect(next.currentSession?.messages.map((m: CoworkMessage) => m.id)).toEqual(['b']);
+    });
+
+    // ── 2. 删除全部消息 ──────────────────────────────────────────────────────
+    test('删除所有消息后 messages 为空数组', () => {
+        const messages = [makeMessage('a'), makeMessage('b')];
+        const state = { currentSession: makeSession('session-1', messages) } as any;
+
+        const next = coworkReducer(state, deleteMessages({ sessionId: 'session-1', messageIds: ['a', 'b'] }));
+
+        expect(next.currentSession?.messages).toEqual([]);
+    });
+
+    // ── 3. 不存在的 ID 不影响结果 ───────────────────────────────────────────
+    test('messageIds 中包含不存在的 ID → 现有消息不受影响', () => {
+        const messages = [makeMessage('a'), makeMessage('b')];
+        const state = { currentSession: makeSession('session-1', messages) } as any;
+
+        const next = coworkReducer(state, deleteMessages({ sessionId: 'session-1', messageIds: ['x', 'y'] }));
+
+        expect(next.currentSession?.messages.map((m: CoworkMessage) => m.id)).toEqual(['a', 'b']);
+    });
+
+    // ── 4. sessionId 不匹配时不删除 ─────────────────────────────────────────
+    test('sessionId 与 currentSession 不匹配 → 消息不被删除', () => {
+        const messages = [makeMessage('a'), makeMessage('b')];
+        const state = { currentSession: makeSession('session-1', messages) } as any;
+
+        const next = coworkReducer(state, deleteMessages({ sessionId: 'session-OTHER', messageIds: ['a'] }));
+
+        expect(next.currentSession?.messages.map((m: CoworkMessage) => m.id)).toEqual(['a', 'b']);
+    });
+
+    // ── 5. messageIds 为空数组 ───────────────────────────────────────────────
+    test('messageIds 为空数组 → 消息不变', () => {
+        const messages = [makeMessage('a'), makeMessage('b')];
+        const state = { currentSession: makeSession('session-1', messages) } as any;
+
+        const next = coworkReducer(state, deleteMessages({ sessionId: 'session-1', messageIds: [] }));
+
+        expect(next.currentSession?.messages.map((m: CoworkMessage) => m.id)).toEqual(['a', 'b']);
+    });
+
+    // ── 6. currentSession 为 null 时不崩溃 ──────────────────────────────────
+    test('currentSession 为 null → 不崩溃', () => {
+        const state = { currentSession: null } as any;
+
+        expect(() => {
+            coworkReducer(state, deleteMessages({ sessionId: 'session-1', messageIds: ['a'] }));
+        }).not.toThrow();
+    });
+
+    // ── 7. 保持消息顺序 ──────────────────────────────────────────────────────
+    test('删除后剩余消息保持原始顺序', () => {
+        const messages = ['a', 'b', 'c', 'd', 'e'].map(id => makeMessage(id));
+        const state = { currentSession: makeSession('session-1', messages) } as any;
+
+        const next = coworkReducer(state, deleteMessages({ sessionId: 'session-1', messageIds: ['b', 'd'] }));
+
+        expect(next.currentSession?.messages.map((m: CoworkMessage) => m.id)).toEqual(['a', 'c', 'e']);
+    });
+
+});

--- a/tests/coworkStore.deleteMessages.test.ts
+++ b/tests/coworkStore.deleteMessages.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import initSqlJs from 'sql.js';
+import type { Database } from 'sql.js';
+import { CoworkStore } from '../src/main/coworkStore';
+
+// ---------------------------------------------------------------------------
+// Setup — shared in-memory SQLite DB
+// ---------------------------------------------------------------------------
+
+let db: Database;
+let store: CoworkStore;
+
+async function createInMemoryDb(): Promise<Database> {
+    const SQL = await initSqlJs();
+    const database = new SQL.Database();
+
+    database.run(`
+    CREATE TABLE IF NOT EXISTS cowork_sessions (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      claude_session_id TEXT,
+      status TEXT NOT NULL DEFAULT 'idle',
+      pinned INTEGER NOT NULL DEFAULT 0,
+      cwd TEXT NOT NULL,
+      system_prompt TEXT NOT NULL DEFAULT '',
+      execution_mode TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+
+    database.run(`
+    CREATE TABLE IF NOT EXISTS cowork_messages (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      metadata TEXT,
+      created_at INTEGER NOT NULL,
+      sequence INTEGER,
+      FOREIGN KEY (session_id) REFERENCES cowork_sessions(id) ON DELETE CASCADE
+    );
+  `);
+
+    return database;
+}
+
+function insertSession(db: Database, sessionId: string): void {
+    db.run(
+        `INSERT INTO cowork_sessions (id, title, status, pinned, cwd, system_prompt, created_at, updated_at)
+     VALUES (?, 'Test', 'idle', 0, '/', '', ?, ?)`,
+        [sessionId, Date.now(), Date.now()],
+    );
+}
+
+function insertMessage(db: Database, id: string, sessionId: string): void {
+    db.run(
+        `INSERT INTO cowork_messages (id, session_id, type, content, created_at)
+     VALUES (?, ?, 'user', 'content', ?)`,
+        [id, sessionId, Date.now()],
+    );
+}
+
+function queryMessageIds(db: Database, sessionId: string): string[] {
+    const result = db.exec(
+        'SELECT id FROM cowork_messages WHERE session_id = ? ORDER BY created_at',
+        [sessionId],
+    );
+    return result[0]?.values.map((row) => row[0] as string) ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CoworkStore — deleteMessages', () => {
+    beforeEach(async () => {
+        db = await createInMemoryDb();
+        store = new CoworkStore(db, () => { });
+        insertSession(db, 'session-1');
+        insertSession(db, 'session-2');
+    });
+
+    // ── 1. 基础删除 ─────────────────────────────────────────────────────────
+    test('删除指定 ID 的消息', () => {
+        insertMessage(db, 'a', 'session-1');
+        insertMessage(db, 'b', 'session-1');
+        insertMessage(db, 'c', 'session-1');
+
+        store.deleteMessages('session-1', ['a', 'c']);
+
+        expect(queryMessageIds(db, 'session-1')).toEqual(['b']);
+    });
+
+    // ── 2. 删除全部消息 ──────────────────────────────────────────────────────
+    test('删除所有消息后表中无记录', () => {
+        insertMessage(db, 'a', 'session-1');
+        insertMessage(db, 'b', 'session-1');
+
+        store.deleteMessages('session-1', ['a', 'b']);
+
+        expect(queryMessageIds(db, 'session-1')).toEqual([]);
+    });
+
+    // ── 3. 不删除其他 session 的消息 ────────────────────────────────────────
+    test('只删除指定 sessionId 下的消息，其他 session 不受影响', () => {
+        insertMessage(db, 'a', 'session-1');
+        insertMessage(db, 'b', 'session-2');
+
+        store.deleteMessages('session-1', ['a']);
+
+        expect(queryMessageIds(db, 'session-1')).toEqual([]);
+        expect(queryMessageIds(db, 'session-2')).toEqual(['b']);
+    });
+
+    // ── 4. 多条消息批量删除 ──────────────────────────────────────────────────
+    test('一次删除多条消息，其余消息保持不变', () => {
+        ['m1', 'm2', 'm3', 'm4', 'm5'].forEach(id => insertMessage(db, id, 'session-1'));
+
+        store.deleteMessages('session-1', ['m1', 'm3', 'm5']);
+
+        expect(queryMessageIds(db, 'session-1')).toEqual(['m2', 'm4']);
+    });
+
+    // ── 5. messageIds 为空数组时不执行删除 ─────────────────────────────────
+    test('messageIds 为空数组 → 提前返回，消息不变', () => {
+        insertMessage(db, 'a', 'session-1');
+        insertMessage(db, 'b', 'session-1');
+
+        store.deleteMessages('session-1', []);
+
+        expect(queryMessageIds(db, 'session-1')).toEqual(['a', 'b']);
+    });
+
+    // ── 6. 包含不存在的 ID 不报错 ───────────────────────────────────────────
+    test('messageIds 中含不存在的 ID → 不报错，现有消息正常删除', () => {
+        insertMessage(db, 'a', 'session-1');
+
+        expect(() => store.deleteMessages('session-1', ['a', 'ghost-id'])).not.toThrow();
+        expect(queryMessageIds(db, 'session-1')).toEqual([]);
+    });
+
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
     environment: 'node',
   },
 });


### PR DESCRIPTION
### 概述

在 Cowork 会话视图中新增消息删除功能，交互设计参考豆包。所有删除操作统一通过多选模式进行，支持灵活的消息联动选中与批量确认删除。

---

### 交互设计

**入口**：鼠标悬停消息时，右上角出现删除按钮，点击后立即进入多选模式，并预选当前消息所在对话轮次的全部相关消息。

**多选模式**：
- 每条可见消息左侧出现复选框
- 点击任意复选框可增减选中范围
- 点击 User 消息时，自动联动选中同一轮次的所有 Assistant 消息（反之亦然）
- 取消所有选中后自动退出多选模式
- **底部居中悬浮工具栏**显示当前选中数量，提供「删除」和「取消」按钮
- AI 流式输出期间禁用所有删除操作

**确认删除**：点击「删除」弹出确认对话框，确认后执行删除。

**联动规则**（参考豆包）：
- 选中 User 消息 → 自动删除同轮次所有 Assistant 消息
- 选中任意 Assistant 消息 → 自动删除同轮次 User 消息及所有 Assistant 消息
- `tool_call` / `tool_result` 始终作为一组原子删除，不可拆分

> **注**：删除仅影响本地 SQLite 数据库及 UI 显示。OpenClaw 引擎独立维护 transcript 文件且不提供按消息删除接口，因此 AI 上下文不受影响，与 OpenClaw 自身 Web UI 的删除行为一致。

---

### 文件变更

| 文件 | 说明 |
|------|------|
| `src/renderer/utils/coworkDeleteUtils.ts` *(新增)* | 纯函数：将选中 ID 扩展为需原子删除的完整 ID 集合 |
| `src/main/coworkStore.ts` | 新增 `deleteMessages()` SQLite 物理删除 |
| `src/main/main.ts` | 注册 `cowork:deleteMessages` IPC handler |
| `src/main/preload.ts` | context bridge 暴露 `deleteMessages` |
| `src/renderer/types/electron.d.ts` | 补充类型声明 |
| `src/renderer/services/cowork.ts` | 新增 service 封装，删除后同步 dispatch Redux |
| `src/renderer/store/slices/coworkSlice.ts` | 新增 `deleteMessages` reducer |
| `src/renderer/components/cowork/CoworkSessionDetail.tsx` | 多选模式 UI 及删除交互 |
| `src/renderer/services/i18n.ts` | 新增 UI 文案（中英文） |

---

### 测试

新增 26 个自动化测试，覆盖删除功能完整调用链：

| 文件 | 测试数 | 覆盖层级 |
|------|-------|---------|
| `tests/coworkDeleteUtils.test.ts` | 13 | 核心联动扩展逻辑 |
| `tests/coworkSlice.deleteMessages.test.ts` | 7 | Redux reducer |
| `tests/coworkStore.deleteMessages.test.ts` | 6 | SQLite 集成测试 |

```
Test Files  3 passed (3)
Tests      26 passed (26)
```