### PR TITLE
feat(cowork): 新增文件浏览面板，支持浏览工作目录

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3342,6 +3342,147 @@ if (!gotTheLock) {
     }
   });
 
+  // File browser IPC handlers
+  const HIDDEN_ENTRIES = new Set(['node_modules', '.git', '__pycache__', '.DS_Store', 'Thumbs.db', '.venv', 'dist-electron']);
+  const BINARY_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.mp3', '.mp4', '.wav', '.mov', '.avi', '.zip', '.tar', '.gz', '.rar', '.7z', '.exe', '.dll', '.so', '.dylib', '.woff', '.woff2', '.ttf', '.eot', '.pdf', '.sqlite', '.db']);
+  const EXTENSION_LANGUAGE_MAP: Record<string, string> = {
+    '.ts': 'typescript', '.tsx': 'tsx', '.js': 'javascript', '.jsx': 'jsx',
+    '.json': 'json', '.md': 'markdown', '.html': 'html', '.css': 'css',
+    '.scss': 'scss', '.less': 'less', '.py': 'python', '.rb': 'ruby',
+    '.go': 'go', '.rs': 'rust', '.java': 'java', '.kt': 'kotlin',
+    '.swift': 'swift', '.c': 'c', '.cpp': 'cpp', '.h': 'c', '.hpp': 'cpp',
+    '.sh': 'bash', '.bash': 'bash', '.zsh': 'bash', '.yml': 'yaml', '.yaml': 'yaml',
+    '.xml': 'xml', '.sql': 'sql', '.graphql': 'graphql', '.vue': 'vue',
+    '.svelte': 'svelte', '.toml': 'toml', '.ini': 'ini', '.env': 'bash',
+    '.gitignore': 'bash', '.dockerfile': 'dockerfile',
+  };
+
+  ipcMain.handle(
+    'files:listDirectory',
+    async (_event, options?: { dirPath?: string; showHidden?: boolean }) => {
+      try {
+        const config = getCoworkStore().getConfig();
+        const cwd = config.workingDirectory;
+        if (!cwd) {
+          return { success: false, error: 'No working directory configured', entries: [] };
+        }
+
+        const targetDir = options?.dirPath
+          ? path.resolve(options.dirPath)
+          : path.resolve(cwd);
+
+        // Security: ensure target is within cwd
+        const resolvedCwd = path.resolve(cwd);
+        if (!targetDir.startsWith(resolvedCwd + path.sep) && targetDir !== resolvedCwd) {
+          return { success: false, error: 'Path outside working directory', entries: [] };
+        }
+
+        const dirents = await fs.promises.readdir(targetDir, { withFileTypes: true });
+        const entries: Array<{
+          name: string;
+          path: string;
+          isDirectory: boolean;
+          size: number;
+          modifiedAt: number;
+        }> = [];
+
+        for (const dirent of dirents) {
+          if (!options?.showHidden && (dirent.name.startsWith('.') || HIDDEN_ENTRIES.has(dirent.name))) {
+            continue;
+          }
+          try {
+            const fullPath = path.join(targetDir, dirent.name);
+            const stat = await fs.promises.stat(fullPath);
+            entries.push({
+              name: dirent.name,
+              path: fullPath,
+              isDirectory: dirent.isDirectory(),
+              size: stat.size,
+              modifiedAt: stat.mtimeMs,
+            });
+          } catch {
+            // Skip entries that can't be stat'd (broken symlinks, etc.)
+          }
+        }
+
+        // Sort: directories first, then files, each group alphabetically
+        entries.sort((a, b) => {
+          if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+          return a.name.localeCompare(b.name);
+        });
+
+        return { success: true, entries };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : 'Unknown error', entries: [] };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'files:readFileContent',
+    async (_event, options?: { filePath?: string; maxSize?: number }) => {
+      try {
+        const filePath = options?.filePath;
+        if (!filePath) {
+          return { success: false, error: 'No file path provided' };
+        }
+
+        const config = getCoworkStore().getConfig();
+        const cwd = config.workingDirectory;
+        if (!cwd) {
+          return { success: false, error: 'No working directory configured' };
+        }
+
+        const resolved = path.resolve(filePath);
+        const resolvedCwd = path.resolve(cwd);
+        if (!resolved.startsWith(resolvedCwd + path.sep) && resolved !== resolvedCwd) {
+          return { success: false, error: 'Path outside working directory' };
+        }
+
+        const stat = await fs.promises.stat(resolved);
+        const maxSize = options?.maxSize ?? 512 * 1024; // 512KB default
+
+        const ext = path.extname(resolved).toLowerCase();
+        if (BINARY_EXTENSIONS.has(ext)) {
+          return {
+            success: true,
+            content: null,
+            isBinary: true,
+            size: stat.size,
+            language: null,
+          };
+        }
+
+        const isTruncated = stat.size > maxSize;
+        const buffer = Buffer.alloc(Math.min(stat.size, maxSize));
+        const fd = await fs.promises.open(resolved, 'r');
+        try {
+          await fd.read(buffer, 0, buffer.length, 0);
+        } finally {
+          await fd.close();
+        }
+
+        const content = buffer.toString('utf-8');
+        const baseName = path.basename(resolved).toLowerCase();
+        const language = EXTENSION_LANGUAGE_MAP[ext]
+          || (baseName === 'dockerfile' ? 'dockerfile' : null)
+          || (baseName === 'makefile' ? 'makefile' : null)
+          || null;
+
+        return {
+          success: true,
+          content,
+          isBinary: false,
+          size: stat.size,
+          isTruncated,
+          language,
+        };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+      }
+    }
+  );
+
   // App update download & install
   ipcMain.handle('appUpdate:download', async (event, url: string) => {
     try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -258,6 +258,12 @@ contextBridge.exposeInMainWorld('electron', {
     showItemInFolder: (filePath: string) => ipcRenderer.invoke('shell:showItemInFolder', filePath),
     openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url),
   },
+  files: {
+    listDirectory: (options?: { dirPath?: string; showHidden?: boolean }) =>
+      ipcRenderer.invoke('files:listDirectory', options),
+    readFileContent: (options: { filePath: string; maxSize?: number }) =>
+      ipcRenderer.invoke('files:readFileContent', options),
+  },
   autoLaunch: {
     get: () => ipcRenderer.invoke('app:getAutoLaunch'),
     set: (enabled: boolean) => ipcRenderer.invoke('app:setAutoLaunch', enabled),

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -15,6 +15,8 @@ import {
   PhotoIcon,
 } from '@heroicons/react/24/outline';
 import { FolderIcon } from '@heroicons/react/24/solid';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import FilePanel from './FilePanel';
 import { coworkService } from '../../services/cowork';
 import SidebarToggleIcon from '../icons/SidebarToggleIcon';
 import ComposeIcon from '../icons/ComposeIcon';
@@ -1314,6 +1316,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
   const [isExportingImage, setIsExportingImage] = useState(false);
 
+  // File panel state
+  const [isFilePanelOpen, setIsFilePanelOpen] = useState(false);
+
   // Rename states
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState('');
@@ -1910,17 +1915,32 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
         {/* Right side: Folder + Menu */}
         <div className="non-draggable flex items-center gap-1">
-          {/* Folder button */}
+          {/* Folder button - toggles file panel */}
           <button
             type="button"
-            onClick={handleOpenFolder}
-            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover dark:hover:text-claude-darkText hover:text-claude-text transition-colors"
-            aria-label={i18nService.t('coworkOpenFolder')}
+            onClick={() => setIsFilePanelOpen(!isFilePanelOpen)}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm transition-colors ${
+              isFilePanelOpen
+                ? 'dark:bg-claude-darkSurfaceHover bg-claude-surfaceHover dark:text-claude-darkText text-claude-text'
+                : 'dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover dark:hover:text-claude-darkText hover:text-claude-text'
+            }`}
+            aria-label={i18nService.t('filePanelTitle')}
           >
             <FolderIcon className="h-4 w-4" />
             <span className="max-w-[120px] truncate text-xs">
               {truncatePath(currentSession.cwd)}
             </span>
+          </button>
+
+          {/* Open in system button */}
+          <button
+            type="button"
+            onClick={handleOpenFolder}
+            className="p-1.5 rounded-lg dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-colors"
+            aria-label={i18nService.t('filePanelOpenInSystem')}
+            title={i18nService.t('filePanelOpenInSystem')}
+          >
+            <ArrowTopRightOnSquareIcon className="h-4 w-4" />
           </button>
 
           {/* Menu button */}
@@ -2030,52 +2050,64 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         </div>
       )}
 
-      {/* Messages */}
-      <div className="relative flex-1 min-h-0">
-        <div
-          ref={scrollContainerRef}
-          onScroll={handleMessagesScroll}
-          className="h-full min-h-0 overflow-y-auto pt-3"
-        >
-          {renderConversationTurns()}
-          <div className="h-20" />
+      {/* Messages + File Panel */}
+      <div className="relative flex-1 min-h-0 flex">
+        {/* Messages */}
+        <div className="relative flex-1 min-h-0">
+          <div
+            ref={scrollContainerRef}
+            onScroll={handleMessagesScroll}
+            className="h-full min-h-0 overflow-y-auto pt-3"
+          >
+            {renderConversationTurns()}
+            <div className="h-20" />
+          </div>
+
+          {/* Turn Navigation Buttons */}
+          {turns.length > 1 && isScrollable && (
+            <div
+              className={`absolute right-6 top-1/2 -translate-y-1/2 flex flex-col rounded-lg overflow-hidden shadow-lg transition-opacity duration-300 z-10
+
+                dark:bg-claude-darkSurface/90 bg-claude-surface/90 backdrop-blur-sm
+                border dark:border-claude-darkBorder border-claude-border
+                ${showTurnNav ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+            >
+              <button
+                type="button"
+                onClick={() => currentTurnIndex > 0 && navigateToTurn('prev')}
+                className={`px-1.5 py-3 transition-colors dark:text-claude-darkText text-claude-text
+                  ${currentTurnIndex <= 0
+                    ? 'opacity-30 cursor-default'
+                    : 'dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover cursor-pointer'}`}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-4 h-4">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+                </svg>
+              </button>
+              <div className="dark:border-claude-darkBorder border-claude-border border-t" />
+              <button
+                type="button"
+                onClick={() => currentTurnIndex < turns.length - 1 && navigateToTurn('next')}
+                className={`px-1.5 py-3 transition-colors dark:text-claude-darkText text-claude-text
+                  ${currentTurnIndex >= turns.length - 1
+                    ? 'opacity-30 cursor-default'
+                    : 'dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover cursor-pointer'}`}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-4 h-4">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                </svg>
+              </button>
+            </div>
+          )}
         </div>
 
-        {/* Turn Navigation Buttons */}
-        {turns.length > 1 && isScrollable && (
-          <div
-            className={`absolute right-6 top-1/2 -translate-y-1/2 flex flex-col rounded-lg overflow-hidden shadow-lg transition-opacity duration-300 z-10
-
-              dark:bg-claude-darkSurface/90 bg-claude-surface/90 backdrop-blur-sm
-              border dark:border-claude-darkBorder border-claude-border
-              ${showTurnNav ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
-          >
-            <button
-              type="button"
-              onClick={() => currentTurnIndex > 0 && navigateToTurn('prev')}
-              className={`px-1.5 py-3 transition-colors dark:text-claude-darkText text-claude-text
-                ${currentTurnIndex <= 0
-                  ? 'opacity-30 cursor-default'
-                  : 'dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover cursor-pointer'}`}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-4 h-4">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
-              </svg>
-            </button>
-            <div className="dark:border-claude-darkBorder border-claude-border border-t" />
-            <button
-              type="button"
-              onClick={() => currentTurnIndex < turns.length - 1 && navigateToTurn('next')}
-              className={`px-1.5 py-3 transition-colors dark:text-claude-darkText text-claude-text
-                ${currentTurnIndex >= turns.length - 1
-                  ? 'opacity-30 cursor-default'
-                  : 'dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover cursor-pointer'}`}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-4 h-4">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-              </svg>
-            </button>
-          </div>
+        {/* File Panel */}
+        {isFilePanelOpen && currentSession?.cwd && (
+          <FilePanel
+            cwd={currentSession.cwd}
+            onClose={() => setIsFilePanelOpen(false)}
+            onOpenInSystem={handleOpenFolder}
+          />
         )}
       </div>
 

--- a/src/renderer/components/cowork/FilePanel.tsx
+++ b/src/renderer/components/cowork/FilePanel.tsx
@@ -1,0 +1,476 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  FolderIcon,
+  FolderOpenIcon,
+  DocumentTextIcon,
+  PhotoIcon,
+  ChevronRightIcon,
+  ArrowTopRightOnSquareIcon,
+  XMarkIcon,
+  MagnifyingGlassIcon,
+} from '@heroicons/react/24/outline';
+import { i18nService } from '../../services/i18n';
+
+type FileEntry = {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+  size: number;
+  modifiedAt: number;
+};
+
+type DirState = {
+  entries: FileEntry[];
+  loading: boolean;
+  error: string | null;
+  expanded: boolean;
+};
+
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg', '.ico']);
+
+const formatFileSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const getFileExtension = (name: string): string => {
+  const i = name.lastIndexOf('.');
+  return i > 0 ? name.slice(i).toLowerCase() : '';
+};
+
+const isImageFile = (name: string): boolean => IMAGE_EXTENSIONS.has(getFileExtension(name));
+
+interface FileTreeItemProps {
+  entry: FileEntry;
+  depth: number;
+  selectedPath: string | null;
+  onSelect: (entry: FileEntry) => void;
+  dirStates: Map<string, DirState>;
+  onToggleDir: (dirPath: string) => void;
+  searchQuery: string;
+}
+
+const FileTreeItem: React.FC<FileTreeItemProps> = ({
+  entry,
+  depth,
+  selectedPath,
+  onSelect,
+  dirStates,
+  onToggleDir,
+  searchQuery,
+}) => {
+  const isSelected = selectedPath === entry.path;
+  const dirState = entry.isDirectory ? dirStates.get(entry.path) : null;
+  const isExpanded = dirState?.expanded ?? false;
+
+  const handleClick = () => {
+    if (entry.isDirectory) {
+      onToggleDir(entry.path);
+    } else {
+      onSelect(entry);
+    }
+  };
+
+  // Filter by search query
+  if (searchQuery && !entry.isDirectory && !entry.name.toLowerCase().includes(searchQuery.toLowerCase())) {
+    return null;
+  }
+
+  return (
+    <>
+      <div
+        className={`group w-full flex items-center gap-1.5 px-2 py-1 text-left text-xs transition-colors rounded-md cursor-pointer
+          ${isSelected
+            ? 'dark:bg-claude-darkSurfaceHover bg-claude-surfaceHover dark:text-claude-darkText text-claude-text'
+            : 'dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover/50 hover:bg-claude-surfaceHover/50'
+          }`}
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        onClick={handleClick}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleClick(); }}
+      >
+        {entry.isDirectory ? (
+          <>
+            <ChevronRightIcon
+              className={`h-3 w-3 flex-shrink-0 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+            />
+            {isExpanded
+              ? <FolderOpenIcon className="h-4 w-4 flex-shrink-0 text-blue-500" />
+              : <FolderIcon className="h-4 w-4 flex-shrink-0 text-blue-500" />
+            }
+          </>
+        ) : (
+          <>
+            <span className="w-3 flex-shrink-0" />
+            {isImageFile(entry.name)
+              ? <PhotoIcon className="h-4 w-4 flex-shrink-0 text-green-500" />
+              : <DocumentTextIcon className="h-4 w-4 flex-shrink-0" />
+            }
+          </>
+        )}
+        <span className="truncate flex-1">{entry.name}</span>
+        <span className="text-[10px] opacity-50 flex-shrink-0 tabular-nums ml-auto">{formatFileSize(entry.size)}</span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            window.electron.shell.openPath(entry.path);
+          }}
+          className="flex-shrink-0 p-0.5 rounded opacity-0 group-hover:opacity-100 dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:text-claude-darkText hover:text-claude-text transition-opacity"
+          title={i18nService.t('filePanelOpenInSystem')}
+        >
+          <ArrowTopRightOnSquareIcon className="h-3 w-3" />
+        </button>
+      </div>
+
+      {/* Render children if directory is expanded */}
+      {entry.isDirectory && isExpanded && dirState && (
+        <>
+          {dirState.loading && (
+            <div className="text-[10px] dark:text-claude-darkTextSecondary text-claude-textSecondary py-1"
+              style={{ paddingLeft: `${(depth + 1) * 16 + 8}px` }}
+            >
+              {i18nService.t('loading')}...
+            </div>
+          )}
+          {dirState.error && (
+            <div className="text-[10px] text-red-500 py-1"
+              style={{ paddingLeft: `${(depth + 1) * 16 + 8}px` }}
+            >
+              {dirState.error}
+            </div>
+          )}
+          {dirState.entries.map((child) => (
+            <FileTreeItem
+              key={child.path}
+              entry={child}
+              depth={depth + 1}
+              selectedPath={selectedPath}
+              onSelect={onSelect}
+              dirStates={dirStates}
+              onToggleDir={onToggleDir}
+              searchQuery={searchQuery}
+            />
+          ))}
+        </>
+      )}
+    </>
+  );
+};
+
+interface FilePreviewProps {
+  filePath: string;
+  fileName: string;
+}
+
+const FilePreview: React.FC<FilePreviewProps> = ({ filePath, fileName }) => {
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isBinary, setIsBinary] = useState(false);
+  const [language, setLanguage] = useState<string | null>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+  const [isImage, setIsImage] = useState(false);
+  const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadFile = async () => {
+      setLoading(true);
+      setError(null);
+      setContent(null);
+      setIsBinary(false);
+      setIsImage(false);
+      setImageDataUrl(null);
+
+      // Check if image
+      if (isImageFile(fileName)) {
+        try {
+          const result = await window.electron.dialog.readFileAsDataUrl(filePath);
+          if (!cancelled && result.success && result.dataUrl) {
+            setIsImage(true);
+            setImageDataUrl(result.dataUrl);
+            setLoading(false);
+            return;
+          }
+        } catch {
+          // Fall through to text read
+        }
+      }
+
+      try {
+        const result = await window.electron.files.readFileContent({ filePath });
+        if (cancelled) return;
+
+        if (!result.success) {
+          setError(result.error || 'Failed to read file');
+        } else if (result.isBinary) {
+          setIsBinary(true);
+        } else {
+          setContent(result.content ?? '');
+          setLanguage(result.language ?? null);
+          setIsTruncated(result.isTruncated ?? false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unknown error');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    loadFile();
+    return () => { cancelled = true; };
+  }, [filePath, fileName]);
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center dark:text-claude-darkTextSecondary text-claude-textSecondary text-xs">
+        {i18nService.t('loading')}...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-red-500 text-xs px-4 text-center">
+        {error}
+      </div>
+    );
+  }
+
+  if (isImage && imageDataUrl) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-4 overflow-auto">
+        <img src={imageDataUrl} alt={fileName} className="max-w-full max-h-full object-contain rounded" />
+      </div>
+    );
+  }
+
+  if (isBinary) {
+    return (
+      <div className="flex-1 flex items-center justify-center dark:text-claude-darkTextSecondary text-claude-textSecondary text-xs">
+        {i18nService.t('filePanelBinaryFile')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-auto">
+      {isTruncated && (
+        <div className="sticky top-0 px-3 py-1 text-[10px] dark:bg-amber-950/30 bg-amber-50 dark:text-amber-400 text-amber-600 border-b dark:border-claude-darkBorder border-claude-border">
+          {i18nService.t('filePanelTruncated')}
+        </div>
+      )}
+      <pre className="p-3 text-xs leading-relaxed dark:text-claude-darkText text-claude-text font-mono whitespace-pre-wrap break-all">
+        <code className={language ? `language-${language}` : ''}>{content}</code>
+      </pre>
+    </div>
+  );
+};
+
+interface FilePanelProps {
+  cwd: string;
+  onClose: () => void;
+  onOpenInSystem: () => void;
+}
+
+const FilePanel: React.FC<FilePanelProps> = ({ cwd, onClose, onOpenInSystem }) => {
+  const [dirStates, setDirStates] = useState<Map<string, DirState>>(new Map());
+  const [selectedFile, setSelectedFile] = useState<FileEntry | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [panelWidth, setPanelWidth] = useState(320);
+  const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  // Load root directory on mount
+  useEffect(() => {
+    loadDirectory(cwd, true);
+  }, [cwd]);
+
+  const loadDirectory = useCallback(async (dirPath: string, expanded: boolean) => {
+    setDirStates((prev) => {
+      const next = new Map(prev);
+      const existing = next.get(dirPath);
+      if (existing && !expanded) {
+        next.set(dirPath, { ...existing, expanded: false });
+        return next;
+      }
+      next.set(dirPath, { entries: existing?.entries ?? [], loading: true, error: null, expanded: true });
+      return next;
+    });
+
+    try {
+      const result = await window.electron.files.listDirectory({ dirPath });
+      setDirStates((prev) => {
+        const next = new Map(prev);
+        next.set(dirPath, {
+          entries: result.success ? result.entries : [],
+          loading: false,
+          error: result.success ? null : (result.error || 'Failed to load'),
+          expanded: true,
+        });
+        return next;
+      });
+    } catch (err) {
+      setDirStates((prev) => {
+        const next = new Map(prev);
+        next.set(dirPath, {
+          entries: [],
+          loading: false,
+          error: err instanceof Error ? err.message : 'Unknown error',
+          expanded: true,
+        });
+        return next;
+      });
+    }
+  }, []);
+
+  const handleToggleDir = useCallback((dirPath: string) => {
+    const state = dirStates.get(dirPath);
+    if (state?.expanded) {
+      setDirStates((prev) => {
+        const next = new Map(prev);
+        next.set(dirPath, { ...state, expanded: false });
+        return next;
+      });
+    } else {
+      loadDirectory(dirPath, true);
+    }
+  }, [dirStates, loadDirectory]);
+
+  const handleSelectFile = useCallback((entry: FileEntry) => {
+    setSelectedFile(entry);
+  }, []);
+
+  // Resize handling
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    resizeRef.current = { startX: e.clientX, startWidth: panelWidth };
+
+    const handleMove = (ev: MouseEvent) => {
+      if (!resizeRef.current) return;
+      const delta = resizeRef.current.startX - ev.clientX;
+      const newWidth = Math.min(Math.max(resizeRef.current.startWidth + delta, 240), 600);
+      setPanelWidth(newWidth);
+    };
+
+    const handleUp = () => {
+      resizeRef.current = null;
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseup', handleUp);
+    };
+
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('mouseup', handleUp);
+  }, [panelWidth]);
+
+  const rootState = dirStates.get(cwd);
+
+  return (
+    <div
+      className="flex flex-col h-full border-l dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkBg bg-claude-bg"
+      style={{ width: panelWidth }}
+    >
+      {/* Resize handle */}
+      <div
+        className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-claude-accent/30 z-10"
+        onMouseDown={handleResizeStart}
+      />
+
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b dark:border-claude-darkBorder border-claude-border shrink-0">
+        <span className="text-sm font-medium dark:text-claude-darkText text-claude-text">
+          {i18nService.t('filePanelTitle')}
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onOpenInSystem}
+            className="p-1 rounded dark:text-claude-darkTextSecondary text-claude-textSecondary hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors"
+            title={i18nService.t('filePanelOpenInSystem')}
+          >
+            <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded dark:text-claude-darkTextSecondary text-claude-textSecondary hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors"
+            title={i18nService.t('close')}
+          >
+            <XMarkIcon className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Search */}
+      <div className="px-3 py-2 shrink-0">
+        <div className="relative">
+          <MagnifyingGlassIcon className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 dark:text-claude-darkTextSecondary text-claude-textSecondary" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder={i18nService.t('filePanelSearch')}
+            className="w-full pl-7 pr-2 py-1.5 rounded-md text-xs dark:bg-claude-darkSurface bg-claude-surface dark:text-claude-darkText text-claude-text dark:border-claude-darkBorder border-claude-border border focus:outline-none focus:ring-1 focus:ring-claude-accent"
+          />
+        </div>
+      </div>
+
+      {/* File tree + Preview split */}
+      <div className="flex-1 flex flex-col min-h-0">
+        {/* File tree */}
+        <div className={`overflow-y-auto px-1 ${selectedFile ? 'h-1/2 border-b dark:border-claude-darkBorder border-claude-border' : 'flex-1'}`}>
+          {rootState?.loading && !rootState.entries.length ? (
+            <div className="flex items-center justify-center py-8 dark:text-claude-darkTextSecondary text-claude-textSecondary text-xs">
+              {i18nService.t('loading')}...
+            </div>
+          ) : rootState?.error ? (
+            <div className="flex items-center justify-center py-8 text-red-500 text-xs">
+              {rootState.error}
+            </div>
+          ) : (
+            rootState?.entries.map((entry) => (
+              <FileTreeItem
+                key={entry.path}
+                entry={entry}
+                depth={0}
+                selectedPath={selectedFile?.path ?? null}
+                onSelect={handleSelectFile}
+                dirStates={dirStates}
+                onToggleDir={handleToggleDir}
+                searchQuery={searchQuery}
+              />
+            ))
+          )}
+        </div>
+
+        {/* File preview */}
+        {selectedFile ? (
+          <div className="h-1/2 flex flex-col min-h-0">
+            <div className="flex items-center justify-between px-3 py-1.5 border-b dark:border-claude-darkBorder border-claude-border shrink-0">
+              <span className="text-xs font-medium dark:text-claude-darkText text-claude-text truncate">
+                {selectedFile.name}
+              </span>
+              <button
+                type="button"
+                onClick={() => setSelectedFile(null)}
+                className="p-0.5 rounded dark:text-claude-darkTextSecondary text-claude-textSecondary hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover"
+              >
+                <XMarkIcon className="h-3 w-3" />
+              </button>
+            </div>
+            <FilePreview filePath={selectedFile.path} fileName={selectedFile.name} />
+          </div>
+        ) : (
+          <div className="hidden" />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FilePanel;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -447,6 +447,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noRecentFolders: '暂无最近文件夹',
     folderDriveRootNotAllowed: '不支持使用磁盘根目录作为工作目录，请选择一个子文件夹（例如 D:\\Projects）。',
     coworkOpenFolder: '打开文件夹',
+    filePanelTitle: '文件',
+    filePanelSearch: '搜索文件...',
+    filePanelOpenInSystem: '在系统中打开',
+    filePanelBinaryFile: '二进制文件，无法预览',
+    filePanelTruncated: '文件过大，仅显示部分内容',
 
     // Cowork 错误消息
     coworkErrorAuthInvalid: 'API 密钥无效或已过期，请在设置中检查并更新您的 API 密钥。',
@@ -1524,6 +1529,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noRecentFolders: 'No recent folders',
     folderDriveRootNotAllowed: 'Drive root directories are not supported as working directories. Please select a subfolder (e.g. D:\\Projects).',
     coworkOpenFolder: 'Open folder',
+    filePanelTitle: 'Files',
+    filePanelSearch: 'Search files...',
+    filePanelOpenInSystem: 'Open in system',
+    filePanelBinaryFile: 'Binary file, cannot preview',
+    filePanelTruncated: 'File too large, showing partial content',
 
     // Cowork error messages
     coworkErrorAuthInvalid: 'Invalid or expired API key. Please check and update your API key in settings.',

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -353,6 +353,28 @@ interface IElectronAPI {
     showItemInFolder: (filePath: string) => Promise<{ success: boolean; error?: string }>;
     openExternal: (url: string) => Promise<{ success: boolean; error?: string }>;
   };
+  files: {
+    listDirectory: (options?: { dirPath?: string; showHidden?: boolean }) => Promise<{
+      success: boolean;
+      entries: Array<{
+        name: string;
+        path: string;
+        isDirectory: boolean;
+        size: number;
+        modifiedAt: number;
+      }>;
+      error?: string;
+    }>;
+    readFileContent: (options: { filePath: string; maxSize?: number }) => Promise<{
+      success: boolean;
+      content?: string | null;
+      isBinary?: boolean;
+      size?: number;
+      isTruncated?: boolean;
+      language?: string | null;
+      error?: string;
+    }>;
+  };
   autoLaunch: {
     get: () => Promise<{ enabled: boolean }>;
     set: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
## 概述

在 Cowork 对话界面右侧新增文件浏览面板，支持浏览工作目录文件树、预览文件内容、搜索过滤，以及用系统默认程序打开文件/目录，无需离开应用。

## 改动内容

### 后端（Main Process）
- **`src/main/main.ts`**：新增 `files:listDirectory` 和 `files:readFileContent` IPC handler，含路径安全校验（所有路径必须在 `workingDirectory` 内）
- **`src/main/preload.ts`**：通过 `contextBridge` 暴露 `files` 命名空间

### 前端（Renderer）
- **`src/renderer/components/cowork/FilePanel.tsx`**（新文件）：文件浏览面板组件，包含：
  - 层级文件树，支持展开/收起目录
  - 文件搜索过滤
  - 文件内容预览（文本带语言检测、图片预览、二进制文件识别）
  - 可拖拽调整面板宽度（240–600px）
  - 所有文件和目录 hover 时显示"在系统中打开"按钮
- **`src/renderer/components/cowork/CoworkSessionDetail.tsx`**：
  - 拆分文件夹按钮：文件夹名称点击 → 展开/收起文件面板（带激活态样式），新增 ↗ 按钮 → 在系统文件管理器中打开
  - 消息区域改为水平 flex 布局，文件面板展开时与消息列表并排显示
- **`src/renderer/services/i18n.ts`**：新增文件面板相关的中英文翻译
- **`src/renderer/types/electron.d.ts`**：新增 `files` API 的 TypeScript 类型定义

### 安全性
- 所有文件操作均校验请求路径必须在配置的工作目录内
- 默认过滤隐藏文件/目录（`.git`、`node_modules` 等）

## 测试

- [x] TypeScript 编译通过（renderer 和 electron 两套配置均通过 `tsc --noEmit`）
- [x] ESLint 检查通过
- [x] 手动测试：文件树浏览、目录展开/收起、文件预览、搜索过滤、文件和目录的系统打开、面板拖拽缩放、暗色模式