### PR TITLE
feat(cowork): improve error feedback when session fails

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1141,11 +1141,27 @@ export const AssistantTurnBlock: React.FC<{
     const content = mapDisplayText ? mapDisplayText(normalizedContent) : normalizedContent;
     if (!content.trim()) return null;
 
+    const isError = Boolean(message.metadata?.error)
+      || message.content?.startsWith('Error:')
+      || message.id?.startsWith('error-');
+
     return (
-      <div className="rounded-lg border dark:border-claude-darkBorder/70 border-claude-border/70 dark:bg-claude-darkBg/40 bg-claude-bg/60 px-3 py-2">
+      <div className={`rounded-lg border px-3 py-2 ${
+        isError
+          ? 'dark:border-red-500/30 border-red-300/70 dark:bg-red-950/30 bg-red-50/60'
+          : 'dark:border-claude-darkBorder/70 border-claude-border/70 dark:bg-claude-darkBg/40 bg-claude-bg/60'
+      }`}>
         <div className="flex items-start gap-2">
-          <InformationCircleIcon className="h-4 w-4 mt-0.5 dark:text-claude-darkTextSecondary text-claude-textSecondary flex-shrink-0" />
-          <div className="text-xs whitespace-pre-wrap dark:text-claude-darkTextSecondary text-claude-textSecondary">
+          {isError ? (
+            <ExclamationTriangleIcon className="h-4 w-4 mt-0.5 text-red-500 flex-shrink-0" />
+          ) : (
+            <InformationCircleIcon className="h-4 w-4 mt-0.5 dark:text-claude-darkTextSecondary text-claude-textSecondary flex-shrink-0" />
+          )}
+          <div className={`text-xs whitespace-pre-wrap ${
+            isError
+              ? 'text-red-600 dark:text-red-400'
+              : 'dark:text-claude-darkTextSecondary text-claude-textSecondary'
+          }`}>
             {content}
           </div>
         </div>

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -166,17 +166,19 @@ class CoworkService {
     const errorCleanup = cowork.onStreamError(({ sessionId, error }) => {
       store.dispatch(updateSessionStatus({ sessionId, status: 'error' }));
       // Surface the error as a visible message so the user knows what happened.
-      if (error) {
-        store.dispatch(addMessage({
-          sessionId,
-          message: {
-            id: `error-${Date.now()}`,
-            type: 'system',
-            content: classifyError(error),
-            timestamp: Date.now(),
-          },
-        }));
-      }
+      const errorContent = error
+        ? classifyError(error)
+        : i18nService.t('errorOccurred');
+      console.error('[CoworkService] Stream error:', { sessionId, rawError: error, displayError: errorContent });
+      store.dispatch(addMessage({
+        sessionId,
+        message: {
+          id: `error-${Date.now()}`,
+          type: 'system',
+          content: errorContent,
+          timestamp: Date.now(),
+        },
+      }));
     });
     this.streamListenerCleanups.push(errorCleanup);
 
@@ -276,7 +278,10 @@ class CoworkService {
     }
 
     store.dispatch(setStreaming(false));
-    console.error('Failed to start session:', result.error);
+
+    if (result.error) {
+      console.error('Failed to start session:', result.error);
+    }
     return null;
   }
 
@@ -304,6 +309,19 @@ class CoworkService {
       }
       if (result.code !== 'ENGINE_NOT_READY') {
         store.dispatch(updateSessionStatus({ sessionId: options.sessionId, status: 'error' }));
+        // Surface the error as a visible message so the user knows what happened.
+        const errorContent = result.error
+          ? classifyError(result.error)
+          : i18nService.t('errorOccurred');
+        store.dispatch(addMessage({
+          sessionId: options.sessionId,
+          message: {
+            id: `error-${Date.now()}`,
+            type: 'system',
+            content: errorContent,
+            timestamp: Date.now(),
+          },
+        }));
       }
       console.error('Failed to continue session:', result.error);
       return false;


### PR DESCRIPTION
## Summary

模型 token 用完或 API 出错时，用户只看到侧边栏"错误"两字，聊天区无任何提示信息，需要有开发基础打开 DevTools 才能排查原因。本 PR 优化错误反馈体验，让用户能直接在聊天区看到具体错误原因。

## Changes

- **stream error 监听器**：始终创建错误消息，error 为空时回退到"发生错误"兜底文案，并添加 `console.error` 日志输出原始错误便于排查
- **continueSession 失败路径**：补充错误消息展示，通过 `classifyError()` 将已知错误类型（token 耗尽、API Key 失效、限流等）翻译为用户友好提示
- **错误消息样式**：错误类系统消息改用红色边框 + 警告三角图标 + 红色文字，与普通系统提示（灰色信息图标）区分

## Files Changed

- `src/renderer/services/cowork.ts` — error 监听器兜底处理 + continueSession 失败路径补充错误消息
- `src/renderer/components/cowork/CoworkSessionDetail.tsx` — 错误消息视觉样式区分

## How to Verify

1. 配置一个余额为 0 或已过期的 API Key
2. 发送任意消息触发对话
3. 验证聊天区出现红色错误提示（如"API 余额不足，请充值后重试"），而非仅侧边栏显示"错误"状态