### PR TITLE
fix(scheduled-task): deduplicate tasks before migration to prevent duplicates on restart

### DIFF
--- a/src/main/libs/migrateScheduledTasks.ts
+++ b/src/main/libs/migrateScheduledTasks.ts
@@ -183,7 +183,18 @@ export async function migrateScheduledTasksToOpenclaw(deps: MigrationDeps): Prom
 
   console.log(`[MigrateScheduledTasks] Migrating ${rows.length} task(s) to OpenClaw gateway...`);
 
-  // 4. Push each task to the OpenClaw gateway
+  // 4a. Fetch existing tasks from the gateway so we can skip duplicates.
+  //     Prevents re-creating tasks when a prior migration partially succeeded
+  //     but the idempotency flag was not set due to a transient gateway error.
+  let existingNames: Set<string>;
+  try {
+    const existingJobs = await cronJobService.listJobs();
+    existingNames = new Set(existingJobs.map((j) => j.name));
+  } catch {
+    existingNames = new Set();
+  }
+
+  // 4b. Push each task to the OpenClaw gateway, skipping duplicates by name.
   let succeeded = 0;
   let skipped = 0;
   let gatewayErrors = 0;
@@ -191,8 +202,15 @@ export async function migrateScheduledTasksToOpenclaw(deps: MigrationDeps): Prom
     const input = rowToInput(row);
     if (!input) { skipped++; continue; }
 
+    if (existingNames.has(input.name)) {
+      console.log(`[MigrateScheduledTasks] Task "${input.name}" already exists in gateway, skipping`);
+      skipped++;
+      continue;
+    }
+
     try {
       await cronJobService.addJob(input);
+      existingNames.add(input.name);
       console.log(`[MigrateScheduledTasks] Migrated task: "${row.name}"`);
       succeeded++;
     } catch (err) {


### PR DESCRIPTION
## Summary

- Query existing gateway tasks by name before calling `addJob()` during the SQLite → OpenClaw migration, preventing duplicate task creation on app restart.

Closes #775

## Problem

When the scheduled task migration encounters a transient gateway error on **any** task, the idempotency flag (`scheduled_tasks_migrated_to_openclaw_v1`) is intentionally left unset to allow retry. However, tasks that were **already successfully migrated** in the same run are not tracked — so on the next restart, the migration re-creates all tasks, including ones already present in the gateway.

The more restarts with partial failures, the more duplicates accumulate.

## Root Cause

`migrateScheduledTasksToOpenclaw()` uses an all-or-nothing idempotency flag (line 209: `if (gatewayErrors === 0) setKv(...)`) but performs no per-task deduplication. `cronJobService.addJob()` also has no built-in duplicate detection.

## Solution

Before the migration loop, fetch the current task list from the gateway via `cronJobService.listJobs()` and build a `Set<string>` of existing task names. Skip any legacy task whose name already exists in the gateway. This makes the migration safe to run repeatedly regardless of partial failures.

If `listJobs()` itself fails (e.g., gateway not ready), the set is empty and migration proceeds as before — the existing retry-on-error logic remains unchanged.

## Electron-specific behavior

The migration runs once during main process startup (`main.ts:3775`). The fix adds one additional RPC call (`cron.list`) to the OpenClaw gateway before the migration loop. This is a cold-start path only — no impact on runtime performance.

## Changed files

- `src/main/libs/migrateScheduledTasks.ts` — 19 insertions, 1 deletion

## Verification

- `npx tsc -p electron-tsconfig.json --noEmit` — zero errors