### PR TITLE
fix(settings): remove hardcoded export password and prompt user input

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -7,7 +7,7 @@ import { themeService } from '../services/theme';
 import { i18nService, LanguageType } from '../services/i18n';
 import { decryptSecret, encryptWithPassword, decryptWithPassword, EncryptedPayload, PasswordEncryptedPayload } from '../services/encryption';
 import { coworkService } from '../services/cowork';
-import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
+import { APP_ID, EXPORT_FORMAT_TYPE } from '../constants/app';
 import ErrorMessage from './ErrorMessage';
 import { XMarkIcon, Cog6ToothIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, EnvelopeIcon, CpuChipIcon, InformationCircleIcon, UserCircleIcon } from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
@@ -1805,14 +1805,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
       supportsImage: model.supportsImage ?? false,
     }));
 
-  const DEFAULT_EXPORT_PASSWORD = EXPORT_PASSWORD;
-
   const handleExportProviders = async () => {
+    const password = window.prompt(i18nService.t('exportPasswordPrompt'));
+    if (!password) return;
+
     setError(null);
     setIsExportingProviders(true);
 
     try {
-      const payload = await buildProvidersExport(DEFAULT_EXPORT_PASSWORD);
+      const payload = await buildProvidersExport(password);
       const json = JSON.stringify(payload, null, 2);
       const blob = new Blob([json], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
@@ -1959,6 +1960,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
       return;
     }
 
+    const password = window.prompt(i18nService.t('importPasswordPrompt'));
+    if (!password) return;
+
     setIsImportingProviders(true);
 
     try {
@@ -1979,7 +1983,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
           if (apiKeyObj.salt) {
             // Version 2 password-based encryption
             try {
-              apiKey = await decryptWithPassword(apiKeyObj, DEFAULT_EXPORT_PASSWORD);
+              apiKey = await decryptWithPassword(apiKeyObj, password);
             } catch (error) {
               hadDecryptFailure = true;
               console.warn(`Failed to decrypt provider key for ${providerKey}`, error);

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -428,6 +428,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
   const [isTesting, setIsTesting] = useState(false);
   const [isImportingProviders, setIsImportingProviders] = useState(false);
   const [isExportingProviders, setIsExportingProviders] = useState(false);
+  const [passwordModalConfig, setPasswordModalConfig] = useState<{
+    title: string;
+    hint: string;
+    resolve: (password: string | null) => void;
+  } | null>(null);
+  const [passwordInput, setPasswordInput] = useState('');
+  const [passwordError, setPasswordError] = useState('');
   const initialThemeRef = useRef<'light' | 'dark' | 'system'>(themeService.getTheme());
   const initialLanguageRef = useRef<LanguageType>(i18nService.getLanguage());
   const didSaveRef = useRef(false);
@@ -1805,8 +1812,44 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
       supportsImage: model.supportsImage ?? false,
     }));
 
+  const promptPassword = (title: string, hint: string): Promise<string | null> => {
+    return new Promise((resolve) => {
+      setPasswordInput('');
+      setPasswordError('');
+      setPasswordModalConfig({ title, hint, resolve });
+    });
+  };
+
+  const handlePasswordSubmit = () => {
+    if (!passwordModalConfig) return;
+    const pw = passwordInput.trim();
+    if (!pw) {
+      setPasswordError(i18nService.t('passwordRequired'));
+      return;
+    }
+    if (pw.length < 4) {
+      setPasswordError(i18nService.t('passwordTooShort'));
+      return;
+    }
+    passwordModalConfig.resolve(pw);
+    setPasswordModalConfig(null);
+    setPasswordInput('');
+    setPasswordError('');
+  };
+
+  const handlePasswordCancel = () => {
+    if (!passwordModalConfig) return;
+    passwordModalConfig.resolve(null);
+    setPasswordModalConfig(null);
+    setPasswordInput('');
+    setPasswordError('');
+  };
+
   const handleExportProviders = async () => {
-    const password = window.prompt(i18nService.t('exportPasswordPrompt'));
+    const password = await promptPassword(
+      i18nService.t('exportPasswordTitle'),
+      i18nService.t('exportPasswordHint')
+    );
     if (!password) return;
 
     setError(null);
@@ -1960,7 +2003,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
       return;
     }
 
-    const password = window.prompt(i18nService.t('importPasswordPrompt'));
+    const password = await promptPassword(
+      i18nService.t('importPasswordTitle'),
+      i18nService.t('importPasswordHint')
+    );
     if (!password) return;
 
     setIsImportingProviders(true);
@@ -3518,6 +3564,64 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
           </form>
 
         </div>
+
+        {passwordModalConfig && (
+          <div
+            className="absolute inset-0 z-30 flex items-center justify-center bg-black/35 px-4 rounded-2xl"
+            onClick={handlePasswordCancel}
+          >
+            <div
+              role="dialog"
+              aria-modal="true"
+              onClick={(e) => e.stopPropagation()}
+              className="w-full max-w-sm rounded-2xl dark:bg-claude-darkSurface bg-claude-bg dark:border-claude-darkBorder border-claude-border border shadow-modal p-4"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <h4 className="text-sm font-semibold dark:text-claude-darkText text-claude-text">
+                  {passwordModalConfig.title}
+                </h4>
+                <button
+                  type="button"
+                  onClick={handlePasswordCancel}
+                  className="p-1 dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:text-claude-darkText hover:text-claude-text rounded-md dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover"
+                >
+                  <XMarkIcon className="h-4 w-4" />
+                </button>
+              </div>
+              <p className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary mb-3">
+                {passwordModalConfig.hint}
+              </p>
+              <input
+                type="password"
+                value={passwordInput}
+                onChange={(e) => { setPasswordInput(e.target.value); setPasswordError(''); }}
+                onKeyDown={(e) => { if (e.key === 'Enter') handlePasswordSubmit(); }}
+                autoFocus
+                placeholder={i18nService.t('enterPassword')}
+                className="w-full px-3 py-2 text-sm rounded-xl border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkBg bg-claude-bg dark:text-claude-darkText text-claude-text focus:outline-none focus:ring-2 focus:ring-claude-accent/50"
+              />
+              {passwordError && (
+                <p className="mt-1.5 text-xs text-red-500">{passwordError}</p>
+              )}
+              <div className="mt-4 flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={handlePasswordCancel}
+                  className="px-3 py-1.5 text-xs font-medium rounded-xl border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-colors active:scale-[0.98]"
+                >
+                  {i18nService.t('cancel')}
+                </button>
+                <button
+                  type="button"
+                  onClick={handlePasswordSubmit}
+                  className="px-3 py-1.5 text-xs font-medium rounded-xl bg-claude-accent hover:bg-claude-accentHover text-white transition-colors active:scale-[0.98]"
+                >
+                  {i18nService.t('confirm')}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {isTestResultModalOpen && testResult && (
           <div

--- a/src/renderer/constants/app.ts
+++ b/src/renderer/constants/app.ts
@@ -1,4 +1,3 @@
 export const APP_NAME = 'LobsterAI';
 export const APP_ID = 'lobsterai';
 export const EXPORT_FORMAT_TYPE = 'lobsterai.providers';
-export const EXPORT_PASSWORD = 'lobsterai-APP';

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -138,6 +138,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: '两次输入的密码不一致',
     passwordTooShort: '密码长度至少为4位',
     wrongPassword: '密码错误，请检查后重试',
+    exportPasswordPrompt: '请输入导出加密密码（用于保护 API 密钥）',
+    importPasswordPrompt: '请输入导入解密密码（导出时设置的密码）',
     
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
@@ -1215,6 +1217,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: 'Passwords do not match',
     passwordTooShort: 'Password must be at least 4 characters',
     wrongPassword: 'Wrong password, please try again',
+    exportPasswordPrompt: 'Enter a password to encrypt your API keys for export',
+    importPasswordPrompt: 'Enter the password used when exporting this file',
     
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -9,6 +9,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // 通用
     save: '保存',
     cancel: '取消',
+    confirm: '确认',
     saving: '保存中...',
     create: '创建',
     clear: '清除',
@@ -1088,6 +1089,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Common
     save: 'Save',
     cancel: 'Cancel',
+    confirm: 'Confirm',
     saving: 'Saving...',
     create: 'Create',
     clear: 'Clear',


### PR DESCRIPTION
## Summary

- Remove the hardcoded `EXPORT_PASSWORD` constant (`lobsterai-APP`) from source code, which allowed anyone reading the source to decrypt exported API keys
- Replace with `window.prompt()` so users set their own password on export and enter it on import
- Add i18n keys for both export and import password prompts (zh + en)

## Changes

| File | Change |
|------|--------|
| `src/renderer/constants/app.ts` | Remove `EXPORT_PASSWORD` constant |
| `src/renderer/components/Settings.tsx` | Export: prompt user for password; Import v2: prompt user for password instead of using hardcoded value |
| `src/renderer/services/i18n.ts` | Add `exportPasswordPrompt` and `importPasswordPrompt` keys (zh + en) |

## Security Impact

Previously, the encryption password was visible in source code (`EXPORT_PASSWORD = 'lobsterai-APP'`), making exported API key encryption effectively useless. Now each user chooses their own password, so exported files are genuinely protected.

## How to Test

1. Open Settings → scroll to Import/Export section
2. Click Export — a prompt should ask for a password
3. Enter a password → file downloads with encrypted API keys
4. Click Import → select the exported file → a prompt should ask for the same password
5. Enter the correct password → providers import successfully
6. Enter a wrong password → error message appears ("密钥解密失败" / "Failed to decrypt")
7. Cancel the prompt (press Escape) → no action taken

Closes #686