### PR TITLE
feat(ui): add React Error Boundary to catch render crashes

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -30,6 +30,7 @@ import { matchesShortcut } from './services/shortcuts';
 import AppUpdateBadge from './components/update/AppUpdateBadge';
 import AppUpdateModal from './components/update/AppUpdateModal';
 import PrivacyDialog from './components/PrivacyDialog';
+import ErrorBoundary from './components/ErrorBoundary';
 
 const App: React.FC = () => {
   const [showSettings, setShowSettings] = useState(false);
@@ -645,7 +646,8 @@ const App: React.FC = () => {
         <div className={`flex-1 min-w-0 py-1.5 pr-1.5 ${isSidebarCollapsed ? 'pl-1.5' : ''}`}>
           <div className="relative h-full min-h-0 rounded-xl dark:bg-claude-darkBg bg-claude-bg overflow-hidden">
             <EngineStartupOverlay />
-            {mainView === 'skills' ? (
+            <ErrorBoundary>
+              {mainView === 'skills' ? (
               <SkillsView
                 isSidebarCollapsed={isSidebarCollapsed}
                 onToggleSidebar={handleToggleSidebar}
@@ -676,6 +678,7 @@ const App: React.FC = () => {
                 updateBadge={isSidebarCollapsed ? updateBadge : null}
               />
             )}
+            </ErrorBoundary>
           </div>
         </div>
       </div>

--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { i18nService } from '../services/i18n';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error('[ErrorBoundary] uncaught render error:', error, errorInfo.componentStack);
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): React.ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center dark:bg-claude-darkBg bg-claude-bg p-6">
+        <div className="flex flex-col items-center space-y-6 max-w-md">
+          <div className="w-16 h-16 rounded-full bg-red-500 flex items-center justify-center shadow-lg">
+            <ExclamationTriangleIcon className="h-8 w-8 text-white" />
+          </div>
+          <div className="dark:text-claude-darkText text-claude-text text-xl font-medium text-center">
+            {i18nService.t('errorBoundaryTitle')}
+          </div>
+          <div className="dark:text-claude-darkTextSecondary text-claude-textSecondary text-sm text-center">
+            {this.state.error?.message}
+          </div>
+          <div className="flex items-center space-x-3">
+            <button
+              onClick={this.handleReset}
+              className="px-6 py-2.5 bg-claude-accent hover:bg-claude-accentHover text-white rounded-xl shadow-md transition-colors text-sm font-medium"
+            >
+              {i18nService.t('errorBoundaryRetry')}
+            </button>
+            <button
+              onClick={this.handleReload}
+              className="px-6 py-2.5 dark:bg-claude-darkSurface bg-claude-surface dark:text-claude-darkText text-claude-text hover:opacity-80 rounded-xl shadow-md transition-colors text-sm font-medium"
+            >
+              {i18nService.t('errorBoundaryReload')}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -149,6 +149,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     collapse: '收起',
     expand: '展开',
     featureInDevelopment: '正在开发中',
+    errorBoundaryTitle: '页面出现了问题',
+    errorBoundaryRetry: '重试',
+    errorBoundaryReload: '刷新页面',
 
     // 认证相关
     authDailyQuota: '今日额度',
@@ -1254,6 +1257,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     collapse: 'Collapse',
     expand: 'Expand',
     featureInDevelopment: 'In development',
+    errorBoundaryTitle: 'Something went wrong',
+    errorBoundaryRetry: 'Try Again',
+    errorBoundaryReload: 'Reload Page',
 
     // Auth
     authDailyQuota: 'Daily Quota',


### PR DESCRIPTION
## Summary

- Add an `ErrorBoundary` component that catches uncaught render errors in the main content area
- Wrap CoworkView, SkillsView, ScheduledTasksView, and McpView with ErrorBoundary
- Display a recovery UI with retry and reload options instead of a blank white screen
- Add i18n keys for error boundary UI (zh + en)

## Problem

Currently, if any component in the main content area throws an uncaught error during rendering, the entire app crashes to a white screen with no recovery path. Users must force-quit and restart the application.

## Solution

A React class component `ErrorBoundary` using `getDerivedStateFromError` and `componentDidCatch`:

- **Catches** render errors from any child component
- **Logs** the error and component stack via `console.error` for debugging
- **Displays** a styled fallback UI consistent with the existing `initError` screen
- **Provides** two recovery options:
  - "Try Again" — resets the error state to re-render the children
  - "Reload Page" — performs a full page reload as a last resort

No external dependencies added — uses React's built-in error boundary API.

## Changes

| File | Change |
|------|--------|
| `src/renderer/components/ErrorBoundary.tsx` | New component — React class-based error boundary |
| `src/renderer/App.tsx` | Wrap main view content area with `<ErrorBoundary>` |
| `src/renderer/services/i18n.ts` | Add `errorBoundaryTitle`, `errorBoundaryRetry`, `errorBoundaryReload` keys |

## How to Test

1. Temporarily throw an error in any view component's render (e.g., add `throw new Error('test')` in CoworkView)
2. Navigate to that view — should see the error fallback UI with the error message
3. Click "Try Again" — component re-renders (if error is transient, it recovers)
4. Click "Reload Page" — full page reload
5. Remove the test error — app works normally
6. Verify the error is logged in DevTools console with `[ErrorBoundary]` tag