### PR TITLE
fix(skills): prevent disabled skills from being invoked in sessions

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4315,7 +4315,7 @@ if (!gotTheLock) {
     // When skills change (install/enable/disable/delete), re-sync AGENTS.md
     // so OpenClaw's IM channel agents pick up the latest skill list.
     manager.onSkillsChanged(() => {
-      syncOpenClawConfig({ reason: 'skills-changed' }).catch((error) => {
+      syncOpenClawConfig({ reason: 'skills-changed', restartGatewayIfRunning: true }).catch((error) => {
         console.warn('[Main] Failed to sync OpenClaw config after skills change:', error);
       });
     });

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -231,7 +231,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     // Get active skills prompts and combine them
     const activeSkills = activeSkillIds
       .map(id => skills.find(s => s.id === id))
-      .filter((s): s is Skill => s !== undefined);
+      .filter((s): s is Skill => s !== undefined && s.enabled);
     const skillPrompt = activeSkills.length > 0
       ? activeSkills.map(buildInlinedSkillPrompt).join('\n\n')
       : undefined;

--- a/src/renderer/store/slices/skillSlice.ts
+++ b/src/renderer/store/slices/skillSlice.ts
@@ -17,9 +17,9 @@ const skillSlice = createSlice({
   reducers: {
     setSkills: (state, action: PayloadAction<Skill[]>) => {
       state.skills = action.payload;
-      // Remove any active skill IDs that no longer exist
+      // Remove any active skill IDs that no longer exist or are disabled
       state.activeSkillIds = state.activeSkillIds.filter(id =>
-        action.payload.some(skill => skill.id === id)
+        action.payload.some(skill => skill.id === id && skill.enabled)
       );
     },
     addSkill: (state, action: PayloadAction<Skill>) => {
@@ -39,6 +39,10 @@ const skillSlice = createSlice({
       const skill = state.skills.find(s => s.id === action.payload);
       if (skill) {
         skill.enabled = !skill.enabled;
+        // Remove from active skills when disabled
+        if (!skill.enabled) {
+          state.activeSkillIds = state.activeSkillIds.filter(id => id !== action.payload);
+        }
       }
     },
     toggleActiveSkill: (state, action: PayloadAction<string>) => {


### PR DESCRIPTION
## Summary

Fix P0 bug where disabled skills could still be invoked by the AI model. This PR addresses **both** layers where the bug manifests:

1. **Main process (gateway layer)**: Gateway was not restarted after skill toggle, so it kept running with stale skill config — disabled skills remained callable via IM/OpenClaw channels
2. **Renderer layer**: `toggleSkill` reducer did not remove the skill from `activeSkillIds`, so its prompt was still injected into cowork session system prompts

## Root Cause

**Layer 1 — Gateway not reloaded (main process)**

`onSkillsChanged` called `syncOpenClawConfig()` without `restartGatewayIfRunning: true`. The gateway continued running with the pre-toggle skill list, allowing disabled skills to be invoked via all IM channels (Feishu, DingTalk, POPO, etc.).

**Layer 2 — activeSkillIds not cleaned (renderer)**

When a user disables a skill via the toggle switch, `toggleSkill` updated `enabled: false` but left the skill ID in `activeSkillIds`. If the skill was previously selected for a cowork conversation, its prompt was still injected into the session system prompt on the next turn.

## Changes

| File | Change |
|------|--------|
| `src/main/main.ts` | `onSkillsChanged`: add `restartGatewayIfRunning: true` so gateway reloads config immediately |
| `src/renderer/store/slices/skillSlice.ts` | `toggleSkill`: remove skill from `activeSkillIds` when disabling |
| `src/renderer/store/slices/skillSlice.ts` | `setSkills`: filter `activeSkillIds` to exclude disabled skills (bulk update path) |
| `src/renderer/components/cowork/CoworkPromptInput.tsx` | Defensive filter: skip disabled skills when building inline skill prompts |

## How to Test

**Gateway layer (IM channels):**
1. Enable a skill (e.g., web-search) and verify it works via Feishu/DingTalk
2. Disable the skill via the toggle switch
3. Verify the gateway restarts (log: `[Main] gateway restarted after config sync`)
4. Send a message in Feishu/DingTalk that would trigger the skill — verify it is NOT invoked

**Renderer layer (cowork sessions):**
1. Open Skills page → enable a skill (e.g., "web-search")
2. In the chat input, click the skills button → select "web-search" as active
3. Go back to Skills page → disable "web-search" via its toggle
4. Verify the "web-search" badge disappears from the chat input immediately
5. Start a new cowork session → verify the model does NOT invoke web-search

## Verification

- [x] TypeScript compiles with zero errors (`npx tsc --noEmit`)
- [x] Both gateway and renderer code paths fixed
- [x] No behavior change when enabling skills (only disabling path affected)

Closes #763