### PR TITLE
fix(security): add URL scheme allowlist to shell:openExternal

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1899,6 +1899,10 @@ if (!gotTheLock) {
     try {
       const baseUrl = loginUrl || `${getServerApiBaseUrl()}/login`;
       const finalUrl = `${baseUrl}?source=electron`;
+      if (!isSafeExternalUrl(finalUrl)) {
+        console.warn(`[Security] blocked auth:login for disallowed URL scheme: ${finalUrl}`);
+        return { success: false, error: 'URL scheme not allowed' };
+      }
       await shell.openExternal(finalUrl);
       return { success: true };
     } catch (error) {
@@ -3656,6 +3660,10 @@ if (!gotTheLock) {
   });
 
   ipcMain.handle('shell:openExternal', async (_event, url: string) => {
+    if (!isSafeExternalUrl(url)) {
+      console.warn(`[Security] blocked shell:openExternal for disallowed URL scheme: ${url}`);
+      return { success: false, error: 'URL scheme not allowed' };
+    }
     try {
       await shell.openExternal(url);
       return { success: true };
@@ -3855,6 +3863,17 @@ if (!gotTheLock) {
     }
   };
 
+  const ALLOWED_EXTERNAL_SCHEMES = new Set(['https:', 'http:', 'mailto:']);
+
+  const isSafeExternalUrl = (url: string): boolean => {
+    try {
+      const parsed = new URL(url);
+      return ALLOWED_EXTERNAL_SCHEMES.has(parsed.protocol.toLowerCase());
+    } catch {
+      return false;
+    }
+  };
+
   // 设置 Content Security Policy
   const setContentSecurityPolicy = () => {
     session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
@@ -3965,7 +3984,11 @@ if (!gotTheLock) {
           },
         };
       }
-      shell.openExternal(url);
+      if (isSafeExternalUrl(url)) {
+        shell.openExternal(url);
+      } else {
+        console.warn(`[Security] blocked window.open for disallowed URL scheme: ${url}`);
+      }
       return { action: 'deny' };
     });
 


### PR DESCRIPTION
## 变更说明

修复 `shell.openExternal()` 的三处调用缺少 URL scheme 校验的安全漏洞。新增 `isSafeExternalUrl()` 白名单校验函数，仅允许 `https:`、`http:`、`mailto:` 三种安全协议通过，其余全部拦截并记录告警日志。

## 问题

`shell:openExternal` IPC handler、`setWindowOpenHandler` 和 `auth:login` 三处调用 Electron 的 `shell.openExternal()` 时均未校验 URL scheme。渲染进程或 Agent 输出的 markdown 链接可传入任意协议的 URL，操作系统会调用对应的默认程序处理。

**可利用的危险协议及危害：**

| 协议 | 危害 | 严重性 |
|------|------|--------|
| \`file://\` | 用系统编辑器打开本地敏感文件（SSH 密钥、\`.env\`、数据库文件等），泄露机密信息 | 高 |
| \`smb://\` | 触发 SMB 连接，**Windows 自动发送 NTLM 哈希**，攻击者可离线破解用户密码 | 高 |
| \`ssh://\` | 触发 SSH 客户端连接到攻击者服务器 | 中 |
| \`ms-msdt://\` | 曾用于 Follina 漏洞（CVE-2022-30190），可触发远程代码执行 | 高 |
| \`tel:\` | macOS 弹出 FaceTime 拨号 | 低 |

**最现实的攻击场景：** Agent 回复的 markdown 中包含伪装成正常文档的恶意链接（如 \`[点击查看详情](smb://evil.com/doc)\`），用户点击后 Windows 自动发起 SMB 连接，NTLM 凭证泄露，用户完全无感知。

## 修复方案

新增 \`isSafeExternalUrl()\` 函数，使用 \`URL\` 构造器解析后对 \`protocol\` 做白名单检查：

- **白名单**：\`https:\`、\`http:\`、\`mailto:\`
- **解析方式**：\`new URL()\` 构造器（非字符串匹配，防绕过）
- **大小写**：\`.toLowerCase()\` 处理（CVE-2018-1000118 教训）
- **畸形 URL**：\`try/catch\` 兜底，解析失败直接拒绝
- **日志**：被拦截的 URL 输出 \`console.warn\` 告警

覆盖全部三个调用点：

1. **\`shell:openExternal\` IPC handler** — 渲染进程通用外链打开入口
2. **\`setWindowOpenHandler\`** — \`window.open()\` 降级路径
3. **\`auth:login\`** — 渲染端可控的 \`loginUrl\` 参数

## 对标业界实践

| 应用 | 做法 |
|------|------|
| **Electron 官方** | 安全规则 #15：不对不可信内容使用 \`shell.openExternal\` |
| **Signal Desktop** | 仅允许 \`http:\` 和 \`https:\`，其余全部丢弃 |
| **VS Code** | scheme 白名单 + \`URL\` 构造器解析 + 域名信任确认弹窗 |
| **CVE-2018-1000006/1000118** | 协议处理器命令注入，证明黑名单不可靠、必须用白名单 |

## 复现路径

1. \`npm run electron:dev\` 启动应用
2. 打开 DevTools（\`Ctrl+Shift+I\`）
3. Console 输入：\`window.electron.shell.openExternal("file:///etc/hosts")\`
4. **修复前**：系统编辑器打开 \`/etc/hosts\` 文件
5. **修复后**：返回 \`{ success: false, error: "URL scheme not allowed" }\`

## 影响范围

对正常使用**零影响**。所有合法调用点的 URL 均为 \`https://\` 开头（设置页链接、OAuth 验证、技能市场、应用更新等），全部正常通过。被拦截的仅限恶意或非标准协议。