### PR TITLE
fix(openclaw): 修复微信插件未安装时网关启动失败

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -932,14 +932,16 @@ export class OpenClawConfigSync {
     }
 
     // Sync Weixin OpenClaw channel config (via openclaw-weixin plugin)
-    // Always write the channel entry — use enabled:false when disabled so the
-    // Gateway stops the channel instead of falling back to plugin defaults.
-    const weixinChannelEnabled = !!(weixinConfig?.enabled);
-    const weixinChannel: Record<string, unknown> = {
-      enabled: weixinChannelEnabled,
-      ...(weixinConfig?.accountId ? { accountId: weixinConfig.accountId } : {}),
-    };
-    managedConfig.channels = { ...(managedConfig.channels as Record<string, unknown> || {}), 'openclaw-weixin': weixinChannel };
+    // Only write the channel entry when the plugin is actually installed,
+    // otherwise the gateway rejects the config as invalid.
+    if (preinstalledPluginIds.includes('openclaw-weixin')) {
+      const weixinChannelEnabled = !!(weixinConfig?.enabled);
+      const weixinChannel: Record<string, unknown> = {
+        enabled: weixinChannelEnabled,
+        ...(weixinConfig?.accountId ? { accountId: weixinConfig.accountId } : {}),
+      };
+      managedConfig.channels = { ...(managedConfig.channels as Record<string, unknown> || {}), 'openclaw-weixin': weixinChannel };
+    }
 
     const nextContent = `${JSON.stringify(managedConfig, null, 2)}\n`;
     console.log('[OpenClawConfigSync] sync() managedConfig key fields:', {


### PR DESCRIPTION
## 概要
- 修复 `openclaw-weixin` 插件未安装时 OpenClaw 网关无法启动的问题
- `openclaw-weixin` channel 配置被无条件写入 `openclaw.json`，导致网关校验失败并陷入重启循环

## 问题
`openclawConfigSync.ts` 在同步配置时，无论 `openclaw-weixin` 插件是否已安装到 runtime 中，都会将其 channel 条目写入 `openclaw.json`。网关启动时校验配置，发现引用了不存在的 channel ID，报错：
```
Config invalid
- channels.openclaw-weixin: unknown channel id: openclaw-weixin
```
网关因此反复重启失败，导致应用在 OpenClaw 引擎模式下无法使用。

## 修复方式
在写入微信 channel 配置前，增加 `preinstalledPluginIds.includes('openclaw-weixin')` 检查，仅在插件实际安装时才写入。这与其他 channel（telegram、discord、feishu、dingtalk 等）通过各自的插件/配置可用性检查来控制写入的方式一致。