### PR TITLE
阿里百炼 API 密钥 401

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -371,6 +371,17 @@ const buildProviderSelection = (options: {
     };
   }
 
+  // Providers that expose Anthropic-compatible endpoints but authenticate via
+  // Bearer token instead of the native Anthropic `x-api-key` header.
+  // When the selected API format is anthropic-messages AND the provider is one
+  // of these, we force `auth: 'bearer'` so OpenClaw sends
+  // `Authorization: Bearer <key>` instead of `x-api-key: <key>`.
+  const needsBearerForAnthropic = new Set(['qwen', 'volcengine', 'zhipu']);
+  const authMode: 'api-key' | 'bearer' =
+    providerApi === 'anthropic-messages' && needsBearerForAnthropic.has(providerName)
+      ? 'bearer'
+      : 'api-key';
+
   return {
     providerId: 'lobster',
     legacyModelId: options.modelId,
@@ -380,7 +391,7 @@ const buildProviderSelection = (options: {
       baseUrl: stripChatCompletionsSuffix(options.baseURL),
       api: providerApi,
       apiKey: '${LOBSTER_PROVIDER_API_KEY}',
-      auth: 'api-key',
+      auth: authMode,
       models: [
         {
           id: options.modelId,


### PR DESCRIPTION
fix(openclaw): 修复 DashScope/Volcengine/Zhipu Anthropic 兼容模式认证

[问题]
阿里百炼 Qwen API 密钥返回 401，版本升级后出现（v0.2.2 正常）。

[根因]
DashScope/Volcengine/Zhipu 的 Anthropic 兼容端点使用 `Authorization: Bearer` 认证，
但 OpenClaw 在 `api=anthropic-messages` + `auth=api-key` 时发送 `x-api-key` header。

[修复]
在 `buildProviderSelection()` 中检测 qwen/volcengine/zhipu 提供商，
对 Anthropic 兼容模式使用 `auth: 'bearer'` 而非 `auth: 'api-key'`。

涉及文件:
- src/main/libs/openclawConfigSync.ts

[复现路径]
1. 配置阿里百炼 Qwen API（选择 Anthropic 兼容模式）
2. 发送消息，返回 401 Unauthorized
3. 修复后认证正常，对话成功

Closes #732