### PR TITLE
fix(renderer): continue 会话时立即设置 streaming 状态 (#743)

### DIFF
--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -320,6 +320,9 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       .filter(p => p?.trim())
       .join('\n\n') || undefined;
 
+    // Set streaming state immediately so the UI shows the stop button (#743)
+    dispatch(setStreaming(true));
+
     await coworkService.continueSession({
       sessionId: currentSession.id,
       prompt,


### PR DESCRIPTION
fix(renderer): continue 会话时立即设置 streaming 状态

[问题]
在已有会话中发送消息后，发送按钮未切换为停止按钮，用户无法中断 AI 回复。

[根因]
`handleContinueSession` 未调用 `setStreaming(true)`，而 `handleStartSession` 有该调用。
`isStreaming` 状态控制发送/停止按钮的显示。

[修复]
在调用 `coworkService.continueSession()` 前添加 `dispatch(setStreaming(true))`，
与 `handleStartSession` 保持一致。

涉及文件:
- src/renderer/components/cowork/CoworkView.tsx

[复现路径]
1. 打开一个已有会话
2. 发送消息
3. 观察按钮仍为"发送"而非"停止"，点击无法中断

Closes #743