### PR TITLE
Skills 禁用开关不生效

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3946,7 +3946,7 @@ if (!gotTheLock) {
     // When skills change (install/enable/disable/delete), re-sync AGENTS.md
     // so OpenClaw's IM channel agents pick up the latest skill list.
     manager.onSkillsChanged(() => {
-      syncOpenClawConfig({ reason: 'skills-changed' }).catch((error) => {
+      syncOpenClawConfig({ reason: 'skills-changed', restartGatewayIfRunning: true }).catch((error) => {
         console.warn('[Main] Failed to sync OpenClaw config after skills change:', error);
       });
     });


### PR DESCRIPTION
fix(skills): 禁用 skill 后重启 gateway 使其生效

[问题]
在设置中关闭 skill 开关后，该 skill 仍可被调用。

[根因]
`onSkillsChanged` 回调调用 `syncOpenClawConfig()` 时未传递 `restartGatewayIfRunning: true`，
gateway 保持旧的 skill 配置运行，未重新加载新配置。

[修复]
在 `syncOpenClawConfig()` 调用中添加 `restartGatewayIfRunning: true`，
确保 skill 配置变更后立即重启 gateway 生效。

涉及文件:
- src/main/main.ts (约 3948 行)

[复现路径]
1. 启用一个 skill（如 web-search）
2. 在对话中验证 skill 可用
3. 在设置中关闭该 skill
4. 再次对话，观察 skill 仍被调用（修复后不再调用）

Closes #763