### PR TITLE
refactor(cowork): 删除 startSession 中重复的 updateSession 调用 (#758)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2082,10 +2082,6 @@ if (!gotTheLock) {
 
       const runner = getCoworkRunner();
 
-      // Update session status to 'running' before starting async task
-      // This ensures the frontend receives the correct status immediately
-      coworkStoreInstance.updateSession(session.id, { status: 'running' });
-
       // Start the session asynchronously (skip initial user message since we already added it)
       const runtime = getCoworkEngineRouter();
       runtime.startSession(session.id, options.prompt, {


### PR DESCRIPTION
refactor(cowork): 删除 startSession 中重复的 updateSession 调用

[问题]
创建会话时两次调用 `updateSession(status: 'running')`，触发冗余的 SQLite 全表序列化写入。

[根因]
代码中第 2065 行和第 2087 行各有一次 `updateSession` 调用，第二次是多余的。

[修复]
删除第二次重复的 `updateSession` 调用，保留第一次即可。

涉及文件:
- src/main/main.ts (约 2065-2087 行)

[复现路径]
1. 创建新会话
2. 观察日志，可见两次 "updateSession" 调用
3. 修复后只有一次

Closes #758