### PR TITLE
executionMode 配置不生效

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -883,12 +883,20 @@ export class CoworkStore {
     const memoryGuardLevelRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['memoryGuardLevel']);
     const memoryUserMemoriesMaxItemsRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['memoryUserMemoriesMaxItems']);
 
+    const executionModeRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['executionMode']);
+
     const normalizedAgentEngine = normalizeCoworkAgentEngineValue(agentEngineRow?.value);
+
+    const rawExecutionMode = executionModeRow?.value as CoworkExecutionMode | undefined;
+    const executionMode: CoworkExecutionMode =
+      rawExecutionMode === 'auto' || rawExecutionMode === 'sandbox' || rawExecutionMode === 'local'
+        ? rawExecutionMode
+        : 'local';
 
     return {
       workingDirectory: workingDirRow?.value || getDefaultWorkingDirectory(),
       systemPrompt: getDefaultSystemPrompt(),
-      executionMode: 'local' as CoworkExecutionMode,
+      executionMode,
       agentEngine: normalizedAgentEngine,
       memoryEnabled: parseBooleanConfig(memoryEnabledRow?.value, DEFAULT_MEMORY_ENABLED),
       memoryImplicitUpdateEnabled: parseBooleanConfig(

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -17,9 +17,16 @@ export type McpBridgeConfig = {
   tools: McpToolManifestEntry[];
 };
 
-const mapExecutionModeToSandboxMode = (_mode: CoworkExecutionMode): 'off' | 'non-main' | 'all' => {
-  // Sandbox mode disabled — always run locally
-  return 'off';
+const mapExecutionModeToSandboxMode = (mode: CoworkExecutionMode): 'off' | 'non-main' | 'all' => {
+  switch (mode) {
+    case 'sandbox':
+      return 'all';
+    case 'auto':
+      return 'non-main';
+    case 'local':
+    default:
+      return 'off';
+  }
 };
 
 /**


### PR DESCRIPTION
fix(cowork): 修复 executionMode 配置不生效问题

[问题]
设置中选择 auto 或 sandbox 模式后，实际仍按 local 模式运行。

[根因]
两处问题：
1. `coworkStore.getConfig()` 硬编码 `executionMode: 'local'`，未读取数据库真实值
2. `mapExecutionModeToSandboxMode()` 固定返回 'off'，未进行模式映射

[修复]
1. `getConfig()` 改为从 `cowork_config` 表读取 `executionMode`
2. 添加正确映射：local→off, auto→non-main, sandbox→all

涉及文件:
- src/main/coworkStore.ts
- src/main/libs/openclawConfigSync.ts

[复现路径]
1. 在设置中选择 sandbox 模式
2. 创建会话，观察 sandbox 权限未生效（如无法访问文件系统）
3. 修复后 sandbox 模式正常工作

Closes #735