### PR TITLE
fix(api): prevent main process crash when renderer is destroyed durin…

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3790,6 +3790,10 @@ if (!gotTheLock) {
         try {
           while (true) {
             const { value, done } = await reader.read();
+            if (event.sender.isDestroyed()) {
+              reader.cancel();
+              break;
+            }
             if (done) {
               event.sender.send(`api:stream:${options.requestId}:done`);
               break;
@@ -3798,6 +3802,10 @@ if (!gotTheLock) {
             event.sender.send(`api:stream:${options.requestId}:data`, chunk);
           }
         } catch (error) {
+          if (event.sender.isDestroyed()) {
+            // Renderer is gone — silently drop the event to avoid a crash.
+            return;
+          }
           if (error instanceof Error && error.name === 'AbortError') {
             event.sender.send(`api:stream:${options.requestId}:abort`);
           } else {


### PR DESCRIPTION
[问题]                                                                                                                                                                                                                           
  用户在 AI 流式响应未结束时关闭窗口，会导致 Electron 主进程崩溃、整个应用退出，
  所有未保存的会话内容丢失。                                                                                                                                                                                                       
                                                                                                                                                                                                                                   
  [根因]                                                                                                                                                                                                                           
  `api:stream` IPC 处理器中，`readStream()` 以 fire-and-forget 方式调用（无 await），                                                                                                                                              
  在异步循环的每一轮里直接调用 `event.sender.send()` 向渲染进程推送流数据。                                                                                                                                                        
                                                                                                                                                                                                                                   
  问题在于，代码从未检查 `event.sender.isDestroyed()`：                                                                                                                                                                            
                                                                                                                                                                                                                                   
  1. 用户关闭窗口 → WebContents 被销毁                                                                                                                                                                                             
  2. try 块的 `event.sender.send()` 抛出 "Object has been destroyed"
  3. catch 块捕获后，**再次**调用 `event.sender.send()` → 二次抛出                                                                                                                                                                 
  4. 第二次异常在 async 函数内无处捕获，变成 unhandled Promise rejection                                                                                                                                                           
  5. Node.js / Electron 将未处理的 rejection 升级为进程级错误 → 主进程崩溃                                                                                                                                                         
                                                                                                                                                                                                                                   
  [修复]                                                                                                                                                                                                                           
  - **循环内**：每次 `reader.read()` 完成后先检查 `event.sender.isDestroyed()`，                                                                                                                                                   
    若为真则调用 `reader.cancel()` 终止流并跳出循环，不再尝试任何 IPC 调用。                                                                                                                                                       
  - **catch 块顶部**：若 sender 已销毁，直接 `return`，阻止后续对已销毁对象的                                                                                                                                                      
    `send()` 调用，从根本上切断二次抛出的路径。                                                                                                                                                                                    
                                                                                                                                                                                                                                   
  [复现路径]                                                                                                                                                                                                                       
  1. 启动应用，打开一个 Cowork 会话                                                                                                                                                                                                
  2. 发送一条会触发较长流式响应的 prompt（如"写一篇 2000 字的文章"）                                                                                                                                                               
  3. 在响应流式输出过程中，直接关闭应用窗口                                                                                                                                                                                        
  4. 修复前：应用进程随即崩溃退出                                                                                                                                                                                                  
  5. 修复后：流被静默取消，主进程保持正常运行