### PR TITLE
perf(cowork): 使用索引表优化流式消息更新查找性能从 O(n) 到 O(1)

### DIFF
--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -12,6 +12,8 @@ interface CoworkState {
   sessions: CoworkSessionSummary[];
   currentSessionId: string | null;
   currentSession: CoworkSession | null;
+  // O(1) message lookup index: messageId -> array index in currentSession.messages
+  messageIndexById: Record<string, number>;
   draftPrompts: Record<string, string>;
   unreadSessionIds: string[];
   isCoworkActive: boolean;
@@ -25,6 +27,7 @@ const initialState: CoworkState = {
   sessions: [],
   currentSessionId: null,
   currentSession: null,
+  messageIndexById: {},
   draftPrompts: {},
   unreadSessionIds: [],
   isCoworkActive: false,
@@ -56,6 +59,14 @@ const markSessionUnread = (state: CoworkState, sessionId: string) => {
 };
 
 const STREAMING_MERGE_PROBE_CHARS = 512;
+
+const buildMessageIndex = (messages: CoworkMessage[]): Record<string, number> => {
+  const index: Record<string, number> = {};
+  for (let i = 0; i < messages.length; i++) {
+    index[messages[i].id] = i;
+  }
+  return index;
+};
 
 const computeStreamingSuffixPrefixOverlap = (left: string, right: string): number => {
   const leftProbe = left.slice(-STREAMING_MERGE_PROBE_CHARS);
@@ -119,6 +130,7 @@ const coworkSlice = createSlice({
       state.currentSession = action.payload;
       if (action.payload) {
         state.currentSessionId = action.payload.id;
+        state.messageIndexById = buildMessageIndex(action.payload.messages);
         if (!action.payload.id.startsWith('temp-')) {
           const { id, title, status, pinned, createdAt, updatedAt } = action.payload;
           const summary: CoworkSessionSummary = {
@@ -140,6 +152,8 @@ const coworkSlice = createSlice({
           }
         }
         markSessionRead(state, action.payload.id);
+      } else {
+        state.messageIndexById = {};
       }
     },
 
@@ -164,6 +178,7 @@ const coworkSlice = createSlice({
       state.sessions.unshift(summary);
       state.currentSession = action.payload;
       state.currentSessionId = action.payload.id;
+      state.messageIndexById = buildMessageIndex(action.payload.messages);
       markSessionRead(state, action.payload.id);
     },
 
@@ -194,6 +209,7 @@ const coworkSlice = createSlice({
       if (state.currentSessionId === sessionId) {
         state.currentSessionId = null;
         state.currentSession = null;
+        state.messageIndexById = {};
       }
     },
 
@@ -205,6 +221,7 @@ const coworkSlice = createSlice({
       if (state.currentSessionId && sessionIds.has(state.currentSessionId)) {
         state.currentSessionId = null;
         state.currentSession = null;
+        state.messageIndexById = {};
       }
     },
 
@@ -212,8 +229,8 @@ const coworkSlice = createSlice({
       const { sessionId, message } = action.payload;
 
       if (state.currentSession?.id === sessionId) {
-        const exists = state.currentSession.messages.some((item) => item.id === message.id);
-        if (!exists) {
+        if (!(message.id in state.messageIndexById)) {
+          state.messageIndexById[message.id] = state.currentSession.messages.length;
           state.currentSession.messages.push(message);
           state.currentSession.updatedAt = message.timestamp;
         }
@@ -232,8 +249,8 @@ const coworkSlice = createSlice({
       const { sessionId, messageId, content } = action.payload;
 
       if (state.currentSession?.id === sessionId) {
-        const messageIndex = state.currentSession.messages.findIndex(m => m.id === messageId);
-        if (messageIndex !== -1) {
+        const messageIndex = state.messageIndexById[messageId];
+        if (messageIndex !== undefined) {
           const previousContent = state.currentSession.messages[messageIndex].content || '';
           if (state.config.agentEngine === 'yd_cowork') {
             state.currentSession.messages[messageIndex].content = mergeStreamingMessageContent(previousContent, content);
@@ -312,6 +329,7 @@ const coworkSlice = createSlice({
     clearCurrentSession(state) {
       state.currentSessionId = null;
       state.currentSession = null;
+      state.messageIndexById = {};
       state.isStreaming = false;
       state.remoteManaged = false;
     },


### PR DESCRIPTION
## 关联 Issue

Closes #810

## 概述

优化 `coworkSlice.ts` 中流式消息更新的查找性能。原实现在每次 `updateMessageContent` 时使用 `findIndex` 线性遍历消息数组，在长会话中造成性能瓶颈。本 PR 引入 `messageIndexById` 索引表，将查找复杂度从 O(n) 降到 O(1)。

## 改动详情

在 `CoworkState` 中新增 `messageIndexById: Record<string, number>` 字段，维护消息 ID 到数组下标的映射关系：

- **`setCurrentSession`**：加载会话时通过 `buildMessageIndex()` 构建索引；置空时清除索引
- **`addSession`**：创建新会话时构建索引
- **`addMessage`**：新增消息时用 `in` 操作符做 O(1) 去重检查，并同步更新索引
- **`updateMessageContent`**：流式更新时通过索引直接定位消息，从 `findIndex` O(n) 优化为 O(1)
- **`deleteSession` / `deleteSessions` / `clearCurrentSession`**：清除会话时同步清空索引

## 涉及文件

- `src/renderer/store/slices/coworkSlice.ts`

## 性能影响

| 操作 | 优化前 | 优化后 |
|------|--------|--------|
| `updateMessageContent`（每次流式 chunk） | O(n) findIndex | O(1) 哈希查找 |
| `addMessage` 去重检查 | O(n) some | O(1) in 操作符 |
| 会话加载（一次性） | 无额外开销 | O(n) 构建索引 |

对于包含 500 条消息的长会话，流式更新期间累计可减少数万次无效遍历。

## 测试验证

- 本地 `vite build` 构建通过
- 本地 `npm run electron:dev` 启动验证，流式输出、消息增删、会话切换均正常