### PR TITLE
feat(config): 小米渠道新增 MiMo V2 Pro 和 MiMo V2 Omni 模型

### DIFF
--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -351,7 +351,9 @@ export const defaultConfig: AppConfig = {
       baseUrl: 'https://api.xiaomimimo.com/anthropic',
       apiFormat: 'anthropic',
       models: [
-        { id: 'mimo-v2-flash', name: 'MiMo V2 Flash', supportsImage: false }
+        { id: 'mimo-v2-flash', name: 'MiMo V2 Flash', supportsImage: false },
+        { id: 'mimo-v2-pro', name: 'MiMo V2 Pro', supportsImage: true },
+        { id: 'mimo-v2-omni', name: 'MiMo V2 Omni', supportsImage: true }
       ]
     },
     stepfun: {


### PR DESCRIPTION
## 概述

根据小米 MiMo 开放平台定价页面的模型列表，为小米（xiaomi）渠道补充当前缺失的两个模型。

## 新增模型

| 模型 ID | 显示名称 | 支持图像 |
|---------|---------|---------|
| `mimo-v2-pro` | MiMo V2 Pro | 是 |
| `mimo-v2-omni` | MiMo V2 Omni | 是 |

原有模型 `mimo-v2-flash`（不支持图像）保持不变。

## 涉及文件

- `src/renderer/config.ts` — `defaultConfig.providers.xiaomi.models` 数组新增两项