### PR TITLE
fix(auth): unify token refresh lock to eliminate race conditions

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1820,6 +1820,43 @@ if (!gotTheLock) {
     getStore().delete('auth_tokens');
   };
 
+  // Shared token-refresh lock: deduplicates concurrent passive (401) and
+  // proactive (near-expiry) refresh calls so the refresh endpoint is called
+  // at most once at a time.
+  let activeRefreshPromise: Promise<{ accessToken: string; refreshToken: string } | null> | null = null;
+
+  /**
+   * Refresh tokens exactly once, deduplicating concurrent callers.
+   * Returns the new token pair on success, or null on failure.
+   */
+  const performTokenRefresh = (): Promise<{ accessToken: string; refreshToken: string } | null> => {
+    if (activeRefreshPromise) return activeRefreshPromise;
+    activeRefreshPromise = (async () => {
+      try {
+        const tokens = getAuthTokens();
+        if (!tokens?.refreshToken) return null;
+        const serverBaseUrl = getServerApiBaseUrl();
+        const resp = await net.fetch(`${serverBaseUrl}/api/auth/refresh`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refreshToken: tokens.refreshToken }),
+        });
+        if (!resp.ok) return null;
+        const body = await resp.json() as { code: number; data: { accessToken: string; refreshToken?: string } };
+        if (body.code !== 0 || !body.data) return null;
+        const newTokens = {
+          accessToken: body.data.accessToken,
+          refreshToken: body.data.refreshToken || tokens.refreshToken,
+        };
+        saveAuthTokens(newTokens.accessToken, newTokens.refreshToken);
+        return newTokens;
+      } finally {
+        activeRefreshPromise = null;
+      }
+    })();
+    return activeRefreshPromise;
+  };
+
   /**
    * Helper: Fetch with Bearer token, auto-refresh on 401 and retry once.
    */
@@ -1836,18 +1873,9 @@ if (!gotTheLock) {
     let resp = await doFetch(tokens.accessToken);
 
     if (resp.status === 401 && tokens.refreshToken) {
-      const serverBaseUrl = getServerApiBaseUrl();
-      const refreshResp = await net.fetch(`${serverBaseUrl}/api/auth/refresh`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ refreshToken: tokens.refreshToken }),
-      });
-      if (refreshResp.ok) {
-        const refreshBody = await refreshResp.json() as { code: number; data: { accessToken: string; refreshToken?: string } };
-        if (refreshBody.code === 0 && refreshBody.data) {
-          saveAuthTokens(refreshBody.data.accessToken, refreshBody.data.refreshToken || tokens.refreshToken);
-          resp = await doFetch(refreshBody.data.accessToken);
-        }
+      const newTokens = await performTokenRefresh();
+      if (newTokens) {
+        resp = await doFetch(newTokens.accessToken);
       }
     }
 
@@ -2014,19 +2042,9 @@ if (!gotTheLock) {
 
   ipcMain.handle('auth:refreshToken', async () => {
     try {
-      const tokens = getAuthTokens();
-      if (!tokens?.refreshToken) return { success: false };
-      const serverBaseUrl = getServerApiBaseUrl();
-      const resp = await net.fetch(`${serverBaseUrl}/api/auth/refresh`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ refreshToken: tokens.refreshToken }),
-      });
-      if (!resp.ok) return { success: false };
-      const body = await resp.json() as { code: number; data: { accessToken: string; refreshToken?: string } };
-      if (body.code !== 0 || !body.data) return { success: false };
-      saveAuthTokens(body.data.accessToken, body.data.refreshToken || tokens.refreshToken);
-      return { success: true, accessToken: body.data.accessToken };
+      const newTokens = await performTokenRefresh();
+      if (!newTokens) return { success: false };
+      return { success: true, accessToken: newTokens.accessToken };
     } catch {
       return { success: false };
     }
@@ -4242,32 +4260,15 @@ if (!gotTheLock) {
     // The getter proactively triggers a background token refresh when the
     // accessToken is within 5 minutes of expiry, so that the SDK always
     // gets a fresh token without blocking.
-    let refreshPromise: Promise<void> | null = null;
     const refreshTokenAsync = async () => {
-      if (refreshPromise) return;
-      refreshPromise = (async () => {
-        try {
-          const tokens = getAuthTokens();
-          if (!tokens?.refreshToken) return;
-          const serverBaseUrl = getServerApiBaseUrl();
-          const resp = await net.fetch(`${serverBaseUrl}/api/auth/refresh`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ refreshToken: tokens.refreshToken }),
-          });
-          if (resp.ok) {
-            const body = await resp.json() as { code: number; data: { accessToken: string; refreshToken?: string } };
-            if (body.code === 0 && body.data) {
-              saveAuthTokens(body.data.accessToken, body.data.refreshToken || tokens.refreshToken);
-              console.log('[Auth] proactive token refresh succeeded');
-            }
-          }
-        } catch (err) {
-          console.warn('[Auth] proactive token refresh failed:', err);
-        } finally {
-          refreshPromise = null;
+      try {
+        const newTokens = await performTokenRefresh();
+        if (newTokens) {
+          console.log('[Auth] proactive token refresh succeeded');
         }
-      })();
+      } catch (err) {
+        console.warn('[Auth] proactive token refresh failed:', err);
+      }
     };
 
     setAuthTokensGetter(() => {


### PR DESCRIPTION
The three token-refresh paths (passive on 401 in fetchWithAuth, proactive near-expiry in refreshTokenAsync, and manual via auth:refreshToken IPC) each maintained separate or no concurrency guards. When multiple requests received HTTP 401 simultaneously, all of them would concurrently call the refresh endpoint, potentially consuming a rolling refresh token before others could use it, leading to token state inconsistency.

Introduce a single shared `activeRefreshPromise` lock and `performTokenRefresh` helper that deduplicates concurrent callers: the first caller initiates the refresh request and every subsequent caller awaits the same in-flight promise. All three refresh paths now delegate to this helper, ensuring the refresh endpoint is called at most once at a time regardless of the trigger source.