### PR TITLE
feat: prevent installing duplicate skill

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -50,6 +50,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Skill manager errors
     skillErrNoSkillMd: '来源中未找到 SKILL.md',
+    skillErrDuplicate: '技能已存在：{names}，无需重复安装',
 
     // Auth quota
     authPlanFree: '免费',
@@ -91,6 +92,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Skill manager errors
     skillErrNoSkillMd: 'No SKILL.md found in source',
+    skillErrDuplicate: 'Skill already installed: {names}',
 
     // Auth quota
     authPlanFree: 'Free',

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -1516,6 +1516,17 @@ export class SkillManager {
 
       // Safe or scan failed — install directly
       console.log(`[SkillManager] Skill is safe (or scan failed), installing directly`);
+
+      // Check for duplicate skills before installing
+      const duplicateNames = this.findDuplicateSkillNames(skillDirs);
+      if (duplicateNames.length > 0) {
+        cleanupPathSafely(cleanupPath);
+        cleanupPath = null;
+        const nameList = duplicateNames.join(', ');
+        console.log(`[SkillManager] Duplicate skill(s) detected: ${nameList}`);
+        return { success: false, error: t('skillErrDuplicate').replace('{names}', nameList) };
+      }
+
       for (const skillDir of skillDirs) {
         const folderName = normalizeFolderName(path.basename(skillDir));
         let targetDir = resolveWithin(root, folderName);
@@ -1556,6 +1567,15 @@ export class SkillManager {
     if (action === 'cancel') {
       cleanupPathSafely(pending.cleanupPath);
       return { success: true };
+    }
+
+    // Check for duplicate skills before installing
+    const duplicateNames = this.findDuplicateSkillNames(pending.skillDirs);
+    if (duplicateNames.length > 0) {
+      cleanupPathSafely(pending.cleanupPath);
+      const nameList = duplicateNames.join(', ');
+      console.log(`[SkillManager] Duplicate skill(s) detected: ${nameList}`);
+      return { success: false, error: t('skillErrDuplicate').replace('{names}', nameList) };
     }
 
     // Install the skill(s)
@@ -1661,6 +1681,32 @@ export class SkillManager {
     return () => {
       this.changeListeners = this.changeListeners.filter(l => l !== listener);
     };
+  }
+
+  /**
+   * Returns the names of incoming skills that already exist among installed skills.
+   * Compares by normalized skill name from SKILL.md frontmatter.
+   */
+  private findDuplicateSkillNames(incomingSkillDirs: string[]): string[] {
+    const existingSkills = this.listSkills();
+    const existingNames = new Set(existingSkills.map(s => s.name.toLowerCase()));
+
+    const duplicates: string[] = [];
+    for (const skillDir of incomingSkillDirs) {
+      const skillFile = path.join(skillDir, SKILL_FILE_NAME);
+      if (!fs.existsSync(skillFile)) continue;
+      try {
+        const raw = fs.readFileSync(skillFile, 'utf8');
+        const { frontmatter } = parseFrontmatter(raw);
+        const name = (String(frontmatter.name || '') || path.basename(skillDir)).trim() || path.basename(skillDir);
+        if (existingNames.has(name.toLowerCase())) {
+          duplicates.push(name);
+        }
+      } catch {
+        // If we can't parse, skip duplicate check for this dir
+      }
+    }
+    return duplicates;
   }
 
   private parseSkillDir(


### PR DESCRIPTION
### 变更说明

**问题**：通过"添加"按钮上传同一个 skill.zip 时，系统会自动给文件夹名追加 `-1`、`-2` 后缀，导致同一 skill 被重复安装。

**修复**：在安装前增加重复检测，通过解析待安装 skill 的 SKILL.md frontmatter 中的 `name` 字段，与已安装 skill 的名称进行**不区分大小写**的比较。如果发现重复，直接返回错误并阻止安装。

**改动文件**：

1. skillManager.ts — 新增 `findDuplicateSkillNames()` 私有方法，并在两个安装路径（直接安装 和 安全审核确认后安装）中调用：
   - skillManager.ts：`downloadSkill()` 中安全检查通过后、实际复制文件前
   - skillManager.ts：`confirmPendingInstall()` 中用户确认后、实际复制文件前

2. i18n.ts — 新增 `skillErrDuplicate` 双语错误提示：
   - 中文：`技能已存在：{names}，无需重复安装`
   - 英文：`Skill already installed: {names}`

### 关联 issue
#776 

### UI 变更附截图
<img width="1576" height="770" alt="image" src="https://github.com/user-attachments/assets/6e4dfdf0-dce2-4643-bd28-b24e5da63505" />
