### PR TITLE
fix(security): prevent path traversal in localfile:// protocol handler

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4218,10 +4218,41 @@ if (!gotTheLock) {
     console.log('[Main] initApp: default project dir ensured');
 
     // 注册 localfile:// 自定义协议，用于安全加载本地文件（图片等）
-    protocol.handle('localfile', (request) => {
+    // Security: resolve symlinks and validate path stays within allowed directories
+    protocol.handle('localfile', async (request) => {
       const url = new URL(request.url);
-      const filePath = decodeURIComponent(url.pathname);
-      return net.fetch(`file://${filePath}`);
+      const rawPath = decodeURIComponent(url.pathname);
+
+      // Resolve symlinks to prevent symlink-based bypass
+      let resolvedPath: string;
+      try {
+        resolvedPath = await fs.promises.realpath(path.resolve(rawPath));
+      } catch {
+        return new Response('Not Found', { status: 404 });
+      }
+
+      // Allow only paths under app data, temp dir, or the cowork working directory
+      const allowedRoots = [
+        app.getPath('userData'),
+        app.getPath('temp'),
+      ];
+      try {
+        const workingDir = getCoworkStore().getConfig().workingDirectory;
+        if (workingDir) {
+          allowedRoots.push(workingDir);
+        }
+      } catch {
+        // Store not yet initialized; only allow app directories
+      }
+      const isAllowed = allowedRoots.some(
+        (root) => resolvedPath.startsWith(root + path.sep) || resolvedPath === root
+      );
+      if (!isAllowed) {
+        console.warn('[Main] localfile:// blocked path traversal attempt');
+        return new Response('Forbidden', { status: 403 });
+      }
+
+      return net.fetch(`file://${resolvedPath}`);
     });
 
     console.log('[Main] initApp: starting initStore()');


### PR DESCRIPTION
[问题]                                      
  自定义 localfile:// 协议处理器未对请求路径做任何校验，攻击者可构造恶意 URL（如 localfile:///../../etc/passwd）读取宿主机上的任意文件，包括 SSH 私钥、AWS 凭据等敏感数据。
                                                                                                                                                                                                                                         
  [根因]
  protocol.handle('localfile', ...) 直接将 decodeURIComponent(url.pathname) 拼接到 file:// 传给 net.fetch()，没有：                                                                                                                      
  1. 路径规范化 — 未处理 ../ 等相对路径片段   
  2. 白名单校验 — 未限制可访问的目录范围 
  3. 符号链接解析 — 未防止通过 symlink 绕过路径检查

  [修复]
  1. 使用 fs.promises.realpath(path.resolve(rawPath)) 同时规范化路径并解析符号链接，防止 ../ 穿越和 symlink 绕过
  2. 将白名单从 os.homedir()（覆盖 ~/.ssh/ 等敏感目录）收窄为 app.getPath('userData') + app.getPath('temp') + cowork 工作目录                                                                                                            
  3. 文件不存在时 realpath 抛异常，返回 404 而非 crash                                                                       
  4. 移除日志中的完整路径信息，避免泄露文件系统结构                                                                                                                                                                                      
  5. try-catch 保护 getCoworkStore() 调用，处理 store 未初始化的边界情况                                                                                                                                                                 
                                                                                                                                                                                                                                         
  [复现路径]                                                                                                                                                                                                                             
  1. 在 Markdown 消息中插入一张引用恶意路径的图片：![img](file:///../../etc/passwd)                                                                                                                                                      
  2. 渲染器会将 file:// 替换为 localfile://（见 MarkdownContent.tsx:482）                                                                                                                                                                
  3. 修复前：协议处理器会返回 /etc/passwd 的内容                         
  4. 修复后：返回 HTTP 403 Forbidden