### PR TITLE
chore: upgrade moltbot-popo plugin to 1.0.66

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
       {
         "id": "moltbot-popo",
         "npm": "moltbot-popo",
-        "version": "1.0.65-beta.21",
+        "version": "1.0.66",
         "registry": "https://npm.nie.netease.com",
         "optional": true
       },


### PR DESCRIPTION
## Summary
- Upgrade moltbot-popo plugin from `1.0.65-beta.21` to `1.0.66`

## Test plan
- [ ] Verify POPO channel connection works with new plugin version
- [ ] Verify message send/receive through POPO

🤖 Generated with [Claude Code](https://claude.com/claude-code)