### PR TITLE
fix: handle duplicate local skill imports

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1774,13 +1774,13 @@ if (!gotTheLock) {
   });
 
   ipcMain.handle('skills:confirmInstall', async (_event, pendingId: string, action: string) => {
-    const validActions = ['install', 'installDisabled', 'cancel'];
+    const validActions = ['install', 'installDisabled', 'cancel', 'keepBoth', 'replaceExisting'];
     if (!validActions.includes(action)) {
       return { success: false, error: 'Invalid action' };
     }
     return getSkillManager().confirmPendingInstall(
       pendingId,
-      action as 'install' | 'installDisabled' | 'cancel'
+      action as 'install' | 'installDisabled' | 'cancel' | 'keepBoth' | 'replaceExisting'
     );
   });
 

--- a/src/main/skillInstallIdentity.test.ts
+++ b/src/main/skillInstallIdentity.test.ts
@@ -1,0 +1,242 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, expect, test } from 'vitest';
+import { computeSkillFingerprint, decideSkillInstall, resolveSkillConflictDecision } from './skillInstallIdentity';
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (!root) continue;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function createTempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lobsterai-skill-identity-'));
+  tempRoots.push(root);
+  return root;
+}
+
+function createSkillDir(root: string, dirName: string, files: Record<string, string>): string {
+  const skillDir = path.join(root, dirName);
+  fs.mkdirSync(skillDir, { recursive: true });
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(skillDir, relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content, 'utf8');
+  }
+  return skillDir;
+}
+
+test('computeSkillFingerprint: identical skill content in different temp roots yields the same fingerprint', () => {
+  const rootA = createTempRoot();
+  const rootB = createTempRoot();
+  const files = {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+    'scripts/run.js': 'console.log("demo");\n',
+  };
+
+  const skillA = createSkillDir(rootA, 'demo-skill', files);
+  const skillB = createSkillDir(rootB, 'demo-skill-copy', files);
+
+  expect(computeSkillFingerprint(skillA)).toBe(computeSkillFingerprint(skillB));
+});
+
+test('computeSkillFingerprint: managed file changes update the fingerprint', () => {
+  const root = createTempRoot();
+  const skillA = createSkillDir(root, 'demo-a', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+    'scripts/run.js': 'console.log("demo");\n',
+  });
+  const skillB = createSkillDir(root, 'demo-b', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo v2\n',
+    'scripts/run.js': 'console.log("demo");\n',
+  });
+
+  expect(computeSkillFingerprint(skillA)).not.toBe(computeSkillFingerprint(skillB));
+});
+
+test('computeSkillFingerprint: ignored runtime files do not affect the fingerprint', () => {
+  const root = createTempRoot();
+  const files = {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+    'scripts/run.js': 'console.log("demo");\n',
+  };
+
+  const skillA = createSkillDir(root, 'demo-a', files);
+  const skillB = createSkillDir(root, 'demo-b', {
+    ...files,
+    '.env': 'API_KEY=secret\n',
+    '.DS_Store': 'ignored\n',
+    'node_modules/pkg/index.js': 'module.exports = "ignored";\n',
+    '.git/HEAD': 'ref: refs/heads/main\n',
+  });
+
+  expect(computeSkillFingerprint(skillA)).toBe(computeSkillFingerprint(skillB));
+});
+
+test('decideSkillInstall: identical writable skill content overwrites the existing install and keeps the id', () => {
+  const installRoot = createTempRoot();
+  const sourceRoot = createTempRoot();
+  const installedDir = createSkillDir(installRoot, 'demo-skill', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+    'scripts/run.js': 'console.log("demo");\n',
+    '.env': 'API_KEY=secret\n',
+  });
+  const candidateDir = createSkillDir(sourceRoot, 'demo-skill-upload', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+    'scripts/run.js': 'console.log("demo");\n',
+  });
+
+  const decision = decideSkillInstall({
+    candidateDir,
+    desiredId: 'demo-skill',
+    installRoot,
+    installedSkills: [
+      { id: 'demo-skill', dir: installedDir, writable: true },
+    ],
+  });
+
+  expect(decision.action).toBe('overwrite');
+  expect(decision.targetId).toBe('demo-skill');
+  expect(decision.targetDir).toBe(installedDir);
+});
+
+test('decideSkillInstall: identical read-only skill content is treated as a no-op', () => {
+  const installRoot = createTempRoot();
+  const bundledRoot = createTempRoot();
+  const candidateRoot = createTempRoot();
+  const bundledDir = createSkillDir(bundledRoot, 'demo-skill', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+    'scripts/run.js': 'console.log("demo");\n',
+  });
+  const candidateDir = createSkillDir(candidateRoot, 'demo-skill-upload', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+    'scripts/run.js': 'console.log("demo");\n',
+  });
+
+  const decision = decideSkillInstall({
+    candidateDir,
+    desiredId: 'demo-skill',
+    installRoot,
+    installedSkills: [
+      { id: 'demo-skill', dir: bundledDir, writable: false },
+    ],
+  });
+
+  expect(decision.action).toBe('skip');
+  expect(decision.reason).toBe('readonly-duplicate');
+});
+
+test('decideSkillInstall: same name but different content enters conflict resolution', () => {
+  const installRoot = createTempRoot();
+  const candidateRoot = createTempRoot();
+  const existingDir = createSkillDir(installRoot, 'demo-skill', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+    'scripts/run.js': 'console.log("demo");\n',
+  });
+  const candidateDir = createSkillDir(candidateRoot, 'demo-skill-upload', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo 2\n',
+    'scripts/run.js': 'console.log("demo");\n',
+  });
+
+  const decision = decideSkillInstall({
+    candidateDir,
+    desiredId: 'demo-skill',
+    installRoot,
+    installedSkills: [
+      { id: 'demo-skill', dir: path.join(installRoot, 'demo-skill'), writable: true },
+    ],
+  });
+
+  expect(decision.action).toBe('conflict');
+  expect(decision.existingId).toBe('demo-skill');
+  expect(decision.existingDir).toBe(existingDir);
+});
+
+test('resolveSkillConflictDecision: keepBoth installs under the next available id', () => {
+  const installRoot = createTempRoot();
+  const existingDir = createSkillDir(installRoot, 'demo-skill', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+  });
+  const conflictDecision = {
+    action: 'conflict' as const,
+    fingerprint: 'abc',
+    desiredId: 'demo-skill',
+    existingId: 'demo-skill',
+    existingDir,
+    existingWritable: true,
+  };
+
+  const resolved = resolveSkillConflictDecision(conflictDecision, 'keepBoth', installRoot);
+
+  expect(resolved.action).toBe('install');
+  expect(resolved.targetId).toBe('demo-skill-1');
+  expect(resolved.targetDir).toBe(path.join(installRoot, 'demo-skill-1'));
+});
+
+test('resolveSkillConflictDecision: replaceExisting overwrites the current writable install', () => {
+  const installRoot = createTempRoot();
+  const existingDir = createSkillDir(installRoot, 'demo-skill', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+  });
+  const conflictDecision = {
+    action: 'conflict' as const,
+    fingerprint: 'abc',
+    desiredId: 'demo-skill',
+    existingId: 'demo-skill',
+    existingDir,
+    existingWritable: true,
+  };
+
+  const resolved = resolveSkillConflictDecision(conflictDecision, 'replaceExisting', installRoot);
+
+  expect(resolved.action).toBe('overwrite');
+  expect(resolved.targetId).toBe('demo-skill');
+  expect(resolved.targetDir).toBe(existingDir);
+});
+
+test('resolveSkillConflictDecision: replaceExisting shadows a read-only skill from the writable root', () => {
+  const installRoot = createTempRoot();
+  const bundledRoot = createTempRoot();
+  const existingDir = createSkillDir(bundledRoot, 'demo-skill', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+  });
+  const conflictDecision = {
+    action: 'conflict' as const,
+    fingerprint: 'abc',
+    desiredId: 'demo-skill',
+    existingId: 'demo-skill',
+    existingDir,
+    existingWritable: false,
+  };
+
+  const resolved = resolveSkillConflictDecision(conflictDecision, 'replaceExisting', installRoot);
+
+  expect(resolved.action).toBe('install');
+  expect(resolved.targetId).toBe('demo-skill');
+  expect(resolved.targetDir).toBe(path.join(installRoot, 'demo-skill'));
+});
+
+test('decideSkillInstall: importing an already installed directory is a no-op', () => {
+  const installRoot = createTempRoot();
+  const installedDir = createSkillDir(installRoot, 'demo-skill', {
+    'SKILL.md': '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+    'scripts/run.js': 'console.log("demo");\n',
+  });
+
+  const decision = decideSkillInstall({
+    candidateDir: installedDir,
+    desiredId: 'demo-skill',
+    installRoot,
+    installedSkills: [
+      { id: 'demo-skill', dir: installedDir, writable: true },
+    ],
+  });
+
+  expect(decision.action).toBe('skip');
+  expect(decision.reason).toBe('same-directory');
+});

--- a/src/main/skillInstallIdentity.ts
+++ b/src/main/skillInstallIdentity.ts
@@ -1,0 +1,234 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+const IGNORED_ENTRY_NAMES = new Set([
+  '.DS_Store',
+  '.env',
+  '.git',
+  'node_modules',
+]);
+
+export type InstalledSkillInstallTarget = {
+  id: string;
+  dir: string;
+  writable: boolean;
+  fingerprint?: string;
+};
+
+type BaseSkillInstallDecision = {
+  fingerprint: string;
+};
+
+export type SkillInstallDecision =
+  | (BaseSkillInstallDecision & {
+    action: 'install';
+    targetId: string;
+    targetDir: string;
+  })
+  | (BaseSkillInstallDecision & {
+    action: 'conflict';
+    desiredId: string;
+    existingId: string;
+    existingDir: string;
+    existingWritable: boolean;
+  })
+  | (BaseSkillInstallDecision & {
+    action: 'overwrite';
+    targetId: string;
+    targetDir: string;
+  })
+  | (BaseSkillInstallDecision & {
+    action: 'skip';
+    reason: 'readonly-duplicate' | 'same-directory';
+  });
+
+function shouldIgnoreEntry(relativePath: string): boolean {
+  if (!relativePath) return false;
+  return relativePath.split(path.sep).some(segment => IGNORED_ENTRY_NAMES.has(segment));
+}
+
+function collectManagedEntries(root: string): string[] {
+  const managedEntries: string[] = [];
+  const queue: string[] = [''];
+
+  while (queue.length > 0) {
+    const currentRelative = queue.shift();
+    if (currentRelative === undefined) continue;
+
+    const currentPath = currentRelative ? path.join(root, currentRelative) : root;
+    const entries = fs.readdirSync(currentPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const relativePath = currentRelative
+        ? path.join(currentRelative, entry.name)
+        : entry.name;
+
+      if (shouldIgnoreEntry(relativePath)) {
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        queue.push(relativePath);
+        continue;
+      }
+
+      managedEntries.push(relativePath);
+    }
+  }
+
+  managedEntries.sort((a, b) => a.localeCompare(b));
+  return managedEntries;
+}
+
+export function computeSkillFingerprint(skillDir: string): string {
+  const hash = crypto.createHash('sha256');
+  const resolvedDir = path.resolve(skillDir);
+  const entries = collectManagedEntries(resolvedDir);
+
+  for (const relativePath of entries) {
+    const absolutePath = path.join(resolvedDir, relativePath);
+    const stat = fs.lstatSync(absolutePath);
+    hash.update(`path:${relativePath}\n`);
+
+    if (stat.isSymbolicLink()) {
+      hash.update(`symlink:${fs.readlinkSync(absolutePath)}\n`);
+      continue;
+    }
+
+    hash.update(fs.readFileSync(absolutePath));
+    hash.update('\n');
+  }
+
+  return hash.digest('hex');
+}
+
+function resolveUniqueTargetId(installRoot: string, desiredId: string): { targetId: string; targetDir: string } {
+  let targetId = desiredId;
+  let targetDir = path.join(installRoot, targetId);
+  let suffix = 1;
+
+  while (fs.existsSync(targetDir)) {
+    targetId = `${desiredId}-${suffix}`;
+    targetDir = path.join(installRoot, targetId);
+    suffix += 1;
+  }
+
+  return { targetId, targetDir };
+}
+
+export function decideSkillInstall(options: {
+  candidateDir: string;
+  desiredId: string;
+  installRoot: string;
+  installedSkills: InstalledSkillInstallTarget[];
+}): SkillInstallDecision {
+  const candidateDir = path.resolve(options.candidateDir);
+  const fingerprint = computeSkillFingerprint(candidateDir);
+
+  let writableDuplicate: InstalledSkillInstallTarget | null = null;
+  let readonlyDuplicate: InstalledSkillInstallTarget | null = null;
+  let sameNameConflict: InstalledSkillInstallTarget | null = null;
+
+  for (const installedSkill of options.installedSkills) {
+    const installedDir = path.resolve(installedSkill.dir);
+    if (installedDir === candidateDir) {
+      return {
+        action: 'skip',
+        fingerprint,
+        reason: 'same-directory',
+      };
+    }
+
+    if (installedSkill.id === options.desiredId && !sameNameConflict) {
+      sameNameConflict = installedSkill;
+    }
+
+    const installedFingerprint = installedSkill.fingerprint ?? computeSkillFingerprint(installedSkill.dir);
+    if (installedFingerprint !== fingerprint) {
+      continue;
+    }
+
+    if (installedSkill.writable) {
+      writableDuplicate = installedSkill;
+      break;
+    }
+
+    if (!readonlyDuplicate) {
+      readonlyDuplicate = installedSkill;
+    }
+  }
+
+  if (writableDuplicate) {
+    return {
+      action: 'overwrite',
+      fingerprint,
+      targetId: writableDuplicate.id,
+      targetDir: path.resolve(writableDuplicate.dir),
+    };
+  }
+
+  if (readonlyDuplicate) {
+    return {
+      action: 'skip',
+      fingerprint,
+      reason: 'readonly-duplicate',
+    };
+  }
+
+  if (sameNameConflict) {
+    return {
+      action: 'conflict',
+      fingerprint,
+      desiredId: options.desiredId,
+      existingId: sameNameConflict.id,
+      existingDir: path.resolve(sameNameConflict.dir),
+      existingWritable: sameNameConflict.writable,
+    };
+  }
+
+  const { targetId, targetDir } = resolveUniqueTargetId(
+    path.resolve(options.installRoot),
+    options.desiredId
+  );
+
+  return {
+    action: 'install',
+    fingerprint,
+    targetId,
+    targetDir,
+  };
+}
+
+export function resolveSkillConflictDecision(
+  decision: Extract<SkillInstallDecision, { action: 'conflict' }>,
+  action: 'keepBoth' | 'replaceExisting',
+  installRoot: string
+): Extract<SkillInstallDecision, { action: 'install' | 'overwrite' }> {
+  if (action === 'keepBoth') {
+    const { targetId, targetDir } = resolveUniqueTargetId(path.resolve(installRoot), decision.desiredId);
+    return {
+      action: 'install',
+      fingerprint: decision.fingerprint,
+      targetId,
+      targetDir,
+    };
+  }
+
+  if (decision.existingWritable) {
+    return {
+      action: 'overwrite',
+      fingerprint: decision.fingerprint,
+      targetId: decision.existingId,
+      targetDir: decision.existingDir,
+    };
+  }
+
+  const overrideTargetDir = path.join(path.resolve(installRoot), decision.desiredId);
+  return {
+    action: fs.existsSync(overrideTargetDir) ? 'overwrite' : 'install',
+    fingerprint: decision.fingerprint,
+    targetId: decision.desiredId,
+    targetDir: overrideTargetDir,
+  };
+}

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -9,8 +9,14 @@ import { SqliteStore } from './sqliteStore';
 import { cpRecursiveSync } from './fsCompat';
 import { getElectronNodeRuntimePath } from './libs/coworkUtil';
 import { appendPythonRuntimeToEnv } from './libs/pythonRuntime';
-import { scanSkillSecurity, scanMultipleSkillDirs, mergeReports } from './libs/skillSecurity/skillSecurityScanner';
+import { scanMultipleSkillDirs, mergeReports } from './libs/skillSecurity/skillSecurityScanner';
 import type { SkillSecurityReport, SecurityReportAction } from './libs/skillSecurity/skillSecurityTypes';
+import {
+  decideSkillInstall,
+  resolveSkillConflictDecision,
+  type InstalledSkillInstallTarget,
+  type SkillInstallDecision,
+} from './skillInstallIdentity';
 import { t } from './i18n';
 
 /**
@@ -254,6 +260,7 @@ const SKILL_STATE_KEY = 'skills_state';
 const WATCH_DEBOUNCE_MS = 250;
 const CLAUDE_SKILLS_DIR_NAME = '.claude';
 const CLAUDE_SKILLS_SUBDIR = 'skills';
+const PRESERVED_SKILL_ENTRY_NAMES = ['.env', 'node_modules'];
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
@@ -1086,6 +1093,7 @@ export class SkillManager {
     cleanupPath: string | null;
     root: string;
     skillDirs: string[];
+    installPlans?: Array<{ skillDir: string; decision: SkillInstallDecision }>;
     timer: NodeJS.Timeout;
   }>();
 
@@ -1291,6 +1299,207 @@ export class SkillManager {
     return skills;
   }
 
+  private collectInstalledSkillTargets(primaryRoot: string): InstalledSkillInstallTarget[] {
+    const roots = this.getSkillRoots(primaryRoot);
+    const installedSkills: InstalledSkillInstallTarget[] = [];
+
+    for (const root of roots) {
+      if (!fs.existsSync(root)) continue;
+      const writable = path.resolve(root) === path.resolve(primaryRoot);
+      const skillDirs = listSkillDirs(root);
+      for (const dir of skillDirs) {
+        installedSkills.push({
+          id: path.basename(dir),
+          dir,
+          writable,
+        });
+      }
+    }
+
+    return installedSkills;
+  }
+
+  private planSkillInstalls(primaryRoot: string, skillDirs: string[]): Array<{ skillDir: string; decision: SkillInstallDecision }> {
+    const installedSkills = this.collectInstalledSkillTargets(primaryRoot);
+    return skillDirs.map((skillDir) => {
+      const decision = decideSkillInstall({
+        candidateDir: skillDir,
+        desiredId: normalizeFolderName(path.basename(skillDir)),
+        installRoot: primaryRoot,
+        installedSkills,
+      });
+
+      if (decision.action === 'install') {
+        installedSkills.push({
+          id: decision.targetId,
+          dir: decision.targetDir,
+          writable: true,
+          fingerprint: decision.fingerprint,
+        });
+      } else if (decision.action === 'overwrite') {
+        installedSkills.push({
+          id: decision.targetId,
+          dir: decision.targetDir,
+          writable: true,
+          fingerprint: decision.fingerprint,
+        });
+      }
+
+      return { skillDir, decision };
+    });
+  }
+
+  private refreshInstalledSkill(skillDir: string, targetDir: string): void {
+    const resolvedSource = path.resolve(skillDir);
+    const resolvedTarget = path.resolve(targetDir);
+
+    if (resolvedSource === resolvedTarget) {
+      console.log(`[SkillManager] refreshInstalledSkill: source and target are the same directory, skipping refresh for ${path.basename(targetDir)}`);
+      return;
+    }
+
+    const stagedDir = `${resolvedTarget}.__replace__-${crypto.randomUUID()}`;
+
+    try {
+      cpRecursiveSync(resolvedSource, stagedDir);
+
+      for (const entryName of PRESERVED_SKILL_ENTRY_NAMES) {
+        const existingPath = path.join(resolvedTarget, entryName);
+        if (!fs.existsSync(existingPath)) continue;
+        cpRecursiveSync(existingPath, path.join(stagedDir, entryName), {
+          dereference: true,
+          force: true,
+        });
+      }
+
+      fs.rmSync(resolvedTarget, { recursive: true, force: true });
+      fs.renameSync(stagedDir, resolvedTarget);
+    } catch (error) {
+      if (fs.existsSync(stagedDir)) {
+        fs.rmSync(stagedDir, { recursive: true, force: true });
+      }
+      throw error;
+    }
+  }
+
+  private applySkillInstallPlans(plans: Array<{ skillDir: string; decision: SkillInstallDecision }>): { changed: boolean; installedIds: string[] } {
+    const installedIds: string[] = [];
+    let changed = false;
+
+    for (const { skillDir, decision } of plans) {
+      if (decision.action === 'skip') {
+        console.log(`[SkillManager] applySkillInstallPlans: skipped ${path.basename(skillDir)} (${decision.reason})`);
+        continue;
+      }
+
+      if (decision.action === 'conflict') {
+        throw new Error(`Unresolved skill name conflict for "${decision.desiredId}"`);
+      }
+
+      if (decision.action === 'overwrite') {
+        console.log(`[SkillManager] applySkillInstallPlans: refreshing existing install "${decision.targetId}"`);
+        this.refreshInstalledSkill(skillDir, decision.targetDir);
+        changed = true;
+        continue;
+      }
+
+      console.log(`[SkillManager] applySkillInstallPlans: installing "${decision.targetId}"`);
+      cpRecursiveSync(skillDir, decision.targetDir);
+      installedIds.push(decision.targetId);
+      changed = true;
+    }
+
+    return { changed, installedIds };
+  }
+
+  private getConflictPrompt(plans: Array<{ skillDir: string; decision: SkillInstallDecision }>) {
+    const conflict = plans.find(
+      (plan): plan is { skillDir: string; decision: Extract<SkillInstallDecision, { action: 'conflict' }> } => plan.decision.action === 'conflict'
+    );
+    if (!conflict) {
+      return null;
+    }
+
+    const incomingSkill = this.parseSkillDir(
+      conflict.skillDir,
+      this.loadSkillStateMap(),
+      {},
+      false
+    );
+    const existingSkill = this.listSkills().find(skill => skill.id === conflict.decision.existingId);
+
+    return {
+      incomingSkillId: conflict.decision.desiredId,
+      incomingSkillName: incomingSkill?.name || conflict.decision.desiredId,
+      existingSkillId: conflict.decision.existingId,
+      existingSkillName: existingSkill?.name || conflict.decision.existingId,
+    };
+  }
+
+  private async scanInstallPlans(
+    skillDirs: string[]
+  ): Promise<SkillSecurityReport | null> {
+    try {
+      console.log(`[SkillManager] Starting security scan for ${skillDirs.length} skill dir(s)...`);
+      const reports = await scanMultipleSkillDirs(skillDirs);
+      const auditReport = mergeReports(reports);
+      if (auditReport) {
+        console.log(`[SkillManager] Security scan complete: riskLevel=${auditReport.riskLevel}, score=${auditReport.riskScore}, findings=${auditReport.findings.length}, duration=${auditReport.scanDurationMs}ms`);
+        for (const f of auditReport.findings) {
+          console.log(`[SkillManager]   [${f.severity}] ${f.dimension} | ${f.ruleId} → ${f.file}${f.line ? ':' + f.line : ''}`);
+        }
+      }
+      return auditReport;
+    } catch (err) {
+      console.warn('[SkillManager] Security scan failed (non-blocking):', err);
+      return null;
+    }
+  }
+
+  private resolvePendingConflictPlans(
+    pending: {
+      root: string;
+      installPlans?: Array<{ skillDir: string; decision: SkillInstallDecision }>;
+    },
+    action: 'keepBoth' | 'replaceExisting'
+  ): Array<{ skillDir: string; decision: SkillInstallDecision }> {
+    const plans = pending.installPlans ?? [];
+    return plans.map((plan) => {
+      if (plan.decision.action !== 'conflict') {
+        return plan;
+      }
+      return {
+        skillDir: plan.skillDir,
+        decision: resolveSkillConflictDecision(plan.decision, action, pending.root),
+      };
+    });
+  }
+
+  private createPendingInstall(params: {
+    tempDir: string;
+    cleanupPath: string | null;
+    root: string;
+    skillDirs: string[];
+    installPlans?: Array<{ skillDir: string; decision: SkillInstallDecision }>;
+  }): string {
+    const pendingId = crypto.randomUUID();
+    const timer = setTimeout(() => {
+      const pending = this.pendingInstalls.get(pendingId);
+      if (pending) {
+        cleanupPathSafely(pending.cleanupPath);
+        this.pendingInstalls.delete(pendingId);
+        console.log(`[SkillManager] Pending install ${pendingId} expired (TTL)`);
+      }
+    }, 5 * 60 * 1000);
+
+    this.pendingInstalls.set(pendingId, {
+      ...params,
+      timer,
+    });
+
+    return pendingId;
+  }
+
   buildAutoRoutingPrompt(): string | null {
     const skills = this.listSkills();
     const enabled = skills.filter(s => s.enabled && s.prompt);
@@ -1354,6 +1563,12 @@ export class SkillManager {
     error?: string;
     auditReport?: SkillSecurityReport;
     pendingInstallId?: string;
+    installConflict?: {
+      incomingSkillId: string;
+      incomingSkillName: string;
+      existingSkillId: string;
+      existingSkillName: string;
+    };
   }> {
     let cleanupPath: string | null = null;
     try {
@@ -1470,42 +1685,48 @@ export class SkillManager {
         return { success: false, error: t('skillErrNoSkillMd') };
       }
 
-      // Security scan before installation
-      let auditReport: SkillSecurityReport | null = null;
-      try {
-        console.log(`[SkillManager] Starting security scan for ${skillDirs.length} skill dir(s)...`);
-        const reports = await scanMultipleSkillDirs(skillDirs);
-        auditReport = mergeReports(reports);
-        if (auditReport) {
-          console.log(`[SkillManager] Security scan complete: riskLevel=${auditReport.riskLevel}, score=${auditReport.riskScore}, findings=${auditReport.findings.length}, duration=${auditReport.scanDurationMs}ms`);
-          for (const f of auditReport.findings) {
-            console.log(`[SkillManager]   [${f.severity}] ${f.dimension} | ${f.ruleId} → ${f.file}${f.line ? ':' + f.line : ''}`);
-          }
-        }
-      } catch (err) {
-        console.warn('[SkillManager] Security scan failed (non-blocking):', err);
-      }
-
-      // If risk detected, cache for user confirmation instead of auto-installing
-      if (auditReport && auditReport.riskLevel !== 'safe') {
-        const pendingId = crypto.randomUUID();
-        console.log(`[SkillManager] Risk detected (${auditReport.riskLevel}), pending user confirmation: ${pendingId}`);
-        const timer = setTimeout(() => {
-          const pending = this.pendingInstalls.get(pendingId);
-          if (pending) {
-            cleanupPathSafely(pending.cleanupPath);
-            this.pendingInstalls.delete(pendingId);
-            console.log(`[SkillManager] Pending install ${pendingId} expired (TTL)`);
-          }
-        }, 5 * 60 * 1000);
-
-        this.pendingInstalls.set(pendingId, {
+      const installPlans = this.planSkillInstalls(root, skillDirs);
+      const conflictPrompt = this.getConflictPrompt(installPlans);
+      if (conflictPrompt) {
+        const pendingId = this.createPendingInstall({
           tempDir: localSource,
           cleanupPath,
           root,
           skillDirs,
-          timer,
+          installPlans,
         });
+
+        return {
+          success: true,
+          pendingInstallId: pendingId,
+          installConflict: conflictPrompt,
+        };
+      }
+
+      if (installPlans.every(({ decision }) => decision.action !== 'install')) {
+        const result = this.applySkillInstallPlans(installPlans);
+        cleanupPathSafely(cleanupPath);
+        cleanupPath = null;
+        if (result.changed) {
+          this.startWatching();
+          this.notifySkillsChanged();
+        }
+        return { success: true, skills: this.listSkills() };
+      }
+
+      // Security scan before installation
+      const auditReport = await this.scanInstallPlans(skillDirs);
+
+      // If risk detected, cache for user confirmation instead of auto-installing
+      if (auditReport && auditReport.riskLevel !== 'safe') {
+        const pendingId = this.createPendingInstall({
+          tempDir: localSource,
+          cleanupPath,
+          root,
+          skillDirs,
+          installPlans,
+        });
+        console.log(`[SkillManager] Risk detected (${auditReport.riskLevel}), pending user confirmation: ${pendingId}`);
 
         return {
           success: true,
@@ -1516,16 +1737,7 @@ export class SkillManager {
 
       // Safe or scan failed — install directly
       console.log(`[SkillManager] Skill is safe (or scan failed), installing directly`);
-      for (const skillDir of skillDirs) {
-        const folderName = normalizeFolderName(path.basename(skillDir));
-        let targetDir = resolveWithin(root, folderName);
-        let suffix = 1;
-        while (fs.existsSync(targetDir)) {
-          targetDir = resolveWithin(root, `${folderName}-${suffix}`);
-          suffix += 1;
-        }
-        cpRecursiveSync(skillDir, targetDir);
-      }
+      this.applySkillInstallPlans(installPlans);
 
       cleanupPathSafely(cleanupPath);
       cleanupPath = null;
@@ -1539,10 +1751,10 @@ export class SkillManager {
     }
   }
 
-  confirmPendingInstall(
+  async confirmPendingInstall(
     pendingId: string,
-    action: SecurityReportAction
-  ): { success: boolean; skills?: SkillRecord[]; error?: string } {
+    action: SecurityReportAction | 'keepBoth' | 'replaceExisting'
+  ): Promise<{ success: boolean; skills?: SkillRecord[]; error?: string; auditReport?: SkillSecurityReport; pendingInstallId?: string }> {
     console.log(`[SkillManager] confirmPendingInstall: id=${pendingId}, action=${action}`);
     const pending = this.pendingInstalls.get(pendingId);
     if (!pending) {
@@ -1558,19 +1770,36 @@ export class SkillManager {
       return { success: true };
     }
 
-    // Install the skill(s)
-    const installedIds: string[] = [];
-    for (const skillDir of pending.skillDirs) {
-      const folderName = normalizeFolderName(path.basename(skillDir));
-      let targetDir = resolveWithin(pending.root, folderName);
-      let suffix = 1;
-      while (fs.existsSync(targetDir)) {
-        targetDir = resolveWithin(pending.root, `${folderName}-${suffix}`);
-        suffix += 1;
+    if (action === 'keepBoth' || action === 'replaceExisting') {
+      const installPlans = this.resolvePendingConflictPlans(pending, action);
+      const auditReport = await this.scanInstallPlans(pending.skillDirs);
+      if (auditReport && auditReport.riskLevel !== 'safe') {
+        const nextPendingId = this.createPendingInstall({
+          tempDir: pending.tempDir,
+          cleanupPath: pending.cleanupPath,
+          root: pending.root,
+          skillDirs: pending.skillDirs,
+          installPlans,
+        });
+        return {
+          success: true,
+          auditReport,
+          pendingInstallId: nextPendingId,
+        };
       }
-      cpRecursiveSync(skillDir, targetDir);
-      installedIds.push(path.basename(targetDir));
+
+      const { changed } = this.applySkillInstallPlans(installPlans);
+      cleanupPathSafely(pending.cleanupPath);
+      if (changed) {
+        this.startWatching();
+        this.notifySkillsChanged();
+      }
+      return { success: true, skills: this.listSkills() };
     }
+
+    // Install the skill(s)
+    const installPlans = pending.installPlans ?? this.planSkillInstalls(pending.root, pending.skillDirs);
+    const { installedIds, changed } = this.applySkillInstallPlans(installPlans);
 
     cleanupPathSafely(pending.cleanupPath);
 
@@ -1585,8 +1814,10 @@ export class SkillManager {
       }
     }
 
-    this.startWatching();
-    this.notifySkillsChanged();
+    if (changed) {
+      this.startWatching();
+      this.notifySkillsChanged();
+    }
     return { success: true, skills: this.listSkills() };
   }
 

--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -17,7 +17,7 @@ import { i18nService } from '../../services/i18n';
 import { skillService, resolveLocalizedText } from '../../services/skill';
 import { setSkills } from '../../store/slices/skillSlice';
 import { RootState } from '../../store';
-import { Skill, MarketplaceSkill, MarketTag } from '../../types/skill';
+import { Skill, MarketplaceSkill, MarketTag, SkillInstallConflict } from '../../types/skill';
 import ErrorMessage from '../ErrorMessage';
 import SkillSecurityReport from './SkillSecurityReport';
 
@@ -44,6 +44,7 @@ const SkillsManager: React.FC = () => {
   const [skillPendingDelete, setSkillPendingDelete] = useState<Skill | null>(null);
   const [isDeletingSkill, setIsDeletingSkill] = useState(false);
   const [securityReport, setSecurityReport] = useState<any>(null);
+  const [installConflict, setInstallConflict] = useState<SkillInstallConflict | null>(null);
   const [pendingInstallId, setPendingInstallId] = useState<string | null>(null);
   const [isConfirmingInstall, setIsConfirmingInstall] = useState(false);
 
@@ -143,6 +144,34 @@ const SkillsManager: React.FC = () => {
     };
   }, [selectedSkill, selectedMarketplaceSkill]);
 
+  useEffect(() => {
+    if (!installConflict || !pendingInstallId) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !isConfirmingInstall) {
+        void (async () => {
+          setIsConfirmingInstall(true);
+          try {
+            await skillService.confirmInstall(pendingInstallId, 'cancel');
+          } finally {
+            setInstallConflict(null);
+            setPendingInstallId(null);
+            setIsConfirmingInstall(false);
+            setInstallingSkillId(null);
+            setSkillDownloadSource('');
+            setIsAddSkillMenuOpen(false);
+            setIsGithubImportOpen(false);
+          }
+        })();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [installConflict, isConfirmingInstall, pendingInstallId]);
+
   const filteredSkills = useMemo(() => {
     const query = skillSearchQuery.toLowerCase();
     return skills.filter(skill => {
@@ -235,6 +264,12 @@ const SkillsManager: React.FC = () => {
       setSkillActionError(result.error || i18nService.t('skillDownloadFailed'));
       return;
     }
+    if (result.installConflict && result.pendingInstallId) {
+      setIsGithubImportOpen(false);
+      setInstallConflict(result.installConflict);
+      setPendingInstallId(result.pendingInstallId);
+      return;
+    }
     // Security audit returned — show report modal
     if (result.auditReport && result.pendingInstallId) {
       setIsGithubImportOpen(false);
@@ -294,6 +329,11 @@ const SkillsManager: React.FC = () => {
         setSkillActionError(result.error || i18nService.t('skillInstallFailed'));
         return;
       }
+      if (result.installConflict && result.pendingInstallId) {
+        setInstallConflict(result.installConflict);
+        setPendingInstallId(result.pendingInstallId);
+        return;
+      }
       // Security audit returned — show report modal
       if (result.auditReport && result.pendingInstallId) {
         setSecurityReport(result.auditReport);
@@ -326,6 +366,36 @@ const SkillsManager: React.FC = () => {
     } finally {
       setSecurityReport(null);
       setPendingInstallId(null);
+      setIsConfirmingInstall(false);
+      setInstallingSkillId(null);
+      setSkillDownloadSource('');
+      setIsAddSkillMenuOpen(false);
+      setIsGithubImportOpen(false);
+    }
+  };
+
+  const handleInstallConflictAction = async (action: 'keepBoth' | 'replaceExisting' | 'cancel') => {
+    if (!pendingInstallId) return;
+    setIsConfirmingInstall(true);
+    let nextPendingInstallId: string | null = null;
+    try {
+      const result = await skillService.confirmInstall(pendingInstallId, action);
+      if (result.auditReport && result.pendingInstallId) {
+        setSecurityReport(result.auditReport);
+        nextPendingInstallId = result.pendingInstallId;
+        return;
+      }
+      if (result.success && result.skills) {
+        dispatch(setSkills(result.skills));
+      }
+      if (!result.success && result.error) {
+        setSkillActionError(result.error);
+      }
+    } catch {
+      setSkillActionError(i18nService.t('skillInstallFailed'));
+    } finally {
+      setInstallConflict(null);
+      setPendingInstallId(nextPendingInstallId);
       setIsConfirmingInstall(false);
       setInstallingSkillId(null);
       setSkillDownloadSource('');
@@ -940,6 +1010,68 @@ const SkillsManager: React.FC = () => {
           onAction={handleSecurityReportAction}
           isLoading={isConfirmingInstall}
         />
+      )}
+
+      {installConflict && createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          onClick={() => !isConfirmingInstall && handleInstallConflictAction('cancel')}
+        >
+          <div
+            className="w-full max-w-lg mx-4 rounded-2xl dark:bg-claude-darkBg bg-white shadow-xl border dark:border-claude-darkBorder border-claude-border overflow-hidden"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">
+              <h3 className="text-base font-semibold dark:text-claude-darkText text-claude-text">
+                {i18nService.t('skillNameConflictTitle')}
+              </h3>
+              <button
+                type="button"
+                onClick={() => handleInstallConflictAction('cancel')}
+                disabled={isConfirmingInstall}
+                className="p-1 rounded-lg hover:bg-claude-hover dark:hover:bg-claude-darkHover transition-colors disabled:opacity-50"
+              >
+                <XMarkIcon className="h-4 w-4 dark:text-claude-darkTextSecondary text-claude-textSecondary" />
+              </button>
+            </div>
+            <div className="px-5 py-4">
+              <p className="text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                {i18nService.t('skillNameConflictMessage')
+                  .replace('{incoming}', installConflict.incomingSkillName)
+                  .replace('{existing}', installConflict.existingSkillName)}
+              </p>
+            </div>
+            <div className="flex items-center justify-between gap-2 px-5 py-4 border-t dark:border-claude-darkBorder border-claude-border">
+              <button
+                type="button"
+                onClick={() => handleInstallConflictAction('cancel')}
+                disabled={isConfirmingInstall}
+                className="px-4 py-2 text-sm font-medium rounded-xl dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-colors border dark:border-claude-darkBorder border-claude-border active:scale-[0.98] disabled:opacity-50"
+              >
+                {i18nService.t('cancel')}
+              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleInstallConflictAction('keepBoth')}
+                  disabled={isConfirmingInstall}
+                  className="px-4 py-2 text-sm font-medium rounded-xl bg-claude-accent text-white hover:bg-claude-accent/90 transition-colors active:scale-[0.98] disabled:opacity-50"
+                >
+                  {i18nService.t('skillConflictKeepBoth')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleInstallConflictAction('replaceExisting')}
+                  disabled={isConfirmingInstall}
+                  className="px-4 py-2 text-sm font-medium rounded-xl bg-orange-500/10 text-orange-600 dark:text-orange-400 border border-orange-500/20 hover:bg-orange-500/20 transition-colors active:scale-[0.98] disabled:opacity-50"
+                >
+                  {i18nService.t('skillConflictReplaceExisting')}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -494,6 +494,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     skillInstalling: '安装中',
     skillInstallFailed: '安装失败',
     skillAlreadyInstalled: '已安装',
+    skillNameConflictTitle: '发现同名技能',
+    skillNameConflictMessage: '“{incoming}”与已安装的“{existing}”同名，但内容不同。请选择导入方式。',
+    skillConflictKeepBoth: '保留两份',
+    skillConflictReplaceExisting: '覆盖同名技能',
 
     // Security scan
     lobsterGuardEnabled: '安全防护中',
@@ -1571,6 +1575,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     skillInstalling: 'Installing',
     skillInstallFailed: 'Install failed',
     skillAlreadyInstalled: 'Installed',
+    skillNameConflictTitle: 'Skill Name Conflict',
+    skillNameConflictMessage: '"{incoming}" has the same name as the installed skill "{existing}", but the content is different. Choose how to continue.',
+    skillConflictKeepBoth: 'Keep Both',
+    skillConflictReplaceExisting: 'Replace Existing',
 
     // Security scan
     lobsterGuardEnabled: 'Security Active',

--- a/src/renderer/services/skill.ts
+++ b/src/renderer/services/skill.ts
@@ -1,4 +1,4 @@
-import { Skill, MarketplaceSkill, MarketTag, LocalSkillInfo, LocalizedText } from '../types/skill';
+import { Skill, MarketplaceSkill, MarketTag, LocalSkillInfo, LocalizedText, SkillInstallConflict } from '../types/skill';
 import { getSkillStoreUrl } from './endpoints';
 import { i18nService } from './i18n';
 
@@ -20,6 +20,15 @@ type EmailConnectivityTestResult = {
   testedAt: number;
   verdict: 'pass' | 'fail';
   checks: EmailConnectivityCheck[];
+};
+
+type SkillInstallResult = {
+  success: boolean;
+  skills?: Skill[];
+  error?: string;
+  auditReport?: any;
+  pendingInstallId?: string;
+  installConflict?: SkillInstallConflict;
 };
 
 class SkillService {
@@ -78,13 +87,7 @@ class SkillService {
     }
   }
 
-  async downloadSkill(source: string): Promise<{
-    success: boolean;
-    skills?: Skill[];
-    error?: string;
-    auditReport?: any;
-    pendingInstallId?: string;
-  }> {
+  async downloadSkill(source: string): Promise<SkillInstallResult> {
     try {
       const result = await window.electron.skills.download(source);
       if (result.success && result.skills) {
@@ -101,7 +104,7 @@ class SkillService {
   async confirmInstall(
     pendingId: string,
     action: string
-  ): Promise<{ success: boolean; skills?: Skill[]; error?: string }> {
+  ): Promise<SkillInstallResult> {
     try {
       const result = await window.electron.skills.confirmInstall(pendingId, action);
       if (result.success && result.skills) {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -38,6 +38,13 @@ interface CoworkMessage {
   metadata?: Record<string, unknown>;
 }
 
+interface SkillInstallConflict {
+  incomingSkillId: string;
+  incomingSkillName: string;
+  existingSkillId: string;
+  existingSkillName: string;
+}
+
 interface CoworkSessionSummary {
   id: string;
   title: string;
@@ -226,8 +233,8 @@ interface IElectronAPI {
     list: () => Promise<{ success: boolean; skills?: Skill[]; error?: string }>;
     setEnabled: (options: { id: string; enabled: boolean }) => Promise<{ success: boolean; skills?: Skill[]; error?: string }>;
     delete: (id: string) => Promise<{ success: boolean; skills?: Skill[]; error?: string }>;
-    download: (source: string) => Promise<{ success: boolean; skills?: Skill[]; error?: string; auditReport?: any; pendingInstallId?: string }>;
-    confirmInstall: (pendingId: string, action: string) => Promise<{ success: boolean; skills?: Skill[]; error?: string }>;
+    download: (source: string) => Promise<{ success: boolean; skills?: Skill[]; error?: string; auditReport?: any; pendingInstallId?: string; installConflict?: SkillInstallConflict }>;
+    confirmInstall: (pendingId: string, action: string) => Promise<{ success: boolean; skills?: Skill[]; error?: string; auditReport?: any; pendingInstallId?: string; installConflict?: SkillInstallConflict }>;
     getRoot: () => Promise<{ success: boolean; path?: string; error?: string }>;
     autoRoutingPrompt: () => Promise<{ success: boolean; prompt?: string | null; error?: string }>;
     getConfig: (skillId: string) => Promise<{ success: boolean; config?: Record<string, string>; error?: string }>;

--- a/src/renderer/types/skill.ts
+++ b/src/renderer/types/skill.ts
@@ -40,3 +40,10 @@ export interface MarketplaceSkill {
     author?: string;        // Author name
   };
 }
+
+export interface SkillInstallConflict {
+  incomingSkillId: string;
+  incomingSkillName: string;
+  existingSkillId: string;
+  existingSkillName: string;
+}


### PR DESCRIPTION
[问题]
重复导入同一个本地 skill zip 时，应用会安装出多份重复 skill。若 skill 名称相同但内容不同，原逻辑也会直接落到自动追加目录后缀，用户无法选择是保留两份还是覆盖旧技能。

[根因]
安装流程只按目标目录名处理冲突，没有对解压后的 skill 内容建立稳定指纹，因此相同内容会被当作全新导入；同名不同内容也只能走自动重命名分支。

[修复]
新增主进程 skill 内容指纹能力，并在直接安装与 pending install 确认流里统一复用。相同内容的 custom skill 会原地刷新并保留原 id / enabled 状态；相同内容的内置 skill 视为成功 no-op；同名但指纹不同的 skill 会弹出“保留两份 / 覆盖同名技能 / 取消导入”选择。

[复现路径]
1. 导入同一个本地 skill zip 两次，第二次不应再新增重复 skill。
2. 导入另一个名字相同但内容不同的本地 skill zip，应弹出保留两份 / 覆盖 / 取消导入的选择框。

[验证]
- 手动验证通过
- `fnm exec --using=24.3.0 npm test -- skillInstallIdentity`
- `git diff --check`
- `fnm exec --using=24.3.0 npm run lint` 未通过，失败点在仓库现有 `vendor/openclaw-*` 与少量旧文件，非本次改动引入

Closes #776