### PR TITLE
fix(polling): prevent overlapping runtime poll cycles

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { OpenClawRuntimeAdapter } from './openclawRuntimeAdapter';
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+test('startChannelPolling does not overlap channel polls while a previous cycle is still running', async () => {
+  vi.useFakeTimers();
+
+  const adapter = new OpenClawRuntimeAdapter({} as any, {} as any);
+  (adapter as any).channelSessionSync = {} as any;
+  (adapter as any).gatewayClient = {} as any;
+
+  const firstPoll = createDeferred<void>();
+  const pollChannelSessions = vi.fn(() => firstPoll.promise);
+  (adapter as any).pollChannelSessions = pollChannelSessions;
+
+  adapter.startChannelPolling();
+  expect(pollChannelSessions).toHaveBeenCalledTimes(1);
+
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(pollChannelSessions).toHaveBeenCalledTimes(1);
+
+  firstPoll.resolve();
+  await Promise.resolve();
+});
+
+test('startChannelPolling schedules the next channel poll only after the previous one finishes', async () => {
+  vi.useFakeTimers();
+
+  const adapter = new OpenClawRuntimeAdapter({} as any, {} as any);
+  (adapter as any).channelSessionSync = {} as any;
+  (adapter as any).gatewayClient = {} as any;
+
+  const firstPoll = createDeferred<void>();
+  const secondPoll = createDeferred<void>();
+  const pollChannelSessions = vi
+    .fn<() => Promise<void>>()
+    .mockImplementationOnce(() => firstPoll.promise)
+    .mockImplementationOnce(() => secondPoll.promise);
+  (adapter as any).pollChannelSessions = pollChannelSessions;
+
+  adapter.startChannelPolling();
+  expect(pollChannelSessions).toHaveBeenCalledTimes(1);
+
+  await vi.advanceTimersByTimeAsync(10_000);
+  expect(pollChannelSessions).toHaveBeenCalledTimes(1);
+
+  firstPoll.resolve();
+  await Promise.resolve();
+
+  await vi.advanceTimersByTimeAsync(9_999);
+  expect(pollChannelSessions).toHaveBeenCalledTimes(1);
+
+  await vi.advanceTimersByTimeAsync(1);
+  expect(pollChannelSessions).toHaveBeenCalledTimes(2);
+
+  secondPoll.resolve();
+  await Promise.resolve();
+});

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -538,7 +538,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private readonly manuallyStoppedSessions = new Set<string>();
   /** Session keys whose origin is "heartbeat" — discovered via polling, used to filter real-time events. */
   private readonly heartbeatSessionKeys = new Set<string>();
-  private channelPollingTimer: ReturnType<typeof setInterval> | null = null;
+  private channelPollingTimer: ReturnType<typeof setTimeout> | null = null;
+  private channelPollInFlight: Promise<void> | null = null;
 
   private static readonly CHANNEL_POLL_INTERVAL_MS = 10_000;
   private static readonly FULL_HISTORY_SYNC_LIMIT = 50;
@@ -718,20 +719,45 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       return;
     }
     // Already running
-    if (this.channelPollingTimer) { console.log('[ChannelSync] startChannelPolling: already running, skipping'); return; }
+    if (this.channelPollingTimer || this.channelPollInFlight) { console.log('[ChannelSync] startChannelPolling: already running, skipping'); return; }
 
     console.log('[ChannelSync] startChannelPolling: starting periodic channel session discovery');
-    // Run once immediately, then at interval
-    void this.pollChannelSessions();
-    this.channelPollingTimer = setInterval(() => {
-      void this.pollChannelSessions();
-    }, OpenClawRuntimeAdapter.CHANNEL_POLL_INTERVAL_MS);
+    void this.runChannelPollCycle();
   }
 
   stopChannelPolling(): void {
     if (this.channelPollingTimer) {
-      clearInterval(this.channelPollingTimer);
+      clearTimeout(this.channelPollingTimer);
       this.channelPollingTimer = null;
+    }
+  }
+
+  private scheduleNextChannelPoll(delayMs: number): void {
+    if (!this.channelSessionSync) return;
+    if (this.channelPollingTimer) {
+      clearTimeout(this.channelPollingTimer);
+    }
+    this.channelPollingTimer = setTimeout(() => {
+      this.channelPollingTimer = null;
+      void this.runChannelPollCycle();
+    }, delayMs);
+  }
+
+  private async runChannelPollCycle(): Promise<void> {
+    if (!this.channelSessionSync || this.channelPollInFlight) return;
+
+    const pollPromise = this.pollChannelSessions();
+    this.channelPollInFlight = pollPromise;
+
+    try {
+      await pollPromise;
+    } finally {
+      if (this.channelPollInFlight === pollPromise) {
+        this.channelPollInFlight = null;
+      }
+      if (this.channelSessionSync && this.gatewayClient) {
+        this.scheduleNextChannelPoll(OpenClawRuntimeAdapter.CHANNEL_POLL_INTERVAL_MS);
+      }
     }
   }
 

--- a/src/main/libs/cronJobService.test.ts
+++ b/src/main/libs/cronJobService.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { CronJobService } from './cronJobService';
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+test('startPolling does not overlap poll cycles while a previous poll is still running', async () => {
+  vi.useFakeTimers();
+
+  const service = new CronJobService({
+    getGatewayClient: () => null,
+    ensureGatewayReady: async () => {},
+  });
+
+  const firstPoll = createDeferred<void>();
+  const pollOnce = vi.fn(() => firstPoll.promise);
+  (service as any).pollOnce = pollOnce;
+
+  service.startPolling();
+  expect(pollOnce).toHaveBeenCalledTimes(1);
+
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(pollOnce).toHaveBeenCalledTimes(1);
+
+  firstPoll.resolve();
+  await Promise.resolve();
+});
+
+test('startPolling waits for the previous poll to finish before scheduling the next cycle', async () => {
+  vi.useFakeTimers();
+
+  const service = new CronJobService({
+    getGatewayClient: () => null,
+    ensureGatewayReady: async () => {},
+  });
+
+  const firstPoll = createDeferred<void>();
+  const secondPoll = createDeferred<void>();
+  const pollOnce = vi
+    .fn<() => Promise<void>>()
+    .mockImplementationOnce(() => firstPoll.promise)
+    .mockImplementationOnce(() => secondPoll.promise);
+  (service as any).pollOnce = pollOnce;
+
+  service.startPolling();
+  expect(pollOnce).toHaveBeenCalledTimes(1);
+
+  await vi.advanceTimersByTimeAsync(15_000);
+  expect(pollOnce).toHaveBeenCalledTimes(1);
+
+  firstPoll.resolve();
+  await Promise.resolve();
+
+  await vi.advanceTimersByTimeAsync(14_999);
+  expect(pollOnce).toHaveBeenCalledTimes(1);
+
+  await vi.advanceTimersByTimeAsync(1);
+  expect(pollOnce).toHaveBeenCalledTimes(2);
+
+  secondPoll.resolve();
+  await Promise.resolve();
+});

--- a/src/main/libs/cronJobService.ts
+++ b/src/main/libs/cronJobService.ts
@@ -270,10 +270,11 @@ function extractRunTitle(summary?: string): string | undefined {
 export class CronJobService {
   private readonly getGatewayClient: () => GatewayClientLike | null;
   private readonly ensureGatewayReady: () => Promise<void>;
-  private pollingTimer: ReturnType<typeof setInterval> | null = null;
+  private pollingTimer: ReturnType<typeof setTimeout> | null = null;
   private lastKnownStates: Map<string, string> = new Map();
   private lastKnownRunAtMs: Map<string, number> = new Map();
   private polling = false;
+  private pollInFlight: Promise<void> | null = null;
   private firstPollDone = false;
   /** Synchronous jobId → name cache, populated during polling. */
   private jobNameCache: Map<string, string> = new Map();
@@ -453,22 +454,48 @@ export class CronJobService {
   startPolling(): void {
     if (this.polling) return;
     this.polling = true;
-    this.pollOnce();
-    this.pollingTimer = setInterval(() => {
-      void this.pollOnce();
-    }, CronJobService.POLL_INTERVAL_MS);
+    void this.runPollCycle();
   }
 
   stopPolling(): void {
     this.polling = false;
     if (this.pollingTimer) {
-      clearInterval(this.pollingTimer);
+      clearTimeout(this.pollingTimer);
       this.pollingTimer = null;
     }
     this.lastKnownStates.clear();
     this.lastKnownRunAtMs.clear();
     this.jobNameCache.clear();
     this.firstPollDone = false;
+  }
+
+  private scheduleNextPoll(delayMs: number): void {
+    if (!this.polling) return;
+    if (this.pollingTimer) {
+      clearTimeout(this.pollingTimer);
+    }
+    this.pollingTimer = setTimeout(() => {
+      this.pollingTimer = null;
+      void this.runPollCycle();
+    }, delayMs);
+  }
+
+  private async runPollCycle(): Promise<void> {
+    if (!this.polling || this.pollInFlight) return;
+
+    const pollPromise = this.pollOnce();
+    this.pollInFlight = pollPromise;
+
+    try {
+      await pollPromise;
+    } finally {
+      if (this.pollInFlight === pollPromise) {
+        this.pollInFlight = null;
+      }
+      if (this.polling) {
+        this.scheduleNextPoll(CronJobService.POLL_INTERVAL_MS);
+      }
+    }
   }
 
   private async pollOnce(): Promise<void> {


### PR DESCRIPTION
## Summary
- replace interval-based cron polling with non-overlapping self-rescheduling cycles
- replace OpenClaw channel polling with the same non-overlapping scheduling model
- add regression tests that prove slow poll cycles do not overlap

## Test Plan
- [x] `npm test`
- [x] `npm test -- src/main/libs/cronJobService.test.ts src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts`
- [x] `./node_modules/.bin/eslint src/main/libs/cronJobService.ts src/main/libs/cronJobService.test.ts src/main/libs/agentEngine/openclawRuntimeAdapter.ts src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts --ext ts`

## Notes
- `npm run lint` still reports pre-existing errors in vendor and runtime mirror directories unrelated to this change.