### PR TITLE
fix(wechat): Unable to select WeChat as the notification channel for scheduled tasks

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -94,6 +94,7 @@ const SCHEDULED_TASK_CHANNEL_OPTIONS = [
   { value: 'qqbot', label: 'QQ' },
   { value: 'wecom', label: 'WeCom' },
   { value: 'popo', label: 'POPO' },
+  { value: 'weixin', label: 'WeChat' },
 ] as const;
 const MIME_EXTENSION_MAP: Record<string, string> = {
   'image/png': '.png',
@@ -1427,7 +1428,7 @@ function mergeCoworkSystemPrompt(
 }
 
 // 获取正确的预加载脚本路径
-const PRELOAD_PATH = app.isPackaged 
+const PRELOAD_PATH = app.isPackaged
   ? path.join(__dirname, 'preload.js')
   : path.join(__dirname, '../dist-electron/preload.js');
 
@@ -3127,7 +3128,7 @@ if (!gotTheLock) {
   ipcMain.handle('permissions:checkCalendar', async () => {
     try {
       const status = await checkCalendarPermission();
-      
+
       // Development mode: Auto-request permission if not determined
       // This provides a better dev experience without affecting production
       if (isDev && status === 'not-determined' && process.platform === 'darwin') {
@@ -3141,7 +3142,7 @@ if (!gotTheLock) {
           console.warn('[Permissions] Development mode: Auto-request failed:', requestError);
         }
       }
-      
+
       return { success: true, status };
     } catch (error) {
       console.error('[Main] Error checking calendar permission:', error);
@@ -4026,7 +4027,7 @@ if (!gotTheLock) {
         mainWindow?.loadURL(DEV_SERVER_URL).catch((err) => {
           console.error('Failed to load URL:', err);
           retryCount++;
-          
+
           if (retryCount < maxRetries) {
             console.log(`Retrying to load URL (${retryCount}/${maxRetries})...`);
             setTimeout(tryLoadURL, 3000);
@@ -4040,7 +4041,7 @@ if (!gotTheLock) {
       };
 
       tryLoadURL();
-      
+
       // 打开开发者工具
       mainWindow.webContents.openDevTools();
     } else {
@@ -4466,4 +4467,4 @@ if (!gotTheLock) {
       app.quit();
     }
   });
-} 
+}


### PR DESCRIPTION
[问题]
调度任务中无法选择微信作为channel进行通知

[根因]
在channel [支持微信](https://github.com/netease-youdao/LobsterAI/pull/655) 后出现。定时调度本身允许选择的channel是有白名单的，其在 文件 `src/main/main.ts` 中通过 `SCHEDULED_TASK_CHANNEL_OPTIONS` 声明。添加微信为新channel后，这个名单未更新，导致界面上无法选择wechat

[修复]
在 `SCHEDULED_TASK_CHANNEL_OPTIONS` 列表中新增了 wechat 配置，后续新增了channel 这里都需要添加

[复现路径]（可选）
<img width="953" height="944" alt="image" src="https://github.com/user-attachments/assets/a7893423-f9a5-4bd7-9958-e6f4af804a76" />

