### PR TITLE
feat(settings): replace shortcut text input with keyboard recorder

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -409,6 +409,81 @@ const joinWorkspacePath = (dir: string | undefined, filename: string): string =>
     : `${base}${sep}${filename}`;
 };
 
+// System shortcuts that should not be captured (clipboard, undo, select-all, quit, etc.)
+const isSystemShortcut = (e: KeyboardEvent): boolean => {
+  const key = e.key.toLowerCase();
+  if (e.metaKey && ['c', 'v', 'x', 'z', 'y', 'a', 'q', 'w'].includes(key)) return true;
+  if (e.metaKey && e.shiftKey && key === 'z') return true;
+  if (e.ctrlKey && ['c', 'v', 'x', 'z', 'y', 'a', 'w'].includes(key)) return true;
+  return false;
+};
+
+const formatShortcutFromEvent = (e: React.KeyboardEvent): string | null => {
+  // Skip standalone modifier keys
+  if (['Meta', 'Control', 'Alt', 'Shift'].includes(e.key)) return null;
+  // Require at least one non-Shift modifier
+  if (!e.metaKey && !e.ctrlKey && !e.altKey) return null;
+  if (isSystemShortcut(e.nativeEvent)) return null;
+
+  const parts: string[] = [];
+  if (e.metaKey) parts.push('Cmd');
+  if (e.ctrlKey) parts.push('Ctrl');
+  if (e.altKey) parts.push('Alt');
+  if (e.shiftKey) parts.push('Shift');
+
+  const keyMap: Record<string, string> = {
+    ArrowUp: 'Up', ArrowDown: 'Down', ArrowLeft: 'Left', ArrowRight: 'Right',
+    ' ': 'Space', Escape: 'Esc', Enter: 'Enter', Backspace: 'Backspace',
+    Delete: 'Delete', Tab: 'Tab',
+  };
+  const key = keyMap[e.key] ?? (e.key.length === 1 ? e.key.toUpperCase() : e.key);
+  parts.push(key);
+  return parts.join('+');
+};
+
+const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void }> = ({ value, onChange }) => {
+  const [recording, setRecording] = useState(false);
+  const divRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!recording) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.key === 'Escape') { setRecording(false); return; }
+    if (e.key === 'Delete' || e.key === 'Backspace') { onChange(''); setRecording(false); return; }
+    const shortcut = formatShortcutFromEvent(e);
+    if (shortcut) { onChange(shortcut); setRecording(false); }
+  };
+
+  useEffect(() => {
+    if (!recording) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (divRef.current && !divRef.current.contains(e.target as Node)) setRecording(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [recording]);
+
+  return (
+    <div
+      ref={divRef}
+      tabIndex={0}
+      data-shortcut-input="true"
+      onKeyDown={handleKeyDown}
+      onClick={() => setRecording(true)}
+      onBlur={() => setRecording(false)}
+      className={`w-36 rounded-xl border px-3 py-1.5 text-sm cursor-pointer select-none text-center outline-none transition-colors
+        dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset dark:text-claude-darkText text-claude-text
+        ${recording
+          ? 'border-claude-accent ring-1 ring-claude-accent/30 dark:text-claude-darkTextSecondary text-claude-textSecondary'
+          : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
+        }`}
+    >
+      {value || i18nService.t('shortcutNotSet')}
+    </div>
+  );
+};
+
 const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpdateFound }) => {
   const dispatch = useDispatch();
   // 状态
@@ -3246,33 +3321,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <span className="text-sm dark:text-claude-darkText text-claude-text">{i18nService.t('newChat')}</span>
-                  <input
-                    type="text"
-                    value={shortcuts.newChat}
-                    onChange={(e) => handleShortcutChange('newChat', e.target.value)}
-                    data-shortcut-input="true"
-                    className="w-32 rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-1.5 text-sm"
-                  />
+                  <ShortcutRecorder value={shortcuts.newChat} onChange={(v) => handleShortcutChange('newChat', v)} />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm dark:text-claude-darkText text-claude-text">{i18nService.t('search')}</span>
-                  <input
-                    type="text"
-                    value={shortcuts.search}
-                    onChange={(e) => handleShortcutChange('search', e.target.value)}
-                    data-shortcut-input="true"
-                    className="w-32 rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-1.5 text-sm"
-                  />
+                  <ShortcutRecorder value={shortcuts.search} onChange={(v) => handleShortcutChange('search', v)} />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm dark:text-claude-darkText text-claude-text">{i18nService.t('openSettings')}</span>
-                  <input
-                    type="text"
-                    value={shortcuts.settings}
-                    onChange={(e) => handleShortcutChange('settings', e.target.value)}
-                    data-shortcut-input="true"
-                    className="w-32 rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-1.5 text-sm"
-                  />
+                  <ShortcutRecorder value={shortcuts.settings} onChange={(v) => handleShortcutChange('settings', v)} />
                 </div>
               </div>
             </div>

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -141,6 +141,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
+    shortcutNotSet: '未设置',
     newChat: '新建任务',
     search: '搜索任务',
     openSettings: '打开设置',
@@ -1246,6 +1247,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
+    shortcutNotSet: 'Not set',
     newChat: 'New Task',
     search: 'Search Tasks',
     openSettings: 'Open Settings',


### PR DESCRIPTION
## 需求背景

  设置页面 → 快捷键 Tab 中，原来的输入框需要手动输入快捷键字符串（如 "Ctrl+N"），操作不直观且容易输入错误格式。需要改为：点击后直接按下目标组合键即可完成录制，所见即所得。

  ## 变更说明

  - **新增 `ShortcutRecorder` 组件**：替换原有的 `<input type="text">`，点击后进入录制状态（边框高亮），用户按下组合键即直接写入，无需手动输入文字
  - **Escape** 取消录制，恢复原值；**Delete / Backspace** 清除当前快捷键绑定
  - **系统快捷键屏蔽**：`Cmd/Ctrl + C/V/X/Z/Y/A/Q/W`（剪贴板、撤销、退出等）不响应
  - **修饰键约束**：必须包含至少一个非 Shift 修饰键（Cmd / Ctrl / Alt），避免单字母被误设为快捷键
  - **兼容现有存储格式**：输出格式（如 `Cmd+Shift+K`）与现有 `parseShortcut()` / `matchesShortcut()` 完全兼容，无需改动快捷键匹配逻辑
  - 新增 `shortcutNotSet`（"未设置" / "Not set"）i18n key，用于空值占位展示

  ## 变更文件范围

  | 文件 | 说明 |
  |------|------|
  | `src/renderer/components/Settings.tsx` | 新增 `isSystemShortcut`、`formatShortcutFromEvent`、`ShortcutRecorder` 组件；替换快捷键 Tab 中三处输入框 |
  | `src/renderer/services/i18n.ts` | 新增 `shortcutNotSet` 中英文 i18n key |

  ## 效果

  - 默认状态：显示当前快捷键（如 `Ctrl+N`）
  - 录制状态：边框高亮，按下组合键立即生效
  - 空值状态：显示"未设置" / "Not set"