### PR TITLE
fix(markdown): preserve single tilde ranges in chat rendering

### DIFF
--- a/src/renderer/components/MarkdownContent.test.ts
+++ b/src/renderer/components/MarkdownContent.test.ts
@@ -1,0 +1,30 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { expect, test } from 'vitest';
+import MarkdownContent from './MarkdownContent';
+
+function renderMarkdown(content: string): string {
+  return renderToStaticMarkup(React.createElement(MarkdownContent, { content }));
+}
+
+test('renders weather ranges with single tilde as plain text across one paragraph', () => {
+  const html = renderMarkdown(
+    [
+      '当前：晴，20°C，体感20°C；湿度46%；西北风约4 km/h。  ',
+      '今天（3/25）：11~21°C，白天晴到少云，晚间转晴，整体不太会下雨。  ',
+      '明天（3/26）：12~16°C，多云到阴，傍晚到夜间有小雨。  ',
+      '后天（3/27）：11~12°C，阴雨为主，体感偏凉。',
+    ].join('\n')
+  );
+
+  expect(html).toContain('11~21°C');
+  expect(html).toContain('12~16°C');
+  expect(html).toContain('11~12°C');
+  expect(html).not.toContain('<del>');
+});
+
+test('keeps double-tilde strikethrough rendering intact', () => {
+  const html = renderMarkdown('建议：~~记得带伞~~最好加一件薄外套。');
+
+  expect(html).toContain('<del>记得带伞</del>');
+});

--- a/src/renderer/components/MarkdownContent.tsx
+++ b/src/renderer/components/MarkdownContent.tsx
@@ -608,7 +608,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
   return (
     <div className={`markdown-content text-[15px] leading-6 ${className}`}>
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkMath]}
+        remarkPlugins={[[remarkGfm, { singleTilde: false }], remarkMath]}
         rehypePlugins={[rehypeKatex]}
         urlTransform={safeUrlTransform}
         components={components}


### PR DESCRIPTION
## Summary
- disable single-tilde strikethrough parsing in the shared markdown renderer
- add a regression test for weather-style ranges like 11~21°C and 12~16°C in one paragraph
- keep double-tilde markdown strikethrough behavior unchanged

## Test Plan
- [x] `fnm exec --using 24.3.0 pnpm exec eslint src/renderer/components/MarkdownContent.tsx src/renderer/components/MarkdownContent.test.ts --ext ts,tsx`
- [x] `fnm exec --using 24.3.0 node --input-type=module -e "..."` verified weather ranges stay plain text and `~~...~~` still renders as strikethrough
- [ ] `fnm exec --using 24.3.0 pnpm test -- src/renderer/components/MarkdownContent.test.ts` currently fails before running tests because the repo has a pre-existing `vitest@4` / `vite@5` startup incompatibility (`ERR_PACKAGE_PATH_NOT_EXPORTED`)

Closes #824