### PR TITLE
fix(cowork): batch config writes in transaction

### DIFF
--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -1,0 +1,85 @@
+import type { Database } from 'sql.js';
+import { describe, expect, test, vi } from 'vitest';
+import { CoworkStore } from './coworkStore';
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getAppPath: () => '/tmp',
+    getPath: () => '/tmp',
+  },
+}));
+
+vi.mock('uuid', () => ({
+  v4: () => 'test-id',
+}));
+
+function createStore(runImpl?: (sql: string, params?: unknown[]) => void) {
+  const run = vi.fn(runImpl);
+  const exec = vi.fn(() => []);
+  const saveDb = vi.fn();
+  const db = {
+    run,
+    exec,
+  } as unknown as Database;
+
+  return {
+    run,
+    saveDb,
+    store: new CoworkStore(db, saveDb),
+  };
+}
+
+describe('CoworkStore.setConfig', () => {
+  test('wraps batched config updates in a transaction and saves once', () => {
+    const { store, run, saveDb } = createStore();
+
+    store.setConfig({
+      workingDirectory: '/tmp/workspace',
+      agentEngine: 'openclaw',
+      memoryEnabled: false,
+    });
+
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(run.mock.calls[0]?.[0]).toBe('BEGIN');
+    expect(run.mock.calls[2]?.[0]).toBe('COMMIT');
+
+    const [insertSql, insertParams] = run.mock.calls[1] ?? [];
+    expect(insertSql).toContain('INSERT INTO cowork_config');
+    expect(insertSql).toContain('VALUES (?, ?, ?), (?, ?, ?), (?, ?, ?)');
+    expect(insertParams).toEqual([
+      'workingDirectory',
+      '/tmp/workspace',
+      expect.any(Number),
+      'agentEngine',
+      'openclaw',
+      expect.any(Number),
+      'memoryEnabled',
+      '0',
+      expect.any(Number),
+    ]);
+    expect(saveDb).toHaveBeenCalledTimes(1);
+  });
+
+  test('rolls back the transaction when the batched upsert fails', () => {
+    const error = new Error('write failed');
+    const { store, run, saveDb } = createStore((sql) => {
+      if (sql.includes('INSERT INTO cowork_config')) {
+        throw error;
+      }
+    });
+
+    expect(() => {
+      store.setConfig({
+        workingDirectory: '/tmp/workspace',
+        agentEngine: 'openclaw',
+      });
+    }).toThrow(error);
+
+    expect(run.mock.calls[0]?.[0]).toBe('BEGIN');
+    expect(run.mock.calls[1]?.[0]).toContain('INSERT INTO cowork_config');
+    expect(run.mock.calls[2]?.[0]).toBe('ROLLBACK');
+    expect(run.mock.calls.map(([sql]) => sql)).not.toContain('COMMIT');
+    expect(saveDb).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -906,86 +906,77 @@ export class CoworkStore {
 
   setConfig(config: CoworkConfigUpdate): void {
     const now = Date.now();
+    const updates: Array<{ key: string; value: string }> = [];
 
     if (config.workingDirectory !== undefined) {
-      this.db.run(`
-        INSERT INTO cowork_config (key, value, updated_at)
-        VALUES ('workingDirectory', ?, ?)
-        ON CONFLICT(key) DO UPDATE SET
-          value = excluded.value,
-          updated_at = excluded.updated_at
-      `, [config.workingDirectory, now]);
+      updates.push({ key: 'workingDirectory', value: config.workingDirectory });
     }
 
     if (config.executionMode !== undefined) {
-      this.db.run(`
-        INSERT INTO cowork_config (key, value, updated_at)
-        VALUES ('executionMode', ?, ?)
-        ON CONFLICT(key) DO UPDATE SET
-          value = excluded.value,
-          updated_at = excluded.updated_at
-      `, [config.executionMode, now]);
+      updates.push({ key: 'executionMode', value: config.executionMode });
     }
 
     if (config.agentEngine !== undefined) {
-      const normalizedAgentEngine = normalizeCoworkAgentEngineValue(config.agentEngine);
-      this.db.run(`
-        INSERT INTO cowork_config (key, value, updated_at)
-        VALUES ('agentEngine', ?, ?)
-        ON CONFLICT(key) DO UPDATE SET
-          value = excluded.value,
-          updated_at = excluded.updated_at
-      `, [normalizedAgentEngine, now]);
+      updates.push({
+        key: 'agentEngine',
+        value: normalizeCoworkAgentEngineValue(config.agentEngine),
+      });
     }
 
     if (config.memoryEnabled !== undefined) {
-      this.db.run(`
-        INSERT INTO cowork_config (key, value, updated_at)
-        VALUES ('memoryEnabled', ?, ?)
-        ON CONFLICT(key) DO UPDATE SET
-          value = excluded.value,
-          updated_at = excluded.updated_at
-      `, [config.memoryEnabled ? '1' : '0', now]);
+      updates.push({ key: 'memoryEnabled', value: config.memoryEnabled ? '1' : '0' });
     }
 
     if (config.memoryImplicitUpdateEnabled !== undefined) {
-      this.db.run(`
-        INSERT INTO cowork_config (key, value, updated_at)
-        VALUES ('memoryImplicitUpdateEnabled', ?, ?)
-        ON CONFLICT(key) DO UPDATE SET
-          value = excluded.value,
-          updated_at = excluded.updated_at
-      `, [config.memoryImplicitUpdateEnabled ? '1' : '0', now]);
+      updates.push({
+        key: 'memoryImplicitUpdateEnabled',
+        value: config.memoryImplicitUpdateEnabled ? '1' : '0',
+      });
     }
 
     if (config.memoryLlmJudgeEnabled !== undefined) {
-      this.db.run(`
-        INSERT INTO cowork_config (key, value, updated_at)
-        VALUES ('memoryLlmJudgeEnabled', ?, ?)
-        ON CONFLICT(key) DO UPDATE SET
-          value = excluded.value,
-          updated_at = excluded.updated_at
-      `, [config.memoryLlmJudgeEnabled ? '1' : '0', now]);
+      updates.push({
+        key: 'memoryLlmJudgeEnabled',
+        value: config.memoryLlmJudgeEnabled ? '1' : '0',
+      });
     }
 
     if (config.memoryGuardLevel !== undefined) {
-      this.db.run(`
-        INSERT INTO cowork_config (key, value, updated_at)
-        VALUES ('memoryGuardLevel', ?, ?)
-        ON CONFLICT(key) DO UPDATE SET
-          value = excluded.value,
-          updated_at = excluded.updated_at
-      `, [normalizeMemoryGuardLevel(config.memoryGuardLevel), now]);
+      updates.push({
+        key: 'memoryGuardLevel',
+        value: normalizeMemoryGuardLevel(config.memoryGuardLevel),
+      });
     }
 
     if (config.memoryUserMemoriesMaxItems !== undefined) {
-      this.db.run(`
-        INSERT INTO cowork_config (key, value, updated_at)
-        VALUES ('memoryUserMemoriesMaxItems', ?, ?)
-        ON CONFLICT(key) DO UPDATE SET
-          value = excluded.value,
-          updated_at = excluded.updated_at
-      `, [String(clampMemoryUserMemoriesMaxItems(config.memoryUserMemoriesMaxItems)), now]);
+      updates.push({
+        key: 'memoryUserMemoriesMaxItems',
+        value: String(clampMemoryUserMemoriesMaxItems(config.memoryUserMemoriesMaxItems)),
+      });
+    }
+
+    if (updates.length > 0) {
+      const placeholders = updates.map(() => '(?, ?, ?)').join(', ');
+      const values = updates.flatMap(({ key, value }) => [key, value, now]);
+
+      this.db.run('BEGIN');
+      try {
+        this.db.run(`
+          INSERT INTO cowork_config (key, value, updated_at)
+          VALUES ${placeholders}
+          ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            updated_at = excluded.updated_at
+        `, values);
+        this.db.run('COMMIT');
+      } catch (error) {
+        try {
+          this.db.run('ROLLBACK');
+        } catch {
+          // Best-effort rollback; preserve the original error.
+        }
+        throw error;
+      }
     }
 
     this.saveDb();


### PR DESCRIPTION
## Summary
- batch `CoworkStore.setConfig()` updates into a single upsert wrapped by an explicit transaction
- preserve the existing config normalization rules while reducing per-field SQL overhead
- add regression tests for transaction commit and rollback behavior

## Test Plan
- [x] `fnm exec --using v24.3.0 -- env NODE_PATH=/Users/leelei/.codex/worktrees/b792/LobsterAI/node_modules /Users/leelei/.codex/worktrees/b792/LobsterAI/node_modules/.bin/vitest run src/main/coworkStore.test.ts`
- [x] `NODE_PATH=/Users/leelei/.codex/worktrees/b792/LobsterAI/node_modules /Users/leelei/.codex/worktrees/b792/LobsterAI/node_modules/.bin/eslint src/main/coworkStore.ts src/main/coworkStore.test.ts --ext ts`