### PR TITLE
fix(renderer): attachments disappear when change different task session

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -10,18 +10,15 @@ import { SkillsButton, ActiveSkillBadge } from '../skills';
 import { i18nService } from '../../services/i18n';
 import { skillService } from '../../services/skill';
 import { RootState } from '../../store';
-import { setDraftPrompt } from '../../store/slices/coworkSlice';
+import { setDraftPrompt, setDraftAttachments, clearDraftAttachments, type DraftAttachment } from '../../store/slices/coworkSlice';
 import { setSkills, toggleActiveSkill } from '../../store/slices/skillSlice';
 import { Skill } from '../../types/skill';
 import { CoworkImageAttachment } from '../../types/cowork';
 import { getCompactFolderName } from '../../utils/path';
 
-type CoworkAttachment = {
-  path: string;
-  name: string;
-  isImage?: boolean;
-  dataUrl?: string;
-};
+// CoworkAttachment is aliased from the Redux-persisted DraftAttachment type
+// so that attachment state survives view switches (cowork ↔ skills, etc.)
+type CoworkAttachment = DraftAttachment;
 
 const INPUT_FILE_LABEL = '输入文件';
 
@@ -115,8 +112,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const dispatch = useDispatch();
     const draftKey = sessionId || '__home__';
     const draftPrompt = useSelector((state: RootState) => state.cowork.draftPrompts[draftKey] || '');
+    const attachments = useSelector((state: RootState) => state.cowork.draftAttachments[draftKey] || []) as CoworkAttachment[];
     const [value, setValue] = useState(draftPrompt);
-    const [attachments, setAttachments] = useState<CoworkAttachment[]>([]);
     const [showFolderMenu, setShowFolderMenu] = useState(false);
     const [showFolderRequiredWarning, setShowFolderRequiredWarning] = useState(false);
     const [isDraggingFiles, setIsDraggingFiles] = useState(false);
@@ -186,7 +183,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       const shouldClear = detail?.clear ?? true;
       if (shouldClear) {
         setValue('');
-        setAttachments([]);
+        dispatch(clearDraftAttachments(draftKey));
       }
       requestAnimationFrame(() => {
         textareaRef.current?.focus();
@@ -274,7 +271,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     if (result === false) return;
     setValue('');
     dispatch(setDraftPrompt({ sessionId: draftKey, draft: '' }));
-    setAttachments([]);
+    dispatch(clearDraftAttachments(draftKey));
     setImageVisionHint(false);
   }, [value, isStreaming, disabled, onSubmit, activeSkillIds, skills, attachments, showFolderSelector, workingDirectory, dispatch]);
 
@@ -334,31 +331,32 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
 
   const addAttachment = useCallback((filePath: string, imageInfo?: { isImage: boolean; dataUrl?: string }) => {
     if (!filePath) return;
-    setAttachments((prev) => {
-      if (prev.some((attachment) => attachment.path === filePath)) {
-        return prev;
-      }
-      return [...prev, {
+    const current = attachments;
+    if (current.some((attachment) => attachment.path === filePath)) return;
+    dispatch(setDraftAttachments({
+      draftKey,
+      attachments: [...current, {
         path: filePath,
         name: getFileNameFromPath(filePath),
         isImage: imageInfo?.isImage,
         dataUrl: imageInfo?.dataUrl,
-      }];
-    });
-  }, []);
+      }],
+    }));
+  }, [attachments, dispatch, draftKey]);
 
   const addImageAttachmentFromDataUrl = useCallback((name: string, dataUrl: string) => {
     // Use the dataUrl as the unique key (no file path for inline images)
     const pseudoPath = `inline:${name}:${Date.now()}`;
-    setAttachments((prev) => {
-      return [...prev, {
+    dispatch(setDraftAttachments({
+      draftKey,
+      attachments: [...attachments, {
         path: pseudoPath,
         name,
         isImage: true,
         dataUrl,
-      }];
-    });
-  }, []);
+      }],
+    }));
+  }, [attachments, dispatch, draftKey]);
 
   const fileToDataUrl = useCallback((file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
@@ -527,8 +525,11 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   }, [addAttachment, isAddingFile, disabled, isStreaming, modelSupportsImage]);
 
   const handleRemoveAttachment = useCallback((path: string) => {
-    setAttachments((prev) => prev.filter((attachment) => attachment.path !== path));
-  }, []);
+    dispatch(setDraftAttachments({
+      draftKey,
+      attachments: attachments.filter((attachment) => attachment.path !== path),
+    }));
+  }, [attachments, dispatch, draftKey]);
 
   const hasFileTransfer = (dataTransfer: DataTransfer | null): boolean => {
     if (!dataTransfer) return false;

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -8,11 +8,20 @@ import type {
   CoworkSessionStatus,
 } from '../../types/cowork';
 
+export interface DraftAttachment {
+  path: string;
+  name: string;
+  isImage?: boolean;
+  dataUrl?: string;
+}
+
 interface CoworkState {
   sessions: CoworkSessionSummary[];
   currentSessionId: string | null;
   currentSession: CoworkSession | null;
   draftPrompts: Record<string, string>;
+  /** Keyed by draftKey (sessionId or '__home__'), stores pending attachments */
+  draftAttachments: Record<string, DraftAttachment[]>;
   unreadSessionIds: string[];
   isCoworkActive: boolean;
   isStreaming: boolean;
@@ -26,6 +35,7 @@ const initialState: CoworkState = {
   currentSessionId: null,
   currentSession: null,
   draftPrompts: {},
+  draftAttachments: {},
   unreadSessionIds: [],
   isCoworkActive: false,
   isStreaming: false,
@@ -315,6 +325,19 @@ const coworkSlice = createSlice({
       state.isStreaming = false;
       state.remoteManaged = false;
     },
+
+    setDraftAttachments(state, action: PayloadAction<{ draftKey: string; attachments: DraftAttachment[] }>) {
+      const { draftKey, attachments } = action.payload;
+      if (attachments.length === 0) {
+        delete state.draftAttachments[draftKey];
+      } else {
+        state.draftAttachments[draftKey] = attachments;
+      }
+    },
+
+    clearDraftAttachments(state, action: PayloadAction<string>) {
+      delete state.draftAttachments[action.payload];
+    },
   },
 });
 
@@ -324,6 +347,8 @@ export const {
   setCurrentSessionId,
   setCurrentSession,
   setDraftPrompt,
+  setDraftAttachments,
+  clearDraftAttachments,
   addSession,
   updateSessionStatus,
   deleteSession,


### PR DESCRIPTION
## [问题]

1. 新建任务，上传图片之类的附件，点击菜单栏技能，查看技能后回到新建任务发现附件丢失

![Kapture 2026-03-25 at 18 26 17](https://github.com/user-attachments/assets/4cc3d3ca-4897-4ed2-ae05-5bd1ab149f51)


2. 在不同任务记录上传附件后，切换其他任务，发现附件未区分任务，并且在多个任务中展示

![Kapture 2026-03-25 at 18 25 14](https://github.com/user-attachments/assets/e4649d27-4ee7-4735-8d6b-89806dfa3fca)

## [根因]

设计上未根据draftKey存储附件，导致条件渲染触发组件卸载，本地 useState 随之销毁

## [修复]

### 方向

将 attachments 提升到 Redux，与 draftPrompts 保持一致的持久化策略

### 思路

将 attachments 从 CoworkPromptInput 的本地 state 提升到 Redux store，与已有的 draftPrompts（草稿文本）保持一致的设计模式——同一个 draftKey（sessionId 或 '__home__'）下的草稿文本和附件一并缓存。

### 改动点

#### coworkSlice.ts：

新增 DraftAttachment 类型（export 供组件使用）
CoworkState 新增 draftAttachments: Record<string, DraftAttachment[]> 字段
新增两个 reducer：setDraftAttachments（设置/更新）、clearDraftAttachments（清空）

#### CoworkPromptInput.tsx：

删除本地 const [attachments, setAttachments] = useState(...)
改为 useSelector 从 Redux 读取 state.cowork.draftAttachments[draftKey]
所有 setAttachments(...) 调用改为 dispatch(setDraftAttachments(...)) 或 dispatch(clearDraftAttachments(...))

## 预览

![Kapture 2026-03-25 at 18 30 24](https://github.com/user-attachments/assets/d65da036-e94e-487c-9878-8518b099c98c)
