### PR TITLE
fix(main): 窗口销毁后 event.sender 调用导致主进程崩溃

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2642,6 +2642,9 @@ if (!gotTheLock) {
         return { success: false, error: 'Capture rect is required' };
       }
 
+      if (event.sender.isDestroyed()) {
+        return { success: false, error: 'Window has been closed' };
+      }
       const image = await event.sender.capturePage(captureRect);
       return savePngWithDialog(event.sender, image.toPNG(), defaultFileName);
     } catch (error) {
@@ -2664,6 +2667,9 @@ if (!gotTheLock) {
         return { success: false, error: 'Capture rect is required' };
       }
 
+      if (event.sender.isDestroyed()) {
+        return { success: false, error: 'Window has been closed' };
+      }
       const image = await event.sender.capturePage(captureRect);
       const pngBuffer = image.toPNG();
 
@@ -3790,6 +3796,7 @@ if (!gotTheLock) {
         try {
           while (true) {
             const { value, done } = await reader.read();
+            if (event.sender.isDestroyed()) break;
             if (done) {
               event.sender.send(`api:stream:${options.requestId}:done`);
               break;
@@ -3798,6 +3805,7 @@ if (!gotTheLock) {
             event.sender.send(`api:stream:${options.requestId}:data`, chunk);
           }
         } catch (error) {
+          if (event.sender.isDestroyed()) return;
           if (error instanceof Error && error.name === 'AbortError') {
             event.sender.send(`api:stream:${options.requestId}:abort`);
           } else {


### PR DESCRIPTION
## Summary

修复窗口关闭后，仍在运行的异步操作通过 `event.sender` 发送 IPC 消息或调用 `capturePage()` 导致主进程抛出未处理异常的问题。

关联 Issue: #624

## 问题分析

`ipcMain.handle` 注册的回调中，部分异步操作（SSE 流式读取、页面截图）在执行过程中，发起 IPC 调用的渲染窗口可能已被用户关闭。此时 `event.sender`（`WebContents`）已被销毁，直接调用其方法会抛出异常：

- `event.sender.send()` → `TypeError: Object has been destroyed`
- `event.sender.capturePage()` → 同上

由于这些调用发生在 `async` 函数内部但**不在 IPC handler 的直接 try-catch 中**（例如 `readStream` 是独立的 async 函数），异常会成为 unhandled rejection，可能导致主进程崩溃。

## 修复内容

在以下位置添加 `event.sender.isDestroyed()` 前置检查：

### SSE 流式代理（`api:stream`）
- **循环体内**：每次 `reader.read()` 返回后，发送数据前检查窗口是否存活；若已销毁则静默退出循环
- **错误处理**：catch 块中发送错误/中断事件前检查，避免在通知错误时再次抛出异常

### 页面截图（`cowork:session:exportResultImage` / `captureImageChunk`）
- 调用 `capturePage()` 前检查窗口状态，返回明确的错误对象而非抛出异常

## 改动文件

- `src/main/main.ts` — 4 处添加 `isDestroyed()` guard

## Test Plan

- [x] `npx tsc --noEmit -p electron-tsconfig.json` 类型检查通过
- [ ] 手动验证：启动 App → 开始 Cowork 对话 → 在流式输出过程中关闭窗口 → 主进程不崩溃