### PR TITLE
feat: add custom theme with user-selectable accent color

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -3,7 +3,7 @@ import { configService } from '../services/config';
 import { apiService } from '../services/api';
 import { checkForAppUpdate } from '../services/appUpdate';
 import type { AppUpdateInfo } from '../services/appUpdate';
-import { themeService } from '../services/theme';
+import { themeService, ThemeType } from '../services/theme';
 import { i18nService, LanguageType } from '../services/i18n';
 import { decryptSecret, encryptWithPassword, decryptWithPassword, EncryptedPayload, PasswordEncryptedPayload } from '../services/encryption';
 import { coworkService } from '../services/cowork';
@@ -413,7 +413,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
   const dispatch = useDispatch();
   // 状态
   const [activeTab, setActiveTab] = useState<TabType>(initialTab ?? 'general');
-  const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system');
+  const [theme, setTheme] = useState<ThemeType>('system');
+  const [accentColor, setAccentColor] = useState<string>('#F472B6');
   const [language, setLanguage] = useState<LanguageType>('zh');
   const [autoLaunch, setAutoLaunchState] = useState(false);
   const [useSystemProxy, setUseSystemProxy] = useState(false);
@@ -428,7 +429,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
   const [isTesting, setIsTesting] = useState(false);
   const [isImportingProviders, setIsImportingProviders] = useState(false);
   const [isExportingProviders, setIsExportingProviders] = useState(false);
-  const initialThemeRef = useRef<'light' | 'dark' | 'system'>(themeService.getTheme());
+  const initialThemeRef = useRef<ThemeType>(themeService.getTheme());
+  const initialAccentRef = useRef<string>(themeService.getAccentColor());
   const initialLanguageRef = useRef<LanguageType>(i18nService.getLanguage());
   const didSaveRef = useRef(false);
 
@@ -631,8 +633,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
       
       // Set general settings
       initialThemeRef.current = config.theme;
+      initialAccentRef.current = themeService.getAccentColor();
       initialLanguageRef.current = config.language;
       setTheme(config.theme);
+      if (config.themeAccentColor) {
+        setAccentColor(config.themeAccentColor);
+      }
       setLanguage(config.language);
       setUseSystemProxy(config.useSystemProxy ?? false);
       const savedTestMode = config.app?.testMode ?? false;
@@ -846,6 +852,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
         return;
       }
       themeService.setTheme(initialThemeRef.current);
+      if (initialThemeRef.current === 'custom') {
+        themeService.setAccentColor(initialAccentRef.current);
+      }
       i18nService.setLanguage(initialLanguageRef.current, { persist: false });
     };
   }, []);
@@ -1388,6 +1397,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
         },
         providers: normalizedProviders, // Save all providers configuration
         theme,
+        themeAccentColor: theme === 'custom' ? accentColor : undefined,
         language,
         useSystemProxy,
         shortcuts,
@@ -2221,12 +2231,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
               <h4 className="text-sm font-medium dark:text-claude-darkText text-claude-text mb-3">
                 {i18nService.t('appearance')}
               </h4>
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-4 gap-3">
                 {([
                   { value: 'light' as const, label: i18nService.t('light') },
                   { value: 'dark' as const, label: i18nService.t('dark') },
                   { value: 'system' as const, label: i18nService.t('system') },
-                ]).map((option) => {
+                  { value: 'custom' as const, label: i18nService.t('custom') },
+                ] as const).map((option) => {
                   const isSelected = theme === option.value;
                   return (
                     <button
@@ -2234,6 +2245,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
                       type="button"
                       onClick={() => {
                         setTheme(option.value);
+                        if (option.value === 'custom') {
+                          themeService.setAccentColor(accentColor);
+                        }
                         themeService.setTheme(option.value);
                       }}
                       className={`flex flex-col items-center rounded-xl border-2 p-3 transition-colors cursor-pointer ${
@@ -2323,6 +2337,31 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
                             </g>
                             {/* Divider line */}
                             <line x1="60" y1="0" x2="60" y2="80" stroke="#888" strokeWidth="0.5" />
+                           </>
+                        )}
+                        {option.value === 'custom' && (
+                          <>
+                            <defs>
+                              <linearGradient id="custom-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+                                <stop offset="0%" stopColor={accentColor} stopOpacity="0.15" />
+                                <stop offset="100%" stopColor={accentColor} stopOpacity="0.05" />
+                              </linearGradient>
+                            </defs>
+                            <rect width="120" height="80" fill="url(#custom-grad)" />
+                            <rect x="0" y="0" width="30" height="80" fill={accentColor} fillOpacity="0.12" />
+                            <rect x="4" y="8" width="22" height="4" rx="2" fill={accentColor} fillOpacity="0.4" />
+                            <rect x="4" y="16" width="18" height="3" rx="1.5" fill={accentColor} fillOpacity="0.2" />
+                            <rect x="4" y="22" width="20" height="3" rx="1.5" fill={accentColor} fillOpacity="0.2" />
+                            <rect x="4" y="28" width="16" height="3" rx="1.5" fill={accentColor} fillOpacity="0.2" />
+                            <rect x="36" y="8" width="78" height="64" rx="4" fill="#FFFFFF" />
+                            <rect x="42" y="16" width="50" height="4" rx="2" fill={accentColor} fillOpacity="0.3" />
+                            <rect x="42" y="24" width="66" height="3" rx="1.5" fill={accentColor} fillOpacity="0.12" />
+                            <rect x="42" y="30" width="60" height="3" rx="1.5" fill={accentColor} fillOpacity="0.12" />
+                            <rect x="42" y="36" width="55" height="3" rx="1.5" fill={accentColor} fillOpacity="0.12" />
+                            <rect x="42" y="46" width="40" height="4" rx="2" fill={accentColor} fillOpacity="0.3" />
+                            <rect x="42" y="54" width="66" height="3" rx="1.5" fill={accentColor} fillOpacity="0.12" />
+                            <rect x="42" y="60" width="58" height="3" rx="1.5" fill={accentColor} fillOpacity="0.12" />
+                            <circle cx="105" cy="12" r="6" fill={accentColor} fillOpacity="0.6" />
                           </>
                         )}
                       </svg>
@@ -2337,6 +2376,29 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
                   );
                 })}
               </div>
+              {theme === 'custom' && (
+                <div className="mt-4 flex items-center gap-3">
+                  <label className="text-sm dark:text-claude-darkText text-claude-text">
+                    {i18nService.t('accentColor')}
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="color"
+                      value={accentColor}
+                      onChange={(e) => {
+                        setAccentColor(e.target.value);
+                        themeService.setAccentColor(e.target.value);
+                        themeService.setTheme('custom');
+                      }}
+                      className="w-8 h-8 rounded-lg border dark:border-claude-darkBorder border-claude-border cursor-pointer appearance-none bg-transparent p-0"
+                      style={{ WebkitAppearance: 'none' }}
+                    />
+                  </div>
+                  <span className="text-xs text-claude-textSecondary font-mono">
+                    {accentColor.toUpperCase()}
+                  </span>
+                </div>
+              )}
             </div>
           </div>
         );

--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -214,7 +214,8 @@ export interface AppConfig {
     };
   };
   // 主题配置
-  theme: 'light' | 'dark' | 'system';
+  theme: 'light' | 'dark' | 'system' | 'custom';
+  themeAccentColor?: string;
   // 语言配置
   language: 'zh' | 'en';
   // 是否使用系统代理

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -2,7 +2,77 @@
 @tailwind components;
 @tailwind utilities;
 
-/* KaTeX styles */
+:root {
+  --claude-bg: #F8F9FB;
+  --claude-surface: #FFFFFF;
+  --claude-surfaceHover: #F0F1F4;
+  --claude-surfaceMuted: #F3F4F6;
+  --claude-surfaceInset: #EBEDF0;
+  --claude-border: #E0E2E7;
+  --claude-borderLight: #EBEDF0;
+  --claude-text: #1A1D23;
+  --claude-textSecondary: #6B7280;
+
+  --claude-darkBg: #0F1117;
+  --claude-darkSurface: #1A1D27;
+  --claude-darkSurfaceHover: #242830;
+  --claude-darkSurfaceMuted: #151820;
+  --claude-darkSurfaceInset: #0C0E14;
+  --claude-darkBorder: #2A2E38;
+  --claude-darkBorderLight: #1F232B;
+  --claude-darkText: #E4E5E9;
+  --claude-darkTextSecondary: #8B8FA3;
+
+  --claude-accent: #3B82F6;
+  --claude-accentHover: #2563EB;
+  --claude-accentLight: #60A5FA;
+  --claude-accentMuted: rgba(59,130,246,0.10);
+
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Inter', system-ui, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
+  font-weight: 400;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.dark {
+  color-scheme: dark;
+  color: var(--claude-darkText);
+  background-color: var(--claude-darkBg);
+}
+
+.light {
+  color-scheme: light;
+  color: var(--claude-text);
+  background-color: var(--claude-bg);
+}
+
+.dark #root,
+.dark .App,
+.dark main {
+  background-color: var(--claude-darkBg);
+  color: var(--claude-darkText);
+}
+
+.light #root,
+.light .App,
+.light main {
+  background-color: var(--claude-bg);
+  color: var(--claude-text);
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+#root {
+  height: 100vh;
+}
+
 .katex-display {
   overflow-x: auto;
   overflow-y: hidden;
@@ -15,10 +85,9 @@
 }
 
 .dark .katex {
-  color: #E4E5E9;
+  color: var(--claude-darkText);
 }
 
-/* Improve code block styles */
 pre {
   @apply dark:bg-claude-darkSurface bg-claude-surfaceHover;
   border-radius: 0.75rem !important;
@@ -31,7 +100,6 @@ code {
   font-family: 'SF Mono', 'Fira Code', Menlo, Monaco, 'Courier New', monospace;
 }
 
-/* Improve table styles */
 table {
   border-collapse: collapse;
   margin: 1em 0;
@@ -48,7 +116,6 @@ th {
   font-weight: bold;
 }
 
-/* Style for blockquotes */
 blockquote {
   @apply dark:border-claude-accent border-claude-accent dark:text-claude-darkTextSecondary text-claude-textSecondary;
   border-left-width: 3px;
@@ -62,57 +129,6 @@ blockquote {
   contain-intrinsic-size: 500px;
 }
 
-:root {
-  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Inter', system-ui, 'Segoe UI', Roboto, sans-serif;
-  line-height: 1.6;
-  font-weight: 400;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-/* Cold modern dark mode */
-.dark {
-  color-scheme: dark;
-  color: #E4E5E9;
-  background-color: #0F1117;
-}
-
-/* Cold modern light mode */
-.light {
-  color-scheme: light;
-  color: #1A1D23;
-  background-color: #F8F9FB;
-}
-
-/* Ensure all containers inherit theme */
-.dark #root,
-.dark .App,
-.dark main {
-  background-color: #0F1117;
-  color: #E4E5E9;
-}
-
-.light #root,
-.light .App,
-.light main {
-  background-color: #F8F9FB;
-  color: #1A1D23;
-}
-
-body {
-  margin: 0;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-#root {
-  height: 100vh;
-}
-
-/* Custom scrollbar styles - cold modern */
 ::-webkit-scrollbar {
   width: 6px;
 }
@@ -130,18 +146,16 @@ body {
   @apply dark:bg-claude-darkTextSecondary bg-claude-textSecondary;
 }
 
-/* Style for select options to match theme */
 .dark option {
-  background-color: #1A1D27;
-  color: #E4E5E9;
+  background-color: var(--claude-darkSurface);
+  color: var(--claude-darkText);
 }
 
 .light option {
-  background-color: #FFFFFF;
-  color: #1A1D23;
+  background-color: var(--claude-surface);
+  color: var(--claude-text);
 }
 
-/* Ensure select elements have proper styling in Firefox */
 select {
   -moz-appearance: none;
   appearance: none;
@@ -170,12 +184,10 @@ select::-ms-expand {
   user-select: none;
 }
 
-/* Focus ring */
 .focus-ring {
   @apply focus:outline-none focus:ring-2 focus:ring-claude-accent focus:ring-offset-2 dark:focus:ring-offset-claude-darkBg focus:ring-offset-claude-bg;
 }
 
-/* Button styles */
 .btn-primary {
   @apply bg-claude-accent hover:bg-claude-accentHover text-white font-medium py-2 px-4 rounded-lg transition-colors;
 }
@@ -184,34 +196,28 @@ select::-ms-expand {
   @apply dark:bg-claude-darkSurface bg-claude-surface dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover dark:text-claude-darkText text-claude-text border dark:border-claude-darkBorder border-claude-border font-medium py-2 px-4 rounded-lg transition-colors;
 }
 
-/* Sidebar width transition - instant toggle, no animation */
 .sidebar-transition {
   transition: none;
 }
 
-/* Subtle separator line */
 .separator {
   @apply dark:border-claude-darkBorderLight border-claude-borderLight;
   border-top-width: 1px;
 }
 
-/* Modal backdrop */
 .modal-backdrop {
   @apply bg-black/40 backdrop-blur-sm;
   animation: fade-in 0.2s ease-out;
 }
 
-/* Modal content entrance */
 .modal-content {
   animation: scale-in 0.2s ease-out;
 }
 
-/* Popover entrance */
 .popover-enter {
   animation: fade-in-down 0.2s ease-out;
 }
 
-/* Skeleton loading */
 .skeleton {
   @apply dark:bg-claude-darkSurface bg-claude-surfaceHover rounded;
   position: relative;
@@ -226,7 +232,6 @@ select::-ms-expand {
   animation: shimmer 1.5s infinite;
 }
 
-/* Streaming activity bar */
 .streaming-bar {
   position: relative;
   height: 2px;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -41,6 +41,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     light: '浅色',
     dark: '深色',
     system: '跟随系统',
+    custom: '自定义',
+    accentColor: '主题色',
     chinese: '中文',
     english: 'English',
     
@@ -1118,6 +1120,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     light: 'Light',
     dark: 'Dark',
     system: 'System',
+    custom: 'Custom',
+    accentColor: 'Accent Color',
     chinese: 'Chinese',
     english: 'English',
     

--- a/src/renderer/services/theme.ts
+++ b/src/renderer/services/theme.ts
@@ -1,23 +1,76 @@
 import { configService } from './config';
 
-type ThemeType = 'light' | 'dark' | 'system';
+export type ThemeType = 'light' | 'dark' | 'system' | 'custom';
 
-// Cold modern color palette
-const COLORS = {
-  light: {
-    bg: '#F8F9FB',
-    text: '#1A1D23',
-  },
-  dark: {
-    bg: '#0F1117',
-    text: '#E4E5E9',
-  },
+function hexToHsl(hex: string): [number, number, number] {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return [0, 0, l * 100];
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h = 0;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  else if (max === g) h = ((b - r) / d + 2) / 6;
+  else h = ((r - g) / d + 4) / 6;
+  return [h * 360, s * 100, l * 100];
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  s /= 100; l /= 100;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+    return Math.round(255 * color).toString(16).padStart(2, '0');
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+function generatePalette(accentHex: string): Record<string, string> {
+  const [h, s] = hexToHsl(accentHex);
+  const pastelS = Math.min(s, 40);
+  return {
+    '--claude-bg': hslToHex(h, pastelS * 0.15, 97),
+    '--claude-surface': '#FFFFFF',
+    '--claude-surfaceHover': hslToHex(h, pastelS * 0.2, 94),
+    '--claude-surfaceMuted': hslToHex(h, pastelS * 0.18, 95.5),
+    '--claude-surfaceInset': hslToHex(h, pastelS * 0.2, 92),
+    '--claude-border': hslToHex(h, pastelS * 0.25, 88),
+    '--claude-borderLight': hslToHex(h, pastelS * 0.2, 92),
+    '--claude-text': hslToHex(h, pastelS * 0.3, 12),
+    '--claude-textSecondary': hslToHex(h, pastelS * 0.15, 45),
+    '--claude-accent': accentHex,
+    '--claude-accentHover': hslToHex(h, Math.min(s * 1.1, 100), Math.max(s > 0 ? 40 : 45, 35)),
+    '--claude-accentLight': hslToHex(h, Math.min(s * 0.8, 90), 65),
+    '--claude-accentMuted': `hsla(${h}, ${Math.round(s)}%, 50%, 0.10)`,
+  };
+}
+
+const DEFAULT_LIGHT_VARS: Record<string, string> = {
+  '--claude-bg': '#F8F9FB',
+  '--claude-surface': '#FFFFFF',
+  '--claude-surfaceHover': '#F0F1F4',
+  '--claude-surfaceMuted': '#F3F4F6',
+  '--claude-surfaceInset': '#EBEDF0',
+  '--claude-border': '#E0E2E7',
+  '--claude-borderLight': '#EBEDF0',
+  '--claude-text': '#1A1D23',
+  '--claude-textSecondary': '#6B7280',
+  '--claude-accent': '#3B82F6',
+  '--claude-accentHover': '#2563EB',
+  '--claude-accentLight': '#60A5FA',
+  '--claude-accentMuted': 'rgba(59,130,246,0.10)',
 };
 
 class ThemeService {
   private mediaQuery: MediaQueryList | null = null;
   private currentTheme: ThemeType = 'system';
   private appliedTheme: 'light' | 'dark' | null = null;
+  private customAccent: string | null = null;
   private initialized = false;
   private mediaQueryListener: ((event: MediaQueryListEvent) => void) | null = null;
 
@@ -27,18 +80,17 @@ class ThemeService {
     }
   }
 
-  // 初始化主题
   initialize(): void {
-    if (this.initialized) {
-      return;
-    }
+    if (this.initialized) return;
     this.initialized = true;
 
     try {
       const config = configService.getConfig();
+      if (config.theme === 'custom' && config.themeAccentColor) {
+        this.customAccent = config.themeAccentColor;
+      }
       this.setTheme(config.theme);
 
-      // 监听系统主题变化
       if (this.mediaQuery) {
         this.mediaQueryListener = (e) => {
           if (this.currentTheme === 'system') {
@@ -49,102 +101,111 @@ class ThemeService {
       }
     } catch (error) {
       console.error('Failed to initialize theme:', error);
-      // 默认使用系统主题
       this.setTheme('system');
     }
   }
 
-  // 设置主题
   setTheme(theme: ThemeType): void {
-    const effectiveTheme = theme === 'system'
-      ? (this.mediaQuery?.matches ? 'dark' : 'light')
-      : theme;
-
-    if (this.currentTheme === theme && this.appliedTheme === effectiveTheme) {
+    if (theme === 'custom') {
+      this.currentTheme = 'custom';
+      this.appliedTheme = null;
+      this.applyCustomTheme(this.customAccent || '#F472B6');
       return;
     }
 
-    console.log(`Setting theme to: ${theme}`);
+    const effectiveTheme = theme === 'system'
+      ? (this.mediaQuery?.matches ? 'dark' : 'light')
+      : theme as 'light' | 'dark';
+
+    if (this.currentTheme === theme && this.appliedTheme === effectiveTheme) return;
+
     this.currentTheme = theme;
-
-    if (theme === 'system') {
-      // 如果是系统主题，则根据系统设置应用
-      console.log(`System theme detected, using: ${effectiveTheme}`);
-    }
-
-    // 直接应用指定主题
     this.applyTheme(effectiveTheme);
   }
 
-  // 获取当前主题
+  setAccentColor(hex: string): void {
+    this.customAccent = hex;
+    if (this.currentTheme === 'custom') {
+      this.applyCustomTheme(hex);
+    }
+  }
+
+  getAccentColor(): string {
+    return this.customAccent || '#F472B6';
+  }
+
   getTheme(): ThemeType {
     return this.currentTheme;
   }
 
-  // 获取当前有效主题（实际应用的明/暗主题）
   getEffectiveTheme(): 'light' | 'dark' {
+    if (this.currentTheme === 'custom') return 'light';
     if (this.currentTheme === 'system') {
       return this.mediaQuery?.matches ? 'dark' : 'light';
     }
-    return this.currentTheme;
+    return this.currentTheme as 'light' | 'dark';
   }
 
-  // 应用主题到DOM
-  private applyTheme(theme: 'light' | 'dark'): void {
-    // 避免重复应用相同主题
-    if (this.appliedTheme === theme) {
-      return;
-    }
-
-    console.log(`Applying theme: ${theme}`);
-    this.appliedTheme = theme;
+  private applyCustomTheme(accentHex: string): void {
     const root = document.documentElement;
-    const colors = COLORS[theme];
+    root.classList.remove('dark');
+    root.classList.add('light');
+    document.body.classList.remove('dark');
+    document.body.classList.add('light');
 
-    if (theme === 'dark') {
-      // Apply dark theme to HTML element (for Tailwind)
-      root.classList.add('dark');
-      root.classList.remove('light');
-
-      // Make sure theme is consistent across entire DOM
-      document.body.classList.add('dark');
-      document.body.classList.remove('light');
-
-      // Set background and text colors
-      root.style.backgroundColor = colors.bg;
-      document.body.style.backgroundColor = colors.bg;
-      document.body.style.color = colors.text;
-    } else {
-      // Apply light theme to HTML element (for Tailwind)
-      root.classList.remove('dark');
-      root.classList.add('light');
-
-      // Make sure theme is consistent across entire DOM
-      document.body.classList.remove('dark');
-      document.body.classList.add('light');
-
-      // Set background and text colors
-      root.style.backgroundColor = colors.bg;
-      document.body.style.backgroundColor = colors.bg;
-      document.body.style.color = colors.text;
+    const palette = generatePalette(accentHex);
+    for (const [key, value] of Object.entries(palette)) {
+      root.style.setProperty(key, value);
     }
 
-    // Update CSS variables for color transition animations
+    const bg = palette['--claude-bg'];
+    const text = palette['--claude-text'];
+    root.style.backgroundColor = bg;
+    document.body.style.backgroundColor = bg;
+    document.body.style.color = text;
+
     root.style.setProperty('--theme-transition', 'background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease');
     document.body.style.transition = 'var(--theme-transition)';
 
-    // Ensure #root element also gets the theme
-    const rootElement = document.getElementById('root');
-    if (rootElement) {
-      if (theme === 'dark') {
-        rootElement.classList.add('dark');
-        rootElement.classList.remove('light');
-        rootElement.style.backgroundColor = colors.bg;
-      } else {
-        rootElement.classList.remove('dark');
-        rootElement.classList.add('light');
-        rootElement.style.backgroundColor = colors.bg;
-      }
+    const rootEl = document.getElementById('root');
+    if (rootEl) {
+      rootEl.classList.remove('dark');
+      rootEl.classList.add('light');
+      rootEl.style.backgroundColor = bg;
+    }
+    this.appliedTheme = 'light';
+  }
+
+  private applyTheme(theme: 'light' | 'dark'): void {
+    if (this.appliedTheme === theme && this.currentTheme !== 'custom') return;
+
+    this.appliedTheme = theme;
+    const root = document.documentElement;
+
+    for (const [key, value] of Object.entries(DEFAULT_LIGHT_VARS)) {
+      root.style.setProperty(key, value);
+    }
+
+    const isDark = theme === 'dark';
+    root.classList.toggle('dark', isDark);
+    root.classList.toggle('light', !isDark);
+    document.body.classList.toggle('dark', isDark);
+    document.body.classList.toggle('light', !isDark);
+
+    const bg = isDark ? '#0F1117' : DEFAULT_LIGHT_VARS['--claude-bg'];
+    const text = isDark ? '#E4E5E9' : DEFAULT_LIGHT_VARS['--claude-text'];
+    root.style.backgroundColor = bg;
+    document.body.style.backgroundColor = bg;
+    document.body.style.color = text;
+
+    root.style.setProperty('--theme-transition', 'background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease');
+    document.body.style.transition = 'var(--theme-transition)';
+
+    const rootEl = document.getElementById('root');
+    if (rootEl) {
+      rootEl.classList.toggle('dark', isDark);
+      rootEl.classList.toggle('light', !isDark);
+      rootEl.style.backgroundColor = bg;
     }
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,9 @@
 /** @type {import('tailwindcss').Config} */
+
+function withOpacity(varName) {
+  return `color-mix(in srgb, var(${varName}) calc(<alpha-value> * 100%), transparent)`;
+}
+
 export default {
   content: [
     "./index.html",
@@ -8,41 +13,37 @@ export default {
   theme: {
     extend: {
       colors: {
-        // Cold modern color palette
         claude: {
-          // Light mode colors
-          bg: '#F8F9FB',              // Cool gray-white background
-          surface: '#FFFFFF',          // Cards, inputs
-          surfaceHover: '#F0F1F4',     // Hover state
-          surfaceMuted: '#F3F4F6',     // Subtle area distinction
-          surfaceInset: '#EBEDF0',     // Inset areas (e.g., input inner)
-          border: '#E0E2E7',           // Default border
-          borderLight: '#EBEDF0',      // Subtle dividers
-          text: '#1A1D23',             // Primary text, near-black
-          textSecondary: '#6B7280',    // Secondary text
-          // Dark mode colors
-          darkBg: '#0F1117',           // Dark background, near-black
-          darkSurface: '#1A1D27',      // Dark cards
-          darkSurfaceHover: '#242830', // Dark hover
-          darkSurfaceMuted: '#151820', // Subtle dark area
-          darkSurfaceInset: '#0C0E14', // Dark inset areas
-          darkBorder: '#2A2E38',       // Dark borders
-          darkBorderLight: '#1F232B',  // Subtle dark dividers
-          darkText: '#E4E5E9',         // Dark primary text
-          darkTextSecondary: '#8B8FA3', // Dark secondary text
-          // Accent (tech blue)
-          accent: '#3B82F6',           // Blue primary
-          accentHover: '#2563EB',      // Blue hover
-          accentLight: '#60A5FA',      // Light blue for badges
-          accentMuted: 'rgba(59,130,246,0.10)', // Very faint blue background
+          bg: withOpacity('--claude-bg'),
+          surface: withOpacity('--claude-surface'),
+          surfaceHover: withOpacity('--claude-surfaceHover'),
+          surfaceMuted: withOpacity('--claude-surfaceMuted'),
+          surfaceInset: withOpacity('--claude-surfaceInset'),
+          border: withOpacity('--claude-border'),
+          borderLight: withOpacity('--claude-borderLight'),
+          text: withOpacity('--claude-text'),
+          textSecondary: withOpacity('--claude-textSecondary'),
+          darkBg: withOpacity('--claude-darkBg'),
+          darkSurface: withOpacity('--claude-darkSurface'),
+          darkSurfaceHover: withOpacity('--claude-darkSurfaceHover'),
+          darkSurfaceMuted: withOpacity('--claude-darkSurfaceMuted'),
+          darkSurfaceInset: withOpacity('--claude-darkSurfaceInset'),
+          darkBorder: withOpacity('--claude-darkBorder'),
+          darkBorderLight: withOpacity('--claude-darkBorderLight'),
+          darkText: withOpacity('--claude-darkText'),
+          darkTextSecondary: withOpacity('--claude-darkTextSecondary'),
+          accent: withOpacity('--claude-accent'),
+          accentHover: withOpacity('--claude-accentHover'),
+          accentLight: withOpacity('--claude-accentLight'),
+          accentMuted: 'var(--claude-accentMuted)',
         },
         primary: {
-          DEFAULT: '#3B82F6',
-          dark: '#2563EB'
+          DEFAULT: 'var(--claude-accent)',
+          dark: 'var(--claude-accentHover)'
         },
         secondary: {
-          DEFAULT: '#6B7280',
-          dark: '#2A2E38'
+          DEFAULT: 'var(--claude-textSecondary)',
+          dark: 'var(--claude-darkBorder)'
         }
       },
       boxShadow: {
@@ -88,16 +89,16 @@ export default {
       typography: {
         DEFAULT: {
           css: {
-            color: '#1A1D23',
+            color: 'var(--claude-text)',
             a: {
-              color: '#3B82F6',
+              color: 'var(--claude-accent)',
               '&:hover': {
-                color: '#2563EB',
+                color: 'var(--claude-accentHover)',
               },
             },
             code: {
-              color: '#1A1D23',
-              backgroundColor: 'rgba(224, 226, 231, 0.5)',
+              color: 'var(--claude-text)',
+              backgroundColor: 'var(--claude-surfaceHover)',
               padding: '0.2em 0.4em',
               borderRadius: '0.25rem',
               fontWeight: '400',
@@ -109,75 +110,55 @@ export default {
               content: '""',
             },
             pre: {
-              backgroundColor: '#F0F1F4',
-              color: '#1A1D23',
+              backgroundColor: 'var(--claude-surfaceHover)',
+              color: 'var(--claude-text)',
               padding: '1em',
               borderRadius: '0.75rem',
               overflowX: 'auto',
             },
             blockquote: {
-              borderLeftColor: '#3B82F6',
-              color: '#6B7280',
+              borderLeftColor: 'var(--claude-accent)',
+              color: 'var(--claude-textSecondary)',
             },
-            h1: {
-              color: '#1A1D23',
-            },
-            h2: {
-              color: '#1A1D23',
-            },
-            h3: {
-              color: '#1A1D23',
-            },
-            h4: {
-              color: '#1A1D23',
-            },
-            strong: {
-              color: '#1A1D23',
-            },
+            h1: { color: 'var(--claude-text)' },
+            h2: { color: 'var(--claude-text)' },
+            h3: { color: 'var(--claude-text)' },
+            h4: { color: 'var(--claude-text)' },
+            strong: { color: 'var(--claude-text)' },
           },
         },
         dark: {
           css: {
-            color: '#E4E5E9',
+            color: 'var(--claude-darkText)',
             a: {
-              color: '#60A5FA',
+              color: 'var(--claude-accentLight)',
               '&:hover': {
                 color: '#93BBFD',
               },
             },
             code: {
-              color: '#E4E5E9',
+              color: 'var(--claude-darkText)',
               backgroundColor: 'rgba(42, 46, 56, 0.5)',
               padding: '0.2em 0.4em',
               borderRadius: '0.25rem',
               fontWeight: '400',
             },
             pre: {
-              backgroundColor: '#1A1D27',
-              color: '#E4E5E9',
+              backgroundColor: 'var(--claude-darkSurface)',
+              color: 'var(--claude-darkText)',
               padding: '1em',
               borderRadius: '0.75rem',
               overflowX: 'auto',
             },
             blockquote: {
-              borderLeftColor: '#3B82F6',
-              color: '#8B8FA3',
+              borderLeftColor: 'var(--claude-accent)',
+              color: 'var(--claude-darkTextSecondary)',
             },
-            h1: {
-              color: '#E4E5E9',
-            },
-            h2: {
-              color: '#E4E5E9',
-            },
-            h3: {
-              color: '#E4E5E9',
-            },
-            h4: {
-              color: '#E4E5E9',
-            },
-            strong: {
-              color: '#E4E5E9',
-            },
+            h1: { color: 'var(--claude-darkText)' },
+            h2: { color: 'var(--claude-darkText)' },
+            h3: { color: 'var(--claude-darkText)' },
+            h4: { color: 'var(--claude-darkText)' },
+            strong: { color: 'var(--claude-darkText)' },
           },
         },
       },


### PR DESCRIPTION
## Summary

Add a custom theme option to Settings > Appearance that allows users to pick any accent color and have a complete UI palette auto-generated from it. This is a zero-component-change implementation — all customization is achieved through CSS variable overrides.

- Migrate all hardcoded Tailwind colors to CSS variables with `color-mix()` opacity support
- Add HSL-based palette generation that derives bg/surface/border/text colors from a single accent
- Add "Custom" as 4th theme option with a native color picker and live preview
- Fix a bug where custom theme CSS variables would persist when switching back to light/dark
- Add i18n translations for custom theme UI (zh/en)

## Screenshots

[
<img width="2162" height="1698" alt="Snip20260325_6" src="https://github.com/user-attachments/assets/a5182aae-3f71-4d12-995e-fc346bcd3e7e" />
](url)

## Changes

| File | Change |
|------|--------|
| `tailwind.config.js` | Replace hardcoded colors with CSS variable references using `color-mix()` for Tailwind opacity modifier support |
| `src/renderer/index.css` | Define CSS variables in `:root`, use `var()` in `.dark`/`.light` classes instead of hardcoded hex |
| `src/renderer/services/theme.ts` | Add `ThemeType = 'custom'`, palette generation (`generatePalette`), `setAccentColor()`/`getAccentColor()`, fix CSS variable cleanup on theme switch |
| `src/renderer/config.ts` | Extend `theme` type with `'custom'`, add optional `themeAccentColor` field |
| `src/renderer/components/Settings.tsx` | Add 4th theme button with SVG thumbnail, conditional color picker UI, accent color state management, save/cancel logic |
| `src/renderer/services/i18n.ts` | Add `custom`/`accentColor` keys for both zh and en |

## How it works

1. User selects "Custom" in Settings > Appearance
2. A color picker appears below the theme buttons
3. Picking a color calls `themeService.setAccentColor(hex)` which runs `generatePalette()` to derive a full palette via HSL color space
4. The generated palette overwrites CSS variables on `<html>`, and all components update instantly (zero component changes needed)
5. On save, the accent color is persisted to config; on cancel, the original theme is restored

## Test plan

- [ ] Light → Dark → System switching still works (regression)
- [ ] Select Custom → pick a color → UI updates in real-time
- [ ] Save custom theme → restart app → theme persists
- [ ] Cancel without saving → theme reverts to previous
- [ ] Switch Custom → Dark → accent resets to default blue (no pink residual)
- [ ] Try various accent colors: pink, green, orange, teal, dark colors
- [ ] Build passes (`npm run build`)
- [x] Lint passes (`npx eslint` on changed files)