### PR TITLE
fix(sqlite): use atomic write-then-rename for database persistence

### DIFF
--- a/src/main/sqliteStore.test.ts
+++ b/src/main/sqliteStore.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for the atomic write pattern in SqliteStore.save().
+ *
+ * The save logic is mirrored inline because SqliteStore.create() depends on
+ * Electron's `app` module which is unavailable in Vitest.
+ */
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import initSqlJs, { Database } from 'sql.js';
+
+// ---------------------------------------------------------------------------
+// Mirror of SqliteStore.save() — must stay in sync with sqliteStore.ts
+// ---------------------------------------------------------------------------
+
+function atomicSave(db: Database, dbPath: string): void {
+  const data = db.export();
+  const buffer = Buffer.from(data);
+  const tmpPath = `${dbPath}.tmp`;
+  fs.writeFileSync(tmpPath, buffer);
+  fs.renameSync(tmpPath, dbPath);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlitestore-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function makeDb(): Promise<Database> {
+  const SQL = await initSqlJs();
+  return new SQL.Database();
+}
+
+function dbPath(): string {
+  return path.join(tmpDir, 'test.sqlite');
+}
+
+// ---------------------------------------------------------------------------
+// Basic save behavior
+// ---------------------------------------------------------------------------
+
+describe('atomicSave', () => {
+  test('writes a new database file that can be read back', async () => {
+    const db = await makeDb();
+    db.run('CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)');
+    db.run("INSERT INTO t VALUES (1, 'hello')");
+
+    const target = dbPath();
+    atomicSave(db, target);
+
+    expect(fs.existsSync(target)).toBe(true);
+    expect(fs.existsSync(`${target}.tmp`)).toBe(false);
+
+    const SQL = await initSqlJs();
+    const loaded = new SQL.Database(fs.readFileSync(target));
+    const rows = loaded.exec('SELECT val FROM t WHERE id = 1');
+    expect(rows[0].values[0][0]).toBe('hello');
+    loaded.close();
+    db.close();
+  });
+
+  test('overwrites an existing file atomically', async () => {
+    const db = await makeDb();
+    const target = dbPath();
+
+    db.run('CREATE TABLE t (v INTEGER)');
+    db.run('INSERT INTO t VALUES (1)');
+    atomicSave(db, target);
+
+    db.run('INSERT INTO t VALUES (2)');
+    atomicSave(db, target);
+
+    expect(fs.existsSync(`${target}.tmp`)).toBe(false);
+
+    const SQL = await initSqlJs();
+    const loaded = new SQL.Database(fs.readFileSync(target));
+    const rows = loaded.exec('SELECT v FROM t ORDER BY v');
+    expect(rows[0].values).toEqual([[1], [2]]);
+    loaded.close();
+    db.close();
+  });
+
+  test('no leftover .tmp file after successful save', async () => {
+    const db = await makeDb();
+    const target = dbPath();
+
+    for (let i = 0; i < 5; i++) {
+      atomicSave(db, target);
+    }
+
+    const files = fs.readdirSync(tmpDir);
+    const tmpFiles = files.filter((f) => f.endsWith('.tmp'));
+    expect(tmpFiles).toEqual([]);
+    db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Crash resistance — writeFileSync failure
+// ---------------------------------------------------------------------------
+
+describe('crash resistance: write failure', () => {
+  test('original file untouched when writeFileSync throws', async () => {
+    const db = await makeDb();
+    const target = dbPath();
+
+    db.run('CREATE TABLE t (v TEXT)');
+    db.run("INSERT INTO t VALUES ('original')");
+    atomicSave(db, target);
+
+    const originalContent = fs.readFileSync(target);
+
+    db.run("INSERT INTO t VALUES ('should-not-persist')");
+
+    const realWriteFileSync = fs.writeFileSync;
+    vi.spyOn(fs, 'writeFileSync').mockImplementation((...args: unknown[]) => {
+      const filePath = args[0] as string;
+      if (typeof filePath === 'string' && filePath.endsWith('.tmp')) {
+        throw new Error('Simulated disk full');
+      }
+      return realWriteFileSync.apply(fs, args as Parameters<typeof realWriteFileSync>);
+    });
+
+    expect(() => atomicSave(db, target)).toThrow('Simulated disk full');
+
+    vi.restoreAllMocks();
+
+    const afterContent = fs.readFileSync(target);
+    expect(Buffer.compare(originalContent, afterContent)).toBe(0);
+
+    const SQL = await initSqlJs();
+    const loaded = new SQL.Database(afterContent);
+    const rows = loaded.exec('SELECT v FROM t');
+    expect(rows[0].values).toEqual([['original']]);
+    loaded.close();
+    db.close();
+  });
+
+  test('no .tmp file left behind when writeFileSync throws', async () => {
+    const db = await makeDb();
+    const target = dbPath();
+
+    vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+      throw new Error('Simulated I/O error');
+    });
+
+    expect(() => atomicSave(db, target)).toThrow('Simulated I/O error');
+
+    vi.restoreAllMocks();
+
+    expect(fs.existsSync(`${target}.tmp`)).toBe(false);
+    db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Crash resistance — renameSync failure
+// ---------------------------------------------------------------------------
+
+describe('crash resistance: rename failure', () => {
+  test('original file untouched when renameSync throws', async () => {
+    const db = await makeDb();
+    const target = dbPath();
+
+    db.run('CREATE TABLE t (v TEXT)');
+    db.run("INSERT INTO t VALUES ('safe')");
+    atomicSave(db, target);
+
+    const originalContent = fs.readFileSync(target);
+
+    db.run("INSERT INTO t VALUES ('risky')");
+
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw new Error('Simulated rename failure');
+    });
+
+    expect(() => atomicSave(db, target)).toThrow('Simulated rename failure');
+
+    vi.restoreAllMocks();
+
+    const afterContent = fs.readFileSync(target);
+    expect(Buffer.compare(originalContent, afterContent)).toBe(0);
+
+    const SQL = await initSqlJs();
+    const loaded = new SQL.Database(afterContent);
+    const rows = loaded.exec('SELECT v FROM t');
+    expect(rows[0].values).toEqual([['safe']]);
+    loaded.close();
+    db.close();
+  });
+
+  test('.tmp file exists as recovery artifact when rename fails', async () => {
+    const db = await makeDb();
+    const target = dbPath();
+
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw new Error('Simulated rename failure');
+    });
+
+    db.run('CREATE TABLE t (v INTEGER)');
+    db.run('INSERT INTO t VALUES (42)');
+
+    expect(() => atomicSave(db, target)).toThrow('Simulated rename failure');
+
+    vi.restoreAllMocks();
+
+    expect(fs.existsSync(`${target}.tmp`)).toBe(true);
+
+    const SQL = await initSqlJs();
+    const recovered = new SQL.Database(fs.readFileSync(`${target}.tmp`));
+    const rows = recovered.exec('SELECT v FROM t');
+    expect(rows[0].values).toEqual([[42]]);
+    recovered.close();
+    db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Data integrity across multiple save cycles
+// ---------------------------------------------------------------------------
+
+describe('data integrity', () => {
+  test('100 sequential saves produce correct final state', async () => {
+    const db = await makeDb();
+    const target = dbPath();
+
+    db.run('CREATE TABLE counter (n INTEGER)');
+    db.run('INSERT INTO counter VALUES (0)');
+
+    for (let i = 1; i <= 100; i++) {
+      db.run('UPDATE counter SET n = ?', [i]);
+      atomicSave(db, target);
+    }
+
+    const SQL = await initSqlJs();
+    const loaded = new SQL.Database(fs.readFileSync(target));
+    const rows = loaded.exec('SELECT n FROM counter');
+    expect(rows[0].values[0][0]).toBe(100);
+    loaded.close();
+    db.close();
+  });
+
+  test('file size matches exported buffer size', async () => {
+    const db = await makeDb();
+    const target = dbPath();
+
+    db.run('CREATE TABLE data (payload TEXT)');
+    db.run("INSERT INTO data VALUES (?)", ['x'.repeat(10000)]);
+    atomicSave(db, target);
+
+    const exported = Buffer.from(db.export());
+    const fileSize = fs.statSync(target).size;
+    expect(fileSize).toBe(exported.length);
+    db.close();
+  });
+});

--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -247,7 +247,11 @@ export class SqliteStore {
   save() {
     const data = this.db.export();
     const buffer = Buffer.from(data);
-    fs.writeFileSync(this.dbPath, buffer);
+    // Atomic write: write to a temp file then rename, so a crash mid-write
+    // cannot corrupt the main database file.
+    const tmpPath = `${this.dbPath}.tmp`;
+    fs.writeFileSync(tmpPath, buffer);
+    fs.renameSync(tmpPath, this.dbPath);
   }
 
   onDidChange<T = unknown>(key: string, callback: (newValue: T | undefined, oldValue: T | undefined) => void) {


### PR DESCRIPTION
## Summary

- **Fix non-atomic database writes that could corrupt the SQLite file on crash.** The previous `save()` used a bare `fs.writeFileSync` to the database path — if the app crashed or lost power mid-write, the file could be left partially written and unreadable.
- **Replace with the standard atomic pattern**: write to `<dbPath>.tmp` first, then `fs.renameSync` over the original. `rename` is atomic on POSIX and effectively atomic on NTFS for same-volume moves, so the database file is always in a consistent state (either the old data or the new data, never a partial write).
- **Add a comprehensive Vitest test suite** (`sqliteStore.test.ts`) with 9 test cases covering normal round-trip, overwrite, crash resistance (write failure and rename failure), and data integrity across 100 sequential save cycles.

## Changes

| File | Change |
|------|--------|
| `src/main/sqliteStore.ts` | Refactor `save()` to use write-to-temp-then-rename |
| `src/main/sqliteStore.test.ts` | New test suite for atomic write behavior |

## Test plan

- [x] All 9 new atomic write tests pass (`npx vitest run src/main/sqliteStore.test.ts`)
- [x] All 33 existing + new tests pass (`npx vitest run`)
- [x] App starts normally with the new save logic — database loads correctly
- [x] No leftover `.tmp` files after save operations
- [x] Manual: change settings or create a cowork session, restart app, verify data persists
- [x] Manual: verify no `.tmp` file at `~/Library/Application Support/LobsterAI/lobsterai.sqlite.tmp` after normal usage
