### PR TITLE
fix(openclaw): 切换模型时显示网关启动遮罩且消息卡在输入框

### DIFF
--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -159,6 +159,7 @@ export class OpenClawEngineManager extends EventEmitter {
   private gatewayPort: number | null = null;
   private startGatewayPromise: Promise<OpenClawEngineStatus> | null = null;
   private secretEnvVars: Record<string, string> = {};
+  private pendingEnvRestart = false;
 
   constructor() {
     super();
@@ -206,6 +207,18 @@ export class OpenClawEngineManager extends EventEmitter {
   /** Return the current secret env vars snapshot (for change detection). */
   getSecretEnvVars(): Record<string, string> {
     return this.secretEnvVars;
+  }
+
+  /** Mark that the gateway needs a restart due to env var changes. */
+  markPendingEnvRestart(): void {
+    this.pendingEnvRestart = true;
+  }
+
+  /** Check and consume the pending env restart flag. */
+  consumePendingEnvRestart(): boolean {
+    if (!this.pendingEnvRestart) return false;
+    this.pendingEnvRestart = false;
+    return true;
   }
 
   override on<U extends keyof OpenClawEngineManagerEvents>(
@@ -300,18 +313,19 @@ export class OpenClawEngineManager extends EventEmitter {
     return this.getStatus();
   }
 
-  async startGateway(): Promise<OpenClawEngineStatus> {
+  async startGateway(options?: { silent?: boolean }): Promise<OpenClawEngineStatus> {
     if (this.startGatewayPromise) {
       console.log('[OpenClaw] startGateway: already in progress, reusing existing promise');
       return this.startGatewayPromise;
     }
-    this.startGatewayPromise = this.doStartGateway().finally(() => {
+    this.startGatewayPromise = this.doStartGateway(options).finally(() => {
       this.startGatewayPromise = null;
     });
     return this.startGatewayPromise;
   }
 
-  private async doStartGateway(): Promise<OpenClawEngineStatus> {
+  private async doStartGateway(options?: { silent?: boolean }): Promise<OpenClawEngineStatus> {
+    const silent = options?.silent ?? false;
     this.shutdownRequested = false;
     const t0 = Date.now();
     const elapsed = () => `${Date.now() - t0}ms`;
@@ -392,13 +406,15 @@ export class OpenClawEngineManager extends EventEmitter {
     this.ensureConfigFile();
     console.log(`[OpenClaw] startGateway: pre-fork setup done (${elapsed()})`);
 
-    this.setStatus({
-      phase: 'starting',
-      version: runtime.version,
-      progressPercent: 10,
-      message: 'Starting OpenClaw gateway...',
-      canRetry: false,
-    });
+    if (!silent) {
+      this.setStatus({
+        phase: 'starting',
+        version: runtime.version,
+        progressPercent: 10,
+        message: 'Starting OpenClaw gateway...',
+        canRetry: false,
+      });
+    }
 
     const compileCacheDir = path.join(this.stateDir, '.compile-cache');
     console.log(`[OpenClaw] compile cache dir: ${compileCacheDir}`);
@@ -501,7 +517,7 @@ export class OpenClawEngineManager extends EventEmitter {
       console.log(`[OpenClaw] gateway process spawned (${elapsed()}), pid=${child.pid}`);
     });
 
-    const ready = await this.waitForGatewayReady(port, GATEWAY_BOOT_TIMEOUT_MS);
+    const ready = await this.waitForGatewayReady(port, GATEWAY_BOOT_TIMEOUT_MS, { silent });
     console.log(`[OpenClaw] startGateway: waitForGatewayReady returned (${elapsed()}), ready=${ready}`);
     if (!ready) {
       this.setStatus({
@@ -526,7 +542,8 @@ export class OpenClawEngineManager extends EventEmitter {
     return this.getStatus();
   }
 
-  async stopGateway(): Promise<void> {
+  async stopGateway(options?: { silent?: boolean }): Promise<void> {
+    const silent = options?.silent ?? false;
     this.shutdownRequested = true;
 
     if (this.gatewayRestartTimer) {
@@ -539,15 +556,17 @@ export class OpenClawEngineManager extends EventEmitter {
       this.gatewayProcess = null;
     }
 
-    const runtime = this.resolveRuntimeMetadata();
-    this.setStatus({
-      phase: runtime.root ? 'ready' : 'not_installed',
-      version: runtime.version,
-      message: runtime.root
-        ? 'OpenClaw runtime is ready. Gateway is stopped.'
-        : `Bundled OpenClaw runtime is missing. Expected: ${runtime.expectedPathHint}`,
-      canRetry: !runtime.root,
-    });
+    if (!silent) {
+      const runtime = this.resolveRuntimeMetadata();
+      this.setStatus({
+        phase: runtime.root ? 'ready' : 'not_installed',
+        version: runtime.version,
+        message: runtime.root
+          ? 'OpenClaw runtime is ready. Gateway is stopped.'
+          : `Bundled OpenClaw runtime is missing. Expected: ${runtime.expectedPathHint}`,
+        canRetry: !runtime.root,
+      });
+    }
   }
 
   async restartGateway(): Promise<OpenClawEngineStatus> {
@@ -1144,7 +1163,8 @@ export class OpenClawEngineManager extends EventEmitter {
     return healthy;
   }
 
-  private waitForGatewayReady(port: number, timeoutMs: number): Promise<boolean> {
+  private waitForGatewayReady(port: number, timeoutMs: number, options?: { silent?: boolean }): Promise<boolean> {
+    const silent = options?.silent ?? false;
     const startedAt = Date.now();
     let pollCount = 0;
     return new Promise((resolve) => {
@@ -1181,13 +1201,15 @@ export class OpenClawEngineManager extends EventEmitter {
 
         // Update progress from 10% → 90% during the wait, so the UI shows meaningful feedback.
         const progress = Math.min(90, 10 + Math.round((elapsedMs / timeoutMs) * 80));
-        this.setStatus({
-          phase: 'starting',
-          version: this.status.version,
-          progressPercent: progress,
-          message: `Starting OpenClaw gateway... (${Math.round(elapsedMs / 1000)}s)`,
-          canRetry: false,
-        });
+        if (!silent) {
+          this.setStatus({
+            phase: 'starting',
+            version: this.status.version,
+            progressPercent: progress,
+            message: `Starting OpenClaw gateway... (${Math.round(elapsedMs / 1000)}s)`,
+            canRetry: false,
+          });
+        }
 
         if (pollCount % 5 === 0) {
           console.log(`[OpenClaw] waitForGatewayReady: poll #${pollCount}, elapsed=${elapsedMs}ms, progress=${progress}%`);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -699,6 +699,21 @@ const bootstrapOpenClawEngine = async (options: { forceReinstall?: boolean; reas
 const ensureOpenClawRunningForCowork = async () => {
   const manager = getOpenClawEngineManager();
   const status = manager.getStatus();
+
+  // If secret env vars changed since the last gateway spawn (e.g. model switch),
+  // we need to restart so the new process picks up the updated env vars and
+  // a fresh openclaw.json is written atomically with the restart.
+  if (status.phase === 'running' && manager.consumePendingEnvRestart()) {
+    console.log('[OpenClaw] ensureRunning: pending env restart — performing silent restart');
+    if (openClawRuntimeAdapter) {
+      openClawRuntimeAdapter.disconnectGatewayClient();
+    }
+    await manager.stopGateway({ silent: true });
+    getOpenClawConfigSync().sync('ensureRunning:pendingEnvRestart');
+    const restarted = await manager.startGateway({ silent: true });
+    return restarted;
+  }
+
   if (status.phase === 'running') {
     return status;
   }
@@ -885,6 +900,31 @@ const syncOpenClawConfig = async (
     }
   }
 
+  // Pre-flight: when the caller does NOT want a synchronous restart (e.g.
+  // model switch via app_config), peek at whether secret env vars will change.
+  // If they will, we must NOT write openclaw.json yet — OpenClaw's file watcher
+  // would hot-reload the new provider config while the running process still
+  // has stale env vars, causing 401s.  Instead, schedule a deferred restart
+  // that will write + restart atomically.
+  if (!options.restartGatewayIfRunning) {
+    const nextSecretEnvVars = getOpenClawConfigSync().collectSecretEnvVars();
+    const prevSecretEnvVars = getOpenClawEngineManager().getSecretEnvVars();
+    const secretEnvVarsChanged = JSON.stringify(nextSecretEnvVars) !== JSON.stringify(prevSecretEnvVars);
+
+    if (secretEnvVarsChanged) {
+      const manager = getOpenClawEngineManager();
+      manager.setSecretEnvVars(nextSecretEnvVars);
+      if (manager.getStatus().phase === 'running') {
+        console.log(`[OpenClaw] syncOpenClawConfig: secret env vars changed, deferring config write + restart until next session start (reason: ${options.reason})`);
+        manager.markPendingEnvRestart();
+        return {
+          success: true,
+          changed: true,
+        };
+      }
+    }
+  }
+
   const syncResult = getOpenClawConfigSync().sync(options.reason);
   if (!syncResult.ok) {
     const status = getOpenClawEngineManager().setExternalError(
@@ -904,17 +944,21 @@ const syncOpenClawConfig = async (
   const nextSecretEnvVars = getOpenClawConfigSync().collectSecretEnvVars();
   const prevSecretEnvVars = getOpenClawEngineManager().getSecretEnvVars();
   const secretEnvVarsChanged = JSON.stringify(nextSecretEnvVars) !== JSON.stringify(prevSecretEnvVars);
+  // Always cache the latest env vars so the next gateway spawn picks them up.
   getOpenClawEngineManager().setSecretEnvVars(nextSecretEnvVars);
 
-  // When secret env vars change, the running gateway must be restarted even if
-  // the caller didn't request it — the ${VAR} placeholders in openclaw.json
-  // resolve from the process environment which is fixed at spawn time.
+  // When secret env vars change, the running gateway process needs a restart
+  // because its environment is fixed at spawn time.  However, if the caller
+  // did NOT request a restart (e.g. the change is just a model switch via
+  // app_config), we only mark the env as dirty and skip the immediate restart.
+  // The next ensureOpenClawRunningForCowork() call (at session start) will
+  // detect the stale env and restart the gateway just-in-time.
   const needsRestart = syncResult.changed || secretEnvVarsChanged;
 
-  if (!needsRestart || (!options.restartGatewayIfRunning && !secretEnvVarsChanged)) {
+  if (!needsRestart || !options.restartGatewayIfRunning) {
     return {
       success: true,
-      changed: syncResult.changed,
+      changed: syncResult.changed || secretEnvVarsChanged,
     };
   }
 

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -302,16 +302,30 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       imageAttachmentsBase64Lengths: imageAttachments?.map(a => a.base64Data.length),
     });
 
-    // Capture active skill IDs before clearing
     const sessionSkillIds = [...activeSkillIds];
 
-    // Clear active skills after capturing so they don't persist to next message
     if (sessionSkillIds.length > 0) {
       dispatch(clearActiveSkills());
     }
 
-    // Combine skill prompt with system prompt for continuation
-    // If no manual skill selected, use auto-routing prompt
+    // Optimistic update: show user message in chat immediately and mark session
+    // as running so the input clears without waiting for the IPC round-trip
+    // (which may block while the OpenClaw gateway silently restarts).
+    const optimisticMessage = {
+      id: `optimistic-${Date.now()}`,
+      type: 'user' as const,
+      content: prompt,
+      timestamp: Date.now(),
+      metadata: (sessionSkillIds.length > 0 || (imageAttachments && imageAttachments.length > 0))
+        ? {
+          ...(sessionSkillIds.length > 0 ? { skillIds: sessionSkillIds } : {}),
+          ...(imageAttachments && imageAttachments.length > 0 ? { imageAttachments } : {}),
+        }
+        : undefined,
+    };
+    dispatch(addMessage({ sessionId: currentSession.id, message: optimisticMessage }));
+    dispatch(setStreaming(true));
+
     let effectiveSkillPrompt = skillPrompt;
     if (!skillPrompt) {
       effectiveSkillPrompt = await skillService.getAutoRoutingPrompt() || undefined;
@@ -320,12 +334,14 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       .filter(p => p?.trim())
       .join('\n\n') || undefined;
 
-    await coworkService.continueSession({
+    coworkService.continueSession({
       sessionId: currentSession.id,
       prompt,
       systemPrompt: combinedSystemPrompt,
       activeSkillIds: sessionSkillIds.length > 0 ? sessionSkillIds : undefined,
       imageAttachments,
+    }).catch((error) => {
+      console.error('[CoworkView] continueSession failed:', error);
     });
   };
 

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -212,6 +212,24 @@ const coworkSlice = createSlice({
       const { sessionId, message } = action.payload;
 
       if (state.currentSession?.id === sessionId) {
+        // When a real user message arrives from the main process, replace any
+        // optimistic placeholder that was inserted to give instant UI feedback.
+        if (message.type === 'user' && !message.id.startsWith('optimistic-')) {
+          const optimisticIdx = state.currentSession.messages.findIndex(
+            (m) => m.id.startsWith('optimistic-') && m.type === 'user' && m.content === message.content,
+          );
+          if (optimisticIdx !== -1) {
+            state.currentSession.messages[optimisticIdx] = message;
+            state.currentSession.updatedAt = message.timestamp;
+            const sessionIndex = state.sessions.findIndex(s => s.id === sessionId);
+            if (sessionIndex !== -1) {
+              state.sessions[sessionIndex].updatedAt = message.timestamp;
+            }
+            markSessionUnread(state, sessionId);
+            return;
+          }
+        }
+
         const exists = state.currentSession.messages.some((item) => item.id === message.id);
         if (!exists) {
           state.currentSession.messages.push(message);


### PR DESCRIPTION
## Problem

切换模型（如 Qwen → MiniMax）会触发 OpenClaw 网关重启，弹出"AI 引擎正在启动网关..."遮罩 3-5 秒，期间发送的消息卡在输入框无法发出。

## Fix

- **延迟 config 写入 + 重启**：切模型时如果只是 API key 变化（`secretEnvVarsChanged`），不立即写 `openclaw.json` 也不立即重启网关，而是设置 `pendingEnvRestart` 标志。下次发消息时 `ensureOpenClawRunningForCowork` 检测到标志后，原子执行 config 写入 + env vars 更新 + 重启，避免 OpenClaw file watcher 热加载新 provider config 时使用旧 env vars 导致 401。
- **静默重启**：`startGateway`/`stopGateway`/`waitForGatewayReady` 新增 `{ silent: true }` 选项，跳过 `setStatus({ phase: 'starting' })` 的 emit，避免触发 `EngineStartupOverlay`。
- **前端乐观更新**：`handleContinueSession` 在调用 IPC 之前先 dispatch 用户消息到 Redux 并设置 `streaming=true`，fire-and-forget `continueSession`（不 await），输入框立即清空，消息立即显示在聊天区。`addMessage` reducer 增加 optimistic → real 消息替换逻辑避免重复。

## Reproduce

1. 使用 OpenClaw 引擎
2. 从 Qwen 3.5 切换到 MiniMax（或任何使用不同 API key 的模型）
3. 观察"AI 引擎正在启动网关..."遮罩
4. 切换后立即发送消息，观察消息卡在输入框

## Changed files

- `src/main/libs/openclawEngineManager.ts` — silent mode for gateway lifecycle
- `src/main/main.ts` — deferred config write + pending env restart
- `src/renderer/components/cowork/CoworkView.tsx` — optimistic user message dispatch
- `src/renderer/store/slices/coworkSlice.ts` — optimistic → real message replacement in reducer