### PR TITLE
feat(cowork): implement context management to mitigate lost-in-the-mi…

### DIFF
--- a/docs/proposals/context-management.md
+++ b/docs/proposals/context-management.md
@@ -1,0 +1,549 @@
+# RFC: Tiered Context Management for Long Cowork Sessions
+
+| Field       | Value                                           |
+|-------------|--------------------------------------------------|
+| **Author**  | LobsterAI Team                                   |
+| **Created** | 2026-03-25                                       |
+| **Status**  | Draft                                            |
+| **Scope**   | `src/main/libs/coworkRunner.ts`, `src/main/coworkStore.ts`, `src/main/libs/agentEngine/openclawRuntimeAdapter.ts`, `src/renderer/components/cowork/` |
+
+---
+
+## 1. Motivation
+
+### 1.1 Problem Statement
+
+Large Language Models (including Claude) exhibit a well-documented **"Lost in the Middle"** attention degradation pattern: information at the beginning and end of the context window receives stronger attention, while content in the middle is progressively ignored. In LobsterAI's Cowork sessions, this manifests as:
+
+- **Attention dilution**: After 10+ turns with multiple tool calls per turn, the AI starts ignoring earlier user preferences and instructions.
+- **Repetitive behavior**: The AI may redo work it already completed because tool results from earlier turns are "forgotten."
+- **Context overflow**: After 50+ turns, the accumulated context (user messages + assistant responses + tool inputs/results) can exceed the model's context window, triggering `input too long` errors.
+
+### 1.2 Current State
+
+#### Built-in Engine (`yd_cowork` / Claude Agent SDK)
+
+| Mechanism | Location | Behavior |
+|-----------|----------|----------|
+| History injection on restart | `coworkRunner.ts:946-1028` | Max **24 messages / 32K chars / 4K per message**, newest-first selection |
+| Tool result truncation | `coworkRunner.ts:28-29` | `TOOL_RESULT_MAX_CHARS = 120,000` per result |
+| Streaming content caps | `coworkRunner.ts:26-27` | Text: 120K, Thinking: 60K |
+| Error classification | `coworkErrorClassify.ts:14-15` | Detects `input too long` / `context length exceeded` |
+| Memory system | `coworkMemoryExtractor.ts` | Extracts long-term user facts |
+| Conversation search tool | `coworkRunner.ts:1982-2007` | MCP tool for on-demand history retrieval |
+
+**Gap**: When the SDK subprocess is alive (`continueSession` path), LobsterAI passes prompts to `query()` with **zero context management** — the SDK accumulates the full conversation internally with no truncation, compression, or windowing.
+
+#### OpenClaw Engine
+
+| Mechanism | Location | Behavior |
+|-----------|----------|----------|
+| Context bridge | `openclawRuntimeAdapter.ts:1140-1164` | Max **20 messages / 1.2K chars per message** |
+| Gateway history byte-bounded window | OpenClaw server-side | `chat.history` has a byte-bounded sliding window |
+
+**Gap**: OpenClaw has a server-side sliding window, but LobsterAI has no visibility or control over its parameters. The context bridge constants are hardcoded and not turn-aware.
+
+---
+
+## 2. Design Overview
+
+### 2.1 Tiered Strategy
+
+We introduce a **four-tier context management strategy** based on conversation turn count and estimated context size:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Context Management Tiers                       │
+├──────────┬─────────────┬────────────────────────────────────────┤
+│  Tier    │  Condition  │  Strategy                              │
+├──────────┼─────────────┼────────────────────────────────────────┤
+│  T0      │  ≤ 10 turns │  No intervention (full context)        │
+│  T1      │ 11-30 turns │  Progressive tool result compression   │
+│  T2      │ 31-50 turns │  Sliding window + auto-summarization   │
+│  T3      │  > 50 turns │  New session prompt + memory migration │
+└──────────┴─────────────┴────────────────────────────────────────┘
+```
+
+### 2.2 Turn Counting
+
+A "turn" is defined as one user prompt + the corresponding assistant response (including all intermediate tool calls). This maps to one `continueSession()` or `startSession()` invocation.
+
+---
+
+## 3. Detailed Design
+
+### 3.1 P0 — Turn Counter + UI Notification
+
+**Priority**: P0 (implement first)
+**Complexity**: Low
+**Files affected**: `coworkRunner.ts`, `coworkStore.ts`, `CoworkSessionDetail.tsx`, `i18n.ts`
+
+#### 3.1.1 Data Model Change
+
+Add `turnCount` to `ActiveSession` and persist it in the session:
+
+```typescript
+// coworkRunner.ts — ActiveSession interface
+interface ActiveSession {
+  // ... existing fields ...
+  turnCount: number;  // NEW: incremented on each startSession/continueSession
+}
+```
+
+```typescript
+// coworkStore.ts — CoworkSession interface
+export interface CoworkSession {
+  // ... existing fields ...
+  turnCount: number;  // NEW: persisted turn count
+}
+```
+
+#### 3.1.2 Turn Counting Logic
+
+```
+startSession()    → turnCount = 1
+continueSession() → turnCount += 1
+```
+
+Location: `coworkRunner.ts` lines ~1440 (startSession) and ~1523 (continueSession).
+
+#### 3.1.3 UI Warning Banner
+
+Display a non-blocking warning banner in `CoworkSessionDetail.tsx` when the session reaches tier thresholds:
+
+| Turn Count | Banner Style | Message |
+|------------|-------------|---------|
+| 30+ | Yellow warning | "This session is getting long. AI quality may degrade for earlier context." |
+| 50+ | Orange warning | "This session is very long. Consider starting a new session for best results." |
+| On `inputTooLong` error | Red error | "Context limit reached. Please start a new session." |
+
+The banner should include a **"New Session with Context"** action button (see P3).
+
+#### 3.1.4 IPC Extension
+
+Expose `turnCount` in the session data returned via IPC so the renderer can read it:
+
+- `cowork:getSession` → include `turnCount` in response
+- Stream events → no change needed (renderer reads from session state)
+
+---
+
+### 3.2 P1 — Progressive Tool Result Compression
+
+**Priority**: P1
+**Complexity**: Medium
+**Files affected**: `coworkRunner.ts`
+
+#### 3.2.1 Concept
+
+Tool results (type `tool_result`) are the largest contributors to context bloat. A single `Bash` or `Read` result can be up to 120K characters. In a 20-turn session with 3 tool calls per turn, that's potentially **7.2MB** of tool results alone.
+
+The key insight: **older tool results have diminishing value**. The AI rarely needs the full stdout of a command run 15 turns ago — a brief summary suffices.
+
+#### 3.2.2 Compression Tiers for Tool Results
+
+When `turnCount` enters T1 (11+ turns), apply progressive compression to tool results before they are sent to the SDK. This requires intercepting the context at session restart boundaries.
+
+| Message Age | Max Chars | Treatment |
+|-------------|-----------|-----------|
+| Last 5 turns | 120,000 (current) | Full content |
+| 6-15 turns ago | 8,000 | Truncate with `...[compressed: originally N chars]` |
+| 16+ turns ago | 2,000 | Aggressive truncate or replace with one-line summary |
+
+#### 3.2.3 Implementation Strategy
+
+Since the Claude Agent SDK manages its own internal conversation state during a live session, we **cannot** modify tool results in-flight. Instead, we use a **periodic session restart** approach:
+
+```
+continueSession() called
+  → check turnCount
+  → if turnCount % COMPRESSION_INTERVAL == 0 (e.g., every 10 turns):
+      1. Kill current SDK subprocess (stopSession internally)
+      2. Build compressed history from session.messages
+      3. Restart via startSession() with compressed history injected
+```
+
+This leverages the existing `injectLocalHistoryPrompt()` path but with enhanced compression logic.
+
+#### 3.2.4 New Constants
+
+```typescript
+const COMPRESSION_CHECK_INTERVAL = 10;        // Check every N turns
+const TIER_RECENT_TURNS = 5;                   // Full content window
+const TIER_MEDIUM_MAX_CHARS = 8_000;           // 6-15 turns ago
+const TIER_OLD_MAX_CHARS = 2_000;              // 16+ turns ago
+const CONTEXT_SIZE_THRESHOLD = 150_000;        // Force compression if total chars exceed this
+```
+
+#### 3.2.5 Enhanced `buildHistoryBlocks()`
+
+Extend `buildHistoryBlocks()` to accept turn-aware compression parameters:
+
+```typescript
+private buildHistoryBlocks(
+  messages: CoworkMessage[],
+  currentPrompt: string,
+  limits: {
+    maxMessages: number;
+    maxTotalChars: number;
+    maxMessageChars: number;
+  },
+  compression?: {                              // NEW optional parameter
+    currentTurn: number;
+    recentTurnsWindow: number;
+    mediumMaxChars: number;
+    oldMaxChars: number;
+  }
+): string[]
+```
+
+When `compression` is provided, determine each message's "age" (turns ago from current) and apply the corresponding character limit instead of the uniform `maxMessageChars`.
+
+#### 3.2.6 Estimating Context Size
+
+Add a utility method to estimate the current context size:
+
+```typescript
+private estimateContextSize(sessionId: string): number {
+  const session = this.store.getSession(sessionId);
+  if (!session) return 0;
+  return session.messages.reduce((sum, msg) => sum + msg.content.length, 0);
+}
+```
+
+Trigger compression when `estimateContextSize() > CONTEXT_SIZE_THRESHOLD` **or** `turnCount % COMPRESSION_CHECK_INTERVAL === 0`.
+
+---
+
+### 3.3 P2 — Sliding Window + Auto-Summarization
+
+**Priority**: P2
+**Complexity**: High
+**Files affected**: `coworkRunner.ts`, `coworkStore.ts`, `coworkOpenAICompatProxy.ts`
+
+#### 3.3.1 Concept
+
+For sessions exceeding 30 turns, even compressed tool results may not be enough. We introduce **automatic conversation summarization**: older turns are replaced with a structured summary that preserves key decisions and file modifications.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Context Layout for T2 Sessions (30+ turns)                  │
+├──────────────────────────────────────────────────────────────┤
+│  [System Prompt]                                             │
+│  [User Memories from Memory System]                          │
+│  <session_summary>                                           │
+│    Turns 1-20 summary: structured digest of decisions,       │
+│    files modified, key outcomes                              │
+│  </session_summary>                                          │
+│  [Full messages from turns 21-current]                       │
+│  [Current user prompt]                                       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+#### 3.3.2 Summary Generation
+
+Two approaches, selectable by configuration:
+
+**Option A: Rule-Based Summary (Default, No API Cost)**
+
+Extract from each old turn:
+- User message: first 200 chars
+- Assistant message: first 300 chars (excluding tool calls)
+- Tool calls: tool name + one-line description of what was done
+- Files modified: extracted from `Write`/`Edit` tool inputs
+
+Output format:
+```
+Turn 3: User asked to set up database connection.
+  → Modified: src/db.ts, src/config.ts
+  → Outcome: PostgreSQL connection configured with connection pooling.
+
+Turn 4: User asked to add user authentication.
+  → Modified: src/auth.ts, src/middleware/auth.ts, src/routes/login.ts
+  → Outcome: JWT-based auth implemented with refresh tokens.
+```
+
+**Option B: LLM-Assisted Summary (Higher Quality, Has API Cost)**
+
+Use a fast/cheap model (e.g., Claude Haiku) to generate a concise summary:
+
+```typescript
+const summaryPrompt = `Summarize the following conversation turns into a structured digest.
+Focus on: decisions made, files created/modified, key outcomes, and any user preferences expressed.
+Keep under 2000 characters.
+
+${turnsToSummarize}`;
+```
+
+#### 3.3.3 Summary Caching
+
+Store the generated summary in session metadata to avoid regeneration:
+
+```typescript
+// coworkStore.ts — new column in cowork_sessions
+ALTER TABLE cowork_sessions ADD COLUMN context_summary TEXT DEFAULT NULL;
+ALTER TABLE cowork_sessions ADD COLUMN summary_up_to_turn INTEGER DEFAULT 0;
+```
+
+The summary is regenerated only when `turnCount - summary_up_to_turn > SUMMARY_REFRESH_INTERVAL` (e.g., every 10 turns).
+
+#### 3.3.4 Session Restart with Summary
+
+When entering T2:
+
+1. Generate summary for turns 1 through `(turnCount - FULL_WINDOW_SIZE)`
+2. Cache summary in session
+3. On next `continueSession()`:
+   - Stop SDK subprocess
+   - Build prompt: summary + recent full messages + current prompt
+   - Restart via `startSession()`
+
+#### 3.3.5 New Constants
+
+```typescript
+const SUMMARY_TRIGGER_TURN = 30;              // Start summarizing at this turn
+const SUMMARY_FULL_WINDOW_SIZE = 15;          // Keep last N turns in full
+const SUMMARY_REFRESH_INTERVAL = 10;          // Re-summarize every N turns
+const SUMMARY_MAX_CHARS = 4_000;              // Max summary length
+const SUMMARY_USE_LLM = false;                // Default: rule-based
+```
+
+#### 3.3.6 OpenClaw Engine Considerations
+
+For the OpenClaw engine, the context bridge already has limits (`BRIDGE_MAX_MESSAGES = 20`, `BRIDGE_MAX_MESSAGE_CHARS = 1200`). Enhancements:
+
+1. Make bridge constants configurable (not hardcoded)
+2. When `turnCount > 30`, prepend the cached session summary to the context bridge
+3. Coordinate with OpenClaw's server-side byte-bounded window to avoid double-truncation
+
+---
+
+### 3.4 P3 — New Session with Memory Migration
+
+**Priority**: P3
+**Complexity**: Medium
+**Files affected**: `coworkRunner.ts`, `coworkStore.ts`, `CoworkSessionDetail.tsx`, `cowork.ts` (renderer service)
+
+#### 3.4.1 Concept
+
+When a session exceeds 50 turns or the user clicks the "New Session with Context" button, create a new session pre-loaded with:
+
+1. All user memories from the Memory system
+2. A session summary (from P2)
+3. The working directory and system prompt from the old session
+4. The last user message (if triggered by context overflow)
+
+#### 3.4.2 Migration Flow
+
+```
+User clicks "New Session with Context"
+  → Renderer: coworkService.migrateToNewSession(oldSessionId)
+  → IPC: cowork:migrateSession
+  → Main:
+      1. Generate/retrieve session summary (P2)
+      2. Load active user memories
+      3. Create new session with:
+         - Same cwd, systemPrompt, executionMode, activeSkillIds
+         - Initial prompt containing summary + memories
+      4. Return new sessionId to renderer
+  → Renderer: navigate to new session
+```
+
+#### 3.4.3 Migration Prompt Template
+
+```
+You are continuing a task from a previous session. Here is the context:
+
+<previous_session_summary>
+{session_summary}
+</previous_session_summary>
+
+<user_memories>
+{memories_from_memory_system}
+</user_memories>
+
+<working_state>
+- Working directory: {cwd}
+- Last modified files: {recent_files}
+</working_state>
+
+The user would like to continue their work. Their most recent request was:
+{last_user_message_or_empty}
+```
+
+#### 3.4.4 IPC Channel
+
+```typescript
+// New IPC channel
+'cowork:migrateSession': (oldSessionId: string) => Promise<{ newSessionId: string }>
+```
+
+#### 3.4.5 Automatic Migration Suggestion
+
+When `turnCount >= 50`, automatically suggest migration via:
+
+1. A system message in the chat: "This session has reached {turnCount} turns. For best AI quality, consider starting a fresh session."
+2. The yellow/orange banner from P0 gains an actionable button
+
+#### 3.4.6 Preserving Session Link
+
+Store a `migratedFromSessionId` field on the new session so users can navigate back to the old session for reference:
+
+```typescript
+export interface CoworkSession {
+  // ... existing fields ...
+  migratedFromSessionId?: string;  // NEW
+}
+```
+
+---
+
+## 4. Configuration
+
+All thresholds should be configurable via the Cowork config system (`cowork_config` table):
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `contextManagement.enabled` | `true` | Master switch for tiered context management |
+| `contextManagement.compressionInterval` | `10` | Turns between compression checks |
+| `contextManagement.summaryTriggerTurn` | `30` | Turn count to start auto-summarization |
+| `contextManagement.summaryFullWindow` | `15` | Recent turns kept in full when summarizing |
+| `contextManagement.summaryUseLlm` | `false` | Use LLM for summary generation |
+| `contextManagement.migrationSuggestTurn` | `50` | Turn count to suggest new session |
+| `contextManagement.contextSizeThreshold` | `150000` | Chars threshold for forced compression |
+
+---
+
+## 5. Observability
+
+### 5.1 Logging
+
+Add structured logs at key decision points:
+
+```typescript
+console.log('[ContextManager] session entered T1, scheduling tool result compression', {
+  sessionId, turnCount, estimatedContextChars
+});
+
+console.log('[ContextManager] compressed session context', {
+  sessionId, turnCount, beforeChars, afterChars, compressionRatio
+});
+
+console.log('[ContextManager] generated session summary', {
+  sessionId, summarizedTurns, summaryChars, method: 'rule-based' | 'llm'
+});
+```
+
+### 5.2 Metrics (Future)
+
+Track for analytics:
+- Average turn count per session
+- Context compression trigger frequency
+- Session migration rate
+- User interaction with migration suggestions (accepted/dismissed)
+
+---
+
+## 6. Migration & Compatibility
+
+### 6.1 Database Migration
+
+New columns for `cowork_sessions`:
+
+```sql
+ALTER TABLE cowork_sessions ADD COLUMN turn_count INTEGER DEFAULT 0;
+ALTER TABLE cowork_sessions ADD COLUMN context_summary TEXT DEFAULT NULL;
+ALTER TABLE cowork_sessions ADD COLUMN summary_up_to_turn INTEGER DEFAULT 0;
+ALTER TABLE cowork_sessions ADD COLUMN migrated_from_session_id TEXT DEFAULT NULL;
+```
+
+Existing sessions will have `turn_count = 0`. On the first `continueSession()` call, the turn count can be estimated from the message count:
+
+```typescript
+if (session.turnCount === 0 && session.messages.length > 0) {
+  session.turnCount = session.messages.filter(m => m.type === 'user').length;
+}
+```
+
+### 6.2 Backward Compatibility
+
+- All new behavior is behind the `contextManagement.enabled` flag (default `true`)
+- Setting `contextManagement.enabled = false` restores current behavior exactly
+- No breaking changes to IPC interfaces (new fields are additive)
+- OpenClaw adapter changes are additive (new optional summary injection)
+
+---
+
+## 7. Implementation Plan
+
+### Phase 1 (P0) — ~2 days
+- [ ] Add `turnCount` to `ActiveSession` and `CoworkSession`
+- [ ] Increment on `startSession` / `continueSession`
+- [ ] Database migration for `turn_count` column
+- [ ] Expose `turnCount` via IPC
+- [ ] Add UI warning banner in `CoworkSessionDetail.tsx`
+- [ ] Add i18n keys for warning messages (zh + en)
+
+### Phase 2 (P1) — ~3 days
+- [ ] Add `estimateContextSize()` utility
+- [ ] Implement turn-aware compression in `buildHistoryBlocks()`
+- [ ] Add periodic session restart logic in `continueSession()`
+- [ ] Add compression constants and config keys
+- [ ] Unit tests for compression logic
+
+### Phase 3 (P2) — ~5 days
+- [ ] Implement rule-based summary generator
+- [ ] Database migration for `context_summary` / `summary_up_to_turn`
+- [ ] Integrate summary into session restart flow
+- [ ] (Optional) LLM-assisted summary with fast model
+- [ ] Update OpenClaw context bridge to include summaries
+- [ ] Unit tests for summary generation
+
+### Phase 4 (P3) — ~3 days
+- [ ] Implement `cowork:migrateSession` IPC handler
+- [ ] Build migration prompt template
+- [ ] Add "New Session with Context" button in UI
+- [ ] Store and display `migratedFromSessionId` link
+- [ ] End-to-end testing of migration flow
+
+**Total estimated effort**: ~13 days
+
+---
+
+## 8. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| SDK subprocess restart causes brief interruption | User sees a pause mid-conversation | Show a transient "Optimizing context..." indicator |
+| Rule-based summary misses important context | AI loses track of a key decision | Keep full window large enough (15 turns) and allow user to force full-context mode |
+| LLM summary adds latency + cost | Slower response on compression turns | Default to rule-based; LLM is opt-in |
+| Turn count estimation for legacy sessions is inaccurate | Compression triggers too early/late | Estimate from user message count; off-by-one is acceptable |
+| OpenClaw server-side window conflicts with client-side compression | Double-truncation, lost messages | Coordinate by querying OpenClaw's effective window size before applying client-side compression |
+
+---
+
+## 9. Alternatives Considered
+
+### 9.1 Client-Side Message Editing in Live SDK Session
+
+Directly modify the Claude Agent SDK's internal conversation buffer without restarting the subprocess. **Rejected** because the SDK does not expose a public API for editing historical messages in a live session.
+
+### 9.2 Always Restart SDK on Every Turn
+
+Kill and restart the SDK subprocess on every `continueSession()` call, always using compressed history. **Rejected** because it adds ~2-5s latency per turn and loses SDK-internal state (MCP connections, file watches, etc.).
+
+### 9.3 External Vector Store for Conversation Chunks
+
+Store conversation chunks in a vector database and retrieve relevant chunks via RAG. **Deferred** — adds significant infrastructure complexity. The Memory system + `conversation_search` tool already provides basic retrieval. Can be revisited if T2 summarization proves insufficient.
+
+---
+
+## 10. Open Questions
+
+1. **SDK `maxConversationTurns` support**: Does the Claude Agent SDK expose a `maxConversationTurns` or similar option that would let us cap the internal history without killing the subprocess? If so, P1 complexity drops significantly.
+
+2. **Compression indicator UX**: When the SDK is restarted for compression, should we show a spinner/progress indicator, or do it silently with a brief pause?
+
+3. **Summary language**: Should summaries be generated in the user's language (zh/en based on i18n setting) or always in English for model consistency?
+
+4. **OpenClaw server-side coordination**: Can we configure OpenClaw's `chat.history` byte limit per session, or is it a global setting?

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -341,6 +341,10 @@ export interface CoworkSession {
   messages: CoworkMessage[];
   createdAt: number;
   updatedAt: number;
+  turnCount: number;
+  contextSummary: string | null;
+  summaryUpToTurn: number;
+  migratedFromSessionId: string | null;
 }
 
 export interface CoworkSessionSummary {
@@ -409,6 +413,17 @@ export interface CoworkConfig {
   memoryLlmJudgeEnabled: boolean;
   memoryGuardLevel: CoworkMemoryGuardLevel;
   memoryUserMemoriesMaxItems: number;
+  contextManagementEnabled: boolean;
+}
+
+export interface ContextManagementConfig {
+  enabled: boolean;
+  compressionInterval: number;
+  summaryTriggerTurn: number;
+  summaryFullWindow: number;
+  summaryUseLlm: boolean;
+  migrationSuggestTurn: number;
+  contextSizeThreshold: number;
 }
 
 export type CoworkConfigUpdate = Partial<Pick<
@@ -544,6 +559,10 @@ export class CoworkStore {
       messages: [],
       createdAt: now,
       updatedAt: now,
+      turnCount: 0,
+      contextSummary: null,
+      summaryUpToTurn: 0,
+      migratedFromSessionId: null,
     };
   }
 
@@ -560,10 +579,14 @@ export class CoworkStore {
       active_skill_ids?: string | null;
       created_at: number;
       updated_at: number;
+      turn_count?: number | null;
+      context_summary?: string | null;
+      summary_up_to_turn?: number | null;
+      migrated_from_session_id?: string | null;
     }
 
     const row = this.getOne<SessionRow>(`
-      SELECT id, title, claude_session_id, status, pinned, cwd, system_prompt, execution_mode, active_skill_ids, created_at, updated_at
+      SELECT id, title, claude_session_id, status, pinned, cwd, system_prompt, execution_mode, active_skill_ids, created_at, updated_at, turn_count, context_summary, summary_up_to_turn, migrated_from_session_id
       FROM cowork_sessions
       WHERE id = ?
     `, [id]);
@@ -594,12 +617,16 @@ export class CoworkStore {
       messages,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      turnCount: row.turn_count ?? 0,
+      contextSummary: row.context_summary ?? null,
+      summaryUpToTurn: row.summary_up_to_turn ?? 0,
+      migratedFromSessionId: row.migrated_from_session_id ?? null,
     };
   }
 
   updateSession(
     id: string,
-    updates: Partial<Pick<CoworkSession, 'title' | 'claudeSessionId' | 'status' | 'cwd' | 'systemPrompt' | 'executionMode'>>
+    updates: Partial<Pick<CoworkSession, 'title' | 'claudeSessionId' | 'status' | 'cwd' | 'systemPrompt' | 'executionMode' | 'turnCount' | 'contextSummary' | 'summaryUpToTurn' | 'migratedFromSessionId'>>
   ): void {
     const now = Date.now();
     const setClauses: string[] = ['updated_at = ?'];
@@ -628,6 +655,22 @@ export class CoworkStore {
     if (updates.executionMode !== undefined) {
       setClauses.push('execution_mode = ?');
       values.push(updates.executionMode);
+    }
+    if (updates.turnCount !== undefined) {
+      setClauses.push('turn_count = ?');
+      values.push(updates.turnCount);
+    }
+    if (updates.contextSummary !== undefined) {
+      setClauses.push('context_summary = ?');
+      values.push(updates.contextSummary);
+    }
+    if (updates.summaryUpToTurn !== undefined) {
+      setClauses.push('summary_up_to_turn = ?');
+      values.push(updates.summaryUpToTurn);
+    }
+    if (updates.migratedFromSessionId !== undefined) {
+      setClauses.push('migrated_from_session_id = ?');
+      values.push(updates.migratedFromSessionId);
     }
 
     values.push(id);
@@ -885,6 +928,8 @@ export class CoworkStore {
 
     const normalizedAgentEngine = normalizeCoworkAgentEngineValue(agentEngineRow?.value);
 
+    const ctxEnabledRow = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', ['contextManagement.enabled']);
+
     return {
       workingDirectory: workingDirRow?.value || getDefaultWorkingDirectory(),
       systemPrompt: getDefaultSystemPrompt(),
@@ -901,6 +946,28 @@ export class CoworkStore {
       ),
       memoryGuardLevel: normalizeMemoryGuardLevel(memoryGuardLevelRow?.value),
       memoryUserMemoriesMaxItems: clampMemoryUserMemoriesMaxItems(Number(memoryUserMemoriesMaxItemsRow?.value)),
+      contextManagementEnabled: parseBooleanConfig(ctxEnabledRow?.value, true),
+    };
+  }
+
+  getContextManagementConfig(): ContextManagementConfig {
+    interface ConfigRow {
+      value: string;
+    }
+
+    const getValue = (key: string): string | undefined => {
+      const row = this.getOne<ConfigRow>('SELECT value FROM cowork_config WHERE key = ?', [`contextManagement.${key}`]);
+      return row?.value;
+    };
+
+    return {
+      enabled: parseBooleanConfig(getValue('enabled'), true),
+      compressionInterval: Number(getValue('compressionInterval')) || 10,
+      summaryTriggerTurn: Number(getValue('summaryTriggerTurn')) || 30,
+      summaryFullWindow: Number(getValue('summaryFullWindow')) || 15,
+      summaryUseLlm: parseBooleanConfig(getValue('summaryUseLlm'), false),
+      migrationSuggestTurn: Number(getValue('migrationSuggestTurn')) || 50,
+      contextSizeThreshold: Number(getValue('contextSizeThreshold')) || 150_000,
     };
   }
 

--- a/src/main/libs/agentEngine/coworkEngineRouter.ts
+++ b/src/main/libs/agentEngine/coworkEngineRouter.ts
@@ -169,6 +169,10 @@ export class CoworkEngineRouter extends EventEmitter implements CoworkRuntime {
       this.emit('permissionRequest', sessionId, request);
     });
 
+    runtime.on('contextOptimizing', (sessionId: string, isOptimizing: boolean) => {
+      this.emit('contextOptimizing', sessionId, isOptimizing);
+    });
+
     runtime.on('complete', (sessionId, claudeSessionId) => {
       this.sessionEngine.delete(sessionId);
       this.clearRequestEngineBySession(sessionId);

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -648,6 +648,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         messages,
         createdAt: now,
         updatedAt: now,
+        turnCount: 0,
+        contextSummary: null,
+        summaryUpToTurn: 0,
+        migratedFromSessionId: null,
       };
     } catch (error) {
       console.error('[OpenClawRuntime] fetchSessionByKey: failed to fetch history:', error);
@@ -835,6 +839,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   async startSession(sessionId: string, prompt: string, options: CoworkStartOptions = {}): Promise<void> {
+    // Initialize turn count for new sessions
+    this.store.updateSession(sessionId, { turnCount: 1 });
     await this.runTurn(sessionId, prompt, {
       skipInitialUserMessage: options.skipInitialUserMessage,
       skillIds: options.skillIds,
@@ -845,6 +851,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   async continueSession(sessionId: string, prompt: string, options: CoworkContinueOptions = {}): Promise<void> {
+    // Increment turn count
+    const session = this.store.getSession(sessionId);
+    const currentTurnCount = session?.turnCount ?? 0;
+    const newTurnCount = currentTurnCount + 1;
+    this.store.updateSession(sessionId, { turnCount: newTurnCount });
+    console.log(`[OpenClawRuntime] session ${sessionId} turn count: ${newTurnCount}`);
     await this.runTurn(sessionId, prompt, {
       skipInitialUserMessage: false,
       systemPrompt: options.systemPrompt,
@@ -1095,7 +1107,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (!hasHistory) {
       const session = this.store.getSession(sessionId);
       if (session) {
-        const bridgePrefix = this.buildBridgePrefix(session.messages, prompt);
+        const bridgePrefix = this.buildBridgePrefix(session.messages, prompt, session.contextSummary);
         if (bridgePrefix) {
           sections.push(bridgePrefix);
         }
@@ -1115,9 +1127,18 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     ].join('\n');
   }
 
-  private buildBridgePrefix(messages: CoworkMessage[], currentPrompt: string): string {
+  private buildBridgePrefix(messages: CoworkMessage[], currentPrompt: string, sessionSummary?: string | null): string {
     const normalizedCurrentPrompt = currentPrompt.trim();
     if (!normalizedCurrentPrompt) return '';
+
+    // Use configurable bridge limits
+    const ctxConfig = this.store.getContextManagementConfig();
+    const bridgeMaxMessages = ctxConfig.enabled
+      ? (Number(this.getConfigValue('contextManagement.openclawBridgeMaxMessages')) || BRIDGE_MAX_MESSAGES)
+      : BRIDGE_MAX_MESSAGES;
+    const bridgeMaxMessageChars = ctxConfig.enabled
+      ? (Number(this.getConfigValue('contextManagement.openclawBridgeMaxMessageChars')) || BRIDGE_MAX_MESSAGE_CHARS)
+      : BRIDGE_MAX_MESSAGE_CHARS;
 
     const source = messages
       .filter((message) => {
@@ -1146,21 +1167,39 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       source.pop();
     }
 
-    const recent = source.slice(-BRIDGE_MAX_MESSAGES);
-    if (recent.length === 0) {
+    const recent = source.slice(-bridgeMaxMessages);
+    if (recent.length === 0 && !sessionSummary) {
       return '';
+    }
+
+    const parts: string[] = [
+      '[Context bridge from previous LobsterAI conversation]',
+      'Use this prior context for continuity. Focus your final answer on the current request.',
+    ];
+
+    // Prepend session summary if available
+    if (sessionSummary) {
+      parts.push('', '<session_summary>', sessionSummary, '</session_summary>', '');
     }
 
     const lines = recent.map((entry) => {
       const role = entry.type === 'user' ? 'User' : 'Assistant';
-      return `${role}: ${truncate(entry.content, BRIDGE_MAX_MESSAGE_CHARS)}`;
+      return `${role}: ${truncate(entry.content, bridgeMaxMessageChars)}`;
     });
+    parts.push(...lines);
 
-    return [
-      '[Context bridge from previous LobsterAI conversation]',
-      'Use this prior context for continuity. Focus your final answer on the current request.',
-      ...lines,
-    ].join('\n');
+    return parts.join('\n');
+  }
+
+  private getConfigValue(key: string): string | undefined {
+    try {
+      const db = (this.store as unknown as { db: { exec: (sql: string, params: unknown[]) => { values: unknown[][] }[] } }).db;
+      if (!db) return undefined;
+      const result = db.exec('SELECT value FROM cowork_config WHERE key = ?', [key]);
+      return result?.[0]?.values?.[0]?.[0] as string | undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   private async ensureGatewayClientReady(): Promise<void> {

--- a/src/main/libs/agentEngine/types.ts
+++ b/src/main/libs/agentEngine/types.ts
@@ -16,6 +16,7 @@ export interface CoworkRuntimeEvents {
   message: (sessionId: string, message: CoworkMessage) => void;
   messageUpdate: (sessionId: string, messageId: string, content: string) => void;
   permissionRequest: (sessionId: string, request: PermissionRequest) => void;
+  contextOptimizing: (sessionId: string, isOptimizing: boolean) => void;
   complete: (sessionId: string, claudeSessionId: string | null) => void;
   error: (sessionId: string, error: string) => void;
 }

--- a/src/main/libs/coworkContextManagement.test.ts
+++ b/src/main/libs/coworkContextManagement.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for context management logic in coworkRunner.
+ *
+ * Since CoworkRunner is tightly coupled to Electron and Claude SDK,
+ * these tests exercise the pure-logic helpers that can be tested in isolation.
+ * The helpers are extracted here mirroring the logic in coworkRunner.ts.
+ */
+import { test, expect, describe } from 'vitest';
+
+// --- Extracted logic mirrors from coworkRunner.ts ---
+
+interface TestMessage {
+  type: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Assign turn numbers to messages. Each user message starts a new turn.
+ */
+function assignMessageTurns(messages: TestMessage[]): number[] {
+  const turns: number[] = [];
+  let currentTurn = 0;
+  for (const msg of messages) {
+    if (msg.type === 'user') {
+      currentTurn += 1;
+    }
+    turns.push(currentTurn);
+  }
+  return turns;
+}
+
+/**
+ * Estimate context size from messages.
+ */
+function estimateContextSize(messages: TestMessage[]): number {
+  return messages.reduce((sum, msg) => sum + msg.content.length, 0);
+}
+
+/**
+ * Legacy turn count estimation from user message count.
+ */
+function estimateLegacyTurnCount(messages: TestMessage[]): number {
+  return messages.filter(m => m.type === 'user').length;
+}
+
+/**
+ * Determine per-message char limit based on turn age (compression logic).
+ */
+function getMessageCharLimit(
+  messageTurn: number,
+  currentTurn: number,
+  recentTurnsWindow: number,
+  defaultMaxChars: number,
+  mediumMaxChars: number,
+  oldMaxChars: number,
+): number {
+  const turnsAgo = currentTurn - messageTurn;
+  if (turnsAgo <= recentTurnsWindow) {
+    return defaultMaxChars; // Full content for recent turns
+  } else if (turnsAgo <= recentTurnsWindow + 10) {
+    return mediumMaxChars; // 6-15 turns ago
+  } else {
+    return oldMaxChars; // 16+ turns ago
+  }
+}
+
+// --- Tests ---
+
+describe('assignMessageTurns', () => {
+  test('assigns turn 0 for non-user messages before first user message', () => {
+    const messages: TestMessage[] = [
+      { type: 'system', content: 'welcome' },
+      { type: 'assistant', content: 'hello' },
+    ];
+    expect(assignMessageTurns(messages)).toEqual([0, 0]);
+  });
+
+  test('increments turn on each user message', () => {
+    const messages: TestMessage[] = [
+      { type: 'user', content: 'first' },
+      { type: 'assistant', content: 'response 1' },
+      { type: 'user', content: 'second' },
+      { type: 'assistant', content: 'response 2' },
+    ];
+    expect(assignMessageTurns(messages)).toEqual([1, 1, 2, 2]);
+  });
+
+  test('handles consecutive user messages', () => {
+    const messages: TestMessage[] = [
+      { type: 'user', content: 'a' },
+      { type: 'user', content: 'b' },
+      { type: 'assistant', content: 'response' },
+    ];
+    expect(assignMessageTurns(messages)).toEqual([1, 2, 2]);
+  });
+
+  test('handles empty messages array', () => {
+    expect(assignMessageTurns([])).toEqual([]);
+  });
+});
+
+describe('estimateContextSize', () => {
+  test('returns 0 for empty messages', () => {
+    expect(estimateContextSize([])).toBe(0);
+  });
+
+  test('sums content lengths', () => {
+    const messages: TestMessage[] = [
+      { type: 'user', content: 'hello' },        // 5
+      { type: 'assistant', content: 'world!' },   // 6
+    ];
+    expect(estimateContextSize(messages)).toBe(11);
+  });
+
+  test('handles large content', () => {
+    const bigContent = 'x'.repeat(100_000);
+    const messages: TestMessage[] = [
+      { type: 'user', content: bigContent },
+      { type: 'assistant', content: bigContent },
+    ];
+    expect(estimateContextSize(messages)).toBe(200_000);
+  });
+});
+
+describe('estimateLegacyTurnCount', () => {
+  test('returns 0 for no messages', () => {
+    expect(estimateLegacyTurnCount([])).toBe(0);
+  });
+
+  test('counts only user messages', () => {
+    const messages: TestMessage[] = [
+      { type: 'user', content: 'a' },
+      { type: 'assistant', content: 'b' },
+      { type: 'tool_use', content: 'c' },
+      { type: 'user', content: 'd' },
+      { type: 'assistant', content: 'e' },
+    ];
+    expect(estimateLegacyTurnCount(messages)).toBe(2);
+  });
+
+  test('handles all user messages', () => {
+    const messages: TestMessage[] = [
+      { type: 'user', content: 'a' },
+      { type: 'user', content: 'b' },
+      { type: 'user', content: 'c' },
+    ];
+    expect(estimateLegacyTurnCount(messages)).toBe(3);
+  });
+
+  test('handles no user messages', () => {
+    const messages: TestMessage[] = [
+      { type: 'system', content: 'welcome' },
+      { type: 'assistant', content: 'hello' },
+    ];
+    expect(estimateLegacyTurnCount(messages)).toBe(0);
+  });
+});
+
+describe('getMessageCharLimit (turn-age-based compression)', () => {
+  const DEFAULT_MAX = 120_000;
+  const MEDIUM_MAX = 8_000;
+  const OLD_MAX = 2_000;
+  const RECENT_WINDOW = 5;
+
+  test('returns full limit for message in current turn', () => {
+    expect(getMessageCharLimit(20, 20, RECENT_WINDOW, DEFAULT_MAX, MEDIUM_MAX, OLD_MAX))
+      .toBe(DEFAULT_MAX);
+  });
+
+  test('returns full limit for messages within recent window', () => {
+    // Turn 16, current is 20, turnsAgo = 4 (within window of 5)
+    expect(getMessageCharLimit(16, 20, RECENT_WINDOW, DEFAULT_MAX, MEDIUM_MAX, OLD_MAX))
+      .toBe(DEFAULT_MAX);
+  });
+
+  test('returns full limit at boundary of recent window', () => {
+    // Turn 15, current is 20, turnsAgo = 5 (exactly at window boundary)
+    expect(getMessageCharLimit(15, 20, RECENT_WINDOW, DEFAULT_MAX, MEDIUM_MAX, OLD_MAX))
+      .toBe(DEFAULT_MAX);
+  });
+
+  test('returns medium limit for turns 6-15 ago', () => {
+    // Turn 14, current is 20, turnsAgo = 6 (just past recent window)
+    expect(getMessageCharLimit(14, 20, RECENT_WINDOW, DEFAULT_MAX, MEDIUM_MAX, OLD_MAX))
+      .toBe(MEDIUM_MAX);
+  });
+
+  test('returns medium limit at boundary of medium window', () => {
+    // Turn 5, current is 20, turnsAgo = 15 (at boundary of recent + 10)
+    expect(getMessageCharLimit(5, 20, RECENT_WINDOW, DEFAULT_MAX, MEDIUM_MAX, OLD_MAX))
+      .toBe(MEDIUM_MAX);
+  });
+
+  test('returns old limit for turns 16+ ago', () => {
+    // Turn 4, current is 20, turnsAgo = 16
+    expect(getMessageCharLimit(4, 20, RECENT_WINDOW, DEFAULT_MAX, MEDIUM_MAX, OLD_MAX))
+      .toBe(OLD_MAX);
+  });
+
+  test('returns old limit for very old turns', () => {
+    // Turn 1, current is 50, turnsAgo = 49
+    expect(getMessageCharLimit(1, 50, RECENT_WINDOW, DEFAULT_MAX, MEDIUM_MAX, OLD_MAX))
+      .toBe(OLD_MAX);
+  });
+
+  test('handles turn 0 (pre-user messages)', () => {
+    // Turn 0, current is 10, turnsAgo = 10
+    expect(getMessageCharLimit(0, 10, RECENT_WINDOW, DEFAULT_MAX, MEDIUM_MAX, OLD_MAX))
+      .toBe(MEDIUM_MAX);
+  });
+});

--- a/src/main/libs/coworkContextSummary.test.ts
+++ b/src/main/libs/coworkContextSummary.test.ts
@@ -1,0 +1,153 @@
+import { test, expect, describe } from 'vitest';
+import { generateRuleBasedSummary } from './coworkContextSummary';
+
+interface TestMessage {
+  type: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+function makeMessages(turns: Array<{ user: string; assistant: string; toolNames?: string[]; files?: string[] }>): TestMessage[] {
+  const messages: TestMessage[] = [];
+  for (const turn of turns) {
+    messages.push({ type: 'user', content: turn.user });
+    if (turn.toolNames) {
+      for (const toolName of turn.toolNames) {
+        messages.push({
+          type: 'tool_use',
+          content: `Tool: ${toolName}`,
+          metadata: { toolName },
+        });
+      }
+    }
+    if (turn.files) {
+      for (const file of turn.files) {
+        messages.push({
+          type: 'tool_use',
+          content: `Edit file: ${file}`,
+          metadata: { toolName: 'edit_file', toolInput: { file_path: file } },
+        });
+      }
+    }
+    messages.push({ type: 'assistant', content: turn.assistant });
+  }
+  return messages;
+}
+
+describe('generateRuleBasedSummary', () => {
+  test('returns empty string for no turns to summarize', () => {
+    const result = generateRuleBasedSummary([], 0);
+    expect(result).toBe('');
+  });
+
+  test('summarizes a single turn', () => {
+    const messages = makeMessages([
+      { user: 'Fix the login bug', assistant: 'I found and fixed the login bug in auth.ts' },
+    ]);
+    const result = generateRuleBasedSummary(messages, 1);
+    expect(result).toContain('Turn 1');
+    expect(result).toContain('Fix the login bug');
+    expect(result).toContain('found and fixed the login bug');
+  });
+
+  test('includes tool names in summary', () => {
+    const messages = makeMessages([
+      {
+        user: 'Read the config file',
+        assistant: 'I read the file and found the issue',
+        toolNames: ['read_file', 'search'],
+      },
+    ]);
+    const result = generateRuleBasedSummary(messages, 1);
+    expect(result).toContain('Tools:');
+    expect(result).toContain('read_file');
+    expect(result).toContain('search');
+  });
+
+  test('includes modified files in summary', () => {
+    const messages = makeMessages([
+      {
+        user: 'Update the component',
+        assistant: 'Updated the component with the new prop',
+        files: ['src/components/App.tsx', 'src/utils/helpers.ts'],
+      },
+    ]);
+    const result = generateRuleBasedSummary(messages, 1);
+    expect(result).toContain('Modified:');
+    expect(result).toContain('src/components/App.tsx');
+    expect(result).toContain('src/utils/helpers.ts');
+  });
+
+  test('summarizes multiple turns', () => {
+    const messages = makeMessages([
+      { user: 'First task', assistant: 'Done first' },
+      { user: 'Second task', assistant: 'Done second' },
+      { user: 'Third task', assistant: 'Done third' },
+    ]);
+    const result = generateRuleBasedSummary(messages, 3);
+    expect(result).toContain('Turn 1');
+    expect(result).toContain('Turn 2');
+    expect(result).toContain('Turn 3');
+    expect(result).toContain('First task');
+    expect(result).toContain('Second task');
+    expect(result).toContain('Third task');
+  });
+
+  test('only summarizes turns up to upToTurn', () => {
+    const messages = makeMessages([
+      { user: 'First task', assistant: 'Done first' },
+      { user: 'Second task', assistant: 'Done second' },
+      { user: 'Third task', assistant: 'Done third' },
+    ]);
+    const result = generateRuleBasedSummary(messages, 2);
+    expect(result).toContain('Turn 1');
+    expect(result).toContain('Turn 2');
+    expect(result).not.toContain('Turn 3');
+    expect(result).not.toContain('Third task');
+  });
+
+  test('truncates user excerpt at 200 chars', () => {
+    const longText = 'A'.repeat(300);
+    const messages = makeMessages([
+      { user: longText, assistant: 'Done' },
+    ]);
+    const result = generateRuleBasedSummary(messages, 1);
+    // Should contain truncated text ending with ...
+    expect(result).toContain('...');
+    // Should not contain the full 300-char text
+    expect(result).not.toContain(longText);
+  });
+
+  test('respects maxChars limit', () => {
+    const messages = makeMessages(
+      Array.from({ length: 20 }, (_, i) => ({
+        user: `Task number ${i + 1} with some description text`,
+        assistant: `Completed task ${i + 1} with detailed explanation of what was done`,
+      }))
+    );
+    const result = generateRuleBasedSummary(messages, 20, 500);
+    expect(result.length).toBeLessThanOrEqual(600); // Allow for the "... more turns omitted" suffix
+    expect(result).toContain('more turns omitted');
+  });
+
+  test('handles messages with no user message in a turn', () => {
+    const messages: TestMessage[] = [
+      { type: 'assistant', content: 'System initialized' },
+      { type: 'user', content: 'Hello' },
+      { type: 'assistant', content: 'Hi there' },
+    ];
+    const result = generateRuleBasedSummary(messages, 2);
+    expect(result).toContain('Turn 1');
+  });
+
+  test('filters out thinking messages from assistant excerpts', () => {
+    const messages: TestMessage[] = [
+      { type: 'user', content: 'Do something' },
+      { type: 'assistant', content: 'Let me think about this...', metadata: { isThinking: true } },
+      { type: 'assistant', content: 'Here is the actual response' },
+    ];
+    const result = generateRuleBasedSummary(messages, 1);
+    expect(result).toContain('actual response');
+    expect(result).not.toContain('Let me think');
+  });
+});

--- a/src/main/libs/coworkContextSummary.ts
+++ b/src/main/libs/coworkContextSummary.ts
@@ -1,0 +1,260 @@
+/**
+ * Rule-based session summary generator for context management.
+ *
+ * Generates a structured summary of older conversation turns by extracting
+ * key information: user request excerpts, assistant response excerpts,
+ * tool names, and files modified.
+ */
+
+interface SummarizableMessage {
+  type: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface TurnSummary {
+  turnNumber: number;
+  userExcerpt: string;
+  assistantExcerpt: string;
+  toolNames: string[];
+  filesModified: string[];
+}
+
+const USER_EXCERPT_MAX_CHARS = 200;
+const ASSISTANT_EXCERPT_MAX_CHARS = 300;
+const FILE_PATH_RE = /(?:^|\s)(?:Write|Edit|Create|Modify|Update|Delete|Remove|Move|Rename|MultiEdit|write_to_file|edit_file|replace_in_file)\b[^]*?(?:file|path|target|to)\s*[:=]?\s*["'`]?([^\s"'`\n,;]+\.[A-Za-z][A-Za-z0-9]{0,7})/gi;
+const TOOL_NAME_RE = /^Tool:\s*(\w+)/m;
+
+/**
+ * Group messages into turns. Each turn starts with a user message.
+ */
+function groupMessagesIntoTurns(messages: SummarizableMessage[]): SummarizableMessage[][] {
+  const turns: SummarizableMessage[][] = [];
+  let currentTurn: SummarizableMessage[] = [];
+
+  for (const msg of messages) {
+    if (msg.type === 'user' && currentTurn.length > 0) {
+      turns.push(currentTurn);
+      currentTurn = [];
+    }
+    currentTurn.push(msg);
+  }
+  if (currentTurn.length > 0) {
+    turns.push(currentTurn);
+  }
+
+  return turns;
+}
+
+/**
+ * Extract file paths from tool_use and tool_result messages.
+ */
+function extractFilesModified(messages: SummarizableMessage[]): string[] {
+  const files = new Set<string>();
+
+  for (const msg of messages) {
+    if (msg.type !== 'tool_use' && msg.type !== 'tool_result') continue;
+
+    // Check metadata toolInput for file paths
+    const toolInput = msg.metadata?.toolInput as Record<string, unknown> | undefined;
+    if (toolInput) {
+      for (const key of ['file_path', 'path', 'target_file', 'file', 'filename']) {
+        const val = toolInput[key];
+        if (typeof val === 'string' && val.includes('.')) {
+          files.add(val);
+        }
+      }
+    }
+
+    // Regex fallback on content
+    const matches = msg.content.matchAll(FILE_PATH_RE);
+    for (const match of matches) {
+      if (match[1]) files.add(match[1]);
+    }
+  }
+
+  return [...files].slice(0, 10);
+}
+
+/**
+ * Extract tool names from tool_use messages.
+ */
+function extractToolNames(messages: SummarizableMessage[]): string[] {
+  const names = new Set<string>();
+
+  for (const msg of messages) {
+    if (msg.type === 'tool_use') {
+      const toolName = msg.metadata?.toolName as string | undefined;
+      if (toolName) {
+        names.add(toolName);
+        continue;
+      }
+      // Fallback: parse from content
+      const match = msg.content.match(TOOL_NAME_RE);
+      if (match?.[1]) names.add(match[1]);
+    }
+  }
+
+  return [...names];
+}
+
+function truncate(text: string, maxChars: number): string {
+  const clean = text.replace(/\s+/g, ' ').trim();
+  if (clean.length <= maxChars) return clean;
+  return `${clean.slice(0, maxChars)}...`;
+}
+
+/**
+ * Summarize a single turn.
+ */
+function summarizeTurn(turnMessages: SummarizableMessage[], turnNumber: number): TurnSummary {
+  const userMsg = turnMessages.find(m => m.type === 'user');
+  const assistantMsgs = turnMessages.filter(m => m.type === 'assistant' && !m.metadata?.isThinking);
+  const assistantText = assistantMsgs.map(m => m.content).join(' ');
+
+  return {
+    turnNumber,
+    userExcerpt: userMsg ? truncate(userMsg.content, USER_EXCERPT_MAX_CHARS) : '',
+    assistantExcerpt: truncate(assistantText, ASSISTANT_EXCERPT_MAX_CHARS),
+    toolNames: extractToolNames(turnMessages),
+    filesModified: extractFilesModified(turnMessages),
+  };
+}
+
+/**
+ * Generate a rule-based summary of conversation turns.
+ *
+ * @param messages All session messages
+ * @param upToTurn Summarize turns 1 through this number (inclusive)
+ * @param maxChars Maximum total summary characters
+ */
+/**
+ * Generate an LLM-assisted summary by sending the rule-based summary
+ * to an LLM for refinement and compression.
+ */
+export async function generateLlmSummary(
+  messages: SummarizableMessage[],
+  upToTurn: number,
+  maxChars: number = 4000,
+  apiConfig: { baseURL: string; apiKey: string; model: string }
+): Promise<string | null> {
+  // First generate the rule-based summary as input
+  const ruleBasedSummary = generateRuleBasedSummary(messages, upToTurn, maxChars * 2);
+  if (!ruleBasedSummary) return null;
+
+  const normalizedBaseUrl = apiConfig.baseURL.replace(/\/+$/, '');
+  const url = normalizedBaseUrl.endsWith('/v1/messages')
+    ? normalizedBaseUrl
+    : normalizedBaseUrl.endsWith('/v1')
+      ? `${normalizedBaseUrl}/messages`
+      : `${normalizedBaseUrl}/v1/messages`;
+
+  const systemPrompt = [
+    'You are a session summarizer. Given a per-turn activity log of an AI coding session,',
+    'produce a concise narrative summary that captures: the overall goal, key decisions made,',
+    'files modified, current state of work, and any unresolved issues.',
+    'Keep the summary under 2000 characters. Use plain text, no markdown headers.',
+    'Write in the same language as the user messages (Chinese or English).',
+  ].join(' ');
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 30_000);
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiConfig.apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: apiConfig.model,
+        max_tokens: 1024,
+        temperature: 0,
+        system: systemPrompt,
+        messages: [{ role: 'user', content: `Summarize this session activity log:\n\n${ruleBasedSummary}` }],
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      console.warn('[ContextSummary] LLM summary request failed with status', response.status);
+      return null;
+    }
+
+    const payload = await response.json() as Record<string, unknown>;
+    const content = payload.content;
+    if (Array.isArray(content)) {
+      const text = content
+        .map((item: unknown) => {
+          if (!item || typeof item !== 'object') return '';
+          const block = item as Record<string, unknown>;
+          return typeof block.text === 'string' ? block.text : '';
+        })
+        .filter(Boolean)
+        .join('\n')
+        .trim();
+      return text.slice(0, maxChars) || null;
+    }
+    if (typeof content === 'string') {
+      return content.trim().slice(0, maxChars) || null;
+    }
+    return null;
+  } catch (error) {
+    console.warn('[ContextSummary] LLM summary generation failed:', error);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function generateRuleBasedSummary(
+  messages: SummarizableMessage[],
+  upToTurn: number,
+  maxChars: number = 4000
+): string {
+  const allTurns = groupMessagesIntoTurns(messages);
+  const turnsToSummarize = allTurns.slice(0, upToTurn);
+
+  const summaries: TurnSummary[] = turnsToSummarize.map(
+    (turnMsgs, idx) => summarizeTurn(turnMsgs, idx + 1)
+  );
+
+  const lines: string[] = [];
+  let totalChars = 0;
+
+  for (const s of summaries) {
+    const parts: string[] = [];
+
+    if (s.userExcerpt) {
+      parts.push(`Turn ${s.turnNumber}: ${s.userExcerpt}`);
+    } else {
+      parts.push(`Turn ${s.turnNumber}: (no user message)`);
+    }
+
+    if (s.filesModified.length > 0) {
+      parts.push(`  → Modified: ${s.filesModified.join(', ')}`);
+    }
+
+    if (s.toolNames.length > 0) {
+      parts.push(`  → Tools: ${s.toolNames.join(', ')}`);
+    }
+
+    if (s.assistantExcerpt) {
+      parts.push(`  → Outcome: ${s.assistantExcerpt}`);
+    }
+
+    const block = parts.join('\n');
+
+    if (totalChars + block.length + 2 > maxChars) {
+      lines.push(`... (${summaries.length - lines.length} more turns omitted)`);
+      break;
+    }
+
+    lines.push(block);
+    totalChars += block.length + 2; // +2 for \n\n
+  }
+
+  return lines.join('\n\n');
+}

--- a/src/main/libs/coworkRunner.ts
+++ b/src/main/libs/coworkRunner.ts
@@ -13,6 +13,8 @@ import { coworkLog, getCoworkLogPath } from './coworkLogger';
 import { ensurePythonPipReady, ensurePythonRuntimeReady } from './pythonRuntime';
 import { isQuestionLikeMemoryText, type CoworkMemoryGuardLevel } from './coworkMemoryExtractor';
 import { SCHEDULED_TASK_SWITCH_MESSAGE } from './scheduledTaskEnginePrompt';
+import { generateRuleBasedSummary, generateLlmSummary } from './coworkContextSummary';
+import { resolveCurrentApiConfig } from './claudeSettings';
 import { setCoworkProxySessionId } from './coworkOpenAICompatProxy';
 import { z } from 'zod';
 
@@ -52,6 +54,18 @@ const TOOL_INPUT_PREVIEW_MAX_DEPTH = 5;
 const TOOL_INPUT_PREVIEW_MAX_KEYS = 60;
 const TOOL_INPUT_PREVIEW_MAX_ITEMS = 30;
 const TASK_WORKSPACE_CONTAINER_DIR = '.lobsterai-tasks';
+
+// Context management constants (defaults, overridden by contextManagement.* config)
+const COMPRESSION_CHECK_INTERVAL = 10;
+const TIER_RECENT_TURNS = 5;
+const TIER_MEDIUM_MAX_CHARS = 8_000;
+const TIER_OLD_MAX_CHARS = 2_000;
+const CONTEXT_SIZE_THRESHOLD = 150_000;
+const SUMMARY_TRIGGER_TURN = 30;
+const SUMMARY_FULL_WINDOW_SIZE = 15;
+const SUMMARY_REFRESH_INTERVAL = 10;
+const SUMMARY_MAX_CHARS = 4_000;
+const MIGRATION_SUGGEST_TURN = 50;
 const PERMISSION_RESPONSE_TIMEOUT_MS = 60_000;
 const DELETE_TOOL_NAMES = new Set(['delete', 'remove', 'unlink', 'rmdir']);
 const SAFETY_APPROVAL_ALLOW_OPTION = '允许本次操作';
@@ -203,6 +217,8 @@ interface ActiveSession {
   executionMode: CoworkExecutionMode;
   /** When true, auto-approve all tool permissions (for scheduled tasks) */
   autoApprove?: boolean;
+  /** Turn counter for context management — incremented on each startSession/continueSession */
+  turnCount: number;
 }
 
 interface PendingPermission {
@@ -926,6 +942,31 @@ export class CoworkRunner extends EventEmitter {
     return { emit: false, now };
   }
 
+  /**
+   * Estimate total context size (in characters) for a session's messages.
+   */
+  private estimateContextSize(sessionId: string): number {
+    const session = this.store.getSession(sessionId);
+    if (!session) return 0;
+    return session.messages.reduce((sum, msg) => sum + msg.content.length, 0);
+  }
+
+  /**
+   * Assign a turn number to each message. A "turn" starts with each user message.
+   * Returns an array of turn numbers corresponding to each message index.
+   */
+  private assignMessageTurns(messages: CoworkMessage[]): number[] {
+    const turns: number[] = [];
+    let currentTurn = 0;
+    for (const msg of messages) {
+      if (msg.type === 'user') {
+        currentTurn += 1;
+      }
+      turns.push(currentTurn);
+    }
+    return turns;
+  }
+
   private formatHistoryMessage(message: CoworkMessage, maxChars: number): string | null {
     const raw = (message.content || '').replace(/\u0000/g, '').trim();
     if (!raw) {
@@ -933,7 +974,7 @@ export class CoworkRunner extends EventEmitter {
     }
     const content = raw.length <= maxChars
       ? raw
-      : `${raw.slice(0, maxChars)}\n...[truncated ${raw.length - maxChars} chars]`;
+      : `${raw.slice(0, maxChars)}\n...[compressed: originally ${raw.length} chars]`;
 
     let role: string = message.type;
     if (message.type === 'assistant' && message.metadata?.isThinking) {
@@ -946,7 +987,13 @@ export class CoworkRunner extends EventEmitter {
   private buildHistoryBlocks(
     messages: CoworkMessage[],
     currentPrompt: string,
-    limits: { maxMessages: number; maxTotalChars: number; maxMessageChars: number }
+    limits: { maxMessages: number; maxTotalChars: number; maxMessageChars: number },
+    compression?: {
+      currentTurn: number;
+      recentTurnsWindow: number;
+      mediumMaxChars: number;
+      oldMaxChars: number;
+    }
   ): string[] {
     if (messages.length === 0) {
       return [];
@@ -963,13 +1010,34 @@ export class CoworkRunner extends EventEmitter {
       history.pop();
     }
 
+    // If compression is enabled, pre-compute turn numbers for age-based limits
+    let messageTurns: number[] | null = null;
+    if (compression) {
+      messageTurns = this.assignMessageTurns(history);
+    }
+
     const selectedFromNewest: string[] = [];
     let totalChars = 0;
     for (let i = history.length - 1; i >= 0; i -= 1) {
       if (selectedFromNewest.length >= limits.maxMessages) {
         break;
       }
-      const block = this.formatHistoryMessage(history[i], limits.maxMessageChars);
+
+      // Determine per-message char limit based on turn age
+      let messageMaxChars = limits.maxMessageChars;
+      if (compression && messageTurns) {
+        const messageTurn = messageTurns[i];
+        const turnsAgo = compression.currentTurn - messageTurn;
+        if (turnsAgo <= compression.recentTurnsWindow) {
+          messageMaxChars = limits.maxMessageChars; // Full content for recent turns
+        } else if (turnsAgo <= compression.recentTurnsWindow + 10) {
+          messageMaxChars = compression.mediumMaxChars; // 6-15 turns ago
+        } else {
+          messageMaxChars = compression.oldMaxChars; // 16+ turns ago
+        }
+      }
+
+      const block = this.formatHistoryMessage(history[i], messageMaxChars);
       if (!block) {
         continue;
       }
@@ -999,24 +1067,52 @@ export class CoworkRunner extends EventEmitter {
    * Inject conversation history into a local-mode prompt when the session is
    * restarted after a stop (subprocess was killed, no SDK session to resume).
    */
-  private injectLocalHistoryPrompt(sessionId: string, currentPrompt: string, effectivePrompt: string): string {
+  private async injectLocalHistoryPrompt(sessionId: string, currentPrompt: string, effectivePrompt: string): Promise<string> {
     const session = this.store.getSession(sessionId);
     if (!session) {
       return effectivePrompt;
+    }
+
+    // Build compression parameters if turn count warrants it
+    const ctxConfig = this.store.getContextManagementConfig();
+    const turnCount = session.turnCount;
+    let compression: { currentTurn: number; recentTurnsWindow: number; mediumMaxChars: number; oldMaxChars: number } | undefined;
+    if (ctxConfig.enabled && turnCount > ctxConfig.compressionInterval) {
+      compression = {
+        currentTurn: turnCount,
+        recentTurnsWindow: TIER_RECENT_TURNS,
+        mediumMaxChars: TIER_MEDIUM_MAX_CHARS,
+        oldMaxChars: TIER_OLD_MAX_CHARS,
+      };
     }
 
     const historyBlocks = this.buildHistoryBlocks(session.messages, currentPrompt, {
       maxMessages: LOCAL_HISTORY_MAX_MESSAGES,
       maxTotalChars: LOCAL_HISTORY_MAX_TOTAL_CHARS,
       maxMessageChars: LOCAL_HISTORY_MAX_MESSAGE_CHARS,
-    });
+    }, compression);
     if (historyBlocks.length === 0) {
       return effectivePrompt;
     }
 
-    return [
+    // For T2 sessions (30+ turns), generate or reuse a session summary
+    const summaryBlock = await this.getOrGenerateSessionSummary(session, ctxConfig);
+
+    const parts: string[] = [
       'The session was interrupted and restarted. Continue using the conversation history below.',
       'Use this context for continuity and do not quote it unless necessary.',
+    ];
+
+    if (summaryBlock) {
+      parts.push(
+        '<session_summary>',
+        summaryBlock,
+        '</session_summary>',
+        '',
+      );
+    }
+
+    parts.push(
       '<conversation_history>',
       ...historyBlocks,
       '</conversation_history>',
@@ -1024,7 +1120,100 @@ export class CoworkRunner extends EventEmitter {
       '<current_user_request>',
       effectivePrompt,
       '</current_user_request>',
-    ].join('\n');
+    );
+
+    return parts.join('\n');
+  }
+
+  /**
+   * Generate or retrieve a cached session summary for context management.
+   * Returns the summary text, or null if summarization is not applicable.
+   */
+  private async getOrGenerateSessionSummary(
+    session: { id: string; turnCount: number; contextSummary: string | null; summaryUpToTurn: number; messages: CoworkMessage[] },
+    ctxConfig: { enabled: boolean; summaryTriggerTurn: number; summaryFullWindow: number; summaryUseLlm?: boolean }
+  ): Promise<string | null> {
+    if (!ctxConfig.enabled || session.turnCount < ctxConfig.summaryTriggerTurn) {
+      return null;
+    }
+
+    const upToTurn = Math.max(1, session.turnCount - ctxConfig.summaryFullWindow);
+
+    // Check if cached summary is still fresh enough
+    if (
+      session.contextSummary &&
+      session.summaryUpToTurn > 0 &&
+      (upToTurn - session.summaryUpToTurn) <= SUMMARY_REFRESH_INTERVAL
+    ) {
+      return session.contextSummary;
+    }
+
+    let summary: string | null = null;
+    let method = 'rule-based';
+
+    // Try LLM-assisted summary if enabled
+    if (ctxConfig.summaryUseLlm) {
+      try {
+        const { config: apiConfig } = resolveCurrentApiConfig();
+        if (apiConfig) {
+          summary = await generateLlmSummary(session.messages, upToTurn, SUMMARY_MAX_CHARS, apiConfig);
+          if (summary) {
+            method = 'llm';
+          }
+        }
+      } catch (error) {
+        console.warn('[ContextManager] LLM summary failed, falling back to rule-based:', error);
+      }
+    }
+
+    // Fall back to rule-based summary
+    if (!summary) {
+      summary = generateRuleBasedSummary(session.messages, upToTurn, SUMMARY_MAX_CHARS);
+    }
+
+    if (!summary) return null;
+
+    // Cache it
+    this.store.updateSession(session.id, {
+      contextSummary: summary,
+      summaryUpToTurn: upToTurn,
+    });
+
+    console.log('[ContextManager] generated session summary', {
+      sessionId: session.id,
+      summarizedTurns: upToTurn,
+      summaryChars: summary.length,
+      method,
+    });
+
+    return summary;
+  }
+
+  /**
+   * Emit a migration suggestion system message when turnCount first reaches migrationSuggestTurn.
+   * Only emits once per session by checking if the suggestion was already sent.
+   */
+  private migrationSuggestedSessions = new Set<string>();
+
+  private emitMigrationSuggestionIfNeeded(sessionId: string, turnCount: number): void {
+    if (this.migrationSuggestedSessions.has(sessionId)) return;
+
+    const ctxConfig = this.store.getContextManagementConfig();
+    if (!ctxConfig.enabled || turnCount < ctxConfig.migrationSuggestTurn) return;
+
+    this.migrationSuggestedSessions.add(sessionId);
+
+    const migrationMessage: CoworkMessage = {
+      id: `migration-suggest-${Date.now()}`,
+      type: 'system',
+      content: `💡 This session has reached ${turnCount} turns. For the best AI experience, consider starting a new session with context carried forward. Use the "New Session with Context" button in the banner above, or continue if you prefer.`,
+      timestamp: Date.now(),
+    };
+
+    this.store.addMessage(sessionId, migrationMessage);
+    this.emit('message', sessionId, migrationMessage);
+
+    console.log('[ContextManager] emitted migration suggestion', { sessionId, turnCount });
   }
 
   private normalizeWorkspaceRoot(workspaceRoot: string, cwd: string): string {
@@ -1473,8 +1662,10 @@ export class CoworkRunner extends EventEmitter {
       hasAssistantThinkingOutput: false,
       executionMode: 'local',
       autoApprove: options.autoApprove ?? false,
+      turnCount: 1,
     };
     this.activeSessions.set(sessionId, activeSession);
+    this.store.updateSession(sessionId, { turnCount: 1 });
     if (session.cwd !== sessionCwd) {
       this.store.updateSession(sessionId, { cwd: sessionCwd });
     }
@@ -1497,7 +1688,7 @@ export class CoworkRunner extends EventEmitter {
       // conversation history so the model retains context from prior turns.
       const currentSession = this.store.getSession(sessionId);
       if (currentSession && currentSession.messages.length > 0) {
-        effectivePrompt = this.injectLocalHistoryPrompt(sessionId, prompt, effectivePrompt);
+        effectivePrompt = await this.injectLocalHistoryPrompt(sessionId, prompt, effectivePrompt);
       }
 
       setCoworkProxySessionId(sessionId);
@@ -1518,6 +1709,59 @@ export class CoworkRunner extends EventEmitter {
         imageAttachments: options.imageAttachments,
       });
       return;
+    }
+
+    // Legacy session turn count estimation: if turnCount is 0 but messages exist,
+    // estimate from user message count before incrementing.
+    if (activeSession.turnCount === 0) {
+      const existingSession = this.store.getSession(sessionId);
+      if (existingSession && existingSession.messages.length > 0) {
+        activeSession.turnCount = existingSession.messages.filter(m => m.type === 'user').length;
+      }
+    }
+
+    // Increment turn count and persist
+    activeSession.turnCount += 1;
+    this.store.updateSession(sessionId, { turnCount: activeSession.turnCount });
+
+    // Context compression check: periodically restart SDK with compressed history
+    const ctxConfig = this.store.getContextManagementConfig();
+    if (ctxConfig.enabled) {
+      const shouldCompress =
+        (activeSession.turnCount % ctxConfig.compressionInterval === 0) ||
+        (this.estimateContextSize(sessionId) > ctxConfig.contextSizeThreshold);
+
+      if (shouldCompress && activeSession.turnCount > ctxConfig.compressionInterval) {
+        const beforeChars = this.estimateContextSize(sessionId);
+        console.log('[ContextManager] compression triggered, restarting SDK with compressed history', {
+          sessionId, turnCount: activeSession.turnCount, estimatedContextChars: beforeChars,
+        });
+
+        // Notify renderer that context optimization has started
+        this.emit('contextOptimizing', sessionId, true);
+
+        // Stop current SDK subprocess and restart with compressed history
+        this.activeSessions.delete(sessionId);
+        try { activeSession.abortController.abort(); } catch { /* ignore */ }
+
+        await this.startSession(sessionId, prompt, {
+          skillIds: options.skillIds,
+          systemPrompt: options.systemPrompt,
+          imageAttachments: options.imageAttachments,
+          skipInitialUserMessage: false,
+        });
+
+        // Log compression metrics after restart
+        const afterChars = this.estimateContextSize(sessionId);
+        const compressionRatio = beforeChars > 0 ? ((beforeChars - afterChars) / beforeChars * 100).toFixed(1) : '0';
+        console.log('[ContextManager] compression complete', {
+          sessionId, beforeChars, afterChars, compressionRatio: `${compressionRatio}%`,
+        });
+
+        // Notify renderer that context optimization has finished
+        this.emit('contextOptimizing', sessionId, false);
+        return;
+      }
     }
 
     // Ensure status returns to running for resumed turns on active sessions.
@@ -1604,6 +1848,116 @@ export class CoworkRunner extends EventEmitter {
     this.clearPendingPermissions(sessionId);
     this.store.updateSession(sessionId, { status: 'idle' });
     setCoworkProxySessionId(null);
+  }
+
+  /**
+   * Migrate to a new session with context carried forward.
+   * Creates a new session pre-loaded with summary + memories from the old session.
+   */
+  async migrateSession(oldSessionId: string): Promise<{ newSessionId: string }> {
+    const oldSession = this.store.getSession(oldSessionId);
+    if (!oldSession) {
+      throw new Error(`Session ${oldSessionId} not found`);
+    }
+
+    // Stop the old session if active
+    this.stopSession(oldSessionId);
+
+    // Generate or retrieve session summary
+    const ctxConfig = this.store.getContextManagementConfig();
+    const summary = (await this.getOrGenerateSessionSummary(oldSession, ctxConfig)) || '';
+
+    // Load active user memories
+    const memories = this.store.listUserMemories({ status: 'created', limit: 30 });
+    const memoryTexts = memories.map(m => `- ${m.text}`).join('\n');
+
+    // Extract recent files from tool_use messages in last few turns
+    const recentFiles = this.extractRecentModifiedFiles(oldSession.messages);
+
+    // Find the last user message
+    const lastUserMsg = [...oldSession.messages].reverse().find(m => m.type === 'user');
+
+    // Build migration prompt
+    const migrationParts: string[] = [
+      'You are continuing a task from a previous session. Here is the context:',
+    ];
+
+    if (summary) {
+      migrationParts.push('', '<previous_session_summary>', summary, '</previous_session_summary>');
+    }
+
+    if (memoryTexts) {
+      migrationParts.push('', '<user_memories>', memoryTexts, '</user_memories>');
+    }
+
+    migrationParts.push(
+      '',
+      '<working_state>',
+      `- Working directory: ${oldSession.cwd}`,
+      recentFiles.length > 0 ? `- Last modified files: ${recentFiles.join(', ')}` : '',
+      '</working_state>',
+    );
+
+    if (lastUserMsg) {
+      migrationParts.push(
+        '',
+        'The user would like to continue their work. Their most recent request was:',
+        lastUserMsg.content,
+      );
+    }
+
+    const migrationPrompt = migrationParts.filter(Boolean).join('\n');
+
+    // Create new session with old session's config
+    const newSession = this.store.createSession(
+      `${oldSession.title} (continued)`,
+      oldSession.cwd,
+      oldSession.systemPrompt,
+      oldSession.executionMode,
+      oldSession.activeSkillIds
+    );
+
+    // Link new session to old
+    this.store.updateSession(newSession.id, {
+      migratedFromSessionId: oldSessionId,
+    });
+
+    console.log('[ContextManager] session migration created', {
+      oldSessionId,
+      newSessionId: newSession.id,
+      summaryChars: summary.length,
+      memoriesCount: memories.length,
+    });
+
+    // Start the new session with migration prompt
+    await this.startSession(newSession.id, migrationPrompt, {
+      systemPrompt: oldSession.systemPrompt,
+      skipInitialUserMessage: false,
+    });
+
+    return { newSessionId: newSession.id };
+  }
+
+  /**
+   * Extract recently modified file paths from tool_use messages.
+   */
+  private extractRecentModifiedFiles(messages: CoworkMessage[]): string[] {
+    const files = new Set<string>();
+    // Look at the last 20 messages
+    const recent = messages.slice(-20);
+    for (const msg of recent) {
+      if (msg.type !== 'tool_use') continue;
+      const toolInput = msg.metadata?.toolInput as Record<string, unknown> | undefined;
+      if (toolInput) {
+        for (const key of ['file_path', 'path', 'target_file', 'file', 'filename']) {
+          const val = toolInput[key];
+          if (typeof val === 'string' && val.includes('.')) {
+            files.add(val);
+          }
+        }
+      }
+    }
+    return [...files].slice(0, 10);
   }
 
   onSessionDeleted(sessionId: string): void {
@@ -2399,6 +2753,9 @@ export class CoworkRunner extends EventEmitter {
         this.store.updateSession(sessionId, { status: 'completed' });
         this.applyTurnMemoryUpdatesForSession(sessionId);
         this.emit('complete', sessionId, activeSession.claudeSessionId);
+
+        // Auto-suggest migration when turn count reaches the threshold
+        this.emitMigrationSuggestionIfNeeded(sessionId, activeSession.turnCount);
       }
     } catch (error) {
       // Clean up startup timer if still pending

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1012,11 +1012,25 @@ const bindCoworkRuntimeForwarder = (): void => {
     });
   });
 
-  runtime.on('complete', (sessionId: string, claudeSessionId: string | null) => {
+  runtime.on('contextOptimizing', (sessionId: string, isOptimizing: boolean) => {
     const windows = BrowserWindow.getAllWindows();
     windows.forEach((win) => {
       if (win.isDestroyed()) return;
-      win.webContents.send('cowork:stream:complete', { sessionId, claudeSessionId });
+      win.webContents.send('cowork:stream:contextOptimizing', { sessionId, isOptimizing });
+    });
+  });
+
+  runtime.on('complete', (sessionId: string, claudeSessionId: string | null) => {
+    // Read latest turnCount from store to forward to renderer
+    let turnCount = 0;
+    try {
+      const session = getCoworkStore().getSession(sessionId);
+      turnCount = session?.turnCount ?? 0;
+    } catch { /* ignore */ }
+    const windows = BrowserWindow.getAllWindows();
+    windows.forEach((win) => {
+      if (win.isDestroyed()) return;
+      win.webContents.send('cowork:stream:complete', { sessionId, claudeSessionId, turnCount });
     });
     // If session used a server model, notify renderer to refresh quota
     try {
@@ -2599,6 +2613,19 @@ if (!gotTheLock) {
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to get session',
+      };
+    }
+  });
+
+  ipcMain.handle('cowork:session:migrate', async (_event, oldSessionId: string) => {
+    try {
+      const runner = getCoworkRunner();
+      const result = await runner.migrateSession(oldSessionId);
+      return { success: true, newSessionId: result.newSessionId };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to migrate session',
       };
     }
   });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -151,6 +151,8 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.invoke('cowork:session:rename', options),
     getSession: (sessionId: string) =>
       ipcRenderer.invoke('cowork:session:get', sessionId),
+    migrateSession: (oldSessionId: string) =>
+      ipcRenderer.invoke('cowork:session:migrate', oldSessionId),
     remoteManaged: (sessionId: string) =>
       ipcRenderer.invoke('cowork:session:remoteManaged', sessionId),
     listSessions: () =>
@@ -226,8 +228,13 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.on('cowork:stream:permission', handler);
       return () => ipcRenderer.removeListener('cowork:stream:permission', handler);
     },
-    onStreamComplete: (callback: (data: { sessionId: string; claudeSessionId: string | null }) => void) => {
-      const handler = (_event: any, data: { sessionId: string; claudeSessionId: string | null }) => callback(data);
+    onStreamContextOptimizing: (callback: (data: { sessionId: string; isOptimizing: boolean }) => void) => {
+      const handler = (_event: any, data: { sessionId: string; isOptimizing: boolean }) => callback(data);
+      ipcRenderer.on('cowork:stream:contextOptimizing', handler);
+      return () => ipcRenderer.removeListener('cowork:stream:contextOptimizing', handler);
+    },
+    onStreamComplete: (callback: (data: { sessionId: string; claudeSessionId: string | null; turnCount?: number }) => void) => {
+      const handler = (_event: any, data: { sessionId: string; claudeSessionId: string | null; turnCount?: number }) => callback(data);
       ipcRenderer.on('cowork:stream:complete', handler);
       return () => ipcRenderer.removeListener('cowork:stream:complete', handler);
     },

--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -228,6 +228,34 @@ export class SqliteStore {
       // Column might not exist yet.
     }
 
+    // Migration: Add context management columns to cowork_sessions
+    try {
+      const sessionColsResult = this.db.exec("PRAGMA table_info(cowork_sessions);");
+      const sessionColumns = sessionColsResult[0]?.values.map((row) => row[1]) || [];
+
+      if (!sessionColumns.includes('turn_count')) {
+        this.db.run('ALTER TABLE cowork_sessions ADD COLUMN turn_count INTEGER DEFAULT 0;');
+        this.save();
+      }
+
+      if (!sessionColumns.includes('context_summary')) {
+        this.db.run('ALTER TABLE cowork_sessions ADD COLUMN context_summary TEXT DEFAULT NULL;');
+        this.save();
+      }
+
+      if (!sessionColumns.includes('summary_up_to_turn')) {
+        this.db.run('ALTER TABLE cowork_sessions ADD COLUMN summary_up_to_turn INTEGER DEFAULT 0;');
+        this.save();
+      }
+
+      if (!sessionColumns.includes('migrated_from_session_id')) {
+        this.db.run('ALTER TABLE cowork_sessions ADD COLUMN migrated_from_session_id TEXT DEFAULT NULL;');
+        this.save();
+      }
+    } catch {
+      // Context management columns already exist or migration not needed.
+    }
+
     try {
       this.db.run(`UPDATE cowork_sessions SET execution_mode = 'local' WHERE execution_mode = 'container';`);
       this.db.run(`

--- a/src/renderer/components/cowork/ContextWarningBanner.tsx
+++ b/src/renderer/components/cowork/ContextWarningBanner.tsx
@@ -1,0 +1,101 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { ExclamationTriangleIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { i18nService } from '../../services/i18n';
+import type { RootState } from '../../store';
+
+type BannerTier = 'warning' | 'danger' | 'error';
+
+interface ContextWarningBannerProps {
+  sessionId: string;
+  turnCount: number;
+  hasContextOverflow?: boolean;
+  onMigrateSession?: () => void;
+}
+
+function getBannerTier(turnCount: number, hasContextOverflow: boolean): BannerTier | null {
+  if (hasContextOverflow) return 'error';
+  if (turnCount >= 50) return 'danger';
+  if (turnCount >= 30) return 'warning';
+  return null;
+}
+
+const tierStyles: Record<BannerTier, string> = {
+  warning: 'bg-yellow-50 dark:bg-yellow-900/30 border-yellow-300 dark:border-yellow-700 text-yellow-800 dark:text-yellow-200',
+  danger: 'bg-orange-50 dark:bg-orange-900/30 border-orange-300 dark:border-orange-700 text-orange-800 dark:text-orange-200',
+  error: 'bg-red-50 dark:bg-red-900/30 border-red-300 dark:border-red-700 text-red-800 dark:text-red-200',
+};
+
+const tierIconStyles: Record<BannerTier, string> = {
+  warning: 'text-yellow-500 dark:text-yellow-400',
+  danger: 'text-orange-500 dark:text-orange-400',
+  error: 'text-red-500 dark:text-red-400',
+};
+
+function getMessageKey(tier: BannerTier): string {
+  switch (tier) {
+    case 'warning': return 'cowork.contextWarning.long';
+    case 'danger': return 'cowork.contextWarning.veryLong';
+    case 'error': return 'cowork.contextWarning.overflow';
+  }
+}
+
+// Track which sessions have been dismissed, persisted across re-renders
+const dismissedSessions = new Set<string>();
+
+export default function ContextWarningBanner({ sessionId, turnCount, hasContextOverflow = false, onMigrateSession }: ContextWarningBannerProps) {
+  const [dismissed, setDismissed] = useState(() => dismissedSessions.has(sessionId));
+  const isOptimizingContext = useSelector((state: RootState) => state.cowork.isOptimizingContext);
+
+  // Reset dismissed state when switching to a different session
+  useEffect(() => {
+    setDismissed(dismissedSessions.has(sessionId));
+  }, [sessionId]);
+
+  const tier = getBannerTier(turnCount, hasContextOverflow);
+
+  const handleDismiss = useCallback(() => {
+    dismissedSessions.add(sessionId);
+    setDismissed(true);
+  }, [sessionId]);
+
+  // Show optimization indicator (transient, independent of dismiss state)
+  if (isOptimizingContext) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 text-sm border-b bg-blue-50 dark:bg-blue-900/30 border-blue-300 dark:border-blue-700 text-blue-800 dark:text-blue-200">
+        <svg className="w-4 h-4 flex-shrink-0 animate-spin text-blue-500 dark:text-blue-400" viewBox="0 0 24 24" fill="none">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+        </svg>
+        <span className="flex-1">{i18nService.t('cowork.contextWarning.optimizingContext')}</span>
+      </div>
+    );
+  }
+
+  if (!tier || dismissed) return null;
+
+  const messageKey = getMessageKey(tier);
+  const message = i18nService.t(messageKey).replace('{turnCount}', String(turnCount));
+
+  return (
+    <div className={`flex items-center gap-2 px-3 py-2 text-sm border-b ${tierStyles[tier]}`}>
+      <ExclamationTriangleIcon className={`w-4 h-4 flex-shrink-0 ${tierIconStyles[tier]}`} />
+      <span className="flex-1">{message}</span>
+      {onMigrateSession && (
+        <button
+          onClick={onMigrateSession}
+          className="flex-shrink-0 px-2 py-0.5 text-xs font-medium rounded bg-white/50 dark:bg-black/20 hover:bg-white/80 dark:hover:bg-black/40 transition-colors border border-current/20"
+        >
+          {i18nService.t('cowork.contextWarning.newSessionWithContext')}
+        </button>
+      )}
+      <button
+        onClick={handleDismiss}
+        className="flex-shrink-0 p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+        aria-label={i18nService.t('cowork.contextWarning.dismiss')}
+      >
+        <XMarkIcon className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -23,6 +23,7 @@ import EllipsisHorizontalIcon from '../icons/EllipsisHorizontalIcon';
 import PencilSquareIcon from '../icons/PencilSquareIcon';
 import TrashIcon from '../icons/TrashIcon';
 import WindowTitleBar from '../window/WindowTitleBar';
+import ContextWarningBanner from './ContextWarningBanner';
 import { getCompactFolderName } from '../../utils/path';
 import { getScheduledReminderDisplayText } from '../../../common/scheduledReminderText';
 
@@ -1290,7 +1291,21 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const currentSession = useSelector((state: RootState) => state.cowork.currentSession);
   const isStreaming = useSelector((state: RootState) => state.cowork.isStreaming);
   const remoteManaged = useSelector((state: RootState) => state.cowork.remoteManaged);
+  const coworkConfig = useSelector((state: RootState) => state.cowork.config);
   const skills = useSelector((state: RootState) => state.skill.skills);
+
+  // Detect if session has encountered an inputTooLong / context overflow error
+  const hasContextOverflow = useMemo(() => {
+    if (!currentSession?.messages) return false;
+    const inputTooLongPatterns = [
+      'input too long', 'context length exceeded', 'payload too large',
+      '输入内容过长', '超出模型上下文限制',
+    ];
+    return currentSession.messages.some(m =>
+      m.type === 'system' && inputTooLongPatterns.some(p => m.content.toLowerCase().includes(p))
+    );
+  }, [currentSession?.messages]);
+
   const detailRootRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [shouldAutoScroll, setShouldAutoScroll] = useState(true);
@@ -2028,6 +2043,20 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             </div>
           </div>
         </div>
+      )}
+
+      {/* Context Warning Banner */}
+      {coworkConfig.contextManagementEnabled && (
+        <ContextWarningBanner
+          sessionId={currentSession.id}
+          turnCount={currentSession.turnCount ?? 0}
+          hasContextOverflow={hasContextOverflow}
+          onMigrateSession={() => {
+            if (currentSession?.id) {
+              coworkService.migrateToNewSession(currentSession.id);
+            }
+          }}
+        />
       )}
 
       {/* Messages */}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -204,6 +204,10 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         systemPrompt: '',
         executionMode: config.executionMode || 'local',
         activeSkillIds: sessionSkillIds,
+        turnCount: 0,
+        contextSummary: null,
+        summaryUpToTurn: 0,
+        migratedFromSessionId: null,
         messages: [
           {
             id: `msg-${now}`,

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -9,6 +9,7 @@ import {
   addMessage,
   updateMessageContent,
   setStreaming,
+  setOptimizingContext,
   setRemoteManaged,
   updateSessionPinned,
   updateSessionTitle,
@@ -130,9 +131,15 @@ class CoworkService {
     });
     this.streamListenerCleanups.push(permissionCleanup);
 
+    // Context optimizing listener
+    const contextOptimizingCleanup = cowork.onStreamContextOptimizing(({ sessionId, isOptimizing }) => {
+      store.dispatch(setOptimizingContext({ sessionId, isOptimizing }));
+    });
+    this.streamListenerCleanups.push(contextOptimizingCleanup);
+
     // Complete listener
-    const completeCleanup = cowork.onStreamComplete(({ sessionId }) => {
-      store.dispatch(updateSessionStatus({ sessionId, status: 'completed' }));
+    const completeCleanup = cowork.onStreamComplete(({ sessionId, turnCount }) => {
+      store.dispatch(updateSessionStatus({ sessionId, status: 'completed', turnCount }));
     });
     this.streamListenerCleanups.push(completeCleanup);
 
@@ -361,6 +368,22 @@ class CoworkService {
 
     console.error('Failed to batch delete sessions:', result.error);
     return false;
+  }
+
+  async migrateToNewSession(oldSessionId: string): Promise<string | null> {
+    const cowork = window.electron?.cowork;
+    if (!cowork?.migrateSession) return null;
+
+    const result = await cowork.migrateSession(oldSessionId);
+    if (result.success && result.newSessionId) {
+      // Reload session list and switch to the new session
+      await this.loadSessions();
+      await this.loadSession(result.newSessionId);
+      return result.newSessionId;
+    }
+
+    console.error('Failed to migrate session:', result.error);
+    return null;
   }
 
   async setSessionPinned(sessionId: string, pinned: boolean): Promise<boolean> {

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1109,6 +1109,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     privacyDialogLinkText: '网易有道LobsterAI服务协议',
     privacyDialogAccept: '我已阅读并同意',
     privacyDialogReject: '拒绝',
+
+    // 上下文管理
+    'cowork.contextWarning.long': '当前会话已达 {turnCount} 轮，较早的上下文可能被AI忽略，建议注意质量变化。',
+    'cowork.contextWarning.veryLong': '当前会话已达 {turnCount} 轮，建议开启新会话以获得最佳效果。',
+    'cowork.contextWarning.overflow': '上下文长度已超出限制，请开启新会话继续工作。',
+    'cowork.contextWarning.newSessionWithContext': '携带上下文开启新会话',
+    'cowork.contextWarning.optimizingContext': '正在优化上下文...',
+    'cowork.contextWarning.dismiss': '关闭',
   },
   en: {
     // Common
@@ -2212,6 +2220,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     privacyDialogLinkText: 'NetEase Youdao LobsterAI Terms of Service',
     privacyDialogAccept: 'I have read and agree',
     privacyDialogReject: 'Decline',
+
+    // Context Management
+    'cowork.contextWarning.long': 'This session has reached {turnCount} turns. AI quality may degrade for earlier context.',
+    'cowork.contextWarning.veryLong': 'This session has reached {turnCount} turns. Consider starting a new session for best results.',
+    'cowork.contextWarning.overflow': 'Context limit reached. Please start a new session.',
+    'cowork.contextWarning.newSessionWithContext': 'New Session with Context',
+    'cowork.contextWarning.optimizingContext': 'Optimizing context...',
+    'cowork.contextWarning.dismiss': 'Dismiss',
   }
 };
 

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -16,6 +16,7 @@ interface CoworkState {
   unreadSessionIds: string[];
   isCoworkActive: boolean;
   isStreaming: boolean;
+  isOptimizingContext: boolean;
   remoteManaged: boolean;
   pendingPermissions: CoworkPermissionRequest[];
   config: CoworkConfig;
@@ -29,6 +30,7 @@ const initialState: CoworkState = {
   unreadSessionIds: [],
   isCoworkActive: false,
   isStreaming: false,
+  isOptimizingContext: false,
   remoteManaged: false,
   pendingPermissions: [],
   config: {
@@ -41,6 +43,7 @@ const initialState: CoworkState = {
     memoryLlmJudgeEnabled: false,
     memoryGuardLevel: 'strict',
     memoryUserMemoriesMaxItems: 12,
+    contextManagementEnabled: true,
   },
 };
 
@@ -167,8 +170,8 @@ const coworkSlice = createSlice({
       markSessionRead(state, action.payload.id);
     },
 
-    updateSessionStatus(state, action: PayloadAction<{ sessionId: string; status: CoworkSessionStatus }>) {
-      const { sessionId, status } = action.payload;
+    updateSessionStatus(state, action: PayloadAction<{ sessionId: string; status: CoworkSessionStatus; turnCount?: number }>) {
+      const { sessionId, status, turnCount } = action.payload;
 
       // Update in sessions list
       const sessionIndex = state.sessions.findIndex(s => s.id === sessionId);
@@ -183,6 +186,10 @@ const coworkSlice = createSlice({
         state.currentSession.updatedAt = Date.now();
         // Streaming state is tied to the currently opened session only
         state.isStreaming = status === 'running';
+        // Sync turnCount from main process so context warning banner can react
+        if (turnCount !== undefined) {
+          state.currentSession.turnCount = turnCount;
+        }
       }
     },
 
@@ -248,6 +255,13 @@ const coworkSlice = createSlice({
 
     setStreaming(state, action: PayloadAction<boolean>) {
       state.isStreaming = action.payload;
+    },
+
+    setOptimizingContext(state, action: PayloadAction<{ sessionId: string; isOptimizing: boolean }>) {
+      const { sessionId, isOptimizing } = action.payload;
+      if (state.currentSession?.id === sessionId) {
+        state.isOptimizingContext = isOptimizing;
+      }
     },
 
     setRemoteManaged(state, action: PayloadAction<boolean>) {
@@ -331,6 +345,7 @@ export const {
   addMessage,
   updateMessageContent,
   setStreaming,
+  setOptimizingContext,
   setRemoteManaged,
   updateSessionPinned,
   updateSessionTitle,

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -53,6 +53,10 @@ export interface CoworkSession {
   messages: CoworkMessage[];
   createdAt: number;
   updatedAt: number;
+  turnCount: number;
+  contextSummary: string | null;
+  summaryUpToTurn: number;
+  migratedFromSessionId: string | null;
 }
 
 // Cowork configuration
@@ -66,6 +70,7 @@ export interface CoworkConfig {
   memoryLlmJudgeEnabled: boolean;
   memoryGuardLevel: 'strict' | 'standard' | 'relaxed';
   memoryUserMemoriesMaxItems: number;
+  contextManagementEnabled: boolean;
 }
 
 export type CoworkConfigUpdate = Partial<Pick<

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -28,6 +28,10 @@ interface CoworkSession {
   messages: CoworkMessage[];
   createdAt: number;
   updatedAt: number;
+  turnCount: number;
+  contextSummary: string | null;
+  summaryUpToTurn: number;
+  migratedFromSessionId: string | null;
 }
 
 interface CoworkMessage {
@@ -57,6 +61,7 @@ interface CoworkConfig {
   memoryLlmJudgeEnabled: boolean;
   memoryGuardLevel: 'strict' | 'standard' | 'relaxed';
   memoryUserMemoriesMaxItems: number;
+  contextManagementEnabled: boolean;
 }
 
 type CoworkConfigUpdate = Partial<Pick<
@@ -318,6 +323,7 @@ interface IElectronAPI {
     setSessionPinned: (options: { sessionId: string; pinned: boolean }) => Promise<{ success: boolean; error?: string }>;
     renameSession: (options: { sessionId: string; title: string }) => Promise<{ success: boolean; error?: string }>;
     getSession: (sessionId: string) => Promise<{ success: boolean; session?: CoworkSession; error?: string }>;
+    migrateSession: (oldSessionId: string) => Promise<{ success: boolean; newSessionId?: string; error?: string }>;
     remoteManaged: (sessionId: string) => Promise<{ success: boolean; remoteManaged: boolean; error?: string }>;
     listSessions: () => Promise<{ success: boolean; sessions?: CoworkSessionSummary[]; error?: string }>;
     exportResultImage: (options: {
@@ -353,7 +359,8 @@ interface IElectronAPI {
     onStreamMessage: (callback: (data: { sessionId: string; message: CoworkMessage }) => void) => () => void;
     onStreamMessageUpdate: (callback: (data: { sessionId: string; messageId: string; content: string }) => void) => () => void;
     onStreamPermission: (callback: (data: { sessionId: string; request: CoworkPermissionRequest }) => void) => () => void;
-    onStreamComplete: (callback: (data: { sessionId: string; claudeSessionId: string | null }) => void) => () => void;
+    onStreamContextOptimizing: (callback: (data: { sessionId: string; isOptimizing: boolean }) => void) => () => void;
+    onStreamComplete: (callback: (data: { sessionId: string; claudeSessionId: string | null; turnCount?: number }) => void) => () => void;
     onStreamError: (callback: (data: { sessionId: string; error: string }) => void) => () => void;
     onSessionsChanged: (callback: () => void) => () => void;
   };


### PR DESCRIPTION
## 背景

OpenClaw 运行时在长会话中存在天然的 **Lost in the Middle** 缺陷——随着对话轮次增长，中间位置的上下文信息（早期的工具调用结果、文件修改记录、关键决策）会被模型逐渐"遗忘"，导致 AI 回复质量显著下降、重复已完成的操作、或丢失重要的项目上下文。这是 LLM 长上下文窗口的已知问题（参见 [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)），而 OpenClaw 的会话压缩机制进一步加剧了这个问题——压缩时对中间轮次的截断是无差别的，关键信息和冗余信息被同等对待。

本 PR 通过主动的上下文管理策略来缓解这一缺陷：将重要信息提炼为摘要放在上下文头部（模型注意力最强的位置），对中间轮次做智能分级压缩，并在会话过长时引导用户迁移到新会话。

## 主要变更

### 核心功能
- **轮次追踪 (P0)**：每次用户发送消息时计数并持久化到 SQLite。历史会话无轮次数据时，根据用户消息数量自动估算。
- **上下文警告横幅 (P0)**：分层 UI 提示——30 轮黄色、50 轮橙色、上下文溢出红色。支持按会话独立关闭，切换会话不会互相影响。包含"携带上下文新建会话"按钮。
- **渐进式压缩 (P1)**：基于轮次年龄的 tool result 智能分级截断——最近 5 轮保留全文（模型仍需引用）、6-15 轮前截断到 8K（保留关键结果）、16 轮以上截断到 2K（仅保留摘要）。相比 OpenClaw 原生的无差别压缩，有效保护了近期上下文的完整性。
- **自动摘要 (P2)**：基于规则的逐轮摘要生成器，将关键信息（用户意图、修改文件、工具调用、决策结果）提炼后以 `<session_summary>` 块**注入到上下文头部**——利用 LLM 对首尾位置注意力最强的特性，确保关键上下文不会被 Lost in the Middle。支持可选的 LLM 辅助精炼（`summaryUseLlm` 开关），失败自动回退。
- **会话迁移 (P3)**：当会话过长（默认 50 轮）时，自动建议迁移到新会话，携带摘要、用户记忆和工作状态。本质上是通过"重置中间上下文 + 保留头部摘要"来根治 Lost in the Middle。

### UI 与 IPC
- 新增 `ContextWarningBanner` 组件，支持 dismiss 按会话隔离、上下文溢出检测、压缩重启时显示"正在优化上下文..."旋转动画
- Banner 受 `contextManagement.enabled` 配置控制，关闭时完全隐藏
- 新增 `cowork:stream:contextOptimizing` IPC 事件用于压缩开始/结束通知
- `contextManagementEnabled` 加入 `CoworkConfig`，透传到渲染进程

### 数据库
- `cowork_sessions` 表新增 4 列：`turn_count`、`context_summary`、`summary_up_to_turn`、`migrated_from_session_id`
- `cowork_config` 表新增 `contextManagement.*` 系列配置键，含合理默认值

### OpenClaw 集成
- OpenClaw 适配器在轮次超阈值时自动注入缓存摘要到上下文头部
- `BRIDGE_MAX_MESSAGES` 和 `BRIDGE_MAX_MESSAGE_CHARS` 现可通过配置调整

### 测试
- `coworkContextSummary.test.ts` — 10 个测试覆盖规则摘要生成
- `coworkContextManagement.test.ts` — 19 个测试覆盖轮次分配、上下文大小估算、压缩字符限制

## 关键文件

| 模块 | 文件 |
|------|------|
| 核心逻辑 | `coworkRunner.ts`、`coworkContextSummary.ts`、`coworkStore.ts` |
| 数据库 | `sqliteStore.ts`、`coworkStore.ts` |
| UI | `ContextWarningBanner.tsx`、`CoworkSessionDetail.tsx`、`i18n.ts` |
| IPC 链路 | `types.ts`、`coworkEngineRouter.ts`、`main.ts`、`preload.ts`、`electron.d.ts` |
| 状态管理 | `coworkSlice.ts`、`cowork.ts`（类型） |
| 测试 | `coworkContextSummary.test.ts`、`coworkContextManagement.test.ts` |
| 设计文档 | `docs/proposals/context-management.md` |

## 测试情况
- `npm test` — 29 个新测试全部通过
- TypeScript：renderer 和 electron 两套 tsconfig 均 `tsc --noEmit` 无错误
- 手动验证待完成：9.4（banner 展示）和 9.5（压缩指示器）