### PR TITLE
fix(sqlite): add transaction protection for memory deletion operations

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -1280,26 +1280,36 @@ export class CoworkStore {
 
     const now = Date.now();
     let deleted = 0;
-    for (const row of rows) {
-      if (!shouldAutoDeleteMemoryText(row.text)) {
-        continue;
+    
+    // Use transaction to ensure data consistency
+    this.db.run('BEGIN TRANSACTION;');
+    try {
+      for (const row of rows) {
+        if (!shouldAutoDeleteMemoryText(row.text)) {
+          continue;
+        }
+        this.db.run(`
+          UPDATE user_memories
+          SET status = 'deleted', updated_at = ?
+          WHERE id = ?
+        `, [now, row.id]);
+        this.db.run(`
+          UPDATE user_memory_sources
+          SET is_active = 0
+          WHERE memory_id = ?
+        `, [row.id]);
+        deleted += 1;
       }
-      this.db.run(`
-        UPDATE user_memories
-        SET status = 'deleted', updated_at = ?
-        WHERE id = ?
-      `, [now, row.id]);
-      this.db.run(`
-        UPDATE user_memory_sources
-        SET is_active = 0
-        WHERE memory_id = ?
-      `, [row.id]);
-      deleted += 1;
+      this.db.run('COMMIT;');
+      
+      if (deleted > 0) {
+        this.saveDb();
+      }
+    } catch (error) {
+      this.db.run('ROLLBACK;');
+      throw error;
     }
-
-    if (deleted > 0) {
-      this.saveDb();
-    }
+    
     return deleted;
   }
 


### PR DESCRIPTION
[问题]
autoDeleteNonPersonalMemories() 方法存在严重的事务不一致问题：
- 循环中多次执行 SQL 操作，但没有事务保护
- 如果中间某个操作失败，会导致部分记忆被标记删除但对应的源记录未更新
- 数据库状态不一致，可能导致孤儿数据和后续查询异常

[根因]
缺少事务边界保护，多个相关的数据库操作没有原子性保证：
- user_memories 表的 status 更新和 user_memory_sources 表的 is_active 更新分离
- 循环中任意一次操作失败都会导致数据不一致状态
- 没有错误回滚机制，失败后无法恢复到操作前的一致状态

[修复]
为批量删除操作添加完整的事务保护：
- 使用 BEGIN TRANSACTION 包装所有相关操作
- 确保 user_memories 和 user_memory_sources 的更新具有原子性
- 添加 COMMIT 确认成功完成的操作
- 添加 ROLLBACK 在异常时恢复数据一致性
- 只在事务成功提交后调用 saveDb() 持久化
Closes #867