### PR TITLE
fix(security): 限制 shell.openExternal 的 URL 协议白名单，防止远程代码执行

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -352,6 +352,12 @@ const TITLEBAR_COLORS = {
   light: { color: '#F3F4F6', symbolColor: '#1A1D23' },
 } as const;
 
+// Allowlist of URL protocols permitted for shell.openExternal().
+// Blocks dangerous schemes (file://, smb://, ms-msdt://, vscode://, etc.) that
+// could trigger local program execution or credential leakage.
+// See: https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-shellopenexternal-with-untrusted-content
+const ALLOWED_EXTERNAL_PROTOCOLS = new Set(['https:', 'http:', 'mailto:']);
+
 const safeDecodeURIComponent = (value: string): string => {
   try {
     return decodeURIComponent(value);
@@ -1899,6 +1905,11 @@ if (!gotTheLock) {
     try {
       const baseUrl = loginUrl || `${getServerApiBaseUrl()}/login`;
       const finalUrl = `${baseUrl}?source=electron`;
+      const parsed = new URL(finalUrl);
+      if (!ALLOWED_EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
+        console.warn(`[Auth] blocked login URL with disallowed protocol: ${parsed.protocol}`);
+        return { success: false, error: `Protocol not allowed: ${parsed.protocol}` };
+      }
       await shell.openExternal(finalUrl);
       return { success: true };
     } catch (error) {
@@ -3657,6 +3668,11 @@ if (!gotTheLock) {
 
   ipcMain.handle('shell:openExternal', async (_event, url: string) => {
     try {
+      const parsed = new URL(url);
+      if (!ALLOWED_EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
+        console.warn(`[shell:openExternal] blocked disallowed protocol: ${parsed.protocol}`);
+        return { success: false, error: `Protocol not allowed: ${parsed.protocol}` };
+      }
       await shell.openExternal(url);
       return { success: true };
     } catch (error) {
@@ -3965,7 +3981,16 @@ if (!gotTheLock) {
           },
         };
       }
-      shell.openExternal(url);
+      try {
+        const parsed = new URL(url);
+        if (ALLOWED_EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
+          shell.openExternal(url);
+        } else {
+          console.warn(`[WindowOpenHandler] blocked disallowed protocol: ${parsed.protocol}`);
+        }
+      } catch {
+        console.warn(`[WindowOpenHandler] blocked invalid URL: ${url}`);
+      }
       return { action: 'deny' };
     });
 


### PR DESCRIPTION
## 概述

对主进程中所有 `shell.openExternal()` 调用点添加 URL 协议白名单校验，仅允许 `https:`、`http:`、`mailto:` 协议，阻止 `file://`、`smb://`、`ms-msdt://`、`vscode://` 等危险协议被传递给操作系统执行。

## 安全风险说明

### 问题背景

`shell.openExternal(url)` 的底层行为是将 URL 交给操作系统的默认处理程序（macOS `open`、Windows `ShellExecuteW`、Linux `xdg-open`）。当前代码对传入的 `url` 参数 **没有做任何协议过滤**，意味着不仅是 `https://` 链接，任何 URI scheme 都会被操作系统执行。

**Electron 官方安全文档明确警告了这一风险：**
> [Do not use shell.openExternal with untrusted content](https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-shellopenexternal-with-untrusted-content)

### 攻击向量

| 危险协议 | 操作系统行为 | 风险等级 |
|---------|------------|---------|
| `file:///Applications/Calculator.app` | macOS 启动本地任意应用 | **高** |
| `smb://attacker.com/share` | Windows 触发 SMB 连接，泄露 NTLM hash | **高** |
| `ms-msdt:/id PCWDiagnostic /skip force /param ...` | Windows MSDT 协议，可导致远程代码执行 (CVE-2022-30190 Follina) | **严重** |
| `ms-officecmd:...` | 启动 Office 并执行宏 | **高** |
| `vscode://vscode.github-authentication/...` | 打开 VS Code 执行操作 | **中** |

### 实际攻击路径

最现实的触发方式是通过 **AI 回复中的 Markdown 链接**（`MarkdownContent.tsx` 组件）。如果 AI 回复被 prompt injection 注入恶意内容：

```markdown
请点击 [这里](ms-msdt:/id PCWDiagnostic ...) 查看详情
```

渲染进程的 `isExternalHref()` 函数将其判定为"外部链接" → 用户点击后通过 `shell:openExternal` IPC 发送到主进程 → 主进程不做检查直接交给操作系统 → **触发本地代码执行**。

### 受影响的调用点（本 PR 全部修复）

1. **`shell:openExternal` IPC handler** (`main.ts`) — 渲染进程通过 preload 暴露的 API 调用，是最主要的攻击入口
2. **`auth:login` IPC handler** (`main.ts`) — 接受渲染进程传入的可选 `loginUrl` 参数，可被用于钓鱼攻击
3. **`setWindowOpenHandler` fallback** (`main.ts`) — 处理 `window.open()` 请求中非企微 URL 的兜底逻辑

## 修改内容

- 在模块顶层定义 `ALLOWED_EXTERNAL_PROTOCOLS` 白名单常量（`https:`、`http:`、`mailto:`）
- 在上述 3 个调用点使用 `new URL()` 解析后校验协议，不在白名单内的一律阻止并记录警告日志
- 无效 URL 格式也会被 `new URL()` 的异常捕获阻止

## 影响范围

- **零功能影响**：项目中所有现有调用传入的都是 `https://` 链接（登录页、用户手册、服务条款、Skill 来源、OAuth 验证等）
- 编译通过：`npm run compile:electron` 无错误

## 参考文档

- [Electron Security — Do not use shell.openExternal with untrusted content](https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-shellopenexternal-with-untrusted-content)
- [CVE-2022-30190 (Follina) — MSDT Remote Code Execution](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-30190)