### PR TITLE
fix(cowork): auto-scroll to bottom when user sends message after scrolling up

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1872,6 +1872,18 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     }
   }, [currentSession?.messages?.length, lastMessageContent, isStreaming, shouldAutoScroll, turns.length]);
 
+  // Wrap onContinue to reset auto-scroll when user sends a new message
+  const handleContinue = useCallback(
+    (prompt: string, skillPrompt?: string, imageAttachments?: CoworkImageAttachment[]) => {
+      setShouldAutoScroll(true);
+      const container = scrollContainerRef.current;
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+      }
+      return onContinue(prompt, skillPrompt, imageAttachments);
+    },
+    [onContinue]
+  );
 
   if (!currentSession) {
     return null;
@@ -2202,7 +2214,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       <div className="p-4 shrink-0">
         <div className="max-w-3xl mx-auto">
           <CoworkPromptInput
-            onSubmit={onContinue}
+            onSubmit={handleContinue}
             onStop={onStop}
             isStreaming={isStreaming}
             placeholder={i18nService.t(remoteManaged ? 'coworkRemoteManagedPlaceholder' : 'coworkContinuePlaceholder')}


### PR DESCRIPTION
## Summary

- Fix chat view not auto-scrolling to bottom when user sends a new message after scrolling up to review history
- User's new message and AI streaming response were invisible until manually scrolling down

## Problem

When a user scrolls up in a cowork session to review previous messages (more than 120px from bottom), `shouldAutoScroll` is set to `false`. Sending a new message via `onContinue` does not reset this flag, so the auto-scroll effect skips scrolling — the view stays at the current position.

## Solution

Wrap the `onContinue` callback in `CoworkSessionDetail` with `handleContinue`, which:
1. Resets `shouldAutoScroll` to `true`
2. Immediately scrolls the container to bottom
3. Forwards the call to the original `onContinue`

This ensures the view always follows new content after an explicit user send action, while preserving the existing behavior of not force-scrolling during passive streaming when the user is reviewing history.

## Changes

- `src/renderer/components/cowork/CoworkSessionDetail.tsx`
  - Added `handleContinue` wrapper using `useCallback`
  - Changed `CoworkPromptInput`'s `onSubmit` from `onContinue` to `handleContinue`

## Testing

- Open a cowork session with existing message history
- Scroll up to review older messages (past the 120px threshold)
- Send a new message
- **Expected**: View scrolls to bottom, new message and AI response are visible
- **Before fix**: View stays at scroll position, new content is hidden