### PR TITLE
fix(cowork): capture getRowsModified before subsequent SQL in deleteU…

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -1291,13 +1291,14 @@ export class CoworkStore {
       SET status = 'deleted', updated_at = ?
       WHERE id = ?
     `, [now, id]);
+    const memoryModified = (this.db.getRowsModified?.() || 0) > 0;
     this.db.run(`
       UPDATE user_memory_sources
       SET is_active = 0
       WHERE memory_id = ?
     `, [id]);
     this.saveDb();
-    return (this.db.getRowsModified?.() || 0) > 0;
+    return memoryModified;
   }
 
   getUserMemoryStats(): CoworkUserMemoryStats {


### PR DESCRIPTION
…serMemory

getRowsModified() returns the count from the most recent SQL statement. In deleteUserMemory(), the second UPDATE on user_memory_sources was overwriting the result of the first UPDATE on user_memories, causing the method to report incorrect deletion status.

Capture the modification count immediately after the target UPDATE so the return value correctly reflects whether the memory was found and marked as deleted.