### PR TITLE
fix(cowork): prevent duplicate error messages on continueSession failure

### DIFF
--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -292,23 +292,19 @@ class CoworkService {
             message: {
               id: `error-${Date.now()}`,
               type: 'system',
-              content: i18nService.t('coworkErrorSessionContinueFailed').replace('{error}', result.error),
+              content: classifyError(result.error),
               timestamp: Date.now(),
             },
           }));
         }
-      }
-      // Show a user-visible error message in the session
-      if (result.error) {
-        const errorContent = result.code === 'ENGINE_NOT_READY'
-          ? i18nService.t('coworkErrorEngineNotReady')
-          : classifyError(result.error);
+      } else if (result.error) {
+        // ENGINE_NOT_READY: show a specific engine-not-ready message
         store.dispatch(addMessage({
           sessionId: options.sessionId,
           message: {
             id: `error-${Date.now()}`,
             type: 'system',
-            content: errorContent,
+            content: i18nService.t('coworkErrorEngineNotReady'),
             timestamp: Date.now(),
           },
         }));


### PR DESCRIPTION
When continueSession() returned an error with a code other than ENGINE_NOT_READY, two non-exclusive if-blocks both dispatched an error message to the session — one with the raw error text and another with the classified error. This caused the user to see two error messages for a single failure.

Restructure the logic into if/else-if so that:
- Non-ENGINE_NOT_READY errors show a single classifyError() message
- ENGINE_NOT_READY errors show the dedicated engine-not-ready message