### PR TITLE
fix(sqlite): 启用外键约束，修复删除 session 不级联删除 messages 导致数据库膨胀

### DIFF
--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -68,6 +68,8 @@ export class SqliteStore {
   }
 
   private initializeTables(basePath: string) {
+    this.db.run('PRAGMA foreign_keys = ON;');
+
     this.db.run(`
       CREATE TABLE IF NOT EXISTS kv (
         key TEXT PRIMARY KEY,
@@ -241,6 +243,11 @@ export class SqliteStore {
 
     this.migrateLegacyMemoryFileToUserMemories();
     this.migrateFromElectronStore(basePath);
+
+    // Clean up orphaned rows left by prior runs where foreign keys were not enforced.
+    this.db.run(`DELETE FROM cowork_messages WHERE session_id NOT IN (SELECT id FROM cowork_sessions)`);
+    this.db.run(`DELETE FROM user_memory_sources WHERE memory_id NOT IN (SELECT id FROM user_memories)`);
+
     this.save();
   }
 


### PR DESCRIPTION
## Summary

修复 sql.js 默认不启用外键约束导致 `ON DELETE CASCADE` 失效的问题。

Closes #879

## 问题分析

sql.js（基于 WebAssembly 的 SQLite）遵循 SQLite 默认行为：**外键约束默认关闭**（`PRAGMA foreign_keys = OFF`）。建表语句中声明的 `ON DELETE CASCADE` 完全无效：

```sql
-- cowork_messages 表
FOREIGN KEY (session_id) REFERENCES cowork_sessions(id) ON DELETE CASCADE  -- 不生效

-- user_memory_sources 表
FOREIGN KEY (memory_id) REFERENCES user_memories(id) ON DELETE CASCADE  -- 不生效
```

**后果**：删除 session 时关联的 messages 不会被删除，删除 memory 时关联的 sources 不会被删除。孤儿行永久残留，数据库只增不减。由于 `save()` 每次序列化整个数据库写盘，孤儿数据越多写盘耗时越长。

这不是边缘情况——**每次 session 删除都会产生孤儿数据**。

## 修复内容

1. **启用外键约束**：在 `initializeTables()` 最前面执行 `PRAGMA foreign_keys = ON`，确保后续所有 `ON DELETE CASCADE` 生效
2. **清理历史孤儿数据**：一次性删除已有的孤儿 `cowork_messages` 和 `user_memory_sources` 行

## 改动文件

- `src/main/sqliteStore.ts` — 2 处改动（+7 行）

## 参考

- [SQLite Foreign Key Support](https://www.sqlite.org/foreignkeys.html): *"Foreign key constraints are disabled by default (for backwards compatibility), so must be enabled separately for each database connection."*

## Test Plan

- [x] `npx tsc --noEmit -p electron-tsconfig.json` 类型检查通过
- [x] `npm test` 24 个测试全部通过
- [ ] 手动验证：创建会话 → 发送消息 → 删除会话 → 检查 messages 表确认级联删除生效