### PR TITLE
fix(popo): 修复 POPO 消息中换行显示为原始 <br /> 文本的问题

### DIFF
--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -940,7 +940,11 @@ export class IMCoworkHandler extends EventEmitter {
    * Appends media metadata to content so AI can access the files
    */
   private formatMessageWithMedia(message: IMMessage): string {
-    let content = message.content;
+    // POPO's moltbot-popo plugin converts newlines to HTML break tags (<br />),
+    // causing raw <br /> to appear in the AI conversation instead of actual line breaks.
+    let content = message.platform === 'popo'
+      ? message.content.replace(/<br\s*\/?>/gi, '\n')
+      : message.content;
 
     if (message.attachments && message.attachments.length > 0) {
       const mediaInfo = message.attachments.map((att: IMMediaAttachment) => {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -2791,7 +2791,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         && this.channelSessionSync.isChannelSessionKey(turn.sessionKey);
       if (isChannel) {
         const latestOnly = this.reCreatedChannelSessionIds.has(sessionId);
-        this.syncChannelUserMessages(sessionId, history.messages, latestOnly, turn.sessionKey.includes(':discord:'), turn.sessionKey.includes(':qqbot:'));
+                this.syncChannelUserMessages(sessionId, history.messages, latestOnly, turn.sessionKey.includes(':discord:'), turn.sessionKey.includes(':qqbot:'), turn.sessionKey.includes(':moltbot-popo:'));
       }
 
       // Stale turn protection: only skip assistant text alignment (which could overwrite
@@ -2896,6 +2896,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     historyMessages: unknown[],
     isDiscord: boolean,
     isQQ: boolean,
+    isPopo: boolean = false,
   ): ChannelHistorySyncEntry[] {
     const historyEntries: ChannelHistorySyncEntry[] = [];
     for (const message of historyMessages) {
@@ -2903,6 +2904,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       const role = typeof message.role === 'string' ? message.role.trim().toLowerCase() : '';
       if (role !== 'user' && role !== 'assistant') continue;
       let text = extractMessageText(message).trim();
+      // POPO's moltbot-popo plugin converts newlines to HTML break tags (<br />),
+      // causing raw <br /> to appear in the UI and AI conversation.
+      if (isPopo) text = text.replace(/<br\s*\/?>/gi, '\n');
       if (isDiscord) text = stripDiscordMentions(text);
       if (isQQ && role === 'user') text = stripQQBotSystemPrompt(text);
       if (text) {
@@ -3046,8 +3050,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
    * because OpenClaw's `chat.history` window can slide due to byte limits well before
    * the requested message count is reached.
    */
-  private syncChannelUserMessages(sessionId: string, historyMessages: unknown[], latestOnly = false, isDiscord = false, isQQ = false): void {
-    const historyEntries = this.collectChannelHistoryEntries(historyMessages, isDiscord, isQQ);
+  private syncChannelUserMessages(sessionId: string, historyMessages: unknown[], latestOnly = false, isDiscord = false, isQQ = false, isPopo = false): void {
+    const historyEntries = this.collectChannelHistoryEntries(historyMessages, isDiscord, isQQ, isPopo);
 
     const cursor = this.channelSyncCursor.get(sessionId) ?? 0;
 
@@ -3393,7 +3397,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           this.markGatewayHistoryWindowConsumed(sessionId, history.messages);
           const latestOnly = this.reCreatedChannelSessionIds.has(sessionId);
           const beforeCount = this.getUserMessageCount(sessionId);
-          this.syncChannelUserMessages(sessionId, history.messages, latestOnly, sessionKey.includes(':discord:'), sessionKey.includes(':qqbot:'));
+                  this.syncChannelUserMessages(sessionId, history.messages, latestOnly, sessionKey.includes(':discord:'), sessionKey.includes(':qqbot:'), sessionKey.includes(':moltbot-popo:'));
           const afterCount = this.getUserMessageCount(sessionId);
           const newUserMessages = afterCount - beforeCount;
           console.log('[Debug:prefetch] synced user messages:', newUserMessages, '(before:', beforeCount, 'after:', afterCount, ')');


### PR DESCRIPTION
## 概述
修复 POPO 渠道发送的带换行消息在 LobsterAI 客户端中显示为原始 `<br />` 文本而非正常换行的问题。其他 IM 渠道（飞书、微信等）不受影响。

## 根因分析
POPO 的 moltbot-popo 插件在传递消息时，会将用户输入中的换行符（`\n`）转换为 HTML 换行标签（`<br />`）。LobsterAI 接收后直接存储和渲染，导致：
1. 客户端 Markdown 渲染器将 `<br />` 当纯文本显示
2. AI 收到含 `<br />` 的用户消息，可能在回复中复述这些标签

## 解决方案
在消息进入系统时，仅针对 POPO 平台将 HTML 换行标签还原为 `\n`，覆盖两条链路：

| 文件 | 处理链路 | 平台判断 |
|------|---------|---------|
| `openclawRuntimeAdapter.ts` | Channel 消息同步入库 → 客户端显示 | `sessionKey.includes(':moltbot-popo:')` |
| `imCoworkHandler.ts` | 消息格式化 → 传给 AI | `message.platform === 'popo'` |

## 影响范围
- 仅影响 POPO 渠道的消息接收处理
- 飞书、微信、钉钉、Discord、Telegram、QQ 等其他渠道完全不受影响
- 匹配方式与现有 Discord（`:discord:`）、QQ（`:qqbot:`）保持一致

龙虾客户端显示：
<img width="790" height="476" alt="image" src="https://github.com/user-attachments/assets/346aebf3-334d-4f11-9e45-429e6fa1b8c0" />

POPO发送端显示：
<img width="213" height="174" alt="image" src="https://github.com/user-attachments/assets/10b976e6-a7b1-4cf4-9dca-ccb8a23d49f9" />

