### PR TITLE
fix(security): validate URL protocol in shell:openExternal IPC handler

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3657,6 +3657,19 @@ if (!gotTheLock) {
 
   ipcMain.handle('shell:openExternal', async (_event, url: string) => {
     try {
+      if (typeof url !== 'string' || !url.trim()) {
+        return { success: false, error: 'Missing URL' };
+      }
+      const ALLOWED_PROTOCOLS = ['https:', 'http:', 'mailto:'];
+      let parsed: URL;
+      try {
+        parsed = new URL(url);
+      } catch {
+        return { success: false, error: 'Invalid URL' };
+      }
+      if (!ALLOWED_PROTOCOLS.includes(parsed.protocol)) {
+        return { success: false, error: `Blocked protocol: ${parsed.protocol}` };
+      }
       await shell.openExternal(url);
       return { success: true };
     } catch (error) {


### PR DESCRIPTION
## Summary
- Add URL protocol validation to `shell:openExternal` IPC handler to only allow `https:`, `http:`, and `mailto:` protocols
- Reject `file://`, `javascript:`, and custom protocol URLs that could launch arbitrary local programs
- Add input validation for missing/empty URL strings and malformed URLs

## Problem
The `shell:openExternal` handler at `src/main/main.ts:3658` accepted any URL from the renderer process without protocol validation. A compromised renderer (e.g. via XSS) could pass `file://` or custom protocol URLs to launch arbitrary local applications.

## Changes
- `src/main/main.ts`: Added protocol allowlist check before calling `shell.openExternal()`