### PR TITLE
fix(security): restrict open IPC bridge with channel allowlists

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -92,9 +92,24 @@ contextBridge.exposeInMainWorld('electron', {
   },
   ipcRenderer: {
     send: (channel: string, ...args: any[]) => {
+      const ALLOWED_SEND_CHANNELS = [
+        'network:status-change',
+      ];
+      if (!ALLOWED_SEND_CHANNELS.includes(channel)) {
+        console.warn(`[preload] Blocked ipcRenderer.send on disallowed channel: ${channel}`);
+        return;
+      }
       ipcRenderer.send(channel, ...args);
     },
     on: (channel: string, func: (...args: any[]) => void) => {
+      const ALLOWED_ON_CHANNELS = [
+        'app:openSettings',
+        'app:newTask',
+      ];
+      if (!ALLOWED_ON_CHANNELS.includes(channel)) {
+        console.warn(`[preload] Blocked ipcRenderer.on for disallowed channel: ${channel}`);
+        return () => {};
+      }
       const handler = (_event: any, ...args: any[]) => func(...args);
       ipcRenderer.on(channel, handler);
       return () => ipcRenderer.removeListener(channel, handler);


### PR DESCRIPTION
## Summary
- Add explicit channel allowlists to the generic `ipcRenderer.send()` and `ipcRenderer.on()` bridge in `preload.ts`
- Block any channel not in the allowlist with a console warning
- Only 3 channels are actually used through this bridge: `network:status-change`, `app:openSettings`, `app:newTask`

## Problem
The `window.electron.ipcRenderer` bridge at `src/main/preload.ts:93-101` exposed unrestricted `ipcRenderer.send()` and `ipcRenderer.on()` to the renderer process with **no channel filtering**. If the renderer were compromised via XSS, an attacker could send messages on any IPC channel (e.g. `cowork:session:start`, `store:set`, `appUpdate:install`) and listen on any channel — completely bypassing Electron's process isolation security model.

## Changes
- `src/main/preload.ts`: Added `ALLOWED_SEND_CHANNELS` and `ALLOWED_ON_CHANNELS` allowlists, blocking unrecognized channels with a warning log