### PR TITLE
fix: use nullish check in store.getItem to preserve falsy values

### DIFF
--- a/src/renderer/services/store.ts
+++ b/src/renderer/services/store.ts
@@ -9,7 +9,7 @@ class LocalStoreService implements LocalStore {
   async getItem<T>(key: string): Promise<T | null> {
     try {
       const value = await window.electron.store.get(key);
-      return value || null;
+      return (value !== undefined && value !== null) ? value : null;
     } catch (error) {
       console.error('Failed to get item from store:', error);
       return null;


### PR DESCRIPTION
## Summary
- Replace `value || null` with explicit null/undefined check in `LocalStoreService.getItem()`
- Prevents legitimately stored falsy values (`0`, `false`, `""`) from being silently dropped as `null`

## Problem
`src/renderer/services/store.ts:12` used `return value || null`. The logical OR (`||`) treats `0`, `false`, and `""` as falsy, so any stored value of those types would be incorrectly returned as `null`. This could cause subtle bugs when storing boolean flags or numeric counters via the store service.

## Changes
- `src/renderer/services/store.ts`: Changed `value || null` to `(value !== undefined && value !== null) ? value : null`