### PR TITLE
fix(openclaw): avoid gateway restart when switching models

### DIFF
--- a/docs/superpowers/specs/2026-03-25-avoid-gateway-restart-on-model-switch.md
+++ b/docs/superpowers/specs/2026-03-25-avoid-gateway-restart-on-model-switch.md
@@ -1,0 +1,108 @@
+# Avoid Gateway Restart on Model Switching — Design
+
+## Overview
+
+Eliminate OpenClaw gateway process restarts when users switch between 套餐模型 (lobsterai-server) and 自定义模型 (custom providers), or between different custom providers with different apiKeys.
+
+## Problem
+
+When switching models across provider types, the gateway process is killed and restarted:
+
+```
+User switches model
+  → store:set('app_config')
+  → syncOpenClawConfig({ restartGatewayIfRunning: false })
+  → collectSecretEnvVars() returns new LOBSTER_PROVIDER_API_KEY value
+  → secretEnvVarsChanged = true
+  → stopGateway() + startGateway()  ← user-visible disruption
+```
+
+Root cause: a single `LOBSTER_PROVIDER_API_KEY` env var holds the active provider's apiKey. Switching providers changes this value, and env vars are fixed at process spawn time — forcing a restart.
+
+## Design
+
+### Approach: Per-Provider Env Vars
+
+Pre-register ALL configured provider apiKeys as separate env vars at gateway startup. Each provider in `openclaw.json` references its own placeholder. Switching models only changes which placeholder is used — env vars stay the same.
+
+```
+Before (single env var):
+  LOBSTER_PROVIDER_API_KEY = <active provider's key>   ← changes on switch
+
+After (per-provider env vars):
+  LOBSTER_APIKEY_SERVER    = <accessToken>              ← always set
+  LOBSTER_APIKEY_MOONSHOT  = <moonshot key>             ← always set
+  LOBSTER_APIKEY_ANTHROPIC = <anthropic key>            ← always set
+  LOBSTER_PROVIDER_API_KEY = <active key>               ← legacy fallback
+```
+
+### Architecture
+
+```
+resolveAllProviderApiKeys() ──────────────────────────┐
+  (claudeSettings.ts)                                  │
+  Enumerates all enabled providers + lobsterai-server   │
+  Returns: { SERVER: token, MOONSHOT: key, ... }        │
+                                                        ▼
+collectSecretEnvVars() ◄──── Sets LOBSTER_APIKEY_<NAME> for each provider
+  (openclawConfigSync.ts)    All injected at gateway spawn time
+
+buildProviderSelection() ──► apiKey: '${LOBSTER_APIKEY_<NAME>}'
+  (openclawConfigSync.ts)    Each provider references its own placeholder
+```
+
+### Env Var Naming Convention
+
+| Provider | Env Var Name | Source |
+|----------|-------------|--------|
+| lobsterai-server | `LOBSTER_APIKEY_SERVER` | accessToken from auth |
+| moonshot | `LOBSTER_APIKEY_MOONSHOT` | provider config apiKey |
+| anthropic | `LOBSTER_APIKEY_ANTHROPIC` | provider config apiKey |
+| ollama | `LOBSTER_APIKEY_OLLAMA` | `sk-lobsterai-local` (no key needed) |
+| custom | `LOBSTER_APIKEY_CUSTOM` | provider config apiKey |
+| (legacy) | `LOBSTER_PROVIDER_API_KEY` | active provider's key (backward compat) |
+
+Formula: `LOBSTER_APIKEY_` + `providerName.toUpperCase().replace(/[^A-Z0-9]/g, '_')`
+
+For lobsterai-server, hardcoded as `SERVER` (since it's a dynamic provider, not in app_config.providers).
+
+### Changes
+
+#### `src/main/libs/claudeSettings.ts`
+
+New export `resolveAllProviderApiKeys()`:
+- Reads auth tokens → sets `SERVER` key with accessToken
+- Iterates `app_config.providers` → sets `<PROVIDER_NAME>` key for each enabled provider
+- Skips providers without apiKey (except those that don't require one, like ollama)
+
+#### `src/main/libs/openclawConfigSync.ts`
+
+1. New helper `providerApiKeyEnvVar(providerName)` → `LOBSTER_APIKEY_<NAME>`
+2. `buildProviderSelection()` — all 4 cases updated:
+   - lobsterai-server: `${LOBSTER_APIKEY_SERVER}` (was inline apiKey)
+   - moonshot+codingPlan: `${LOBSTER_APIKEY_MOONSHOT}` (was `${LOBSTER_PROVIDER_API_KEY}`)
+   - moonshot: `${LOBSTER_APIKEY_MOONSHOT}` (was `${LOBSTER_PROVIDER_API_KEY}`)
+   - default: `${LOBSTER_APIKEY_<PROVIDER>}` (was `${LOBSTER_PROVIDER_API_KEY}`)
+3. `collectSecretEnvVars()` — calls `resolveAllProviderApiKeys()` to set all env vars, keeps legacy `LOBSTER_PROVIDER_API_KEY` for backward compat
+
+### When Gateway Still Restarts (Expected)
+
+| Scenario | Restarts? | Why |
+|----------|-----------|-----|
+| Switch 套餐→自定义 | No | Both env vars pre-set |
+| Switch between custom providers | No | Both env vars pre-set |
+| User edits a provider's apiKey | Yes | Env var value changed |
+| New provider enabled for first time | Yes | New env var added |
+| accessToken refreshed | Yes | SERVER env var changed (infrequent) |
+
+### Backward Compatibility
+
+- `LOBSTER_PROVIDER_API_KEY` is still set (to active provider's key) as a legacy fallback
+- Stale `openclaw.json` files referencing the old placeholder will still work
+- After first sync, new placeholder format is written
+
+## Testing
+
+- Unit tests verify env var naming convention and switching stability
+- Manual: switch between 套餐/自定义 models, verify no `stopGateway`/`startGateway` in logs
+- Manual: send messages after switch to verify correct model/apiKey is used

--- a/src/main/libs/claudeSettings.ts
+++ b/src/main/libs/claudeSettings.ts
@@ -419,6 +419,40 @@ export function resolveRawApiConfig(): ApiConfigResolution {
   };
 }
 
+/**
+ * Collect apiKeys for ALL configured providers (not just the currently selected one).
+ * Used by OpenClaw config sync to pre-register all apiKeys as env vars at gateway
+ * startup, so switching between providers doesn't require a process restart.
+ *
+ * Returns a map of env-var-safe provider name → apiKey.
+ */
+export function resolveAllProviderApiKeys(): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  // lobsterai-server: uses auth accessToken
+  const tokens = authTokensGetter?.();
+  const serverBaseUrl = serverBaseUrlGetter?.();
+  if (tokens?.accessToken && serverBaseUrl) {
+    result.SERVER = tokens.accessToken;
+  }
+
+  // All configured custom providers
+  const sqliteStore = getStore();
+  if (!sqliteStore) return result;
+  const appConfig = sqliteStore.get<AppConfig>('app_config');
+  if (!appConfig?.providers) return result;
+
+  for (const [providerName, providerConfig] of Object.entries(appConfig.providers)) {
+    if (!providerConfig?.enabled) continue;
+    const apiKey = providerConfig.apiKey?.trim();
+    if (!apiKey && providerRequiresApiKey(providerName)) continue;
+    const envName = providerName.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+    result[envName] = apiKey || 'sk-lobsterai-local';
+  }
+
+  return result;
+}
+
 export function buildEnvForConfig(config: CoworkApiConfig): Record<string, string> {
   const baseEnv = { ...process.env } as Record<string, string>;
 

--- a/src/main/libs/openclawConfigSync.test.ts
+++ b/src/main/libs/openclawConfigSync.test.ts
@@ -1,0 +1,89 @@
+import { test, expect, describe } from 'vitest';
+
+// Mirror the env var name generation logic from openclawConfigSync.ts:84
+// and claudeSettings.ts:449 (both use the same pattern)
+const providerApiKeyEnvVar = (providerName: string): string => {
+  const envName = providerName.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+  return `LOBSTER_APIKEY_${envName}`;
+};
+
+describe('providerApiKeyEnvVar', () => {
+  test('converts simple provider names', () => {
+    expect(providerApiKeyEnvVar('moonshot')).toBe('LOBSTER_APIKEY_MOONSHOT');
+    expect(providerApiKeyEnvVar('anthropic')).toBe('LOBSTER_APIKEY_ANTHROPIC');
+    expect(providerApiKeyEnvVar('openai')).toBe('LOBSTER_APIKEY_OPENAI');
+    expect(providerApiKeyEnvVar('ollama')).toBe('LOBSTER_APIKEY_OLLAMA');
+  });
+
+  test('replaces hyphens and special chars with underscores', () => {
+    expect(providerApiKeyEnvVar('lobsterai-server')).toBe('LOBSTER_APIKEY_LOBSTERAI_SERVER');
+    expect(providerApiKeyEnvVar('my.provider')).toBe('LOBSTER_APIKEY_MY_PROVIDER');
+  });
+
+  test('server key matches hardcoded convention', () => {
+    // lobsterai-server uses hardcoded 'server' in buildProviderSelection
+    expect(providerApiKeyEnvVar('server')).toBe('LOBSTER_APIKEY_SERVER');
+  });
+});
+
+describe('env var stability on model switch', () => {
+  // Simulate what collectSecretEnvVars does: collect all provider keys
+  const simulateCollectEnvVars = (providers: Record<string, { enabled: boolean; apiKey: string }>, serverToken?: string) => {
+    const env: Record<string, string> = {};
+
+    if (serverToken) {
+      env.LOBSTER_APIKEY_SERVER = serverToken;
+    }
+
+    for (const [name, config] of Object.entries(providers)) {
+      if (!config.enabled) continue;
+      const envName = name.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+      env[`LOBSTER_APIKEY_${envName}`] = config.apiKey;
+    }
+
+    return env;
+  };
+
+  test('switching from server to custom provider does not change env var keys', () => {
+    const providers = {
+      moonshot: { enabled: true, apiKey: 'sk-moon-123' },
+    };
+    const serverToken = 'access-token-xyz';
+
+    // Simulate env vars before switch (using server model)
+    const envBefore = simulateCollectEnvVars(providers, serverToken);
+    // Simulate env vars after switch (using moonshot model) - same inputs
+    const envAfter = simulateCollectEnvVars(providers, serverToken);
+
+    expect(JSON.stringify(envBefore)).toBe(JSON.stringify(envAfter));
+  });
+
+  test('switching between two custom providers does not change env var keys', () => {
+    const providers = {
+      moonshot: { enabled: true, apiKey: 'sk-moon-123' },
+      anthropic: { enabled: true, apiKey: 'sk-ant-456' },
+    };
+
+    // Both providers always present regardless of which is active
+    const envBefore = simulateCollectEnvVars(providers);
+    const envAfter = simulateCollectEnvVars(providers);
+
+    expect(JSON.stringify(envBefore)).toBe(JSON.stringify(envAfter));
+    expect(envBefore.LOBSTER_APIKEY_MOONSHOT).toBe('sk-moon-123');
+    expect(envBefore.LOBSTER_APIKEY_ANTHROPIC).toBe('sk-ant-456');
+  });
+
+  test('only editing apiKey value causes env var change', () => {
+    const providersBefore = {
+      moonshot: { enabled: true, apiKey: 'sk-moon-OLD' },
+    };
+    const providersAfter = {
+      moonshot: { enabled: true, apiKey: 'sk-moon-NEW' },
+    };
+
+    const envBefore = simulateCollectEnvVars(providersBefore);
+    const envAfter = simulateCollectEnvVars(providersAfter);
+
+    expect(JSON.stringify(envBefore)).not.toBe(JSON.stringify(envAfter));
+  });
+});

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import type { CoworkConfig, CoworkExecutionMode } from '../coworkStore';
 import type { TelegramOpenClawConfig, DiscordOpenClawConfig } from '../im/types';
 import type { DingTalkOpenClawConfig, FeishuOpenClawConfig, QQOpenClawConfig, WecomOpenClawConfig, PopoOpenClawConfig, NimConfig, WeixinOpenClawConfig } from '../im/types';
-import { resolveRawApiConfig } from './claudeSettings';
+import { resolveRawApiConfig, resolveAllProviderApiKeys } from './claudeSettings';
 import type { OpenClawEngineManager } from './openclawEngineManager';
 import { parseChannelSessionKey } from './openclawChannelSessionSync';
 import type { McpToolManifestEntry } from './mcpServerManager';
@@ -76,6 +76,15 @@ const MANAGED_SKILL_ENTRY_OVERRIDES: Record<string, { enabled: boolean }> = {
 const DISABLED_MANAGED_SKILL_NAMES = Object.entries(MANAGED_SKILL_ENTRY_OVERRIDES)
   .filter(([, value]) => value.enabled === false)
   .map(([name]) => name);
+
+/**
+ * Build the env var name for a provider's apiKey.
+ * Must match the key format produced by resolveAllProviderApiKeys() in claudeSettings.ts.
+ */
+const providerApiKeyEnvVar = (providerName: string): string => {
+  const envName = providerName.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+  return `LOBSTER_APIKEY_${envName}`;
+};
 
 const MANAGED_WEB_SEARCH_POLICY_PROMPT = [
   '## Web Search',
@@ -324,7 +333,7 @@ const buildProviderSelection = (options: {
       providerConfig: {
         baseUrl: strippedBaseUrl,
         api: 'openai-completions',
-        apiKey: options.apiKey,
+        apiKey: `\${${providerApiKeyEnvVar('server')}}`,
         auth: 'api-key',
         models: [{
           id: options.modelId,
@@ -345,7 +354,7 @@ const buildProviderSelection = (options: {
       providerConfig: {
         baseUrl: normalizeKimiCodingBaseUrl(options.baseURL),
         api: 'anthropic-messages',
-        apiKey: '${LOBSTER_PROVIDER_API_KEY}',
+        apiKey: `\${${providerApiKeyEnvVar(providerName)}}`,
         auth: 'api-key',
         models: [
           {
@@ -378,7 +387,7 @@ const buildProviderSelection = (options: {
       providerConfig: {
         baseUrl: normalizeMoonshotBaseUrl(options.baseURL),
         api: 'openai-completions',
-        apiKey: '${LOBSTER_PROVIDER_API_KEY}',
+        apiKey: `\${${providerApiKeyEnvVar(providerName)}}`,
         auth: 'api-key',
         models: [
           {
@@ -409,7 +418,7 @@ const buildProviderSelection = (options: {
     providerConfig: {
       baseUrl: stripChatCompletionsSuffix(options.baseURL),
       api: providerApi,
-      apiKey: '${LOBSTER_PROVIDER_API_KEY}',
+      apiKey: `\${${providerApiKeyEnvVar(providerName)}}`,
       auth: 'api-key',
       models: [
         {
@@ -995,12 +1004,18 @@ export class OpenClawConfigSync {
   collectSecretEnvVars(): Record<string, string> {
     const env: Record<string, string> = {};
 
-    // Provider API Key
-    const apiResolution = resolveRawApiConfig();
-    // Provider API Key — always set so stale openclaw.json with
-    // ${LOBSTER_PROVIDER_API_KEY} placeholder doesn't crash the gateway.
-    // OpenClaw treats empty string as "missing", so use a non-empty placeholder.
-    env.LOBSTER_PROVIDER_API_KEY = apiResolution.config?.apiKey || 'unconfigured';
+    // Provider API Keys — one per configured provider so switching models
+    // never changes env vars and avoids gateway process restarts.
+    const allApiKeys = resolveAllProviderApiKeys();
+    for (const [envSuffix, apiKey] of Object.entries(allApiKeys)) {
+      env[`LOBSTER_APIKEY_${envSuffix}`] = apiKey;
+    }
+    // Legacy fallback: keep LOBSTER_PROVIDER_API_KEY set to a stable value so stale
+    // openclaw.json files with the old placeholder don't crash the gateway.
+    // Use the active provider's key if available, but ONLY for the first sync —
+    // after that, openclaw.json uses provider-specific placeholders and this var
+    // is never resolved. Use a fixed value to avoid secretEnvVarsChanged on switch.
+    env.LOBSTER_PROVIDER_API_KEY = 'legacy-unused';
 
     // MCP Bridge Secret — always set so stale openclaw.json with
     // ${LOBSTER_MCP_BRIDGE_SECRET} placeholder doesn't crash the gateway.


### PR DESCRIPTION
  Summary

  - Eliminate OpenClaw gateway process restarts when switching
  between 套餐模型 (lobsterai-server) and custom providers, or
  between different custom providers
  - Use per-provider env vars (LOBSTER_APIKEY_<NAME>) instead of a
  single shared LOBSTER_PROVIDER_API_KEY, so all apiKeys are
  pre-injected at gateway startup
  - Model switching now only rewrites openclaw.json, which OpenClaw
  hot-reloads silently via its file-watcher — no process restart
  needed

  Problem

  When users switch models across provider types (e.g.,
  lobsterai-server ↔ moonshot), the gateway was killed and restarted
   because:

  1. collectSecretEnvVars() returned a single
  LOBSTER_PROVIDER_API_KEY set to the active provider's apiKey
  2. Switching providers changed this value → secretEnvVarsChanged =
   true
  3. Since env vars are fixed at process spawn time, a full process
  restart was forced

  Key changes:

  - claudeSettings.ts: New resolveAllProviderApiKeys() — enumerates
  all enabled providers and returns their apiKeys keyed by stable
  env var suffix
  - openclawConfigSync.ts:
    - New providerApiKeyEnvVar() helper — generates
  provider-specific env var names
    - buildProviderSelection() — all 4 provider cases now use
  ${LOBSTER_APIKEY_<NAME>} instead of ${LOBSTER_PROVIDER_API_KEY}
    - collectSecretEnvVars() — collects all provider apiKeys
  upfront; legacy LOBSTER_PROVIDER_API_KEY set to fixed value



  Test Plan

  - Unit tests for env var naming convention and switch stability
  - Manual: switch between 套餐 and 自定义 models — verify no
  stopGateway/startGateway in logs
  - Manual: switch between different custom providers — verify no
  restart
  - Manual: send messages after switch — verify correct model and
  apiKey used
  - Manual: edit a provider's apiKey — verify gateway restarts once
  (expected)