### PR TITLE
fix(openclaw): fix model name loss and gateway infinite restart loop

### DIFF
--- a/src/main/libs/claudeSettings.ts
+++ b/src/main/libs/claudeSettings.ts
@@ -23,6 +23,7 @@ const MOONSHOT_CODING_PLAN_ANTHROPIC_BASE_URL = 'https://api.kimi.com/coding';
 
 type ProviderModel = {
   id: string;
+  name?: string;
   supportsImage?: boolean;
 };
 
@@ -50,6 +51,7 @@ export type ApiConfigResolution = {
     providerName: string;
     codingPlanEnabled: boolean;
     supportsImage?: boolean;
+    modelName?: string;
   };
 };
 
@@ -108,6 +110,7 @@ type MatchedProvider = {
   apiFormat: AnthropicApiFormat;
   baseURL: string;
   supportsImage?: boolean;
+  modelName?: string;
 };
 
 function getEffectiveProviderApiFormat(providerName: string, apiFormat: unknown): AnthropicApiFormat {
@@ -285,6 +288,7 @@ function resolveMatchedProvider(appConfig: AppConfig): { matched: MatchedProvide
       apiFormat,
       baseURL,
       supportsImage: matchedModel?.supportsImage,
+      modelName: matchedModel?.name,
     },
   };
 }
@@ -415,6 +419,7 @@ export function resolveRawApiConfig(): ApiConfigResolution {
       providerName: matched.providerName,
       codingPlanEnabled: !!matched.providerConfig.codingPlanEnabled,
       supportsImage: matched.supportsImage,
+      modelName: matched.modelName,
     },
   };
 }

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -42,7 +42,19 @@ const normalizeModelName = (modelId: string): string => {
   const trimmed = modelId.trim();
   if (!trimmed) return 'default-model';
   const slashIndex = trimmed.lastIndexOf('/');
-  return slashIndex >= 0 ? trimmed.slice(slashIndex + 1) : trimmed;
+  const name = slashIndex >= 0 ? trimmed.slice(slashIndex + 1) : trimmed;
+  // Ensure the result is never empty after stripping prefix
+  return name.trim() || 'default-model';
+};
+
+/**
+ * Resolve the effective model display name with fallback chain:
+ * userModelName → normalizeModelName(modelId) → 'default-model'
+ */
+const resolveModelDisplayName = (modelId: string, userModelName?: string): string => {
+  const userName = userModelName?.trim();
+  if (userName) return userName;
+  return normalizeModelName(modelId);
 };
 
 const MANAGED_OWNER_ALLOW_FROM = [
@@ -299,8 +311,9 @@ const buildProviderSelection = (options: {
   providerName?: string;
   codingPlanEnabled?: boolean;
   supportsImage?: boolean;
+  modelName?: string;
 }): OpenClawProviderSelection => {
-  const providerModelName = normalizeModelName(options.modelId);
+  const providerModelName = resolveModelDisplayName(options.modelId, options.modelName);
   const providerApi = mapApiTypeToOpenClawApi(options.apiType);
   const modelInput: string[] = options.supportsImage ? ['text', 'image'] : ['text'];
   const providerName = options.providerName ?? '';
@@ -534,6 +547,7 @@ export class OpenClawConfigSync {
       providerName: apiResolution.providerMetadata?.providerName,
       codingPlanEnabled: apiResolution.providerMetadata?.codingPlanEnabled,
       supportsImage: apiResolution.providerMetadata?.supportsImage,
+      modelName: apiResolution.providerMetadata?.modelName,
     });
     const sandboxMode = mapExecutionModeToSandboxMode(coworkConfig.executionMode || 'auto');
 

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -16,7 +16,8 @@ const DEFAULT_OPENCLAW_VERSION = '2026.2.23';
 const DEFAULT_GATEWAY_PORT = 18789;
 const GATEWAY_PORT_SCAN_LIMIT = 80;
 const GATEWAY_BOOT_TIMEOUT_MS = 300 * 1000;
-const GATEWAY_RESTART_DELAY_MS = 3000;
+const GATEWAY_MAX_RESTART_ATTEMPTS = 5;
+const GATEWAY_RESTART_DELAYS = [3_000, 5_000, 10_000, 20_000, 30_000];
 
 export type OpenClawEnginePhase =
   | 'not_installed'
@@ -154,6 +155,7 @@ export class OpenClawEngineManager extends EventEmitter {
   private gatewayProcess: GatewayProcess | null = null;
   private readonly expectedGatewayExits = new WeakSet<object>();
   private gatewayRestartTimer: NodeJS.Timeout | null = null;
+  private gatewayRestartAttempt = 0;
   private shutdownRequested = false;
   private gatewayPort: number | null = null;
   private startGatewayPromise: Promise<OpenClawEngineStatus> | null = null;
@@ -513,6 +515,8 @@ export class OpenClawEngineManager extends EventEmitter {
     }
 
     console.log(`[OpenClaw] startGateway: gateway is running, total startup time: ${elapsed()}`);
+    // Reset restart counter on successful start — gateway is healthy
+    this.gatewayRestartAttempt = 0;
     this.setStatus({
       phase: 'running',
       version: runtime.version,
@@ -551,6 +555,8 @@ export class OpenClawEngineManager extends EventEmitter {
   async restartGateway(): Promise<OpenClawEngineStatus> {
     console.log('[OpenClaw] restartGateway: stopping existing gateway...');
     await this.stopGateway();
+    // Reset restart counter on manual restart so user can always retry
+    this.gatewayRestartAttempt = 0;
     console.log('[OpenClaw] restartGateway: starting gateway with new env...');
     return this.startGateway();
   }
@@ -1292,11 +1298,26 @@ export class OpenClawEngineManager extends EventEmitter {
     if (this.shutdownRequested) return;
     if (this.gatewayRestartTimer) return;
 
+    if (this.gatewayRestartAttempt >= GATEWAY_MAX_RESTART_ATTEMPTS) {
+      console.error(`[OpenClaw] gateway auto-restart limit reached (${GATEWAY_MAX_RESTART_ATTEMPTS} attempts), giving up`);
+      this.setStatus({
+        phase: 'error',
+        version: this.status.version,
+        message: `OpenClaw gateway failed to start after ${GATEWAY_MAX_RESTART_ATTEMPTS} attempts. Check model configuration or restart manually.`,
+        canRetry: true,
+      });
+      return;
+    }
+
+    const delay = GATEWAY_RESTART_DELAYS[Math.min(this.gatewayRestartAttempt, GATEWAY_RESTART_DELAYS.length - 1)];
+    this.gatewayRestartAttempt++;
+    console.log(`[OpenClaw] scheduling gateway restart attempt ${this.gatewayRestartAttempt}/${GATEWAY_MAX_RESTART_ATTEMPTS} in ${delay}ms`);
+
     this.gatewayRestartTimer = setTimeout(() => {
       this.gatewayRestartTimer = null;
       if (this.shutdownRequested) return;
       void this.startGateway();
-    }, GATEWAY_RESTART_DELAY_MS);
+    }, delay);
   }
 
   private setStatus(next: OpenClawEngineStatus): void {


### PR DESCRIPTION
## 概述

修复 #858 和 #859 —— OpenClaw 集成中两个相互关联的 bug：

1. **模型名称丢失 (#858)：** 自定义模型的显示名称在 OpenClaw 配置同步时被丢弃。`buildProviderSelection()` 通过 `normalizeModelName()` 从模型 ID 重新推导名称，而非使用用户在设置中填写的名称。
2. **Gateway 无限崩溃重启 (#859)：** 当 OpenClaw Gateway 启动失败时（如 #858 导致的无效配置），`scheduleGatewayRestart()` 每 3 秒无限重试，无上限，持续消耗系统资源超过 10 分钟。

## 改动说明

### 模型名称端到端传递（`claudeSettings.ts`、`openclawConfigSync.ts`）

- `ProviderModel` 类型增加可选 `name` 字段，与实际存储的数据结构一致
- 模型显示名称沿 `resolveMatchedProvider()` → `resolveRawApiConfig()` → `providerMetadata.modelName` 链路传递
- `buildProviderSelection()` 通过新增的 `resolveModelDisplayName()` 优先使用用户填写的名称，回退链：用户名称 → `normalizeModelName(modelId)` → `'default-model'`
- `normalizeModelName()` 增加空字符串保护，修复 `modelId="prefix/"` 等边界情况

### Gateway 有限重启（`openclawEngineManager.ts`）

- 引入有限重启机制：最多 5 次，退避间隔为 `[3s, 5s, 10s, 20s, 30s]`
- 达到上限后设置终态 `error` 状态，`canRetry: true` 允许用户手动重试
- 计数器重置时机：
  - ✅ 健康检查通过（Gateway 确实启动成功）
  - ✅ 用户主动调用 `restartGateway()`
  - ❌ `startGateway()` 被自动化逻辑调用时**不重置**，防止 adapter 重连等场景绕过限制
- 移除不再使用的 `GATEWAY_RESTART_DELAY_MS` 常量

## 验证

- TypeScript 编译通过（`tsconfig.json` 和 `electron-tsconfig.json`）
- 全部 24 个单元测试通过
- 手动验证：自定义模型名称正确写入 `openclaw.json`

Closes #858, Closes #859