### PR TITLE
fix(config): prevent empty model name when modelId ends with slash

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -42,7 +42,8 @@ const normalizeModelName = (modelId: string): string => {
   const trimmed = modelId.trim();
   if (!trimmed) return 'default-model';
   const slashIndex = trimmed.lastIndexOf('/');
-  return slashIndex >= 0 ? trimmed.slice(slashIndex + 1) : trimmed;
+  const afterSlash = slashIndex >= 0 ? trimmed.slice(slashIndex + 1) : trimmed;
+  return afterSlash || trimmed;
 };
 
 const MANAGED_OWNER_ALLOW_FROM = [


### PR DESCRIPTION
## Summary

Fixes `normalizeModelName()` returning an empty string when the custom model ID ends with `/`, which causes the OpenClaw gateway to crash on startup due to schema validation failure (`name.length >= 1`).

Closes #858

## Root Cause

`normalizeModelName()` in `openclawConfigSync.ts` extracts the portion after the last `/` in a model ID. When the ID ends with `/` (e.g. `some-provider/`), `trimmed.slice(slashIndex + 1)` returns `""`. This empty string is written to `openclaw.json` as `models.providers.lobster.models.0.name`, failing the OpenClaw Zod schema validation and crashing the gateway process.

## Fix

Fall back to the full trimmed model ID when the after-slash portion is empty:

```typescript
const afterSlash = slashIndex >= 0 ? trimmed.slice(slashIndex + 1) : trimmed;
return afterSlash || trimmed;
```

## Edge Cases Verified

| Input | Before | After |
|-------|--------|-------|
| `gpt-4` | `gpt-4` | `gpt-4` |
| `openai/gpt-4o` | `gpt-4o` | `gpt-4o` |
| `some-model/` | `""` (BUG) | `some-model/` |
| `a/b/c/` | `""` (BUG) | `a/b/c/` |
| `/` | `""` (BUG) | `/` |
| `""` | `default-model` | `default-model` |

## Files Changed

- `src/main/libs/openclawConfigSync.ts` — 1 line change in `normalizeModelName()`