### PR TITLE
fix(openclaw): add circuit breaker to prevent infinite gateway crash-restart loop

### DIFF
--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -17,6 +17,8 @@ const DEFAULT_GATEWAY_PORT = 18789;
 const GATEWAY_PORT_SCAN_LIMIT = 80;
 const GATEWAY_BOOT_TIMEOUT_MS = 300 * 1000;
 const GATEWAY_RESTART_DELAY_MS = 3000;
+const MAX_CONSECUTIVE_CRASHES = 5;
+const CRASH_WINDOW_MS = 60_000;
 
 export type OpenClawEnginePhase =
   | 'not_installed'
@@ -155,6 +157,8 @@ export class OpenClawEngineManager extends EventEmitter {
   private readonly expectedGatewayExits = new WeakSet<object>();
   private gatewayRestartTimer: NodeJS.Timeout | null = null;
   private shutdownRequested = false;
+  private consecutiveCrashes = 0;
+  private lastCrashTime = 0;
   private gatewayPort: number | null = null;
   private startGatewayPromise: Promise<OpenClawEngineStatus> | null = null;
   private secretEnvVars: Record<string, string> = {};
@@ -513,6 +517,7 @@ export class OpenClawEngineManager extends EventEmitter {
     }
 
     console.log(`[OpenClaw] startGateway: gateway is running, total startup time: ${elapsed()}`);
+    this.consecutiveCrashes = 0;
     this.setStatus({
       phase: 'running',
       version: runtime.version,
@@ -550,6 +555,7 @@ export class OpenClawEngineManager extends EventEmitter {
 
   async restartGateway(): Promise<OpenClawEngineStatus> {
     console.log('[OpenClaw] restartGateway: stopping existing gateway...');
+    this.consecutiveCrashes = 0;
     await this.stopGateway();
     console.log('[OpenClaw] restartGateway: starting gateway with new env...');
     return this.startGateway();
@@ -1278,6 +1284,13 @@ export class OpenClawEngineManager extends EventEmitter {
       }
       if (this.shutdownRequested) return;
 
+      const now = Date.now();
+      if (now - this.lastCrashTime > CRASH_WINDOW_MS) {
+        this.consecutiveCrashes = 0;
+      }
+      this.consecutiveCrashes++;
+      this.lastCrashTime = now;
+
       this.setStatus({
         phase: 'error',
         version: this.status.version,
@@ -1292,11 +1305,26 @@ export class OpenClawEngineManager extends EventEmitter {
     if (this.shutdownRequested) return;
     if (this.gatewayRestartTimer) return;
 
+    if (this.consecutiveCrashes >= MAX_CONSECUTIVE_CRASHES) {
+      console.error(
+        `[OpenClaw] gateway crashed ${this.consecutiveCrashes} times within ${CRASH_WINDOW_MS / 1000}s — halting restarts`
+      );
+      this.setStatus({
+        phase: 'error',
+        version: this.status.version,
+        message: `OpenClaw gateway crashed ${this.consecutiveCrashes} times in rapid succession. Automatic restarts have been halted to prevent resource exhaustion. Please check your configuration and retry manually.`,
+        canRetry: true,
+      });
+      return;
+    }
+
+    const backoffMs = GATEWAY_RESTART_DELAY_MS * Math.pow(2, this.consecutiveCrashes - 1);
+
     this.gatewayRestartTimer = setTimeout(() => {
       this.gatewayRestartTimer = null;
       if (this.shutdownRequested) return;
       void this.startGateway();
-    }, GATEWAY_RESTART_DELAY_MS);
+    }, backoffMs);
   }
 
   private setStatus(next: OpenClawEngineStatus): void {


### PR DESCRIPTION
## Summary

- Adds a circuit breaker to `scheduleGatewayRestart()` that halts automatic restarts after 5 rapid crashes within 60 seconds, preventing infinite crash-restart loops caused by persistent configuration errors (e.g. invalid model names from #858)
- Replaces the fixed 3-second restart delay with exponential backoff (3s → 6s → 12s → 24s), reducing resource waste during transient failures
- Resets the crash counter on successful gateway startup and on user-initiated `restartGateway()`, so manual retry always works after the circuit breaker trips

## Problem

When the OpenClaw gateway crashes due to a non-transient error (e.g. invalid config produced by the `normalizeModelName` slash bug in #858), the process exit handler unconditionally calls `scheduleGatewayRestart()` every 3 seconds. Since the root cause is never resolved by restarting, this creates an infinite crash loop that:

- Wastes CPU spawning doomed processes every 3 seconds
- Floods logs with repetitive crash/restart entries
- Degrades user experience with rapidly flickering error → starting → error status
- Continues for 10+ minutes until the user force-quits the app

Note: the WebSocket reconnection path (`scheduleGatewayReconnect` in `openclawRuntimeAdapter.ts`) already has a 10-attempt limit. The process-level restart path had no such protection.

## Changes

**`src/main/libs/openclawEngineManager.ts`** (1 file, +29 −1):

| Area | Change |
|------|--------|
| Constants | Add `MAX_CONSECUTIVE_CRASHES = 5` and `CRASH_WINDOW_MS = 60_000` |
| Private fields | Add `consecutiveCrashes` counter and `lastCrashTime` timestamp |
| Exit handler | Track crash frequency with a 60-second sliding window reset |
| `scheduleGatewayRestart()` | Check circuit breaker threshold before scheduling; apply exponential backoff `3s × 2^(n-1)` |
| `doStartGateway()` success | Reset `consecutiveCrashes = 0` when gateway reaches `running` phase |
| `restartGateway()` | Reset `consecutiveCrashes = 0` so user-initiated restart always bypasses the circuit breaker |

## Behavior

| Crash # | Delay | Action |
|---------|-------|--------|
| 1st | 3s | Restart |
| 2nd | 6s | Restart |
| 3rd | 12s | Restart |
| 4th | 24s | Restart |
| 5th+ | — | Halt restarts, set `phase: 'error'` with actionable message, `canRetry: true` |

If crashes are spaced more than 60 seconds apart, the counter resets — so occasional transient failures still get unlimited retries with no circuit breaker interference.

## Electron-Specific Notes

- The circuit breaker operates on the main process exit handler for `UtilityProcess | ChildProcess` — no IPC or renderer changes
- `canRetry: true` is preserved so the existing UI retry button continues to work as a manual override

## Verification

- `npx tsc --noEmit` passes with zero errors
- Minimal change surface: 1 file, focused on the restart path only

Closes #859