### PR TITLE
perf(cowork): replace O(n²) streaming overlap with KMP linear algorithm

### DIFF
--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeStreamingSuffixPrefixOverlap,
+  mergeStreamingMessageContent,
+} from './coworkSlice';
+
+describe('computeStreamingSuffixPrefixOverlap', () => {
+  it('returns 0 for empty strings', () => {
+    expect(computeStreamingSuffixPrefixOverlap('', '')).toBe(0);
+    expect(computeStreamingSuffixPrefixOverlap('abc', '')).toBe(0);
+    expect(computeStreamingSuffixPrefixOverlap('', 'abc')).toBe(0);
+  });
+
+  it('returns 0 when no overlap exists', () => {
+    expect(computeStreamingSuffixPrefixOverlap('abc', 'xyz')).toBe(0);
+  });
+
+  it('detects exact suffix-prefix overlap', () => {
+    expect(computeStreamingSuffixPrefixOverlap('hello world', 'world peace')).toBe(5);
+    expect(computeStreamingSuffixPrefixOverlap('abcdef', 'defghi')).toBe(3);
+  });
+
+  it('detects single-character overlap', () => {
+    expect(computeStreamingSuffixPrefixOverlap('abc', 'cde')).toBe(1);
+  });
+
+  it('detects full overlap when right is a suffix of left', () => {
+    expect(computeStreamingSuffixPrefixOverlap('abcdef', 'def')).toBe(3);
+  });
+
+  it('detects full overlap when left ends with entire right', () => {
+    expect(computeStreamingSuffixPrefixOverlap('xxxabc', 'abc')).toBe(3);
+  });
+
+  it('handles identical strings', () => {
+    expect(computeStreamingSuffixPrefixOverlap('abc', 'abc')).toBe(3);
+  });
+
+  it('handles repeated patterns correctly', () => {
+    expect(computeStreamingSuffixPrefixOverlap('ababab', 'ababc')).toBe(4);
+    expect(computeStreamingSuffixPrefixOverlap('aaaaaa', 'aaab')).toBe(3);
+  });
+
+  it('handles long strings within probe window', () => {
+    const left = 'x'.repeat(400) + 'overlap_here';
+    const right = 'overlap_here' + 'y'.repeat(400);
+    expect(computeStreamingSuffixPrefixOverlap(left, right)).toBe(12);
+  });
+});
+
+describe('mergeStreamingMessageContent', () => {
+  it('returns incoming when previous is empty', () => {
+    expect(mergeStreamingMessageContent('', 'hello')).toBe('hello');
+  });
+
+  it('returns previous when incoming is empty', () => {
+    expect(mergeStreamingMessageContent('hello', '')).toBe('hello');
+  });
+
+  it('returns same content when identical', () => {
+    expect(mergeStreamingMessageContent('hello', 'hello')).toBe('hello');
+  });
+
+  it('handles snapshot mode (incoming extends previous)', () => {
+    expect(mergeStreamingMessageContent('hello', 'hello world')).toBe('hello world');
+  });
+
+  it('keeps previous when incoming is a prefix (partial rollback)', () => {
+    expect(mergeStreamingMessageContent('hello world', 'hello')).toBe('hello world');
+  });
+
+  it('merges delta with overlap', () => {
+    expect(mergeStreamingMessageContent('hello world', 'world peace')).toBe('hello world peace');
+  });
+
+  it('appends delta with no overlap', () => {
+    expect(mergeStreamingMessageContent('hello', ' world')).toBe('hello world');
+  });
+});

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -57,19 +57,35 @@ const markSessionUnread = (state: CoworkState, sessionId: string) => {
 
 const STREAMING_MERGE_PROBE_CHARS = 512;
 
-const computeStreamingSuffixPrefixOverlap = (left: string, right: string): number => {
+export const computeStreamingSuffixPrefixOverlap = (left: string, right: string): number => {
   const leftProbe = left.slice(-STREAMING_MERGE_PROBE_CHARS);
   const rightProbe = right.slice(0, STREAMING_MERGE_PROBE_CHARS);
-  const maxOverlap = Math.min(leftProbe.length, rightProbe.length);
-  for (let size = maxOverlap; size > 0; size -= 1) {
-    if (leftProbe.slice(-size) === rightProbe.slice(0, size)) {
-      return size;
+  if (leftProbe.length === 0 || rightProbe.length === 0) return 0;
+
+  // KMP failure-function approach: O(n + m) instead of O(n * m).
+  // Concatenate rightProbe + sentinel + leftProbe and compute the failure
+  // table. The last entry gives the longest prefix of rightProbe that equals
+  // a suffix of leftProbe — exactly the overlap we need.
+  const sentinel = '\x00';
+  const combined = rightProbe + sentinel + leftProbe;
+  const len = combined.length;
+  const fail = new Int32Array(len);
+
+  for (let i = 1; i < len; i++) {
+    let j = fail[i - 1];
+    while (j > 0 && combined[i] !== combined[j]) {
+      j = fail[j - 1];
     }
+    if (combined[i] === combined[j]) {
+      j++;
+    }
+    fail[i] = j;
   }
-  return 0;
+
+  return fail[len - 1];
 };
 
-const mergeStreamingMessageContent = (previousContent: string, incomingContent: string): string => {
+export const mergeStreamingMessageContent = (previousContent: string, incomingContent: string): string => {
   if (!incomingContent) return previousContent;
   if (!previousContent) return incomingContent;
   if (incomingContent === previousContent) return previousContent;


### PR DESCRIPTION
## Summary

- Replaces the brute-force O(n·m) suffix-prefix overlap detection in `computeStreamingSuffixPrefixOverlap()` with a KMP failure-function algorithm that runs in O(n+m), eliminating per-iteration string allocations on the renderer main thread during high-frequency streaming updates
- Adds 16 unit tests covering edge cases (empty strings, identical strings, repeated patterns, partial overlaps, long strings)

## Problem

During streaming message updates, `mergeStreamingMessageContent()` calls `computeStreamingSuffixPrefixOverlap()` to detect overlapping content between the previous and incoming chunks. The existing implementation:

```typescript
for (let size = maxOverlap; size > 0; size -= 1) {
  if (leftProbe.slice(-size) === rightProbe.slice(0, size)) {
    return size;
  }
}
```

For each candidate overlap size, it creates **two new string slices** and performs a character-by-character comparison. With `STREAMING_MERGE_PROBE_CHARS = 512`, worst-case is `512 × 512 / 2 ≈ 131K` character comparisons **per streaming chunk** — all on the renderer main thread. During rapid streaming output, this causes visible UI jank in long conversations.

## Solution

Apply the KMP (Knuth-Morris-Pratt) failure-function technique:

1. Concatenate `rightProbe + sentinel('\0') + leftProbe`
2. Build the failure table in a single linear pass — O(n + m)
3. The last failure value equals the longest prefix of `rightProbe` that matches a suffix of `leftProbe` — exactly the overlap we need

This eliminates:
- All per-iteration `slice()` allocations (512 × 2 string objects worst case → 1 `Int32Array` + 1 concatenated string)
- The quadratic comparison loop
- GC pressure from ephemeral string objects during streaming

## Complexity

| | Before | After |
|---|--------|-------|
| Time | O(n · m), worst ~131K ops | O(n + m), always ~1024 ops |
| Space | O(n) per iteration (slice allocs) | O(n + m) once (Int32Array) |
| GC pressure | ~1024 ephemeral strings | 1 Int32Array + 1 string |

Where n, m ≤ 512 (`STREAMING_MERGE_PROBE_CHARS`).

## Changes

**`src/renderer/store/slices/coworkSlice.ts`** (+15 −7):
- Replace brute-force loop with KMP failure-function algorithm
- Add early return for empty probe strings
- Export `computeStreamingSuffixPrefixOverlap` and `mergeStreamingMessageContent` for testing

**`src/renderer/store/slices/coworkSlice.test.ts`** (+79, new):
- 9 tests for `computeStreamingSuffixPrefixOverlap`: empty strings, no overlap, exact overlap, single char, full overlap, identical strings, repeated patterns, long strings
- 7 tests for `mergeStreamingMessageContent`: empty previous/incoming, identical, snapshot mode, partial rollback, delta with overlap, delta without overlap

## Verification

- `npx tsc --noEmit` — zero errors
- `npx vitest run` — 16/16 tests pass (3ms)

Closes #887