### PR TITLE
fix(sidebar): 侧边栏折叠过渡动画 + macOS 告警横幅文字遮挡修复

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -134,6 +134,12 @@ const Sidebar: React.FC<SidebarProps> = ({
       className={`shrink-0 dark:bg-claude-darkSurfaceMuted bg-claude-surfaceMuted flex flex-col sidebar-transition overflow-hidden ${
         isCollapsed ? 'w-0' : 'w-60'
       }`}
+      style={{
+        opacity: isCollapsed ? 0 : 1,
+        transition: isCollapsed
+          ? 'width 220ms cubic-bezier(0.4,0,0.2,1), opacity 120ms cubic-bezier(0.4,0,0.2,1)'
+          : 'width 220ms cubic-bezier(0.4,0,0.2,1), opacity 180ms cubic-bezier(0.4,0,0.2,1) 60ms',
+      }}
     >
       <div className="pt-3 pb-3">
         <div className="draggable sidebar-header-drag h-8 flex items-center justify-between px-3">

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -461,10 +461,10 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
 
   // Engine status banner for error/non-running states (starting overlay is now global in App.tsx)
   const engineStatusBanner = shouldShowEngineStatus && openClawStatus && openClawStatus.phase !== 'starting' ? (
-    <div className={`shrink-0 flex items-center justify-between px-4 py-2 text-xs ${isEngineError
+    <div className={`shrink-0 flex items-center justify-between py-2 text-xs ${isEngineError
       ? 'bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-300'
       : 'bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-300'
-    }`}>
+    } ${isMac && isSidebarCollapsed ? 'pl-[84px] pr-4' : 'px-4'}`}>
       <div className="flex items-center gap-2">
         <span>{resolveEngineStatusText(openClawStatus)}</span>
         {typeof openClawStatus.progressPercent === 'number' && (

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -184,9 +184,9 @@ select::-ms-expand {
   @apply dark:bg-claude-darkSurface bg-claude-surface dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover dark:text-claude-darkText text-claude-text border dark:border-claude-darkBorder border-claude-border font-medium py-2 px-4 rounded-lg transition-colors;
 }
 
-/* Sidebar width transition - instant toggle, no animation */
+/* Sidebar width transition */
 .sidebar-transition {
-  transition: none;
+  transition: width 220ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* Subtle separator line */


### PR DESCRIPTION
## 问题描述

本次 PR 修复两个独立但相关的侧边栏交互问题：

### 1. 侧边栏折叠无过渡动画

`src/renderer/index.css` 中存在一条显式规则 `.sidebar-transition { transition: none }`，导致侧边栏收起/展开时宽度瞬间跳变，内容布局随之突然重排，视觉冲击感强，用户容易失去空间感。

### 2. macOS 下侧边栏收起时告警横幅文字被遮挡

`CoworkView.tsx` 中的 `engineStatusBanner`（引擎状态告警条）渲染在整个视图的最顶部。当侧边栏展开时，告警条左侧由侧边栏本身填充，不存在问题；但当侧边栏**收起**后，macOS 交通灯按钮区域（约 68px）落在了告警条上，而告警条仅有 `px-4`（16px）的左内边距，导致告警文字直接被交通灯按钮遮住，无法阅读。

---

## 修改内容

### `src/renderer/index.css`

将 `.sidebar-transition` 的 `transition: none` 改为平滑的宽度过渡动画：

```css
.sidebar-transition {
  transition: width 220ms cubic-bezier(0.4, 0, 0.2, 1);
}
```

使用 Material Design 标准缓动曲线（ease-in-out），持续时间 220ms，与系统原生侧边栏动画节奏接近。

### `src/renderer/components/Sidebar.tsx`

在 `<aside>` 元素上叠加 `opacity` 过渡，配合宽度动画提升质感：

- **收起时**：opacity 以 120ms 快速淡出，让内容在宽度收缩过程中先消失，避免文字被 `overflow-hidden` 硬截断时的生硬感。
- **展开时**：opacity 延迟 60ms 后再以 180ms 淡入，确保文字出现时宽度已经足够容纳，不会看到被截断的瞬间。

```tsx
style={{
  opacity: isCollapsed ? 0 : 1,
  transition: isCollapsed
    ? 'width 220ms cubic-bezier(0.4,0,0.2,1), opacity 120ms cubic-bezier(0.4,0,0.2,1)'
    : 'width 220ms cubic-bezier(0.4,0,0.2,1), opacity 180ms cubic-bezier(0.4,0,0.2,1) 60ms',
}}
```

### `src/renderer/components/cowork/CoworkView.tsx`

修复 `engineStatusBanner` 在 macOS + 侧边栏收起状态下的左内边距：

```tsx
// 修复前
className={`... px-4`}

// 修复后
className={`... ${isMac && isSidebarCollapsed ? 'pl-[84px] pr-4' : 'px-4'}`}
```

`84px` = 交通灯区域 68px + 原始左内边距 16px，与 `CoworkSessionDetail` header 中按钮组的 `pl-[68px]` 保持一致的视觉对齐。

---

## 影响范围

- 纯样式/布局修改，不涉及任何业务逻辑和数据流
- macOS 交通灯遮挡修复仅在 `isMac && isSidebarCollapsed` 条件下生效，不影响 Windows/Linux 及侧边栏展开状态
- 过渡动画不影响无障碍（`prefers-reduced-motion` 未额外处理，可后续跟进）