### PR TITLE
fix(cowork): skip auto-routing skill prompt injection for   OpenClaw engine

### DIFF
--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -229,10 +229,13 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       dispatch(clearActiveSkills());
       dispatch(clearSelection());
 
-      // Combine skill prompt with system prompt
-      // If no manual skill selected, use auto-routing prompt
+      // Combine skill prompt with system prompt.
+      // OpenClaw loads skills natively via skills.load.extraDirs, so skip the
+      // auto-routing prompt to avoid injecting Claude SDK tool-calling instructions
+      // that confuse non-Claude models (e.g. kimi-k2.5 falls back to text-based
+      // tool calls, producing empty tool names and err=true failures).
       let effectiveSkillPrompt = skillPrompt;
-      if (!skillPrompt) {
+      if (!skillPrompt && !isOpenClawEngine) {
         effectiveSkillPrompt = await skillService.getAutoRoutingPrompt() || undefined;
       }
       const combinedSystemPrompt = [effectiveSkillPrompt, config.systemPrompt]
@@ -310,10 +313,10 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       dispatch(clearActiveSkills());
     }
 
-    // Combine skill prompt with system prompt for continuation
-    // If no manual skill selected, use auto-routing prompt
+    // Combine skill prompt with system prompt for continuation.
+    // Skip auto-routing prompt for OpenClaw — skills are loaded natively.
     let effectiveSkillPrompt = skillPrompt;
-    if (!skillPrompt) {
+    if (!skillPrompt && !isOpenClawEngine) {
       effectiveSkillPrompt = await skillService.getAutoRoutingPrompt() || undefined;
     }
     const combinedSystemPrompt = [effectiveSkillPrompt, config.systemPrompt]


### PR DESCRIPTION
问题

  客户使用 kimi-k2.5 模型通过 OpenClaw                                    
  引擎执行文件操作时，频繁出现工具调用失败（tool=
  空、call_auto_1、err=true）。同模型同文件在其他应用中无此问题。         
                                                                  
  日志表现

  [agent/embedded] embedded run tool start: tool= toolCallId=call_auto_1
  [ws] → event agent stream=tool tool=result: call=call_auto_1 err=true
                                                                          
  成功的工具调用使用 functions.read:0（OpenAI function calling            
  原生格式），失败的使用 call_auto_1（OpenClaw                            
  从文本自动解析），说明模型部分工具调用退化为文本输出。                  
                                                                  
  根因分析                                                                
       
  CoworkView.tsx 在每次会话（startSession / continueSession）中无条件注入 
  getAutoRoutingPrompt()，生成约 9,300 字符的 Claude SDK          
  风格技能路由提示：                                                      
                                               
  ## Skills (mandatory)
  - read its SKILL.md at <location> with the Read tool, then follow it.   
  <available_skills>                                                      
    <skill><location>...\SKILLs\docx\SKILL.md</location></skill>          
    ... (21 个技能)                                                       
  </available_skills>                                                     
                                                                          
  但 OpenClaw 已通过 skills.load.extraDirs                                
  原生加载了这些技能，此注入完全多余。更严重的是：                        
                                                                          
  1. "with the Read tool" 指令与 OpenClaw 的原生工具系统冲突，导致        
  kimi-k2.5 等非 Claude 模型 function calling 行为不一致
  2. 额外占用 ~9,300 字符（约占总 prompt 的 24%），加重模型负担           
                                                                          
  修改                                                                    
                                                                          
  在 OpenClaw 引擎模式下跳过 getAutoRoutingPrompt() 注入，保留            
  yd_cowork（Claude SDK）引擎的兼容性。                           
                                                                          
  改动文件： src/renderer/components/cowork/CoworkView.tsx（2 处）        
   
  - if (!skillPrompt) {                                                   
  + if (!skillPrompt && !isOpenClawEngine) {                              
      effectiveSkillPrompt = await skillService.getAutoRoutingPrompt() || 
  undefined;                                                              
    }                                                                     
                                                                          
  效果                                                                    
                                                                          
  - 消除 OpenClaw 模式下工具调用文本退化问题                              
  - 减少 ~9,300 字符 prompt 注入（promptChars 从 ~22K 降至 ~13K） 
  - 手动选择技能（skillPrompt 有值）不受影响                              
  - yd_cowork 引擎行为不变                                                
                                                                          
  验证方式                                                                
                                                                          
  1. OpenClaw + kimi-k2.5 模型，发起文件读写操作，确认不再出现 call_auto_1
   + err=true
  2. 对比日志中 [context-diag] promptChars 和 [OpenClawRuntime] chat.send 
  messageLength 应明显减小                                                
  3. 手动选择技能后发消息，确认技能 prompt 仍正常注入