### PR TITLE
perf(build): enable esbuild minification for production builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,8 @@ import fs from 'fs';
 const devPort = 5175;
 const katexVersion = process.env.npm_package_dependencies_katex?.replace(/^[~^]/, '') || '0.16.0';
 
+const isProduction = process.env.NODE_ENV === 'production';
+
 export default defineConfig({
   define: {
     // KaTeX ESM bundle references this compile-time constant.
@@ -24,7 +26,7 @@ export default defineConfig({
           build: {
             sourcemap: true,
             outDir: 'dist-electron',
-            minify: false,
+            minify: isProduction,
             rollupOptions: {
               external: (id) => {
                 const staticExternals = ['sql.js', 'discord.js', 'zlib-sync', '@discordjs/opus', 'bufferutil', 'utf-8-validate', 'node-nim', 'nim-web-sdk-ng'];
@@ -51,7 +53,7 @@ export default defineConfig({
           build: {
             sourcemap: true,
             outDir: 'dist-electron',
-            minify: false,
+            minify: isProduction,
           },
         },
         onstart() {},
@@ -69,7 +71,6 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
     sourcemap: true,
-    minify: false,
   },
   server: {
     port: devPort,


### PR DESCRIPTION
## Summary

- Production builds shipped **unminified** code because all three Vite build targets had `minify: false` hardcoded
- Renderer: removed explicit `minify: false` — Vite defaults to esbuild minification in production mode
- Main process & preload: changed to `minify: isProduction` (conditional on `NODE_ENV === 'production'`), so dev builds remain unminified for easy debugging

## Impact

| Target | Before | After | Reduction |
|--------|--------|-------|-----------|
| Renderer `index.js` | 3,646 KB | 2,047 KB | **-43.9%** |
| Main `main.js` | 6,030 KB | 2,573 KB | **-57.3%** |
| Preload `preload.js` | 17 KB | 11 KB | **-35.2%** |
| **Total** | **9,693 KB** | **4,631 KB** | **-52.2%** |

Sourcemaps are preserved (`sourcemap: true`) for production error tracking.

## Test Plan

- [x] `npm run build` produces minified output with correct sizes
- [x] `npm run electron:dev` still works without minification (dev mode unaffected)
- [x] Sourcemaps generated alongside minified bundles
- [x] `npm run dist:mac` packages correctly with minified bundles