### PR TITLE
feat: add openclaw install local plugin

### DIFF
--- a/docs/openclaw-install-local-plugin.md
+++ b/docs/openclaw-install-local-plugin.md
@@ -1,0 +1,48 @@
+## openclaw 安装本地插件使用指南
+
+1、将本地打包好的插件，放入该项目vendor目录下
+
+目录结构如下
+
+```
+LobsterAI/
+└── vendor/
+    └── local-plugins/
+        └── clawtrace-1.0.1.tgz   ← 每次发布新版本替换这里
+```
+
+2、更新根目录下package.json中的插件字段
+
+```
+{
+  "openclaw": {
+    "plugins": [
+      ...其他已有插件...,
+      {
+        "id": "openclaw-plugin-name",
+        "npm": "openclaw-plugin-name",
+        "version": "file:vendor/local-plugins/openclaw-plugin-name-1.0.0.tgz"
+      }
+    ]
+  }
+}
+
+```
+
+3、随后进行打包流程
+
+mac&linux
+
+windows
+
+```
+# 强制重新安装插件（忽略缓存）
+
+$env:OPENCLAW_FORCE_PLUGIN_INSTALL="1"; npm run openclaw:plugins
+# 同步本地 openclaw-extensions/ 目录
+
+npm run openclaw:extensions:local
+# 然后直接启动（跳过 OpenClaw 版本重建）
+
+$env:OPENCLAW_SKIP_ENSURE="1"; npm run electron:dev:openclaw
+```

--- a/scripts/ensure-openclaw-plugins.cjs
+++ b/scripts/ensure-openclaw-plugins.cjs
@@ -159,7 +159,17 @@ for (const plugin of plugins) {
   const installInfoPath = path.join(cacheDir, 'plugin-install-info.json');
   const targetDir = path.join(runtimeExtensionsDir, id);
 
+  // Resolve file: paths (local tgz) relative to rootDir so they work from
+  // any working directory (including the npm install tmp dir).
+  const isLocalTgz = typeof version === 'string' && version.startsWith('file:');
+  const resolvedVersion = isLocalTgz
+    ? `file:${path.resolve(rootDir, version.slice('file:'.length))}`
+    : version;
+
   log(`--- Plugin: ${id} (${npmSpec}@${version}) ---`);
+  if (isLocalTgz) {
+    log(`  Local tgz: ${resolvedVersion}`);
+  }
 
   // Check cache
   let needsDownload = true;
@@ -181,13 +191,15 @@ for (const plugin of plugins) {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `openclaw-plugin-${id}-`));
 
     try {
-      // Create a minimal wrapper package.json
+      // Create a minimal wrapper package.json.
+      // Use resolvedVersion so that file: paths are absolute and work from
+      // the tmp directory regardless of cwd.
       const wrapperPkg = {
         name: `openclaw-plugin-wrapper-${id}`,
         version: '0.0.0',
         private: true,
         dependencies: {
-          [npmSpec]: version,
+          [npmSpec]: resolvedVersion,
         },
       };
       fs.writeFileSync(


### PR DESCRIPTION
目前进行编译打包时，openclaw的插件仅支持从公共仓库拉取插件，或者将源码放在openclaw-extensions目录下进行打包，但是插件可能是单独的仓库，方便代码维护，增加支持本地安装的形式，使用说明位于：docs\openclaw-install-local-plugin.md