### PR TITLE
fix: agent deletion IM binding cleanup & SKILLS_ROOT gateway env

### DIFF
--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from 'events';
 import fs from 'fs';
 import net from 'net';
 import path from 'path';
-import { getElectronNodeRuntimePath, ensureElectronNodeShim } from './coworkUtil';
+import { getElectronNodeRuntimePath, ensureElectronNodeShim, getSkillsRoot } from './coworkUtil';
 import { syncLocalOpenClawExtensionsIntoRuntime } from './openclawLocalExtensions';
 import { appendPythonRuntimeToEnv } from './pythonRuntime';
 import { isSystemProxyEnabled, resolveSystemProxyUrl } from './systemProxy';
@@ -390,9 +390,12 @@ export class OpenClawEngineManager extends EventEmitter {
     console.log(`[OpenClaw] compile cache dir: ${compileCacheDir}`);
     const electronNodeRuntimePath = getElectronNodeRuntimePath();
     const cliShimDir = this.ensureBundledCliShims();
+    const skillsRoot = getSkillsRoot().replace(/\\/g, '/');
 
     const env: NodeJS.ProcessEnv = {
       ...process.env,
+      SKILLS_ROOT: skillsRoot,
+      LOBSTERAI_SKILLS_ROOT: skillsRoot,
       OPENCLAW_HOME: runtime.root,
       OPENCLAW_STATE_DIR: this.stateDir,
       OPENCLAW_CONFIG_PATH: this.configPath,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2693,6 +2693,31 @@ if (!gotTheLock) {
   ipcMain.handle('agents:delete', async (_event, id: string) => {
     try {
       const result = getAgentManager().deleteAgent(id);
+
+      // Clean up IM platform bindings that reference the deleted agent
+      // so that channels fall back to the default 'main' agent.
+      try {
+        const imStore = getIMGatewayManager()?.getIMStore();
+        if (imStore) {
+          const imSettings = imStore.getIMSettings();
+          const bindings = imSettings.platformAgentBindings;
+          if (bindings) {
+            let changed = false;
+            for (const [platform, agentId] of Object.entries(bindings)) {
+              if (agentId === id) {
+                delete bindings[platform];
+                changed = true;
+              }
+            }
+            if (changed) {
+              imStore.setIMSettings({ platformAgentBindings: bindings });
+            }
+          }
+        }
+      } catch {
+        // IM store may not be initialised yet; safe to ignore.
+      }
+
       syncOpenClawConfig({ reason: 'agent-deleted' }).catch(() => {});
       return { success: true, deleted: result };
     } catch (error) {


### PR DESCRIPTION
## Summary
- Fix: deleting an agent now clears its IM platform bindings, so channels correctly fall back to the 'main' agent instead of retaining the deleted agent's persona
- Fix: inject `SKILLS_ROOT` / `LOBSTERAI_SKILLS_ROOT` into the OpenClaw gateway process environment, so skill scripts (e.g. web-search) using `$SKILLS_ROOT` resolve correctly

## Test plan
- [x] Delete an agent bound to an IM platform (e.g. WeCom), verify IM conversations use 'main' agent afterward
- [x] Verify web-search skill exec via IM channel resolves `$SKILLS_ROOT` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)