### PR TITLE
fix(openclaw): ensure gateway handshake completes before cron polling

### DIFF
--- a/src/scheduled-task/cronJobService.ts
+++ b/src/scheduled-task/cronJobService.ts
@@ -559,6 +559,7 @@ export class CronJobService {
     if (!this.polling) return;
 
     try {
+      await this.ensureGatewayReady();
       const client = this.getGatewayClient();
       if (!client) return;
 


### PR DESCRIPTION
pollOnce() was sending cron.list requests through a GatewayClient whose WebSocket connect handshake had not yet completed, causing the server to reject with "invalid handshake: first request must be connect" (1008).