### PR TITLE
fix(cowork): 修复输入框回车后延迟清空及长会话卡顿问题

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2558,8 +2558,7 @@ if (!gotTheLock) {
         });
       });
 
-      const session = getCoworkStore().getSession(options.sessionId);
-      return { success: true, session };
+      return { success: true };
     } catch (error) {
       return {
         success: false,

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -270,12 +270,33 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         base64Lengths: imageAtts.map(a => a.base64Data.length),
       });
     }
-    const result = await onSubmit(finalPrompt, skillPrompt, imageAtts.length > 0 ? imageAtts : undefined);
-    if (result === false) return;
+    // Save original values for potential restore
+    const originalValue = value;
+    const originalAttachments = [...attachments];
+
+    // Clear the input immediately for instant feedback, before awaiting onSubmit
     setValue('');
     dispatch(setDraftPrompt({ sessionId: draftKey, draft: '' }));
     setAttachments([]);
     setImageVisionHint(false);
+
+    let result: boolean | void;
+    try {
+      result = await onSubmit(finalPrompt, skillPrompt, imageAtts.length > 0 ? imageAtts : undefined);
+    } catch (error) {
+      console.error('[CoworkPromptInput] onSubmit threw an error, restoring input:', error);
+      // Restore input and attachments so user can retry
+      setValue(originalValue);
+      dispatch(setDraftPrompt({ sessionId: draftKey, draft: originalValue }));
+      setAttachments(originalAttachments);
+      return;
+    }
+    if (result === false) {
+      // onSubmit explicitly rejected, restore input and attachments so user can retry
+      setValue(originalValue);
+      dispatch(setDraftPrompt({ sessionId: draftKey, draft: originalValue }));
+      setAttachments(originalAttachments);
+    }
   }, [value, isStreaming, disabled, onSubmit, activeSkillIds, skills, attachments, showFolderSelector, workingDirectory, dispatch]);
 
   const handleSelectSkill = useCallback((skill: Skill) => {

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -232,13 +232,20 @@ const coworkSlice = createSlice({
       const { sessionId, messageId, content } = action.payload;
 
       if (state.currentSession?.id === sessionId) {
-        const messageIndex = state.currentSession.messages.findIndex(m => m.id === messageId);
+        const messages = state.currentSession.messages;
+        // Optimization: streaming usually updates the last message, check it first
+        let messageIndex = -1;
+        if (messages.length > 0 && messages[messages.length - 1].id === messageId) {
+          messageIndex = messages.length - 1;
+        } else {
+          messageIndex = messages.findIndex(m => m.id === messageId);
+        }
         if (messageIndex !== -1) {
-          const previousContent = state.currentSession.messages[messageIndex].content || '';
+          const previousContent = messages[messageIndex].content || '';
           if (state.config.agentEngine === 'yd_cowork') {
-            state.currentSession.messages[messageIndex].content = mergeStreamingMessageContent(previousContent, content);
+            messages[messageIndex].content = mergeStreamingMessageContent(previousContent, content);
           } else {
-            state.currentSession.messages[messageIndex].content = content;
+            messages[messageIndex].content = content;
           }
         }
       }


### PR DESCRIPTION
## 问题描述

在 Cowork 会话中，当会话上下文较长时，用户按回车提交后输入框内容有明显延迟才清空，严重时甚至完全不清空（内容残留）。

## 修改内容
1. `CoworkPromptInput.tsx` — 立即清空输入框
将清空操作（`setValue('')`、清空 attachments）移到 `await onSubmit()` **之前** 如果 `onSubmit` 抛出异常或返回 `false`，恢复原始输入内容和附件，方便用户重试
2. `main.ts` — 移除不必要的 IPC 数据传输
`continueSession` handler 不再返回完整 session 对象，仅返回 `{ success: true }`
渲染进程只使用 `success`/`error`/`engineStatus`/`code` 字段，消息更新通过 stream 事件推送
3. `coworkSlice.ts` — 优化消息查找
`updateMessageContent` 先检查最后一条消息是否匹配，命中则跳过 `findIndex` 遍历
Streaming 场景下几乎 100% 命中，将 O(n) 降为 O(1)

## 补充说明：
注意到 upstream 近期合并了 `feat/chat-virtual-scroll`（LazyRenderTurn 懒渲染）和 `4edaa54`（React.memo/useMemo/防抖等渲染优化），已从渲染层面大幅降低了长会话的性能开销，间接缓解了输入框延迟清空的感知。
但本 PR 的改动与渲染优化是**互补关系，而非替代关系**：

- **渲染优化是"间接解决"**：因为渲染变快了，所以 `await onSubmit()` 后的 `setValue('')` 也能较快生效。但如果未来出现渲染回退（复杂内容、新功能引入额外开销）或 IPC 耗时增加（主进程繁忙、Skill 处理耗时），延迟仍会复现。
- **本 PR 是"确定性保障"**：将清空操作前置到 `await` 之前，无论渲染性能或 IPC 耗时如何，输入框都能立即响应。同时补充了 try-catch 错误处理和失败恢复逻辑，这是原代码缺失的。
- **移除 `continueSession` 返回的 session 对象**：该返回值渲染进程完全未使用（消息通过 stream 事件推送），属于不必要的 IPC 序列化开销，此问题在 upstream 中尚未修复。


### 问题截图（另外指令在正常执行，但是输出框内容最后没清空情况忘记截图了）
<img width="899" height="525" alt="image" src="https://github.com/user-attachments/assets/84d084a8-935e-4af0-adf0-a7f2a31d7aba" />
