### PR TITLE
fix(mcp): fix scrollbar overflowing modal rounded corners

### DIFF
--- a/src/renderer/components/mcp/McpServerFormModal.tsx
+++ b/src/renderer/components/mcp/McpServerFormModal.tsx
@@ -223,16 +223,16 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-lg mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6 max-h-[80vh] overflow-y-auto"
+        className="w-full max-w-lg mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl max-h-[80vh] overflow-hidden flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center justify-between px-6 pt-6 pb-3">
           <div className="text-lg font-semibold dark:text-claude-darkText text-claude-text">
             {modalTitle}
           </div>
         </div>
 
-        <div className="space-y-4">
+        <div className="space-y-4 overflow-y-auto px-6">
           {/* Name */}
           <div className="space-y-1.5">
             <label className={labelClass}>{i18nService.t('mcpServerName')}</label>
@@ -416,23 +416,23 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
           {error && (
             <div className="text-xs text-red-500">{error}</div>
           )}
+        </div>
 
-          <div className="flex items-center justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-3 py-1.5 text-xs rounded-lg border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-colors"
-            >
-              {i18nService.t('cancel')}
-            </button>
-            <button
-              type="button"
-              onClick={handleSave}
-              className="px-3 py-1.5 text-xs rounded-lg bg-claude-accent text-white hover:bg-claude-accent/90 transition-colors"
-            >
-              {saveText}
-            </button>
-          </div>
+        <div className="flex items-center justify-end gap-2 px-6 pt-3 pb-6">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs rounded-lg border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-colors"
+          >
+            {i18nService.t('cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            className="px-3 py-1.5 text-xs rounded-lg bg-claude-accent text-white hover:bg-claude-accent/90 transition-colors"
+          >
+            {saveText}
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- MCP 自定义服务器弹框滚动条溢出圆角的视觉问题修复
- 将弹框容器从单层（圆角+滚动同一 div）拆分为三层结构（外层裁剪 + 中间滚动 + 底部固定按钮）

## 问题

MCP 自定义服务器弹框（McpServerFormModal）内容超出 `max-h-[80vh]` 触发滚动时，滚动条溢出弹框的 `rounded-2xl` 圆角，视觉上破坏了圆角效果。

## 根因

`rounded-2xl` 和 `overflow-y-auto` 同时设置在同一个 `div` 上。当滚动条出现时，浏览器原生滚动条不会被圆角裁剪，因为 `overflow-y-auto` 的滚动区域覆盖了整个容器包括圆角区域。

## 修复

将弹框容器拆分为三层结构：
- **外层**：`rounded-2xl` + `overflow-hidden`（负责圆角裁剪）+ `flex flex-col`
- **标题区**：固定在顶部（`px-6 pt-6 pb-3`），不参与滚动
- **表单内容区**：`overflow-y-auto`（独立滚动，被外层 `overflow-hidden` 裁剪）
- **按钮区**：固定在底部（`px-6 pt-3 pb-6`），不参与滚动

## 复现路径

1. 打开设置 → MCP 服务器管理
2. 点击添加自定义 MCP 服务器
3. 添加多行环境变量使内容超出弹框高度
4. 观察滚动条溢出圆角