### PR TITLE
feat(im): switch DingTalk plugin to community package and remove app-level cron reply routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "repo": "https://github.com/openclaw/openclaw.git",
     "plugins": [
       {
-        "id": "dingtalk-connector",
-        "npm": "@dingtalk-real-ai/dingtalk-connector",
-        "version": "0.7.9"
+        "id": "dingtalk",
+        "npm": "@soimy/dingtalk",
+        "version": "3.3.0"
       },
       {
         "id": "feishu-openclaw-plugin",

--- a/scripts/patches/v2026.3.2/openclaw-cron-delivery-inference.patch
+++ b/scripts/patches/v2026.3.2/openclaw-cron-delivery-inference.patch
@@ -67,13 +67,13 @@ index 14df690102..c36714ece6 100644
      return null;
    }
  
-+  if (head === "dingtalk-connector") {
++  if (head === "dingtalk") {
 +    const accountId = parts[1]?.trim();
 +    const senderId = parts[2]?.trim();
 +    if (accountId && senderId) {
 +      const delivery: CronDelivery = {
 +        mode: "announce",
-+        channel: "dingtalk-connector" as CronMessageChannel,
++        channel: "dingtalk" as CronMessageChannel,
 +        to: `user:${senderId}`,
 +        accountId,
 +      };

--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -1774,27 +1774,6 @@ export class IMGatewayManager extends EventEmitter {
   async sendConversationReply(platform: IMPlatform, conversationId: string, text: string): Promise<boolean> {
     try {
       switch (platform) {
-        case 'dingtalk': {
-          const target = await this.resolveDingTalkConversationReplyTarget(conversationId)
-            ?? this.parseDingTalkConversationTarget(conversationId);
-          if (!target) {
-            // Fallback: try to extract userId directly from conversationId (raw peerId).
-            const fallbackUserId = conversationId.trim();
-            if (!fallbackUserId) {
-              console.warn(`[IMGatewayManager] Cannot resolve DingTalk target from conversationId: ${conversationId}`);
-              return false;
-            }
-            return this.sendDingTalkDirectHttp(fallbackUserId, text);
-          }
-          // Extract userId from target string like "user:0146552636218419"
-          const userId = target.target.startsWith('user:')
-            ? target.target.slice(5)
-            : target.target;
-          return this.sendDingTalkDirectHttp(userId, text);
-        }
-        case 'nim':
-          console.log('[IMGatewayManager] NIM conversation reply via OpenClaw not yet supported');
-          return false;
         case 'xiaomifeng':
           await this.xiaomifengGateway.sendConversationNotification(conversationId, text);
           return true;
@@ -2047,7 +2026,7 @@ export class IMGatewayManager extends EventEmitter {
     return {
       coworkSessionId: normalizedCoworkSessionId,
       candidateSessionKeys,
-      dingtalkSessionKeys: this.collectSessionKeysByChannel(sessions, 'dingtalk-connector'),
+      dingtalkSessionKeys: this.collectSessionKeysByChannel(sessions, 'dingtalk'),
       resolved: resolveOpenClawDeliveryRouteForSessionKeys(candidateSessionKeys, sessions)
         ?? resolveManagedSessionDeliveryRoute(normalizedCoworkSessionId, sessions),
     };
@@ -2174,7 +2153,7 @@ export class IMGatewayManager extends EventEmitter {
       return {
         sessionKey,
         route: {
-          channel: 'dingtalk-connector',
+          channel: 'dingtalk',
           to,
           ...(accountId ? { accountId } : {}),
         },

--- a/src/main/libs/openclawChannelSessionSync.ts
+++ b/src/main/libs/openclawChannelSessionSync.ts
@@ -63,7 +63,7 @@ export const CHANNEL_PLATFORM_MAP: Record<string, IMPlatform> = {
   telegram: 'telegram',
   discord: 'discord',
   feishu: 'feishu',
-  'dingtalk-connector': 'dingtalk',
+  dingtalk: 'dingtalk',
   qqbot: 'qq',
   'wecom-openclaw-plugin': 'wecom',
   wecom: 'wecom',

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -676,7 +676,7 @@ export class OpenClawConfigSync {
               // When a channel is disabled in the UI, its plugin must also be
               // disabled so OpenClaw doesn't load it at all.
               const pluginEnabled = (() => {
-                if (id === 'dingtalk-connector') return !!(dingTalkConfig?.enabled && dingTalkConfig.clientId);
+                if (id === 'dingtalk') return !!(dingTalkConfig?.enabled && dingTalkConfig.clientId);
                 if (id === 'feishu-openclaw-plugin') return !!(feishuConfig?.enabled && feishuConfig.appId);
                 if (id === 'qqbot') return !!(qqConfig?.enabled && qqConfig.appId);
                 if (id === 'wecom-openclaw-plugin') return !!(wecomConfig?.enabled && wecomConfig.botId);
@@ -875,7 +875,7 @@ export class OpenClawConfigSync {
         ...(dingTalkConfig.gatewayBaseUrl ? { gatewayBaseUrl: dingTalkConfig.gatewayBaseUrl } : {}),
         ...(gatewayToken ? { gatewayToken: '${LOBSTER_DINGTALK_GW_TOKEN}' } : {}),
       };
-      managedConfig.channels = { ...(managedConfig.channels as Record<string, unknown> || {}), 'dingtalk-connector': dingtalkChannel };
+      managedConfig.channels = { ...(managedConfig.channels as Record<string, unknown> || {}), 'dingtalk': dingtalkChannel };
     }
 
     // Sync QQ OpenClaw channel config (via qqbot plugin)
@@ -1009,7 +1009,7 @@ export class OpenClawConfigSync {
     if (platformBindingsForSentinel) {
       // Map openclaw channel key → platform key
       const channelToPlatform: Record<string, string> = {
-        'dingtalk-connector': 'dingtalk',
+        dingtalk: 'dingtalk',
         feishu: 'feishu',
         telegram: 'telegram',
         discord: 'discord',
@@ -1487,7 +1487,7 @@ export class OpenClawConfigSync {
 
     // Map openclaw channel name → platform key used in platformAgentBindings
     const channelMap: Array<{ getter: () => { enabled: boolean } | null; channel: string; platform: string }> = [
-      { getter: () => this.getDingTalkConfig(), channel: 'dingtalk-connector', platform: 'dingtalk' },
+      { getter: () => this.getDingTalkConfig(), channel: 'dingtalk', platform: 'dingtalk' },
       { getter: () => this.getFeishuConfig(), channel: 'feishu', platform: 'feishu' },
       { getter: () => this.getTelegramOpenClawConfig?.() ?? null, channel: 'telegram', platform: 'telegram' },
       { getter: () => this.getDiscordOpenClawConfig?.() ?? null, channel: 'discord', platform: 'discord' },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -90,7 +90,7 @@ const IPC_MAX_ITEMS = 40;
 const MAX_INLINE_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 const ENGINE_NOT_READY_CODE = 'ENGINE_NOT_READY';
 const SCHEDULED_TASK_CHANNEL_OPTIONS = [
-  { value: 'dingtalk-connector', label: 'DingTalk' },
+  { value: 'dingtalk', label: 'DingTalk' },
   { value: 'feishu', label: 'Feishu' },
   { value: 'telegram', label: 'Telegram' },
   { value: 'discord', label: 'Discord' },
@@ -1358,13 +1358,13 @@ const getIMGatewayManager = () => {
           return openClawRuntimeAdapter?.getSessionKeysForSession(sessionId) ?? [];
         },
         createScheduledTask: async ({ sessionId, message, request }) => {
-          if (message.platform === 'dingtalk') {
-            await getIMGatewayManager().primeConversationReplyRoute(
-              message.platform,
-              message.conversationId,
-              sessionId,
-            );
-          }
+          // if (message.platform === 'dingtalk') {
+          //   await getIMGatewayManager().primeConversationReplyRoute(
+          //     message.platform,
+          //     message.conversationId,
+          //     sessionId,
+          //   );
+          // }
           const channelName = PLATFORM_TO_CHANNEL_MAP[message.platform];
           const hasChannel = !!(channelName && message.conversationId);
           // Strip IM subtype prefix (e.g. "direct:ou_xxx" -> "ou_xxx")
@@ -1506,7 +1506,7 @@ function listScheduledTaskChannels(): Array<{ value: string; label: string }> {
   }
 
   return SCHEDULED_TASK_CHANNEL_OPTIONS.filter((option) => {
-    if (option.value === 'dingtalk-connector') {
+    if (option.value === 'dingtalk') {
       return enabledConfigKeys.has('dingtalk');
     }
     if (option.value === 'qqbot') {

--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -58,7 +58,7 @@ const DEFAULT_FORM_STATE: FormState = {
 };
 
 const IM_CHANNEL_VALUES = new Set([
-  'dingtalk-connector',
+  'dingtalk',
   'feishu',
   'telegram',
   'discord',
@@ -421,7 +421,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
           >
             <option value="none">{i18nService.t('scheduledTasksFormNotifyChannelNone')}</option>
             {channelOptions.map((channel) => {
-              const unsupported = channel.value === 'openclaw-weixin' || channel.value === 'qqbot';
+              const unsupported = channel.value === 'openclaw-weixin' || channel.value === 'qqbot' || channel.value === 'xiaomifeng';
               return (
                 <option key={channel.value} value={channel.value} disabled={unsupported}>
                   {unsupported

--- a/src/scheduled-task/enginePrompt.ts
+++ b/src/scheduled-task/enginePrompt.ts
@@ -11,6 +11,7 @@ export function buildScheduledTaskEnginePrompt(engine: CoworkAgentEngine): strin
       '- For scheduled-task creation, call native `cron` with `action: "add"` / `cron.add` instead of any channel-specific helper.',
       '- Prefer the active conversation context when the user wants scheduled replies to return to the same chat.',
       '- Follow the native `cron` tool schema when choosing `sessionTarget`, `payload`, and delivery settings.',
+      '- When `cron.add` includes any channel delivery config (e.g. `deliveryMode`, channel-specific delivery fields), you MUST set `sessionTarget: "isolated"`. Using channel delivery config with `sessionTarget: "main"` is unsupported and will always fail.',
       '- For one-time reminders (`schedule.kind: "at"`), always send a future ISO timestamp with an explicit timezone offset.',
       '- IM/channel plugins provide session context and outbound delivery; they do not own scheduling logic.',
       '- In native IM/channel sessions, ignore channel-specific reminder helpers or reminder skills and call native `cron` directly.',

--- a/src/scheduled-task/origin.test.ts
+++ b/src/scheduled-task/origin.test.ts
@@ -53,7 +53,7 @@ test('infer: telegram channel key -> im origin + im_session binding', () => {
 
 test('infer: dingtalk connector channel key -> im origin', () => {
   const result = inferOriginAndBinding(
-    makeTask({ sessionKey: 'agent:main:openai-user:dingtalk-connector:acct1:user:peer1' })
+    makeTask({ sessionKey: 'agent:main:openai-user:dingtalk:acct1:user:peer1' })
   );
   expect(result.origin.kind).toBe(OriginKind.IM);
   expect((result.origin as any).platform).toBe('dingtalk');


### PR DESCRIPTION
 - Replace the official `@dingtalk-real-ai/dingtalk-connector` plugin (id: dingtalk-connector)
  with the community plugin `@soimy/dingtalk` (id: dingtalk, v3.3.0). The community plugin
  handles scheduled-task channel delivery natively, so the app-level
  `primeConversationReplyRoute` call in `createScheduledTask` is no longer needed and has
  been removed.
 - All internal references to the old channel key `dingtalk-connector` (config sync, gateway
  manager, task channel options, platform bindings) are updated to `dingtalk` to match the
  new plugin id.
 - Also adds an engine-prompt rule requiring `sessionTarget: "isolated"` whenever a cron task
  includes channel delivery config, preventing the UNAVAILABLE error seen at runtime.