### PR TITLE
continueSession 双重错误消息

### DIFF
--- a/src/renderer/services/cowork.test.ts
+++ b/src/renderer/services/cowork.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * BUG-1 验证测试: continueSession 双重错误消息
+ *
+ * 问题: 修改前，当 continueSession 失败时，会连续 dispatch 两条系统错误消息
+ *       （一条 coworkErrorSessionContinueFailed，一条 classifyError）
+ * 修复: 合并为一条 classifyError 消息
+ *
+ * 测试策略: 提取错误处理的核心逻辑为纯函数，分别模拟修改前和修改后的行为，
+ *          对比 dispatch 调用次数和消息内容。
+ */
+
+// ---- 模拟依赖 ----
+
+/** 模拟 classifyErrorKey（从 coworkErrorClassify.ts 提取的简化版） */
+function classifyErrorKey(error: string): string | null {
+  if (/authentication.*error|api.*key.*invalid|unauthorized|\b401\b/i.test(error)) {
+    return 'coworkErrorAuthInvalid';
+  }
+  if (/\b429\b|rate.*limit|too many requests/i.test(error)) {
+    return 'coworkErrorRateLimit';
+  }
+  if (/insufficient.*(balance|quota)/i.test(error)) {
+    return 'coworkErrorInsufficientBalance';
+  }
+  return null;
+}
+
+/** 模拟 i18nService.t */
+const translations: Record<string, string> = {
+  coworkErrorSessionContinueFailed: '继续会话失败: {error}',
+  coworkErrorEngineNotReady: '引擎未就绪',
+  coworkErrorAuthInvalid: 'API 密钥无效或已过期',
+  coworkErrorRateLimit: '请求频率超限，请稍后重试',
+  coworkErrorInsufficientBalance: '账户余额不足',
+};
+
+function t(key: string): string {
+  return translations[key] ?? key;
+}
+
+function classifyError(error: string): string {
+  const key = classifyErrorKey(error);
+  return key ? t(key) : error;
+}
+
+// ---- 模拟 continueSession 失败时的错误处理逻辑 ----
+
+interface DispatchedMessage {
+  id: string;
+  type: string;
+  content: string;
+  timestamp: number;
+}
+
+interface FailureResult {
+  success: false;
+  error?: string;
+  code?: string;
+  engineStatus?: unknown;
+}
+
+/**
+ * 修改前的错误处理逻辑（BUG 版本）
+ * 会产生两条错误消息
+ */
+function handleContinueFailure_BEFORE(
+  result: FailureResult,
+  sessionId: string,
+): DispatchedMessage[] {
+  const messages: DispatchedMessage[] = [];
+
+  if (result.code !== 'ENGINE_NOT_READY') {
+    // 第一条消息: coworkErrorSessionContinueFailed
+    if (result.error) {
+      messages.push({
+        id: `error-${Date.now()}`,
+        type: 'system',
+        content: t('coworkErrorSessionContinueFailed').replace('{error}', result.error),
+        timestamp: Date.now(),
+      });
+    }
+  }
+
+  // 第二条消息: classifyError
+  if (result.error) {
+    const errorContent = result.code === 'ENGINE_NOT_READY'
+      ? t('coworkErrorEngineNotReady')
+      : classifyError(result.error);
+    messages.push({
+      id: `error-${Date.now()}`,
+      type: 'system',
+      content: errorContent,
+      timestamp: Date.now(),
+    });
+  }
+
+  return messages;
+}
+
+/**
+ * 修改后的错误处理逻辑（修复版本）
+ * 只产生一条错误消息
+ */
+function handleContinueFailure_AFTER(
+  result: FailureResult,
+  sessionId: string,
+): DispatchedMessage[] {
+  const messages: DispatchedMessage[] = [];
+
+  // 只添加一条消息
+  if (result.error) {
+    const errorContent = result.code === 'ENGINE_NOT_READY'
+      ? t('coworkErrorEngineNotReady')
+      : classifyError(result.error);
+    messages.push({
+      id: `error-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      type: 'system',
+      content: errorContent,
+      timestamp: Date.now(),
+    });
+  }
+
+  return messages;
+}
+
+// ---- 测试用例 ----
+
+describe('BUG-1: continueSession 双重错误消息', () => {
+
+  describe('场景1: 普通 API 错误（如认证失败）', () => {
+    const result: FailureResult = {
+      success: false,
+      error: 'authentication error: invalid api key',
+      code: undefined,
+    };
+
+    it('修改前: 产生 2 条错误消息（BUG）', () => {
+      const messages = handleContinueFailure_BEFORE(result, 'session-1');
+      expect(messages).toHaveLength(2);
+      // 第一条: 原始的 coworkErrorSessionContinueFailed 模板
+      expect(messages[0].content).toBe(
+        '继续会话失败: authentication error: invalid api key'
+      );
+      // 第二条: classifyError 分类后的消息
+      expect(messages[1].content).toBe('API 密钥无效或已过期');
+    });
+
+    it('修改后: 只产生 1 条错误消息（修复）', () => {
+      const messages = handleContinueFailure_AFTER(result, 'session-1');
+      expect(messages).toHaveLength(1);
+      // 唯一一条: classifyError 分类后的精确消息
+      expect(messages[0].content).toBe('API 密钥无效或已过期');
+    });
+  });
+
+  describe('场景2: 速率限制错误', () => {
+    const result: FailureResult = {
+      success: false,
+      error: '429 too many requests',
+      code: undefined,
+    };
+
+    it('修改前: 产生 2 条错误消息（BUG）', () => {
+      const messages = handleContinueFailure_BEFORE(result, 'session-2');
+      expect(messages).toHaveLength(2);
+      expect(messages[0].content).toBe('继续会话失败: 429 too many requests');
+      expect(messages[1].content).toBe('请求频率超限，请稍后重试');
+    });
+
+    it('修改后: 只产生 1 条错误消息（修复）', () => {
+      const messages = handleContinueFailure_AFTER(result, 'session-2');
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('请求频率超限，请稍后重试');
+    });
+  });
+
+  describe('场景3: 未分类的错误（无匹配规则）', () => {
+    const result: FailureResult = {
+      success: false,
+      error: 'some unexpected weird error from provider',
+      code: undefined,
+    };
+
+    it('修改前: 产生 2 条内容几乎相同的消息（BUG）', () => {
+      const messages = handleContinueFailure_BEFORE(result, 'session-3');
+      expect(messages).toHaveLength(2);
+      // 第一条: 模板包裹原始错误
+      expect(messages[0].content).toBe(
+        '继续会话失败: some unexpected weird error from provider'
+      );
+      // 第二条: classifyError 无匹配，直接返回原始错误
+      expect(messages[1].content).toBe('some unexpected weird error from provider');
+    });
+
+    it('修改后: 只产生 1 条消息，直接展示原始错误', () => {
+      const messages = handleContinueFailure_AFTER(result, 'session-3');
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('some unexpected weird error from provider');
+    });
+  });
+
+  describe('场景4: ENGINE_NOT_READY 错误', () => {
+    const result: FailureResult = {
+      success: false,
+      error: 'OpenClaw engine is not ready',
+      code: 'ENGINE_NOT_READY',
+    };
+
+    it('修改前: 产生 1 条消息（此场景无双重问题）', () => {
+      const messages = handleContinueFailure_BEFORE(result, 'session-4');
+      // code === ENGINE_NOT_READY 时，第一段不执行，只有第二段执行
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('引擎未就绪');
+    });
+
+    it('修改后: 仍然产生 1 条消息（行为一致）', () => {
+      const messages = handleContinueFailure_AFTER(result, 'session-4');
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('引擎未就绪');
+    });
+  });
+
+  describe('场景5: 无 error 字段', () => {
+    const result: FailureResult = {
+      success: false,
+      error: undefined,
+      code: undefined,
+    };
+
+    it('修改前: 不产生消息', () => {
+      const messages = handleContinueFailure_BEFORE(result, 'session-5');
+      expect(messages).toHaveLength(0);
+    });
+
+    it('修改后: 不产生消息（行为一致）', () => {
+      const messages = handleContinueFailure_AFTER(result, 'session-5');
+      expect(messages).toHaveLength(0);
+    });
+  });
+
+  describe('BUG-2 附带验证: 消息 ID 唯一性', () => {
+    const result: FailureResult = {
+      success: false,
+      error: 'authentication error',
+      code: undefined,
+    };
+
+    it('修改前: 两条消息的 ID 可能相同（BUG）', () => {
+      const messages = handleContinueFailure_BEFORE(result, 'session-6');
+      expect(messages).toHaveLength(2);
+      // 两条消息在同一毫秒生成，ID 格式为 error-{timestamp}，很可能相同
+      // 这里验证它们使用的是相同的 ID 格式（无随机后缀）
+      expect(messages[0].id).toMatch(/^error-\d+$/);
+      expect(messages[1].id).toMatch(/^error-\d+$/);
+    });
+
+    it('修改后: 消息 ID 包含随机后缀，保证唯一性', () => {
+      const messages = handleContinueFailure_AFTER(result, 'session-6');
+      expect(messages).toHaveLength(1);
+      // 新格式: error-{timestamp}-{random}
+      expect(messages[0].id).toMatch(/^error-\d+-[a-z0-9]+$/);
+    });
+  });
+});

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -286,19 +286,8 @@ class CoworkService {
       }
       if (result.code !== 'ENGINE_NOT_READY') {
         store.dispatch(updateSessionStatus({ sessionId: options.sessionId, status: 'error' }));
-        if (result.error) {
-          store.dispatch(addMessage({
-            sessionId: options.sessionId,
-            message: {
-              id: `error-${Date.now()}`,
-              type: 'system',
-              content: i18nService.t('coworkErrorSessionContinueFailed').replace('{error}', result.error),
-              timestamp: Date.now(),
-            },
-          }));
-        }
       }
-      // Show a user-visible error message in the session
+      // Show a single user-visible error message in the session
       if (result.error) {
         const errorContent = result.code === 'ENGINE_NOT_READY'
           ? i18nService.t('coworkErrorEngineNotReady')
@@ -306,7 +295,7 @@ class CoworkService {
         store.dispatch(addMessage({
           sessionId: options.sessionId,
           message: {
-            id: `error-${Date.now()}`,
+            id: `error-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
             type: 'system',
             content: errorContent,
             timestamp: Date.now(),


### PR DESCRIPTION
**文件**: `src/renderer/services/cowork.ts` 第 282-317 行

#### 问题描述

当 `continueSession()` 失败且 `code !== 'ENGINE_NOT_READY'` 时，代码会**连续 dispatch 两条系统错误消息**到同一个 session 中：

1. 第 289-298 行：添加 `coworkErrorSessionContinueFailed` 消息
2. 第 306-314 行：添加 `classifyError(result.error)` 消息

用户会在聊天界面看到两条内容几乎相同的红色错误提示，造成困惑。

#### 影响范围

- 所有使用 Cowork 继续对话的场景
- 当网络异常、API 配额耗尽、模型不可用时都会触发
- 影响所有用户

#### 复现步骤

1. 启动一个 Cowork 会话
2. 在对话过程中断网或让 API Key 失效
3. 发送新消息继续对话
4. 观察到聊天区域出现两条错误消息

#### 修复方案

合并两段错误处理逻辑，只保留一条用户可见的错误消息：

#### 修复价值

- **消除用户困惑**: 错误时只展示一条清晰明确的提示，用户能立即理解问题原因（如"API 密钥无效"而非两条模糊消息）
- **降低支持成本**: 减少因"出现两条错误"而产生的用户反馈和工单
- **提升产品专业感**: 重复错误消息是典型的"未打磨"信号，修复后整体质感提升
- **代码可维护性**: 合并后错误处理逻辑集中在一处，未来修改只需改一个地方