### PR TITLE
fix(cowork): prevent session menu from closing during streaming scroll

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1381,16 +1381,14 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         closeMenu();
       }
     };
-    const handleScroll = () => closeMenu();
+    const handleResize = () => closeMenu();
     document.addEventListener('mousedown', handleClickOutside);
     document.addEventListener('keydown', handleEscape);
-    window.addEventListener('scroll', handleScroll, true);
-    window.addEventListener('resize', handleScroll);
+    window.addEventListener('resize', handleResize);
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleEscape);
-      window.removeEventListener('scroll', handleScroll, true);
-      window.removeEventListener('resize', handleScroll);
+      window.removeEventListener('resize', handleResize);
     };
   }, [menuPosition]);
 


### PR DESCRIPTION
## Summary

The ellipsis (⋯) menu in the cowork session header auto-closes whenever streaming content is appended, making it impossible to interact with menu items during an active AI response.

## Problem

Users click the ⋯ button to access session actions (rename, delete, open folder, etc.) while an AI response is streaming. The menu appears briefly, then immediately closes as the message container auto-scrolls to show new content.

**Steps to reproduce:**
1. Start a cowork session and send a prompt
2. While the AI response is streaming, click the ⋯ button (upper right)
3. Menu appears then closes automatically before you can click any item

## Root Cause

The scroll listener in `CoworkSessionDetail.tsx` was registered with **capture mode** (`addEventListener('scroll', handler, true)`). Capture mode intercepts events at the top of the DOM tree before they reach their target, so it caught internal `div` scroll events that never bubble to `window`. When streaming content caused the message container to auto-scroll, the captured event triggered `closeMenu()`.

```typescript
// Before: capture=true intercepts ALL scroll events in the component tree
window.addEventListener('scroll', handleScroll, true);  // ← root cause

// After: removed — the menu is fixed-positioned so scroll doesn't move it
```

The menu uses `position: fixed` CSS, so scrolling the message container does not change the menu's position. There is no reason to close it on scroll.

## Changes

| File | Change |
|------|--------|
| `src/renderer/components/cowork/CoworkSessionDetail.tsx` | Remove capture-mode scroll listener; rename handler for clarity |

The `resize` listener is kept because window resize invalidates the absolute coordinates stored in `menuPosition`.

## Verification

- [x] TypeScript compiles with zero errors (`npx tsc --noEmit`)
- [x] Menu stays open during streaming (no spurious scroll events)
- [x] Menu still closes on: click outside, Escape key, window resize
- [x] No behavior change for click-outside or keyboard dismiss paths

Closes #814