### PR TITLE
fix(openclaw): show hint when model returns thinking-only response

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -35,6 +35,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Timeout hint
     taskTimedOut: '[任务超时] 任务因超过最大允许时长而被自动停止。你可以继续对话以从中断处继续。',
 
+    // Thinking-only hint
+    taskThinkingOnly: '[模型未输出内容] 模型已完成思考但未生成可见回复。你可以继续对话，让模型重新输出结果。',
+
     // Feishu bot install
     feishuVerifyCredentialsFailed: '凭证验证失败，请检查 App ID 和 App Secret 是否正确',
     feishuVerifyFailed: '验证失败',
@@ -87,6 +90,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Timeout hint
     taskTimedOut: '[Task timed out] The task was automatically stopped because it exceeded the maximum allowed duration. You can continue the conversation to pick up where it left off.',
+
+    // Thinking-only hint
+    taskThinkingOnly: '[No output] The model finished thinking but did not generate a visible reply. You can continue the conversation to ask it to output the result.',
 
     // Feishu bot install
     feishuVerifyCredentialsFailed: 'Credential validation failed. Please check your App ID and App Secret.',

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -2577,6 +2577,30 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     // Awaited so that IM handlers reading from the store see reconciled data.
     await this.reconcileWithHistory(sessionId, turn.sessionKey);
 
+    // Detect thinking-only response: the last API call returned no visible text
+    // (only a thinking block), causing the run to complete silently without output.
+    // This happens with qwen3.5-plus under very large context (~380K tokens).
+    // Signal: turn.currentText is empty AND there was at least one tool call in the run.
+    const sessionAfterReconcile = this.store.getSession(sessionId);
+    if (sessionAfterReconcile) {
+      const msgs = sessionAfterReconcile.messages;
+      const hadToolCall = msgs.some((m) => m.type === 'tool_result');
+      const lastApiResponseHadNoText = !turn.currentText.trim();
+      console.debug('[OpenClawRuntime] run end diagnostics, sessionId:', sessionId,
+        'turn.currentText:', JSON.stringify(turn.currentText?.slice(0, 100)),
+        'turn.committedAssistantText:', JSON.stringify(turn.committedAssistantText?.slice(0, 100)),
+        'hadToolCall:', hadToolCall,
+        'lastApiResponseHadNoText:', lastApiResponseHadNoText);
+      if (hadToolCall && lastApiResponseHadNoText) {
+        const hintMessage = this.store.addMessage(sessionId, {
+          type: 'system',
+          content: t('taskThinkingOnly'),
+        });
+        this.emit('message', sessionId, hintMessage);
+        console.warn('[OpenClawRuntime] thinking-only response detected, sessionId:', sessionId);
+      }
+    }
+
     this.store.updateSession(sessionId, { status: 'completed' });
     this.emit('complete', sessionId, payload.runId ?? turn.runId);
     this.cleanupSessionTurn(sessionId);


### PR DESCRIPTION
[问题]
模型（qwen3.5-plus）在超大 context 下偶发性返回 thinking-only 响应 （只含 thinking block，无 text block），run 正常结束（isError=false）， UI 显示"已完成"，用户无法感知任务实际未完成

[根因]
reconcileWithHistory 完成后直接 emit('complete')，未检测最后一次 API 响应是否有可见文字输出

[修复]
- 在 emit('complete') 前检测 turn.currentText 是否为空且存在 tool_result
- 若是，插入 system 类型 hint 消息"[模型未输出内容] 模型已完成思考但未生成可见回复"
- 新增 i18n key: taskThinkingOnly（zh/en 双语）

[复现路径]
使用 qwen3.5-plus，在超大 context（> 30 万 token）下执行工具调用密集任务， 偶发触发 thinking-only 响应，run 结束后 UI 应显示提示消息而非静默完成

[其他]
https://github.com/openclaw/openclaw/pull/53064