### PR TITLE
fix(ui): prevent modal from closing on drag-to-outside text selection

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import Modal from './common/Modal';
 import { configService } from '../services/config';
 import { apiService } from '../services/api';
 import { checkForAppUpdate } from '../services/appUpdate';
@@ -3422,14 +3423,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 modal-backdrop flex items-center justify-center"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    <Modal
+      onClose={onClose}
+      overlayClassName="fixed inset-0 z-50 modal-backdrop flex items-center justify-center"
+      className="relative flex w-[900px] h-[80vh] rounded-2xl dark:border-claude-darkBorder border-claude-border border shadow-modal overflow-hidden modal-content"
+      onClick={handleSettingsClick}
     >
-      <div
-        className="relative flex w-[900px] h-[80vh] rounded-2xl dark:border-claude-darkBorder border-claude-border border shadow-modal overflow-hidden modal-content"
-        onClick={handleSettingsClick}
-      >
         {/* Left sidebar */}
         <div className="w-[220px] shrink-0 flex flex-col dark:bg-claude-darkSurfaceMuted bg-claude-surfaceMuted border-r dark:border-claude-darkBorder border-claude-border rounded-l-2xl overflow-y-auto">
           <div className="px-5 pt-5 pb-3">
@@ -3775,11 +3774,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
                   </button>
                 </div>
               </div>
-            </div>
-          )}
-      </div>
-    </div>
+          </div>
+        )}
+    </Modal>
   );
 };
 
-export default Settings; 
+export default Settings;

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
+import Modal from './common/Modal';
 import { useSelector } from 'react-redux';
 import { RootState } from '../store';
 import { agentService } from '../services/agent';
@@ -321,14 +322,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       )}
       {/* Batch Delete Confirmation Modal */}
       {showBatchDeleteConfirm && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => setShowBatchDeleteConfirm(false)}
-        >
-          <div
-            className="w-full max-w-sm mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-xl overflow-hidden"
-            onClick={(e) => e.stopPropagation()}
-          >
+        <Modal onClose={() => setShowBatchDeleteConfirm(false)} className="w-full max-w-sm mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-xl overflow-hidden">
             <div className="flex items-center gap-3 px-5 py-4">
               <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
                 <ExclamationTriangleIcon className="h-5 w-5 text-red-600 dark:text-red-500" />
@@ -356,8 +350,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                 {i18nService.t('batchDelete')} ({selectedIds.size})
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       )}
     </aside>
   );

--- a/src/renderer/components/agent/AgentCreateModal.tsx
+++ b/src/renderer/components/agent/AgentCreateModal.tsx
@@ -3,6 +3,7 @@ import { agentService } from '../../services/agent';
 import { i18nService } from '../../services/i18n';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import AgentSkillSelector from './AgentSkillSelector';
+import Modal from '../common/Modal';
 
 interface AgentCreateModalProps {
   isOpen: boolean;
@@ -45,11 +46,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
-      <div
-        className="w-full max-w-md mx-4 rounded-xl shadow-xl bg-white dark:bg-claude-darkSurface border dark:border-claude-darkBorder border-claude-border"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal isOpen={isOpen} onClose={onClose} className="w-full max-w-md mx-4 rounded-xl shadow-xl bg-white dark:bg-claude-darkSurface border dark:border-claude-darkBorder border-claude-border">
         <div className="flex items-center justify-between px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">
           <h3 className="text-base font-semibold dark:text-claude-darkText text-claude-text">
             {i18nService.t('createAgent') || 'Create Agent'}
@@ -125,8 +122,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
             {creating ? (i18nService.t('creating') || 'Creating...') : (i18nService.t('create') || 'Create')}
           </button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/renderer/components/agent/AgentSettingsPanel.tsx
+++ b/src/renderer/components/agent/AgentSettingsPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
+import Modal from '../common/Modal';
 import { agentService } from '../../services/agent';
 import { imService } from '../../services/im';
 import { i18nService } from '../../services/i18n';
@@ -153,11 +154,7 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
   ];
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
-      <div
-        className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-white dark:bg-claude-darkSurface border dark:border-claude-darkBorder border-claude-border max-h-[80vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal onClose={onClose} className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-white dark:bg-claude-darkSurface border dark:border-claude-darkBorder border-claude-border max-h-[80vh] flex flex-col">
         {/* Header: agent icon + name + close */}
         <div className="flex items-center justify-between px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">
           <div className="flex items-center gap-2">
@@ -381,8 +378,7 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
             </button>
           </div>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/renderer/components/common/Modal.tsx
+++ b/src/renderer/components/common/Modal.tsx
@@ -1,0 +1,56 @@
+import React, { useRef } from 'react';
+
+interface ModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  className?: string;
+  overlayClassName?: string;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+  children: React.ReactNode;
+}
+
+/**
+ * Modal — A base modal overlay component with correct close-on-backdrop behavior.
+ *
+ * Only closes when the user clicks the backdrop directly (mousedown + mouseup both on backdrop).
+ * Dragging text from inside the modal to outside will NOT close the modal.
+ */
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  className,
+  overlayClassName,
+  onClick,
+  children,
+}) => {
+  const mouseDownOnBackdropRef = useRef(false);
+
+  if (isOpen === false) return null;
+
+  return (
+    <div
+      className={overlayClassName ?? 'fixed inset-0 z-50 flex items-center justify-center bg-black/50'}
+      onMouseDown={(e) => {
+        // Record whether mousedown started on the backdrop (not on modal content)
+        mouseDownOnBackdropRef.current = e.target === e.currentTarget;
+      }}
+      onClick={(e) => {
+        // Only close if both mousedown and click ended on the backdrop
+        if (e.target === e.currentTarget && mouseDownOnBackdropRef.current) {
+          mouseDownOnBackdropRef.current = false;
+          onClose();
+        }
+      }}
+    >
+      <div
+        className={className}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => { e.stopPropagation(); onClick?.(e); }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/renderer/components/cowork/CoworkSearchModal.tsx
+++ b/src/renderer/components/cowork/CoworkSearchModal.tsx
@@ -4,6 +4,7 @@ import SearchIcon from '../icons/SearchIcon';
 import { i18nService } from '../../services/i18n';
 import type { CoworkSessionSummary } from '../../types/cowork';
 import CoworkSessionList from './CoworkSessionList';
+import Modal from '../common/Modal';
 
 const emptySet = new Set<string>();
 
@@ -67,16 +68,15 @@ const CoworkSearchModal: React.FC<CoworkSearchModalProps> = ({
   if (!isOpen) return null;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center modal-backdrop p-6"
-      onClick={onClose}
+    <Modal
+      onClose={onClose}
+      overlayClassName="fixed inset-0 z-50 flex items-start justify-center modal-backdrop p-6"
+      className="modal-content w-full max-w-2xl mt-10 rounded-2xl border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface bg-claude-surface shadow-modal overflow-hidden"
     >
       <div
-        className="modal-content w-full max-w-2xl mt-10 rounded-2xl border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface bg-claude-surface shadow-modal overflow-hidden"
         role="dialog"
         aria-modal="true"
         aria-label={i18nService.t('search')}
-        onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-center gap-3 px-4 py-3 border-b dark:border-claude-darkBorder border-claude-border">
           <div className="relative flex-1">
@@ -120,7 +120,7 @@ const CoworkSearchModal: React.FC<CoworkSearchModalProps> = ({
           )}
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import Modal from '../common/Modal';
 import { RootState } from '../../store';
 import { i18nService } from '../../services/i18n';
 import type { CoworkMessage, CoworkMessageMetadata, CoworkImageAttachment } from '../../types/cowork';
@@ -2060,14 +2061,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
       {/* Delete Confirmation Modal */}
       {showConfirmDelete && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
-          onClick={handleCancelDelete}
+        <Modal
+          onClose={handleCancelDelete}
+          overlayClassName="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
+          className="w-full max-w-sm mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal overflow-hidden modal-content"
         >
-          <div
-            className="w-full max-w-sm mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal overflow-hidden modal-content"
-            onClick={(e) => e.stopPropagation()}
-          >
             {/* Header */}
             <div className="flex items-center gap-3 px-5 py-4">
               <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
@@ -2100,8 +2098,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 {i18nService.t('deleteSession')}
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       )}
 
       {/* Messages */}

--- a/src/renderer/components/cowork/CoworkSessionItem.tsx
+++ b/src/renderer/components/cowork/CoworkSessionItem.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import Modal from '../common/Modal';
 import type { CoworkSessionSummary, CoworkSessionStatus } from '../../types/cowork';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import EllipsisHorizontalIcon from '../icons/EllipsisHorizontalIcon';
@@ -427,14 +428,7 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
 
       {/* Delete Confirmation Modal */}
       {showConfirmDelete && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={handleCancelDelete}
-        >
-          <div
-            className="w-full max-w-sm mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-xl overflow-hidden"
-            onClick={(e) => e.stopPropagation()}
-          >
+        <Modal onClose={handleCancelDelete} className="w-full max-w-sm mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-xl overflow-hidden">
             {/* Header */}
             <div className="flex items-center gap-3 px-5 py-4">
               <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
@@ -467,8 +461,7 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
                 {i18nService.t('deleteSession')}
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       )}
     </div>
   );

--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import Modal from '../common/Modal';
 import { SignalIcon, XMarkIcon, CheckCircleIcon, XCircleIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
 import { RootState } from '../../store';
@@ -3818,14 +3819,11 @@ const IMSettings: React.FC = () => {
         )}
 
         {connectivityModalPlatform && (
-          <div
-            className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
-            onClick={() => setConnectivityModalPlatform(null)}
+          <Modal
+            onClose={() => setConnectivityModalPlatform(null)}
+            overlayClassName="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
+            className="w-full max-w-2xl dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal border dark:border-claude-darkBorder border-claude-border overflow-hidden"
           >
-            <div
-              className="w-full max-w-2xl dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal border dark:border-claude-darkBorder border-claude-border overflow-hidden"
-              onClick={(e) => e.stopPropagation()}
-            >
               <div className="px-4 py-3 border-b dark:border-claude-darkBorder border-claude-border flex items-center justify-between">
                 <div className="text-sm font-semibold dark:text-claude-darkText text-claude-text">
                   {`${i18nService.t(connectivityModalPlatform)} ${i18nService.t('imConnectivitySectionTitle')}`}
@@ -3894,8 +3892,7 @@ const IMSettings: React.FC = () => {
               <div className="px-4 py-3 border-t dark:border-claude-darkBorder border-claude-border flex items-center justify-end">
                 {renderConnectivityTestButton(connectivityModalPlatform)}
               </div>
-            </div>
-          </div>
+          </Modal>
         )}
       </div>
     </div>

--- a/src/renderer/components/mcp/McpManager.tsx
+++ b/src/renderer/components/mcp/McpManager.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import Modal from '../common/Modal';
 import { useDispatch, useSelector } from 'react-redux';
 import SearchIcon from '../icons/SearchIcon';
 import TrashIcon from '../icons/TrashIcon';
@@ -672,14 +673,7 @@ const McpManager: React.FC = () => {
 
       {/* Delete confirmation modal */}
       {pendingDelete && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={handleCancelDelete}
-        >
-          <div
-            className="w-full max-w-sm mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-5"
-            onClick={(event) => event.stopPropagation()}
-          >
+        <Modal onClose={handleCancelDelete} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-sm mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-5">
             <div className="text-lg font-semibold dark:text-claude-darkText text-claude-text">
               {i18nService.t('deleteMcpServer')}
             </div>
@@ -709,8 +703,7 @@ const McpManager: React.FC = () => {
                 {i18nService.t('confirmDelete')}
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       )}
 
       {/* Edit / Registry-install form modal */}

--- a/src/renderer/components/mcp/McpServerFormModal.tsx
+++ b/src/renderer/components/mcp/McpServerFormModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { i18nService } from '../../services/i18n';
+import Modal from '../common/Modal';
 import { McpServerConfig, McpServerFormData, McpRegistryEntry } from '../../types/mcp';
 
 interface McpServerFormModalProps {
@@ -218,14 +219,7 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
     : i18nService.t('saveMcpServer');
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={onClose}
-    >
-      <div
-        className="w-full max-w-lg mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6 max-h-[80vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal onClose={onClose} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-lg mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6 max-h-[80vh] overflow-y-auto">
         <div className="flex items-center justify-between mb-5">
           <div className="text-lg font-semibold dark:text-claude-darkText text-claude-text">
             {modalTitle}
@@ -434,8 +428,7 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
             </button>
           </div>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/renderer/components/skills/SkillSecurityReport.tsx
+++ b/src/renderer/components/skills/SkillSecurityReport.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
+import Modal from '../common/Modal';
 import {
   ShieldCheckIcon,
   ChevronDownIcon,
@@ -90,14 +91,11 @@ const SkillSecurityReport: React.FC<SkillSecurityReportProps> = ({
   }
 
   return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={() => onAction('cancel')}
+    <Modal
+      onClose={() => onAction('cancel')}
+      overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="w-full max-w-xl mx-4 rounded-2xl dark:bg-claude-darkBg bg-white shadow-xl border dark:border-claude-darkBorder border-claude-border overflow-hidden"
     >
-      <div
-        className="w-full max-w-xl mx-4 rounded-2xl dark:bg-claude-darkBg bg-white shadow-xl border dark:border-claude-darkBorder border-claude-border overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">
           <div className="flex items-center gap-2.5">
@@ -212,8 +210,7 @@ const SkillSecurityReport: React.FC<SkillSecurityReportProps> = ({
             </button>
           </div>
         </div>
-      </div>
-    </div>,
+    </Modal>,
     document.body
   );
 };

--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import Modal from '../common/Modal';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   ArrowDownTrayIcon,
@@ -630,14 +631,11 @@ const SkillsManager: React.FC = () => {
       )}
 
       {selectedMarketplaceSkill && createPortal(
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => setSelectedMarketplaceSkill(null)}
+        <Modal
+          onClose={() => setSelectedMarketplaceSkill(null)}
+          overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          className="w-full max-w-md mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6"
         >
-          <div
-            className="w-full max-w-md mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6"
-            onClick={(event) => event.stopPropagation()}
-          >
             <div className="flex items-start justify-between mb-4">
               <div className="flex items-center gap-3 min-w-0">
                 <div className="w-9 h-9 rounded-lg dark:bg-claude-darkBg bg-claude-bg flex items-center justify-center flex-shrink-0">
@@ -714,19 +712,15 @@ const SkillsManager: React.FC = () => {
                 {installingSkillId === selectedMarketplaceSkill.id ? i18nService.t('skillInstalling') : i18nService.t('skillInstall')}
               </button>
             )}
-          </div>
-        </div>
+        </Modal>
       , document.body)}
 
       {selectedSkill && createPortal(
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => setSelectedSkill(null)}
+        <Modal
+          onClose={() => setSelectedSkill(null)}
+          overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          className="w-full max-w-md mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6"
         >
-          <div
-            className="w-full max-w-md mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6"
-            onClick={(event) => event.stopPropagation()}
-          >
             <div className="flex items-start justify-between mb-4">
               <div className="flex items-center gap-3 min-w-0">
                 <div className="w-9 h-9 rounded-lg dark:bg-claude-darkBg bg-claude-bg flex items-center justify-center flex-shrink-0">
@@ -828,19 +822,15 @@ const SkillsManager: React.FC = () => {
                 />
               </div>
             </div>
-          </div>
-        </div>
+        </Modal>
       , document.body)}
 
       {skillPendingDelete && createPortal(
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={handleCancelDeleteSkill}
+        <Modal
+          onClose={handleCancelDeleteSkill}
+          overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          className="w-full max-w-sm mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-5"
         >
-          <div
-            className="w-full max-w-sm mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-5"
-            onClick={(event) => event.stopPropagation()}
-          >
             <div className="text-lg font-semibold dark:text-claude-darkText text-claude-text">
               {i18nService.t('deleteSkill')}
             </div>
@@ -870,19 +860,15 @@ const SkillsManager: React.FC = () => {
                 {i18nService.t('confirmDelete')}
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       , document.body)}
 
       {isGithubImportOpen && createPortal(
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => setIsGithubImportOpen(false)}
+        <Modal
+          onClose={() => setIsGithubImportOpen(false)}
+          overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          className="w-full max-w-md mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6"
         >
-          <div
-            className="w-full max-w-md mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6"
-            onClick={(event) => event.stopPropagation()}
-          >
             <div className="flex items-start justify-between">
               <div>
                 <div className="text-lg font-semibold dark:text-claude-darkText text-claude-text">
@@ -930,8 +916,7 @@ const SkillsManager: React.FC = () => {
                 {isDownloadingSkill ? i18nService.t('importingSkill') : i18nService.t('importSkill')}
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       , document.body)}
 
       {securityReport && (

--- a/src/renderer/components/update/AppUpdateModal.tsx
+++ b/src/renderer/components/update/AppUpdateModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { i18nService } from '../../services/i18n';
 import type { AppUpdateInfo, AppUpdateDownloadProgress } from '../../services/appUpdate';
+import Modal from '../common/Modal';
 
 export type UpdateModalState = 'info' | 'downloading' | 'installing' | 'error';
 
@@ -41,21 +42,12 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
   const currentLog = changeLog?.[lang] ?? { title: '', content: [] };
   const isDismissible = modalState === 'info' || modalState === 'error';
 
-  const handleBackdropClick = () => {
-    if (isDismissible) {
-      onCancel();
-    }
-  };
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
-      onClick={handleBackdropClick}
+    <Modal
+      onClose={isDismissible ? onCancel : () => {}}
+      overlayClassName="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
+      className="modal-content w-full max-w-md mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal overflow-hidden"
     >
-      <div
-        className="modal-content w-full max-w-md mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
         {/* Info state - shows changelog and Update/Cancel buttons */}
         {modalState === 'info' && (
           <>
@@ -214,8 +206,7 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
             </div>
           </div>
         )}
-      </div>
-    </div>
+    </Modal>
   );
 };
 


### PR DESCRIPTION
## 问题描述
在弹窗内进行文字选中操作时（例如复制内容），如果鼠标从弹窗内部拖拽到弹窗外部区域后松开，
弹窗会意外关闭，导致用户需要重新打开弹窗，造成操作中断。

## 影响范围
本问题影响应用内**所有含背景遮罩的弹窗**，共 14 处：
- 高频操作弹窗（设置、搜索、技能详情）：用户几乎每天都会使用
- 包含大量可复制文本的弹窗（IM 网络检测日志、技能安全报告）：
  用户最需要复制内容，却最容易被误关闭

**复现步骤：**
1. 打开任意弹窗（设置、技能详情、MCP 配置等）
2. 在弹窗内容区域按下鼠标，向外拖拽至弹窗边界外
3. 松开鼠标
4. 弹窗意外关闭 ❌

**根本原因：**
原有实现仅通过 `onClick` 判断是否点击了背景遮罩层来触发关闭。
但 `onClick` 不区分 `mousedown` 的起始位置 —— 当用户从弹窗内容区开始拖拽、
在遮罩层松手时，同样会触发 `click` 事件，导致误关闭。

## 解决方案
新增公共组件 `src/renderer/components/common/Modal.tsx`，
通过 `ref` 记录 `mousedown` 的起始位置。
只有当 `mousedown` 和 `click`（mouseup）**都发生在遮罩层上**时，才触发关闭。

## 改动范围
- **新增**：`src/renderer/components/common/Modal.tsx` — 封装正确背景点击逻辑的公共弹窗组件
- **重构**：14 处弹窗统一迁移至新 `Modal` 组件，替换原有各自独立的内联实现：
  - `Settings.tsx`（通用设置弹窗）
  - `IMSettings.tsx`（IM 网络检测弹窗）
  - `AgentCreateModal.tsx`、`AgentSettingsPanel.tsx`
  - `McpServerFormModal.tsx`、`McpManager.tsx`（删除确认）
  - `Sidebar.tsx`（批量删除确认）
  - `SkillsManager.tsx`（技能详情 ×2、删除确认、GitHub 导入）
  - `SkillSecurityReport.tsx`
  - `CoworkSessionItem.tsx`、`CoworkSessionDetail.tsx`（会话删除确认）
  - `CoworkSearchModal.tsx`
  - `AppUpdateModal.tsx`

## 测试验证
**验证修复效果：**
1. 打开上述任意弹窗
2. 在内容区按下鼠标并拖拽至弹窗外部松手 → 弹窗**不关闭** ✅
3. 直接点击弹窗外暗色遮罩区域 → 弹窗**正常关闭** ✅
4. 弹窗内所有按钮、输入框功能正常 ✅

