### PR TITLE
fix(agent): fix Create Agent modal overflow problem

### DIFF
--- a/src/renderer/components/agent/AgentCreateModal.tsx
+++ b/src/renderer/components/agent/AgentCreateModal.tsx
@@ -47,10 +47,11 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
       <div
-        className="w-full max-w-md mx-4 rounded-xl shadow-xl bg-white dark:bg-claude-darkSurface border dark:border-claude-darkBorder border-claude-border"
+        className="w-full max-w-md mx-4 rounded-xl shadow-xl bg-white dark:bg-claude-darkSurface border dark:border-claude-darkBorder border-claude-border flex flex-col"
+        style={{ maxHeight: 'calc(100vh - 48px)' }}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">
+        <div className="flex-shrink-0 flex items-center justify-between px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">
           <h3 className="text-base font-semibold dark:text-claude-darkText text-claude-text">
             {i18nService.t('createAgent') || 'Create Agent'}
           </h3>
@@ -58,7 +59,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
             <XMarkIcon className="h-5 w-5 dark:text-claude-darkTextSecondary text-claude-textSecondary" />
           </button>
         </div>
-        <div className="px-5 py-4 space-y-4">
+        <div className="overflow-y-auto px-5 py-4 space-y-4">
           <div>
             <label className="block text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary mb-1">
               {i18nService.t('agentName') || 'Name'} *
@@ -108,7 +109,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
           </div>
           <AgentSkillSelector selectedSkillIds={skillIds} onChange={setSkillIds} />
         </div>
-        <div className="flex justify-end gap-2 px-5 py-4 border-t dark:border-claude-darkBorder border-claude-border">
+        <div className="flex-shrink-0 flex justify-end gap-2 px-5 py-4 border-t dark:border-claude-darkBorder border-claude-border">
           <button
             type="button"
             onClick={onClose}


### PR DESCRIPTION
## Summary

修复了 `AgentCreateModal` 弹窗在内容超出页面高度时，标题栏和操作栏被截断的问题。弹窗现在会自适应视口边界，标题栏和操作栏始终固定可见，仅内容区域滚动。

## 问题

`AgentCreateModal` 弹窗高度完全由内容撑开，没有最大高度约束。当内容（尤其技能选择列表展开后）超过当前页面可视高度时，弹窗顶部的标题栏和底部的操作按钮区域会被截断，用户无法看到也无法点击关闭/取消/创建按钮。
<img width="1902" height="1512" alt="image" src="https://github.com/user-attachments/assets/6be0121b-e382-4f10-9207-dcba102ba861" />



## 复现路径

1. 打开 LobsterAI，进入 Agent 管理页面
2. 点击「创建 Agent」按钮，弹出 `AgentCreateModal`
3. 在技能选择区域展开较多技能选项，或在小屏/低分辨率窗口下操作
4. 观察弹窗：顶部标题栏（含关闭按钮）或底部操作栏（含取消/创建按钮）被视口截断，无法正常交互

## 根因

弹窗容器（`.max-w-md` 的 `div`）未设置 `max-height`，高度完全由子内容决定。当内容高度超过 `100vh` 时，弹窗整体超出视口，而外层 flex 容器（`items-center`）会将弹窗垂直居中，导致顶部和底部均被截断，且页面无法滚动到被截断区域。

## 修复

**文件**: `src/renderer/components/agent/AgentCreateModal.tsx`

三处改动：

1. **弹窗容器**：添加 `flex flex-col` 布局，并通过 `style={{ maxHeight: 'calc(100vh - 48px)' }}` 设置动态最大高度。`48px` 为上下各 `24px` 的安全边距，确保弹窗在任意页面尺寸下都完整显示在视口内。

2. **Header**：添加 `flex-shrink-0`，使标题栏在 flex 布局下不参与压缩，始终完整显示。

3. **内容区**：添加 `overflow-y-auto`，内容超出时仅内容区出现滚动条，header 和 footer 保持固定。

4. **Footer**：添加 `flex-shrink-0`，使操作栏在 flex 布局下不参与压缩，始终固定在弹窗底部。

## 最终效果
<img width="1910" height="1208" alt="image" src="https://github.com/user-attachments/assets/cebcbf5b-13ca-4c0a-9808-7c913ca37ba3" />
