### PR TITLE
fix(openclaw): defer gateway client exposure until connect handshake

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -523,6 +523,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private gatewayClient: GatewayClientLike | null = null;
   private gatewayClientVersion: string | null = null;
   private gatewayClientEntryPath: string | null = null;
+  /** Holds the client between start() and onHelloOk so stopGatewayClient can clean it up. */
+  private pendingGatewayClient: GatewayClientLike | null = null;
   private gatewayReadyPromise: Promise<void> | null = null;
   /** Serializes concurrent calls to ensureGatewayClientReady to prevent duplicate clients. */
   private gatewayClientInitLock: Promise<void> | null = null;
@@ -1373,6 +1375,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       scopes: ['operator.admin'],
       onHelloOk: () => {
         console.log('[ChannelSync] GatewayClient: onHelloOk — handshake succeeded');
+        // Expose the client only after the connect handshake completes.
+        // Setting gatewayClient earlier would let concurrent code send
+        // request frames before the connect frame, causing 1008 rejection.
+        this.gatewayClient = client;
+        this.gatewayClientVersion = connection.version;
+        this.gatewayClientEntryPath = connection.clientEntryPath;
         settleResolve();
         this.lastTickTimestamp = Date.now();
         this.startTickWatchdog();
@@ -1384,6 +1392,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       onClose: (_code: number, reason: string) => {
         console.log('[ChannelSync] GatewayClient: onClose — code:', _code, 'reason:', reason, 'settled:', settled);
         if (!settled) {
+          // Handshake never completed — clean up the pending client so the next
+          // ensureGatewayClientReady call creates a fresh one instead of reusing
+          // this broken instance forever.
+          this.pendingGatewayClient = null;
           settleReject(new Error(reason || 'OpenClaw gateway disconnected before handshake'));
           return;
         }
@@ -1417,9 +1429,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       },
     });
 
-    this.gatewayClient = client;
-    this.gatewayClientVersion = connection.version;
-    this.gatewayClientEntryPath = connection.clientEntryPath;
+    // gatewayClient/version/entryPath are now set inside onHelloOk,
+    // after the connect handshake succeeds. We only keep a local ref
+    // for stopGatewayClient() cleanup if start() fails synchronously.
+    this.pendingGatewayClient = client;
     client.start();
   }
 
@@ -1428,12 +1441,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     this.stopChannelPolling();
     this.cancelGatewayReconnect();
     this.stopTickWatchdog();
+    // Stop whichever client exists — the promoted one or the pending one.
+    const clientToStop = this.gatewayClient ?? this.pendingGatewayClient;
     try {
-      this.gatewayClient?.stop();
+      clientToStop?.stop();
     } catch (error) {
       console.warn('[OpenClawRuntime] Failed to stop gateway client:', error);
     }
     this.gatewayClient = null;
+    this.pendingGatewayClient = null;
     this.gatewayClientVersion = null;
     this.gatewayClientEntryPath = null;
     this.gatewayReadyPromise = null;


### PR DESCRIPTION
## Summary                                                                     
                                                                             
  - Defer `this.gatewayClient` assignment from `createGatewayClient()` into the  
  `onHelloOk` callback, so the client is only visible to concurrent code after   
  the WebSocket connect handshake succeeds                                       
  - Introduce `pendingGatewayClient` to hold the client reference during the     
  handshake window, allowing `stopGatewayClient()` to clean up properly          
  - Clean up `pendingGatewayClient` in the `onClose` (!settled) path when        
  handshake fails                                                                
                                                                  
  ## Problem                                                                     
                                                                  
  `createGatewayClient()` was assigning `this.gatewayClient = client` **before** 
  `client.start()`, creating a race window where concurrent code (e.g.
  `CronJobService.pollOnce`, `pollChannelSessions`) could obtain the client via  
  `getGatewayClient()` and call `client.request()` before the connect frame was
  sent. The request frame arriving at the OpenClaw server before the connect
  frame caused a 1008 rejection: "invalid handshake: first request must be
  connect".

  PR #935 patched `pollOnce` by adding `await ensureGatewayReady()`, but the root
   cause remained — any code path that reads `gatewayClient` without going
  through the init lock could still hit the same race.                           
                                                                  
  Before (race window):                                                          
    this.gatewayClient = client   ← exposed immediately
    client.start()                ← WS connect begins                            
    await gatewayReadyPromise     ← handshake in progress                        
    // concurrent code can call gatewayClient.request() here                     
                                                                                 
  After (no race window):                                                        
    this.pendingGatewayClient = client   ← internal only                         
    client.start()                                                               
    // onHelloOk fires:                                                          
    //   this.gatewayClient = client     ← exposed after handshake               
    //   settleResolve()                                                         
                                                                                 
  ## Test plan                                                                   
                                                                                 
  - [ ] Start LobsterAI with OpenClaw engine and IM channels enabled, verify no  
  1008 handshake errors in logs                                                  
  - [ ] Trigger gateway restart (e.g. config sync), verify reconnection succeeds 
  without handshake errors                                                       
  - [ ] Start a cowork session while CronJobService is polling, verify no race
  condition                                                                      
  - [ ] Kill OpenClaw process, verify auto-reconnect works correctly
  - [ ] System sleep/resume, verify `onSystemResume` reconnects properly