### PR TITLE
fix(security): reject protocol-relative URLs in markdown link transform

### DIFF
--- a/src/renderer/components/MarkdownContent.tsx
+++ b/src/renderer/components/MarkdownContent.tsx
@@ -123,8 +123,15 @@ const safeUrlTransform = (url: string): string => {
   const trimmed = url.trim();
   if (!trimmed) return trimmed;
 
+  // Reject protocol-relative URLs (e.g. //evil.com) — they inherit the page
+  // protocol and bypass the scheme whitelist check below.
+  if (trimmed.startsWith('//')) {
+    return '';
+  }
+
   const match = trimmed.match(/^([a-z][a-z0-9+.-]*):/i);
   if (!match) {
+    // No scheme at all — treat as a relative path (safe for anchor hrefs).
     return trimmed;
   }
 


### PR DESCRIPTION
## Problem

`safeUrlTransform` in `MarkdownContent.tsx` uses a scheme whitelist (`http`, `https`, `mailto`, etc.) to block dangerous URLs like `javascript:alert(1)`. However, protocol-relative URLs such as `//evil.com/steal` have no explicit scheme and were returned as-is, bypassing the whitelist entirely.

A malicious markdown link like:
```
[click me](//evil.com/steal?token=xyz)
```
would be rendered as a clickable anchor pointing to an attacker-controlled origin, inheriting the page protocol at navigation time.

## Fix

Add an explicit `startsWith('//')` guard before the scheme regex so that protocol-relative URLs are always rejected, consistent with the intent of `SAFE_URL_PROTOCOLS`.

## Reproduction

1. In any chat message, send: `[test](//evil.com)`
2. **Before fix**: link renders and navigates to `evil.com`
3. **After fix**: link href is stripped to empty string, no navigation occurs

## Changed Files

- `src/renderer/components/MarkdownContent.tsx` — +5 lines in `safeUrlTransform`