### PR TITLE
fix(im): xiaomifeng gateway unrecoverable after kicked-offline event

### DIFF
--- a/src/main/im/xiaomifengGateway.ts
+++ b/src/main/im/xiaomifengGateway.ts
@@ -439,19 +439,13 @@ export class XiaomifengGateway extends EventEmitter {
         const isKickedByOtherClient = kickReason === 1 || kickReason === 3;
         
         if (isKickedByOtherClient) {
-          // 被其他客户端踢下线，设置错误消息并不再重连
           this.kickedByOtherClient = true;
-          
-          // 清理任何已存在的重连定时器
-          if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-          }
-          
           this.status.lastError = '账号已在其它地方登录';
           console.warn('[Xiaomifeng Gateway] 账号已在其它地方登录，不再自动重连');
           this.emit('error', new Error('账号已在其它地方登录'));
-          this.emit('kickedByOtherClient'); // 发出特殊事件以便上层处理
+          this.emit('kickedByOtherClient');
+          // 完整清理 SDK 连接，使上层可以在问题解决后重新调用 start()
+          void this.stop();
         } else {
           // 其他踢出原因，仍然尝试重连
           this.status.lastError = 'Kicked offline';


### PR DESCRIPTION
## Problem

When the Xiaomifeng account was kicked offline by another client (`kickReason === 1 || 3`), the handler manually cleared `reconnectTimer` but left `v2Client` non-null.

Because `start()` has an early guard:
```ts
if (this.v2Client) {
  throw new Error('Xiaomifeng gateway already running');
}
```
any attempt to reconnect after the conflict was resolved would throw immediately, making the gateway permanently dead until the user restarted the entire application.

## Fix

Replace the manual `reconnectTimer` cleanup with a single `stop()` call. `stop()` already handles timer cleanup **and** nulls `v2Client`, so the gateway can be restarted cleanly once the user resolves the login conflict.

Also removes 6 lines of duplicated cleanup logic now handled by `stop()`.

## Reproduction

1. Enable Xiaomifeng gateway and connect successfully
2. Log in with the same account on another device
3. Original device receives kicked-offline event → gateway stops
4. Log out on the second device (conflict resolved)
5. **Before fix**: calling `start()` throws `'Xiaomifeng gateway already running'` — gateway permanently dead, full app restart required
6. **After fix**: gateway restarts cleanly without any app restart

## Changed Files

- `src/main/im/xiaomifengGateway.ts` — 3 insertions, 9 deletions