### PR TITLE
fix: 修复 agent skill 选项列表的间距缺失问题

### DIFF
--- a/src/renderer/components/agent/AgentSkillSelector.tsx
+++ b/src/renderer/components/agent/AgentSkillSelector.tsx
@@ -58,7 +58,7 @@ const AgentSkillSelector: React.FC<AgentSkillSelectorProps> = ({ selectedSkillId
           </div>
         </div>
       )}
-      <div className={isExpanded ? 'flex-1 overflow-y-auto' : 'max-h-48 overflow-y-auto'}>
+      <div className={isExpanded ? 'flex-1 overflow-y-auto' : 'max-h-48 px-2 pb-2 overflow-y-auto'}>
         {filteredSkills.length === 0 ? (
           <div className="px-3 py-3 text-sm dark:text-claude-darkTextSecondary/50 text-claude-textSecondary/50 text-center">
             {enabledSkills.length === 0 ? 'No skills installed' : 'No matching skills'}
@@ -71,7 +71,7 @@ const AgentSkillSelector: React.FC<AgentSkillSelectorProps> = ({ selectedSkillId
                 key={skill.id}
                 type="button"
                 onClick={() => toggle(skill.id)}
-                className={`w-full flex items-start gap-2.5 px-3 py-2 text-left hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors rounded-lg ${
+                className={`w-full flex items-start gap-2.5 px-3 py-2 text-left mt-2 hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors rounded-lg ${
                   isSelected ? 'bg-claude-accent/5 dark:bg-claude-accent/10' : ''
                 }`}
               >


### PR DESCRIPTION
## Summary

修复了 Create Agent 弹窗和 Preset Agent 修改弹窗中 Skills 选项列表的间距缺失问题。

## 问题

Create Agent 弹窗中的 Skills 列表部分，进行选择时看到已选中的选项间是紧挨着的，中间没有间距，且左右上下也没有留出任何间距，如下图：
<img width="1642" height="1322" alt="image" src="https://github.com/user-attachments/assets/6f1eb164-80ad-46d4-8208-5bda66c2a31c" />
Preset Agent 修改弹窗中，Skills 选项被选中时，各选项间也是没有任何间距：
<img width="1630" height="1328" alt="image" src="https://github.com/user-attachments/assets/5e916405-1e67-4650-8480-36ab7fb90bd9" />
且由于上述两个场景中的选项都存在圆角，所以当没有间距时会使得问题看起来更严重。

## 复现路径

#### Create Agent
1. 打开 LobsterAI，进入 Agent 管理页面
2. 点击「My Agents」
3. 点击「New Agent」，弹出 「Create Agent 」弹窗
4. 点击「Skills」选项框，选中多个 Skills；
5. 观察列表效果

#### Create Agent
1. 打开 LobsterAI，进入 Agent 管理页面
2. 点击「My Agents」
3. 在「Preset Agents」中选择任意一个，点击「Add 」添加
4. 点击添加的「Agent」，打开「Agent 编辑」页面
5. 点击「Skills」切换到 Skills 列表
6. 选中多个 Skills
7. 观察列表效果

## 根因

两个组件中的 Skills 列表都未针对选项本身设置任何间距样式。

## 修复

由于两个组件引用的都是同一个组件展示的 Skills 列表，因此直接修改公共文件即可完成两处修复: `src/renderer/components/agent/AgentSkillSelector.tsx`


## 最终效果
<img width="1636" height="1322" alt="image" src="https://github.com/user-attachments/assets/54fed860-c7ff-446d-bcdc-44498b438172" />
<img width="1630" height="1316" alt="image" src="https://github.com/user-attachments/assets/400347fe-38a4-4ba4-916b-84b2a666d6e1" />
