### PR TITLE
Fix Incorrect Modifier Key for Shortcuts on macOS-issue 973

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -29,6 +29,7 @@ import IMSettings from './im/IMSettings';
 import { imService } from '../services/im';
 import EmailSkillConfig from './skills/EmailSkillConfig';
 import { defaultConfig, type AppConfig, getVisibleProviders } from '../config';
+import { getDefaultShortcuts } from '../services/shortcuts';
 import {
   OpenAIIcon,
   DeepSeekIcon,
@@ -453,11 +454,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
   const updateCheckTimerRef = useRef<number | null>(null);
   
   // 快捷键设置
-  const [shortcuts, setShortcuts] = useState({
-    newChat: 'Ctrl+N',
-    search: 'Ctrl+F',
-    settings: 'Ctrl+,',
-  });
+  const [shortcuts, setShortcuts] = useState(getDefaultShortcuts());
 
   // State for model editing
   const [isAddingModel, setIsAddingModel] = useState(false);

--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -1,3 +1,5 @@
+import { getDefaultShortcuts } from './services/shortcuts';
+
 // 配置类型定义
 export interface AppConfig {
   // API 配置
@@ -414,11 +416,7 @@ export const defaultConfig: AppConfig = {
     isDevelopment: process.env.NODE_ENV === 'development',
     testMode: process.env.NODE_ENV === 'development',
   },
-  shortcuts: {
-    newChat: 'Ctrl+N',
-    search: 'Ctrl+F',
-    settings: 'Ctrl+,',
-  }
+  shortcuts: getDefaultShortcuts()
 };
 
 // 配置存储键

--- a/src/renderer/services/config.ts
+++ b/src/renderer/services/config.ts
@@ -1,5 +1,18 @@
 import { AppConfig, CONFIG_KEYS, defaultConfig } from '../config';
 import { localStore } from './store';
+import { getDefaultShortcuts } from './shortcuts';
+
+/**
+ * Check if shortcuts look like old default values (all using Ctrl)
+ * This helps migrate users from the old Windows-centric defaults to platform-specific defaults
+ */
+const shouldMigrateShortcuts = (shortcuts: AppConfig['shortcuts'] | undefined): boolean => {
+  if (!shortcuts) return false;
+  // If all shortcuts start with 'Ctrl+', they are likely the old defaults
+  const values = Object.values(shortcuts);
+  if (values.length === 0) return false;
+  return values.every(s => s?.startsWith('Ctrl+'));
+};
 
 const getFixedProviderApiFormat = (providerKey: string): 'anthropic' | 'openai' | null => {
   if (providerKey === 'openai' || providerKey === 'gemini' || providerKey === 'stepfun' || providerKey === 'youdaozhiyun') {
@@ -158,10 +171,13 @@ class ConfigService {
             ...defaultConfig.app,
             ...storedConfig.app,
           },
-          shortcuts: {
-            ...defaultConfig.shortcuts!,
-            ...(storedConfig.shortcuts ?? {}),
-          } as AppConfig['shortcuts'],
+          // Migrate shortcuts from old Ctrl-based defaults to platform-specific defaults
+          shortcuts: shouldMigrateShortcuts(storedConfig.shortcuts)
+            ? getDefaultShortcuts()
+            : {
+                ...defaultConfig.shortcuts!,
+                ...(storedConfig.shortcuts ?? {}),
+              } as AppConfig['shortcuts'],
           providers: mergedProviders as AppConfig['providers'],
         };
       }

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -141,6 +141,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
+    pressShortcut: '按下快捷键...',
     newChat: '新建任务',
     search: '搜索任务',
     openSettings: '打开设置',
@@ -1294,6 +1295,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
+    pressShortcut: 'Press shortcut...',
     newChat: 'New Task',
     search: 'Search Tasks',
     openSettings: 'Open Settings',

--- a/src/renderer/services/shortcuts.ts
+++ b/src/renderer/services/shortcuts.ts
@@ -124,3 +124,83 @@ export const matchesShortcut = (event: KeyboardEvent, shortcut?: string): boolea
 
   return true;
 };
+
+/**
+ * Detect if the current platform is macOS
+ */
+const isMacPlatform = (): boolean => {
+  // Check if running in Electron renderer process
+  if (typeof window !== 'undefined' && (window as any).electron?.platform) {
+    return (window as any).electron.platform === 'darwin';
+  }
+  // Fallback to navigator.userAgent for web environment
+  return navigator.platform.toLowerCase().includes('mac') || 
+         navigator.userAgent.toLowerCase().includes('mac');
+};
+
+/**
+ * Get the default modifier key label for the current platform
+ * Returns 'Cmd' for macOS, 'Ctrl' for Windows/Linux
+ */
+export const getDefaultModifierKey = (): 'Cmd' | 'Ctrl' => {
+  return isMacPlatform() ? 'Cmd' : 'Ctrl';
+};
+
+/**
+ * Get default shortcuts for the current platform
+ * macOS: Uses Cmd (⌘) as the primary modifier
+ * Windows/Linux: Uses Ctrl as the primary modifier
+ */
+export const getDefaultShortcuts = (): { newChat: string; search: string; settings: string } => {
+  const modifier = getDefaultModifierKey();
+  return {
+    newChat: `${modifier}+N`,
+    search: `${modifier}+F`,
+    settings: `${modifier}+,`,
+  };
+};
+
+/**
+ * Convert a KeyboardEvent to a shortcut string
+ * e.g. KeyboardEvent with metaKey=true and key='n' → 'Cmd+N' (on macOS)
+ */
+export const keyboardEventToShortcut = (event: KeyboardEvent): string | null => {
+  const parts: string[] = [];
+  
+  // Add modifiers in consistent order: Cmd/Ctrl, Alt, Shift
+  if (event.metaKey) {
+    parts.push('Cmd');
+  }
+  if (event.ctrlKey) {
+    parts.push('Ctrl');
+  }
+  if (event.altKey) {
+    parts.push('Alt');
+  }
+  if (event.shiftKey) {
+    parts.push('Shift');
+  }
+  
+  // Get the main key
+  let key = event.key;
+  
+  // Ignore modifier-only combinations
+  if (key === 'Meta' || key === 'Control' || key === 'Alt' || key === 'Shift') {
+    return null;
+  }
+  
+  // Normalize key names
+  if (key === ' ') {
+    key = 'Space';
+  } else if (key.length === 1) {
+    // Single character keys - uppercase for letters, keep as-is for others
+    key = key.toUpperCase();
+  } else {
+    // Special keys - capitalize first letter
+    key = key.charAt(0).toUpperCase() + key.slice(1);
+  }
+  
+  parts.push(key);
+  
+  return parts.join('+');
+};


### PR DESCRIPTION
macOS 快捷键修复
src/renderer/services/shortcuts.ts - 添加了 isMacPlatform(), getDefaultModifierKey(), getDefaultShortcuts() 函数
src/renderer/config.ts - 使用 getDefaultShortcuts() 作为默认快捷键
src/renderer/services/config.ts - 添加迁移逻辑，将旧的 Ctrl+... 快捷键转换为平台相关默认值
src/renderer/components/Settings.tsx - 使用 getDefaultShortcuts() 作为初始状态
