### PR TITLE
fix(agent): 修复 Agent 技能选择器中技能描述未跟随语言切换的问题

### DIFF
--- a/src/renderer/components/agent/AgentSkillSelector.tsx
+++ b/src/renderer/components/agent/AgentSkillSelector.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import { i18nService } from '../../services/i18n';
+import { skillService } from '../../services/skill';
 import { CheckIcon, MagnifyingGlassIcon, ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 
 interface AgentSkillSelectorProps {
@@ -15,6 +16,14 @@ const AgentSkillSelector: React.FC<AgentSkillSelectorProps> = ({ selectedSkillId
   const skills = useSelector((state: RootState) => state.skill.skills);
   const [expanded, setExpanded] = useState(false);
   const [search, setSearch] = useState('');
+  const [i18nReady, setI18nReady] = useState(false);
+
+  // Load localized skill descriptions from marketplace API
+  useEffect(() => {
+    skillService.fetchMarketplaceSkills()
+      .then(() => setI18nReady(true))
+      .catch(() => setI18nReady(true));
+  }, []);
 
   const enabledSkills = useMemo(
     () => skills.filter((s) => s.enabled),
@@ -88,7 +97,9 @@ const AgentSkillSelector: React.FC<AgentSkillSelectorProps> = ({ selectedSkillId
                   </div>
                   {skill.description && (
                     <div className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 truncate">
-                      {skill.description}
+                      {i18nReady
+                        ? skillService.getLocalizedSkillDescription(skill.id, skill.name, skill.description)
+                        : skill.description}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## 问题描述
Agent 设置面板的「技能」选项卡中，技能描述始终显示英文原文，未跟随应用语言切换。而技能管理页面（Skills）中同样的技能描述已正确显示中文。

## 原因分析
`AgentSkillSelector` 组件直接使用 `skill.description` 渲染描述，未调用 `skillService.getLocalizedSkillDescription()` 进行本地化。同时，该方法依赖 `fetchMarketplaceSkills()` 预加载翻译数据到内存，但 `AgentSkillSelector` 未触发此加载，导致翻译 Map 为空。

## 修改内容
- 组件挂载时调用 `skillService.fetchMarketplaceSkills()` 加载本地化翻译数据
- 使用 `skillService.getLocalizedSkillDescription()` 渲染技能描述（与 `SkillsManager`、`SkillsPopover` 保持一致）
- 新增 `i18nReady` state，翻译数据加载完成后触发重渲染，确保界面及时更新

## 问题截图
<img width="1071" height="653" alt="image" src="https://github.com/user-attachments/assets/456861e4-cfc9-491c-9fa7-8c84742bb835" />