### PR TITLE
hotfix：增加对 sse 和 流式http 的mcp支持

### DIFF
--- a/src/main/libs/mcpServerManager.ts
+++ b/src/main/libs/mcpServerManager.ts
@@ -11,6 +11,8 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { McpServerRecord } from '../mcpStore';
 import { getElectronNodeRuntimePath, getEnhancedEnv } from './coworkUtil';
 
@@ -24,7 +26,7 @@ export interface McpToolManifestEntry {
 interface ManagedMcpServer {
   record: McpServerRecord;
   client: Client;
-  transport: StdioClientTransport;
+  transport: StdioClientTransport | SSEClientTransport | StreamableHTTPClientTransport;
   tools: McpToolManifestEntry[];
 }
 
@@ -267,12 +269,10 @@ export class McpServerManager {
    * Start MCP servers and discover their tools.
    */
   async startServers(enabledServers: McpServerRecord[]): Promise<McpToolManifestEntry[]> {
-    // Only handle stdio servers for now
-    const stdioServers = enabledServers.filter(s => s.transportType === 'stdio');
-    log('INFO', `Starting ${stdioServers.length} stdio MCP servers`);
+    log('INFO', `Starting ${enabledServers.length} MCP servers (stdio, sse, http)`);
 
     const results = await Promise.allSettled(
-      stdioServers.map(server => this.startSingleServer(server))
+      enabledServers.map(server => this.startSingleServer(server))
     );
 
     // Collect tools from all successfully started servers
@@ -281,7 +281,7 @@ export class McpServerManager {
       if (result.status === 'fulfilled' && result.value) {
         this._toolManifest.push(...result.value.tools);
       } else if (result.status === 'rejected') {
-        log('WARN', `Failed to start MCP server "${stdioServers[i].name}": ${result.reason}`);
+        log('WARN', `Failed to start MCP server "${enabledServers[i].name}": ${result.reason}`);
       }
     }
 
@@ -290,18 +290,26 @@ export class McpServerManager {
   }
 
   private async startSingleServer(record: McpServerRecord): Promise<ManagedMcpServer | null> {
-    if (record.transportType !== 'stdio') {
-      log('WARN', `Skipping non-stdio server "${record.name}" (type=${record.transportType})`);
-      return null;
+    if (record.transportType === 'stdio') {
+      return this.startStdioServer(record);
+    } else if (record.transportType === 'sse') {
+      return this.startSseServer(record);
+    } else if (record.transportType === 'http') {
+      return this.startHttpServer(record);
     }
 
+    log('WARN', `Unknown transport type "${record.transportType}" for server "${record.name}"`);
+    return null;
+  }
+
+  private async startStdioServer(record: McpServerRecord): Promise<ManagedMcpServer | null> {
     const resolved = await resolveStdioCommand(record);
     if (!resolved.command) {
       log('WARN', `Server "${record.name}" has no command, skipping`);
       return null;
     }
 
-    log('INFO', `Starting "${record.name}": command=${resolved.command}, args=${JSON.stringify(resolved.args)}`);
+    log('INFO', `Starting stdio "${record.name}": command=${resolved.command}, args=${JSON.stringify(resolved.args)}`);
 
     const enhancedEnv = await getEnhancedEnv();
     const spawnEnv: Record<string, string> = {
@@ -328,6 +336,56 @@ export class McpServerManager {
       });
     }
 
+    return this.connectAndDiscoverTools(record, transport, stderrChunks);
+  }
+
+  private async startSseServer(record: McpServerRecord): Promise<ManagedMcpServer | null> {
+    if (!record.url) {
+      log('WARN', `SSE server "${record.name}" has no URL, skipping`);
+      return null;
+    }
+
+    log('INFO', `Starting SSE "${record.name}": url=${record.url}`);
+
+    const headers = record.headers || {};
+    const transport = new SSEClientTransport(new URL(record.url), {
+      requestInit: {
+        headers: Object.entries(headers).reduce((acc, [key, value]) => {
+          acc[key] = value;
+          return acc;
+        }, {} as Record<string, string>),
+      },
+    });
+
+    return this.connectAndDiscoverTools(record, transport);
+  }
+
+  private async startHttpServer(record: McpServerRecord): Promise<ManagedMcpServer | null> {
+    if (!record.url) {
+      log('WARN', `HTTP server "${record.name}" has no URL, skipping`);
+      return null;
+    }
+
+    log('INFO', `Starting HTTP "${record.name}": url=${record.url}`);
+
+    const headers = record.headers || {};
+    const transport = new StreamableHTTPClientTransport(new URL(record.url), {
+      requestInit: {
+        headers: Object.entries(headers).reduce((acc, [key, value]) => {
+          acc[key] = value;
+          return acc;
+        }, {} as Record<string, string>),
+      },
+    });
+
+    return this.connectAndDiscoverTools(record, transport);
+  }
+
+  private async connectAndDiscoverTools(
+    record: McpServerRecord,
+    transport: StdioClientTransport | SSEClientTransport | StreamableHTTPClientTransport,
+    stderrChunks?: string[],
+  ): Promise<ManagedMcpServer | null> {
     const client = new Client(
       { name: `lobsterai-mcp-bridge`, version: '1.0.0' },
       { capabilities: {} },
@@ -338,7 +396,7 @@ export class McpServerManager {
       log('INFO', `Connected to MCP server "${record.name}"`);
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
-      const stderrSummary = stderrChunks.length > 0
+      const stderrSummary = stderrChunks && stderrChunks.length > 0
         ? ` | stderr: ${stderrChunks.join(' ').slice(0, 500)}`
         : '';
       log('ERROR', `Failed to connect to "${record.name}": ${errMsg}${stderrSummary}`);


### PR DESCRIPTION
**问题现象：**
当mcp传输类型 =  SSE、流式http 时，点击保存后，虽然显式 MCP 同步完成，但实际上 mcp 配置不生效。
<img width="1651" height="701" alt="image" src="https://github.com/user-attachments/assets/dd15fa2a-b7f6-487b-a661-d4b6611441bb" />

**原因：**
在 mcpServerMagnager.ts 的 startServers 方法中，只启用 传输类型 = stdio 的 mcp
<img width="1956" height="559" alt="image" src="https://github.com/user-attachments/assets/4cc8fd0e-92cb-4099-815a-90dfbfd003cc" />
但是在 客户端选择时，却能选择所有类型：
<img width="1072" height="1020" alt="image" src="https://github.com/user-attachments/assets/08fa1e2e-4fd7-44e5-b8ae-8a0334cd43a1" />

**解决方案：**
增加对 SSE 和 流式http的支持。

**改动后效果：**
在本地启动后，配置 流式http mcp：
<img width="1127" height="750" alt="image" src="https://github.com/user-attachments/assets/eaa91683-57fc-418d-8074-9a20f23d6f45" />
随后调用该 mcp 成功：
<img width="1593" height="1099" alt="image" src="https://github.com/user-attachments/assets/7ab08669-07c9-4949-8d4a-bb7d11ca0ccf" />
