### PR TITLE
fix(cowork): 移除 McpBridgeServer secret 鉴权，消除 app 重启后 secret 不匹配导致的 40…

### DIFF
--- a/src/main/libs/mcpBridgeServer.ts
+++ b/src/main/libs/mcpBridgeServer.ts
@@ -46,14 +46,12 @@ export class McpBridgeServer {
   private server: http.Server | null = null;
   private _port: number | null = null;
   private readonly mcpManager: McpServerManager;
-  private readonly secret: string;
   private readonly pendingAskUser = new Map<string, PendingAskUser>();
   private onAskUserCallback: ((request: AskUserRequest) => void) | null = null;
   private onAskUserDismissCallback: ((requestId: string) => void) | null = null;
 
-  constructor(mcpManager: McpServerManager, secret: string) {
+  constructor(mcpManager: McpServerManager) {
     this.mcpManager = mcpManager;
-    this.secret = secret;
   }
 
   get port(): number | null {
@@ -148,14 +146,6 @@ export class McpBridgeServer {
     if (req.method !== 'POST') {
       res.writeHead(404, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Not found' }));
-      return;
-    }
-
-    // Verify secret token (accept either header name)
-    const authHeader = req.headers['x-mcp-bridge-secret'] || req.headers['x-ask-user-secret'];
-    if (authHeader !== this.secret) {
-      res.writeHead(401, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Unauthorized' }));
       return;
     }
 

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -14,7 +14,6 @@ import { buildScheduledTaskEnginePrompt } from '../../scheduled-task/enginePromp
 export type McpBridgeConfig = {
   callbackUrl: string;
   askUserCallbackUrl: string;
-  secret: string;
   tools: McpToolManifestEntry[];
 };
 
@@ -733,7 +732,7 @@ export class OpenClawConfigSync {
         ...entries['mcp-bridge'],
         config: {
           callbackUrl: mcpBridgeCfg.callbackUrl,
-          secret: '${LOBSTER_MCP_BRIDGE_SECRET}',
+          secret: 'local',
           tools: mcpBridgeCfg.tools,
         },
       };
@@ -747,7 +746,7 @@ export class OpenClawConfigSync {
         enabled: true,
         config: {
           callbackUrl: mcpBridgeCfg.askUserCallbackUrl,
-          secret: '${LOBSTER_MCP_BRIDGE_SECRET}',
+          secret: 'local',
         },
       };
     }
@@ -1118,10 +1117,10 @@ export class OpenClawConfigSync {
     // is never resolved. Use a fixed value to avoid secretEnvVarsChanged on switch.
     env.LOBSTER_PROVIDER_API_KEY = 'legacy-unused';
 
-    // MCP Bridge Secret — always set so stale openclaw.json with
-    // ${LOBSTER_MCP_BRIDGE_SECRET} placeholder doesn't crash the gateway.
-    const mcpBridgeCfg = this.getMcpBridgeConfig?.();
-    env.LOBSTER_MCP_BRIDGE_SECRET = mcpBridgeCfg?.secret || 'unconfigured';
+    // MCP Bridge Secret — kept for backwards-compat with stale openclaw.json files
+    // that still contain the ${LOBSTER_MCP_BRIDGE_SECRET} placeholder.
+    // The server no longer validates this value; a fixed string is sufficient.
+    env.LOBSTER_MCP_BRIDGE_SECRET = 'local';
 
     // Telegram
     const tgConfig = this.getTelegramOpenClawConfig?.();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -563,7 +563,6 @@ let skillManager: SkillManager | null = null;
 let mcpStore: McpStore | null = null;
 let mcpServerManager: McpServerManager | null = null;
 let mcpBridgeServer: McpBridgeServer | null = null;
-let mcpBridgeSecret: string | null = null;
 let mcpBridgeStartPromise: Promise<McpBridgeConfig | null> | null = null;
 let imGatewayManager: IMGatewayManager | null = null;
 let cronJobService: CronJobService | null = null;
@@ -658,7 +657,7 @@ const bootstrapOpenClawEngine = async (options: { forceReinstall?: boolean; reas
         return null as McpBridgeConfig | null;
       });
       console.log(`[OpenClaw] bootstrap: MCP bridge setup done (${elapsed()}), result=${bridgeResult ? `${bridgeResult.tools.length} tools` : 'null'}`);
-      console.log(`[OpenClaw] bootstrap: mcpBridgeServer=${mcpBridgeServer?.callbackUrl || 'null'}, mcpServerManager.tools=${mcpServerManager?.toolManifest?.length ?? 'null'}, secret=${mcpBridgeSecret ? 'set' : 'null'}`);
+      console.log(`[OpenClaw] bootstrap: mcpBridgeServer=${mcpBridgeServer?.callbackUrl || 'null'}, mcpServerManager.tools=${mcpServerManager?.toolManifest?.length ?? 'null'}`);
 
       // Ensure IDENTITY.md has default content in the current workspace
       try {
@@ -857,13 +856,12 @@ const getOpenClawConfigSync = (): OpenClawConfigSync => {
         }
       },
       getMcpBridgeConfig: (): McpBridgeConfig | null => {
-        if (!mcpBridgeServer?.callbackUrl || !mcpBridgeServer?.askUserCallbackUrl || !mcpBridgeSecret) {
+        if (!mcpBridgeServer?.callbackUrl || !mcpBridgeServer?.askUserCallbackUrl) {
           return null;
         }
         return {
           callbackUrl: mcpBridgeServer.callbackUrl,
           askUserCallbackUrl: mcpBridgeServer.askUserCallbackUrl,
-          secret: mcpBridgeSecret,
           tools: mcpServerManager?.toolManifest ?? [],
         };
       },
@@ -1161,12 +1159,6 @@ const startMcpBridge = (): Promise<McpBridgeConfig | null> => {
   try {
     console.log('[McpBridge] startMcpBridge called');
 
-    // Generate a per-session secret for bridge auth
-    if (!mcpBridgeSecret) {
-      const crypto = await import('crypto');
-      mcpBridgeSecret = crypto.randomUUID();
-    }
-
     // Discover MCP tools (may be empty if no servers configured)
     const enabledServers = getMcpStore().getEnabledServers();
     console.log(`[McpBridge] enabledServers: ${enabledServers.length} (${enabledServers.map(s => s.name).join(', ')})`);
@@ -1186,7 +1178,7 @@ const startMcpBridge = (): Promise<McpBridgeConfig | null> => {
       mcpServerManager = new McpServerManager();
     }
     if (!mcpBridgeServer) {
-      mcpBridgeServer = new McpBridgeServer(mcpServerManager, mcpBridgeSecret);
+      mcpBridgeServer = new McpBridgeServer(mcpServerManager);
     }
     if (!mcpBridgeServer.port) {
       console.log('[McpBridge] starting HTTP callback server...');
@@ -1236,7 +1228,7 @@ const startMcpBridge = (): Promise<McpBridgeConfig | null> => {
     }
 
     console.log(`[McpBridge] started: ${tools.length} MCP tools, callback=${callbackUrl}`);
-    return { callbackUrl, askUserCallbackUrl, secret: mcpBridgeSecret, tools };
+    return { callbackUrl, askUserCallbackUrl, tools };
   } catch (error) {
     console.error('[McpBridge] startup error:', error instanceof Error ? error.stack || error.message : String(error));
     return null;


### PR DESCRIPTION
…1 问题

两个插件的 config 改用固定值 'local'，env var LOBSTER_MCP_BRIDGE_SECRET 同步固定， 服务端 handleRequest 去掉 secret 校验。server 已绑定 127.0.0.1，本机访问安全可保障。