### PR TITLE
fix(cowork): shell.openExternal 未校验 URL 协议，可触发任意应用启动

### DIFF
--- a/src/main/libs/urlSafety.ts
+++ b/src/main/libs/urlSafety.ts
@@ -1,0 +1,20 @@
+/**
+ * URL protocol validation for shell.openExternal() calls.
+ *
+ * Prevents arbitrary-protocol attacks (cmd://, powershell://, file://, etc.)
+ * by enforcing a strict allowlist of safe protocols before opening any URL
+ * in the user's default browser or application.
+ *
+ * @see https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-shellopenexternal-with-untrusted-content
+ */
+
+const SAFE_EXTERNAL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
+
+export function isSafeExternalUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return SAFE_EXTERNAL_PROTOCOLS.has(parsed.protocol);
+  } catch {
+    return false;
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -73,6 +73,7 @@ import {
   restoreOriginalProxyEnv,
   setSystemProxyEnabled,
 } from './libs/systemProxy';
+import { isSafeExternalUrl } from './libs/urlSafety';
 
 // 设置应用程序名称
 app.name = APP_NAME;
@@ -2006,6 +2007,9 @@ if (!gotTheLock) {
     try {
       const baseUrl = loginUrl || `${getServerApiBaseUrl()}/login`;
       const finalUrl = `${baseUrl}?source=electron`;
+      if (!isSafeExternalUrl(finalUrl)) {
+        return { success: false, error: 'Blocked: unsafe URL protocol' };
+      }
       await shell.openExternal(finalUrl);
       return { success: true };
     } catch (error) {
@@ -4007,6 +4011,9 @@ if (!gotTheLock) {
 
   ipcMain.handle('shell:openExternal', async (_event, url: string) => {
     try {
+      if (!isSafeExternalUrl(url)) {
+        return { success: false, error: 'Blocked: unsafe URL protocol' };
+      }
       await shell.openExternal(url);
       return { success: true };
     } catch (error) {
@@ -4315,7 +4322,9 @@ if (!gotTheLock) {
           },
         };
       }
-      shell.openExternal(url);
+      if (isSafeExternalUrl(url)) {
+        shell.openExternal(url);
+      }
       return { action: 'deny' };
     });
 

--- a/src/renderer/components/MarkdownContent.tsx
+++ b/src/renderer/components/MarkdownContent.tsx
@@ -22,7 +22,7 @@ const SYNTAX_HIGHLIGHTER_STYLE = {
   borderRadius: 0,
   background: '#282c34',
 };
-const SAFE_URL_PROTOCOLS = new Set(['http', 'https', 'mailto', 'tel', 'file']);
+const SAFE_URL_PROTOCOLS = new Set(['http', 'https', 'mailto', 'tel']);
 
 const encodeFileUrl = (url: string): string => {
   const encoded = encodeURI(url);


### PR DESCRIPTION
## Summary

- **问题**：`shell.openExternal()` 的 3 个 main process 调用点均未校验 URL 协议，攻击者可构造 `cmd://`、`powershell://`、`file://` 等恶意 URL 触发任意应用启动；MarkdownContent 的渲染层白名单包含 `file` 协议也存在风险
- **修复**：新增 `urlSafety.ts` 提供 `isSafeExternalUrl()` 协议白名单校验（仅允许 `http:`、`https:`、`mailto:`），在 main process 3 个调用点加入拦截，MarkdownContent 移除 `file` 协议，形成纵深防御

## 复现路径

1. 构造含 `file:///etc/passwd` 或 `cmd://c/calc.exe` 的 markdown 链接
2. 用户在 cowork 会话中点击该链接
3. 触发 `shell.openExternal()` → 打开任意本地文件或启动任意应用

## Changes

| 文件 | 变更 |
|------|------|
| `src/main/libs/urlSafety.ts` | 新增 `isSafeExternalUrl()` — 使用 `new URL()` 解析后校验协议白名单 |
| `src/main/main.ts` | 3 个调用点加入校验：`auth:login` IPC、`shell:openExternal` IPC、`setWindowOpenHandler` |
| `src/renderer/components/MarkdownContent.tsx` | `SAFE_URL_PROTOCOLS` 移除 `file` 协议 |