### PR TITLE
fix(im): replace auto-derived PLATFORM_TO_CHANNEL_MAP with explicit definition

### DIFF
--- a/src/main/libs/openclawChannelSessionSync.ts
+++ b/src/main/libs/openclawChannelSessionSync.ts
@@ -74,10 +74,29 @@ export const CHANNEL_PLATFORM_MAP: Record<string, IMPlatform> = {
   xiaomifeng: 'xiaomifeng',
 };
 
-/** Reverse map: IM platform → preferred OpenClaw channel name. */
-export const PLATFORM_TO_CHANNEL_MAP: Record<string, string> = Object.fromEntries(
-  Object.entries(CHANNEL_PLATFORM_MAP).map(([channel, platform]) => [platform, channel]),
-);
+/**
+ * Reverse map: IM platform → preferred OpenClaw channel key.
+ *
+ * Explicitly defined rather than auto-derived from CHANNEL_PLATFORM_MAP because
+ * multiple channel names map to the same platform (e.g. 'popo' and 'moltbot-popo'
+ * both map to platform 'popo').  Auto-deriving via Object.fromEntries would
+ * silently pick whichever entry appears last, making correctness depend on
+ * insertion order — a fragile invariant.
+ *
+ * Each value here MUST match the channel key used in openclaw.json `channels.*`.
+ */
+export const PLATFORM_TO_CHANNEL_MAP: Record<string, string> = {
+  telegram: 'telegram',
+  discord: 'discord',
+  feishu: 'feishu',
+  dingtalk: 'dingtalk-connector',
+  qq: 'qqbot',
+  wecom: 'wecom',
+  popo: 'moltbot-popo',
+  nim: 'nim',
+  weixin: 'openclaw-weixin',
+  xiaomifeng: 'xiaomifeng',
+};
 
 /** Parse a channel sessionKey into platform + conversationId.
  *  Supports three formats:


### PR DESCRIPTION
## 问题

`PLATFORM_TO_CHANNEL_MAP` 通过 `Object.fromEntries` 自动反转 `CHANNEL_PLATFORM_MAP` 生成。但 `CHANNEL_PLATFORM_MAP` 中存在多对一映射：

- `popo` 和 `moltbot-popo` 都映射到平台 `popo`
- `wecom` 和 `wecom-openclaw-plugin` 都映射到平台 `wecom`

`Object.fromEntries` 遇到重复 key 时，后出现的条目会覆盖前面的，使反向映射的正确性完全依赖于 `CHANNEL_PLATFORM_MAP` 中条目的**插入顺序**。当前顺序碰巧产生了正确结果，但这是一个脆弱的隐式约定。

## 修改

将 `PLATFORM_TO_CHANNEL_MAP` 从自动推导改为显式定义，每个 platform 明确映射到它在 `openclaw.json` `channels.*` 中使用的 channel key。

**运行时的实际值没有任何变化**，这是一个纯粹的健壮性改进。

## 影响范围

- `src/main/libs/openclawChannelSessionSync.ts` — 仅修改 `PLATFORM_TO_CHANNEL_MAP` 定义方式
- 所有消费方（`cronJobService.ts` 的 `toGatewayDelivery`、`mapGatewayJob` 等）行为不变