### PR TITLE
security: shell:openExternal IPC 接口未校验 URL 协议，存在任意协议调用风险

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4007,6 +4007,12 @@ if (!gotTheLock) {
 
   ipcMain.handle('shell:openExternal', async (_event, url: string) => {
     try {
+      // Only allow http/https URLs to prevent exploitation via file://, custom
+      // protocol handlers (ms-excel://, steam://, etc.) or other OS-level vectors.
+      const parsed = new URL(url);
+      if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+        return { success: false, error: `Blocked unsafe protocol: ${parsed.protocol}` };
+      }
       await shell.openExternal(url);
       return { success: true };
     } catch (error) {


### PR DESCRIPTION
问题描述
`src/main/main.ts` 中 `shell:openExternal` IPC handler 对传入的 URL 不做任何校验，
直接调用 `shell.openExternal(url)`：
ipcMain.handle('shell:openExternal', async (_event, url: string) => {
  await shell.openExternal(url);  // 无任何校验
});
攻击者（或恶意注入的渲染层代码）可传入非 http/https 协议的 URL，例如：
- file:///etc/passwd、file://C:/Windows/System32/cmd.exe：直接以系统默认程序打开本地文件
- ms-excel://、steam://、zoommtg:// 等自定义协议：触发已安装的第三方应用的任意操作
- javascript: 等其他危险协议
Electron 官方安全文档明确警告：必须在调用 shell.openExternal 前校验 URL 协议。

影响范围
所有版本，所有平台（Windows/macOS/Linux）

修复方案
仅允许 https: 和 http: 协议，其他协议一律返回错误，不执行打开操作。
