### PR TITLE
fix(security): shell:openExternal IPC 接口未校验 URL 协议，存在任意协议调用风险

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4007,6 +4007,12 @@ if (!gotTheLock) {
 
   ipcMain.handle('shell:openExternal', async (_event, url: string) => {
     try {
+      // Only allow http/https URLs to prevent exploitation via file://, custom
+      // protocol handlers (ms-excel://, steam://, etc.) or other OS-level vectors.
+      const parsed = new URL(url);
+      if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+        return { success: false, error: `Blocked unsafe protocol: ${parsed.protocol}` };
+      }
       await shell.openExternal(url);
       return { success: true };
     } catch (error) {


### PR DESCRIPTION
## 问题
`shell:openExternal` IPC handler 对传入 URL 无任何校验，可被用于打开
`file://`、自定义协议（`ms-excel://`、`steam://` 等）等危险 URL。
关联 Issue：#1031

## 修复
在调用 `shell.openExternal` 前用 `new URL(url)` 解析协议，
仅允许 `https:` 和 `http:`，其余返回错误拒绝执行。

## 改动文件
- `src/main/main.ts`
- 
## 测试
- 传入 `https://` URL：正常打开
- 传入 `file://`：返回 `{ success: false, error: 'Blocked unsafe protocol: file:' }`
- TypeScript 编译通过（无报错）