### PR TITLE
fix(im): NimGateway 重连后消息去重缓存未清空，导致正常消息被静默丢弃

### DIFF
--- a/src/main/im/nimGateway.ts
+++ b/src/main/im/nimGateway.ts
@@ -30,8 +30,6 @@ import {
 import { parseMediaMarkers, stripMediaMarkers } from './dingtalkMediaParser';
 import { NimQChatClient, QChatInboundMessage } from './nimQChatClient';
 
-// Message deduplication cache
-const processedMessages = new Map<string, number>();
 const MESSAGE_DEDUP_TTL = 5 * 60 * 1000; // 5 minutes
 
 /** Maximum characters per text message */
@@ -219,6 +217,13 @@ export class NimGateway extends EventEmitter {
    * QChat client instance for circle group messages
    */
   private qchatClient: NimQChatClient | null = null;
+
+  /**
+   * Per-instance message deduplication cache. Kept as an instance field so
+   * that stop()/start() cycles (reconnects) start with a clean slate and
+   * cannot accidentally suppress messages from a fresh session.
+   */
+  private processedMessages: Map<string, number> = new Map();
 
   constructor() {
     super();
@@ -721,10 +726,10 @@ export class NimGateway extends EventEmitter {
    */
   private isMessageProcessed(messageId: string): boolean {
     this.cleanupProcessedMessages();
-    if (processedMessages.has(messageId)) {
+    if (this.processedMessages.has(messageId)) {
       return true;
     }
-    processedMessages.set(messageId, Date.now());
+    this.processedMessages.set(messageId, Date.now());
     return false;
   }
 
@@ -733,9 +738,9 @@ export class NimGateway extends EventEmitter {
    */
   private cleanupProcessedMessages(): void {
     const now = Date.now();
-    processedMessages.forEach((timestamp, messageId) => {
+    this.processedMessages.forEach((timestamp, messageId) => {
       if (now - timestamp > MESSAGE_DEDUP_TTL) {
-        processedMessages.delete(messageId);
+        this.processedMessages.delete(messageId);
       }
     });
   }


### PR DESCRIPTION
## 问题
`processedMessages` 为模块级全局 Map，网关重连后旧会话的消息 ID 仍残留其中，
导致 5 分钟 TTL 内的正常消息被误判为重复而静默丢弃。
关联 Issue：# 1035

## 修复
将 `processedMessages` 改为 `NimGateway` 私有实例属性，重连时自动获得干净缓存。

## 改动文件
- `src/main/im/nimGateway.ts`
- 
## 测试
- TypeScript 编译通过（无报错）
- 重连场景下不再产生跨会话的去重误判