### PR TITLE
fix(proxy): 确保流式响应的 ReadableStream reader 在异常时也能释放

### DIFF
--- a/src/main/libs/coworkOpenAICompatProxy.ts
+++ b/src/main/libs/coworkOpenAICompatProxy.ts
@@ -2000,48 +2000,48 @@ async function handleResponsesStreamResponse(
     }
   };
 
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) {
-      break;
-    }
-
-    buffer += decoder.decode(value, { stream: true });
-
-    let boundary = findSSEPacketBoundary(buffer);
-    while (boundary) {
-      const packet = buffer.slice(0, boundary.index);
-      buffer = buffer.slice(boundary.index + boundary.separatorLength);
-
-      const parsedPacket = parseSSEPacket(packet);
-      const payload = parsedPacket.payload;
-      if (!payload) {
-        boundary = findSSEPacketBoundary(buffer);
-        continue;
-      }
-
-      if (payload === '[DONE]') {
-        flushDone();
-        sawDoneMarker = true;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
         break;
       }
 
-      try {
-        const parsed = JSON.parse(payload) as Record<string, unknown>;
-        processResponsesStreamEvent(res, state, context, parsedPacket.event, parsed);
-      } catch {
-        // Ignore malformed stream chunks.
+      buffer += decoder.decode(value, { stream: true });
+
+      let boundary = findSSEPacketBoundary(buffer);
+      while (boundary) {
+        const packet = buffer.slice(0, boundary.index);
+        buffer = buffer.slice(boundary.index + boundary.separatorLength);
+
+        const parsedPacket = parseSSEPacket(packet);
+        const payload = parsedPacket.payload;
+        if (!payload) {
+          boundary = findSSEPacketBoundary(buffer);
+          continue;
+        }
+
+        if (payload === '[DONE]') {
+          flushDone();
+          sawDoneMarker = true;
+          break;
+        }
+
+        try {
+          const parsed = JSON.parse(payload) as Record<string, unknown>;
+          processResponsesStreamEvent(res, state, context, parsedPacket.event, parsed);
+        } catch {
+          // Ignore malformed stream chunks.
+        }
+
+        boundary = findSSEPacketBoundary(buffer);
       }
 
-      boundary = findSSEPacketBoundary(buffer);
+      if (sawDoneMarker) {
+        break;
+      }
     }
-
-    if (sawDoneMarker) {
-      break;
-    }
-  }
-
-  if (sawDoneMarker) {
+  } finally {
     try {
       await reader.cancel();
     } catch {
@@ -2094,58 +2094,58 @@ async function handleChatCompletionsStreamResponse(
 
   console.log('[CoworkProxy] Stream: starting to read upstream SSE chunks');
 
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) {
-      console.log(`[CoworkProxy] Stream: upstream done after ${chunkCount} chunks, sawDoneMarker=${sawDoneMarker}`);
-      break;
-    }
-
-    chunkCount++;
-    buffer += decoder.decode(value, { stream: true });
-
-    let boundary = findSSEPacketBoundary(buffer);
-    while (boundary) {
-      const packet = buffer.slice(0, boundary.index);
-      buffer = buffer.slice(boundary.index + boundary.separatorLength);
-
-      const lines = packet.split(/\r?\n/);
-      const dataLines: string[] = [];
-
-      for (const line of lines) {
-        if (line.startsWith('data:')) {
-          dataLines.push(line.slice(5).trimStart());
-        }
-      }
-
-      const payload = dataLines.join('\n');
-      if (!payload) {
-        boundary = findSSEPacketBoundary(buffer);
-        continue;
-      }
-
-      if (payload === '[DONE]') {
-        flushDone();
-        sawDoneMarker = true;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        console.log(`[CoworkProxy] Stream: upstream done after ${chunkCount} chunks, sawDoneMarker=${sawDoneMarker}`);
         break;
       }
 
-      try {
-        const parsed = JSON.parse(payload) as OpenAIStreamChunk;
-        processOpenAIChunk(res, state, parsed);
-      } catch {
-        // Ignore malformed stream chunks.
+      chunkCount++;
+      buffer += decoder.decode(value, { stream: true });
+
+      let boundary = findSSEPacketBoundary(buffer);
+      while (boundary) {
+        const packet = buffer.slice(0, boundary.index);
+        buffer = buffer.slice(boundary.index + boundary.separatorLength);
+
+        const lines = packet.split(/\r?\n/);
+        const dataLines: string[] = [];
+
+        for (const line of lines) {
+          if (line.startsWith('data:')) {
+            dataLines.push(line.slice(5).trimStart());
+          }
+        }
+
+        const payload = dataLines.join('\n');
+        if (!payload) {
+          boundary = findSSEPacketBoundary(buffer);
+          continue;
+        }
+
+        if (payload === '[DONE]') {
+          flushDone();
+          sawDoneMarker = true;
+          break;
+        }
+
+        try {
+          const parsed = JSON.parse(payload) as OpenAIStreamChunk;
+          processOpenAIChunk(res, state, parsed);
+        } catch {
+          // Ignore malformed stream chunks.
+        }
+
+        boundary = findSSEPacketBoundary(buffer);
       }
 
-      boundary = findSSEPacketBoundary(buffer);
+      if (sawDoneMarker) {
+        break;
+      }
     }
-
-    if (sawDoneMarker) {
-      break;
-    }
-  }
-
-  if (sawDoneMarker) {
+  } finally {
     try {
       await reader.cancel();
     } catch {


### PR DESCRIPTION
## 问题

`handleResponsesStreamResponse` 和 `handleChatCompletionsStreamResponse` 两个函数中，`reader.cancel()` 被放在 `if (sawDoneMarker)` 条件块内，只有在成功接收到 `[DONE]` 标记时才会执行。

以下场景均不会触发 `cancel()`，导致 reader 永久泄漏：
- 网络中断或超时
- 服务端提前关闭连接（未发送 `[DONE]`）
- 上游 API 返回错误
- 用户点击"停止会话"

`ReadableStreamDefaultReader` 持有底层 TCP socket 的独占锁，不释放则连接无法归还连接池，文件描述符持续积累。长期使用或网络质量差的环境下，最终触发 `EMFILE: too many open files`，导致 Cowork AI 请求全部失败，需要重启应用才能恢复。

## 修复

将两个函数的 `while` 读取循环包裹在 `try/finally` 中，无论正常结束、抛出异常还是外部 abort，`reader.cancel()` 都在 `finally` 块中被调用，保证资源必然释放。

逻辑行为完全不变，仅资源释放路径更健壮。

## 涉及文件

- `src/main/libs/coworkOpenAICompatProxy.ts`
  - `handleResponsesStreamResponse`
  - `handleChatCompletionsStreamResponse`