### PR TITLE
fix(renderer): use useMaskClose hook to unify modal backdrop close lo…

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useMaskClose } from '../utils/useMaskClose';
 import { configService } from '../services/config';
 import { apiService } from '../services/api';
 import { checkForAppUpdate } from '../services/appUpdate';
@@ -411,6 +412,7 @@ const joinWorkspacePath = (dir: string | undefined, filename: string): string =>
 
 const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpdateFound }) => {
   const dispatch = useDispatch();
+  const maskProps = useMaskClose(onClose);
   // 状态
   const [activeTab, setActiveTab] = useState<TabType>(initialTab ?? 'general');
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system');
@@ -3424,7 +3426,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
   return (
     <div
       className="fixed inset-0 z-50 modal-backdrop flex items-center justify-center"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      {...maskProps}
     >
       <div
         className="relative flex w-[900px] h-[80vh] rounded-2xl dark:border-claude-darkBorder border-claude-border border shadow-modal overflow-hidden modal-content"

--- a/src/renderer/components/agent/AgentCreateModal.tsx
+++ b/src/renderer/components/agent/AgentCreateModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useMaskClose } from '../../utils/useMaskClose';
 import { agentService } from '../../services/agent';
 import { i18nService } from '../../services/i18n';
 import { XMarkIcon } from '@heroicons/react/24/outline';
@@ -16,6 +17,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
   const [icon, setIcon] = useState('');
   const [skillIds, setSkillIds] = useState<string[]>([]);
   const [creating, setCreating] = useState(false);
+  const maskProps = useMaskClose(onClose);
 
   if (!isOpen) return null;
 
@@ -45,10 +47,9 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" {...maskProps}>
       <div
         className="w-full max-w-md mx-4 rounded-xl shadow-xl bg-white dark:bg-claude-darkSurface border dark:border-claude-darkBorder border-claude-border"
-        onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">
           <h3 className="text-base font-semibold dark:text-claude-darkText text-claude-text">

--- a/src/renderer/components/agent/AgentSettingsPanel.tsx
+++ b/src/renderer/components/agent/AgentSettingsPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useMaskClose } from '../../utils/useMaskClose';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import { agentService } from '../../services/agent';
@@ -43,11 +44,11 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
   const [saving, setSaving] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [activeTab, setActiveTab] = useState<SettingsTab>('basic');
-
   // IM binding state
   const [imConfig, setImConfig] = useState<IMGatewayConfig | null>(null);
   const [boundPlatforms, setBoundPlatforms] = useState<Set<IMPlatform>>(new Set());
   const [initialBoundPlatforms, setInitialBoundPlatforms] = useState<Set<IMPlatform>>(new Set());
+  const maskProps = useMaskClose(onClose);
 
   useEffect(() => {
     if (!agentId) return;
@@ -153,10 +154,9 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
   ];
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" {...maskProps}>
       <div
         className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-white dark:bg-claude-darkSurface border dark:border-claude-darkBorder border-claude-border max-h-[80vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
       >
         {/* Header: agent icon + name + close */}
         <div className="flex items-center justify-between px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">

--- a/src/renderer/components/mcp/McpServerFormModal.tsx
+++ b/src/renderer/components/mcp/McpServerFormModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useMaskClose } from '../../utils/useMaskClose';
 import { i18nService } from '../../services/i18n';
 import { McpServerConfig, McpServerFormData, McpRegistryEntry } from '../../types/mcp';
 
@@ -31,6 +32,7 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
   const [url, setUrl] = useState('');
   const [headerRows, setHeaderRows] = useState<{ key: string; value: string }[]>([]);
   const [error, setError] = useState('');
+  const maskProps = useMaskClose(onClose);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -220,11 +222,10 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={onClose}
+      {...maskProps}
     >
       <div
         className="w-full max-w-lg mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6 max-h-[80vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-5">
           <div className="text-lg font-semibold dark:text-claude-darkText text-claude-text">

--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useMaskClose } from '../../utils/useMaskClose';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   ArrowDownTrayIcon,
@@ -50,6 +51,10 @@ const SkillsManager: React.FC = () => {
   const addSkillMenuRef = useRef<HTMLDivElement>(null);
   const addSkillButtonRef = useRef<HTMLButtonElement>(null);
   const githubImportInputRef = useRef<HTMLInputElement>(null);
+
+  const marketplaceSkillMaskProps = useMaskClose(() => setSelectedMarketplaceSkill(null));
+  const selectedSkillMaskProps = useMaskClose(() => setSelectedSkill(null));
+  const githubImportMaskProps = useMaskClose(() => setIsGithubImportOpen(false));
 
   useEffect(() => {
     let isActive = true;
@@ -632,11 +637,10 @@ const SkillsManager: React.FC = () => {
       {selectedMarketplaceSkill && createPortal(
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => setSelectedMarketplaceSkill(null)}
+          {...marketplaceSkillMaskProps}
         >
           <div
             className="w-full max-w-md mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6"
-            onClick={(event) => event.stopPropagation()}
           >
             <div className="flex items-start justify-between mb-4">
               <div className="flex items-center gap-3 min-w-0">
@@ -721,11 +725,10 @@ const SkillsManager: React.FC = () => {
       {selectedSkill && createPortal(
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => setSelectedSkill(null)}
+          {...selectedSkillMaskProps}
         >
           <div
             className="w-full max-w-md mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6"
-            onClick={(event) => event.stopPropagation()}
           >
             <div className="flex items-start justify-between mb-4">
               <div className="flex items-center gap-3 min-w-0">
@@ -877,11 +880,10 @@ const SkillsManager: React.FC = () => {
       {isGithubImportOpen && createPortal(
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => setIsGithubImportOpen(false)}
+          {...githubImportMaskProps}
         >
           <div
             className="w-full max-w-md mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6"
-            onClick={(event) => event.stopPropagation()}
           >
             <div className="flex items-start justify-between">
               <div>

--- a/src/renderer/utils/useMaskClose.ts
+++ b/src/renderer/utils/useMaskClose.ts
@@ -1,0 +1,18 @@
+import { useRef } from 'react';
+import type { MouseEventHandler } from 'react';
+
+/**
+ * Returns props to spread on a modal mask element so that clicking the mask
+ * closes the modal, while dragging from inside the modal onto the mask does not.
+ */
+export function useMaskClose(onClose: () => void): {
+  onMouseDown: MouseEventHandler;
+  onClick: MouseEventHandler;
+} {
+  const mouseDownOnMask = useRef(false);
+
+  return {
+    onMouseDown: (e) => { mouseDownOnMask.current = e.target === e.currentTarget; },
+    onClick: (e) => { if (e.target === e.currentTarget && mouseDownOnMask.current) onClose(); },
+  };
+}


### PR DESCRIPTION
## 问题

部分弹窗选中文本时，释放鼠标在弹窗遮罩（背景）区域，窗口会直接关闭，导致信息未保存丢失或拷贝失败。

![Kapture 2026-03-30 at 16 11 43](https://github.com/user-attachments/assets/ea62b199-75c8-4e98-8e21-fdd698c6a513)

## 根因

代码实现问题，未考虑鼠标press失焦等场景。

## 修复

1. 用 useRef 记录 mousedown 是否发生在遮罩本身，只有 mousedown 和 click 都在遮罩上才触发关闭。
2. 同时移除了子容器上多余的 e.stopPropagation()，逻辑更清晰，也避免了阻断子容器内部正常的事件冒泡。
3. 抽离通用hooks便于复用

``` javascript
import { useRef } from 'react';
import type { MouseEventHandler } from 'react';

/**
 * Returns props to spread on a modal mask element so that clicking the mask
 * closes the modal, while dragging from inside the modal onto the mask does not.
 */
export function useMaskClose(onClose: () => void): {
  onMouseDown: MouseEventHandler;
  onClick: MouseEventHandler;
} {
  const mouseDownOnMask = useRef(false);

  return {
    onMouseDown: (e) => { mouseDownOnMask.current = e.target === e.currentTarget; },
    onClick: (e) => { if (e.target === e.currentTarget && mouseDownOnMask.current) onClose(); },
  };
}

```

## 影响面

本次修复仅对容易误触、可能需要拷贝信息等场景下的弹窗进行统一调整。便于回归测试

### 1. Agent编辑/新建

<img width="1066" height="698" alt="image" src="https://github.com/user-attachments/assets/3b2e4664-41e9-4143-af77-65c622814446" />

### 2. 自定义MCP

<img width="990" height="716" alt="image" src="https://github.com/user-attachments/assets/8a8e1336-e4a2-4eed-96a5-5fcc177fcb9e" />

### 3. 技能详情

<img width="964" height="485" alt="image" src="https://github.com/user-attachments/assets/3d97fe65-23ba-4839-a449-e257d21a256c" />

### 4. 设置页面

<img width="1108" height="698" alt="image" src="https://github.com/user-attachments/assets/b8049e69-defe-4b5e-ab6c-4ffb6e9da92a" />
 
