### PR TITLE
fix(openclaw): 两处竞态条件导致 AI 会话永久无法启动

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1318,8 +1318,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private async ensureGatewayClientReady(): Promise<void> {
     // Serialize concurrent calls: if another init is already in progress, wait for it.
     if (this.gatewayClientInitLock) {
-      await this.gatewayClientInitLock;
-      return;
+      await this.gatewayClientInitLock.catch(() => {});
+      // The first caller may have failed (e.g. engine not yet running). If the
+      // gateway client is still null after the lock releases, run our own init
+      // instead of silently returning — otherwise requireGatewayClient() would
+      // immediately throw and leave the session in a permanently broken state.
+      if (this.gatewayClient) return;
     }
     this.gatewayClientInitLock = this._ensureGatewayClientReadyImpl();
     try {
@@ -3594,7 +3598,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private ensureActiveTurn(sessionId: string, sessionKey: string, runId: string): void {
     if (this.activeTurns.has(sessionId)) return;
     if (this.manuallyStoppedSessions.has(sessionId)) {
-      console.warn('[OpenClawRuntime] ensureActiveTurn called after manual stop — sessionId:', sessionId, 'runId:', runId, 'sessionKey:', sessionKey);
+      // The session was manually stopped. Late-arriving gateway events must not
+      // create a new ActiveTurn — doing so would cause the next startSession()
+      // call to find activeTurns.has(sessionId) === true and throw
+      // "Session is still running", permanently blocking the user from restarting.
+      console.warn('[OpenClawRuntime] ensureActiveTurn: ignoring late event for manually-stopped session —', sessionId, 'runId:', runId);
+      return;
     }
     const turnRunId = runId || randomUUID();
     const turnToken = this.nextTurnToken(sessionId);


### PR DESCRIPTION
问题
修复两处导致 AI 会话永久无法启动的竞态条件，关联 Issue：#1051
**S-07**：`ensureGatewayClientReady` 并发初始化失败后，等待者直接 return
不检查 `gatewayClient` 是否就绪，后续调用永久报错无法恢复。
**S-08**：`ensureActiveTurn` 对已手动停止的 session 仅打印警告仍创建
ActiveTurn，导致下次 `startSession` 报 `Session is still running`，
session 永久被锁死。

 修复
- `ensureGatewayClientReady`：等待者捕获 lock rejection，`gatewayClient`
  仍为 null 时重新执行初始化而非静默返回
- `ensureActiveTurn`：`manuallyStoppedSessions` 命中时直接 `return`，
  丢弃迟到事件不创建 ActiveTurn

 改动文件
- `src/main/libs/agentEngine/openclawRuntimeAdapter.ts`
- 
 测试
- TypeScript 编译通过（无报错）