### PR TITLE
fix(modal): modal close button unclickable when overlapping title bar drag region

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -199,6 +199,13 @@ select::-ms-expand {
 .modal-backdrop {
   @apply bg-black/40 backdrop-blur-sm;
   animation: fade-in 0.2s ease-out;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
+
+.fixed {
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
 }
 
 /* Modal content entrance */


### PR DESCRIPTION
## 问题

当 Modal 弹窗高度触及顶部栏时，关闭按钮无法点击。

## 根因

顶部栏 header 元素带有 `.draggable` 类（`-webkit-app-region: drag`），Electron 的窗口拖拽区域会拦截该区域所有鼠标事件，优先级高于 z-index，导致 Modal 顶部区域内的按钮完全失去响应。

## 修复

在 `index.css` 中为 `.fixed` 和 `.modal-backdrop` 添加 `-webkit-app-region: no-drag`，所有使用 `fixed` 定位的弹窗（Modal/Popover）自动覆盖底层拖拽区域，一次性修复全部弹窗场景。

## 复现路径

1. 打开「创建 Agent」弹窗
2. 展开技能下拉列表，使 Modal 高度触及顶部栏
3. 点击 Modal 关闭按钮 → 按钮无响应

Closes #1053