### PR TITLE
fix(i18n): add missing planStandard English translation

### DIFF
--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1339,6 +1339,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     authValueAddedServices: 'Premium Services',
     authZeroCredits: '0 credits',
     planFree: 'Free',
+    planStandard: 'Standard',
     planAdvanced: 'Advanced',
     planPro: 'Pro',
     


### PR DESCRIPTION
## Summary

- The English locale in `src/renderer/services/i18n.ts` was missing the `planStandard` key.
- The Chinese locale already had `planStandard: '标准'` (line 174), but the English block only had `planFree`, `planAdvanced`, and `planPro`.
- Without this key, any UI component rendering the `planStandard` translation in English mode would display the raw key string instead of `'Standard'`.

## Change

Added `planStandard: 'Standard'` to the English translations object, directly after `planFree: 'Free'`, matching the ordering in the Chinese block.

## Testing

Verified that both `zh` and `en` locale objects now have identical sets of plan-related keys:
- `planFree` / `planStandard` / `planAdvanced` / `planPro`