### PR TITLE
fix(cowork): remove debug console.log calls from production code

### DIFF
--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -301,13 +301,6 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       return false;
     }
 
-    console.log('[CoworkView] handleContinueSession called', {
-      hasImageAttachments: !!imageAttachments,
-      imageAttachmentsCount: imageAttachments?.length ?? 0,
-      imageAttachmentsNames: imageAttachments?.map(a => a.name),
-      imageAttachmentsBase64Lengths: imageAttachments?.map(a => a.base64Data.length),
-    });
-
     // Capture active skill IDs before clearing
     const sessionSkillIds = [...activeSkillIds];
 

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -74,30 +74,13 @@ class CoworkService {
 
     // Message listener - also check if session exists (for IM-created sessions)
     const messageCleanup = cowork.onStreamMessage(async ({ sessionId, message }) => {
-      // Debug: log user messages to check if imageAttachments are preserved
-      if (message.type === 'user') {
-        const meta = message.metadata as Record<string, unknown> | undefined;
-        console.log('[CoworkService] onStreamMessage received user message', {
-          sessionId,
-          messageId: message.id,
-          hasMetadata: !!meta,
-          metadataKeys: meta ? Object.keys(meta) : [],
-          hasImageAttachments: !!(meta?.imageAttachments),
-          imageAttachmentsCount: Array.isArray(meta?.imageAttachments) ? (meta.imageAttachments as unknown[]).length : 0,
-        });
-      }
       // Check if session exists in current list
       const state = store.getState().cowork;
       const sessionExists = state.sessions.some(s => s.id === sessionId);
 
-      console.log('[CoworkService] onStreamMessage: sessionId=', sessionId, 'type=', message.type, 'sessionExists=', sessionExists, 'totalSessions=', state.sessions.length);
       if (!sessionExists) {
         // Session was created by IM or another source, refresh the session list
-        console.log('[CoworkService] onStreamMessage: session NOT found in Redux, calling loadSessions...');
         await this.loadSessions();
-        const newState = store.getState().cowork;
-        const nowExists = newState.sessions.some(s => s.id === sessionId);
-        console.log('[CoworkService] onStreamMessage: after loadSessions, sessionExists=', nowExists, 'totalSessions=', newState.sessions.length);
       }
 
       // A new user turn means this session is actively running again
@@ -162,13 +145,8 @@ class CoworkService {
 
     // Sessions changed listener (new channel sessions discovered by polling)
     const sessionsChangedCleanup = cowork.onSessionsChanged(() => {
-      const beforeState = store.getState().cowork;
-      console.log('[CoworkService] onSessionsChanged: received IPC event, before sessions:', beforeState.sessions.length, 'sessionIds:', beforeState.sessions.map(s => s.id).slice(0, 5));
-      void this.loadSessions().then(() => {
-        const state = store.getState().cowork;
-        console.log('[CoworkService] onSessionsChanged: loadSessions complete, total sessions:', state.sessions.length, 'sessionIds:', state.sessions.map(s => s.id).slice(0, 5));
-      }).catch((err) => {
-        console.error('[CoworkService] onSessionsChanged: loadSessions FAILED:', err);
+      void this.loadSessions().catch((err) => {
+        console.error('[CoworkService] onSessionsChanged: loadSessions failed:', err);
       });
     });
     this.streamListenerCleanups.push(sessionsChangedCleanup);


### PR DESCRIPTION
## Summary

Three debug-only `console.log` statements were left in production code, violating the project logging guidelines.

## Changes

**`src/renderer/services/cowork.ts`**
- `onStreamMessage`: removed a per-message dump that printed `sessionId`, `messageId`, metadata keys, and image attachment counts on every incoming message. Also removed before/after `loadSessions` debug logs.
- `onSessionsChanged`: removed session-list dumps (before count + IDs, after count + IDs); kept only the `console.error` on failure path.

**`src/renderer/components/cowork/CoworkView.tsx`**
- `handleContinueSession`: removed a log that printed `base64Data.length` for every image attachment — this fires on every user message submission containing an image and leaks the size of potentially sensitive data.

## Guidelines violated (per AGENTS.md)

> No per-tick logging at info level. Polling loops, sync cycles, and heartbeats that fire every few seconds must use `console.debug` or be removed entirely.
> No variable-name labels. Write `received 5 messages` not `historyMessages: 5`.
> Errors must include the error object.

## Testing

`tsc --noEmit` passes with no errors.