### PR TITLE
fix(memory): filter thinking blocks from LLM judge response

### DIFF
--- a/src/main/libs/coworkMemoryJudge.ts
+++ b/src/main/libs/coworkMemoryJudge.ts
@@ -146,8 +146,14 @@ function extractTextFromAnthropicResponse(payload: unknown): string {
   const content = record.content;
   if (Array.isArray(content)) {
     return content
+      .filter((item) => {
+        if (!item || typeof item !== 'object') return false;
+        const block = item as Record<string, unknown>;
+        // Exclude thinking blocks — they contain internal chain-of-thought text
+        // that must not be mixed into the judgment output.
+        return block.type !== 'thinking';
+      })
       .map((item) => {
-        if (!item || typeof item !== 'object') return '';
         const block = item as Record<string, unknown>;
         return typeof block.text === 'string' ? block.text : '';
       })


### PR DESCRIPTION
## Summary

`extractTextFromAnthropicResponse` in `coworkMemoryJudge.ts` iterated over all content blocks without skipping `type="thinking"` blocks. When extended thinking (chain-of-thought) is enabled on the Anthropic API, the response contains thinking blocks with raw internal reasoning *before* the final answer block.

## Root Cause

The original `map` had no guard on `block.type`, so thinking-block text was concatenated alongside the actual answer text and fed to `parseLlmJudgePayload`. This corrupted the structured JSON the parser expected, causing incorrect `accepted`/`confidence` values for memory candidates — memories could be accepted that should have been rejected, or vice versa.

## Fix

Added a `.filter()` before the `.map()` to exclude any block whose `type` is `"thinking"`, ensuring only `text`-type blocks (the actual model reply) are included in the extracted string.

## Testing

`tsc --noEmit` (electron-tsconfig.json) passes with no errors.