### PR TITLE
fix(scheduled-task): prevent data loss when run history JSONL write fails

### DIFF
--- a/src/scheduled-task/migrate.ts
+++ b/src/scheduled-task/migrate.ts
@@ -315,6 +315,7 @@ export async function migrateScheduledTaskRunsToOpenclaw(
 
   let succeeded = 0;
   let skipped = 0;
+  let writeErrors = 0;
 
   // 5. Group runs by task_id (used as-is for the JSONL filename)
   const runsByTaskId = new Map<string, LegacyRunRow[]>();
@@ -362,18 +363,28 @@ export async function migrateScheduledTaskRunsToOpenclaw(
       if (jobName) entry['summary'] = jobName;
 
       lines.push(JSON.stringify(entry));
-      succeeded++;
     }
 
     if (lines.length > 0) {
       try {
         fs.appendFileSync(jsonlPath, lines.join('\n') + '\n', 'utf-8');
+        succeeded += lines.length;
       } catch (err) {
         console.error(`[MigrateRunHistory] Failed to write runs for task ${taskId}:`, err);
+        writeErrors++;
       }
     }
   }
 
-  console.log(`[MigrateRunHistory] Done. succeeded=${succeeded}, skipped=${skipped}`);
-  setKv(RUN_HISTORY_MIGRATION_KEY, 'true');
+  console.log(`[MigrateRunHistory] Done. succeeded=${succeeded}, skipped=${skipped}, writeErrors=${writeErrors}`);
+
+  // Mark as done only when there are no write errors.
+  // Skipped runs (duplicates) are safe and don't block completion.
+  // Write errors may be transient (disk full, permissions), so leave the flag
+  // unset to allow a retry on next launch.
+  if (writeErrors === 0) {
+    setKv(RUN_HISTORY_MIGRATION_KEY, 'true');
+  } else {
+    console.warn(`[MigrateRunHistory] ${writeErrors} write error(s), will retry on next launch`);
+  }
 }


### PR DESCRIPTION
## Problem

`migrateScheduledTaskRunsToOpenclaw` in `migrate.ts` unconditionally calls `setKv(…, "true")` at the end of the function, even when `fs.appendFileSync` fails for some JSONL files. On the next launch, the idempotency guard skips the migration entirely — any run records that failed to write are **permanently lost**.

Additionally, the `succeeded` counter is incremented at `lines.push()` time (before actual disk write), so the log output reports inflated success counts that mask the failure.

### Root Cause

Three issues compound:

1. **`succeeded` counted too early** — incremented when building the in-memory array, not after successful `fs.appendFileSync`
2. **Write errors silently swallowed** — `catch` block logs but sets no failure flag
3. **`setKv` unconditionally marks migration complete** — no guard like the one already used in `migrateScheduledTasksToOpenclaw` (line 208: `if (gatewayErrors === 0)`)

## Fix

- Add `writeErrors` counter to track JSONL write failures
- Move `succeeded` counting from `lines.push()` to after successful `fs.appendFileSync`, so log output reflects actual persisted records
- Gate `setKv` on `writeErrors === 0`, matching the established pattern in `migrateScheduledTasksToOpenclaw`
- Log a warning when write errors occur so the retry intent is visible

## Impact

The existing de-duplication logic (timestamp-based `existingTs` set) ensures that successfully written records are not duplicated on retry, so this change is safe for partial-success scenarios.