### PR TITLE
fix(openclaw): stop auto-creating [OpenClaw] session for main agent heartbeat

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1863,7 +1863,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     // Try to resolve channel-originated sessions (e.g. Telegram via OpenClaw)
     if (!sessionId && sessionKey && this.channelSessionSync) {
       const channelSessionId = this.channelSessionSync.resolveOrCreateSession(sessionKey)
-        || (!this.heartbeatSessionKeys.has(sessionKey) && this.channelSessionSync.resolveOrCreateMainAgentSession(sessionKey))
         || this.channelSessionSync.resolveOrCreateCronSession(sessionKey)
         || null;
       console.log('[Debug:handleAgentEvent] channel resolve — channelSessionId:', channelSessionId);
@@ -2685,7 +2684,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     // Try to resolve channel-originated sessions for approval requests
     if (!sessionId && sessionKey && this.channelSessionSync) {
       const channelSessionId = this.channelSessionSync.resolveOrCreateSession(sessionKey)
-        || (!this.heartbeatSessionKeys.has(sessionKey) && this.channelSessionSync.resolveOrCreateMainAgentSession(sessionKey))
         || this.channelSessionSync.resolveOrCreateCronSession(sessionKey)
         || null;
       if (channelSessionId) {
@@ -2769,7 +2767,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     // Try to resolve channel-originated sessions
     if (sessionKey && this.channelSessionSync) {
       const channelSessionId = this.channelSessionSync.resolveOrCreateSession(sessionKey)
-        || (!this.heartbeatSessionKeys.has(sessionKey) && this.channelSessionSync.resolveOrCreateMainAgentSession(sessionKey))
         || this.channelSessionSync.resolveOrCreateCronSession(sessionKey)
         || null;
       if (channelSessionId) {


### PR DESCRIPTION
## Summary

- 移除 `openclawRuntimeAdapter.ts` 中三处对 `resolveOrCreateMainAgentSession()` 的调用，阻止 OpenClaw 心跳事件自动创建 `[OpenClaw]` Cowork 会话
- 保留方法定义及 `heartbeatSessionKeys` polling 过滤逻辑不受影响

## 问题

OpenClaw 心跳任务会自动在任务记录中创建一条标题为 `[OpenClaw]` 的 Cowork 会话，用户删除后会重新出现。

## 根因

当 OpenClaw 网关通过 `agent:main:main` session key 发送心跳事件时，`resolveOrCreateMainAgentSession()` 会为该 key 创建本地 Cowork 会话。`heartbeatSessionKeys` 过滤仅在 polling 阶段生效，实时 WebSocket 事件到达时尚未被标记为 heartbeat，导致过滤失效。

## 修复

移除三处 fallback 到 `resolveOrCreateMainAgentSession()` 的调用链，main agent session 的事件将被静默跳过，不再产生可见的 `[OpenClaw]` 会话。

Closes #1066