### PR TITLE
重构：拆分 CoworkSessionDetail 单文件，提升可维护性与渲染性能

### DIFF
--- a/openspec/changes/perf-chat-virtualize/meta.yaml
+++ b/openspec/changes/perf-chat-virtualize/meta.yaml
@@ -1,0 +1,12 @@
+id: perf-chat-virtualize
+title: '优化聊天消息列表渲染性能（虚拟化 + memo）'
+status: apply-ready
+created_at: '2026-03-24'
+updated_at: '2026-03-24'
+workflow:
+  spec: done
+  plan: done
+  tasks: done
+  apply: pending
+  verify: pending
+  archive: pending

--- a/openspec/changes/perf-chat-virtualize/plan.md
+++ b/openspec/changes/perf-chat-virtualize/plan.md
@@ -1,0 +1,172 @@
+# Plan: 优化聊天消息列表渲染性能
+
+## 技术方案总览
+
+```
+优化层次（从易到难，按顺序实施）：
+
+┌─────────────────────────────────────────────────────┐
+│  Phase 1: React.memo + 引用稳定化（低风险，高收益）    │
+│                                                     │
+│  AssistantTurnBlock → React.memo                    │
+│  useMemo(turns) → 稳定化引用（只替换变化的 turn）     │
+└───────────────────────┬─────────────────────────────┘
+                        │ 解决流式输出时的重渲染问题
+                        ▼
+┌─────────────────────────────────────────────────────┐
+│  Phase 2: 虚拟化列表（中等风险，解决大数据量卡顿）     │
+│                                                     │
+│  @tanstack/react-virtual（动态高度虚拟化）            │
+│  导出功能适配（暂时展开全量 DOM）                      │
+└─────────────────────────────────────────────────────┘
+```
+
+## Phase 1 详细设计
+
+### 1.1 给 AssistantTurnBlock 加 React.memo
+
+```tsx
+export const AssistantTurnBlock = React.memo(
+  (props) => { ... },
+  (prev, next) =>
+    prev.turn === next.turn &&
+    prev.showTypingIndicator === next.showTypingIndicator &&
+    prev.showCopyButtons === next.showCopyButtons &&
+    prev.resolveLocalFilePath === next.resolveLocalFilePath &&
+    prev.mapDisplayText === next.mapDisplayText
+);
+```
+
+关键：只有当 `turn` 对象引用相同时才跳过渲染，因此需要配合 Phase 1.2。
+
+### 1.2 稳定化 turn 对象引用
+
+当前问题：每次 `buildConversationTurns(displayItems)` 都返回全新的数组和对象。
+
+解决方案：用 `useRef` 缓存上一次的 turns，对比变化，只替换真正变化的 turn：
+
+```
+新 turns 构建完成后：
+  for i in range(turns.length):
+    if turns[i] 内容与 prevTurns[i] 内容相同（通过 id + assistantItems 长度 + 最后一条消息内容判断）:
+      reuse prevTurns[i]  ← 保持引用稳定，React.memo 可拦截
+    else:
+      use turns[i]         ← 新对象，触发重渲染
+```
+
+判断 turn 是否变化的指标（轻量比较，避免深比较）：
+
+- `turn.id` 相同
+- `turn.assistantItems.length` 相同
+- 最后一个 `assistantItem` 的内容 token（message id + content 长度）相同
+
+流式场景下，通常只有最后一个 turn 的最后一条 assistantItem 在变化，
+前序 turn 全部命中缓存，跳过重渲染。
+
+### 1.3 mapDisplayText 已有 useCallback，保持不变
+
+## Phase 2 详细设计
+
+### 2.1 引入 @tanstack/react-virtual
+
+```bash
+npm install @tanstack/react-virtual
+```
+
+使用 `useVirtualizer`，动态高度模式：
+
+```tsx
+const virtualizer = useVirtualizer({
+  count: turns.length,
+  getScrollElement: () => scrollContainerRef.current,
+  estimateSize: () => 200, // 初始估算高度
+  measureElement: true, // 实测真实高度
+  overscan: 5, // 视口外多渲染 5 个，避免滚动白屏
+})
+```
+
+### 2.2 渲染结构变更
+
+```tsx
+// 当前（全量渲染）
+turns.map((turn, index) => <div key={turn.id} ...>...</div>)
+
+// 虚拟化后
+<div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+  {virtualizer.getVirtualItems().map((virtualItem) => {
+    const turn = turns[virtualItem.index];
+    return (
+      <div
+        key={turn.id}
+        data-index={virtualItem.index}
+        ref={virtualizer.measureElement}
+        style={{
+          position: 'absolute',
+          top: virtualItem.start,
+          width: '100%',
+        }}
+      >
+        <ConversationTurnRow turn={turn} ... />
+      </div>
+    );
+  })}
+</div>
+```
+
+### 2.3 自动滚动到底部适配
+
+`virtualizer` 提供 `scrollToIndex` API：
+
+```tsx
+virtualizer.scrollToIndex(turns.length - 1, { align: 'end' })
+```
+
+替换当前的 `container.scrollTop = container.scrollHeight`。
+
+### 2.4 turn index 导航适配
+
+当前导航逻辑依赖 DOM 查询 `[data-turn-index]`，虚拟化后不可见的 turn 没有 DOM 节点。
+
+适配方案：改用 `virtualizer.scrollToIndex(targetIndex)` 先滚动到目标位置，再查找 DOM。
+
+### 2.5 导出功能适配
+
+导出（截图/文本）需要完整 DOM。
+
+策略：导出前临时设置 `virtualizer` 的 `overscan` 为 `Infinity` 或直接 fallback 到非虚拟化渲染（通过 `isExporting` 状态切换），导出完成后恢复。
+
+### 2.6 虚拟化启用阈值
+
+```tsx
+const VIRTUALIZE_THRESHOLD = 30 // turns 数量超过 30 时启用虚拟化
+const useVirtualize = turns.length > VIRTUALIZE_THRESHOLD
+```
+
+小会话直接用原始 `turns.map`，避免引入不必要复杂度。
+
+## 技术选型理由
+
+| 方案                      | 优点                       | 缺点                                              |
+| ------------------------- | -------------------------- | ------------------------------------------------- |
+| `@tanstack/react-virtual` | 成熟、无依赖、支持动态高度 | 需要适配现有滚动/导出逻辑                         |
+| `react-window`            | 轻量                       | 不支持动态高度（需 react-window-infinite-loader） |
+| 手写虚拟化                | 零依赖                     | 工作量大，难以维护                                |
+
+选择 `@tanstack/react-virtual`。
+
+## 风险评估
+
+| 风险                               | 可能性 | 影响 | 缓解措施                                |
+| ---------------------------------- | ------ | ---- | --------------------------------------- |
+| 虚拟化后导出截图不完整             | 中     | 高   | 导出前临时展开全量 DOM                  |
+| 动态高度计算不准导致跳动           | 中     | 中   | 设置合理 estimateSize，加 smooth scroll |
+| turn 引用比较逻辑有 bug 导致不更新 | 低     | 高   | 充分测试流式场景，保守比较策略          |
+| 虚拟化后 data-turn-index 导航失效  | 高     | 中   | 改用 scrollToIndex API                  |
+
+## 实施顺序
+
+Phase 1 先于 Phase 2，因为：
+
+1. Phase 1 风险低，可以立即上线
+2. Phase 1 的收益在流式场景下已经非常显著
+3. Phase 2 如果出现兼容问题，不影响 Phase 1 的收益

--- a/openspec/changes/perf-chat-virtualize/spec.md
+++ b/openspec/changes/perf-chat-virtualize/spec.md
@@ -1,0 +1,66 @@
+# Spec: 优化聊天消息列表渲染性能
+
+## 背景
+
+Issue #645：聊天记录多了之后 UI 非常卡，建议加入聊天记录的局部按需渲染。
+
+经过代码分析，确认以下根本原因：
+
+1. `AssistantTurnBlock` 组件没有 `React.memo`，导致流式输出时所有历史 turn 全量重渲染
+2. `buildConversationTurns` 每次 messages 变化都重建全部 turn 对象引用，破坏潜在的 memo 效果
+3. 没有列表虚拟化，大量消息时 DOM 节点数量线性增长，浏览器 layout/paint 越来越慢
+
+## 功能需求（EARS 格式）
+
+### REQ-1：AssistantTurnBlock 记忆化
+
+WHEN messages 数组发生变化时，
+THE SYSTEM SHALL 仅重新渲染内容实际发生变化的 `AssistantTurnBlock`，
+已渲染的历史 turn 不应重新渲染（除非其内容确实变化）。
+
+### REQ-2：稳定化 turn 对象引用
+
+WHEN 流式消息更新到最后一条消息时，
+THE SYSTEM SHALL 保持前序 turn 的对象引用不变，
+仅替换发生变化的 turn 对象引用，
+使 React.memo 能有效拦截不必要的重渲染。
+
+### REQ-3：消息列表虚拟化
+
+WHEN 会话的 turn 数量超过阈值时，
+THE SYSTEM SHALL 仅渲染当前视口内可见的 turn 节点，
+不可见的 turn 在 DOM 中不挂载（或卸载），
+滚动体验保持流畅。
+
+WHILE 虚拟化处于活跃状态，
+THE SYSTEM SHALL 保持以下现有行为不变：
+
+- 自动滚动到底部（新消息到达时）
+- 导航快捷键（turn index 跳转）
+- 导出功能（截图/文本导出）
+
+### REQ-4：流式输出时性能目标
+
+WHEN 会话处于流式输出状态（isStreaming=true）时，
+THE SYSTEM SHALL 将每次 Redux 状态更新触发的重渲染范围
+限制在最后一个 turn 的相关组件内，
+历史 turn 的组件不参与重渲染。
+
+## 非功能需求
+
+- 不引入破坏性 UI 变化，用户视觉体验保持一致
+- 导出（截图、文本）功能需要在虚拟化模式下继续工作
+- 虚拟化仅在 turn 数量超过阈值（建议 30）时启用，避免小会话引入不必要复杂度
+
+## 范围
+
+**本次变更包含**：
+
+- `CoworkSessionDetail.tsx` 的渲染性能优化
+- turn 引用稳定化逻辑
+
+**本次变更不包含**：
+
+- 分页加载历史消息（数据层面的懒加载）
+- SQLite 查询优化
+- 其他页面的性能优化

--- a/openspec/changes/perf-chat-virtualize/tasks.md
+++ b/openspec/changes/perf-chat-virtualize/tasks.md
@@ -1,0 +1,88 @@
+# Tasks: 优化聊天消息列表渲染性能
+
+## Phase 1: React.memo + 引用稳定化
+
+### TASK-1.1 给 AssistantTurnBlock 包装 React.memo ✅
+
+- **文件**: `src/renderer/components/cowork/CoworkSessionDetail.tsx`
+- **操作**: 将 `AssistantTurnBlock` 的 `React.FC` 声明改为 `React.memo(...)` 包裹，加入自定义比较函数
+- **比较函数**：对比 `turn`、`showTypingIndicator`、`showCopyButtons`、`resolveLocalFilePath`、`mapDisplayText` 五个 props
+- **验收**: React DevTools Profiler 中，历史 turn 在流式输出时不再出现 re-render 高亮
+
+### TASK-1.2 实现 turn 引用稳定化：`prevTurnsRef` ✅
+
+- **文件**: `src/renderer/components/cowork/CoworkSessionDetail.tsx`
+- **操作**:
+  1. 在 refs 区域声明 `prevTurnsRef = useRef<ConversationTurn[]>([])`
+  2. `buildConversationTurns` 结果存入 `rawTurns`，再通过稳定化 useMemo 生成最终 `turns`
+  3. 比较策略：`turn.id` 相同 && `assistantItems.length` 相同 && 最后一个 assistantItem 内容指纹相同则复用旧引用
+  4. 会话切换时在 useEffect 里重置 `prevTurnsRef.current = []`
+- **验收**: 流式场景下前序 turn 的引用保持稳定
+
+### TASK-1.3 确保 mapDisplayText 引用稳定 ✅
+
+- **文件**: `src/renderer/components/cowork/CoworkSessionDetail.tsx`
+- **操作**: 已确认 `mapDisplayText` 用 `useCallback(value => value, [])` 包裹，依赖项为空数组
+- **验收**: `mapDisplayText` 在父组件重渲染时引用不变
+
+---
+
+## Phase 2: 列表虚拟化
+
+### TASK-2.1 安装 @tanstack/react-virtual
+
+- **操作**: `npm install @tanstack/react-virtual`
+- **验收**: `package.json` 中出现该依赖
+
+### TASK-2.2 实现虚拟化渲染逻辑
+
+- **文件**: `src/renderer/components/cowork/CoworkSessionDetail.tsx`
+- **操作**:
+  1. 在 `renderConversationTurns` 函数中，当 `turns.length > VIRTUALIZE_THRESHOLD`（30）时使用虚拟化路径
+  2. 引入 `useVirtualizer`，绑定到现有的 `scrollContainerRef`
+  3. 外层容器改为 `position: relative`，高度为 `virtualizer.getTotalSize()`
+  4. 每个 virtual item 使用 `position: absolute`，`top: virtualItem.start`
+  5. 每个 item 挂载 `ref={virtualizer.measureElement}` 进行动态高度测量
+  6. 保留 `data-turn-index` 属性，值为 `virtualItem.index`
+- **验收**: 大会话（>30 turns）时，DOM 中实际挂载的 turn 节点数量 ≈ 可见 turn 数 + 10（overscan）
+
+### TASK-2.3 适配自动滚动到底部
+
+- **文件**: `src/renderer/components/cowork/CoworkSessionDetail.tsx`
+- **操作**:
+  1. 在虚拟化路径下，将 `container.scrollTop = container.scrollHeight` 替换为 `virtualizer.scrollToIndex(turns.length - 1, { align: 'end' })`
+  2. 非虚拟化路径保持原逻辑不变
+- **验收**: 新消息到达时，虚拟化模式下能正确滚动到底部
+
+### TASK-2.4 适配 turn index 导航
+
+- **文件**: `src/renderer/components/cowork/CoworkSessionDetail.tsx`
+- **操作**:
+  1. 找到当前使用 `querySelectorAll('[data-turn-index]')` 的导航逻辑（`turnElsCacheRef`）
+  2. 在虚拟化模式下，改为先调用 `virtualizer.scrollToIndex(targetIndex)`，再在下一帧查找 DOM
+  3. 非虚拟化路径保持原逻辑不变
+- **验收**: 导航快捷键在虚拟化模式下仍能跳转到目标 turn
+
+### TASK-2.5 适配导出功能（截图/文本导出）
+
+- **文件**: `src/renderer/components/cowork/CoworkSessionDetail.tsx`
+- **操作**:
+  1. 添加 `isExporting` ref/state（默认 false）
+  2. 导出开始前设为 true，触发 fallback 到全量渲染模式（`useVirtualize = false`）
+  3. 等待一个渲染帧（`requestAnimationFrame`）后执行导出
+  4. 导出结束后恢复 `isExporting = false`
+  5. 找到现有导出入口（截图、Markdown 导出），在对应位置插入此逻辑
+- **验收**: 虚拟化模式下执行导出，导出结果包含所有历史消息
+
+---
+
+## 验收标准汇总
+
+| 场景                    | 期望结果                               |
+| ----------------------- | -------------------------------------- |
+| 流式输出，20 条历史消息 | 只有最后一个 turn 重渲染               |
+| 静态会话，100 条消息    | DOM 中 turn 节点数 ≈ 可见数 + overscan |
+| 点击"新消息"            | 虚拟化模式下正确滚动到底部             |
+| 导出截图                | 包含所有消息，无截断                   |
+| 会话切换                | 虚拟化状态重置，不残留上一个会话的状态 |
+| 小会话（≤30 turns）     | 走原始 `turns.map` 路径，无虚拟化      |

--- a/openspec/changes/refactor-cowork-session-detail/meta.yaml
+++ b/openspec/changes/refactor-cowork-session-detail/meta.yaml
@@ -1,0 +1,7 @@
+id: refactor-cowork-session-detail
+title: 'Refactor CoworkSessionDetail: Split 2100+ Line File into Focused Modules'
+type: refactor
+status: apply-ready
+branch: refactor/cowork-session-detail-split
+created_at: '2026-03-30'
+updated_at: '2026-03-30'

--- a/openspec/changes/refactor-cowork-session-detail/plan.md
+++ b/openspec/changes/refactor-cowork-session-detail/plan.md
@@ -1,0 +1,91 @@
+# Plan: Refactor CoworkSessionDetail into Focused Modules
+
+## Technical Approach
+
+逐步抽取子模块，每一步保持可编译，最终用 re-export 确保零破坏性变更。
+
+### Step 1 — 创建 `CoworkSessionDetail.types.ts`
+
+把所有共享 TypeScript 类型和接口提取到独立文件。
+
+- `ToolGroupItem`, `DisplayItem`, `AssistantTurnItem`, `ConversationTurn`, `CoworkSessionDetailProps`, `CaptureRect`
+- 以及内部类型 `TodoStatus`, `ParsedTodoItem`
+
+### Step 2 — 创建 `CoworkSessionDetail.utils.ts`
+
+把所有纯工具函数提取到独立文件（无 React 依赖）：
+
+- 格式化函数：`formatUnknown`, `getStringArray`, `formatStructuredText`, `toTrimmedString`, `truncatePreview`
+- 路径解析函数：`normalizeLocalPath`, `parseRootRelativePath`, `stripFileProtocol`, `safeDecodeURIComponent` 等
+- 工具调用解析：`normalizeToolName`, `getToolDisplayName`, `isBashLikeToolName`, `getToolInputString`, `getToolInputSummary`, `formatToolInput`, `normalizeToolResultText`, `getToolResultDisplay`
+- Todo 解析：`parseTodoWriteItems`, `getTodoWriteSummary`, `normalizeTodoStatus`
+- Cron 解析：`getCronToolSummary`, `isCronToolName`, `isTodoWriteToolName`
+- 会话构建：`buildDisplayItems`, `buildConversationTurns`, `hasRenderableAssistantContent`, `getVisibleAssistantItems` (内部), `isVisibleAssistantTurnItem` (内部)
+- 导出辅助：`sanitizeExportFileName`, `formatExportTimestamp`, `waitForNextFrame`, `loadImageFromBase64`, `domRectToCaptureRect`
+- 其他：`hasText`, `getToolResultLineCount`
+
+### Step 3 — 创建子组件文件
+
+#### `components/CopyButton.tsx`
+
+- `CopyButton` 组件（加 `React.memo`）
+
+#### `components/ToolCallGroup.tsx`
+
+- `PushPinIcon`（纯 SVG）
+- `TodoWriteInputView` (加 `React.memo`)
+- `ToolCallGroup` (加 `React.memo`)
+- 导入 types/utils
+
+#### `components/UserMessageItem.tsx`
+
+- `UserMessageItem`（已有 `React.memo`，迁移过来即可）
+
+#### `components/StreamingActivityBar.tsx`
+
+- `TypingDots` (加 `React.memo`)
+- `StreamingActivityBar` (加 `React.memo`)
+
+#### `components/AssistantTurnBlock.tsx`
+
+- `AssistantMessageItem` (加 `React.memo`)
+- `ThinkingBlock` (加 `React.memo`)
+- `AssistantTurnBlock`（本身作为 export，加 `React.memo`）
+
+### Step 4 — 创建 `CoworkSessionDetail.hooks.ts`
+
+从主组件抽取自定义 hooks：
+
+- `useScrollBehavior(scrollContainerRef, messages, isStreaming)` — auto-scroll 与 scroll 监听
+- `useTurnNavigation(scrollContainerRef, turns)` — turn 导航状态与操作
+- `useSessionMenu(actionButtonRef)` — 下拉菜单位置管理
+- `useRenameSession(session)` — rename 状态管理
+- `useExportImage(session, scrollContainerRef)` — 截图导出逻辑
+
+### Step 5 — 重构 `CoworkSessionDetail.tsx`
+
+- 主组件仅保留 JSX 组织逻辑，使用上述 hooks
+- 在文件末尾添加 re-export 语句，确保所有原有导出仍然可用
+
+## File Dependency Graph
+
+```
+CoworkSessionDetail.types.ts     ← (no deps in our code)
+CoworkSessionDetail.utils.ts     ← types.ts
+CopyButton.tsx                   ← (no local deps)
+ToolCallGroup.tsx                ← types.ts, utils.ts, CopyButton.tsx
+UserMessageItem.tsx              ← types.ts, CopyButton.tsx, MarkdownContent.tsx
+StreamingActivityBar.tsx         ← types.ts, utils.ts
+AssistantTurnBlock.tsx           ← types.ts, utils.ts, AssistantMessageItem, ThinkingBlock, ToolCallGroup.tsx
+CoworkSessionDetail.hooks.ts     ← types.ts, utils.ts, coworkService
+CoworkSessionDetail.tsx          ← ALL above + CoworkPromptInput.tsx
+```
+
+## Risk & Mitigation
+
+| Risk                 | Mitigation                                                         |
+| -------------------- | ------------------------------------------------------------------ |
+| 循环依赖             | types.ts 不依赖任何本地模块；utils.ts 只依赖 types.ts              |
+| 外部 import 路径变化 | CoworkSessionDetail.tsx 用 `export { ... } from './...'` re-export |
+| TypeScript 类型丢失  | 所有 `export type` 也在原文件 re-export                            |
+| 拆分后行为不一致     | 逐步拆分，每步后 lint 检查                                         |

--- a/openspec/changes/refactor-cowork-session-detail/spec.md
+++ b/openspec/changes/refactor-cowork-session-detail/spec.md
@@ -1,0 +1,65 @@
+# Spec: Refactor CoworkSessionDetail into Focused Modules
+
+## Background
+
+`src/renderer/components/cowork/CoworkSessionDetail.tsx` is a monolithic 2100+ line file that contains:
+
+- ~30 pure utility functions
+- ~10 sub-components (some already exported, some internal)
+- Complex scroll logic, export logic, and menu logic in the main component
+- No `React.memo` on several hot-path sub-components
+
+This makes the file hard to maintain and prevents effective tree-shaking or independent testing of sub-components.
+
+## Goals
+
+1. Split the file into focused, single-responsibility modules under `src/renderer/components/cowork/`
+2. Apply `React.memo` to all stateless sub-components that render inside message lists (hot render path)
+3. Preserve **all existing exports** (`UserMessageItem`, `AssistantTurnBlock`, `buildDisplayItems`, `buildConversationTurns`, `hasRenderableAssistantContent`, type exports) so that any external consumers continue to work without changes
+4. Keep `CoworkSessionDetail` as the default export of `CoworkSessionDetail.tsx`; it re-exports everything from the new sub-modules so no import paths in other files change
+5. Zero functional/visual regression — no UI or behavior changes
+
+## Non-Goals
+
+- Changing any Redux state shape
+- Introducing virtual scrolling (separate change)
+- Changing any public API / props interface
+
+## Target File Structure
+
+```
+src/renderer/components/cowork/
+├── CoworkSessionDetail.tsx          (main component, ~400 lines — orchestration only)
+├── CoworkSessionDetail.types.ts     (shared types: DisplayItem, ConversationTurn, etc.)
+├── CoworkSessionDetail.utils.ts     (all pure utility functions: buildDisplayItems, buildConversationTurns, formatToolInput, etc.)
+├── CoworkSessionDetail.hooks.ts     (custom hooks: useScrollBehavior, useTurnNavigation, useSessionMenu, useRenameSession, useExportImage)
+├── components/
+│   ├── ToolCallGroup.tsx            (ToolCallGroup component + TodoWriteInputView)
+│   ├── UserMessageItem.tsx          (UserMessageItem component, already exported)
+│   ├── AssistantTurnBlock.tsx       (AssistantTurnBlock + AssistantMessageItem + ThinkingBlock)
+│   ├── StreamingActivityBar.tsx     (StreamingActivityBar + TypingDots)
+│   └── CopyButton.tsx               (CopyButton)
+```
+
+## Requirements
+
+### WHEN splitting into modules
+
+- THEN each new file must have all necessary imports (no circular deps)
+- THEN utility functions must be pure (no side effects, no React hooks)
+- THEN hooks must not import from component files (only from types/utils)
+
+### WHEN applying React.memo
+
+- THEN `ToolCallGroup`, `AssistantMessageItem`, `ThinkingBlock`, `StreamingActivityBar`, `TypingDots`, `CopyButton` must be wrapped with `React.memo`
+- THEN `UserMessageItem` is already memo'd — preserve that
+
+### WHEN re-exporting from CoworkSessionDetail.tsx
+
+- THEN all previously exported names must remain importable from `CoworkSessionDetail.tsx`
+- THEN `CoworkSessionDetail` remains the default export
+
+### WHEN running the app after refactor
+
+- THEN there must be zero TypeScript compilation errors
+- THEN the visual output and interaction behavior of CoworkSessionDetail must be identical to before

--- a/openspec/changes/refactor-cowork-session-detail/tasks.md
+++ b/openspec/changes/refactor-cowork-session-detail/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: Refactor CoworkSessionDetail
+
+## Status: apply-ready
+
+---
+
+## Task 1 — 创建 `CoworkSessionDetail.types.ts`
+
+- [ ] 新建 `src/renderer/components/cowork/CoworkSessionDetail.types.ts`
+- [ ] 迁移类型：`CaptureRect`, `TodoStatus`, `ParsedTodoItem`, `ToolGroupItem`, `DisplayItem`, `AssistantTurnItem`, `ConversationTurn`, `CoworkSessionDetailProps`
+
+## Task 2 — 创建 `CoworkSessionDetail.utils.ts`
+
+- [ ] 新建 `src/renderer/components/cowork/CoworkSessionDetail.utils.ts`
+- [ ] 迁移所有纯工具函数（约 30 个函数）
+- [ ] 导出需外部使用的：`buildDisplayItems`, `buildConversationTurns`, `hasRenderableAssistantContent`
+
+## Task 3 — 创建 `components/CopyButton.tsx`
+
+- [ ] 新建 `src/renderer/components/cowork/components/CopyButton.tsx`
+- [ ] 迁移 `CopyButton` 并添加 `React.memo`
+
+## Task 4 — 创建 `components/ToolCallGroup.tsx`
+
+- [ ] 新建 `src/renderer/components/cowork/components/ToolCallGroup.tsx`
+- [ ] 迁移 `PushPinIcon`, `TodoWriteInputView`（加 memo）, `ToolCallGroup`（加 memo）
+
+## Task 5 — 创建 `components/UserMessageItem.tsx`
+
+- [ ] 新建 `src/renderer/components/cowork/components/UserMessageItem.tsx`
+- [ ] 迁移 `UserMessageItem`（已有 memo）
+
+## Task 6 — 创建 `components/StreamingActivityBar.tsx`
+
+- [ ] 新建 `src/renderer/components/cowork/components/StreamingActivityBar.tsx`
+- [ ] 迁移 `TypingDots`（加 memo）, `StreamingActivityBar`（加 memo）
+
+## Task 7 — 创建 `components/AssistantTurnBlock.tsx`
+
+- [ ] 新建 `src/renderer/components/cowork/components/AssistantTurnBlock.tsx`
+- [ ] 迁移 `AssistantMessageItem`（加 memo）, `ThinkingBlock`（加 memo）, `AssistantTurnBlock`（加 memo）
+
+## Task 8 — 创建 `CoworkSessionDetail.hooks.ts`
+
+- [ ] 新建 `src/renderer/components/cowork/CoworkSessionDetail.hooks.ts`
+- [ ] 实现 `useScrollBehavior`
+- [ ] 实现 `useTurnNavigation`
+- [ ] 实现 `useSessionMenu`
+- [ ] 实现 `useRenameSession`
+- [ ] 实现 `useExportImage`
+
+## Task 9 — 重写 `CoworkSessionDetail.tsx`
+
+- [ ] 主组件使用上述 hooks 和子组件重写，保留 JSX 逻辑
+- [ ] 在文件末尾添加所有需要 re-export 的名称
+- [ ] 确保原有 export：`UserMessageItem`, `AssistantTurnBlock`, `buildDisplayItems`, `buildConversationTurns`, `hasRenderableAssistantContent`, type `ToolGroupItem`, type `DisplayItem`, type `AssistantTurnItem`, type `ConversationTurn`
+
+## Task 10 — 验证
+
+- [ ] `npm run lint` 通过，无新增 error
+- [ ] `npm run build`（或 `compile:electron`）通过，无 TypeScript 报错
+- [ ] 启动 `npm run electron:dev` 手动验证会话详情页功能完整

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/src/main/im/nimGateway.ts
+++ b/src/main/im/nimGateway.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { app } from 'electron';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const NIM = require('nim-web-sdk-ng/dist/nodejs/nim.js').default;
 import type { V2NIM } from 'nim-web-sdk-ng/dist/nodejs/nim';
 import {

--- a/src/main/im/xiaomifengGateway.ts
+++ b/src/main/im/xiaomifengGateway.ts
@@ -11,7 +11,6 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { app } from 'electron';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const NIM = require('nim-web-sdk-ng/dist/nodejs/nim.js').default;
 import type { V2NIM } from 'nim-web-sdk-ng/dist/nodejs/nim';
 import {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1538,7 +1538,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private async loadGatewayClientCtor(clientEntryPath: string): Promise<GatewayClientCtor> {
     // Use require() with file path directly. TypeScript's CJS output downgrades
     // dynamic import() to require(), which doesn't support file:// URLs.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const loaded = require(clientEntryPath) as Record<string, unknown>;
     const direct = loaded.GatewayClient;
     if (typeof direct === 'function') {

--- a/src/renderer/components/cowork/CoworkSessionDetail.hooks.ts
+++ b/src/renderer/components/cowork/CoworkSessionDetail.hooks.ts
@@ -1,0 +1,515 @@
+import { useState, useRef, useEffect, useCallback, RefObject } from 'react'
+import type { ConversationTurn } from './CoworkSessionDetail.types'
+import type { CoworkSession as FullCoworkSession } from '../../types/cowork'
+import {
+  AUTO_SCROLL_THRESHOLD,
+  NAV_HIDE_DELAY,
+  NAV_SCROLL_LOCK_DURATION,
+  NAV_BOTTOM_SNAP_THRESHOLD,
+  MAX_EXPORT_CANVAS_HEIGHT,
+  MAX_EXPORT_SEGMENTS,
+  sanitizeExportFileName,
+  formatExportTimestamp,
+  waitForNextFrame,
+  loadImageFromBase64,
+  domRectToCaptureRect,
+  parseRootRelativePath,
+  normalizeLocalPath,
+  toAbsolutePathFromCwd,
+} from './CoworkSessionDetail.utils'
+import { coworkService } from '../../services/cowork'
+import { i18nService } from '../../services/i18n'
+import { getCompactFolderName } from '../../utils/path'
+
+// ─── useScrollBehavior ─────────────────────────────────────────────────────────
+
+export interface UseScrollBehaviorResult {
+  shouldAutoScroll: boolean
+  setShouldAutoScroll: React.Dispatch<React.SetStateAction<boolean>>
+  isScrollable: boolean
+  handleMessagesScroll: () => void
+  turnElsCacheRef: RefObject<HTMLElement[]>
+  currentTurnIndex: number
+  setCurrentTurnIndex: React.Dispatch<React.SetStateAction<number>>
+  currentTurnIndexRef: React.MutableRefObject<number>
+  showTurnNav: boolean
+  isNavigatingRef: RefObject<boolean>
+  navigateToTurn: (direction: 'prev' | 'next') => void
+}
+
+export function useScrollBehavior(
+  scrollContainerRef: RefObject<HTMLDivElement>,
+  turns: ConversationTurn[],
+): UseScrollBehaviorResult {
+  const [shouldAutoScroll, setShouldAutoScroll] = useState(true)
+  const [currentTurnIndex, setCurrentTurnIndex] = useState(0)
+  const currentTurnIndexRef = useRef(0)
+  const [showTurnNav, setShowTurnNav] = useState(false)
+  const [isScrollable, setIsScrollable] = useState(false)
+  const hideNavTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isNavigatingRef = useRef(false)
+  const navigatingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const turnElsCacheRef = useRef<HTMLElement[]>([])
+
+  // Cleanup timers on unmount
+  useEffect(() => {
+    return () => {
+      if (hideNavTimerRef.current) clearTimeout(hideNavTimerRef.current)
+      if (navigatingTimerRef.current) clearTimeout(navigatingTimerRef.current)
+    }
+  }, [])
+
+  // Cache turn DOM elements when turns change
+  useEffect(() => {
+    const container = scrollContainerRef.current
+    if (!container) {
+      turnElsCacheRef.current = []
+      return
+    }
+    turnElsCacheRef.current = Array.from(container.querySelectorAll<HTMLElement>('[data-turn-index]'))
+  }, [turns, scrollContainerRef])
+
+  const handleMessagesScroll = useCallback(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+    const distanceToBottom = container.scrollHeight - container.scrollTop - container.clientHeight
+    const isNearBottom = distanceToBottom <= AUTO_SCROLL_THRESHOLD
+    setShouldAutoScroll((prev) => (prev === isNearBottom ? prev : isNearBottom))
+
+    const scrollable = container.scrollHeight > container.clientHeight
+    setIsScrollable((prev) => (prev === scrollable ? prev : scrollable))
+    if (!scrollable) return
+
+    setShowTurnNav((prev) => (prev ? prev : true))
+    if (hideNavTimerRef.current) clearTimeout(hideNavTimerRef.current)
+    hideNavTimerRef.current = setTimeout(() => setShowTurnNav(false), NAV_HIDE_DELAY)
+
+    if (isNavigatingRef.current) return
+
+    const turnEls = turnElsCacheRef.current
+    if (turnEls.length === 0) return
+
+    if (distanceToBottom <= NAV_BOTTOM_SNAP_THRESHOLD) {
+      const lastIndex = turnEls.length - 1
+      currentTurnIndexRef.current = lastIndex
+      setCurrentTurnIndex(lastIndex)
+      return
+    }
+
+    const scrollTop = container.scrollTop
+    let visibleIndex = 0
+    for (let i = 0; i < turnEls.length; i++) {
+      if (turnEls[i].offsetTop <= scrollTop + 80) {
+        visibleIndex = i
+      } else {
+        break
+      }
+    }
+    currentTurnIndexRef.current = visibleIndex
+    setCurrentTurnIndex(visibleIndex)
+  }, [scrollContainerRef])
+
+  const navigateToTurn = useCallback((direction: 'prev' | 'next') => {
+    const turnEls = turnElsCacheRef.current
+    if (turnEls.length === 0) return
+    const idx = currentTurnIndexRef.current
+    const targetIndex = direction === 'prev' ? idx - 1 : idx + 1
+    if (targetIndex < 0 || targetIndex >= turnEls.length) return
+
+    isNavigatingRef.current = true
+    if (navigatingTimerRef.current) clearTimeout(navigatingTimerRef.current)
+    navigatingTimerRef.current = setTimeout(() => {
+      isNavigatingRef.current = false
+    }, NAV_SCROLL_LOCK_DURATION)
+
+    turnEls[targetIndex].scrollIntoView({ behavior: 'smooth', block: 'start' })
+    currentTurnIndexRef.current = targetIndex
+    setCurrentTurnIndex(targetIndex)
+    setShowTurnNav(true)
+    if (hideNavTimerRef.current) clearTimeout(hideNavTimerRef.current)
+    hideNavTimerRef.current = setTimeout(() => setShowTurnNav(false), NAV_HIDE_DELAY)
+  }, [])
+
+  return {
+    shouldAutoScroll,
+    setShouldAutoScroll,
+    isScrollable,
+    handleMessagesScroll,
+    turnElsCacheRef,
+    currentTurnIndex,
+    setCurrentTurnIndex,
+    currentTurnIndexRef,
+    showTurnNav,
+    isNavigatingRef,
+    navigateToTurn,
+  }
+}
+
+// ─── useSessionMenu ────────────────────────────────────────────────────────────
+
+export interface UseSessionMenuResult {
+  menuPosition: { x: number; y: number } | null
+  menuRef: RefObject<HTMLDivElement>
+  showConfirmDelete: boolean
+  setShowConfirmDelete: React.Dispatch<React.SetStateAction<boolean>>
+  openMenu: (e: React.MouseEvent) => void
+  closeMenu: () => void
+}
+
+export function useSessionMenu(
+  actionButtonRef: RefObject<HTMLButtonElement>,
+  isRenaming: boolean,
+): UseSessionMenuResult {
+  const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [showConfirmDelete, setShowConfirmDelete] = useState(false)
+
+  const closeMenu = useCallback(() => {
+    setMenuPosition(null)
+    setShowConfirmDelete(false)
+  }, [])
+
+  useEffect(() => {
+    if (!menuPosition) return
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (!menuRef.current?.contains(target) && !actionButtonRef.current?.contains(target)) {
+        closeMenu()
+      }
+    }
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeMenu()
+    }
+    const handleScroll = () => closeMenu()
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleEscape)
+    window.addEventListener('scroll', handleScroll, true)
+    window.addEventListener('resize', handleScroll)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleEscape)
+      window.removeEventListener('scroll', handleScroll, true)
+      window.removeEventListener('resize', handleScroll)
+    }
+  }, [menuPosition, actionButtonRef, closeMenu])
+
+  const openMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      if (isRenaming) return
+      if (menuPosition) {
+        closeMenu()
+        return
+      }
+      const menuHeight = 160
+      const rect = actionButtonRef.current?.getBoundingClientRect()
+      if (!rect) return
+      const menuWidth = 180
+      const padding = 8
+      const x = Math.min(Math.max(padding, rect.right - menuWidth), window.innerWidth - menuWidth - padding)
+      const y = Math.min(rect.bottom + 8, window.innerHeight - menuHeight - padding)
+      setMenuPosition({ x, y })
+      setShowConfirmDelete(false)
+    },
+    [isRenaming, menuPosition, actionButtonRef, closeMenu],
+  )
+
+  return { menuPosition, menuRef, showConfirmDelete, setShowConfirmDelete, openMenu, closeMenu }
+}
+
+// ─── useRenameSession ──────────────────────────────────────────────────────────
+
+export interface UseRenameSessionResult {
+  isRenaming: boolean
+  renameValue: string
+  setRenameValue: React.Dispatch<React.SetStateAction<string>>
+  renameInputRef: RefObject<HTMLInputElement>
+  handleRenameClick: (e: React.MouseEvent, closeMenuFn: () => void) => void
+  handleRenameSave: (e?: React.SyntheticEvent) => Promise<void>
+  handleRenameCancel: (e?: React.MouseEvent | React.KeyboardEvent) => void
+  handleRenameBlur: (event: React.FocusEvent<HTMLInputElement>) => void
+}
+
+export function useRenameSession(session: FullCoworkSession | null): UseRenameSessionResult {
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [renameValue, setRenameValue] = useState('')
+  const renameInputRef = useRef<HTMLInputElement>(null)
+  const ignoreNextBlurRef = useRef(false)
+
+  useEffect(() => {
+    if (!isRenaming && session) {
+      setRenameValue(session.title)
+      ignoreNextBlurRef.current = false
+    }
+  }, [isRenaming, session?.title])
+
+  useEffect(() => {
+    if (!isRenaming) return
+    requestAnimationFrame(() => {
+      renameInputRef.current?.focus()
+      renameInputRef.current?.select()
+    })
+  }, [isRenaming])
+
+  const handleRenameClick = useCallback(
+    (e: React.MouseEvent, closeMenuFn: () => void) => {
+      e.stopPropagation()
+      if (!session) return
+      ignoreNextBlurRef.current = false
+      setIsRenaming(true)
+      setRenameValue(session.title)
+      closeMenuFn()
+    },
+    [session],
+  )
+
+  const handleRenameSave = useCallback(
+    async (e?: React.SyntheticEvent) => {
+      e?.stopPropagation()
+      if (!session) return
+      ignoreNextBlurRef.current = true
+      const nextTitle = renameValue.trim()
+      if (nextTitle && nextTitle !== session.title) {
+        await coworkService.renameSession(session.id, nextTitle)
+      }
+      setIsRenaming(false)
+    },
+    [session, renameValue],
+  )
+
+  const handleRenameCancel = useCallback(
+    (e?: React.MouseEvent | React.KeyboardEvent) => {
+      e?.stopPropagation()
+      ignoreNextBlurRef.current = true
+      if (session) {
+        setRenameValue(session.title)
+      }
+      setIsRenaming(false)
+    },
+    [session],
+  )
+
+  const handleRenameBlur = useCallback(
+    (event: React.FocusEvent<HTMLInputElement>) => {
+      if (ignoreNextBlurRef.current) {
+        ignoreNextBlurRef.current = false
+        return
+      }
+      handleRenameSave(event)
+    },
+    [handleRenameSave],
+  )
+
+  return {
+    isRenaming,
+    renameValue,
+    setRenameValue,
+    renameInputRef,
+    handleRenameClick,
+    handleRenameSave,
+    handleRenameCancel,
+    handleRenameBlur,
+  }
+}
+
+// ─── useExportImage ────────────────────────────────────────────────────────────
+
+export interface UseExportImageResult {
+  isExportingImage: boolean
+  handleShareClick: (e: React.MouseEvent, closeMenuFn: () => void) => void
+}
+
+export function useExportImage(
+  session: FullCoworkSession | null,
+  scrollContainerRef: RefObject<HTMLDivElement>,
+): UseExportImageResult {
+  const [isExportingImage, setIsExportingImage] = useState(false)
+
+  const handleShareClick = useCallback(
+    (e: React.MouseEvent, closeMenuFn: () => void) => {
+      e.stopPropagation()
+      if (!session || isExportingImage) return
+      closeMenuFn()
+      setIsExportingImage(true)
+
+      window.requestAnimationFrame(() => {
+        void (async () => {
+          try {
+            const scrollContainer = scrollContainerRef.current
+            if (!scrollContainer) throw new Error('Capture target not found')
+
+            const initialScrollTop = scrollContainer.scrollTop
+            try {
+              const scrollRect = domRectToCaptureRect(scrollContainer.getBoundingClientRect())
+              if (scrollRect.width <= 0 || scrollRect.height <= 0) throw new Error('Invalid capture area')
+
+              const scrollContentHeight = Math.max(scrollContainer.scrollHeight, scrollContainer.clientHeight)
+              if (scrollContentHeight <= 0) throw new Error('Invalid content height')
+
+              const toContentY = (viewportY: number): number => {
+                const y = scrollContainer.scrollTop + (viewportY - scrollRect.y)
+                return Math.max(0, Math.min(scrollContentHeight, y))
+              }
+
+              const userAnchors = scrollContainer.querySelectorAll<HTMLElement>('[data-export-role="user-message"]')
+              const assistantAnchors = scrollContainer.querySelectorAll<HTMLElement>(
+                '[data-export-role="assistant-block"]',
+              )
+
+              let contentStart = 0
+              let contentEnd = scrollContentHeight
+
+              if (userAnchors.length > 0) {
+                contentStart = toContentY(userAnchors[0].getBoundingClientRect().top)
+              } else if (assistantAnchors.length > 0) {
+                contentStart = toContentY(assistantAnchors[0].getBoundingClientRect().top)
+              }
+
+              if (assistantAnchors.length > 0) {
+                const lastAssistant = assistantAnchors[assistantAnchors.length - 1]
+                contentEnd = toContentY(lastAssistant.getBoundingClientRect().bottom)
+              } else if (userAnchors.length > 0) {
+                const lastUser = userAnchors[userAnchors.length - 1]
+                contentEnd = toContentY(lastUser.getBoundingClientRect().bottom)
+              }
+
+              const maxStart = Math.max(0, scrollContentHeight - 1)
+              contentStart = Math.max(0, Math.min(maxStart, Math.round(contentStart)))
+              contentEnd = Math.max(contentStart + 1, Math.min(scrollContentHeight, Math.round(contentEnd)))
+
+              const outputHeight = contentEnd - contentStart
+              if (outputHeight > MAX_EXPORT_CANVAS_HEIGHT)
+                throw new Error(`Export image is too tall (${outputHeight}px)`)
+
+              const segmentsEstimate = Math.ceil(outputHeight / Math.max(1, scrollRect.height)) + 1
+              if (segmentsEstimate > MAX_EXPORT_SEGMENTS) throw new Error('Export image is too long')
+
+              const canvas = document.createElement('canvas')
+              canvas.width = scrollRect.width
+              canvas.height = outputHeight
+              const context = canvas.getContext('2d')
+              if (!context) throw new Error('Canvas context unavailable')
+
+              const captureAndLoad = async (rect: typeof scrollRect): Promise<HTMLImageElement> => {
+                const chunk = await coworkService.captureSessionImageChunk({ rect })
+                if (!chunk.success || !chunk.pngBase64) throw new Error(chunk.error || 'Failed to capture image chunk')
+                return loadImageFromBase64(chunk.pngBase64)
+              }
+
+              scrollContainer.scrollTop = Math.min(
+                contentStart,
+                Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight),
+              )
+              await waitForNextFrame()
+              await waitForNextFrame()
+
+              const maxScrollTop = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight)
+              let contentOffset = contentStart
+              while (contentOffset < contentEnd) {
+                const targetScrollTop = Math.min(contentOffset, maxScrollTop)
+                scrollContainer.scrollTop = targetScrollTop
+                await waitForNextFrame()
+                await waitForNextFrame()
+
+                const chunkImage = await captureAndLoad(scrollRect)
+                const sourceYOffset = Math.max(0, contentOffset - targetScrollTop)
+                const drawableHeight = Math.min(scrollRect.height - sourceYOffset, contentEnd - contentOffset)
+                if (drawableHeight <= 0) throw new Error('Failed to stitch export image')
+
+                const scaleY = chunkImage.naturalHeight / scrollRect.height
+                const sourceYInImage = Math.max(0, Math.round(sourceYOffset * scaleY))
+                const sourceHeightInImage = Math.max(
+                  1,
+                  Math.min(chunkImage.naturalHeight - sourceYInImage, Math.round(drawableHeight * scaleY)),
+                )
+
+                context.drawImage(
+                  chunkImage,
+                  0,
+                  sourceYInImage,
+                  chunkImage.naturalWidth,
+                  sourceHeightInImage,
+                  0,
+                  contentOffset - contentStart,
+                  scrollRect.width,
+                  drawableHeight,
+                )
+                contentOffset += drawableHeight
+              }
+
+              const pngDataUrl = canvas.toDataURL('image/png')
+              const base64Index = pngDataUrl.indexOf(',')
+              if (base64Index < 0) throw new Error('Failed to encode export image')
+
+              const timestamp = formatExportTimestamp(new Date())
+              const saveResult = await coworkService.saveSessionResultImage({
+                pngBase64: pngDataUrl.slice(base64Index + 1),
+                defaultFileName: sanitizeExportFileName(`${session.title}-${timestamp}.png`),
+              })
+
+              if (saveResult.success && !saveResult.canceled) {
+                window.dispatchEvent(
+                  new CustomEvent('app:showToast', { detail: i18nService.t('coworkExportImageSuccess') }),
+                )
+                return
+              }
+              if (!saveResult.success) throw new Error(saveResult.error || 'Failed to export image')
+            } finally {
+              scrollContainer.scrollTop = initialScrollTop
+            }
+          } catch (error) {
+            console.error('Failed to export session image:', error)
+            window.dispatchEvent(new CustomEvent('app:showToast', { detail: i18nService.t('coworkExportImageFailed') }))
+          } finally {
+            setIsExportingImage(false)
+          }
+        })()
+      })
+    },
+    [session, isExportingImage, scrollContainerRef],
+  )
+
+  return { isExportingImage, handleShareClick }
+}
+
+// ─── useResolveLocalFilePath ───────────────────────────────────────────────────
+
+export function useResolveLocalFilePath(cwd: string | undefined): (href: string, text: string) => string | null {
+  return useCallback(
+    (href: string, text: string) => {
+      const hrefValue = typeof href === 'string' ? href.trim() : ''
+      const textValue = typeof text === 'string' ? text.trim() : ''
+      if (!hrefValue && !textValue) return null
+
+      const hrefRootRelative = hrefValue ? parseRootRelativePath(hrefValue) : null
+      if (hrefRootRelative) return hrefRootRelative
+
+      const hrefPath = hrefValue ? normalizeLocalPath(hrefValue) : null
+      if (hrefPath) {
+        if (hrefPath.isRelative && cwd) return toAbsolutePathFromCwd(hrefPath.path, cwd)
+        if (hrefPath.isAbsolute) return hrefPath.path
+      }
+
+      const textRootRelative = textValue ? parseRootRelativePath(textValue) : null
+      if (textRootRelative) return textRootRelative
+
+      const textPath = textValue ? normalizeLocalPath(textValue) : null
+      if (textPath) {
+        if (textPath.isRelative && cwd) return toAbsolutePathFromCwd(textPath.path, cwd)
+        if (textPath.isAbsolute) return textPath.path
+      }
+
+      return null
+    },
+    [cwd],
+  )
+}
+
+// ─── useTruncatePath ──────────────────────────────────────────────────────────
+
+export function useTruncatePath(): (path: string, maxLength?: number) => string {
+  return useCallback((path: string, maxLength = 20): string => {
+    if (!path) return i18nService.t('noFolderSelected')
+    return getCompactFolderName(path, maxLength) || i18nService.t('noFolderSelected')
+  }, [])
+}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1,1280 +1,44 @@
-import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import { RootState } from '../../store';
-import { i18nService } from '../../services/i18n';
-import type { CoworkMessage, CoworkMessageMetadata, CoworkImageAttachment } from '../../types/cowork';
-import type { Skill } from '../../types/skill';
-import CoworkPromptInput from './CoworkPromptInput';
-import MarkdownContent from '../MarkdownContent';
+import React, { useRef, useEffect, useCallback, useMemo } from 'react'
+import { useSelector } from 'react-redux'
+import { RootState } from '../../store'
+import { i18nService } from '../../services/i18n'
+import CoworkPromptInput from './CoworkPromptInput'
+import SidebarToggleIcon from '../icons/SidebarToggleIcon'
+import ComposeIcon from '../icons/ComposeIcon'
+import EllipsisHorizontalIcon from '../icons/EllipsisHorizontalIcon'
+import PencilSquareIcon from '../icons/PencilSquareIcon'
+import TrashIcon from '../icons/TrashIcon'
+import WindowTitleBar from '../window/WindowTitleBar'
+import { FolderIcon } from '@heroicons/react/24/solid'
+import { ShareIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+import { coworkService } from '../../services/cowork'
+import { buildDisplayItems, buildConversationTurns, hasRenderableAssistantContent } from './CoworkSessionDetail.utils'
 import {
-  CheckIcon,
-  InformationCircleIcon,
-  ShareIcon,
-  ExclamationTriangleIcon,
-  ChevronRightIcon,
-  PhotoIcon,
-} from '@heroicons/react/24/outline';
-import { FolderIcon } from '@heroicons/react/24/solid';
-import { coworkService } from '../../services/cowork';
-import SidebarToggleIcon from '../icons/SidebarToggleIcon';
-import ComposeIcon from '../icons/ComposeIcon';
-import PuzzleIcon from '../icons/PuzzleIcon';
-import EllipsisHorizontalIcon from '../icons/EllipsisHorizontalIcon';
-import PencilSquareIcon from '../icons/PencilSquareIcon';
-import TrashIcon from '../icons/TrashIcon';
-import WindowTitleBar from '../window/WindowTitleBar';
-import { getCompactFolderName } from '../../utils/path';
-import { getScheduledReminderDisplayText } from '../../../common/scheduledReminderText';
-
-interface CoworkSessionDetailProps {
-  onManageSkills?: () => void;
-  onContinue: (prompt: string, skillPrompt?: string, imageAttachments?: CoworkImageAttachment[]) => void;
-  onStop: () => void;
-  onNavigateHome?: () => void;
-  isSidebarCollapsed?: boolean;
-  onToggleSidebar?: () => void;
-  onNewChat?: () => void;
-  updateBadge?: React.ReactNode;
-}
-
-const AUTO_SCROLL_THRESHOLD = 120;
-const NAV_HIDE_DELAY = 3000;
-const NAV_SCROLL_LOCK_DURATION = 500;
-const NAV_BOTTOM_SNAP_THRESHOLD = 20;
-const INVALID_FILE_NAME_PATTERN = /[<>:"/\\|?*\u0000-\u001F]/g;
-
-const sanitizeExportFileName = (value: string): string => {
-  const sanitized = value.replace(INVALID_FILE_NAME_PATTERN, ' ').replace(/\s+/g, ' ').trim();
-  return sanitized || 'cowork-session';
-};
-
-const formatExportTimestamp = (value: Date): string => {
-  const pad = (num: number): string => String(num).padStart(2, '0');
-  return `${value.getFullYear()}${pad(value.getMonth() + 1)}${pad(value.getDate())}-${pad(value.getHours())}${pad(value.getMinutes())}${pad(value.getSeconds())}`;
-};
-
-type CaptureRect = { x: number; y: number; width: number; height: number };
-
-const MAX_EXPORT_CANVAS_HEIGHT = 32760;
-const MAX_EXPORT_SEGMENTS = 240;
-
-const waitForNextFrame = (): Promise<void> =>
-  new Promise((resolve) => {
-    window.requestAnimationFrame(() => resolve());
-  });
-
-const loadImageFromBase64 = (pngBase64: string): Promise<HTMLImageElement> =>
-  new Promise((resolve, reject) => {
-    const img = new Image();
-    img.onload = () => resolve(img);
-    img.onerror = () => reject(new Error('Failed to decode captured image'));
-    img.src = `data:image/png;base64,${pngBase64}`;
-  });
-
-const domRectToCaptureRect = (rect: DOMRect): CaptureRect => ({
-  x: Math.max(0, Math.round(rect.x)),
-  y: Math.max(0, Math.round(rect.y)),
-  width: Math.max(0, Math.round(rect.width)),
-  height: Math.max(0, Math.round(rect.height)),
-});
-
-// PushPinIcon component for pin/unpin functionality
-const PushPinIcon: React.FC<React.SVGProps<SVGSVGElement> & { slashed?: boolean }> = ({
-  slashed,
-  ...props
-}) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    {...props}
-  >
-    <g transform="rotate(45 12 12)">
-      <path d="M9 3h6l-1 5 2 2v2H8v-2l2-2-1-5z" />
-      <path d="M12 12v9" />
-    </g>
-    {slashed && <path d="M5 5L19 19" />}
-  </svg>
-);
-
-const formatUnknown = (value: unknown): string => {
-  if (typeof value === 'string') {
-    return value;
-  }
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
-};
-
-const getStringArray = (value: unknown): string | null => {
-  if (!Array.isArray(value)) return null;
-  const lines = value.filter((item) => typeof item === 'string') as string[];
-  return lines.length > 0 ? lines.join('\n') : null;
-};
-
-type TodoStatus = 'completed' | 'in_progress' | 'pending' | 'unknown';
-
-type ParsedTodoItem = {
-  primaryText: string;
-  secondaryText: string | null;
-  status: TodoStatus;
-};
-
-const normalizeToolName = (value: string): string => value.toLowerCase().replace(/[\s_]+/g, '');
-
-const TOOL_USE_ERROR_TAG_PATTERN = /^<tool_use_error>([\s\S]*?)<\/tool_use_error>$/i;
-const ANSI_ESCAPE_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/g;
-
-const getToolDisplayName = (toolName: string | undefined): string => {
-  if (!toolName) return 'Tool';
-  const normalized = normalizeToolName(toolName);
-  switch (normalized) {
-    case 'cron':
-      return 'Cron';
-    case 'exec':
-    case 'bash':
-    case 'shell':
-      return 'Bash';
-    case 'read':
-    case 'readfile':
-      return 'Read';
-    case 'write':
-    case 'writefile':
-      return 'Write';
-    case 'edit':
-    case 'editfile':
-      return 'Edit';
-    case 'multiedit':
-      return 'MultiEdit';
-    case 'process':
-      return 'Process';
-    default:
-      return toolName;
-  }
-};
-
-const isBashLikeToolName = (toolName: string | undefined): boolean => {
-  if (!toolName) return false;
-  const normalized = normalizeToolName(toolName);
-  return normalized === 'bash' || normalized === 'exec' || normalized === 'shell';
-};
-
-const getToolInputString = (
-  input: Record<string, unknown>,
-  keys: string[],
-): string | null => {
-  for (const key of keys) {
-    const value = input[key];
-    if (typeof value === 'string' && value.trim()) {
-      return value;
-    }
-  }
-  return null;
-};
-
-const truncatePreview = (value: string, maxLength = 120): string =>
-  value.length <= maxLength ? value : `${value.slice(0, maxLength - 3)}...`;
-
-const normalizeToolResultText = (value: string): string => {
-  const withoutAnsi = value.replace(ANSI_ESCAPE_PATTERN, '');
-  const errorTagMatch = withoutAnsi.trim().match(TOOL_USE_ERROR_TAG_PATTERN);
-  return errorTagMatch ? errorTagMatch[1].trim() : withoutAnsi;
-};
-
-const isTodoWriteToolName = (toolName: string | undefined): boolean => {
-  if (!toolName) return false;
-  return normalizeToolName(toolName) === 'todowrite';
-};
-
-const isCronToolName = (toolName: string | undefined): boolean => {
-  if (!toolName) return false;
-  return normalizeToolName(toolName) === 'cron';
-};
-
-const getCronToolSummary = (input: Record<string, unknown>): string | null => {
-  const action = getToolInputString(input, ['action']);
-  if (!action) return null;
-
-  const job = input.job && typeof input.job === 'object'
-    ? input.job as Record<string, unknown>
-    : null;
-  const jobName = job
-    ? getToolInputString(job, ['name', 'id'])
-    : null;
-  const jobId = getToolInputString(input, ['jobId', 'id'])
-    ?? (job ? getToolInputString(job, ['id']) : null);
-  const wakeText = getToolInputString(input, ['text']);
-
-  switch (action) {
-    case 'add':
-      return [action, jobName ?? jobId].filter(Boolean).join(' · ');
-    case 'update':
-    case 'remove':
-    case 'run':
-    case 'runs':
-      return [action, jobId ?? jobName].filter(Boolean).join(' · ');
-    case 'wake':
-      return [action, wakeText].filter(Boolean).join(' · ');
-    default:
-      return action;
-  }
-};
-
-const formatStructuredText = (value: string): string => {
-  const trimmed = value.trim();
-  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
-    return value;
-  }
-
-  try {
-    return JSON.stringify(JSON.parse(trimmed), null, 2);
-  } catch {
-    return value;
-  }
-};
-
-const toTrimmedString = (value: unknown): string | null => (
-  typeof value === 'string' && value.trim() ? value.trim() : null
-);
-
-const normalizeTodoStatus = (value: unknown): TodoStatus => {
-  const normalized = typeof value === 'string'
-    ? value.trim().toLowerCase().replace(/-/g, '_')
-    : '';
-
-  if (normalized === 'completed') return 'completed';
-  if (normalized === 'in_progress' || normalized === 'running') return 'in_progress';
-  if (normalized === 'pending' || normalized === 'todo') return 'pending';
-  return 'unknown';
-};
-
-const parseTodoWriteItems = (input: unknown): ParsedTodoItem[] | null => {
-  if (!input || typeof input !== 'object') return null;
-  const record = input as Record<string, unknown>;
-  if (!Array.isArray(record.todos)) return null;
-
-  const parsedItems = record.todos
-    .map((rawTodo) => {
-      if (!rawTodo || typeof rawTodo !== 'object') {
-        return null;
-      }
-
-      const todo = rawTodo as Record<string, unknown>;
-      const activeForm = toTrimmedString(todo.activeForm);
-      const content = toTrimmedString(todo.content);
-      const primaryText = activeForm ?? content ?? i18nService.t('coworkTodoUntitled');
-      const secondaryText = content && content !== primaryText ? content : null;
-
-      return {
-        primaryText,
-        secondaryText,
-        status: normalizeTodoStatus(todo.status),
-      } satisfies ParsedTodoItem;
-    })
-    .filter((item): item is ParsedTodoItem => item !== null);
-
-  return parsedItems.length > 0 ? parsedItems : null;
-};
-
-const getTodoWriteSummary = (items: ParsedTodoItem[]): string => {
-  const completedCount = items.filter((item) => item.status === 'completed').length;
-  const inProgressCount = items.filter((item) => item.status === 'in_progress').length;
-  const pendingCount = items.length - completedCount - inProgressCount;
-
-  const summary = [
-    `${items.length} ${i18nService.t('coworkTodoItems')}`,
-    `${completedCount} ${i18nService.t('coworkTodoCompleted')}`,
-    `${inProgressCount} ${i18nService.t('coworkTodoInProgress')}`,
-    `${pendingCount} ${i18nService.t('coworkTodoPending')}`,
-  ];
-
-  const activeItem = items.find((item) => item.status === 'in_progress');
-  if (activeItem) {
-    summary.push(activeItem.primaryText);
-  }
-
-  return summary.join(' · ');
-};
-
-const getToolInputSummary = (
-  toolName: string | undefined,
-  toolInput?: Record<string, unknown>
-): string | null => {
-  if (!toolName || !toolInput) return null;
-  const input = toolInput as Record<string, unknown>;
-  if (isTodoWriteToolName(toolName)) {
-    const items = parseTodoWriteItems(input);
-    return items ? getTodoWriteSummary(items) : null;
-  }
-
-  const normalizedToolName = normalizeToolName(toolName);
-
-  switch (normalizedToolName) {
-    case 'cron':
-      return getCronToolSummary(input);
-    case 'bash':
-    case 'exec':
-    case 'shell':
-      return getToolInputString(input, ['command', 'cmd', 'script'])
-        ?? getStringArray(input.commands);
-    case 'read':
-    case 'readfile':
-    case 'write':
-    case 'writefile':
-    case 'edit':
-    case 'editfile':
-    case 'multiedit':
-      return getToolInputString(input, ['file_path', 'path', 'filePath', 'target_file', 'targetFile'])
-        ?? (
-          typeof input.content === 'string' && input.content.trim()
-            ? truncatePreview(input.content.split('\n')[0].trim())
-            : null
-        );
-    case 'glob':
-    case 'grep':
-      return getToolInputString(input, ['pattern', 'query']);
-    case 'task':
-      return getToolInputString(input, ['description', 'task']);
-    case 'webfetch':
-      return getToolInputString(input, ['url']);
-    case 'process': {
-      const action = getToolInputString(input, ['action']);
-      const sessionId = getToolInputString(input, ['sessionId', 'session_id']);
-      if (action && sessionId) return `${action} · ${sessionId}`;
-      return action ?? sessionId;
-    }
-    default:
-      return null;
-  }
-};
-
-const formatToolInput = (
-  toolName: string | undefined,
-  toolInput?: Record<string, unknown>
-): string | null => {
-  if (!toolInput) return null;
-  const summary = getToolInputSummary(toolName, toolInput);
-  if (summary && summary.trim()) {
-    return summary;
-  }
-  return formatUnknown(toolInput);
-};
-
-const hasText = (value: unknown): value is string =>
-  typeof value === 'string' && value.trim().length > 0;
-
-const getToolResultDisplay = (message: CoworkMessage): string => {
-  if (hasText(message.content)) {
-    return formatStructuredText(normalizeToolResultText(message.content));
-  }
-  if (hasText(message.metadata?.toolResult)) {
-    return formatStructuredText(normalizeToolResultText(message.metadata?.toolResult ?? ''));
-  }
-  if (hasText(message.metadata?.error)) {
-    return formatStructuredText(normalizeToolResultText(message.metadata?.error ?? ''));
-  }
-  return '';
-};
-
-const safeDecodeURIComponent = (value: string): string => {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-};
-
-const stripHashAndQuery = (value: string): string => value.split('#')[0].split('?')[0];
-
-const stripFileProtocol = (value: string): string => {
-  let cleaned = value.replace(/^file:\/\//i, '');
-  if (/^\/[A-Za-z]:/.test(cleaned)) {
-    cleaned = cleaned.slice(1);
-  }
-  return cleaned;
-};
-
-const hasScheme = (value: string): boolean => /^[a-z][a-z0-9+.-]*:/i.test(value);
-
-const isAbsolutePath = (value: string): boolean => (
-  value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)
-);
-
-const isRelativePath = (value: string): boolean => !isAbsolutePath(value) && !hasScheme(value);
-
-const parseRootRelativePath = (value: string): string | null => {
-  const trimmed = value.trim();
-  if (!/^file:\/\//i.test(trimmed)) return null;
-  const separatorIndex = trimmed.indexOf('::');
-  if (separatorIndex < 0) return null;
-
-  const rootPart = trimmed.slice(0, separatorIndex);
-  const relativePart = trimmed.slice(separatorIndex + 2);
-  if (!relativePart.trim()) return null;
-
-  const rootPath = safeDecodeURIComponent(stripFileProtocol(stripHashAndQuery(rootPart)));
-  const relativePath = safeDecodeURIComponent(stripHashAndQuery(relativePart));
-  if (!rootPath || !relativePath) return null;
-
-  const normalizedRoot = rootPath.replace(/[\\/]+$/, '');
-  const normalizedRelative = relativePath.replace(/^[\\/]+/, '');
-  if (!normalizedRelative) return null;
-
-  return `${normalizedRoot}/${normalizedRelative}`;
-};
-
-const normalizeLocalPath = (
-  value: string
-): { path: string; isRelative: boolean; isAbsolute: boolean } | null => {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-
-  const fileScheme = /^file:\/\//i.test(trimmed);
-  const schemePresent = hasScheme(trimmed);
-  if (schemePresent && !fileScheme && !isAbsolutePath(trimmed)) return null;
-
-  let raw = trimmed;
-  if (fileScheme) {
-    raw = stripFileProtocol(raw);
-  }
-  raw = stripHashAndQuery(raw);
-  const decoded = safeDecodeURIComponent(raw);
-  const path = decoded || raw;
-  if (!path) return null;
-
-  const isAbsolute = isAbsolutePath(path);
-  const isRelative = isRelativePath(path);
-  return { path, isRelative, isAbsolute };
-};
-
-const toAbsolutePathFromCwd = (filePath: string, cwd: string): string => {
-  if (isAbsolutePath(filePath)) {
-    return filePath;
-  }
-  return `${cwd.replace(/\/$/, '')}/${filePath.replace(/^\.\//, '')}`;
-};
-
-export type ToolGroupItem = {
-  type: 'tool_group';
-  toolUse: CoworkMessage;
-  toolResult?: CoworkMessage | null;
-};
-
-export type DisplayItem =
-  | { type: 'message'; message: CoworkMessage }
-  | ToolGroupItem;
-
-export type AssistantTurnItem =
-  | { type: 'assistant'; message: CoworkMessage }
-  | { type: 'system'; message: CoworkMessage }
-  | { type: 'tool_group'; group: ToolGroupItem }
-  | { type: 'tool_result'; message: CoworkMessage };
-
-export type ConversationTurn = {
-  id: string;
-  userMessage: CoworkMessage | null;
-  assistantItems: AssistantTurnItem[];
-};
-
-export const buildDisplayItems = (messages: CoworkMessage[]): DisplayItem[] => {
-  const items: DisplayItem[] = [];
-  const groupsByToolUseId = new Map<string, ToolGroupItem>();
-  let pendingAdjacentGroup: ToolGroupItem | null = null;
-
-  for (const message of messages) {
-    if (message.type === 'tool_use') {
-      const group: ToolGroupItem = { type: 'tool_group', toolUse: message };
-      items.push(group);
-
-      const toolUseId = message.metadata?.toolUseId;
-      if (typeof toolUseId === 'string' && toolUseId.trim()) {
-        groupsByToolUseId.set(toolUseId, group);
-      }
-      pendingAdjacentGroup = group;
-      continue;
-    }
-
-    if (message.type === 'tool_result') {
-      let matched = false;
-      const toolUseId = message.metadata?.toolUseId;
-      if (typeof toolUseId === 'string' && groupsByToolUseId.has(toolUseId)) {
-        const group = groupsByToolUseId.get(toolUseId);
-        if (group) {
-          group.toolResult = message;
-          matched = true;
-        }
-      } else if (pendingAdjacentGroup && !pendingAdjacentGroup.toolResult) {
-        pendingAdjacentGroup.toolResult = message;
-        matched = true;
-      }
-
-      pendingAdjacentGroup = null;
-      if (!matched) {
-        items.push({ type: 'message', message });
-      }
-      continue;
-    }
-
-    pendingAdjacentGroup = null;
-    items.push({ type: 'message', message });
-  }
-
-  return items;
-};
-
-export const buildConversationTurns = (items: DisplayItem[]): ConversationTurn[] => {
-  const turns: ConversationTurn[] = [];
-  let currentTurn: ConversationTurn | null = null;
-  let orphanIndex = 0;
-
-  const ensureTurn = (): ConversationTurn => {
-    if (currentTurn) return currentTurn;
-    const orphanTurn: ConversationTurn = {
-      id: `orphan-${orphanIndex++}`,
-      userMessage: null,
-      assistantItems: [],
-    };
-    turns.push(orphanTurn);
-    currentTurn = orphanTurn;
-    return orphanTurn;
-  };
-
-  for (const item of items) {
-    if (item.type === 'message' && item.message.type === 'user') {
-      currentTurn = {
-        id: item.message.id,
-        userMessage: item.message,
-        assistantItems: [],
-      };
-      turns.push(currentTurn);
-      continue;
-    }
-
-    const turn = ensureTurn();
-    if (item.type === 'tool_group') {
-      turn.assistantItems.push({ type: 'tool_group', group: item });
-      continue;
-    }
-
-    const message = item.message;
-    if (message.type === 'assistant') {
-      turn.assistantItems.push({ type: 'assistant', message });
-      continue;
-    }
-
-    if (message.type === 'system') {
-      turn.assistantItems.push({ type: 'system', message });
-      continue;
-    }
-
-    if (message.type === 'tool_result') {
-      turn.assistantItems.push({ type: 'tool_result', message });
-      continue;
-    }
-
-    if (message.type === 'tool_use') {
-      turn.assistantItems.push({
-        type: 'tool_group',
-        group: {
-          type: 'tool_group',
-          toolUse: message,
-        },
-      });
-    }
-  }
-
-  return turns;
-};
-
-const isRenderableAssistantOrSystemMessage = (message: CoworkMessage): boolean => {
-  if (hasText(message.content) || hasText(message.metadata?.error)) {
-    return true;
-  }
-  if (message.metadata?.isThinking) {
-    return Boolean(message.metadata?.isStreaming);
-  }
-  return false;
-};
-
-const isVisibleAssistantTurnItem = (item: AssistantTurnItem): boolean => {
-  if (item.type === 'assistant' || item.type === 'system') {
-    return isRenderableAssistantOrSystemMessage(item.message);
-  }
-  if (item.type === 'tool_result') {
-    return hasText(getToolResultDisplay(item.message));
-  }
-  return true;
-};
-
-const getVisibleAssistantItems = (assistantItems: AssistantTurnItem[]): AssistantTurnItem[] =>
-  assistantItems.filter(isVisibleAssistantTurnItem);
-
-export const hasRenderableAssistantContent = (turn: ConversationTurn): boolean => (
-  getVisibleAssistantItems(turn.assistantItems).length > 0
-);
-
-const getToolResultLineCount = (result: string): number => {
-  if (!result) return 0;
-  return result.split('\n').length;
-};
-
-const TodoWriteInputView: React.FC<{ items: ParsedTodoItem[] }> = ({ items }) => {
-  const getStatusCheckboxClass = (status: TodoStatus): string => {
-    switch (status) {
-      case 'completed':
-        return 'bg-green-500/10 border-green-500 text-green-500';
-      case 'in_progress':
-        return 'bg-transparent border-blue-500';
-      case 'pending':
-      case 'unknown':
-      default:
-        return 'bg-transparent dark:border-claude-darkTextSecondary/60 border-claude-textSecondary/60';
-    }
-  };
-
-  return (
-    <div className="space-y-2">
-      {items.map((item, index) => (
-        <div
-          key={`todo-item-${index}`}
-          className="flex items-start gap-2"
-        >
-          <span className={`mt-0.5 h-4 w-4 rounded-[4px] border flex-shrink-0 inline-flex items-center justify-center ${getStatusCheckboxClass(item.status)}`}>
-            {item.status === 'completed' && <CheckIcon className="h-3 w-3 stroke-[2.5]" />}
-          </span>
-          <div className="min-w-0 flex-1">
-            <div className={`text-xs whitespace-pre-wrap break-words leading-5 ${
-              item.status === 'completed'
-                ? 'dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/80'
-                : 'dark:text-claude-darkText text-claude-text'
-            }`}>
-              {item.primaryText}
-            </div>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-};
-
-const ToolCallGroup: React.FC<{
-  group: ToolGroupItem;
-  isLastInSequence?: boolean;
-  mapDisplayText?: (value: string) => string;
-}> = ({
-  group,
-  isLastInSequence = true,
-  mapDisplayText,
-}) => {
-  const { toolUse, toolResult } = group;
-  const rawToolName = typeof toolUse.metadata?.toolName === 'string' ? toolUse.metadata.toolName : 'Tool';
-  const toolName = getToolDisplayName(rawToolName);
-  const toolInput = toolUse.metadata?.toolInput;
-  const isCronTool = isCronToolName(rawToolName);
-  const isTodoWriteTool = isTodoWriteToolName(rawToolName);
-  const todoItems = isTodoWriteTool ? parseTodoWriteItems(toolInput) : null;
-  const mapText = mapDisplayText ?? ((value: string) => value);
-  const toolInputDisplayRaw = formatToolInput(rawToolName, toolInput);
-  const toolInputDisplay = toolInputDisplayRaw ? mapText(toolInputDisplayRaw) : null;
-  const toolInputSummaryRaw = getToolInputSummary(rawToolName, toolInput) ?? toolInputDisplayRaw;
-  const toolInputSummary = toolInputSummaryRaw ? mapText(toolInputSummaryRaw) : null;
-  const toolResultDisplayRaw = toolResult ? getToolResultDisplay(toolResult) : '';
-  const toolResultDisplay = mapText(toolResultDisplayRaw);
-  const hasToolResultText = hasText(toolResultDisplay);
-  const isToolError = Boolean(toolResult?.metadata?.isError || toolResult?.metadata?.error);
-  const showNoDetailError = isToolError && !hasToolResultText;
-  const toolResultFallback = showNoDetailError ? i18nService.t('coworkToolNoErrorDetail') : '';
-  const displayToolResult = hasToolResultText ? toolResultDisplay : toolResultFallback;
-  const [isExpanded, setIsExpanded] = useState(false);
-  const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0;
-  const toolResultSummary = isCronTool && hasToolResultText
-    ? truncatePreview(toolResultDisplay.replace(/\s+/g, ' '))
-    : null;
-
-  // Check if this is a Bash-like tool that should show terminal style
-  const isBashTool = isBashLikeToolName(rawToolName);
-
-  return (
-    <div className="relative py-1">
-      {/* Vertical connecting line to next tool group */}
-      {!isLastInSequence && (
-        <div className="absolute left-[3.5px] top-[14px] bottom-[-8px] w-px dark:bg-claude-darkTextSecondary/30 bg-claude-textSecondary/30" />
-      )}
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-start gap-2 text-left group relative z-10"
-      >
-        <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
-          !toolResult
-            ? 'bg-blue-500 animate-pulse'
-            : isToolError
-              ? 'bg-red-500'
-              : 'bg-green-500'
-        }`} />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-              {toolName}
-            </span>
-            {toolInputSummary && (
-              <code className="text-xs dark:text-claude-darkTextSecondary/80 text-claude-textSecondary/80 font-mono truncate max-w-[400px]">
-                {toolInputSummary}
-              </code>
-            )}
-          </div>
-          {toolResult && !isTodoWriteTool && (hasToolResultText || showNoDetailError) && (
-            <div className={`text-xs mt-0.5 ${
-              hasToolResultText
-                ? 'dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60'
-                : showNoDetailError
-                  ? 'text-red-500/80'
-                  : 'dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60'
-            }`}>
-              {hasToolResultText
-                ? (toolResultSummary ?? `${resultLineCount} ${resultLineCount === 1 ? 'line' : 'lines'} of output`)
-                : toolResultFallback}
-            </div>
-          )}
-          {!toolResult && (
-            <div className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-0.5">
-              {i18nService.t('coworkToolRunning')}
-            </div>
-          )}
-        </div>
-      </button>
-      {isExpanded && (
-        <div className="ml-4 mt-2">
-          {isBashTool ? (
-            // Terminal-style display for Bash commands
-            <div className="rounded-lg overflow-hidden border dark:border-claude-darkBorder border-claude-border">
-              {/* Terminal header */}
-              <div className="flex items-center gap-1.5 px-3 py-1.5 dark:bg-claude-darkSurface bg-claude-surfaceInset">
-                <div className="w-2.5 h-2.5 rounded-full bg-red-500" />
-                <div className="w-2.5 h-2.5 rounded-full bg-yellow-500" />
-                <div className="w-2.5 h-2.5 rounded-full bg-green-500" />
-                <span className="ml-2 text-[10px] dark:text-claude-darkTextSecondary text-claude-textSecondary font-medium">Terminal</span>
-              </div>
-              {/* Terminal content */}
-              <div className="dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset px-3 py-3 max-h-72 overflow-y-auto font-mono text-xs">
-                {toolInputDisplay && (
-                  <div className="dark:text-claude-darkText text-claude-text">
-                    <span className="text-claude-accent select-none">$ </span>
-                    <span className="whitespace-pre-wrap break-words">{toolInputDisplay}</span>
-                  </div>
-                )}
-                {toolResult && (hasToolResultText || showNoDetailError) && (
-                  <div className={`mt-1.5 whitespace-pre-wrap break-words ${
-                    isToolError
-                      ? 'text-red-400'
-                      : hasToolResultText
-                        ? 'dark:text-claude-darkTextSecondary text-claude-textSecondary'
-                        : 'dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/70 italic'
-                  }`}>
-                    {displayToolResult}
-                  </div>
-                )}
-                {!toolResult && (
-                  <div className="dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-1.5 italic">
-                    {i18nService.t('coworkToolRunning')}
-                  </div>
-                )}
-              </div>
-            </div>
-          ) : isTodoWriteTool && todoItems ? (
-            <TodoWriteInputView items={todoItems} />
-          ) : (
-            // Standard display for other tools with input/output labels
-            <div className="space-y-2">
-              {toolInputDisplay && (
-                <div>
-                  <div className="text-[10px] font-medium dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/70 uppercase tracking-wider mb-1">
-                    {i18nService.t('coworkToolInput')}
-                  </div>
-                  <div className="max-h-48 overflow-y-auto">
-                    <pre className="text-xs dark:text-claude-darkText text-claude-text whitespace-pre-wrap break-words font-mono">
-                      {toolInputDisplay}
-                    </pre>
-                  </div>
-                </div>
-              )}
-              {toolResult && (hasToolResultText || showNoDetailError) && (
-                <div>
-                  <div className="text-[10px] font-medium dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/70 uppercase tracking-wider mb-1">
-                    {i18nService.t('coworkToolResult')}
-                  </div>
-                  <div className="max-h-64 overflow-y-auto">
-                    <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${
-                      isToolError
-                        ? 'text-red-500'
-                        : hasToolResultText
-                          ? 'dark:text-claude-darkText text-claude-text'
-                          : 'dark:text-claude-darkTextSecondary text-claude-textSecondary italic'
-                    }`}>
-                      {displayToolResult}
-                    </pre>
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
-
-// Copy button component
-const CopyButton: React.FC<{
-  content: string;
-  visible: boolean;
-}> = ({ content, visible }) => {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    try {
-      await navigator.clipboard.writeText(content);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy:', err);
-    }
-  };
-
-  return (
-    <button
-      onClick={handleCopy}
-      className={`p-1.5 rounded-md dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-all duration-200 ${
-        visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
-      }`}
-      title={i18nService.t('copyToClipboard')}
-    >
-      {copied ? (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="w-4 h-4 text-green-500"
-          aria-hidden="true"
-        >
-          <polyline points="20 6 9 17 4 12"></polyline>
-        </svg>
-      ) : (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="w-4 h-4 text-[var(--icon-secondary)]"
-          aria-hidden="true"
-        >
-          <rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect>
-          <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>
-        </svg>
-      )}
-    </button>
-  );
-};
-
-export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[] }> = React.memo(({ message, skills }) => {
-  const [isHovered, setIsHovered] = useState(false);
-  const [expandedImage, setExpandedImage] = useState<string | null>(null);
-
-  // Get skills used for this message
-  const messageSkillIds = (message.metadata as CoworkMessageMetadata)?.skillIds || [];
-  const messageSkills = messageSkillIds
-    .map(id => skills.find(s => s.id === id))
-    .filter((s): s is NonNullable<typeof s> => s !== undefined);
-
-  // Get image attachments from metadata
-  const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ?? []) as CoworkImageAttachment[];
-
-  return (
-    <div
-      className="py-2 px-4"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <div className="max-w-3xl mx-auto">
-        <div className="pl-4 sm:pl-8 md:pl-12">
-          <div className="flex items-start gap-3 flex-row-reverse">
-            <div className="w-full min-w-0 flex flex-col items-end">
-              <div className="w-fit max-w-[42rem] rounded-2xl px-4 py-2.5 dark:bg-claude-darkSurface bg-claude-surface dark:text-claude-darkText text-claude-text shadow-subtle">
-                {message.content?.trim() && (
-                  <MarkdownContent
-                    content={message.content}
-                    className="max-w-none whitespace-pre-wrap break-words"
-                  />
-                )}
-                {imageAttachments.length > 0 && (
-                  <div className={`flex flex-wrap gap-2 ${message.content?.trim() ? 'mt-2' : ''}`}>
-                    {imageAttachments.map((img, idx) => (
-                      <div key={idx} className="relative group">
-                        <img
-                          src={`data:${img.mimeType};base64,${img.base64Data}`}
-                          alt={img.name}
-                          className="max-h-48 max-w-[16rem] rounded-lg object-contain cursor-pointer border dark:border-claude-darkBorder/50 border-claude-border/50 hover:border-claude-accent/50 transition-colors"
-                          title={img.name}
-                          onClick={() => setExpandedImage(`data:${img.mimeType};base64,${img.base64Data}`)}
-                        />
-                        <div className="absolute bottom-1 left-1 right-1 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/50 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity truncate pointer-events-none">
-                          <PhotoIcon className="h-3 w-3 flex-shrink-0" />
-                          <span className="truncate">{img.name}</span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-              <div className="flex items-center justify-end gap-1.5 mt-1">
-                {messageSkills.map(skill => (
-                  <div
-                    key={skill.id}
-                    className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md bg-claude-accent/5 dark:bg-claude-accent/10"
-                    title={skill.description}
-                  >
-                    <PuzzleIcon className="h-2.5 w-2.5 text-claude-accent/70" />
-                    <span className="text-[10px] font-medium text-claude-accent/70 max-w-[60px] truncate">
-                      {skill.name}
-                    </span>
-                  </div>
-                ))}
-                <CopyButton
-                  content={message.content}
-                  visible={isHovered}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      {/* Image lightbox overlay */}
-      {expandedImage && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 cursor-pointer"
-          onClick={() => setExpandedImage(null)}
-        >
-          <img
-            src={expandedImage}
-            alt="Preview"
-            className="max-h-[90vh] max-w-[90vw] object-contain rounded-lg shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-          />
-        </div>
-      )}
-    </div>
-  );
-});
-
-const AssistantMessageItem: React.FC<{
-  message: CoworkMessage;
-  resolveLocalFilePath?: (href: string, text: string) => string | null;
-  mapDisplayText?: (value: string) => string;
-  showCopyButton?: boolean;
-}> = ({
-  message,
-  resolveLocalFilePath,
-  mapDisplayText,
-  showCopyButton = false,
-}) => {
-  const [isHovered, setIsHovered] = useState(false);
-  const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content;
-
-  return (
-    <div
-      className="relative"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <div className="dark:text-claude-darkText text-claude-text">
-        <MarkdownContent
-          content={displayContent}
-          className="prose dark:prose-invert max-w-none"
-          resolveLocalFilePath={resolveLocalFilePath}
-        />
-      </div>
-      {showCopyButton && (
-        <div className="flex items-center gap-1.5 mt-1">
-          <CopyButton
-            content={displayContent}
-            visible={isHovered}
-          />
-        </div>
-      )}
-    </div>
-  );
-};
-
-// Streaming activity bar shown between messages and input
-const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ messages }) => {
-  // Walk messages backwards to find the latest tool_use without a paired tool_result
-  const getStatusText = (): string => {
-    const toolUseIds = new Set<string>();
-    const toolResultIds = new Set<string>();
-    for (const msg of messages) {
-      const id = msg.metadata?.toolUseId;
-      if (typeof id === 'string') {
-        if (msg.type === 'tool_result') toolResultIds.add(id);
-        if (msg.type === 'tool_use') toolUseIds.add(id);
-      }
-    }
-    // Walk backwards to find latest unresolved tool_use
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (msg.type === 'tool_use') {
-        const id = msg.metadata?.toolUseId;
-        if (typeof id === 'string' && !toolResultIds.has(id)) {
-          const toolName = typeof msg.metadata?.toolName === 'string' ? msg.metadata.toolName : null;
-          if (toolName) {
-            return `${i18nService.t('coworkToolRunning')} ${toolName}...`;
-          }
-        }
-      }
-    }
-    return `${i18nService.t('coworkToolRunning')}`;
-  };
-
-  return (
-    <div className="shrink-0 animate-fade-in px-4">
-      <div className="max-w-3xl mx-auto">
-        <div className="streaming-bar" />
-        <div className="py-1">
-          <span className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">
-            {getStatusText()}
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const TypingDots: React.FC = () => (
-  <div className="flex items-center space-x-1.5 py-1">
-    <div className="w-2 h-2 rounded-full bg-claude-accent animate-bounce" style={{ animationDelay: '0ms' }} />
-    <div className="w-2 h-2 rounded-full bg-claude-accent animate-bounce" style={{ animationDelay: '150ms' }} />
-    <div className="w-2 h-2 rounded-full bg-claude-accent animate-bounce" style={{ animationDelay: '300ms' }} />
-  </div>
-);
-
-const ThinkingBlock: React.FC<{
-  message: CoworkMessage;
-  mapDisplayText?: (value: string) => string;
-}> = ({ message, mapDisplayText }) => {
-  const isCurrentlyStreaming = Boolean(message.metadata?.isStreaming);
-  const [isExpanded, setIsExpanded] = useState(isCurrentlyStreaming);
-  const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content;
-
-  // Auto-expand while streaming, auto-collapse when streaming completes
-  useEffect(() => {
-    if (isCurrentlyStreaming) {
-      setIsExpanded(true);
-    } else {
-      setIsExpanded(false);
-    }
-  }, [isCurrentlyStreaming]);
-
-  return (
-    <div className="rounded-lg border dark:border-claude-darkBorder/50 border-claude-border/50 overflow-hidden">
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center gap-2 px-3 py-2 text-left dark:hover:bg-claude-darkSurfaceHover/50 hover:bg-claude-surfaceHover/50 transition-colors"
-      >
-        <ChevronRightIcon
-          className={`h-3.5 w-3.5 dark:text-claude-darkTextSecondary text-claude-textSecondary flex-shrink-0 transition-transform duration-200 ${
-            isExpanded ? 'rotate-90' : ''
-          }`}
-        />
-        <span className="text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-          {i18nService.t('reasoning')}
-        </span>
-        {isCurrentlyStreaming && (
-          <span className="w-1.5 h-1.5 rounded-full bg-claude-accent animate-pulse" />
-        )}
-      </button>
-      {isExpanded && (
-        <div className="px-3 pb-3 max-h-64 overflow-y-auto">
-          <div className="text-xs leading-relaxed dark:text-claude-darkTextSecondary/80 text-claude-textSecondary/80 whitespace-pre-wrap">
-            {displayContent}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-};
-
-export const AssistantTurnBlock: React.FC<{
-  turn: ConversationTurn;
-  resolveLocalFilePath?: (href: string, text: string) => string | null;
-  mapDisplayText?: (value: string) => string;
-  showTypingIndicator?: boolean;
-  showCopyButtons?: boolean;
-}> = ({
-  turn,
-  resolveLocalFilePath,
-  mapDisplayText,
-  showTypingIndicator = false,
-  showCopyButtons = true,
-}) => {
-  const visibleAssistantItems = getVisibleAssistantItems(turn.assistantItems);
-
-  const renderSystemMessage = (message: CoworkMessage) => {
-    const rawContent = hasText(message.content)
-      ? message.content
-      : (typeof message.metadata?.error === 'string' ? message.metadata.error : '');
-    const normalizedContent = getScheduledReminderDisplayText(rawContent) ?? rawContent;
-    const content = mapDisplayText ? mapDisplayText(normalizedContent) : normalizedContent;
-    if (!content.trim()) return null;
-
-    return (
-      <div className="rounded-lg border dark:border-claude-darkBorder/70 border-claude-border/70 dark:bg-claude-darkBg/40 bg-claude-bg/60 px-3 py-2">
-        <div className="flex items-start gap-2">
-          <InformationCircleIcon className="h-4 w-4 mt-0.5 dark:text-claude-darkTextSecondary text-claude-textSecondary flex-shrink-0" />
-          <div className="text-xs whitespace-pre-wrap dark:text-claude-darkTextSecondary text-claude-textSecondary">
-            {content}
-          </div>
-        </div>
-      </div>
-    );
-  };
-
-  const renderOrphanToolResult = (message: CoworkMessage) => {
-    const toolResultDisplayRaw = getToolResultDisplay(message);
-    const toolResultDisplay = mapDisplayText ? mapDisplayText(toolResultDisplayRaw) : toolResultDisplayRaw;
-    const isToolError = Boolean(message.metadata?.isError || message.metadata?.error);
-    const hasToolResultText = hasText(toolResultDisplay);
-    const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0;
-    const showNoDetailError = isToolError && !hasToolResultText;
-    const fallbackText = showNoDetailError ? i18nService.t('coworkToolNoErrorDetail') : '';
-    const displayText = hasToolResultText ? toolResultDisplay : fallbackText;
-    return (
-      <div className="py-1">
-        <div className="flex items-start gap-2">
-          <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
-            isToolError ? 'bg-red-500' : 'bg-claude-darkTextSecondary/50'
-          }`} />
-          <div className="flex-1 min-w-0">
-            <div className="text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
-              {i18nService.t('coworkToolResult')}
-            </div>
-            {resultLineCount > 0 && (
-              <div className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-0.5">
-                {resultLineCount} {resultLineCount === 1 ? 'line' : 'lines'} of output
-              </div>
-            )}
-            {resultLineCount === 0 && showNoDetailError && (
-              <div className={`text-xs mt-0.5 ${
-                isToolError
-                  ? 'text-red-500/80'
-                  : 'dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60'
-              }`}>
-                {fallbackText}
-              </div>
-            )}
-            {(hasToolResultText || showNoDetailError) && (
-              <div className="mt-2 px-3 py-2 rounded-lg dark:bg-claude-darkSurface/50 bg-claude-surface/50 max-h-64 overflow-y-auto">
-                <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${
-                  isToolError
-                    ? 'text-red-500'
-                    : hasToolResultText
-                      ? 'dark:text-claude-darkText text-claude-text'
-                      : 'dark:text-claude-darkTextSecondary text-claude-textSecondary italic'
-                }`}>
-                  {displayText}
-                </pre>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-    );
-  };
-
-  return (
-    <div className="px-4 py-2">
-      <div className="max-w-3xl mx-auto">
-        <div className="flex items-start gap-3">
-          <div className="flex-1 min-w-0 px-4 py-3 space-y-3">
-            {visibleAssistantItems.map((item, index) => {
-              if (item.type === 'assistant') {
-                if (item.message.metadata?.isThinking) {
-                  return (
-                    <ThinkingBlock
-                      key={item.message.id}
-                      message={item.message}
-                      mapDisplayText={mapDisplayText}
-                    />
-                  );
-                }
-                // Check if there are any tool_group items after this assistant message
-                const hasToolGroupAfter = visibleAssistantItems
-                  .slice(index + 1)
-                  .some(laterItem => laterItem.type === 'tool_group');
-
-                return (
-                  <AssistantMessageItem
-                    key={item.message.id}
-                    message={item.message}
-                    resolveLocalFilePath={resolveLocalFilePath}
-                    mapDisplayText={mapDisplayText}
-                    showCopyButton={showCopyButtons && !hasToolGroupAfter}
-                  />
-                );
-              }
-
-              if (item.type === 'tool_group') {
-                const nextItem = visibleAssistantItems[index + 1];
-                const isLastInSequence = !nextItem || nextItem.type !== 'tool_group';
-                return (
-                  <ToolCallGroup
-                    key={`tool-${item.group.toolUse.id}`}
-                    group={item.group}
-                    isLastInSequence={isLastInSequence}
-                    mapDisplayText={mapDisplayText}
-                  />
-                );
-              }
-
-              if (item.type === 'system') {
-                const systemMessage = renderSystemMessage(item.message);
-                if (!systemMessage) {
-                  return null;
-                }
-                return (
-                  <div key={item.message.id}>
-                    {systemMessage}
-                  </div>
-                );
-              }
-
-              return (
-                <div key={item.message.id}>
-                  {renderOrphanToolResult(item.message)}
-                </div>
-              );
-            })}
-            {showTypingIndicator && <TypingDots />}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
+  useScrollBehavior,
+  useSessionMenu,
+  useRenameSession,
+  useExportImage,
+  useResolveLocalFilePath,
+  useTruncatePath,
+} from './CoworkSessionDetail.hooks'
+import { UserMessageItem } from './components/UserMessageItem'
+import { AssistantTurnBlock } from './components/AssistantTurnBlock'
+import { StreamingActivityBar } from './components/StreamingActivityBar'
+import { PushPinIcon } from './components/ToolCallGroup'
+
+// Re-export all public types and functions so existing import paths remain valid
+export type {
+  ToolGroupItem,
+  DisplayItem,
+  AssistantTurnItem,
+  ConversationTurn,
+  CoworkSessionDetailProps,
+} from './CoworkSessionDetail.types'
+export { buildDisplayItems, buildConversationTurns, hasRenderableAssistantContent } from './CoworkSessionDetail.utils'
+export { UserMessageItem } from './components/UserMessageItem'
+export { AssistantTurnBlock } from './components/AssistantTurnBlock'
+
+import type { CoworkSessionDetailProps } from './CoworkSessionDetail.types'
 
 const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   onManageSkills,
@@ -1286,554 +50,134 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   onNewChat,
   updateBadge,
 }) => {
-  const isMac = window.electron.platform === 'darwin';
-  const currentSession = useSelector((state: RootState) => state.cowork.currentSession);
-  const isStreaming = useSelector((state: RootState) => state.cowork.isStreaming);
-  const skills = useSelector((state: RootState) => state.skill.skills);
-  const detailRootRef = useRef<HTMLDivElement>(null);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const [shouldAutoScroll, setShouldAutoScroll] = useState(true);
+  const isMac = window.electron.platform === 'darwin'
+  const currentSession = useSelector((state: RootState) => state.cowork.currentSession)
+  const isStreaming = useSelector((state: RootState) => state.cowork.isStreaming)
+  const skills = useSelector((state: RootState) => state.skill.skills)
+  const detailRootRef = useRef<HTMLDivElement>(null)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const actionButtonRef = useRef<HTMLButtonElement>(null)
 
-  // Turn navigation states
-  // currentTurnIndex (state) drives UI rendering; currentTurnIndexRef (ref) provides
-  // up-to-date value inside callbacks (avoids stale closure). Both must be updated together.
-  const [currentTurnIndex, setCurrentTurnIndex] = useState(0);
-  const currentTurnIndexRef = useRef(0);
-  const [showTurnNav, setShowTurnNav] = useState(false);
-  const hideNavTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isNavigatingRef = useRef(false);
-  const navigatingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const turnElsCacheRef = useRef<HTMLElement[]>([]);
-  const [isScrollable, setIsScrollable] = useState(false);
+  const messages = currentSession?.messages
+  const displayItems = useMemo(() => (messages ? buildDisplayItems(messages) : []), [messages])
+  const turns = useMemo(() => buildConversationTurns(displayItems), [displayItems])
 
-  // Menu and action states
-  const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const actionButtonRef = useRef<HTMLButtonElement>(null);
-  const [showConfirmDelete, setShowConfirmDelete] = useState(false);
-  const [isExportingImage, setIsExportingImage] = useState(false);
+  const {
+    shouldAutoScroll,
+    setShouldAutoScroll,
+    isScrollable,
+    handleMessagesScroll,
+    currentTurnIndex,
+    setCurrentTurnIndex,
+    currentTurnIndexRef,
+    showTurnNav,
+    navigateToTurn,
+  } = useScrollBehavior(scrollContainerRef, turns)
 
-  // Rename states
-  const [isRenaming, setIsRenaming] = useState(false);
-  const [renameValue, setRenameValue] = useState('');
-  const renameInputRef = useRef<HTMLInputElement>(null);
-  const ignoreNextBlurRef = useRef(false);
+  const {
+    isRenaming,
+    renameValue,
+    setRenameValue,
+    renameInputRef,
+    handleRenameClick,
+    handleRenameSave,
+    handleRenameCancel,
+    handleRenameBlur,
+  } = useRenameSession(currentSession)
 
-  // Reset rename value when session changes
+  const { menuPosition, menuRef, showConfirmDelete, setShowConfirmDelete, openMenu, closeMenu } = useSessionMenu(
+    actionButtonRef,
+    isRenaming,
+  )
+
+  const { isExportingImage, handleShareClick } = useExportImage(currentSession, scrollContainerRef)
+
+  const resolveLocalFilePath = useResolveLocalFilePath(currentSession?.cwd)
+  const truncatePath = useTruncatePath()
+
+  const mapDisplayText = useCallback((value: string): string => value, [])
+
   useEffect(() => {
-    if (!isRenaming && currentSession) {
-      setRenameValue(currentSession.title);
-      ignoreNextBlurRef.current = false;
+    setShouldAutoScroll(true)
+  }, [currentSession?.id, setShouldAutoScroll])
+
+  const lastMessage = currentSession?.messages?.[currentSession.messages.length - 1]
+  const lastMessageContent = lastMessage?.content
+
+  useEffect(() => {
+    if (!shouldAutoScroll) return
+    const container = scrollContainerRef.current
+    if (container) {
+      container.scrollTop = container.scrollHeight
     }
-  }, [isRenaming, currentSession?.title]);
-
-  useEffect(() => {
-    setShouldAutoScroll(true);
-  }, [currentSession?.id]);
-
-  // Focus rename input when entering rename mode
-  useEffect(() => {
-    if (!isRenaming) return;
-    requestAnimationFrame(() => {
-      renameInputRef.current?.focus();
-      renameInputRef.current?.select();
-    });
-  }, [isRenaming]);
-
-  // Cleanup nav timers on unmount
-  useEffect(() => {
-    return () => {
-      if (hideNavTimerRef.current) clearTimeout(hideNavTimerRef.current);
-      if (navigatingTimerRef.current) clearTimeout(navigatingTimerRef.current);
-    };
-  }, []);
-
-  // Reset nav state when session changes
-  useEffect(() => {
-    setShowTurnNav(false);
-    setIsScrollable(false);
-    setCurrentTurnIndex(0);
-    currentTurnIndexRef.current = 0;
-    isNavigatingRef.current = false;
-    turnElsCacheRef.current = [];
-    if (hideNavTimerRef.current) clearTimeout(hideNavTimerRef.current);
-    if (navigatingTimerRef.current) clearTimeout(navigatingTimerRef.current);
-  }, [currentSession?.id]);
-
-  // Close menu on outside click
-  useEffect(() => {
-    if (!menuPosition) return;
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (!menuRef.current?.contains(target) && !actionButtonRef.current?.contains(target)) {
-        closeMenu();
-      }
-    };
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        closeMenu();
-      }
-    };
-    const handleScroll = () => closeMenu();
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleEscape);
-    window.addEventListener('scroll', handleScroll, true);
-    window.addEventListener('resize', handleScroll);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEscape);
-      window.removeEventListener('scroll', handleScroll, true);
-      window.removeEventListener('resize', handleScroll);
-    };
-  }, [menuPosition]);
-
-  // Helper: truncate path for display
-  const truncatePath = (path: string, maxLength = 20): string => {
-    if (!path) return i18nService.t('noFolderSelected');
-    return getCompactFolderName(path, maxLength) || i18nService.t('noFolderSelected');
-  };
-
-  // Menu position calculator
-  const calculateMenuPosition = (height: number) => {
-    const rect = actionButtonRef.current?.getBoundingClientRect();
-    if (!rect) return null;
-    const menuWidth = 180;
-    const padding = 8;
-    const x = Math.min(
-      Math.max(padding, rect.right - menuWidth),
-      window.innerWidth - menuWidth - padding
-    );
-    const y = Math.min(rect.bottom + 8, window.innerHeight - height - padding);
-    return { x, y };
-  };
-
-  const openMenu = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (isRenaming) return;
-    if (menuPosition) {
-      closeMenu();
-      return;
+    if (turns.length > 0) {
+      const lastIndex = turns.length - 1
+      currentTurnIndexRef.current = lastIndex
+      setCurrentTurnIndex(lastIndex)
     }
-    const menuHeight = 160;
-    const position = calculateMenuPosition(menuHeight);
-    if (position) {
-      setMenuPosition(position);
-    }
-    setShowConfirmDelete(false);
-  };
+  }, [
+    currentSession?.messages?.length,
+    lastMessageContent,
+    isStreaming,
+    shouldAutoScroll,
+    turns.length,
+    currentTurnIndexRef,
+    setCurrentTurnIndex,
+  ])
 
-  const closeMenu = () => {
-    setMenuPosition(null);
-    setShowConfirmDelete(false);
-  };
-
-  // Open folder in Finder/Explorer
   const handleOpenFolder = useCallback(async () => {
-    if (!currentSession?.cwd) return;
+    if (!currentSession?.cwd) return
     try {
-      await window.electron.shell.openPath(currentSession.cwd);
+      await window.electron.shell.openPath(currentSession.cwd)
     } catch (error) {
-      console.error('Failed to open folder:', error);
+      console.error('Failed to open folder:', error)
     }
-  }, [currentSession?.cwd]);
+  }, [currentSession?.cwd])
 
-  // Rename handlers
-  const handleRenameClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!currentSession) return;
-    ignoreNextBlurRef.current = false;
-    setIsRenaming(true);
-    setShowConfirmDelete(false);
-    setRenameValue(currentSession.title);
-    setMenuPosition(null);
-  };
-
-  const handleRenameSave = async (e?: React.SyntheticEvent) => {
-    e?.stopPropagation();
-    if (!currentSession) return;
-    ignoreNextBlurRef.current = true;
-    const nextTitle = renameValue.trim();
-    if (nextTitle && nextTitle !== currentSession.title) {
-      await coworkService.renameSession(currentSession.id, nextTitle);
-    }
-    setIsRenaming(false);
-  };
-
-  const handleRenameCancel = (e?: React.MouseEvent | React.KeyboardEvent) => {
-    e?.stopPropagation();
-    ignoreNextBlurRef.current = true;
-    if (currentSession) {
-      setRenameValue(currentSession.title);
-    }
-    setIsRenaming(false);
-  };
-
-  const handleRenameBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    if (ignoreNextBlurRef.current) {
-      ignoreNextBlurRef.current = false;
-      return;
-    }
-    handleRenameSave(event);
-  };
-
-  // Pin/unpin handler
   const handleTogglePin = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!currentSession) return;
-    await coworkService.setSessionPinned(currentSession.id, !currentSession.pinned);
-    closeMenu();
-  };
+    e.stopPropagation()
+    if (!currentSession) return
+    await coworkService.setSessionPinned(currentSession.id, !currentSession.pinned)
+    closeMenu()
+  }
 
-  // Delete handlers
   const handleDeleteClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setShowConfirmDelete(true);
-    setMenuPosition(null);
-  };
-
-  const handleShareClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!currentSession || isExportingImage) return;
-    closeMenu();
-    setIsExportingImage(true);
-
-    window.requestAnimationFrame(() => {
-      void (async () => {
-        try {
-          const scrollContainer = scrollContainerRef.current;
-          if (!scrollContainer) {
-            throw new Error('Capture target not found');
-          }
-          const initialScrollTop = scrollContainer.scrollTop;
-          try {
-            const scrollRect = domRectToCaptureRect(scrollContainer.getBoundingClientRect());
-            if (scrollRect.width <= 0 || scrollRect.height <= 0) {
-              throw new Error('Invalid capture area');
-            }
-
-            const scrollContentHeight = Math.max(scrollContainer.scrollHeight, scrollContainer.clientHeight);
-            if (scrollContentHeight <= 0) {
-              throw new Error('Invalid content height');
-            }
-
-            const toContentY = (viewportY: number): number => {
-              const y = scrollContainer.scrollTop + (viewportY - scrollRect.y);
-              return Math.max(0, Math.min(scrollContentHeight, y));
-            };
-
-            const userAnchors = scrollContainer.querySelectorAll<HTMLElement>('[data-export-role="user-message"]');
-            const assistantAnchors = scrollContainer.querySelectorAll<HTMLElement>('[data-export-role="assistant-block"]');
-
-            let contentStart = 0;
-            let contentEnd = scrollContentHeight;
-
-            if (userAnchors.length > 0) {
-              contentStart = toContentY(userAnchors[0].getBoundingClientRect().top);
-            } else if (assistantAnchors.length > 0) {
-              contentStart = toContentY(assistantAnchors[0].getBoundingClientRect().top);
-            }
-
-            if (assistantAnchors.length > 0) {
-              const lastAssistant = assistantAnchors[assistantAnchors.length - 1];
-              contentEnd = toContentY(lastAssistant.getBoundingClientRect().bottom);
-            } else if (userAnchors.length > 0) {
-              const lastUser = userAnchors[userAnchors.length - 1];
-              contentEnd = toContentY(lastUser.getBoundingClientRect().bottom);
-            }
-
-            const maxStart = Math.max(0, scrollContentHeight - 1);
-            contentStart = Math.max(0, Math.min(maxStart, Math.round(contentStart)));
-            contentEnd = Math.max(contentStart + 1, Math.min(scrollContentHeight, Math.round(contentEnd)));
-
-            const outputHeight = contentEnd - contentStart;
-
-            if (outputHeight > MAX_EXPORT_CANVAS_HEIGHT) {
-              throw new Error(`Export image is too tall (${outputHeight}px)`);
-            }
-
-            const segmentsEstimate = Math.ceil(outputHeight / Math.max(1, scrollRect.height)) + 1;
-            if (segmentsEstimate > MAX_EXPORT_SEGMENTS) {
-              throw new Error('Export image is too long');
-            }
-
-            const canvas = document.createElement('canvas');
-            canvas.width = scrollRect.width;
-            canvas.height = outputHeight;
-            const context = canvas.getContext('2d');
-            if (!context) {
-              throw new Error('Canvas context unavailable');
-            }
-
-            const captureAndLoad = async (rect: CaptureRect): Promise<HTMLImageElement> => {
-              const chunk = await coworkService.captureSessionImageChunk({ rect });
-              if (!chunk.success || !chunk.pngBase64) {
-                throw new Error(chunk.error || 'Failed to capture image chunk');
-              }
-              return loadImageFromBase64(chunk.pngBase64);
-            };
-
-            scrollContainer.scrollTop = Math.min(contentStart, Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight));
-            await waitForNextFrame();
-            await waitForNextFrame();
-
-            const maxScrollTop = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
-            let contentOffset = contentStart;
-            while (contentOffset < contentEnd) {
-              const targetScrollTop = Math.min(contentOffset, maxScrollTop);
-              scrollContainer.scrollTop = targetScrollTop;
-              await waitForNextFrame();
-              await waitForNextFrame();
-
-              const chunkImage = await captureAndLoad(scrollRect);
-              const sourceYOffset = Math.max(0, contentOffset - targetScrollTop);
-              const drawableHeight = Math.min(scrollRect.height - sourceYOffset, contentEnd - contentOffset);
-              if (drawableHeight <= 0) {
-                throw new Error('Failed to stitch export image');
-              }
-              const scaleY = chunkImage.naturalHeight / scrollRect.height;
-              const sourceYInImage = Math.max(0, Math.round(sourceYOffset * scaleY));
-              const sourceHeightInImage = Math.max(1, Math.min(
-                chunkImage.naturalHeight - sourceYInImage,
-                Math.round(drawableHeight * scaleY),
-              ));
-
-              context.drawImage(
-                chunkImage,
-                0,
-                sourceYInImage,
-                chunkImage.naturalWidth,
-                sourceHeightInImage,
-                0,
-                contentOffset - contentStart,
-                scrollRect.width,
-                drawableHeight,
-              );
-
-              contentOffset += drawableHeight;
-            }
-
-            const pngDataUrl = canvas.toDataURL('image/png');
-            const base64Index = pngDataUrl.indexOf(',');
-            if (base64Index < 0) {
-              throw new Error('Failed to encode export image');
-            }
-
-            const timestamp = formatExportTimestamp(new Date());
-            const saveResult = await coworkService.saveSessionResultImage({
-              pngBase64: pngDataUrl.slice(base64Index + 1),
-              defaultFileName: sanitizeExportFileName(`${currentSession.title}-${timestamp}.png`),
-            });
-            if (saveResult.success && !saveResult.canceled) {
-              window.dispatchEvent(new CustomEvent('app:showToast', {
-                detail: i18nService.t('coworkExportImageSuccess'),
-              }));
-              return;
-            }
-            if (!saveResult.success) {
-              throw new Error(saveResult.error || 'Failed to export image');
-            }
-          } finally {
-            scrollContainer.scrollTop = initialScrollTop;
-          }
-        } catch (error) {
-          console.error('Failed to export session image:', error);
-          window.dispatchEvent(new CustomEvent('app:showToast', {
-            detail: i18nService.t('coworkExportImageFailed'),
-          }));
-        } finally {
-          setIsExportingImage(false);
-        }
-      })();
-    });
-  };
+    e.stopPropagation()
+    setShowConfirmDelete(true)
+    closeMenu()
+  }
 
   const handleConfirmDelete = async () => {
-    if (!currentSession) return;
-    await coworkService.deleteSession(currentSession.id);
-    setShowConfirmDelete(false);
-    if (onNavigateHome) {
-      onNavigateHome();
-    }
-  };
+    if (!currentSession) return
+    await coworkService.deleteSession(currentSession.id)
+    setShowConfirmDelete(false)
+    if (onNavigateHome) onNavigateHome()
+  }
 
   const handleCancelDelete = (e?: React.MouseEvent) => {
-    e?.stopPropagation();
-    setShowConfirmDelete(false);
-  };
-
-  const handleMessagesScroll = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-    const distanceToBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-    const isNearBottom = distanceToBottom <= AUTO_SCROLL_THRESHOLD;
-    setShouldAutoScroll((prev) => (prev === isNearBottom ? prev : isNearBottom));
-
-    // Check if content overflows the container (use functional updater to avoid redundant re-renders)
-    const scrollable = container.scrollHeight > container.clientHeight;
-    setIsScrollable((prev) => (prev === scrollable ? prev : scrollable));
-    if (!scrollable) return;
-
-    // Show turn nav and reset hide timer (use functional updater to avoid redundant re-renders)
-    setShowTurnNav((prev) => (prev ? prev : true));
-
-    if (hideNavTimerRef.current) clearTimeout(hideNavTimerRef.current);
-    hideNavTimerRef.current = setTimeout(() => setShowTurnNav(false), NAV_HIDE_DELAY);
-
-    // Skip index recalculation during programmatic navigation
-    if (isNavigatingRef.current) return;
-
-    // Update current turn index based on cached turn elements
-    const turnEls = turnElsCacheRef.current;
-    if (turnEls.length === 0) return;
-
-    // If at very bottom, snap to last turn (use smaller threshold than auto-scroll)
-    if (distanceToBottom <= NAV_BOTTOM_SNAP_THRESHOLD) {
-      const lastIndex = turnEls.length - 1;
-      currentTurnIndexRef.current = lastIndex;
-      setCurrentTurnIndex(lastIndex);
-      return;
-    }
-
-    const scrollTop = container.scrollTop;
-    let visibleIndex = 0;
-    for (let i = 0; i < turnEls.length; i++) {
-      if (turnEls[i].offsetTop <= scrollTop + 80) {
-        visibleIndex = i;
-      } else {
-        break;
-      }
-    }
-    currentTurnIndexRef.current = visibleIndex;
-    setCurrentTurnIndex(visibleIndex);
-  }, []);
-
-  const navigateToTurn = useCallback((direction: 'prev' | 'next') => {
-    const turnEls = turnElsCacheRef.current;
-    if (turnEls.length === 0) return;
-    const idx = currentTurnIndexRef.current;
-    const targetIndex = direction === 'prev' ? idx - 1 : idx + 1;
-    if (targetIndex < 0 || targetIndex >= turnEls.length) return;
-
-    // Block scroll handler from overriding index during smooth scroll
-    isNavigatingRef.current = true;
-    if (navigatingTimerRef.current) clearTimeout(navigatingTimerRef.current);
-    navigatingTimerRef.current = setTimeout(() => { isNavigatingRef.current = false; }, NAV_SCROLL_LOCK_DURATION);
-
-    turnEls[targetIndex].scrollIntoView({ behavior: 'smooth', block: 'start' });
-    currentTurnIndexRef.current = targetIndex;
-    setCurrentTurnIndex(targetIndex);
-    // Reset hide timer
-    setShowTurnNav(true);
-    if (hideNavTimerRef.current) clearTimeout(hideNavTimerRef.current);
-    hideNavTimerRef.current = setTimeout(() => setShowTurnNav(false), NAV_HIDE_DELAY);
-  }, []);
-
-  // Get the last message content for auto-scroll on streaming updates
-  const lastMessage = currentSession?.messages?.[currentSession.messages.length - 1];
-  const lastMessageContent = lastMessage?.content;
-
-  const resolveLocalFilePath = useCallback((href: string, text: string) => {
-    const hrefValue = typeof href === 'string' ? href.trim() : '';
-    const textValue = typeof text === 'string' ? text.trim() : '';
-    if (!hrefValue && !textValue) return null;
-
-    const hrefRootRelative = hrefValue ? parseRootRelativePath(hrefValue) : null;
-    if (hrefRootRelative) {
-      return hrefRootRelative;
-    }
-
-    const hrefPath = hrefValue ? normalizeLocalPath(hrefValue) : null;
-    if (hrefPath) {
-      if (hrefPath.isRelative && currentSession?.cwd) {
-        return toAbsolutePathFromCwd(hrefPath.path, currentSession.cwd);
-      }
-      if (hrefPath.isAbsolute) {
-        return hrefPath.path;
-      }
-    }
-
-    const textRootRelative = textValue ? parseRootRelativePath(textValue) : null;
-    if (textRootRelative) {
-      return textRootRelative;
-    }
-
-    const textPath = textValue ? normalizeLocalPath(textValue) : null;
-    if (textPath) {
-      if (textPath.isRelative && currentSession?.cwd) {
-        return toAbsolutePathFromCwd(textPath.path, currentSession.cwd);
-      }
-      if (textPath.isAbsolute) {
-        return textPath.path;
-      }
-    }
-
-    return null;
-  }, [currentSession?.cwd]);
-
-  const mapDisplayText = useCallback((value: string): string => {
-    return value;
-  }, []);
-
-  const messages = currentSession?.messages;
-  const displayItems = useMemo(() => messages ? buildDisplayItems(messages) : [], [messages]);
-  const turns = useMemo(() => buildConversationTurns(displayItems), [displayItems]);
-
-  // Cache turn DOM elements when turns change
-  useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) { turnElsCacheRef.current = []; return; }
-    // DOM is already committed when useEffect runs, query synchronously
-    turnElsCacheRef.current = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-turn-index]')
-    );
-  }, [turns]);
-
-  // Auto scroll to bottom when new messages arrive or content updates (streaming)
-  useEffect(() => {
-    if (!shouldAutoScroll) {
-      return;
-    }
-    const container = scrollContainerRef.current;
-    if (container) {
-      container.scrollTop = container.scrollHeight;
-      setIsScrollable(container.scrollHeight > container.clientHeight);
-    }
-    // Sync turn index to last when auto-scrolled to bottom
-    if (turns.length > 0) {
-      const lastIndex = turns.length - 1;
-      currentTurnIndexRef.current = lastIndex;
-      setCurrentTurnIndex(lastIndex);
-    }
-  }, [currentSession?.messages?.length, lastMessageContent, isStreaming, shouldAutoScroll, turns.length]);
-
-
-  if (!currentSession) {
-    return null;
+    e?.stopPropagation()
+    setShowConfirmDelete(false)
   }
 
   const renderConversationTurns = () => {
     if (turns.length === 0) {
-      if (!isStreaming) return null;
+      if (!isStreaming) return null
       return (
         <div data-export-role="assistant-block">
           <AssistantTurnBlock
-            turn={{
-              id: 'streaming-only',
-              userMessage: null,
-              assistantItems: [],
-            }}
+            turn={{ id: 'streaming-only', userMessage: null, assistantItems: [] }}
             resolveLocalFilePath={resolveLocalFilePath}
             showTypingIndicator
-            showCopyButtons={!isStreaming}
+            showCopyButtons={false}
           />
         </div>
-      );
+      )
     }
 
     return turns.map((turn, index) => {
-      const isLastTurn = index === turns.length - 1;
-      const showTypingIndicator = isStreaming && isLastTurn && !hasRenderableAssistantContent(turn);
-      const showAssistantBlock = turn.assistantItems.length > 0 || showTypingIndicator;
+      const isLastTurn = index === turns.length - 1
+      const showTypingIndicator = isStreaming && isLastTurn && !hasRenderableAssistantContent(turn)
+      const showAssistantBlock = turn.assistantItems.length > 0 || showTypingIndicator
 
       return (
         <div key={turn.id} data-turn-index={index}>
@@ -1854,15 +198,15 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             </div>
           )}
         </div>
-      );
-    });
-  };
+      )
+    })
+  }
+
+  if (!currentSession) return null
 
   return (
     <div ref={detailRootRef} className="flex-1 flex flex-col dark:bg-claude-darkBg bg-claude-bg h-full">
-      {/* Header */}
       <div className="draggable flex h-12 items-center justify-between px-4 border-b dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface/50 bg-claude-surface/50 shrink-0">
-        {/* Left side: Toggle buttons (when collapsed) + Title */}
         <div className="flex h-full items-center gap-2 min-w-0">
           {isSidebarCollapsed && (
             <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
@@ -1890,12 +234,8 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               onChange={(e) => setRenameValue(e.target.value)}
               onClick={(e) => e.stopPropagation()}
               onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  handleRenameSave(e);
-                }
-                if (e.key === 'Escape') {
-                  handleRenameCancel(e);
-                }
+                if (e.key === 'Enter') handleRenameSave(e)
+                if (e.key === 'Escape') handleRenameCancel(e)
               }}
               onBlur={handleRenameBlur}
               className="non-draggable min-w-0 max-w-[300px] rounded-lg border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkBg bg-claude-bg px-2 py-1 text-sm font-medium dark:text-claude-darkText text-claude-text focus:outline-none focus:ring-2 focus:ring-claude-accent"
@@ -1907,9 +247,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
           )}
         </div>
 
-        {/* Right side: Folder + Menu */}
         <div className="non-draggable flex items-center gap-1">
-          {/* Folder button */}
           <button
             type="button"
             onClick={handleOpenFolder}
@@ -1917,12 +255,8 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             aria-label={i18nService.t('coworkOpenFolder')}
           >
             <FolderIcon className="h-4 w-4" />
-            <span className="max-w-[120px] truncate text-xs">
-              {truncatePath(currentSession.cwd)}
-            </span>
+            <span className="max-w-[120px] truncate text-xs">{truncatePath(currentSession.cwd)}</span>
           </button>
-
-          {/* Menu button */}
           <button
             ref={actionButtonRef}
             type="button"
@@ -1936,7 +270,6 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         </div>
       </div>
 
-      {/* Floating Menu */}
       {menuPosition && (
         <div
           ref={menuRef}
@@ -1946,7 +279,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         >
           <button
             type="button"
-            onClick={handleRenameClick}
+            onClick={(e) => handleRenameClick(e, closeMenu)}
             className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm dark:text-claude-darkText text-claude-text hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors"
           >
             <PencilSquareIcon className="h-4 w-4" />
@@ -1965,7 +298,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
           </button>
           <button
             type="button"
-            onClick={handleShareClick}
+            onClick={(e) => handleShareClick(e, closeMenu)}
             disabled={isExportingImage}
             className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm dark:text-claude-darkText text-claude-text hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
@@ -1983,7 +316,6 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         </div>
       )}
 
-      {/* Delete Confirmation Modal */}
       {showConfirmDelete && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
@@ -1993,7 +325,6 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             className="w-full max-w-sm mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal overflow-hidden modal-content"
             onClick={(e) => e.stopPropagation()}
           >
-            {/* Header */}
             <div className="flex items-center gap-3 px-5 py-4">
               <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
                 <ExclamationTriangleIcon className="h-5 w-5 text-red-600 dark:text-red-500" />
@@ -2002,15 +333,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 {i18nService.t('deleteTaskConfirmTitle')}
               </h2>
             </div>
-
-            {/* Content */}
             <div className="px-5 pb-4">
               <p className="text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary">
                 {i18nService.t('deleteTaskConfirmMessage')}
               </p>
             </div>
-
-            {/* Footer */}
             <div className="flex items-center justify-end gap-3 px-5 py-4 border-t dark:border-claude-darkBorder border-claude-border">
               <button
                 onClick={handleCancelDelete}
@@ -2029,35 +356,29 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         </div>
       )}
 
-      {/* Messages */}
       <div className="relative flex-1 min-h-0">
-        <div
-          ref={scrollContainerRef}
-          onScroll={handleMessagesScroll}
-          className="h-full min-h-0 overflow-y-auto pt-3"
-        >
+        <div ref={scrollContainerRef} onScroll={handleMessagesScroll} className="h-full min-h-0 overflow-y-auto pt-3">
           {renderConversationTurns()}
           <div className="h-20" />
         </div>
 
-        {/* Turn Navigation Buttons */}
         {turns.length > 1 && isScrollable && (
           <div
-            className={`absolute right-6 top-1/2 -translate-y-1/2 flex flex-col rounded-lg overflow-hidden shadow-lg transition-opacity duration-300 z-10
-
-              dark:bg-claude-darkSurface/90 bg-claude-surface/90 backdrop-blur-sm
-              border dark:border-claude-darkBorder border-claude-border
-              ${showTurnNav ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+            className={`absolute right-6 top-1/2 -translate-y-1/2 flex flex-col rounded-lg overflow-hidden shadow-lg transition-opacity duration-300 z-10 dark:bg-claude-darkSurface/90 bg-claude-surface/90 backdrop-blur-sm border dark:border-claude-darkBorder border-claude-border ${showTurnNav ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
           >
             <button
               type="button"
               onClick={() => currentTurnIndex > 0 && navigateToTurn('prev')}
-              className={`px-1.5 py-3 transition-colors dark:text-claude-darkText text-claude-text
-                ${currentTurnIndex <= 0
-                  ? 'opacity-30 cursor-default'
-                  : 'dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover cursor-pointer'}`}
+              className={`px-1.5 py-3 transition-colors dark:text-claude-darkText text-claude-text ${currentTurnIndex <= 0 ? 'opacity-30 cursor-default' : 'dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover cursor-pointer'}`}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-4 h-4">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2.5}
+                stroke="currentColor"
+                className="w-4 h-4"
+              >
                 <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
               </svg>
             </button>
@@ -2065,12 +386,16 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             <button
               type="button"
               onClick={() => currentTurnIndex < turns.length - 1 && navigateToTurn('next')}
-              className={`px-1.5 py-3 transition-colors dark:text-claude-darkText text-claude-text
-                ${currentTurnIndex >= turns.length - 1
-                  ? 'opacity-30 cursor-default'
-                  : 'dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover cursor-pointer'}`}
+              className={`px-1.5 py-3 transition-colors dark:text-claude-darkText text-claude-text ${currentTurnIndex >= turns.length - 1 ? 'opacity-30 cursor-default' : 'dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover cursor-pointer'}`}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-4 h-4">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2.5}
+                stroke="currentColor"
+                className="w-4 h-4"
+              >
                 <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
               </svg>
             </button>
@@ -2078,10 +403,8 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         )}
       </div>
 
-      {/* Streaming Activity Bar */}
       {isStreaming && <StreamingActivityBar messages={currentSession.messages} />}
 
-      {/* Input Area */}
       <div className="p-4 shrink-0">
         <div className="max-w-3xl mx-auto">
           <CoworkPromptInput
@@ -2097,7 +420,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         </div>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default CoworkSessionDetail;
+export default CoworkSessionDetail

--- a/src/renderer/components/cowork/CoworkSessionDetail.types.ts
+++ b/src/renderer/components/cowork/CoworkSessionDetail.types.ts
@@ -1,0 +1,49 @@
+import type { CoworkMessage, CoworkImageAttachment } from '../../types/cowork'
+import type { Skill } from '../../types/skill'
+
+export type { CoworkMessage, CoworkImageAttachment, Skill }
+
+export type CaptureRect = { x: number; y: number; width: number; height: number }
+
+export type TodoStatus = 'completed' | 'in_progress' | 'pending' | 'unknown'
+
+export type ParsedTodoItem = {
+  primaryText: string
+  secondaryText: string | null
+  status: TodoStatus
+}
+
+export type ToolGroupItem = {
+  type: 'tool_group'
+  toolUse: CoworkMessage
+  toolResult?: CoworkMessage | null
+}
+
+export type DisplayItem = { type: 'message'; message: CoworkMessage } | ToolGroupItem
+
+export type AssistantTurnItem =
+  | { type: 'assistant'; message: CoworkMessage }
+  | { type: 'system'; message: CoworkMessage }
+  | { type: 'tool_group'; group: ToolGroupItem }
+  | { type: 'tool_result'; message: CoworkMessage }
+
+export type ConversationTurn = {
+  id: string
+  userMessage: CoworkMessage | null
+  assistantItems: AssistantTurnItem[]
+}
+
+export interface CoworkSessionDetailProps {
+  onManageSkills?: () => void
+  onContinue: (
+    prompt: string,
+    skillPrompt?: string,
+    imageAttachments?: CoworkImageAttachment[],
+  ) => boolean | void | Promise<boolean | void>
+  onStop: () => void
+  onNavigateHome?: () => void
+  isSidebarCollapsed?: boolean
+  onToggleSidebar?: () => void
+  onNewChat?: () => void
+  updateBadge?: React.ReactNode
+}

--- a/src/renderer/components/cowork/CoworkSessionDetail.utils.ts
+++ b/src/renderer/components/cowork/CoworkSessionDetail.utils.ts
@@ -1,0 +1,542 @@
+import { i18nService } from '../../services/i18n'
+import type {
+  CoworkMessage,
+  CaptureRect,
+  ParsedTodoItem,
+  TodoStatus,
+  ToolGroupItem,
+  DisplayItem,
+  AssistantTurnItem,
+  ConversationTurn,
+} from './CoworkSessionDetail.types'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const AUTO_SCROLL_THRESHOLD = 120
+export const NAV_HIDE_DELAY = 3000
+export const NAV_SCROLL_LOCK_DURATION = 500
+export const NAV_BOTTOM_SNAP_THRESHOLD = 20
+export const MAX_EXPORT_CANVAS_HEIGHT = 32760
+export const MAX_EXPORT_SEGMENTS = 240
+
+const INVALID_FILE_NAME_PATTERN = /[<>:"/\\|?*\u0000-\u001F]/g
+const TOOL_USE_ERROR_TAG_PATTERN = /^<tool_use_error>([\s\S]*?)<\/tool_use_error>$/i
+const ANSI_ESCAPE_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/g
+
+// ─── Export helpers ────────────────────────────────────────────────────────────
+
+export const sanitizeExportFileName = (value: string): string => {
+  const sanitized = value.replace(INVALID_FILE_NAME_PATTERN, ' ').replace(/\s+/g, ' ').trim()
+  return sanitized || 'cowork-session'
+}
+
+export const formatExportTimestamp = (value: Date): string => {
+  const pad = (num: number): string => String(num).padStart(2, '0')
+  return `${value.getFullYear()}${pad(value.getMonth() + 1)}${pad(value.getDate())}-${pad(value.getHours())}${pad(value.getMinutes())}${pad(value.getSeconds())}`
+}
+
+export const waitForNextFrame = (): Promise<void> =>
+  new Promise((resolve) => {
+    window.requestAnimationFrame(() => resolve())
+  })
+
+export const loadImageFromBase64 = (pngBase64: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error('Failed to decode captured image'))
+    img.src = `data:image/png;base64,${pngBase64}`
+  })
+
+export const domRectToCaptureRect = (rect: DOMRect): CaptureRect => ({
+  x: Math.max(0, Math.round(rect.x)),
+  y: Math.max(0, Math.round(rect.y)),
+  width: Math.max(0, Math.round(rect.width)),
+  height: Math.max(0, Math.round(rect.height)),
+})
+
+// ─── Generic format helpers ────────────────────────────────────────────────────
+
+export const formatUnknown = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value
+  }
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+export const getStringArray = (value: unknown): string | null => {
+  if (!Array.isArray(value)) return null
+  const lines = value.filter((item) => typeof item === 'string') as string[]
+  return lines.length > 0 ? lines.join('\n') : null
+}
+
+export const formatStructuredText = (value: string): string => {
+  const trimmed = value.trim()
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+    return value
+  }
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2)
+  } catch {
+    return value
+  }
+}
+
+export const toTrimmedString = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim() ? value.trim() : null
+
+export const truncatePreview = (value: string, maxLength = 120): string =>
+  value.length <= maxLength ? value : `${value.slice(0, maxLength - 3)}...`
+
+export const hasText = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0
+
+export const getToolResultLineCount = (result: string): number => {
+  if (!result) return 0
+  return result.split('\n').length
+}
+
+// ─── Tool name helpers ─────────────────────────────────────────────────────────
+
+export const normalizeToolName = (value: string): string => value.toLowerCase().replace(/[\s_]+/g, '')
+
+export const getToolDisplayName = (toolName: string | undefined): string => {
+  if (!toolName) return 'Tool'
+  const normalized = normalizeToolName(toolName)
+  switch (normalized) {
+    case 'cron':
+      return 'Cron'
+    case 'exec':
+    case 'bash':
+    case 'shell':
+      return 'Bash'
+    case 'read':
+    case 'readfile':
+      return 'Read'
+    case 'write':
+    case 'writefile':
+      return 'Write'
+    case 'edit':
+    case 'editfile':
+      return 'Edit'
+    case 'multiedit':
+      return 'MultiEdit'
+    case 'process':
+      return 'Process'
+    default:
+      return toolName
+  }
+}
+
+export const isBashLikeToolName = (toolName: string | undefined): boolean => {
+  if (!toolName) return false
+  const normalized = normalizeToolName(toolName)
+  return normalized === 'bash' || normalized === 'exec' || normalized === 'shell'
+}
+
+export const isTodoWriteToolName = (toolName: string | undefined): boolean => {
+  if (!toolName) return false
+  return normalizeToolName(toolName) === 'todowrite'
+}
+
+export const isCronToolName = (toolName: string | undefined): boolean => {
+  if (!toolName) return false
+  return normalizeToolName(toolName) === 'cron'
+}
+
+// ─── Tool input helpers ────────────────────────────────────────────────────────
+
+export const getToolInputString = (input: Record<string, unknown>, keys: string[]): string | null => {
+  for (const key of keys) {
+    const value = input[key]
+    if (typeof value === 'string' && value.trim()) {
+      return value
+    }
+  }
+  return null
+}
+
+export const getCronToolSummary = (input: Record<string, unknown>): string | null => {
+  const action = getToolInputString(input, ['action'])
+  if (!action) return null
+
+  const job = input.job && typeof input.job === 'object' ? (input.job as Record<string, unknown>) : null
+  const jobName = job ? getToolInputString(job, ['name', 'id']) : null
+  const jobId = getToolInputString(input, ['jobId', 'id']) ?? (job ? getToolInputString(job, ['id']) : null)
+  const wakeText = getToolInputString(input, ['text'])
+
+  switch (action) {
+    case 'add':
+      return [action, jobName ?? jobId].filter(Boolean).join(' · ')
+    case 'update':
+    case 'remove':
+    case 'run':
+    case 'runs':
+      return [action, jobId ?? jobName].filter(Boolean).join(' · ')
+    case 'wake':
+      return [action, wakeText].filter(Boolean).join(' · ')
+    default:
+      return action
+  }
+}
+
+// ─── Todo helpers ──────────────────────────────────────────────────────────────
+
+export const normalizeTodoStatus = (value: unknown): TodoStatus => {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase().replace(/-/g, '_') : ''
+
+  if (normalized === 'completed') return 'completed'
+  if (normalized === 'in_progress' || normalized === 'running') return 'in_progress'
+  if (normalized === 'pending' || normalized === 'todo') return 'pending'
+  return 'unknown'
+}
+
+export const parseTodoWriteItems = (input: unknown): ParsedTodoItem[] | null => {
+  if (!input || typeof input !== 'object') return null
+  const record = input as Record<string, unknown>
+  if (!Array.isArray(record.todos)) return null
+
+  const parsedItems = record.todos
+    .map((rawTodo) => {
+      if (!rawTodo || typeof rawTodo !== 'object') {
+        return null
+      }
+
+      const todo = rawTodo as Record<string, unknown>
+      const activeForm = toTrimmedString(todo.activeForm)
+      const content = toTrimmedString(todo.content)
+      const primaryText = activeForm ?? content ?? i18nService.t('coworkTodoUntitled')
+      const secondaryText = content && content !== primaryText ? content : null
+
+      return {
+        primaryText,
+        secondaryText,
+        status: normalizeTodoStatus(todo.status),
+      } satisfies ParsedTodoItem
+    })
+    .filter((item): item is ParsedTodoItem => item !== null)
+
+  return parsedItems.length > 0 ? parsedItems : null
+}
+
+export const getTodoWriteSummary = (items: ParsedTodoItem[]): string => {
+  const completedCount = items.filter((item) => item.status === 'completed').length
+  const inProgressCount = items.filter((item) => item.status === 'in_progress').length
+  const pendingCount = items.length - completedCount - inProgressCount
+
+  const summary = [
+    `${items.length} ${i18nService.t('coworkTodoItems')}`,
+    `${completedCount} ${i18nService.t('coworkTodoCompleted')}`,
+    `${inProgressCount} ${i18nService.t('coworkTodoInProgress')}`,
+    `${pendingCount} ${i18nService.t('coworkTodoPending')}`,
+  ]
+
+  const activeItem = items.find((item) => item.status === 'in_progress')
+  if (activeItem) {
+    summary.push(activeItem.primaryText)
+  }
+
+  return summary.join(' · ')
+}
+
+// ─── Tool input summary ────────────────────────────────────────────────────────
+
+export const getToolInputSummary = (
+  toolName: string | undefined,
+  toolInput?: Record<string, unknown>,
+): string | null => {
+  if (!toolName || !toolInput) return null
+  const input = toolInput as Record<string, unknown>
+  if (isTodoWriteToolName(toolName)) {
+    const items = parseTodoWriteItems(input)
+    return items ? getTodoWriteSummary(items) : null
+  }
+
+  const normalizedToolName = normalizeToolName(toolName)
+
+  switch (normalizedToolName) {
+    case 'cron':
+      return getCronToolSummary(input)
+    case 'bash':
+    case 'exec':
+    case 'shell':
+      return getToolInputString(input, ['command', 'cmd', 'script']) ?? getStringArray(input.commands)
+    case 'read':
+    case 'readfile':
+    case 'write':
+    case 'writefile':
+    case 'edit':
+    case 'editfile':
+    case 'multiedit':
+      return (
+        getToolInputString(input, ['file_path', 'path', 'filePath', 'target_file', 'targetFile']) ??
+        (typeof input.content === 'string' && input.content.trim()
+          ? truncatePreview(input.content.split('\n')[0].trim())
+          : null)
+      )
+    case 'glob':
+    case 'grep':
+      return getToolInputString(input, ['pattern', 'query'])
+    case 'task':
+      return getToolInputString(input, ['description', 'task'])
+    case 'webfetch':
+      return getToolInputString(input, ['url'])
+    case 'process': {
+      const action = getToolInputString(input, ['action'])
+      const sessionId = getToolInputString(input, ['sessionId', 'session_id'])
+      if (action && sessionId) return `${action} · ${sessionId}`
+      return action ?? sessionId
+    }
+    default:
+      return null
+  }
+}
+
+export const formatToolInput = (toolName: string | undefined, toolInput?: Record<string, unknown>): string | null => {
+  if (!toolInput) return null
+  const summary = getToolInputSummary(toolName, toolInput)
+  if (summary && summary.trim()) {
+    return summary
+  }
+  return formatUnknown(toolInput)
+}
+
+// ─── Tool result ───────────────────────────────────────────────────────────────
+
+export const normalizeToolResultText = (value: string): string => {
+  const withoutAnsi = value.replace(ANSI_ESCAPE_PATTERN, '')
+  const errorTagMatch = withoutAnsi.trim().match(TOOL_USE_ERROR_TAG_PATTERN)
+  return errorTagMatch ? errorTagMatch[1].trim() : withoutAnsi
+}
+
+export const getToolResultDisplay = (message: CoworkMessage): string => {
+  if (hasText(message.content)) {
+    return formatStructuredText(normalizeToolResultText(message.content))
+  }
+  if (hasText(message.metadata?.toolResult)) {
+    return formatStructuredText(normalizeToolResultText(message.metadata?.toolResult ?? ''))
+  }
+  if (hasText(message.metadata?.error)) {
+    return formatStructuredText(normalizeToolResultText(message.metadata?.error ?? ''))
+  }
+  return ''
+}
+
+// ─── Path helpers ──────────────────────────────────────────────────────────────
+
+export const safeDecodeURIComponent = (value: string): string => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+export const stripHashAndQuery = (value: string): string => value.split('#')[0].split('?')[0]
+
+export const stripFileProtocol = (value: string): string => {
+  let cleaned = value.replace(/^file:\/\//i, '')
+  if (/^\/[A-Za-z]:/.test(cleaned)) {
+    cleaned = cleaned.slice(1)
+  }
+  return cleaned
+}
+
+const hasScheme = (value: string): boolean => /^[a-z][a-z0-9+.-]*:/i.test(value)
+
+const isAbsolutePath = (value: string): boolean => value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)
+
+const isRelativePath = (value: string): boolean => !isAbsolutePath(value) && !hasScheme(value)
+
+export const parseRootRelativePath = (value: string): string | null => {
+  const trimmed = value.trim()
+  if (!/^file:\/\//i.test(trimmed)) return null
+  const separatorIndex = trimmed.indexOf('::')
+  if (separatorIndex < 0) return null
+
+  const rootPart = trimmed.slice(0, separatorIndex)
+  const relativePart = trimmed.slice(separatorIndex + 2)
+  if (!relativePart.trim()) return null
+
+  const rootPath = safeDecodeURIComponent(stripFileProtocol(stripHashAndQuery(rootPart)))
+  const relativePath = safeDecodeURIComponent(stripHashAndQuery(relativePart))
+  if (!rootPath || !relativePath) return null
+
+  const normalizedRoot = rootPath.replace(/[\\/]+$/, '')
+  const normalizedRelative = relativePath.replace(/^[\\/]+/, '')
+  if (!normalizedRelative) return null
+
+  return `${normalizedRoot}/${normalizedRelative}`
+}
+
+export const normalizeLocalPath = (
+  value: string,
+): { path: string; isRelative: boolean; isAbsolute: boolean } | null => {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const fileScheme = /^file:\/\//i.test(trimmed)
+  const schemePresent = hasScheme(trimmed)
+  if (schemePresent && !fileScheme && !isAbsolutePath(trimmed)) return null
+
+  let raw = trimmed
+  if (fileScheme) {
+    raw = stripFileProtocol(raw)
+  }
+  raw = stripHashAndQuery(raw)
+  const decoded = safeDecodeURIComponent(raw)
+  const path = decoded || raw
+  if (!path) return null
+
+  const isAbsolute = isAbsolutePath(path)
+  const isRelative = isRelativePath(path)
+  return { path, isRelative, isAbsolute }
+}
+
+export const toAbsolutePathFromCwd = (filePath: string, cwd: string): string => {
+  if (isAbsolutePath(filePath)) {
+    return filePath
+  }
+  return `${cwd.replace(/\/$/, '')}/${filePath.replace(/^\.\//, '')}`
+}
+
+// ─── Display building ──────────────────────────────────────────────────────────
+
+export const buildDisplayItems = (messages: CoworkMessage[]): DisplayItem[] => {
+  const items: DisplayItem[] = []
+  const groupsByToolUseId = new Map<string, ToolGroupItem>()
+  let pendingAdjacentGroup: ToolGroupItem | null = null
+
+  for (const message of messages) {
+    if (message.type === 'tool_use') {
+      const group: ToolGroupItem = { type: 'tool_group', toolUse: message }
+      items.push(group)
+
+      const toolUseId = message.metadata?.toolUseId
+      if (typeof toolUseId === 'string' && toolUseId.trim()) {
+        groupsByToolUseId.set(toolUseId, group)
+      }
+      pendingAdjacentGroup = group
+      continue
+    }
+
+    if (message.type === 'tool_result') {
+      let matched = false
+      const toolUseId = message.metadata?.toolUseId
+      if (typeof toolUseId === 'string' && groupsByToolUseId.has(toolUseId)) {
+        const group = groupsByToolUseId.get(toolUseId)
+        if (group) {
+          group.toolResult = message
+          matched = true
+        }
+      } else if (pendingAdjacentGroup && !pendingAdjacentGroup.toolResult) {
+        pendingAdjacentGroup.toolResult = message
+        matched = true
+      }
+
+      pendingAdjacentGroup = null
+      if (!matched) {
+        items.push({ type: 'message', message })
+      }
+      continue
+    }
+
+    pendingAdjacentGroup = null
+    items.push({ type: 'message', message })
+  }
+
+  return items
+}
+
+export const buildConversationTurns = (items: DisplayItem[]): ConversationTurn[] => {
+  const turns: ConversationTurn[] = []
+  let currentTurn: ConversationTurn | null = null
+  let orphanIndex = 0
+
+  const ensureTurn = (): ConversationTurn => {
+    if (currentTurn) return currentTurn
+    const orphanTurn: ConversationTurn = {
+      id: `orphan-${orphanIndex++}`,
+      userMessage: null,
+      assistantItems: [],
+    }
+    turns.push(orphanTurn)
+    currentTurn = orphanTurn
+    return orphanTurn
+  }
+
+  for (const item of items) {
+    if (item.type === 'message' && item.message.type === 'user') {
+      currentTurn = {
+        id: item.message.id,
+        userMessage: item.message,
+        assistantItems: [],
+      }
+      turns.push(currentTurn)
+      continue
+    }
+
+    const turn = ensureTurn()
+    if (item.type === 'tool_group') {
+      turn.assistantItems.push({ type: 'tool_group', group: item })
+      continue
+    }
+
+    const message = item.message
+    if (message.type === 'assistant') {
+      turn.assistantItems.push({ type: 'assistant', message })
+      continue
+    }
+
+    if (message.type === 'system') {
+      turn.assistantItems.push({ type: 'system', message })
+      continue
+    }
+
+    if (message.type === 'tool_result') {
+      turn.assistantItems.push({ type: 'tool_result', message })
+      continue
+    }
+
+    if (message.type === 'tool_use') {
+      turn.assistantItems.push({
+        type: 'tool_group',
+        group: {
+          type: 'tool_group',
+          toolUse: message,
+        },
+      })
+    }
+  }
+
+  return turns
+}
+
+const isRenderableAssistantOrSystemMessage = (message: CoworkMessage): boolean => {
+  if (hasText(message.content) || hasText(message.metadata?.error)) {
+    return true
+  }
+  if (message.metadata?.isThinking) {
+    return Boolean(message.metadata?.isStreaming)
+  }
+  return false
+}
+
+const isVisibleAssistantTurnItem = (item: AssistantTurnItem): boolean => {
+  if (item.type === 'assistant' || item.type === 'system') {
+    return isRenderableAssistantOrSystemMessage(item.message)
+  }
+  if (item.type === 'tool_result') {
+    return hasText(getToolResultDisplay(item.message))
+  }
+  return true
+}
+
+export const getVisibleAssistantItems = (assistantItems: AssistantTurnItem[]): AssistantTurnItem[] =>
+  assistantItems.filter(isVisibleAssistantTurnItem)
+
+export const hasRenderableAssistantContent = (turn: ConversationTurn): boolean =>
+  getVisibleAssistantItems(turn.assistantItems).length > 0

--- a/src/renderer/components/cowork/components/AssistantTurnBlock.tsx
+++ b/src/renderer/components/cowork/components/AssistantTurnBlock.tsx
@@ -1,0 +1,255 @@
+import React, { useState, useEffect } from 'react'
+import { InformationCircleIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
+import { i18nService } from '../../../services/i18n'
+import { getScheduledReminderDisplayText } from '../../../../common/scheduledReminderText'
+import type { CoworkMessage, ConversationTurn, AssistantTurnItem } from '../CoworkSessionDetail.types'
+import {
+  getToolResultDisplay,
+  getToolResultLineCount,
+  getVisibleAssistantItems,
+  hasText,
+} from '../CoworkSessionDetail.utils'
+import MarkdownContent from '../../MarkdownContent'
+import ToolCallGroup from './ToolCallGroup'
+import CopyButton from './CopyButton'
+import { TypingDots } from './StreamingActivityBar'
+
+// ─── AssistantMessageItem ──────────────────────────────────────────────────────
+
+interface AssistantMessageItemProps {
+  message: CoworkMessage
+  resolveLocalFilePath?: (href: string, text: string) => string | null
+  mapDisplayText?: (value: string) => string
+  showCopyButton?: boolean
+}
+
+const AssistantMessageItem: React.FC<AssistantMessageItemProps> = React.memo(
+  ({ message, resolveLocalFilePath, mapDisplayText, showCopyButton = false }) => {
+    const [isHovered, setIsHovered] = useState(false)
+    const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content
+
+    return (
+      <div className="relative" onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+        <div className="dark:text-claude-darkText text-claude-text">
+          <MarkdownContent
+            content={displayContent}
+            className="prose dark:prose-invert max-w-none"
+            resolveLocalFilePath={resolveLocalFilePath}
+          />
+        </div>
+        {showCopyButton && (
+          <div className="flex items-center gap-1.5 mt-1">
+            <CopyButton content={displayContent} visible={isHovered} />
+          </div>
+        )}
+      </div>
+    )
+  },
+)
+
+AssistantMessageItem.displayName = 'AssistantMessageItem'
+
+// ─── ThinkingBlock ─────────────────────────────────────────────────────────────
+
+interface ThinkingBlockProps {
+  message: CoworkMessage
+  mapDisplayText?: (value: string) => string
+}
+
+const ThinkingBlock: React.FC<ThinkingBlockProps> = React.memo(({ message, mapDisplayText }) => {
+  const isCurrentlyStreaming = Boolean(message.metadata?.isStreaming)
+  const [isExpanded, setIsExpanded] = useState(isCurrentlyStreaming)
+  const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content
+
+  useEffect(() => {
+    if (isCurrentlyStreaming) {
+      setIsExpanded(true)
+    } else {
+      setIsExpanded(false)
+    }
+  }, [isCurrentlyStreaming])
+
+  return (
+    <div className="rounded-lg border dark:border-claude-darkBorder/50 border-claude-border/50 overflow-hidden">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left dark:hover:bg-claude-darkSurfaceHover/50 hover:bg-claude-surfaceHover/50 transition-colors"
+      >
+        <ChevronRightIcon
+          className={`h-3.5 w-3.5 dark:text-claude-darkTextSecondary text-claude-textSecondary flex-shrink-0 transition-transform duration-200 ${
+            isExpanded ? 'rotate-90' : ''
+          }`}
+        />
+        <span className="text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
+          {i18nService.t('reasoning')}
+        </span>
+        {isCurrentlyStreaming && <span className="w-1.5 h-1.5 rounded-full bg-claude-accent animate-pulse" />}
+      </button>
+      {isExpanded && (
+        <div className="px-3 pb-3 max-h-64 overflow-y-auto">
+          <div className="text-xs leading-relaxed dark:text-claude-darkTextSecondary/80 text-claude-textSecondary/80 whitespace-pre-wrap">
+            {displayContent}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+})
+
+ThinkingBlock.displayName = 'ThinkingBlock'
+
+// ─── AssistantTurnBlock ────────────────────────────────────────────────────────
+
+interface AssistantTurnBlockProps {
+  turn: ConversationTurn
+  resolveLocalFilePath?: (href: string, text: string) => string | null
+  mapDisplayText?: (value: string) => string
+  showTypingIndicator?: boolean
+  showCopyButtons?: boolean
+}
+
+const renderSystemMessage = (message: CoworkMessage, mapDisplayText?: (value: string) => string): React.ReactNode => {
+  const rawContent = hasText(message.content)
+    ? message.content
+    : typeof message.metadata?.error === 'string'
+      ? message.metadata.error
+      : ''
+  const normalizedContent = getScheduledReminderDisplayText(rawContent) ?? rawContent
+  const content = mapDisplayText ? mapDisplayText(normalizedContent) : normalizedContent
+  if (!content.trim()) return null
+
+  return (
+    <div className="rounded-lg border dark:border-claude-darkBorder/70 border-claude-border/70 dark:bg-claude-darkBg/40 bg-claude-bg/60 px-3 py-2">
+      <div className="flex items-start gap-2">
+        <InformationCircleIcon className="h-4 w-4 mt-0.5 dark:text-claude-darkTextSecondary text-claude-textSecondary flex-shrink-0" />
+        <div className="text-xs whitespace-pre-wrap dark:text-claude-darkTextSecondary text-claude-textSecondary">
+          {content}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const renderOrphanToolResult = (
+  message: CoworkMessage,
+  mapDisplayText?: (value: string) => string,
+): React.ReactNode => {
+  const toolResultDisplayRaw = getToolResultDisplay(message)
+  const toolResultDisplay = mapDisplayText ? mapDisplayText(toolResultDisplayRaw) : toolResultDisplayRaw
+  const isToolError = Boolean(message.metadata?.isError || message.metadata?.error)
+  const hasToolResultText = hasText(toolResultDisplay)
+  const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0
+  const showNoDetailError = isToolError && !hasToolResultText
+  const fallbackText = showNoDetailError ? i18nService.t('coworkToolNoErrorDetail') : ''
+  const displayText = hasToolResultText ? toolResultDisplay : fallbackText
+  return (
+    <div className="py-1">
+      <div className="flex items-start gap-2">
+        <span
+          className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
+            isToolError ? 'bg-red-500' : 'bg-claude-darkTextSecondary/50'
+          }`}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
+            {i18nService.t('coworkToolResult')}
+          </div>
+          {resultLineCount > 0 && (
+            <div className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-0.5">
+              {resultLineCount} {resultLineCount === 1 ? 'line' : 'lines'} of output
+            </div>
+          )}
+          {resultLineCount === 0 && showNoDetailError && (
+            <div
+              className={`text-xs mt-0.5 ${
+                isToolError ? 'text-red-500/80' : 'dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60'
+              }`}
+            >
+              {fallbackText}
+            </div>
+          )}
+          {(hasToolResultText || showNoDetailError) && (
+            <div className="mt-2 px-3 py-2 rounded-lg dark:bg-claude-darkSurface/50 bg-claude-surface/50 max-h-64 overflow-y-auto">
+              <pre
+                className={`text-xs whitespace-pre-wrap break-words font-mono ${
+                  isToolError
+                    ? 'text-red-500'
+                    : hasToolResultText
+                      ? 'dark:text-claude-darkText text-claude-text'
+                      : 'dark:text-claude-darkTextSecondary text-claude-textSecondary italic'
+                }`}
+              >
+                {displayText}
+              </pre>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const AssistantTurnBlock: React.FC<AssistantTurnBlockProps> = React.memo(
+  ({ turn, resolveLocalFilePath, mapDisplayText, showTypingIndicator = false, showCopyButtons = true }) => {
+    const visibleAssistantItems = getVisibleAssistantItems(turn.assistantItems)
+
+    return (
+      <div className="px-4 py-2">
+        <div className="max-w-3xl mx-auto">
+          <div className="flex items-start gap-3">
+            <div className="flex-1 min-w-0 px-4 py-3 space-y-3">
+              {visibleAssistantItems.map((item: AssistantTurnItem, index: number) => {
+                if (item.type === 'assistant') {
+                  if (item.message.metadata?.isThinking) {
+                    return (
+                      <ThinkingBlock key={item.message.id} message={item.message} mapDisplayText={mapDisplayText} />
+                    )
+                  }
+                  const hasToolGroupAfter = visibleAssistantItems
+                    .slice(index + 1)
+                    .some((laterItem) => laterItem.type === 'tool_group')
+
+                  return (
+                    <AssistantMessageItem
+                      key={item.message.id}
+                      message={item.message}
+                      resolveLocalFilePath={resolveLocalFilePath}
+                      mapDisplayText={mapDisplayText}
+                      showCopyButton={showCopyButtons && !hasToolGroupAfter}
+                    />
+                  )
+                }
+
+                if (item.type === 'tool_group') {
+                  const nextItem = visibleAssistantItems[index + 1]
+                  const isLastInSequence = !nextItem || nextItem.type !== 'tool_group'
+                  return (
+                    <ToolCallGroup
+                      key={`tool-${item.group.toolUse.id}`}
+                      group={item.group}
+                      isLastInSequence={isLastInSequence}
+                      mapDisplayText={mapDisplayText}
+                    />
+                  )
+                }
+
+                if (item.type === 'system') {
+                  const systemMessage = renderSystemMessage(item.message, mapDisplayText)
+                  if (!systemMessage) return null
+                  return <div key={item.message.id}>{systemMessage}</div>
+                }
+
+                return <div key={item.message.id}>{renderOrphanToolResult(item.message, mapDisplayText)}</div>
+              })}
+              {showTypingIndicator && <TypingDots />}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  },
+)
+
+AssistantTurnBlock.displayName = 'AssistantTurnBlock'
+
+export default AssistantTurnBlock

--- a/src/renderer/components/cowork/components/CopyButton.tsx
+++ b/src/renderer/components/cowork/components/CopyButton.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react'
+import { i18nService } from '../../../services/i18n'
+
+interface CopyButtonProps {
+  content: string
+  visible: boolean
+}
+
+const CopyButton: React.FC<CopyButtonProps> = React.memo(({ content, visible }) => {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    try {
+      await navigator.clipboard.writeText(content)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error('Failed to copy:', err)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={`p-1.5 rounded-md dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-all duration-200 ${
+        visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+      }`}
+      title={i18nService.t('copyToClipboard')}
+    >
+      {copied ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-4 h-4 text-green-500"
+          aria-hidden="true"
+        >
+          <polyline points="20 6 9 17 4 12"></polyline>
+        </svg>
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-4 h-4 text-[var(--icon-secondary)]"
+          aria-hidden="true"
+        >
+          <rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect>
+          <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>
+        </svg>
+      )}
+    </button>
+  )
+})
+
+CopyButton.displayName = 'CopyButton'
+
+export default CopyButton

--- a/src/renderer/components/cowork/components/StreamingActivityBar.tsx
+++ b/src/renderer/components/cowork/components/StreamingActivityBar.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { i18nService } from '../../../services/i18n'
+import type { CoworkMessage } from '../CoworkSessionDetail.types'
+
+// ─── TypingDots ────────────────────────────────────────────────────────────────
+
+export const TypingDots: React.FC = React.memo(() => (
+  <div className="flex items-center space-x-1.5 py-1">
+    <div className="w-2 h-2 rounded-full bg-claude-accent animate-bounce" style={{ animationDelay: '0ms' }} />
+    <div className="w-2 h-2 rounded-full bg-claude-accent animate-bounce" style={{ animationDelay: '150ms' }} />
+    <div className="w-2 h-2 rounded-full bg-claude-accent animate-bounce" style={{ animationDelay: '300ms' }} />
+  </div>
+))
+
+TypingDots.displayName = 'TypingDots'
+
+// ─── StreamingActivityBar ──────────────────────────────────────────────────────
+
+interface StreamingActivityBarProps {
+  messages: CoworkMessage[]
+}
+
+export const StreamingActivityBar: React.FC<StreamingActivityBarProps> = React.memo(({ messages }) => {
+  const getStatusText = (): string => {
+    const toolResultIds = new Set<string>()
+    for (const msg of messages) {
+      const id = msg.metadata?.toolUseId
+      if (typeof id === 'string' && msg.type === 'tool_result') {
+        toolResultIds.add(id)
+      }
+    }
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i]
+      if (msg.type === 'tool_use') {
+        const id = msg.metadata?.toolUseId
+        if (typeof id === 'string' && !toolResultIds.has(id)) {
+          const toolName = typeof msg.metadata?.toolName === 'string' ? msg.metadata.toolName : null
+          if (toolName) {
+            return `${i18nService.t('coworkToolRunning')} ${toolName}...`
+          }
+        }
+      }
+    }
+    return `${i18nService.t('coworkToolRunning')}`
+  }
+
+  return (
+    <div className="shrink-0 animate-fade-in px-4">
+      <div className="max-w-3xl mx-auto">
+        <div className="streaming-bar" />
+        <div className="py-1">
+          <span className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">
+            {getStatusText()}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+})
+
+StreamingActivityBar.displayName = 'StreamingActivityBar'
+
+export default StreamingActivityBar

--- a/src/renderer/components/cowork/components/ToolCallGroup.tsx
+++ b/src/renderer/components/cowork/components/ToolCallGroup.tsx
@@ -1,0 +1,248 @@
+import React, { useState } from 'react'
+import { CheckIcon } from '@heroicons/react/24/outline'
+import { i18nService } from '../../../services/i18n'
+import type { ToolGroupItem, ParsedTodoItem, TodoStatus } from '../CoworkSessionDetail.types'
+import {
+  getToolDisplayName,
+  isBashLikeToolName,
+  isTodoWriteToolName,
+  isCronToolName,
+  parseTodoWriteItems,
+  formatToolInput,
+  getToolInputSummary,
+  getToolResultDisplay,
+  getToolResultLineCount,
+  truncatePreview,
+  hasText,
+} from '../CoworkSessionDetail.utils'
+
+// ─── PushPinIcon ───────────────────────────────────────────────────────────────
+
+export const PushPinIcon: React.FC<React.SVGProps<SVGSVGElement> & { slashed?: boolean }> = ({ slashed, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <g transform="rotate(45 12 12)">
+      <path d="M9 3h6l-1 5 2 2v2H8v-2l2-2-1-5z" />
+      <path d="M12 12v9" />
+    </g>
+    {slashed && <path d="M5 5L19 19" />}
+  </svg>
+)
+
+// ─── TodoWriteInputView ────────────────────────────────────────────────────────
+
+const getStatusCheckboxClass = (status: TodoStatus): string => {
+  switch (status) {
+    case 'completed':
+      return 'bg-green-500/10 border-green-500 text-green-500'
+    case 'in_progress':
+      return 'bg-transparent border-blue-500'
+    case 'pending':
+    case 'unknown':
+    default:
+      return 'bg-transparent dark:border-claude-darkTextSecondary/60 border-claude-textSecondary/60'
+  }
+}
+
+const TodoWriteInputView: React.FC<{ items: ParsedTodoItem[] }> = React.memo(({ items }) => (
+  <div className="space-y-2">
+    {items.map((item, index) => (
+      <div key={`todo-item-${index}`} className="flex items-start gap-2">
+        <span
+          className={`mt-0.5 h-4 w-4 rounded-[4px] border flex-shrink-0 inline-flex items-center justify-center ${getStatusCheckboxClass(item.status)}`}
+        >
+          {item.status === 'completed' && <CheckIcon className="h-3 w-3 stroke-[2.5]" />}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div
+            className={`text-xs whitespace-pre-wrap break-words leading-5 ${
+              item.status === 'completed'
+                ? 'dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/80'
+                : 'dark:text-claude-darkText text-claude-text'
+            }`}
+          >
+            {item.primaryText}
+          </div>
+        </div>
+      </div>
+    ))}
+  </div>
+))
+
+TodoWriteInputView.displayName = 'TodoWriteInputView'
+
+// ─── ToolCallGroup ─────────────────────────────────────────────────────────────
+
+interface ToolCallGroupProps {
+  group: ToolGroupItem
+  isLastInSequence?: boolean
+  mapDisplayText?: (value: string) => string
+}
+
+const ToolCallGroup: React.FC<ToolCallGroupProps> = React.memo(({ group, isLastInSequence = true, mapDisplayText }) => {
+  const { toolUse, toolResult } = group
+  const rawToolName = typeof toolUse.metadata?.toolName === 'string' ? toolUse.metadata.toolName : 'Tool'
+  const toolName = getToolDisplayName(rawToolName)
+  const toolInput = toolUse.metadata?.toolInput
+  const isCronTool = isCronToolName(rawToolName)
+  const isTodoWriteTool = isTodoWriteToolName(rawToolName)
+  const todoItems = isTodoWriteTool ? parseTodoWriteItems(toolInput) : null
+  const mapText = mapDisplayText ?? ((value: string) => value)
+  const toolInputDisplayRaw = formatToolInput(rawToolName, toolInput)
+  const toolInputDisplay = toolInputDisplayRaw ? mapText(toolInputDisplayRaw) : null
+  const toolInputSummaryRaw = getToolInputSummary(rawToolName, toolInput) ?? toolInputDisplayRaw
+  const toolInputSummary = toolInputSummaryRaw ? mapText(toolInputSummaryRaw) : null
+  const toolResultDisplayRaw = toolResult ? getToolResultDisplay(toolResult) : ''
+  const toolResultDisplay = mapText(toolResultDisplayRaw)
+  const hasToolResultText = hasText(toolResultDisplay)
+  const isToolError = Boolean(toolResult?.metadata?.isError || toolResult?.metadata?.error)
+  const showNoDetailError = isToolError && !hasToolResultText
+  const toolResultFallback = showNoDetailError ? i18nService.t('coworkToolNoErrorDetail') : ''
+  const displayToolResult = hasToolResultText ? toolResultDisplay : toolResultFallback
+  const [isExpanded, setIsExpanded] = useState(false)
+  const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0
+  const toolResultSummary =
+    isCronTool && hasToolResultText ? truncatePreview(toolResultDisplay.replace(/\s+/g, ' ')) : null
+  const isBashTool = isBashLikeToolName(rawToolName)
+
+  return (
+    <div className="relative py-1">
+      {/* Vertical connecting line to next tool group */}
+      {!isLastInSequence && (
+        <div className="absolute left-[3.5px] top-[14px] bottom-[-8px] w-px dark:bg-claude-darkTextSecondary/30 bg-claude-textSecondary/30" />
+      )}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-start gap-2 text-left group relative z-10"
+      >
+        <span
+          className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
+            !toolResult ? 'bg-blue-500 animate-pulse' : isToolError ? 'bg-red-500' : 'bg-green-500'
+          }`}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
+              {toolName}
+            </span>
+            {toolInputSummary && (
+              <code className="text-xs dark:text-claude-darkTextSecondary/80 text-claude-textSecondary/80 font-mono truncate max-w-[400px]">
+                {toolInputSummary}
+              </code>
+            )}
+          </div>
+          {toolResult && !isTodoWriteTool && (hasToolResultText || showNoDetailError) && (
+            <div
+              className={`text-xs mt-0.5 ${
+                hasToolResultText
+                  ? 'dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60'
+                  : showNoDetailError
+                    ? 'text-red-500/80'
+                    : 'dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60'
+              }`}
+            >
+              {hasToolResultText
+                ? (toolResultSummary ?? `${resultLineCount} ${resultLineCount === 1 ? 'line' : 'lines'} of output`)
+                : toolResultFallback}
+            </div>
+          )}
+          {!toolResult && (
+            <div className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-0.5">
+              {i18nService.t('coworkToolRunning')}
+            </div>
+          )}
+        </div>
+      </button>
+      {isExpanded && (
+        <div className="ml-4 mt-2">
+          {isBashTool ? (
+            <div className="rounded-lg overflow-hidden border dark:border-claude-darkBorder border-claude-border">
+              <div className="flex items-center gap-1.5 px-3 py-1.5 dark:bg-claude-darkSurface bg-claude-surfaceInset">
+                <div className="w-2.5 h-2.5 rounded-full bg-red-500" />
+                <div className="w-2.5 h-2.5 rounded-full bg-yellow-500" />
+                <div className="w-2.5 h-2.5 rounded-full bg-green-500" />
+                <span className="ml-2 text-[10px] dark:text-claude-darkTextSecondary text-claude-textSecondary font-medium">
+                  Terminal
+                </span>
+              </div>
+              <div className="dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset px-3 py-3 max-h-72 overflow-y-auto font-mono text-xs">
+                {toolInputDisplay && (
+                  <div className="dark:text-claude-darkText text-claude-text">
+                    <span className="text-claude-accent select-none">$ </span>
+                    <span className="whitespace-pre-wrap break-words">{toolInputDisplay}</span>
+                  </div>
+                )}
+                {toolResult && (hasToolResultText || showNoDetailError) && (
+                  <div
+                    className={`mt-1.5 whitespace-pre-wrap break-words ${
+                      isToolError
+                        ? 'text-red-400'
+                        : hasToolResultText
+                          ? 'dark:text-claude-darkTextSecondary text-claude-textSecondary'
+                          : 'dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/70 italic'
+                    }`}
+                  >
+                    {displayToolResult}
+                  </div>
+                )}
+                {!toolResult && (
+                  <div className="dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-1.5 italic">
+                    {i18nService.t('coworkToolRunning')}
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : isTodoWriteTool && todoItems ? (
+            <TodoWriteInputView items={todoItems} />
+          ) : (
+            <div className="space-y-2">
+              {toolInputDisplay && (
+                <div>
+                  <div className="text-[10px] font-medium dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/70 uppercase tracking-wider mb-1">
+                    {i18nService.t('coworkToolInput')}
+                  </div>
+                  <div className="max-h-48 overflow-y-auto">
+                    <pre className="text-xs dark:text-claude-darkText text-claude-text whitespace-pre-wrap break-words font-mono">
+                      {toolInputDisplay}
+                    </pre>
+                  </div>
+                </div>
+              )}
+              {toolResult && (hasToolResultText || showNoDetailError) && (
+                <div>
+                  <div className="text-[10px] font-medium dark:text-claude-darkTextSecondary/70 text-claude-textSecondary/70 uppercase tracking-wider mb-1">
+                    {i18nService.t('coworkToolResult')}
+                  </div>
+                  <div className="max-h-64 overflow-y-auto">
+                    <pre
+                      className={`text-xs whitespace-pre-wrap break-words font-mono ${
+                        isToolError
+                          ? 'text-red-500'
+                          : hasToolResultText
+                            ? 'dark:text-claude-darkText text-claude-text'
+                            : 'dark:text-claude-darkTextSecondary text-claude-textSecondary italic'
+                      }`}
+                    >
+                      {displayToolResult}
+                    </pre>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+})
+
+ToolCallGroup.displayName = 'ToolCallGroup'
+
+export default ToolCallGroup

--- a/src/renderer/components/cowork/components/UserMessageItem.tsx
+++ b/src/renderer/components/cowork/components/UserMessageItem.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react'
+import { PhotoIcon } from '@heroicons/react/24/outline'
+import type { CoworkMessage, CoworkImageAttachment, Skill } from '../CoworkSessionDetail.types'
+import type { CoworkMessageMetadata } from '../../../types/cowork'
+import MarkdownContent from '../../MarkdownContent'
+import PuzzleIcon from '../../icons/PuzzleIcon'
+import CopyButton from './CopyButton'
+
+interface UserMessageItemProps {
+  message: CoworkMessage
+  skills: Skill[]
+}
+
+export const UserMessageItem: React.FC<UserMessageItemProps> = React.memo(({ message, skills }) => {
+  const [isHovered, setIsHovered] = useState(false)
+  const [expandedImage, setExpandedImage] = useState<string | null>(null)
+
+  const messageSkillIds = (message.metadata as CoworkMessageMetadata)?.skillIds || []
+  const messageSkills = messageSkillIds
+    .map((id) => skills.find((s) => s.id === id))
+    .filter((s): s is NonNullable<typeof s> => s !== undefined)
+
+  const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ??
+    []) as CoworkImageAttachment[]
+
+  return (
+    <div className="py-2 px-4" onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+      <div className="max-w-3xl mx-auto">
+        <div className="pl-4 sm:pl-8 md:pl-12">
+          <div className="flex items-start gap-3 flex-row-reverse">
+            <div className="w-full min-w-0 flex flex-col items-end">
+              <div className="w-fit max-w-[42rem] rounded-2xl px-4 py-2.5 dark:bg-claude-darkSurface bg-claude-surface dark:text-claude-darkText text-claude-text shadow-subtle">
+                {message.content?.trim() && (
+                  <MarkdownContent content={message.content} className="max-w-none whitespace-pre-wrap break-words" />
+                )}
+                {imageAttachments.length > 0 && (
+                  <div className={`flex flex-wrap gap-2 ${message.content?.trim() ? 'mt-2' : ''}`}>
+                    {imageAttachments.map((img, idx) => (
+                      <div key={idx} className="relative group">
+                        <img
+                          src={`data:${img.mimeType};base64,${img.base64Data}`}
+                          alt={img.name}
+                          className="max-h-48 max-w-[16rem] rounded-lg object-contain cursor-pointer border dark:border-claude-darkBorder/50 border-claude-border/50 hover:border-claude-accent/50 transition-colors"
+                          title={img.name}
+                          onClick={() => setExpandedImage(`data:${img.mimeType};base64,${img.base64Data}`)}
+                        />
+                        <div className="absolute bottom-1 left-1 right-1 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/50 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity truncate pointer-events-none">
+                          <PhotoIcon className="h-3 w-3 flex-shrink-0" />
+                          <span className="truncate">{img.name}</span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="flex items-center justify-end gap-1.5 mt-1">
+                {messageSkills.map((skill) => (
+                  <div
+                    key={skill.id}
+                    className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md bg-claude-accent/5 dark:bg-claude-accent/10"
+                    title={skill.description}
+                  >
+                    <PuzzleIcon className="h-2.5 w-2.5 text-claude-accent/70" />
+                    <span className="text-[10px] font-medium text-claude-accent/70 max-w-[60px] truncate">
+                      {skill.name}
+                    </span>
+                  </div>
+                ))}
+                <CopyButton content={message.content} visible={isHovered} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      {expandedImage && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 cursor-pointer"
+          onClick={() => setExpandedImage(null)}
+        >
+          <img
+            src={expandedImage}
+            alt="Preview"
+            className="max-h-[90vh] max-w-[90vw] object-contain rounded-lg shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
+    </div>
+  )
+})
+
+UserMessageItem.displayName = 'UserMessageItem'
+
+export default UserMessageItem


### PR DESCRIPTION
## 背景

`CoworkSessionDetail.tsx` 是对话页面的核心组件，随着功能迭代积累到 **2100+ 行**，包含大量内联纯函数、自定义 Hook 逻辑和子组件，存在以下问题：

- 单文件职责过重，难以定位和维护
- 流式输出时，无关联历史消息因顶层状态更新而触发不必要重渲染
- 纯函数和 UI 逻辑混杂，无法独立测试

---

## 变更内容

### 文件拆分

| 新增文件 | 职责 |
|---|---|
| `CoworkSessionDetail.types.ts` | 所有共享类型定义（`ConversationTurn`、`ToolGroupItem` 等） |
| `CoworkSessionDetail.utils.ts` | 纯函数（`buildConversationTurns`、`formatToolInput` 等 ~30 个） |
| `CoworkSessionDetail.hooks.ts` | 复杂状态逻辑（`useScrollBehavior`、`useRenameSession`、`useExportImage` 等 6 个 Hook） |
| `components/CopyButton.tsx` | 复制按钮子组件 |
| `components/ToolCallGroup.tsx` | 工具调用渲染子组件 |
| `components/UserMessageItem.tsx` | 用户消息渲染子组件 |
| `components/StreamingActivityBar.tsx` | 流式状态栏子组件 |
| `components/AssistantTurnBlock.tsx` | 助手消息块子组件 |

### 主文件瘦身

`CoworkSessionDetail.tsx`：**2100+ 行 → ~350 行**，仅保留编排逻辑。

### 向后兼容

主文件通过 `re-export` 重新导出所有公共类型和函数，**其他模块无需修改任何导入路径**。

---

## 性能优化

- 所有消息渲染路径的子组件均包裹 `React.memo`
- 流式输出期间，历史消息节点不再因顶层 `isStreaming` 状态变化而重渲染
- `buildConversationTurns` / `buildDisplayItems` 通过 `useMemo` 缓存，避免重复计算

---

## 其他修复

- 清理 3 处预存的无效 `eslint-disable` 注释（`nimGateway.ts`、`xiaomifengGateway.ts`、`openclawRuntimeAdapter.ts`）

---

## 验证

- [x] `npx tsc --noEmit` — 0 TypeScript 错误
- [x] `npm run lint` — 0 ESLint 错误
- [ ] 手动验证：会话切换、重命名、置顶/取消置顶、图片导出