### PR TITLE
SQLite 存储层三个数据完整性/可靠性缺陷：CASCADE 失效致孤儿消息累积、save() 非原子写致崩溃损坏、storeInitPromise 超时后永久故障

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -691,6 +691,11 @@ export class CoworkStore {
 
   deleteSession(id: string): void {
     this.markMemorySourcesInactiveBySession(id);
+    // Explicitly delete child messages before the session row.
+    // CASCADE should handle this when PRAGMA foreign_keys = ON, but older
+    // databases may have been created without that pragma, so we delete
+    // defensively to avoid orphan accumulation.
+    this.db.run('DELETE FROM cowork_messages WHERE session_id = ?', [id]);
     this.db.run('DELETE FROM cowork_sessions WHERE id = ?', [id]);
     this.markOrphanImplicitMemoriesStale();
     this.saveDb();
@@ -702,6 +707,8 @@ export class CoworkStore {
       this.markMemorySourcesInactiveBySession(id);
     }
     const placeholders = ids.map(() => '?').join(',');
+    // Explicitly delete child messages before session rows (see deleteSession comment).
+    this.db.run(`DELETE FROM cowork_messages WHERE session_id IN (${placeholders})`, ids);
     this.db.run(`DELETE FROM cowork_sessions WHERE id IN (${placeholders})`, ids);
     this.markOrphanImplicitMemoriesStale();
     this.saveDb();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -578,7 +578,12 @@ const initStore = async (): Promise<SqliteStore> => {
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('Store initialization timed out after 15s')), 15_000)
       ),
-    ]);
+    ]).catch((err) => {
+      // Reset the cached promise so that subsequent calls can retry
+      // instead of permanently returning the same rejected promise.
+      storeInitPromise = null;
+      throw err;
+    });
   }
   return storeInitPromise;
 };

--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -68,6 +68,10 @@ export class SqliteStore {
   }
 
   private initializeTables(basePath: string) {
+    // Enable foreign key enforcement so that ON DELETE CASCADE actually works.
+    // SQLite has this OFF by default; without it, cascade constraints are ignored.
+    this.db.run('PRAGMA foreign_keys = ON;');
+
     this.db.run(`
       CREATE TABLE IF NOT EXISTS kv (
         key TEXT PRIMARY KEY,
@@ -304,7 +308,19 @@ export class SqliteStore {
   save() {
     const data = this.db.export();
     const buffer = Buffer.from(data);
-    fs.writeFileSync(this.dbPath, buffer);
+    // Atomic write: write to a temporary file first, then rename.
+    // A direct writeFileSync can leave a truncated/corrupt database if the
+    // process crashes or is killed mid-write.  Rename is atomic on the same
+    // filesystem, so readers always see either the old or the new complete file.
+    const tmpPath = `${this.dbPath}.tmp-${Date.now()}`;
+    try {
+      fs.writeFileSync(tmpPath, buffer);
+      fs.renameSync(tmpPath, this.dbPath);
+    } catch (err) {
+      // Clean up the temp file on failure so it does not accumulate.
+      try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+      throw err;
+    }
   }
 
   onDidChange<T = unknown>(key: string, callback: (newValue: T | undefined, oldValue: T | undefined) => void) {


### PR DESCRIPTION
关联 Issue
Closes #1071

 修复内容
本 PR 修复 SQLite 存储层三个数据完整性/可靠性缺陷：
 1. 启用 `PRAGMA foreign_keys` + 防御性显式删除子行
- **`src/main/sqliteStore.ts`**：在 `initializeTables()` 开头添加 `PRAGMA foreign_keys = ON`，使 `ON DELETE CASCADE` 约束生效
- **`src/main/coworkStore.ts`**：在 `deleteSession()` 和 `deleteSessions()` 中，于删除 session 行之前显式删除 `cowork_messages` 子行，作为防御性兜底（兼容未启用 pragma 的旧数据库）
 2. `save()` 改用原子写入
- **`src/main/sqliteStore.ts`**：将 `fs.writeFileSync(this.dbPath, buffer)` 替换为 tmp 文件 + `fs.renameSync` 的原子写模式，与项目中 `openclawConfigSync.ts` 的 `atomicWriteFile()` 保持一致。写入失败时清理临时文件。
 3. `storeInitPromise` 超时后重置
- **`src/main/main.ts`**：在 `Promise.race` 后链接 `.catch()` 将 `storeInitPromise` 重置为 `null`，允许后续调用重试初始化，而非永久返回同一个 rejected promise。

 测试
- `npx tsc -p electron-tsconfig.json --noEmit` 编译通过