### PR TITLE
应用缺少 React 渲染异常的顶层兜底机制，任何组件 render 抛错都会导致整个界面白屏且无法恢复

### DIFF
--- a/src/renderer/components/ErrorBoundary.test.ts
+++ b/src/renderer/components/ErrorBoundary.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for ErrorBoundary state machine logic.
+ *
+ * Logic is mirrored inline because the ErrorBoundary component does not exist
+ * yet (RED phase of TDD). Any change to the component's state machine must be
+ * reflected here.
+ */
+import { test, expect, describe } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mirrors from ErrorBoundary (to be implemented)
+// ---------------------------------------------------------------------------
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+function deriveStateFromError(error: Error): ErrorBoundaryState {
+  return { hasError: true, error };
+}
+
+function resetState(): ErrorBoundaryState {
+  return { hasError: false, error: null };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ErrorBoundary state machine', () => {
+  test('initial state has no error', () => {
+    const state = resetState();
+    expect(state.hasError).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  test('deriveStateFromError captures the thrown error', () => {
+    const err = new Error('something broke');
+    const state = deriveStateFromError(err);
+    expect(state.hasError).toBe(true);
+    expect(state.error).toBe(err);
+    expect(state.error?.message).toBe('something broke');
+  });
+
+  test('deriveStateFromError handles TypeError (common render crash)', () => {
+    const err = new TypeError('Cannot read properties of undefined');
+    const state = deriveStateFromError(err);
+    expect(state.hasError).toBe(true);
+    expect(state.error).toBeInstanceOf(TypeError);
+  });
+
+  test('resetState clears error and returns to normal', () => {
+    const err = new Error('transient failure');
+    const errorState = deriveStateFromError(err);
+    expect(errorState.hasError).toBe(true);
+
+    const recovered = resetState();
+    expect(recovered.hasError).toBe(false);
+    expect(recovered.error).toBeNull();
+  });
+
+  test('full lifecycle: normal → error → recovery', () => {
+    // 1. initial (normal)
+    const initial = resetState();
+    expect(initial.hasError).toBe(false);
+    expect(initial.error).toBeNull();
+
+    // 2. error
+    const err = new Error('render failed');
+    const errored = deriveStateFromError(err);
+    expect(errored.hasError).toBe(true);
+    expect(errored.error).toBe(err);
+
+    // 3. recovery
+    const recovered = resetState();
+    expect(recovered.hasError).toBe(false);
+    expect(recovered.error).toBeNull();
+  });
+
+  test('multiple consecutive errors are handled', () => {
+    const err1 = new Error('first crash');
+    const state1 = deriveStateFromError(err1);
+    expect(state1.hasError).toBe(true);
+    expect(state1.error?.message).toBe('first crash');
+
+    // reset between errors
+    const mid = resetState();
+    expect(mid.hasError).toBe(false);
+    expect(mid.error).toBeNull();
+
+    const err2 = new RangeError('second crash');
+    const state2 = deriveStateFromError(err2);
+    expect(state2.hasError).toBe(true);
+    expect(state2.error?.message).toBe('second crash');
+  });
+});

--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error('[ErrorBoundary] uncaught render error:', error, errorInfo);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="h-screen flex flex-col items-center justify-center dark:bg-claude-darkBg bg-claude-bg gap-4">
+          <div className="text-4xl">⚠️</div>
+          <div className="dark:text-claude-darkText text-claude-text text-xl font-medium">
+            页面发生错误
+          </div>
+          <div className="dark:text-claude-darkTextSecondary text-claude-textSecondary text-sm text-center max-w-sm px-4">
+            应用渲染时遇到了意外错误
+          </div>
+          <button
+            onClick={() => window.location.reload()}
+            className="px-4 py-2 bg-claude-accent text-white rounded-lg text-sm hover:opacity-90 transition-opacity"
+          >
+            重新加载
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { store } from './store';
 import App from './App';
+import ErrorBoundary from './components/ErrorBoundary';
 import './index.css';
 
 const rootElement = document.getElementById('root');
@@ -12,11 +13,13 @@ if (!rootElement) {
 
 try {
   ReactDOM.createRoot(rootElement).render(
-    <React.StrictMode>
-      <Provider store={store}>
-        <App />
-      </Provider>
-    </React.StrictMode>
+    <ErrorBoundary>
+      <React.StrictMode>
+        <Provider store={store}>
+          <App />
+        </Provider>
+      </React.StrictMode>
+    </ErrorBoundary>
   );
 } catch (error) {
   console.error('Failed to render the app:', error);

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1110,6 +1110,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
     privacyDialogLinkText: '网易有道LobsterAI服务协议',
     privacyDialogAccept: '我已阅读并同意',
     privacyDialogReject: '拒绝',
+
+    // ErrorBoundary
+    errorBoundaryTitle: '页面发生错误',
+    errorBoundaryMessage: '应用渲染时遇到了意外错误',
+    errorBoundaryReload: '重新加载',
   },
   en: {
     // Common
@@ -2214,6 +2219,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
     privacyDialogLinkText: 'NetEase Youdao LobsterAI Terms of Service',
     privacyDialogAccept: 'I have read and agree',
     privacyDialogReject: 'Decline',
+
+    // Error boundary
+    errorBoundaryTitle: 'Something went wrong',
+    errorBoundaryMessage: 'The application encountered an unexpected error',
+    errorBoundaryReload: 'Reload',
   }
 };
 


### PR DESCRIPTION
概述
- 新增顶层 React ErrorBoundary 组件，捕获渲染阶段异常，展示降级 UI 替代白屏
 问题描述
应用缺少 React 渲染异常的顶层兜底机制。当任何组件在 render 阶段抛出异常时（例如 AI 返回的畸形消息数据导致 TypeError），React 会卸载整棵组件树，用户看到的是一个空白的 Electron 窗口，只能强制关闭并重启应用。Electron 的 `render-process-gone` 进程级崩溃恢复对此无效，因为 JS 异常不会触发进程崩溃事件。
 解决方案
- 新增 `ErrorBoundary` class 组件（`src/renderer/components/ErrorBoundary.tsx`），在 `main.tsx` 中包裹整棵 React 树，位于 `<Provider>` 和 `<StrictMode>` 之外
- 降级 UI 展示中文错误提示和"重新加载"按钮，完全自包含，不依赖任何 service/store/i18n（确保应用异常状态下仍可正常渲染）
- `componentDidCatch` 通过 `console.error` 记录错误信息，遵循项目日志规范
- i18n 的 zh/en 两个语言块均新增对应翻译 key（备用）
- 按照项目现有 vitest/node 环境测试模式，新增状态机逻辑的单元测试
 变更文件
| 文件 | 变更 |
|------|------|
| `src/renderer/components/ErrorBoundary.tsx` | 新增 — 50 行 class 组件 |
| `src/renderer/components/ErrorBoundary.test.ts` | 新增 — 6 个单元测试 |
| `src/renderer/services/i18n.ts` | 新增 3 个 i18n key（zh + en） |
| `src/renderer/main.tsx` | 用 `<ErrorBoundary>` 包裹组件树 |
 验证结果
- `npm test -- ErrorBoundary` → 6/6 通过
- `npx tsc --noEmit` → 无错误
- `npm run lint` → 无新增错误
- `npm run build` → 构建成功
- `npm run electron:dev` → 应用正常启动
- React DevTools 确认 ErrorBoundary 在组件树中就位，状态 `{hasError: false, error: null}`