### PR TITLE
fix(scheduled-task): Run History 迁移写入失败后仍标记完成 → 数据永久丢失

### DIFF
--- a/src/scheduled-task/migrate.ts
+++ b/src/scheduled-task/migrate.ts
@@ -315,6 +315,7 @@ export async function migrateScheduledTaskRunsToOpenclaw(
 
   let succeeded = 0;
   let skipped = 0;
+  let writeErrors = 0;
 
   // 5. Group runs by task_id (used as-is for the JSONL filename)
   const runsByTaskId = new Map<string, LegacyRunRow[]>();
@@ -370,10 +371,13 @@ export async function migrateScheduledTaskRunsToOpenclaw(
         fs.appendFileSync(jsonlPath, lines.join('\n') + '\n', 'utf-8');
       } catch (err) {
         console.error(`[MigrateRunHistory] Failed to write runs for task ${taskId}:`, err);
+        writeErrors++;
       }
     }
   }
 
-  console.log(`[MigrateRunHistory] Done. succeeded=${succeeded}, skipped=${skipped}`);
-  setKv(RUN_HISTORY_MIGRATION_KEY, 'true');
+  console.log(`[MigrateRunHistory] Done. succeeded=${succeeded}, skipped=${skipped}, writeErrors=${writeErrors}`);
+  if (writeErrors === 0) {
+    setKv(RUN_HISTORY_MIGRATION_KEY, 'true');
+  }
 }


### PR DESCRIPTION
位置：src/scheduled-task/migrate.ts，migrateScheduledTaskRunsToOpenclaw() 函数

问题：将旧版 SQLite 中的定时任务执行记录迁移到 OpenClaw JSONL 文件时，如果某个 task 的 JSONL 写入失败（磁盘满、权限不足等），代码仅打

根因：缺少写入错误计数，setKv(key, 'true') 放在循环外无条件