### PR TITLE
 fix: 删除当前 agent 后自动刷新任务列表

### DIFF
--- a/src/renderer/services/agent.ts
+++ b/src/renderer/services/agent.ts
@@ -9,6 +9,7 @@ import {
 } from '../store/slices/agentSlice';
 import { setActiveSkillIds, clearActiveSkills } from '../store/slices/skillSlice';
 import { clearCurrentSession } from '../store/slices/coworkSlice';
+import { coworkService } from './cowork';
 import type { Agent, PresetAgent } from '../types/agent';
 
 class AgentService {
@@ -100,8 +101,15 @@ class AgentService {
 
   async deleteAgent(id: string): Promise<boolean> {
     try {
+      const currentAgentId = store.getState().agent.currentAgentId;
       await window.electron?.agents?.delete(id);
       store.dispatch(removeAgent(id));
+      // If the deleted agent was the current agent, the removeAgent reducer
+      // will auto-switch to 'main'. We need to refresh sessions for the new current agent.
+      if (currentAgentId === id) {
+        const newCurrentAgentId = store.getState().agent.currentAgentId;
+        await coworkService.loadSessions(newCurrentAgentId);
+      }
       return true;
     } catch (error) {
       console.error('Failed to delete agent:', error);


### PR DESCRIPTION
### 问题描述
在 Agent 设置面板中删除 agent 时，如果删除的是当前正在使用的 agent：
1. UI 会正确自动切换到 main agent（由 removeAgent reducer 处理）
2. 但左侧边栏的任务列表不会自动刷新
3. 导致仍然显示已删除 agent 的任务列表，而不是 main agent 的任务列表

修复前效果：
![POPO_RECORDER_20260330213837](https://github.com/user-attachments/assets/1b4699f7-36c8-4935-9b6c-4b4bec4cc1a5)


### 解决方案
在 AgentService.deleteAgent() 中，dispatch removeAgent 后，检查被删除的 agent 是否是当前正在使用的。如果是，则调用 coworkService.loadSessions() 并传入新的当前 agent ID，以刷新任务列表。
变更内容
- src/renderer/services/agent.ts: 添加 coworkService 导入，并在 deleteAgent() 中添加任务列表刷新逻辑

### 测试步骤
1. 创建多个 agent
2. 切换到非 main 的 agent
3. 打开 Agent 设置并删除当前 agent
5. 验证：
   - [x] 当前 agent 自动切换为 main
   - [x] 左侧边栏任务列表刷新为 main agent 的任务列表

Closed #1068

优化后效果：
![POPO_RECORDER_20260330213012](https://github.com/user-attachments/assets/cc19b2dc-3b9e-4a5e-a6be-2cd92d311782)
