### PR TITLE
feat(scheduled-task): 定时任务执行失败时向 IM 推送告警通知

### DIFF
--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -898,6 +898,18 @@ export class IMCoworkHandler extends EventEmitter {
     this.clearPendingPermissionsBySessionId(sessionId);
     const accumulator = this.messageAccumulators.get(sessionId);
     if (accumulator) {
+      // For cron-triggered background deliveries, relay failure notification to IM
+      // so the user is aware the scheduled task failed (symmetric with success path).
+      if (accumulator.backgroundDelivery && this.sendAsyncReply) {
+        const errorText = `⚠️ Scheduled task execution failed: ${error}`;
+        void this.sendAsyncReply(
+          accumulator.backgroundDelivery.platform,
+          accumulator.backgroundDelivery.conversationId,
+          errorText,
+        ).catch((sendErr) => {
+          console.error('[IMCoworkHandler] Failed to relay scheduled task error notification:', sendErr);
+        });
+      }
       this.cleanupAccumulator(sessionId);
       accumulator.reject?.(new Error(error));
     }


### PR DESCRIPTION
当前定时任务（cron job）的执行结果投递存在不对称问题：

✅ 成功时：通过 handleComplete() → sendAsyncReply() 将 Agent 回复投递到 IM 平台
❌ 失败时：handleError() 只 reject 了 Promise 并清理 accumulator，没有向 IM 发送任何通知
这意味着用户必须主动打开定时任务页面才能发现任务失败，容易遗漏。