### PR TITLE
fix(cowork): 修复 continueSession 失败时向用户展示两条重复错误消息

### DIFF
--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -292,17 +292,6 @@ class CoworkService {
       }
       if (result.code !== 'ENGINE_NOT_READY') {
         store.dispatch(updateSessionStatus({ sessionId: options.sessionId, status: 'error' }));
-        if (result.error) {
-          store.dispatch(addMessage({
-            sessionId: options.sessionId,
-            message: {
-              id: `error-${Date.now()}`,
-              type: 'system',
-              content: i18nService.t('coworkErrorSessionContinueFailed').replace('{error}', result.error),
-              timestamp: Date.now(),
-            },
-          }));
-        }
       }
       // Show a user-visible error message in the session
       if (result.error) {


### PR DESCRIPTION
问题
continueSession() 失败时（非 ENGINE_NOT_READY 场景），代码中有两处独立的 addMessage 调用会依次执行：

第一处（行 295-305）：使用 coworkErrorSessionContinueFailed 模板
第二处（行 308-321）：使用 classifyError() 分类
导致用户在会话中看到两条不同格式的错误消息，造成困惑。

对比 startSession() 只有一处 addMessage，不存在此问题。

修复
移除第一处重复的 addMessage 调用，保留第二处更通用的错误处理块（已覆盖 ENGINE_NOT_READY 和普通错误两种场景），与 startSession() 的错误处理模式保持一致。

变更文件
src/renderer/services/cowork.ts (-11 行)