### PR TITLE
feat(settings): replace shortcut text input with keyboard recorder

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -412,6 +412,81 @@ const joinWorkspacePath = (dir: string | undefined, filename: string): string =>
     : `${base}${sep}${filename}`;
 };
 
+// System shortcuts that should not be captured (clipboard, undo, select-all, quit, etc.)
+const isSystemShortcut = (e: KeyboardEvent): boolean => {
+  const key = e.key.toLowerCase();
+  if (e.metaKey && ['c', 'v', 'x', 'z', 'y', 'a', 'q', 'w'].includes(key)) return true;
+  if (e.metaKey && e.shiftKey && key === 'z') return true;
+  if (e.ctrlKey && ['c', 'v', 'x', 'z', 'y', 'a', 'w'].includes(key)) return true;
+  return false;
+};
+
+const formatShortcutFromEvent = (e: React.KeyboardEvent): string | null => {
+  // Skip standalone modifier keys
+  if (['Meta', 'Control', 'Alt', 'Shift'].includes(e.key)) return null;
+  // Require at least one non-Shift modifier
+  if (!e.metaKey && !e.ctrlKey && !e.altKey) return null;
+  if (isSystemShortcut(e.nativeEvent)) return null;
+
+  const parts: string[] = [];
+  if (e.metaKey) parts.push('Cmd');
+  if (e.ctrlKey) parts.push('Ctrl');
+  if (e.altKey) parts.push('Alt');
+  if (e.shiftKey) parts.push('Shift');
+
+  const keyMap: Record<string, string> = {
+    ArrowUp: 'Up', ArrowDown: 'Down', ArrowLeft: 'Left', ArrowRight: 'Right',
+    ' ': 'Space', Escape: 'Esc', Enter: 'Enter', Backspace: 'Backspace',
+    Delete: 'Delete', Tab: 'Tab',
+  };
+  const key = keyMap[e.key] ?? (e.key.length === 1 ? e.key.toUpperCase() : e.key);
+  parts.push(key);
+  return parts.join('+');
+};
+
+const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void }> = ({ value, onChange }) => {
+  const [recording, setRecording] = useState(false);
+  const divRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!recording) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.key === 'Escape') { setRecording(false); return; }
+    if (e.key === 'Delete' || e.key === 'Backspace') { onChange(''); setRecording(false); return; }
+    const shortcut = formatShortcutFromEvent(e);
+    if (shortcut) { onChange(shortcut); setRecording(false); }
+  };
+
+  useEffect(() => {
+    if (!recording) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (divRef.current && !divRef.current.contains(e.target as Node)) setRecording(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [recording]);
+
+  return (
+    <div
+      ref={divRef}
+      tabIndex={0}
+      data-shortcut-input="true"
+      onKeyDown={handleKeyDown}
+      onClick={() => setRecording(true)}
+      onBlur={() => setRecording(false)}
+      className={`w-36 rounded-xl border px-3 py-1.5 text-sm cursor-pointer select-none text-center outline-none transition-colors
+        dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset dark:text-claude-darkText text-claude-text
+        ${recording
+          ? 'border-claude-accent ring-1 ring-claude-accent/30 dark:text-claude-darkTextSecondary text-claude-textSecondary'
+          : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
+        }`}
+    >
+      {value || i18nService.t('shortcutNotSet')}
+    </div>
+  );
+};
+
 const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpdateFound }) => {
   const dispatch = useDispatch();
   // 状态
@@ -3171,33 +3246,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('newChat')}</span>
-                  <input
-                    type="text"
-                    value={shortcuts.newChat}
-                    onChange={(e) => handleShortcutChange('newChat', e.target.value)}
-                    data-shortcut-input="true"
-                    className="w-32 rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-1.5 text-sm"
-                  />
+                  <ShortcutRecorder value={shortcuts.newChat} onChange={(v) => handleShortcutChange('newChat', v)} />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('search')}</span>
-                  <input
-                    type="text"
-                    value={shortcuts.search}
-                    onChange={(e) => handleShortcutChange('search', e.target.value)}
-                    data-shortcut-input="true"
-                    className="w-32 rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-1.5 text-sm"
-                  />
+                  <ShortcutRecorder value={shortcuts.search} onChange={(v) => handleShortcutChange('search', v)} />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('openSettings')}</span>
-                  <input
-                    type="text"
-                    value={shortcuts.settings}
-                    onChange={(e) => handleShortcutChange('settings', e.target.value)}
-                    data-shortcut-input="true"
-                    className="w-32 rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-1.5 text-sm"
-                  />
+                  <ShortcutRecorder value={shortcuts.settings} onChange={(v) => handleShortcutChange('settings', v)} />
                 </div>
               </div>
             </div>

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -141,6 +141,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
+    shortcutNotSet: '未设置',
     newChat: '新建任务',
     search: '搜索任务',
     openSettings: '打开设置',
@@ -1316,6 +1317,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
+    shortcutNotSet: 'Not set',
     newChat: 'New Task',
     search: 'Search Tasks',
     openSettings: 'Open Settings',


### PR DESCRIPTION
## Summary
- Merge PR #845 into release/2026.03.31
- 将快捷键设置从文本输入改为键盘录制器，用户按下组合键即可录入，无需手动输入文本

## Test plan
- [ ] 设置页快捷键配置区域，点击录制按钮后按下组合键，确认能正确识别并保存
- [ ] 验证各种修饰键组合（Ctrl/Alt/Shift/Meta + 字母/数字/功能键）

🤖 Generated with [Claude Code](https://claude.com/claude-code)