### PR TITLE
[Bug] IM 消息并发处理导致重复会话创建和消息响应丢失

### DIFF
--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -83,6 +83,14 @@ export class IMCoworkHandler extends EventEmitter {
   private imSessionIds: Set<string> = new Set();
   private sessionConversationMap: Map<string, { conversationId: string; platform: Platform }> = new Map();
   private pendingPermissionByConversation: Map<string, PendingIMPermission> = new Map();
+
+  // Per-conversation async mutex that serializes message processing.
+  // Without this, two messages arriving simultaneously for the same
+  // conversation can race through getOrCreateCoworkSession() and create
+  // duplicate cowork sessions (the second overwrites the mapping, orphaning
+  // the first).  Sequential messages also replace the active accumulator,
+  // silently dropping the in-flight response for the earlier message.
+  private conversationLocks: Map<string, Promise<unknown>> = new Map();
   private readonly onMessage = this.handleMessage.bind(this);
   private readonly onMessageUpdate = this.handleMessageUpdate.bind(this);
   private readonly onPermissionRequest = this.handlePermissionRequest.bind(this);
@@ -150,6 +158,43 @@ export class IMCoworkHandler extends EventEmitter {
    * Process an incoming IM message using CoworkRuntime
    */
   async processMessage(message: IMMessage): Promise<string> {
+    // Serialize processing per conversation so that concurrent messages
+    // for the same IM thread don't race through session creation or
+    // replace each other's response accumulators.
+    return this.withConversationLock(
+      message.conversationId,
+      message.platform,
+      () => this.processMessageUnlocked(message)
+    );
+  }
+
+  /**
+   * Serialize async work per IM conversation.  Concurrent calls for the
+   * same conversation are queued; each waits for the previous one to
+   * settle before executing.
+   */
+  private async withConversationLock<T>(
+    conversationId: string,
+    platform: Platform,
+    fn: () => Promise<T>
+  ): Promise<T> {
+    const key = `${platform}:${conversationId}`;
+    const prev = this.conversationLocks.get(key) ?? Promise.resolve();
+    // Chain after the previous call regardless of its outcome.
+    const current = prev.then(fn, fn);
+    this.conversationLocks.set(key, current);
+    try {
+      return await current;
+    } finally {
+      // Clean up the map entry once the chain has fully drained,
+      // so we don't leak entries for inactive conversations.
+      if (this.conversationLocks.get(key) === current) {
+        this.conversationLocks.delete(key);
+      }
+    }
+  }
+
+  private async processMessageUnlocked(message: IMMessage): Promise<string> {
     const pendingPermissionReply = await this.handlePendingPermissionReply(message);
     if (pendingPermissionReply !== null) {
       return pendingPermissionReply;
@@ -988,7 +1033,7 @@ export class IMCoworkHandler extends EventEmitter {
       if (accumulator.timeoutId) {
         clearTimeout(accumulator.timeoutId);
       }
-      accumulator.reject(new Error('Handler destroyed'));
+      accumulator.reject?.(new Error('Handler destroyed'));
     });
     this.messageAccumulators.clear();
     this.imSessionIds.clear();


### PR DESCRIPTION
## 关联 Issue
Closes #1099

## 修改内容
### 1. Per-conversation 异步互斥锁
新增 `conversationLocks: Map<string, Promise>` 和 `withConversationLock()` 方法，对同一 IM 会话的消息处理实现串行化。原 `processMessage()` 拆分为入口方法（加锁）和 `processMessageUnlocked()`（原逻辑），确保：
- 同一会话的并发消息排队执行，避免 `getOrCreateCoworkSession()` 竞态导致重复会话
- 前一条消息的 accumulator 不会被后一条覆盖，消息响应不再丢失
- 锁粒度为 `platform:conversationId`，不同会话之间互不阻塞
- 链式排队无论前序成功/失败都继续执行后续消息
- 链条完全消耗后自动清理 Map 条目，不泄漏内存
### 2. destroy() TypeError 修复
`accumulator.reject(...)` 改为 `accumulator.reject?.(...)` 添加可选链，防止 background accumulator 无 reject 回调时抛出 TypeError。

## 测试
- TypeScript 编译通过（`npx tsc -p electron-tsconfig.json --noEmit`）
- 修改范围限于 `imCoworkHandler.ts`，不影响其他模块