### PR TITLE
fix(cowork): 修复跨 provider 切换模型后立即发消息报错「模型服务调用失败」的竞态条件

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -22,6 +22,7 @@ import { scheduledTaskService } from './services/scheduledTask';
 import { checkForAppUpdate, type AppUpdateInfo, type AppUpdateDownloadProgress, UPDATE_POLL_INTERVAL_MS, UPDATE_HEARTBEAT_INTERVAL_MS } from './services/appUpdate';
 import { defaultConfig } from './config';
 import { setAvailableModels, setSelectedModel } from './store/slices/modelSlice';
+import { setStreaming } from './store/slices/coworkSlice';
 import { clearSelection } from './store/slices/quickActionSlice';
 import type { ApiConfig } from './services/api';
 import type { CoworkPermissionResult } from './types/cowork';
@@ -213,12 +214,19 @@ const App: React.FC = () => {
     ) {
       return;
     }
-    void configService.updateConfig({
+    // Dispatch setStreaming(true) to disable the send button while the config
+    // sync (and possible gateway restart for cross-provider switches) completes.
+    // Without this, the user can fire a request before the new provider's API key
+    // is available, causing a "model service call failed" error.
+    store.dispatch(setStreaming(true));
+    configService.updateConfig({
       model: {
         ...config.model,
         defaultModel: selectedModel.id,
         defaultModelProvider: selectedModel.providerKey,
       },
+    }).finally(() => {
+      store.dispatch(setStreaming(false));
     });
   }, [isInitialized, selectedModel?.id, selectedModel?.providerKey]);
 


### PR DESCRIPTION
问题
跨 provider 切换模型（如 Anthropic → DeepSeek）后立即输入提示词，偶发报错「模型服务调用失败」，重试则成功。

根因
App.tsx 中模型切换触发的 configService.updateConfig() 使用 void 丢弃了 Promise（fire-and-forget）。跨 provider 切换时，store:set IPC handler 内部会触发 syncOpenClawConfig()，检测到 API key 环境变量变化后重启 gateway。但由于不等待完成，用户可以在 gateway 重启期间发送消息，导致请求打到正在关闭或尚未就绪的 gateway。