### PR TITLE
[Bug] 钉钉定时任务 IM 通知路由因含前缀的 conversationId 始终无法送达

### DIFF
--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -104,8 +104,13 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
             const imStore = getIMGatewayManager()?.getIMStore();
             const mapping = imStore?.getSessionMapping(rawTo, platform);
             if (mapping) {
+              // Use the stripped delivery.to (without subtype prefix) as the
+              // conversationId for primeConversationReplyRoute.  rawTo still
+              // carries the "direct:"/"group:" prefix that the IM store uses
+              // as its key, but the reply-route registry expects the bare
+              // platform conversation ID (e.g. "ou_xxx", not "direct:ou_xxx").
               await getIMGatewayManager()!.primeConversationReplyRoute(
-                platform, rawTo, mapping.coworkSessionId,
+                platform, delivery.to, mapping.coworkSessionId,
               );
             }
           }
@@ -152,8 +157,13 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
             const imStore = getIMGatewayManager()?.getIMStore();
             const mapping = imStore?.getSessionMapping(rawTo, platform);
             if (mapping) {
+              // Use the stripped delivery.to (without subtype prefix) as the
+              // conversationId for primeConversationReplyRoute.  rawTo still
+              // carries the "direct:"/"group:" prefix that the IM store uses
+              // as its key, but the reply-route registry expects the bare
+              // platform conversation ID (e.g. "ou_xxx", not "direct:ou_xxx").
               await getIMGatewayManager()!.primeConversationReplyRoute(
-                platform, rawTo, mapping.coworkSessionId,
+                platform, delivery.to, mapping.coworkSessionId,
               );
             }
           }


### PR DESCRIPTION
## 关联 Issue
Closes #1105

## 修改内容
`src/main/ipcHandlers/scheduledTask/handlers.ts` 中 Create 和 Update 两个 handler 里，`primeConversationReplyRoute()` 调用由传 `rawTo`（含 `direct:`/`group:` 前缀）改为传 `delivery.to`（已剥离前缀）。
`getSessionMapping()` 仍正确使用 `rawTo` 作为 IM Store 的查找键，只有 `primeConversationReplyRoute` 的参数被修正。

## 测试
- TypeScript 编译通过（`npx tsc -p electron-tsconfig.json --noEmit`）
- 修改范围限于 `handlers.ts`，2 处对称修改