### PR TITLE
feat(openclaw): flush deferred config sync when gateway workloads drain

### DIFF
--- a/src/main/ipcHandlers/scheduledTask/cronJobServiceManager.ts
+++ b/src/main/ipcHandlers/scheduledTask/cronJobServiceManager.ts
@@ -13,6 +13,8 @@ export interface CronJobServiceDeps {
     getGatewayClient: () => GatewayClientLike | null;
     ensureReady: () => Promise<void>;
   } | null;
+  /** Invoked when polling observes all cron jobs transitioned from running to idle. */
+  onRunningJobsDrained?: () => void;
 }
 
 let cronJobService: CronJobService | null = null;
@@ -34,6 +36,7 @@ export function getCronJobService(): CronJobService {
     cronJobService = new CronJobService({
       getGatewayClient: () => adapter.getGatewayClient(),
       ensureGatewayReady: () => adapter.ensureReady(),
+      onRunningJobsDrained: deps.onRunningJobsDrained,
     });
   }
   return cronJobService;

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -543,6 +543,7 @@ const waitWithTimeout = async (promise: Promise<void>, timeoutMs: number): Promi
 export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntime {
   private readonly store: CoworkStore;
   private readonly engineManager: OpenClawEngineManager;
+  private onGatewayWorkloadsMaybeIdle: (() => void) | null = null;
   private readonly activeTurns = new Map<string, ActiveTurn>();
   private readonly sessionIdBySessionKey = new Map<string, string>();
   private readonly sessionIdByRunId = new Map<string, string>();
@@ -625,6 +626,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
   setChannelSessionSync(sync: OpenClawChannelSessionSync): void {
     this.channelSessionSync = sync;
+  }
+
+  setOnGatewayWorkloadsMaybeIdle(cb: (() => void) | null): void {
+    this.onGatewayWorkloadsMaybeIdle = cb;
   }
 
   /**
@@ -3590,6 +3595,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   private cleanupSessionTurn(sessionId: string): void {
+    const hadActiveTurn = this.activeTurns.has(sessionId);
     const turn = this.activeTurns.get(sessionId);
     if (turn) {
       // Clear client-side timeout watchdog
@@ -3612,6 +3618,13 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       });
     }
     this.activeTurns.delete(sessionId);
+    if (hadActiveTurn && this.activeTurns.size === 0) {
+      try {
+        this.onGatewayWorkloadsMaybeIdle?.();
+      } catch (err) {
+        console.error('[OpenClawRuntime] onGatewayWorkloadsMaybeIdle failed:', err);
+      }
+    }
     setCoworkProxySessionId(null);
     // NOTE: Do NOT clear lastSystemPromptBySession here — it must persist
     // across turns so that the system prompt is only injected on the first

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -864,10 +864,12 @@ const getOpenClawConfigSync = (): OpenClawConfigSync => {
 
 // Deferred gateway restart: when a config change requires a gateway restart
 // but active cowork sessions or cron jobs exist, we defer the restart until
-// all workloads complete.  A polling interval checks periodically; a hard
-// timeout ensures the restart eventually happens even if a session hangs.
+// all workloads complete. OpenClawRuntimeAdapter and CronJobService call
+// tryFlushDeferredOpenClawConfigSync when workloads may have drained; a polling
+// interval remains as a fallback; a hard timeout forces sync if something hangs.
 let deferredRestartTimer: ReturnType<typeof setInterval> | null = null;
 let deferredRestartTimeout: ReturnType<typeof setTimeout> | null = null;
+let deferredRestartLatestReason = '';
 const DEFERRED_RESTART_POLL_MS = 3_000;
 const DEFERRED_RESTART_MAX_WAIT_MS = 5 * 60_000; // 5 minutes hard cap
 
@@ -893,29 +895,37 @@ const executeDeferredGatewayRestart = async (reason: string) => {
 };
 
 const scheduleDeferredGatewayRestart = (reason: string) => {
-  // If already scheduled, the latest config is already on disk — just let
-  // the existing timer handle the restart.
+  deferredRestartLatestReason = reason;
+  // Coalesce: SQLite already holds the latest cowork/IM settings; the deferred
+  // sync will regenerate openclaw.json from DB when workloads drain.
   if (deferredRestartTimer) {
-    console.log(`[OpenClaw] scheduleDeferredGatewayRestart: already scheduled, skipping (reason: ${reason})`);
+    console.debug(`[OpenClaw] scheduleDeferredGatewayRestart: already scheduled, coalescing (reason: ${reason})`);
     return;
   }
 
   deferredRestartTimer = setInterval(() => {
     if (!hasActiveGatewayWorkloads()) {
-      void executeDeferredGatewayRestart(reason);
+      void executeDeferredGatewayRestart(deferredRestartLatestReason || reason);
     }
   }, DEFERRED_RESTART_POLL_MS);
 
   // Hard timeout: restart anyway after max wait to avoid config drift.
   deferredRestartTimeout = setTimeout(() => {
     console.warn(`[OpenClaw] scheduleDeferredGatewayRestart: max wait exceeded, forcing restart (reason: ${reason})`);
-    void executeDeferredGatewayRestart(reason);
+    void executeDeferredGatewayRestart(deferredRestartLatestReason || reason);
   }, DEFERRED_RESTART_MAX_WAIT_MS);
+};
+
+/** When deferred sync is pending, run it as soon as no gateway workloads remain. */
+const tryFlushDeferredOpenClawConfigSync = (): void => {
+  if (!deferredRestartTimer && !deferredRestartTimeout) return;
+  if (hasActiveGatewayWorkloads()) return;
+  void executeDeferredGatewayRestart(deferredRestartLatestReason || 'workloads-idle');
 };
 
 const syncOpenClawConfig = async (
   options: { reason: string; restartGatewayIfRunning?: boolean } = { reason: 'unknown' },
-): Promise<{ success: boolean; changed: boolean; status?: OpenClawEngineStatus; error?: string }> => {
+): Promise<{ success: boolean; changed: boolean; status?: OpenClawEngineStatus; error?: string; deferred?: boolean }> => {
   // When the gateway is running and there are active workloads (cowork
   // sessions OR running cron jobs), defer the entire sync — including the
   // config file write — to avoid triggering OpenClaw's built-in file-watcher
@@ -930,6 +940,7 @@ const syncOpenClawConfig = async (
         success: true,
         changed: false,
         status,
+        deferred: true,
       };
     }
   }
@@ -1102,6 +1113,7 @@ const getCoworkEngineRouter = () => {
     }
     if (!openClawRuntimeAdapter) {
       openClawRuntimeAdapter = new OpenClawRuntimeAdapter(getCoworkStore(), getOpenClawEngineManager());
+      openClawRuntimeAdapter.setOnGatewayWorkloadsMaybeIdle(() => tryFlushDeferredOpenClawConfigSync());
       // Wire up channel session sync for IM conversations via OpenClaw
       try {
         const imManager = getIMGatewayManager();
@@ -3152,6 +3164,7 @@ if (!gotTheLock) {
       const switchedToOpenClaw = normalizedAgentEngine === 'openclaw'
         && previousConfig.agentEngine !== 'openclaw';
 
+      let openClawConfigSyncDeferred = false;
       const shouldSyncOpenClawConfig = normalizedExecutionMode !== undefined
         || normalizedAgentEngine !== undefined
         || (normalizedConfig.workingDirectory !== undefined && normalizedConfig.workingDirectory !== previousWorkingDir);
@@ -3168,6 +3181,9 @@ if (!gotTheLock) {
             engineStatus: syncResult.status || getOpenClawEngineManager().getStatus(),
           };
         }
+        if (syncResult.deferred) {
+          openClawConfigSyncDeferred = true;
+        }
       }
 
       if (switchedToOpenClaw) {
@@ -3175,7 +3191,10 @@ if (!gotTheLock) {
           console.error('[OpenClaw] Failed to auto-start gateway after engine switch:', error);
         });
       }
-      return { success: true };
+      return {
+        success: true,
+        ...(openClawConfigSyncDeferred ? { openClawConfigSyncDeferred: true as const } : {}),
+      };
     } catch (error) {
       return {
         success: false,
@@ -3188,6 +3207,7 @@ if (!gotTheLock) {
 
   initCronJobServiceManager({
     getOpenClawRuntimeAdapter: () => openClawRuntimeAdapter,
+    onRunningJobsDrained: () => tryFlushDeferredOpenClawConfigSync(),
   });
   initScheduledTaskHelpers({
     getIMGatewayManager: () => getIMGatewayManager() as any,

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -513,6 +513,11 @@ class CoworkService {
         store.dispatch(clearPendingPermissions());
         store.dispatch(setStreaming(false));
       }
+      if (result.openClawConfigSyncDeferred) {
+        window.dispatchEvent(new CustomEvent('app:showToast', {
+          detail: i18nService.t('coworkOpenClawConfigSyncDeferred'),
+        }));
+      }
       return true;
     }
 

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -540,6 +540,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionStartFailed: '会话启动失败：{error}',
     coworkErrorSessionContinueFailed: '发送消息失败：{error}',
     coworkErrorEngineNotReady: 'AI 引擎正在启动中，请稍等几秒后重试。',
+    coworkOpenClawConfigSyncDeferred:
+      '设置已保存。OpenClaw 配置将在当前会话或定时任务结束后自动同步到网关（必要时重启）。',
     coworkErrorUnknown: '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
 
     // Skills
@@ -1714,6 +1716,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionStartFailed: 'Failed to start session: {error}',
     coworkErrorSessionContinueFailed: 'Failed to send message: {error}',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
+    coworkOpenClawConfigSyncDeferred:
+      'Settings saved. OpenClaw config will sync to the gateway after active sessions or scheduled tasks finish (a restart may occur).',
     coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
 
     // Skills

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -348,7 +348,11 @@ interface IElectronAPI {
     }) => Promise<{ success: boolean; canceled?: boolean; path?: string; error?: string }>;
     respondToPermission: (options: { requestId: string; result: CoworkPermissionResult }) => Promise<{ success: boolean; error?: string }>;
     getConfig: () => Promise<{ success: boolean; config?: CoworkConfig; error?: string }>;
-    setConfig: (config: CoworkConfigUpdate) => Promise<{ success: boolean; error?: string }>;
+    setConfig: (config: CoworkConfigUpdate) => Promise<{
+      success: boolean;
+      error?: string;
+      openClawConfigSyncDeferred?: boolean;
+    }>;
     listMemoryEntries: (input: {
       query?: string;
       limit?: number;

--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -128,6 +128,7 @@ interface GatewayRunLogEntry {
 interface CronJobServiceDeps {
   getGatewayClient: () => GatewayClientLike | null;
   ensureGatewayReady: () => Promise<void>;
+  onRunningJobsDrained?: () => void;
 }
 
 function mapGatewayResultStatus(
@@ -391,6 +392,7 @@ function extractRunTitle(summary?: string): string | undefined {
 export class CronJobService {
   private readonly getGatewayClient: () => GatewayClientLike | null;
   private readonly ensureGatewayReady: () => Promise<void>;
+  private readonly onRunningJobsDrained?: () => void;
   private pollingTimer: ReturnType<typeof setInterval> | null = null;
   private lastKnownStates: Map<string, string> = new Map();
   private lastKnownRunAtMs: Map<string, number> = new Map();
@@ -406,6 +408,7 @@ export class CronJobService {
   constructor(deps: CronJobServiceDeps) {
     this.getGatewayClient = deps.getGatewayClient;
     this.ensureGatewayReady = deps.ensureGatewayReady;
+    this.onRunningJobsDrained = deps.onRunningJobsDrained;
   }
 
   /**
@@ -637,6 +640,8 @@ export class CronJobService {
       });
       const jobs = Array.isArray(result.jobs) ? result.jobs : [];
 
+      const hadRunningBeforePoll = this.runningJobIds.size > 0;
+
       // Refresh jobId → name cache for synchronous lookups (used by session naming).
       this.jobNameCache.clear();
       this.runningJobIds.clear();
@@ -644,6 +649,14 @@ export class CronJobService {
         this.jobNameCache.set(job.id, job.name);
         if (job.state.runningAtMs) {
           this.runningJobIds.add(job.id);
+        }
+      }
+
+      if (hadRunningBeforePoll && this.runningJobIds.size === 0) {
+        try {
+          this.onRunningJobsDrained?.();
+        } catch (err) {
+          console.error('[CronJobService] onRunningJobsDrained failed:', err);
         }
       }
 


### PR DESCRIPTION
## Summary

Builds on the existing behavior that **defers full OpenClaw config sync** while the gateway has active cowork turns or running cron jobs (to avoid file-watcher reload interrupting work).

### What changed

- **Immediate flush** when workloads likely drain:
  - `OpenClawRuntimeAdapter`: after the last in-flight turn cleans up, call into main to run deferred sync if pending.
  - `CronJobService`: when polling observes a transition from “some job running” to “none running”, trigger the same flush (still bounded by the existing ~15s poll granularity).
- **Coalescing**: track `deferredRestartLatestReason` so repeated deferrals while a timer is already scheduled update the reason; interval/timeout use the latest.
- **Comment fix**: clarify that the authoritative pending state is in SQLite until the deferred sync runs.
- **UX**: `cowork:config:set` returns `openClawConfigSyncDeferred` when sync was deferred; renderer shows an i18n toast (zh/en).

### Test plan

- [ ] `npm run compile:electron`
- [ ] With OpenClaw running and an active cowork turn, change execution mode or engine-related settings → expect toast when deferred; after turn ends, gateway sync/restart should run without waiting for the 3s poll (when the only blocker was cowork turns).