### PR TITLE
fix(win): change requestedExecutionLevel to asInvoker for auto-launcc

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -148,7 +148,7 @@
       "nsis"
     ],
     "icon": "build/icons/win/icon.ico",
-    "requestedExecutionLevel": "requireAdministrator",
+    "requestedExecutionLevel": "asInvoker",
     "extraResources": [
       {
         "from": "build-tar/win-resources.tar",


### PR DESCRIPTION
## Summary                                                           
                                                                       
  - Windows 开机自启动失败的根因是 `electron-builder.json` 中          
  `requestedExecutionLevel` 设置为 `requireAdministrator`，导致 Windows
   登录阶段无法弹出 UAC 对话框，应用静默启动失败                       
  - 将 `requestedExecutionLevel` 从 `requireAdministrator` 改为   
  `asInvoker`，使应用以普通用户权限启动，开机自启动恢复正常            
  - NSIS 安装器自身已有独立的 `RequestExecutionLevel
  admin`（`nsis-installer.nsh`），安装流程不受影响                     
                                                                  
  ## 影响范围                                                          
                                                                  
  - **自启动**：修复 `app.setLoginItemSettings()` 写入的 `HKCU\...\Run`
   注册表项在开机时被忽略的问题                                   
  - **安装**：无影响，NSIS 安装器仍以管理员权限运行（解压资源、添加    
  Defender 排除项等）                                                  
  - **更新**：无影响，更新流程通过重新运行 NSIS                      
  安装器实现，不依赖应用自身权限                                       
  - **运行时**：无影响，应用运行时所有写入操作均在用户目录（`%APPDATA%\
  LobsterAI\`、`%TEMP%`），对安装目录仅有读取操作                      
  - **macOS/Linux**：无影响，`requestedExecutionLevel` 仅作用于 Windows
                                                                       
  ## Test plan                                                         
                                                                       
  - [ ] Windows                                                        
  构建安装后，开启"开机自启动"选项，重启系统验证应用正常启动         
  - [ ] 验证安装到 Program Files 目录时应用可正常启动和运行            
  - [ ] 验证应用内更新流程正常（仍会弹出 UAC 提权）                    
  - [ ] macOS 构建和启动不受影响