### PR TITLE
[Feature] 会话出错后支持一键 Retry 重发最后一条消息

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -14,6 +14,7 @@ import {
   ExclamationTriangleIcon,
   ChevronRightIcon,
   PhotoIcon,
+  ArrowPathIcon,
 } from '@heroicons/react/24/outline';
 import { FolderIcon } from '@heroicons/react/24/solid';
 import { coworkService } from '../../services/cowork';
@@ -1292,6 +1293,21 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const isStreaming = useSelector((state: RootState) => state.cowork.isStreaming);
   const remoteManaged = useSelector((state: RootState) => state.cowork.remoteManaged);
   const skills = useSelector((state: RootState) => state.skill.skills);
+
+  // Retry: re-send the last user message when the session has errored.
+  const lastUserMessage = useMemo(() => {
+    if (!currentSession) return null;
+    const msgs = currentSession.messages;
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      if (msgs[i].type === 'user') return msgs[i];
+    }
+    return null;
+  }, [currentSession?.messages]);
+
+  const handleRetry = useCallback(() => {
+    if (!lastUserMessage || isStreaming) return;
+    void onContinue(lastUserMessage.content);
+  }, [lastUserMessage, isStreaming, onContinue]);
   const detailRootRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [shouldAutoScroll, setShouldAutoScroll] = useState(true);
@@ -2337,6 +2353,29 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
       {/* Streaming Activity Bar */}
       {isStreaming && <StreamingActivityBar messages={currentSession.messages} />}
+
+      {/* Error + Retry banner — shown when the session errored and has a retryable user message */}
+      {currentSession.status === 'error' && !isStreaming && lastUserMessage && (
+        <div className="px-4 pb-2 shrink-0">
+          <div className="max-w-3xl mx-auto flex items-center justify-between gap-3 px-3 py-2 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
+            <div className="flex items-center gap-2 min-w-0">
+              <ExclamationTriangleIcon className="h-4 w-4 text-red-500 flex-shrink-0" />
+              <span className="text-xs text-red-700 dark:text-red-400 truncate">
+                {i18nService.t('coworkSessionErrorBanner')}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={handleRetry}
+              title={i18nService.t('coworkSessionRetryTooltip')}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/40 hover:bg-red-200 dark:hover:bg-red-900/70 border border-red-200 dark:border-red-700 transition-colors flex-shrink-0"
+            >
+              <ArrowPathIcon className="h-3.5 w-3.5" />
+              {i18nService.t('coworkSessionRetry')}
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Input Area */}
       <div className="p-4 shrink-0">

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -541,6 +541,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionContinueFailed: '发送消息失败：{error}',
     coworkErrorEngineNotReady: 'AI 引擎正在启动中，请稍等几秒后重试。',
     coworkErrorUnknown: '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
+    coworkSessionErrorBanner: '任务执行出错',
+    coworkSessionRetry: '重试',
+    coworkSessionRetryTooltip: '重新发送最后一条消息',
 
     // Skills
     skills: '技能',
@@ -1715,6 +1718,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionContinueFailed: 'Failed to send message: {error}',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
     coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
+    coworkSessionErrorBanner: 'Task failed',
+    coworkSessionRetry: 'Retry',
+    coworkSessionRetryTooltip: 'Resend the last message',
 
     // Skills
     skills: 'Skills',


### PR DESCRIPTION
## 关联 Issue
Closes #1120

## 修改内容
**`src/renderer/components/cowork/CoworkSessionDetail.tsx`**
- 新增 `lastUserMessage` memo：从当前 session messages 逆序找到最后一条 `type === 'user'` 的消息
- 新增 `handleRetry` callback：调用 `onContinue(lastUserMessage.content)` 重发
- 新增错误横幅 JSX：`currentSession.status === 'error' && !isStreaming && lastUserMessage` 条件下渲染，包含 ExclamationTriangleIcon + 错误文案 + ArrowPathIcon + Retry 按钮
- 新增 `ArrowPathIcon` import（来自已有依赖 `@heroicons/react`）
**`src/renderer/services/i18n.ts`**
- 新增 zh/en 键：`coworkSessionErrorBanner`、`coworkSessionRetry`、`coworkSessionRetryTooltip`

## 测试
- TypeScript 编译通过（`npx tsc -p tsconfig.json --noEmit`）
- 修改 2 个文件，共 45 行新增