### PR TITLE
[Bug]表格Table的顶部和底部，有不明意义的留白

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -134,6 +134,10 @@ export default {
             strong: {
               color: '#1A1D23',
             },
+            table: {
+              marginTop: 0,
+              marginBottom: 0,
+            }
           },
         },
         dark: {


### PR DESCRIPTION
修改点：移除 Tailwind 配置中表格元素的上下外边距

问题截图：
<img width="784" height="367" alt="image" src="https://github.com/user-attachments/assets/b07199b4-0903-45f3-9c99-25f1cd8a2e89" />

期望截图：
<img width="601" height="305" alt="image" src="https://github.com/user-attachments/assets/d6ac425a-97f2-46d7-baf8-c70c38379241" />
