### PR TITLE
fix(mcp): cancel force-close timer in stop() to prevent closing new s…

### DIFF
--- a/src/main/libs/mcpBridgeServer.ts
+++ b/src/main/libs/mcpBridgeServer.ts
@@ -131,16 +131,18 @@ export class McpBridgeServer {
     if (!this.server) return;
 
     return new Promise((resolve) => {
+      // Force-close open connections after a short timeout if server hasn't closed yet
+      const forceCloseTimer = setTimeout(() => {
+        this.server?.closeAllConnections?.();
+      }, 2000);
+
       this.server!.close(() => {
+        clearTimeout(forceCloseTimer);
         log('INFO', 'McpBridgeServer stopped');
         this.server = null;
         this._port = null;
         resolve();
       });
-      // Force-close open connections after a short timeout
-      setTimeout(() => {
-        this.server?.closeAllConnections?.();
-      }, 2000);
     });
   }
 


### PR DESCRIPTION
问题是什么：
stop() 方法在第 141 行设置了一个 2 秒后强制关闭连接的 setTimeout，但没有保存定时器 ID，也没有在 server 关闭时取消它。
后果：
如果 stop() 完成后在 2 秒内又调用了 start() 创建了新 server，那个旧定时器触发时 this.server 已经指向新 server，closeAllConnections() 会错误地关闭新 server 的所有连接。