### PR TITLE
Merge fix/agent-skill-selector-i18n into release/2026.03.31

### DIFF
--- a/src/renderer/components/agent/AgentSkillSelector.tsx
+++ b/src/renderer/components/agent/AgentSkillSelector.tsx
@@ -45,7 +45,7 @@ const AgentSkillSelector: React.FC<AgentSkillSelectorProps> = ({ selectedSkillId
 
   return (
     <div className="flex flex-col h-full">
-      <p className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mb-3">
+      <p className="text-xs text-secondary/60 mb-3">
         {i18nService.t('agentSkillsHint') || 'Select skills available to this Agent. Leave empty to use all enabled skills.'}
       </p>
       {enabledSkills.length > 5 && (


### PR DESCRIPTION
## Summary
- Merge PR #996 (`fix/agent-skill-selector-i18n`) into `release/2026.03.31`
- Resolved conflict in `AgentSkillSelector.tsx`: kept incoming i18n logic with release's semantic CSS classes
- Fixed residual `claude-*` class → `text-secondary/60` in the same file

## Conflict resolution
| File | Resolution |
|------|-----------|
| `AgentSkillSelector.tsx` (imports) | Kept `skillService` import from incoming; kept release's icon imports (no `ChevronDownIcon`/`ChevronUpIcon`) |
| `AgentSkillSelector.tsx` (description) | Kept incoming's `getLocalizedSkillDescription()` logic; used release's semantic `text-secondary/60` class |

## Original PR
https://github.com/netease-youdao/LobsterAI/pull/996