### PR TITLE
fix(api): 修复 Anthropic SSE 流式解析未做行缓冲导致数据丢失的问题

### DIFF
--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -473,33 +473,37 @@ class ApiService {
 
       return new Promise((resolve, reject) => {
         let aborted = false;
+        let sseBuffer = '';
 
         // 设置流式监听器
         const removeDataListener = window.electron.api.onStreamData(requestId, (chunk) => {
-          const lines = chunk.split('\n');
+          sseBuffer += chunk;
+          const lines = sseBuffer.split('\n');
+          sseBuffer = lines.pop() ?? '';
 
-          for (const line of lines) {
-            if (line.startsWith('data: ')) {
-              const data = line.slice(6);
-              if (data === '[DONE]') continue;
+          for (const rawLine of lines) {
+            const line = rawLine.replace(/\r$/, '');
+            if (!line.startsWith('data: ')) continue;
 
-              try {
-                const parsed = JSON.parse(data);
+            const data = line.slice(6);
+            if (data === '[DONE]') continue;
 
-                // Anthropic SSE 事件处理
-                if (parsed.type === 'content_block_delta') {
-                  const delta = parsed.delta;
-                  if (delta.type === 'text_delta') {
-                    fullContent += delta.text;
-                    onProgress?.(fullContent, fullReasoning || undefined);
-                  } else if (delta.type === 'thinking_delta') {
-                    fullReasoning += delta.thinking;
-                    onProgress?.(fullContent, fullReasoning || undefined);
-                  }
+            try {
+              const parsed = JSON.parse(data);
+
+              // Anthropic SSE 事件处理
+              if (parsed.type === 'content_block_delta') {
+                const delta = parsed.delta;
+                if (delta.type === 'text_delta') {
+                  fullContent += delta.text;
+                  onProgress?.(fullContent, fullReasoning || undefined);
+                } else if (delta.type === 'thinking_delta') {
+                  fullReasoning += delta.thinking;
+                  onProgress?.(fullContent, fullReasoning || undefined);
                 }
-              } catch (e) {
-                console.warn('Failed to parse SSE message:', e);
               }
+            } catch (e) {
+              console.warn('Failed to parse SSE message:', e);
             }
           }
         });


### PR DESCRIPTION
## 问题描述

关联 Issue：#922

`src/renderer/services/api.ts` 中 Anthropic 路径的 SSE 流式解析，直接对每个收到的 `chunk` 调用 `chunk.split('\n')` 进行拆行。当一行 `data: ...` 数据恰好被分割在两个相邻的 chunk 中时，`JSON.parse` 会因为收到不完整的 JSON 而失败，错误被 `catch` 静默吞掉，导致该文本片段丢失。在高吞吐或网络拥堵时更容易触发此问题。

## 修复方案

采用与现有 OpenAI 路径相同的 `sseBuffer` 缓冲模式：

1. 在 Promise 前新增 `let sseBuffer = ''` 变量
2. 每次收到 chunk 时，先拼接到 `sseBuffer`，再按 `\n` 分割，将最后一个（可能不完整的）元素重新存回 `sseBuffer` 留待下一次拼接
3. 处理每行时去掉末尾 `\r`，兼容 `\r\n` 换行符

这样可以保证跨 chunk 的 `data:` 行在调用 `JSON.parse` 之前始终被完整拼接，彻底消除数据丢失问题。

## 改动范围

- `src/renderer/services/api.ts`：仅修改 Anthropic SSE 数据监听回调逻辑，不影响其他路径