### PR TITLE
fix(test): correct import path for reminderText test

### DIFF
--- a/tests/reminderText.test.mjs
+++ b/tests/reminderText.test.mjs
@@ -22,7 +22,7 @@ const {
   isSimpleScheduledReminderText,
   parseSimpleScheduledReminderText,
   getScheduledReminderDisplayText,
-} = require('../dist-electron/scheduled-task/reminderText.js');
+} = require('../dist-electron/scheduledTask/reminderText.js');
 
 const PREFIX = 'A scheduled reminder has been triggered. The reminder content is:';
 const INTERNAL = 'Handle this reminder internally. Do not relay it to the user unless explicitly requested.';


### PR DESCRIPTION
## Summary
- Fix `reminderText.test.mjs` import path: `scheduled-task` → `scheduledTask` to match actual `tsc` output directory
- PR #963 had this bug — the test always failed with `MODULE_NOT_FOUND`

## Verification
All 32 tests pass after the fix.