### PR TITLE
fix(agent): 统一 Agent 图标缺省 Emoji 为 🦞

### DIFF
--- a/src/renderer/components/agent/AgentSettingsPanel.tsx
+++ b/src/renderer/components/agent/AgentSettingsPanel.tsx
@@ -150,7 +150,7 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
         {/* Header: agent icon + name + close */}
         <div className="flex items-center justify-between px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">
           <div className="flex items-center gap-2">
-            <span className="text-xl">{icon || '🤖'}</span>
+            <span className="text-xl">{icon || '🦞'}</span>
             <h3 className="text-base font-semibold dark:text-claude-darkText text-claude-text">
               {name || (i18nService.t('agentSettings') || 'Agent Settings')}
             </h3>

--- a/src/renderer/components/agent/AgentsView.tsx
+++ b/src/renderer/components/agent/AgentsView.tsx
@@ -203,7 +203,7 @@ const AgentCard: React.FC<{
         : 'dark:border-claude-darkBorder border-claude-border'
     }`}
   >
-    <span className="text-3xl">{icon || '🤖'}</span>
+    <span className="text-3xl">{icon || '🦞'}</span>
     <div className="min-w-0 w-full">
       <div className="text-sm font-semibold dark:text-claude-darkText text-claude-text truncate">
         {name}
@@ -227,7 +227,7 @@ const UninstalledPresetCard: React.FC<{
   onAdd: () => void;
 }> = ({ icon, name, description, isAdding, onAdd }) => (
   <div className="flex flex-col items-start gap-2 p-4 rounded-xl border-2 border-dashed dark:border-claude-darkBorder border-claude-border opacity-60 hover:opacity-80 transition-opacity min-h-[140px]">
-    <span className="text-3xl">{icon || '🤖'}</span>
+    <span className="text-3xl">{icon || '🦞'}</span>
     <div className="min-w-0 w-full flex-1">
       <div className="text-sm font-semibold dark:text-claude-darkText text-claude-text truncate">
         {name}


### PR DESCRIPTION
## 问题描述

自定义 Agent 未设置图标（icon 为空字符串）时，不同展示位置使用了不同的默认 emoji，导致同一个 Agent 在 UI 各处显示不一致：

| 展示位置 | 修复前 fallback |
|---|---|
| 侧边栏快速切换列表（`Sidebar.tsx`） | 🦞 |
| 我的 Agent 列表卡片（`AgentsView.tsx` - `AgentCard`） | 🤖 |
| 未安装预设卡片（`AgentsView.tsx` - `UninstalledPresetCard`） | 🤖 |
| Agent 设置面板标题（`AgentSettingsPanel.tsx`） | 🤖 |

## 修复方案

将 `AgentsView`（`AgentCard`、`UninstalledPresetCard`）和 `AgentSettingsPanel` 标题三处的 fallback emoji 由 `🤖` 统一改为 `🦞`，与侧边栏保持一致。

## 变更文件

- `src/renderer/components/agent/AgentsView.tsx`：`AgentCard` 和 `UninstalledPresetCard` fallback `🤖` → `🦞`
- `src/renderer/components/agent/AgentSettingsPanel.tsx`：设置面板标题 fallback `🤖` → `🦞`