### PR TITLE
fix(agent): 修复创建 Agent 时默认图标未保存导致侧边栏与我的 Agent 页展示不一致

### DIFF
--- a/src/renderer/components/agent/AgentCreateModal.tsx
+++ b/src/renderer/components/agent/AgentCreateModal.tsx
@@ -13,7 +13,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [systemPrompt, setSystemPrompt] = useState('');
-  const [icon, setIcon] = useState('');
+  const [icon, setIcon] = useState('🤖');
   const [skillIds, setSkillIds] = useState<string[]>([]);
   const [creating, setCreating] = useState(false);
 
@@ -27,7 +27,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
         name: name.trim(),
         description: description.trim(),
         systemPrompt: systemPrompt.trim(),
-        icon: icon.trim() || undefined,
+        icon: icon.trim() || '🤖',
         skillIds,
       });
       if (agent) {
@@ -36,7 +36,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
         setName('');
         setDescription('');
         setSystemPrompt('');
-        setIcon('');
+        setIcon('🤖');
         setSkillIds([]);
       }
     } finally {


### PR DESCRIPTION
## 问题描述

创建 Agent 时，若用户未手动输入图标，侧边栏与「我的 Agent」页面展示的图标不一致：

- **侧边栏**：图标显示为 🦞（龙虾，侧边栏的兜底 fallback）
- **我的 Agent 页面**：图标显示为 🤖（该页面的兜底 fallback）

## 根本原因

`AgentCreateModal.tsx` 中图标输入框的初始状态为空字符串 `''`，`placeholder="🤖"` 只是视觉占位符，不会影响实际值。

提交时的处理逻辑为：

```ts
icon: icon.trim() || undefined,
```

用户未填写图标时，`undefined` 被传入主进程，最终数据库存入空字符串 `''`。

两个页面在渲染时各自用不同的 fallback 值补全空图标，导致同一 Agent 在不同位置看起来不一样。

## 修复方案

将图标的初始状态从 `''` 改为 `'🤖'`，并将提交时的 fallback 也改为 `'🤖'`，确保无论用户是否手动填写图标，数据库中始终写入有效的默认值，从源头消除两处 fallback 不一致的问题。

```ts
// Before
const [icon, setIcon] = useState('');
icon: icon.trim() || undefined,

// After
const [icon, setIcon] = useState('🤖');
icon: icon.trim() || '🤖',
```

## 影响范围

仅修改 `AgentCreateModal.tsx`，不影响已有 Agent 数据及其他功能。