### PR TITLE
feat(scheduled-tasks): show last run time in task list and add running state feedback

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -9,7 +9,7 @@ import { decryptSecret, encryptWithPassword, decryptWithPassword, EncryptedPaylo
 import { coworkService } from '../services/cowork';
 import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
 import ErrorMessage from './ErrorMessage';
-import { XMarkIcon, Cog6ToothIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, EnvelopeIcon, CpuChipIcon, InformationCircleIcon, UserCircleIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, Cog6ToothIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, EnvelopeIcon, CpuChipIcon, InformationCircleIcon, UserCircleIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
 import PlusCircleIcon from './icons/PlusCircleIcon';
 import TrashIcon from './icons/TrashIcon';
@@ -3110,7 +3110,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
                   disabled={isTesting || (providerRequiresApiKey(activeProvider) && !providers[activeProvider].apiKey)}
                   className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-xl border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
                 >
-                  <SignalIcon className="h-3.5 w-3.5 mr-1.5" />
+                  {isTesting
+                    ? <ArrowPathIcon className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                    : <SignalIcon className="h-3.5 w-3.5 mr-1.5" />}
                   {isTesting ? i18nService.t('testing') : i18nService.t('testConnection')}
                 </button>
               </div>

--- a/src/renderer/components/scheduledTasks/TaskDetail.tsx
+++ b/src/renderer/components/scheduledTasks/TaskDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { PlayIcon } from '@heroicons/react/24/outline';
+import { PlayIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import { RootState } from '../../store';
 import { setViewMode } from '../../store/slices/scheduledTaskSlice';
 import { scheduledTaskService } from '../../services/scheduledTask';
@@ -67,9 +67,11 @@ const TaskDetail: React.FC<TaskDetailProps> = ({ task, onRequestDelete }) => {
             onClick={() => void scheduledTaskService.runManually(task.id)}
             disabled={Boolean(task.state.runningAtMs)}
             className="p-2 rounded-lg dark:text-claude-darkTextSecondary text-claude-textSecondary hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors disabled:opacity-50"
-            title={i18nService.t('scheduledTasksRun')}
+            title={task.state.runningAtMs ? i18nService.t('scheduledTasksStatusRunning') : i18nService.t('scheduledTasksRun')}
           >
-            <PlayIcon className="w-4 h-4" />
+            {task.state.runningAtMs
+              ? <ArrowPathIcon className="w-4 h-4 animate-spin" />
+              : <PlayIcon className="w-4 h-4" />}
           </button>
           <button
             type="button"

--- a/src/renderer/components/scheduledTasks/TaskList.tsx
+++ b/src/renderer/components/scheduledTasks/TaskList.tsx
@@ -6,7 +6,7 @@ import { selectTask, setViewMode } from '../../store/slices/scheduledTaskSlice';
 import { scheduledTaskService } from '../../services/scheduledTask';
 import { i18nService } from '../../services/i18n';
 import type { ScheduledTask } from '../../../scheduledTask/types';
-import { formatScheduleLabel, getStatusLabelKey, getStatusTone } from './utils';
+import { formatScheduleLabel, formatDateTime, getStatusLabelKey, getStatusTone } from './utils';
 
 interface TaskListItemProps {
   task: ScheduledTask;
@@ -35,7 +35,7 @@ const TaskListItem: React.FC<TaskListItemProps> = ({ task, onRequestDelete }) =>
 
   return (
     <div
-      className="grid grid-cols-[1.2fr_1fr_110px_40px] items-center gap-3 px-4 py-3 border-b dark:border-claude-darkBorder/50 border-claude-border/50 hover:bg-claude-surfaceHover/50 dark:hover:bg-claude-darkSurfaceHover/50 cursor-pointer transition-colors"
+      className="grid grid-cols-[1.2fr_1fr_130px_40px] items-center gap-3 px-4 py-3 border-b dark:border-claude-darkBorder/50 border-claude-border/50 hover:bg-claude-surfaceHover/50 dark:hover:bg-claude-darkSurfaceHover/50 cursor-pointer transition-colors"
       onClick={() => dispatch(selectTask(task.id))}
     >
       <div className="min-w-0">
@@ -54,7 +54,14 @@ const TaskListItem: React.FC<TaskListItemProps> = ({ task, onRequestDelete }) =>
       </div>
 
       <div className="flex items-center justify-between gap-2">
-        <span className={`text-xs font-medium ${statusTone}`}>{statusLabel}</span>
+        <div className="min-w-0">
+          <span className={`text-xs font-medium ${statusTone}`}>{statusLabel}</span>
+          {task.state.lastRunAtMs && (
+            <div className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mt-0.5 truncate">
+              {formatDateTime(new Date(task.state.lastRunAtMs))}
+            </div>
+          )}
+        </div>
         <button
           type="button"
           onClick={(event) => {
@@ -164,7 +171,7 @@ const TaskList: React.FC<TaskListProps> = ({ onRequestDelete }) => {
 
   return (
     <div>
-      <div className="grid grid-cols-[1.2fr_1fr_110px_40px] items-center gap-3 px-4 py-2 border-b dark:border-claude-darkBorder/50 border-claude-border/50">
+      <div className="grid grid-cols-[1.2fr_1fr_130px_40px] items-center gap-3 px-4 py-2 border-b dark:border-claude-darkBorder/50 border-claude-border/50">
         <div className="text-xs font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary">
           {i18nService.t('scheduledTasksListColTitle')}
         </div>


### PR DESCRIPTION
## Summary

Three small UX polish changes across Scheduled Tasks and Settings — all purely additive, no logic changes.

### 1. Task list: show last execution timestamp

The task list previously showed only a status label (`Success` / `Error` / `Running` / `Idle`). Users had to click into the detail view to find out *when* the task last ran.

Now the timestamp is displayed as a second line below the status label, using the already-available `task.state.lastRunAtMs` field and the existing `formatDateTime()` helper. The column width is widened from `110px` to `130px` to accommodate the extra line.

**Before:** `✓ Success`
**After:**
```
✓ Success
2026/3/31 08:30:00
```

### 2. Task detail: running state on the "Run Now" button

When a task is actively executing (`task.state.runningAtMs` is set), the ▶ button was only grayed out (`disabled:opacity-50`) with no other feedback. Users couldn't tell whether the task was actually running or just disabled.

Now the `PlayIcon` is replaced with a spinning `ArrowPathIcon` while running, and the tooltip changes from "Run" to "Running...".

### 3. Settings: spinner on "Test Connection" button

Clicking the provider test-connection button set `isTesting = true` and changed the button text to "Testing..." but left the icon static. This made it hard to notice the action was in progress.

Now the `SignalIcon` is replaced with a spinning `ArrowPathIcon` while `isTesting` is true, matching the `animate-spin` pattern already used in `IMSettings.tsx` and `AppUpdateModal.tsx`.

## Changes

| File | Change |
|---|---|
| `src/renderer/components/scheduledTasks/TaskList.tsx` | +11 / −3 — add `formatDateTime` import, widen column, show timestamp |
| `src/renderer/components/scheduledTasks/TaskDetail.tsx` | +4 / −2 — add `ArrowPathIcon` import, swap icon when running |
| `src/renderer/components/Settings.tsx` | +3 / −1 — add `ArrowPathIcon` import, swap icon when testing |

## Testing

- `tsc --noEmit` — 0 errors
- `eslint` on all three files — 0 errors/warnings
- No new i18n keys required (reuses `scheduledTasksStatusRunning`, `scheduledTasksRun`, `testing`, `testConnection`)