### PR TITLE
feat(cowork): 对话消息增加时间戳与响应耗时展示

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -942,6 +942,21 @@ export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[]
                     ))}
                   </div>
                 )}
+                {message.timestamp > 0 && (
+                  <div className="flex justify-end mt-1">
+                    <span className="text-[10px] dark:text-claude-darkTextSecondary/50 text-claude-textSecondary/50 select-none">
+                      {(() => {
+                        const d = new Date(message.timestamp);
+                        const mm = String(d.getMonth() + 1).padStart(2, '0');
+                        const dd = String(d.getDate()).padStart(2, '0');
+                        const hh = String(d.getHours()).padStart(2, '0');
+                        const min = String(d.getMinutes()).padStart(2, '0');
+                        const ss = String(d.getSeconds()).padStart(2, '0');
+                        return `${mm}-${dd} ${hh}:${min}:${ss}`;
+                      })()}
+                    </span>
+                  </div>
+                )}
               </div>
               <div className="flex items-center justify-end gap-1.5 mt-1">
                 {messageSkills.map(skill => (
@@ -988,14 +1003,34 @@ const AssistantMessageItem: React.FC<{
   resolveLocalFilePath?: (href: string, text: string) => string | null;
   mapDisplayText?: (value: string) => string;
   showCopyButton?: boolean;
+  durationMs?: number | null;
 }> = ({
   message,
   resolveLocalFilePath,
   mapDisplayText,
   showCopyButton = false,
+  durationMs,
 }) => {
   const [isHovered, setIsHovered] = useState(false);
   const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content;
+
+  const formatTime = (ts: number) => {
+    const d = new Date(ts);
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    const hh = String(d.getHours()).padStart(2, '0');
+    const min = String(d.getMinutes()).padStart(2, '0');
+    const ss = String(d.getSeconds()).padStart(2, '0');
+    return `${mm}-${dd} ${hh}:${min}:${ss}`;
+  };
+
+  const formatDuration = (ms: number) => {
+    if (ms < 1000) return `${ms}ms`;
+    if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+    const m = Math.floor(ms / 60000);
+    const s = Math.round((ms % 60000) / 1000);
+    return `${m}m${s}s`;
+  };
 
   return (
     <div
@@ -1010,14 +1045,24 @@ const AssistantMessageItem: React.FC<{
           resolveLocalFilePath={resolveLocalFilePath}
         />
       </div>
-      {showCopyButton && (
-        <div className="flex items-center gap-1.5 mt-1">
+      <div className="flex items-center gap-1.5 mt-1">
+        {message.timestamp > 0 && (
+          <span className="text-[10px] dark:text-claude-darkTextSecondary/50 text-claude-textSecondary/50 select-none">
+            {formatTime(message.timestamp)}
+          </span>
+        )}
+        {durationMs != null && durationMs > 0 && (
+          <span className="text-[10px] dark:text-claude-darkTextSecondary/40 text-claude-textSecondary/40 select-none">
+            · {formatDuration(durationMs)}
+          </span>
+        )}
+        {showCopyButton && (
           <CopyButton
             content={displayContent}
             visible={isHovered}
           />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };
@@ -1125,12 +1170,14 @@ export const AssistantTurnBlock: React.FC<{
   mapDisplayText?: (value: string) => string;
   showTypingIndicator?: boolean;
   showCopyButtons?: boolean;
+  durationMs?: number | null;
 }> = ({
   turn,
   resolveLocalFilePath,
   mapDisplayText,
   showTypingIndicator = false,
   showCopyButtons = true,
+  durationMs,
 }) => {
   const visibleAssistantItems = getVisibleAssistantItems(turn.assistantItems);
 
@@ -1206,6 +1253,9 @@ export const AssistantTurnBlock: React.FC<{
     );
   };
 
+  const lastAssistantIndex = visibleAssistantItems.reduce<number>((last, item, i) =>
+    item.type === 'assistant' && !item.message.metadata?.isThinking ? i : last, -1);
+
   return (
     <div className="px-4 py-2">
       <div className="max-w-3xl mx-auto">
@@ -1226,6 +1276,7 @@ export const AssistantTurnBlock: React.FC<{
                 const hasToolGroupAfter = visibleAssistantItems
                   .slice(index + 1)
                   .some(laterItem => laterItem.type === 'tool_group');
+                const isLastAssistant = index === lastAssistantIndex;
 
                 return (
                   <AssistantMessageItem
@@ -1234,6 +1285,7 @@ export const AssistantTurnBlock: React.FC<{
                     resolveLocalFilePath={resolveLocalFilePath}
                     mapDisplayText={mapDisplayText}
                     showCopyButton={showCopyButtons && !hasToolGroupAfter}
+                    durationMs={isLastAssistant ? durationMs : null}
                   />
                 );
               }
@@ -1911,6 +1963,17 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       // Always render last 3 turns (needed for streaming, auto-scroll, and smooth UX)
       const alwaysRender = index >= turns.length - 3;
 
+      // Compute duration: from user message send time to first assistant message time
+      let durationMs: number | null = null;
+      if (turn.userMessage && turn.userMessage.timestamp > 0) {
+        const firstAssistant = turn.assistantItems.find(
+          item => item.type === 'assistant' && !item.message.metadata?.isThinking
+        );
+        if (firstAssistant && firstAssistant.type === 'assistant' && firstAssistant.message.timestamp > 0) {
+          durationMs = firstAssistant.message.timestamp - turn.userMessage.timestamp;
+        }
+      }
+
       // Compute rail indices for user/assistant messages (must match rail IIFE logic)
       let asstContent = '';
       for (const item of turn.assistantItems) {
@@ -1936,6 +1999,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 mapDisplayText={mapDisplayText}
                 showTypingIndicator={showTypingIndicator}
                 showCopyButtons={!isStreaming}
+                durationMs={durationMs}
               />
             </div>
           )}


### PR DESCRIPTION
## 功能说明

在 Cowork 对话界面中，为每条消息增加时间戳展示，并为助手消息增加响应耗时展示，方便用户了解消息发送时间和模型响应速度。

---

## 变更详情

### 1. 用户消息 — 气泡右下角显示发送时间

- 在用户消息气泡内容区域的**右下角**新增时间展示
- 格式：`MM-DD HH:mm:ss`，例如 `03-31 14:32:05`
- 样式使用半透明次要文字色，不影响主内容阅读
- 仅在 `timestamp > 0` 时显示，防止历史数据异常

### 2. 助手消息 — 内容左下角显示回复时间与响应耗时

- 在助手消息内容区域的**左下角**新增时间展示，格式同上
- 在时间后方新增**响应耗时**展示，与时间用 `·` 分隔
  - 计算方式：用户发送时间 → 助手第一条消息时间
  - 格式规则：
    - `< 1000ms`：显示毫秒，如 `850ms`
    - `< 60s`：显示秒（保留一位小数），如 `3.2s`
    - `≥ 60s`：显示分秒，如 `1m5s`
- 耗时仅显示在该轮对话**最后一条**助手消息上，避免重复
- 耗时颜色比时间更浅，作为次级信息

---

## 截图

<img width="817" height="731" alt="image" src="https://github.com/user-attachments/assets/d459a6f5-6171-480b-9394-52b6cf4c0e0e" />

---

## 涉及文件

- `src/renderer/components/cowork/CoworkSessionDetail.tsx`
  - `UserMessageItem`：气泡内右下角加时间
  - `AssistantMessageItem`：新增 `durationMs` prop，内容下方展示时间和耗时
  - `AssistantTurnBlock`：新增 `durationMs` prop，计算最后一条助手消息并传入
  - `renderConversationTurns`：计算每轮对话的响应耗时并传给 `AssistantTurnBlock`