### PR TITLE
为 commandSafety 和 coworkMemoryJudge 补充 Vitest 单元测试

### DIFF
--- a/src/main/libs/commandSafety.test.ts
+++ b/src/main/libs/commandSafety.test.ts
@@ -1,0 +1,253 @@
+import { test, expect, describe } from 'vitest';
+import {
+  isDeleteCommand,
+  isDangerousCommand,
+  getCommandDangerLevel,
+} from './commandSafety';
+
+// ---------------------------------------------------------------------------
+// isDeleteCommand
+// ---------------------------------------------------------------------------
+
+describe('isDeleteCommand', () => {
+  test('detects rm', () => {
+    expect(isDeleteCommand('rm file.txt')).toBe(true);
+    expect(isDeleteCommand('rm -rf /tmp/foo')).toBe(true);
+  });
+
+  test('detects rmdir', () => {
+    expect(isDeleteCommand('rmdir mydir')).toBe(true);
+  });
+
+  test('detects unlink', () => {
+    expect(isDeleteCommand('unlink /var/run/app.pid')).toBe(true);
+  });
+
+  test('detects del (Windows)', () => {
+    expect(isDeleteCommand('del C:\\temp\\file.txt')).toBe(true);
+  });
+
+  test('detects erase', () => {
+    expect(isDeleteCommand('erase old.log')).toBe(true);
+  });
+
+  test('detects remove-item (PowerShell)', () => {
+    expect(isDeleteCommand('Remove-Item C:\\foo')).toBe(true);
+    expect(isDeleteCommand('remove-item foo')).toBe(true);
+  });
+
+  test('detects trash', () => {
+    expect(isDeleteCommand('trash dist/')).toBe(true);
+  });
+
+  test('detects find -delete', () => {
+    expect(isDeleteCommand('find . -name "*.log" -delete')).toBe(true);
+    expect(isDeleteCommand('find /tmp -mtime +7 -delete')).toBe(true);
+  });
+
+  test('detects git clean', () => {
+    expect(isDeleteCommand('git clean -fd')).toBe(true);
+    expect(isDeleteCommand('git clean -fdx')).toBe(true);
+  });
+
+  test('detects osascript ... delete', () => {
+    expect(isDeleteCommand('osascript -e \'tell app "Finder" to delete item\'')).toBe(true);
+  });
+
+  test('returns false for safe commands', () => {
+    expect(isDeleteCommand('ls -la')).toBe(false);
+    expect(isDeleteCommand('echo hello')).toBe(false);
+    expect(isDeleteCommand('git status')).toBe(false);
+    expect(isDeleteCommand('npm install')).toBe(false);
+    expect(isDeleteCommand('git log --oneline')).toBe(false);
+  });
+
+  test('returns false for word containing rm but not as standalone', () => {
+    // 'rm' must be a word boundary — 'firmware' should NOT match
+    expect(isDeleteCommand('cat firmware.bin')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDangerousCommand
+// ---------------------------------------------------------------------------
+
+describe('isDangerousCommand', () => {
+  test('is dangerous for delete commands', () => {
+    expect(isDangerousCommand('rm -rf dist')).toBe(true);
+    expect(isDangerousCommand('git clean -fd')).toBe(true);
+  });
+
+  test('is dangerous for git push', () => {
+    expect(isDangerousCommand('git push origin main')).toBe(true);
+    expect(isDangerousCommand('git push')).toBe(true);
+  });
+
+  test('is dangerous for git push --force', () => {
+    expect(isDangerousCommand('git push origin main --force')).toBe(true);
+    expect(isDangerousCommand('git push -f')).toBe(true);
+  });
+
+  test('is dangerous for git reset --hard', () => {
+    expect(isDangerousCommand('git reset --hard HEAD~1')).toBe(true);
+  });
+
+  test('is dangerous for kill/killall/pkill', () => {
+    expect(isDangerousCommand('kill 1234')).toBe(true);
+    expect(isDangerousCommand('killall node')).toBe(true);
+    expect(isDangerousCommand('pkill -f myapp')).toBe(true);
+  });
+
+  test('is dangerous for chmod/chown', () => {
+    expect(isDangerousCommand('chmod 777 script.sh')).toBe(true);
+    expect(isDangerousCommand('chown root:root file')).toBe(true);
+  });
+
+  test('returns false for safe commands', () => {
+    expect(isDangerousCommand('npm run build')).toBe(false);
+    expect(isDangerousCommand('git status')).toBe(false);
+    expect(isDangerousCommand('ls -la')).toBe(false);
+    expect(isDangerousCommand('echo hello')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCommandDangerLevel
+// ---------------------------------------------------------------------------
+
+describe('getCommandDangerLevel', () => {
+  // --- destructive ---
+  test('rm -rf is destructive', () => {
+    const r = getCommandDangerLevel('rm -rf /tmp/build');
+    expect(r.level).toBe('destructive');
+    expect(r.reason).toBe('recursive-delete');
+  });
+
+  test('rm --recursive is destructive', () => {
+    const r = getCommandDangerLevel('rm --recursive dist');
+    expect(r.level).toBe('destructive');
+    expect(r.reason).toBe('recursive-delete');
+  });
+
+  test('rm -fr is destructive (flag order reversed)', () => {
+    const r = getCommandDangerLevel('rm -fr /var/log/old');
+    expect(r.level).toBe('destructive');
+    expect(r.reason).toBe('recursive-delete');
+  });
+
+  test('git push --force is destructive', () => {
+    const r = getCommandDangerLevel('git push origin main --force');
+    expect(r.level).toBe('destructive');
+    expect(r.reason).toBe('git-force-push');
+  });
+
+  test('git push -f is destructive', () => {
+    const r = getCommandDangerLevel('git push -f');
+    expect(r.level).toBe('destructive');
+    expect(r.reason).toBe('git-force-push');
+  });
+
+  test('git reset --hard is destructive', () => {
+    const r = getCommandDangerLevel('git reset --hard HEAD');
+    expect(r.level).toBe('destructive');
+    expect(r.reason).toBe('git-reset-hard');
+  });
+
+  test('dd is destructive', () => {
+    const r = getCommandDangerLevel('dd if=/dev/zero of=/dev/sda');
+    expect(r.level).toBe('destructive');
+    expect(r.reason).toBe('disk-overwrite');
+  });
+
+  test('mkfs is destructive', () => {
+    const r = getCommandDangerLevel('mkfs.ext4 /dev/sdb1');
+    expect(r.level).toBe('destructive');
+    expect(r.reason).toBe('disk-format');
+  });
+
+  // --- caution ---
+  test('rm (non-recursive) is caution', () => {
+    const r = getCommandDangerLevel('rm file.txt');
+    expect(r.level).toBe('caution');
+    expect(r.reason).toBe('file-delete');
+  });
+
+  test('git clean is caution', () => {
+    const r = getCommandDangerLevel('git clean -fd');
+    expect(r.level).toBe('caution');
+    expect(r.reason).toBe('file-delete');
+  });
+
+  test('find -delete is caution', () => {
+    const r = getCommandDangerLevel('find . -name "*.tmp" -delete');
+    expect(r.level).toBe('caution');
+    expect(r.reason).toBe('file-delete');
+  });
+
+  test('git push (no force) is caution', () => {
+    const r = getCommandDangerLevel('git push origin main');
+    expect(r.level).toBe('caution');
+    expect(r.reason).toBe('git-push');
+  });
+
+  test('kill is caution', () => {
+    const r = getCommandDangerLevel('kill -9 1234');
+    expect(r.level).toBe('caution');
+    expect(r.reason).toBe('process-kill');
+  });
+
+  test('killall is caution', () => {
+    const r = getCommandDangerLevel('killall node');
+    expect(r.level).toBe('caution');
+    expect(r.reason).toBe('process-kill');
+  });
+
+  test('pkill is caution', () => {
+    const r = getCommandDangerLevel('pkill -f myapp');
+    expect(r.level).toBe('caution');
+    expect(r.reason).toBe('process-kill');
+  });
+
+  test('chmod is caution', () => {
+    const r = getCommandDangerLevel('chmod +x deploy.sh');
+    expect(r.level).toBe('caution');
+    expect(r.reason).toBe('permission-change');
+  });
+
+  test('chown is caution', () => {
+    const r = getCommandDangerLevel('chown www-data:www-data /var/www');
+    expect(r.level).toBe('caution');
+    expect(r.reason).toBe('permission-change');
+  });
+
+  // --- safe ---
+  test('npm install is safe', () => {
+    const r = getCommandDangerLevel('npm install');
+    expect(r.level).toBe('safe');
+    expect(r.reason).toBe('');
+  });
+
+  test('git status is safe', () => {
+    const r = getCommandDangerLevel('git status');
+    expect(r.level).toBe('safe');
+    expect(r.reason).toBe('');
+  });
+
+  test('ls is safe', () => {
+    const r = getCommandDangerLevel('ls -la');
+    expect(r.level).toBe('safe');
+    expect(r.reason).toBe('');
+  });
+
+  test('echo is safe', () => {
+    const r = getCommandDangerLevel('echo "hello world"');
+    expect(r.level).toBe('safe');
+    expect(r.reason).toBe('');
+  });
+
+  test('git log is safe', () => {
+    const r = getCommandDangerLevel('git log --oneline -10');
+    expect(r.level).toBe('safe');
+    expect(r.reason).toBe('');
+  });
+});

--- a/src/main/libs/coworkMemoryJudge.test.ts
+++ b/src/main/libs/coworkMemoryJudge.test.ts
@@ -1,0 +1,214 @@
+import { test, expect, describe, vi, beforeEach } from 'vitest';
+import type { MemoryJudgeInput } from './coworkMemoryJudge';
+
+// Mock claudeSettings so judgeMemoryCandidate never hits the real API
+vi.mock('./claudeSettings', () => ({
+  resolveCurrentApiConfig: () => ({ config: null }),
+}));
+
+// Import after mock is set up
+const { judgeMemoryCandidate } = await import('./coworkMemoryJudge');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function input(
+  text: string,
+  opts: Partial<Omit<MemoryJudgeInput, 'text'>> = {}
+): MemoryJudgeInput {
+  return {
+    text,
+    isExplicit: false,
+    guardLevel: 'standard',
+    llmEnabled: false,
+    ...opts,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// scoreMemoryText — tested indirectly via judgeMemoryCandidate
+// ---------------------------------------------------------------------------
+
+describe('judgeMemoryCandidate: score — factual personal signal', () => {
+  test('我叫... scores high and is accepted (standard)', async () => {
+    const r = await judgeMemoryCandidate(input('我叫王小明，是一名后端工程师'));
+    expect(r.source).toBe('rule');
+    expect(r.score).toBeGreaterThan(0.7);
+    expect(r.accepted).toBe(true);
+    expect(r.reason).toBe('factual-personal');
+  });
+
+  test('my name is Alice scores high', async () => {
+    const r = await judgeMemoryCandidate(input('my name is Alice and I work as a developer'));
+    expect(r.score).toBeGreaterThan(0.7);
+    expect(r.accepted).toBe(true);
+  });
+
+  test('I prefer dark mode scores high', async () => {
+    const r = await judgeMemoryCandidate(input('I prefer dark mode when coding'));
+    expect(r.accepted).toBe(true);
+  });
+});
+
+describe('judgeMemoryCandidate: score — transient signal', () => {
+  test('today sentence is penalised', async () => {
+    const r = await judgeMemoryCandidate(input('今天天气真好，适合出门'));
+    // transient -0.18, short length -0.2 => score likely low
+    expect(r.accepted).toBe(false);
+  });
+
+  test('this week task context is penalised', async () => {
+    const r = await judgeMemoryCandidate(input('this week I need to finish the report'));
+    expect(r.score).toBeLessThan(0.72);
+  });
+});
+
+describe('judgeMemoryCandidate: score — procedural signal', () => {
+  test('shell command content is rejected', async () => {
+    const r = await judgeMemoryCandidate(input('npm run build && npm test'));
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('procedural-like');
+  });
+
+  test('bash script path is rejected', async () => {
+    const r = await judgeMemoryCandidate(input('run deploy.sh to release'));
+    expect(r.accepted).toBe(false);
+  });
+});
+
+describe('judgeMemoryCandidate: score — request style', () => {
+  test('请帮我 style is penalised', async () => {
+    const r = await judgeMemoryCandidate(input('请帮我查一下今天的天气'));
+    expect(r.accepted).toBe(false);
+  });
+
+  test('please do is penalised', async () => {
+    const r = await judgeMemoryCandidate(input('please summarize the document'));
+    expect(r.score).toBeLessThan(0.72);
+  });
+});
+
+describe('judgeMemoryCandidate: score — question-like', () => {
+  test('question scores very low', async () => {
+    const r = await judgeMemoryCandidate(input('今天天气怎么样？'));
+    expect(r.score).toBeLessThanOrEqual(0.1);
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('question-like');
+  });
+
+  test('English question rejected', async () => {
+    const r = await judgeMemoryCandidate(input('what is the capital of France?'));
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('question-like');
+  });
+});
+
+describe('judgeMemoryCandidate: score — empty/short text', () => {
+  test('empty string scores 0', async () => {
+    const r = await judgeMemoryCandidate(input(''));
+    expect(r.score).toBe(0);
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('empty');
+  });
+
+  test('whitespace-only scores 0', async () => {
+    const r = await judgeMemoryCandidate(input('   '));
+    expect(r.score).toBe(0);
+    expect(r.accepted).toBe(false);
+  });
+
+  test('very short text (<6 chars) is penalised', async () => {
+    const r = await judgeMemoryCandidate(input('ok'));
+    expect(r.accepted).toBe(false);
+  });
+});
+
+describe('judgeMemoryCandidate: score — text length bonus', () => {
+  test('medium length text (6-120 chars) gets bonus', async () => {
+    // 我是 scores factual + medium length bonus
+    const r = await judgeMemoryCandidate(input('我是一名软件工程师，专注于后端开发'));
+    expect(r.score).toBeGreaterThan(0.8);
+    expect(r.accepted).toBe(true);
+  });
+
+  test('very long text (>240 chars) is slightly penalised', async () => {
+    const longText = '我叫张三，' + '这是一段很长的文字。'.repeat(30);
+    const rLong = await judgeMemoryCandidate(input(longText));
+    const rShort = await judgeMemoryCandidate(input('我叫张三，我是后端工程师'));
+    expect(rLong.score).toBeLessThan(rShort.score);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// thresholdByGuardLevel — tested indirectly
+// ---------------------------------------------------------------------------
+
+describe('judgeMemoryCandidate: guard levels', () => {
+  // assistant-preference signal (score ~0.6) — straddles strict vs relaxed thresholds
+  const assistantPrefText = '以后请始终用中文回复我';
+
+  test('relaxed guard accepts borderline candidate', async () => {
+    const r = await judgeMemoryCandidate(input(assistantPrefText, { guardLevel: 'relaxed' }));
+    // relaxed implicit threshold 0.62, score ~0.66 => accepted
+    expect(r.accepted).toBe(true);
+  });
+
+  test('strict guard rejects same borderline candidate', async () => {
+    const r = await judgeMemoryCandidate(input(assistantPrefText, { guardLevel: 'strict' }));
+    // strict implicit threshold 0.80, score ~0.66 => rejected
+    expect(r.accepted).toBe(false);
+  });
+
+  test('isExplicit lowers threshold', async () => {
+    // A borderline text that would fail implicit strict may pass explicit strict (threshold 0.7)
+    const r = await judgeMemoryCandidate(
+      input(assistantPrefText, { guardLevel: 'strict', isExplicit: true })
+    );
+    // explicit strict threshold 0.7, score ~0.66 => still rejected
+    expect(r.source).toBe('rule');
+  });
+
+  test('explicit relaxed has lowest threshold (0.52)', async () => {
+    // neutral text score ~0.56 should pass explicit relaxed (0.52)
+    const r = await judgeMemoryCandidate(
+      input('我在上海工作', { guardLevel: 'relaxed', isExplicit: true })
+    );
+    expect(r.accepted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LLM disabled — always returns rule result
+// ---------------------------------------------------------------------------
+
+describe('judgeMemoryCandidate: llmEnabled=false', () => {
+  test('always uses rule source when llmEnabled is false', async () => {
+    const r = await judgeMemoryCandidate(input('我叫李四', { llmEnabled: false }));
+    expect(r.source).toBe('rule');
+  });
+
+  test('rule result returned even for boundary-score text', async () => {
+    // text that might trigger LLM boundary check but llmEnabled=false
+    const r = await judgeMemoryCandidate(
+      input('以后请始终用中文回复我', { guardLevel: 'standard', llmEnabled: false })
+    );
+    expect(r.source).toBe('rule');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLlmJudgePayload — tested indirectly via LLM mock path
+// (We verify the function handles various LLM response shapes correctly
+//  by enabling llmEnabled=true but with config=null mock — falls back to rule)
+// ---------------------------------------------------------------------------
+
+describe('judgeMemoryCandidate: llm disabled when config is null', () => {
+  test('falls back to rule result when no API config', async () => {
+    // Our mock returns config:null, so LLM path is always skipped
+    const r = await judgeMemoryCandidate(
+      input('我喜欢喝咖啡', { llmEnabled: true, guardLevel: 'standard' })
+    );
+    expect(r.source).toBe('rule');
+  });
+});


### PR DESCRIPTION
关联 Issue：#1154

## 背景

`commandSafety.ts` 和 `coworkMemoryJudge.ts` 是两个核心安全/质量模块，目前均无任何测试覆盖：

- **commandSafety.ts**：危险命令检测，被 `coworkRunner` 和 IM 自动审批逻辑共同使用。误判（false negative）将导致 AI 静默执行 `rm -rf`、`git push --force` 等破坏性命令。
- **coworkMemoryJudge.ts**：记忆候选质量评分，是记忆写入的门卫。评分或阈值逻辑出错会导致大量无关内容写入用户记忆，或有效记忆被丢弃。

## 新增测试

### commandSafety.test.ts（41 个用例）

**`isDeleteCommand`**：`rm/rmdir/unlink/del/erase/remove-item/trash`、`find -delete`、`git clean`、`osascript delete`、单词边界保护、安全命令负例

**`isDangerousCommand`**：删除命令、`git push`（普通 + force）、`git reset --hard`、`kill/killall/pkill`、`chmod/chown`、安全命令负例

**`getCommandDangerLevel`**：
- `destructive`：`rm -rf/fr/--recursive`、`git push --force/-f`、`git reset --hard`、`dd`、`mkfs`
- `caution`：非递归 `rm`、`git clean`、`find -delete`、普通 `git push`、`kill/killall/pkill`、`chmod/chown`
- `safe`：`npm install`、`git status`、`ls`、`echo`、`git log`

### coworkMemoryJudge.test.ts（23 个用例）

通过 `vi.mock` 屏蔽 `claudeSettings`，无真实 API 调用。

**`scoreMemoryText`（间接验证）**：个人信息信号高分、瞬态信号降分、过程命令拒绝、请求式前缀降分、问句低分、空/短文本、中等长度加分、超长惩罚

**`thresholdByGuardLevel`**：`relaxed` vs `strict` 边界对比、`isExplicit` 降低阈值、`explicit+relaxed` 最低阈值 0.52

**LLM 路径**：`llmEnabled=false` 始终 `source=rule`；`config=null` 时优雅回退

## 测试运行

```bash
npm test -- commandSafety      # Tests  41 passed
npm test -- coworkMemoryJudge  # Tests  23 passed
npm test                       # Tests  270 passed (all)
```