### PR TITLE
fix(settings): remove duplicate 'Custom' provider from model settings

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -85,7 +85,6 @@ const providerKeys = [
   'xiaomi',
   'openrouter',
   'ollama',
-  'custom',
   ...CUSTOM_PROVIDER_KEYS,
 ] as const;
 
@@ -157,7 +156,6 @@ const providerMeta: Record<ProviderType, { label: string; icon: React.ReactNode 
   volcengine: { label: 'Volcengine', icon: <VolcengineIcon /> },
   openrouter: { label: 'OpenRouter', icon: <OpenRouterIcon /> },
   ollama: { label: 'Ollama', icon: <OllamaIcon /> },
-  custom: { label: 'Custom', icon: <CustomProviderIcon /> },
   ...Object.fromEntries(
     CUSTOM_PROVIDER_KEYS.map(key => [key, { label: getCustomProviderDefaultName(key), icon: <CustomProviderIcon /> }])
   ) as Record<(typeof CUSTOM_PROVIDER_KEYS)[number], { label: string; icon: React.ReactNode }>,

--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -258,15 +258,6 @@ const buildDefaultProviders = (): AppConfig['providers'] => {
     };
   }
 
-  // custom provider is not in the registry — hardcode defaults
-  providers[ProviderName.Custom] = {
-    enabled: false,
-    apiKey: '',
-    baseUrl: '',
-    apiFormat: ApiFormat.OpenAI,
-    models: [],
-  };
-
   return providers as AppConfig['providers'];
 };
 
@@ -309,7 +300,7 @@ export const CONFIG_KEYS = {
 };
 
 // Provider lists derived from ProviderRegistry — single source of truth
-export const CHINA_PROVIDERS = [...ProviderRegistry.idsByRegion('china'), ProviderName.Custom] as const;
+export const CHINA_PROVIDERS = [...ProviderRegistry.idsByRegion('china')] as const;
 export const GLOBAL_PROVIDERS = ProviderRegistry.idsByRegion('global');
 
 export const getVisibleProviders = (language: 'zh' | 'en'): readonly string[] => {

--- a/src/shared/providers/constants.test.ts
+++ b/src/shared/providers/constants.test.ts
@@ -72,10 +72,10 @@ describe('ProviderRegistry', () => {
     expect(en[2]).toBe(ProviderName.Gemini);
   });
 
-  test('idsForEnLocale puts ollama and custom at end', () => {
+  test('idsForEnLocale puts ollama at end', () => {
     const en = ProviderRegistry.idsForEnLocale();
-    const lastTwo = en.slice(-2);
-    expect(lastTwo).toEqual([ProviderName.Ollama, ProviderName.Custom]);
+    expect(en[en.length - 1]).toBe(ProviderName.Ollama);
+    expect(en).not.toContain(ProviderName.Custom);
   });
 
   test('idsForEnLocale has no duplicates', () => {

--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -481,13 +481,12 @@ class ProviderRegistryImpl {
     const orderedProviders = [...priority, ...china, ...global];
     const unique = [...new Set(orderedProviders)];
 
-    // Move ollama to the end, then append custom last
+    // Move ollama to the end (custom providers are appended dynamically by Settings)
     const ollamaIdx = unique.indexOf(ProviderName.Ollama);
     if (ollamaIdx !== -1) {
       unique.splice(ollamaIdx, 1);
     }
     unique.push(ProviderName.Ollama);
-    unique.push(ProviderName.Custom);
     return unique;
   }
 }


### PR DESCRIPTION
## Summary
- PR #1109 (provider-descriptor-registry refactor) re-introduced the old single `custom` provider that PR #1094 had already replaced with `custom_0`~`custom_9`, causing a duplicate "Custom" entry in the model settings UI
- Remove `custom` from `CHINA_PROVIDERS`, `idsForEnLocale()`, `buildDefaultProviders()`, and Settings `providerKeys`/`providerMeta`
- Keep `ProviderName.Custom` constant and `migrateCustomProviders()` migration logic for backwards compatibility

## Test plan
- [x] `constants.test.ts` — 19 tests passed
- [x] `openclawConfigSync.test.ts` — 23 tests passed
- [ ] Verify UI: model settings should only show Custom0~Custom9 (on demand), no standalone "Custom"
- [ ] Verify legacy migration: users with old `custom` config should auto-migrate to `custom_0` on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)