### PR TITLE
fix(agent): reload main agent sessions after deleting current agent

### DIFF
--- a/src/renderer/services/agent.ts
+++ b/src/renderer/services/agent.ts
@@ -100,8 +100,14 @@ class AgentService {
 
   async deleteAgent(id: string): Promise<boolean> {
     try {
+      const wasCurrentAgent = store.getState().agent.currentAgentId === id;
       await window.electron?.agents?.delete(id);
       store.dispatch(removeAgent(id));
+      if (wasCurrentAgent) {
+        this.switchAgent('main');
+        const { coworkService } = await import('./cowork');
+        coworkService.loadSessions('main');
+      }
       return true;
     } catch (error) {
       console.error('Failed to delete agent:', error);


### PR DESCRIPTION
## Summary
- When deleting the currently active agent, the conversation list stayed empty and clicking "main" in the sidebar had no effect
- Root cause: `agentSlice.removeAgent` sets `currentAgentId` to `'main'`, but no `switchAgent()` or `loadSessions()` was called — so the sidebar guard (`agentId === currentAgentId`) short-circuits on click
- Fix: `deleteAgent()` now detects deletion of the current agent and explicitly runs `switchAgent('main')` + `coworkService.loadSessions('main')`
- This bug existed since the initial multi-agent implementation (`723b000`); PR #1095 only made main visible in the sidebar but didn't address session reload

## Test plan
- [ ] Create a custom agent, add some conversations
- [ ] Switch to that agent's page, then delete it
- [ ] Verify: automatically switches to main agent with its conversations loaded
- [ ] Verify: clicking "main" in sidebar works normally
- [ ] Delete an agent that is NOT the current one — verify no side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)