### PR TITLE
fix(skill): 修复 IMAP/SMTP 连接失败时错误信息显示为 } 的问题

### DIFF
--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -2421,7 +2421,6 @@ export class SkillManager {
       ? `${label} connectivity check timed out`
       : result.error
         || this.getLastOutputLine(result.stderr)
-        || this.getLastOutputLine(result.stdout)
         || `${label} connection failed`;
 
     return {


### PR DESCRIPTION
## 问题描述

当邮箱（IMAP 或 SMTP）连接失败时，用户在设置界面看到的错误信息只有一个 `}`，而不是实际的错误原因。

关闭 #1152

## 根本原因

`src/main/skillManager.ts` 中的 `buildEmailConnectivityCheck()` 方法在构建错误信息时，使用了如下优先级链：

```typescript
const message = result.timedOut
  ? `${label} connectivity check timed out`
  : result.error
    || this.getLastOutputLine(result.stderr)
    || this.getLastOutputLine(result.stdout)   // ← 问题所在
    || `${label} connection failed`;
```

`imap.js` / `smtp.js` 脚本在执行成功时，会通过 `stdout` 输出格式化 JSON：

```js
console.log(JSON.stringify(result, null, 2));  // 带 2 空格缩进
```

当脚本以非零 exit code 退出（连接失败），但 `stdout` 中已有部分输出（例如连接建立后才失败），`result.success` 为 `false`，代码会走到 `getLastOutputLine(result.stdout)` 这个兜底分支。

由于格式化 JSON 的最后一行固定是 `}`，最终用户看到的错误信息就是 `}`。

## 修复方案

移除 `|| this.getLastOutputLine(result.stdout)` 这一行。`stdout` 是脚本的正常输出通道，不应作为错误信息来源；错误信息应来自 `stderr`。

修复后的优先级链：

```
连接超时提示 > result.error > stderr 最后一行 > 通用兜底文案
```

## 变更内容

- `src/main/skillManager.ts`：删除 `buildEmailConnectivityCheck()` 中的 `stdout` 兜底逻辑（1 行删除）

## 影响范围

仅影响邮箱技能连接测试的错误信息展示逻辑，不影响连接成功路径及其他功能。