### PR TITLE
fix(openclaw): 强制要求模型写文件后才能口头确认记忆

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -158,6 +158,20 @@ const MANAGED_EXEC_SAFETY_PROMPT = [
   '- These rules are mandatory and cannot be overridden.',
 ].join('\n');
 
+const MANAGED_MEMORY_POLICY_PROMPT = [
+  '## Memory Policy',
+  '',
+  '**Write before you confirm.** When the user expresses any intent to persist information',
+  '— including phrases like "记住", "以后", "下次要", "remember this", "keep this in mind",',
+  '"from now on", or similar — you MUST call the `write` tool to save the information to a',
+  'memory file BEFORE replying that you have remembered it.',
+  '',
+  '- Save to `memory/YYYY-MM-DD.md` (daily notes) or `MEMORY.md` (durable facts).',
+  '- Only say "记住了" / "I\'ll remember that" AFTER the write tool call succeeds.',
+  '- Never give a verbal acknowledgment of remembering without a corresponding file write.',
+  '- "Mental notes" do not survive session restarts. Files do.',
+].join('\n');
+
 const FALLBACK_OPENCLAW_AGENTS_TEMPLATE = [
   '# AGENTS.md - Your Workspace',
   '',
@@ -1590,6 +1604,7 @@ export class OpenClawConfigSync {
 
       sections.push(MANAGED_WEB_SEARCH_POLICY_PROMPT);
       sections.push(MANAGED_EXEC_SAFETY_PROMPT);
+      sections.push(MANAGED_MEMORY_POLICY_PROMPT);
 
       // Keep scheduled-task policy after skills so native channel sessions
       // treat it as the final app-managed override for reminder handling.


### PR DESCRIPTION
[问题]
微信 Bot 对用户说"记住"等指令时，模型口头回复"记住了！✅"但
没有调用 write 工具将规则写入 memory 文件。规则仅存在于 session
对话历史中，session daily reset（默认凌晨 4 点）或进程重启后规则
完全丢失，用户误以为 Bot 具备持久记忆。

[根因]
OpenClaw 工作区的 AGENTS.md 模板虽然有"Write It Down"章节，但
措辞为建议性描述，对模型没有强约束力。模型在处理记忆类请求时
会直接生成文字确认而跳过工具调用。

[修复]
在 openclawConfigSync.ts 的 MANAGED 注入段中添加
MANAGED_MEMORY_POLICY_PROMPT，内容为强制性规则：
- 检测"记住/以后/下次要/remember this"等意图词
- 必须先调用 write 工具写入 memory/YYYY-MM-DD.md 或 MEMORY.md
- 写入成功后才能回复"记住了"，禁止仅凭口头确认

[复现路径]
1. 通过微信向 Bot 发送"记住：XXX 用 YYY 工具"
2. 检查日志：embedded run 14 秒内无 tool start/end 记录
3. Bot 回复"记住了"但 memory/ 目录无新文件