### PR TITLE
fix(openclaw): use canonical provider ID 'qwen-portal' to stop gateway restart loop

### DIFF
--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -52,7 +52,7 @@ export const OpenClawProviderId = {
   Anthropic: 'anthropic',
   OpenAI: 'openai',
   DeepSeek: 'deepseek',
-  Qwen: 'qwen',
+  Qwen: 'qwen-portal', // OpenClaw normalizes 'qwen' → 'qwen-portal'; use canonical ID to avoid config diff loop
   Zai: 'zai', // OpenClaw official provider ID for Zhipu/GLM
   Volcengine: 'volcengine',
   VolcenginePlan: 'volcengine-plan', // OpenClaw coding plan provider for Volcengine


### PR DESCRIPTION
## Summary
- OpenClaw runtime `normalizeProviderId("qwen")` maps to `"qwen-portal"`, which triggers auto-discovery of the bundled `qwen-portal-auth` extension plugin
- The gateway writes this plugin into `plugins.entries` and stamps a `meta` block, but configSync doesn't declare it — so every sync removes it, the gateway detects the diff and restarts, writes it back, forming a restart loop (~every 15-20s)
- This was exposed by PR #1109 (Provider Descriptor Registry) which changed config from single-provider to all-providers, causing the first config overwrite that kicked off the loop
- Fix: change `OpenClawProviderId.Qwen` from `'qwen'` to `'qwen-portal'` (the canonical ID after gateway normalization), so the gateway no longer needs to inject the plugin entry
- Verified on Windows (2 machines) and Mac — all 3 showed the same `qwen-portal-auth` restart loop

## Test plan
- [ ] With Qwen provider enabled, start the app and verify gateway does NOT restart in a loop
- [ ] Check `openclaw.json` — `providers` should use key `qwen-portal` instead of `qwen`
- [ ] Verify Qwen model conversations still work normally
- [ ] Verify other providers (Volcengine, DeepSeek, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)