### PR TITLE
fix(cowork): prevent input area bottom clipping on narrow window widths

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -659,8 +659,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
               className={textareaClass}
               style={{ minHeight: `${minHeight}px` }}
             />
-            <div className="flex items-center justify-between px-4 pb-2 pt-1.5">
-              <div className="flex items-center gap-2 relative">
+            <div className="flex items-end justify-between gap-2 px-4 pb-2 pt-1.5">
+              <div className="flex items-center gap-2 relative min-w-0 flex-1 flex-wrap">
                 {showFolderSelector && (
                   <>
                     <div className="relative group">
@@ -713,7 +713,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                   </>
                 )}
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 shrink-0">
                 {isStreaming ? (
                   <button
                     type="button"

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1945,7 +1945,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   };
 
   return (
-    <div ref={detailRootRef} className="flex-1 flex flex-col dark:bg-claude-darkBg bg-claude-bg h-full">
+    <div ref={detailRootRef} className="flex-1 flex flex-col dark:bg-claude-darkBg bg-claude-bg min-h-0">
       {/* Header */}
       <div className="draggable flex h-12 items-center justify-between px-4 border-b dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface/50 bg-claude-surface/50 shrink-0">
         {/* Left side: Toggle buttons (when collapsed) + Title */}


### PR DESCRIPTION
## 问题描述

拖拽调整应用窗口宽度变窄时，对话页面底部的输入区域会被遮挡/截断。当启用了多个技能徽标（skill badges）时尤为明显，工具栏需要更多纵向空间来换行显示，但底部内容被裁切。

<img width="2402" height="1686" alt="image" src="https://github.com/user-attachments/assets/fae89460-b904-4dd9-ace1-e94427b339dd" />


## 根本原因

1. **`CoworkSessionDetail` 同时使用了 `h-full` 和 `flex-1`** — 当顶部存在引擎状态横幅（如 OpenClaw 警告条）时，`h-full`（父容器 100% 高度）会让 detail 视图的实际高度超出可用空间。外层容器的 `overflow-hidden` 随即裁切掉溢出的底部内容。
2. **底部工具栏不支持换行** — 包含模型选择器、附件按钮和技能徽标的工具栏使用了不换行的 flex 布局，当水平空间不足时内容会溢出而非自动折行。

## 修复方案

- **`CoworkSessionDetail.tsx`**：将根容器的 `h-full` 替换为 `min-h-0`，让 `flex-1` 正确计算剩余可用高度。
- **`CoworkPromptInput.tsx`**：
  - 工具栏左侧区域添加 `flex-wrap`、`min-w-0`、`flex-1`，使技能徽标在空间不足时自动换行。
  - 发送按钮容器添加 `shrink-0`，防止被挤压。
  - 工具栏垂直对齐从 `items-center` 改为 `items-end`，换行后发送按钮保持在底部对齐。

## 修复之后的效果

<img width="1756" height="1656" alt="image" src="https://github.com/user-attachments/assets/d3910369-425d-4407-9ebf-880de773771f" />

