### PR TITLE
fix(ui): correct malformed Tailwind opacity suffixes from theme migration

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -3850,7 +3850,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
                           className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
                           placeholder={i18nService.t('ollamaModelNamePlaceholder')}
                         />
-                        <p className="mt-1 text-[11px]/70 text-secondary/70">
+                        <p className="mt-1 text-[11px] text-secondary/70">
                           {i18nService.t('ollamaModelNameHint')}
                         </p>
                       </div>
@@ -3870,7 +3870,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
                           className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
                           placeholder={i18nService.t('ollamaDisplayNamePlaceholder')}
                         />
-                        <p className="mt-1 text-[11px]/70 text-secondary/70">
+                        <p className="mt-1 text-[11px] text-secondary/70">
                           {i18nService.t('ollamaDisplayNameHint')}
                         </p>
                       </div>

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -731,7 +731,7 @@ const ToolCallGroup: React.FC<{
               {toolName}
             </span>
             {toolInputSummary && (
-              <code className="text-xs/80 text-secondary/80 font-mono truncate max-w-[400px]">
+              <code className="text-xs text-secondary/80 font-mono truncate max-w-[400px]">
                 {toolInputSummary}
               </code>
             )}
@@ -750,7 +750,7 @@ const ToolCallGroup: React.FC<{
             </div>
           )}
           {!toolResult && (
-            <div className="text-xs/60 text-secondary/60 mt-0.5">
+            <div className="text-xs text-secondary/60 mt-0.5">
               {i18nService.t('coworkToolRunning')}
             </div>
           )}
@@ -831,7 +831,7 @@ const ToolCallGroup: React.FC<{
             <div className="space-y-2">
               {toolInputDisplay && (
                 <div>
-                  <div className="text-[10px] font-medium/70 text-secondary/70 uppercase tracking-wider mb-1">
+                  <div className="text-[10px] font-medium text-secondary/70 uppercase tracking-wider mb-1">
                     {i18nService.t('coworkToolInput')}
                   </div>
                   <div className="max-h-48 overflow-y-auto">
@@ -843,7 +843,7 @@ const ToolCallGroup: React.FC<{
               )}
               {toolResult && (hasToolResultText || showNoDetailError) && (
                 <div>
-                  <div className="text-[10px] font-medium/70 text-secondary/70 uppercase tracking-wider mb-1">
+                  <div className="text-[10px] font-medium text-secondary/70 uppercase tracking-wider mb-1">
                     {i18nService.t('coworkToolResult')}
                   </div>
                   <div className="max-h-64 overflow-y-auto">
@@ -1217,7 +1217,7 @@ export const AssistantTurnBlock: React.FC<{
               {i18nService.t('coworkToolResult')}
             </div>
             {resultLineCount > 0 && (
-              <div className="text-xs/60 text-secondary/60 mt-0.5">
+              <div className="text-xs text-secondary/60 mt-0.5">
                 {resultLineCount} {resultLineCount === 1 ? 'line' : 'lines'} of output
               </div>
             )}

--- a/src/renderer/components/scheduledTasks/TaskList.tsx
+++ b/src/renderer/components/scheduledTasks/TaskList.tsx
@@ -151,11 +151,11 @@ const TaskList: React.FC<TaskListProps> = ({ onRequestDelete }) => {
   if (tasks.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 px-6">
-        <ClockIcon className="h-12 w-12/40 text-secondary/40 mb-4" />
+        <ClockIcon className="h-12 w-12 text-secondary/40 mb-4" />
         <p className="text-sm font-medium text-secondary mb-1">
           {i18nService.t('scheduledTasksEmptyState')}
         </p>
-        <p className="text-xs/70 text-secondary/70 text-center">
+        <p className="text-xs text-secondary/70 text-center">
           {i18nService.t('scheduledTasksEmptyHint')}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- The semantic theme class migration (commit 73c6361) incorrectly merged CSS opacity suffixes into unrelated Tailwind utility classes, e.g. `text-xs/80` (parsed as font-size + line-height), `font-medium/70`, `w-12/40`, `text-[11px]/70`
- Split them back into separate utilities: `text-xs text-secondary/80`, `font-medium text-secondary/70`, `w-12 text-secondary/40`, `text-[11px] text-secondary/70`
- 3 files, 9 occurrences fixed: `CoworkSessionDetail.tsx`, `TaskList.tsx`, `Settings.tsx`

## Test plan
- [ ] Tool call UI: expand any tool call, verify INPUT/RESULT labels and content have normal font size and line height
- [ ] Tool running state: trigger a long-running tool, check the "running..." hint text
- [ ] Tool input summary (collapsed state): verify the gray monospace summary next to tool name
- [ ] Scheduled tasks: empty state page — icon size and hint text
- [ ] Settings > Ollama config: model name / display name hint text below inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)