### PR TITLE
fix(enterprise): reset executionMode when enterprise config is removed

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4474,7 +4474,10 @@ if (!gotTheLock) {
       const hadEnterprise = store.get('enterprise_config');
       if (hadEnterprise) {
         store.delete('enterprise_config');
-        console.log('[Enterprise] config package removed, cleared enterprise mode');
+        // Reset executionMode to default so sandbox mode reverts to "off".
+        const cs = getCoworkStore();
+        cs.setConfig({ executionMode: 'local' });
+        console.log('[Enterprise] config package removed, cleared enterprise mode and reset executionMode');
       }
     }
 


### PR DESCRIPTION
When enterprise config was deleted, only the enterprise_config record was cleared from the app store, but the executionMode in cowork_config remained at the enterprise-set value (e.g. "sandbox"). This left OpenClaw sandbox mode stuck even after the enterprise package was removed. Now explicitly reset executionMode to "local" (sandbox off).