### PR TITLE
fix(cowork): hide OpenClaw main agent sessions from session list

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -565,15 +565,17 @@ export class CoworkStore {
     systemPrompt: string = '',
     executionMode: CoworkExecutionMode = 'local',
     activeSkillIds: string[] = [],
-    agentId: string = 'main'
+    agentId: string = 'main',
+    options?: { hidden?: boolean }
   ): CoworkSession {
     const id = uuidv4();
     const now = Date.now();
+    const hidden = options?.hidden ? 1 : 0;
 
     this.db.run(`
-      INSERT INTO cowork_sessions (id, title, claude_session_id, status, cwd, system_prompt, execution_mode, active_skill_ids, agent_id, pinned, created_at, updated_at)
-      VALUES (?, ?, NULL, 'idle', ?, ?, ?, ?, ?, 0, ?, ?)
-    `, [id, title, cwd, systemPrompt, executionMode, JSON.stringify(activeSkillIds), agentId, now, now]);
+      INSERT INTO cowork_sessions (id, title, claude_session_id, status, cwd, system_prompt, execution_mode, active_skill_ids, agent_id, pinned, hidden, created_at, updated_at)
+      VALUES (?, ?, NULL, 'idle', ?, ?, ?, ?, ?, 0, ?, ?, ?)
+    `, [id, title, cwd, systemPrompt, executionMode, JSON.stringify(activeSkillIds), agentId, hidden, now, now]);
 
     this.saveDb();
 
@@ -728,13 +730,14 @@ export class CoworkStore {
       rows = this.getAll<SessionSummaryRow>(`
         SELECT id, title, status, pinned, agent_id, created_at, updated_at
         FROM cowork_sessions
-        WHERE agent_id = ?
+        WHERE agent_id = ? AND COALESCE(hidden, 0) = 0
         ORDER BY pinned DESC, updated_at DESC
       `, [agentId]);
     } else {
       rows = this.getAll<SessionSummaryRow>(`
         SELECT id, title, status, pinned, agent_id, created_at, updated_at
         FROM cowork_sessions
+        WHERE COALESCE(hidden, 0) = 0
         ORDER BY pinned DESC, updated_at DESC
       `);
     }
@@ -1575,6 +1578,7 @@ export class CoworkStore {
     const clauses: string[] = [
       "m.type IN ('user', 'assistant')",
       `(${likeClauses.join(' OR ')})`,
+      'COALESCE(s.hidden, 0) = 0',
     ];
     const params: Array<string | number> = terms.map((term) => `%${term}%`);
 
@@ -1656,7 +1660,7 @@ export class CoworkStore {
     const beforeMs = parseTimeToMs(options.before);
     const afterMs = parseTimeToMs(options.after);
 
-    const clauses: string[] = [];
+    const clauses: string[] = ['COALESCE(hidden, 0) = 0'];
     const params: Array<string | number> = [];
 
     if (beforeMs !== null) {
@@ -1668,7 +1672,7 @@ export class CoworkStore {
       params.push(afterMs);
     }
 
-    const whereClause = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
+    const whereClause = `WHERE ${clauses.join(' AND ')}`;
 
     const rows = this.getAll<{
       id: string;

--- a/src/main/libs/openclawChannelSessionSync.ts
+++ b/src/main/libs/openclawChannelSessionSync.ts
@@ -408,7 +408,7 @@ export class OpenClawChannelSessionSync {
 
     const cwd = this.getDefaultCwd();
     console.log('[ChannelSessionSync] creating main agent session: key=', sessionKey, 'cwd=', cwd);
-    const session = this.coworkStore.createSession('[OpenClaw]', cwd, '', 'local');
+    const session = this.coworkStore.createSession('[OpenClaw]', cwd, '', 'local', [], 'main', { hidden: true });
     console.log('[ChannelSessionSync] created main agent session:', session.id);
 
     this.syncedSessionKeys.set(sessionKey, session.id);

--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -260,6 +260,19 @@ export class SqliteStore {
       // Column already exists or migration not needed.
     }
 
+    // Migration: Add hidden column to cowork_sessions
+    try {
+      const sessionCols2 = this.db.exec("PRAGMA table_info(cowork_sessions);");
+      const sessionColNames2 = sessionCols2[0]?.values.map((row) => row[1]) || [];
+      if (!sessionColNames2.includes('hidden')) {
+        this.db.run('ALTER TABLE cowork_sessions ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0;');
+        this.db.run("UPDATE cowork_sessions SET hidden = 1 WHERE title = '[OpenClaw]';");
+        this.save();
+      }
+    } catch {
+      // Column already exists or migration not needed.
+    }
+
     // Migration: Ensure default 'main' agent exists
     try {
       const mainAgent = this.db.exec("SELECT id FROM agents WHERE id = 'main'");


### PR DESCRIPTION
## Summary

- The OpenClaw main agent session (used internally for heartbeat/cron routing) was created with a hardcoded `[OpenClaw]` title and appeared in the user-facing Cowork session list, causing user confusion
- Added a `hidden` column to `cowork_sessions` table and mark main agent sessions as hidden on creation
- Filter hidden sessions from `listSessions`, conversation search, and recent sessions queries
- Existing `[OpenClaw]` sessions are retroactively hidden via DB migration

## 问题表现
main任务记录列表透出OpenClaw字样，且任务详情里展示看不懂的信息。会让用户以为是OpenClaw套壳，影响用户体验。
<img width="2404" height="1436" alt="image" src="https://github.com/user-attachments/assets/42a7794d-bf39-456d-97d1-1c6ea0109eb5" />

## Changes

| File | Change |
|------|--------|
| `src/main/sqliteStore.ts` | Add `hidden INTEGER` column migration + retroactive hide of existing `[OpenClaw]` sessions |
| `src/main/coworkStore.ts` | Accept `options.hidden` in `createSession`, filter `hidden=1` in list/search queries |
| `src/main/libs/openclawChannelSessionSync.ts` | Pass `{ hidden: true }` when creating main agent sessions |

## 修复后效果
<img width="1720" height="1582" alt="image" src="https://github.com/user-attachments/assets/aa7c4583-d9f2-41dd-8c58-f98e949e5dc9" />
