### PR TITLE
fix(cowork): add try-catch for metadata JSON.parse in getSessionMessages

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -805,13 +805,23 @@ export class CoworkStore {
         ROWID ASC
     `, [sessionId]);
 
-    return rows.map(row => ({
-      id: row.id,
-      type: row.type as CoworkMessageType,
-      content: row.content,
-      timestamp: row.created_at,
-      metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
-    }));
+    return rows.map(row => {
+      let metadata: Record<string, unknown> | undefined;
+      if (row.metadata) {
+        try {
+          metadata = JSON.parse(row.metadata);
+        } catch {
+          console.warn('[CoworkStore] corrupted message metadata, skipping:', row.id);
+        }
+      }
+      return {
+        id: row.id,
+        type: row.type as CoworkMessageType,
+        content: row.content,
+        timestamp: row.created_at,
+        metadata,
+      };
+    });
   }
 
   addMessage(sessionId: string, message: Omit<CoworkMessage, 'id' | 'timestamp'>): CoworkMessage {


### PR DESCRIPTION
数据库中任意一条消息的 metadata 字段格式异常（写入中断、旧版本格式不兼容等），该 session 的所有消息都无法加载。