### PR TITLE
feat(skills,mcp): add sticky category tag bar in marketplace tabs

### DIFF
--- a/src/renderer/components/mcp/McpManager.tsx
+++ b/src/renderer/components/mcp/McpManager.tsx
@@ -496,7 +496,7 @@ const McpManager: React.FC = () => {
       {activeTab === 'marketplace' && (
         <div>
           {/* Category filter pills */}
-          <div className="flex items-center gap-1.5 mb-4 flex-wrap">
+          <div className="sticky top-0 z-10 bg-background -mx-4 px-4 py-3 flex items-center gap-1.5 flex-wrap border-b border-border mb-4">
             {dynamicCategories.map((cat) => (
               <button
                 key={cat.id}

--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -679,7 +679,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly }) => {
         ) : (
           <>
             {marketTags.length > 0 && (
-              <div className="flex items-center gap-1.5 mb-4 flex-wrap">
+              <div className="sticky top-0 z-10 bg-background -mx-4 px-4 py-3 flex items-center gap-1.5 flex-wrap border-b border-border mb-4">
                 <button
                   type="button"
                   onClick={() => setActiveMarketTag('all')}


### PR DESCRIPTION
## 改动说明

在技能市场和 MCP 市场的分类 tag 区增加滚动吸顶效果。

### 问题
用户在滚动浏览市场列表时，分类 tag 组随页面滚动消失，切换分类需要先滚动回顶部，操作繁琐。

### 解决方案
- `SkillsManager.tsx`：给技能市场的分类 tag 容器加上 `sticky top-0` 吸顶效果
- `McpManager.tsx`：同样处理 MCP 市场的分类 pills 容器
- 使用 `bg-background` 保证吸顶时背景不透明，遮挡下方滚动内容
- 使用 `-mx-4 px-4` 使 tag 条延伸至内容区左右边缘，视觉更整洁
- 添加 `border-b border-border` 吸顶时显示底部分隔线

### 效果
用户在滚动列表时，分类 tag 始终固定在顶部，可随时切换分类，提升使用体验。
<img width="2198" height="1594" alt="image" src="https://github.com/user-attachments/assets/e5bddc01-0911-4c57-a530-0677af14b234" />
