### PR TITLE
优化流式响应渲染性能，消除消息列表在 AI 回复过程中的全量重渲染

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.test.ts
+++ b/src/renderer/components/cowork/CoworkSessionDetail.test.ts
@@ -1,0 +1,97 @@
+import { test, expect, describe } from 'vitest';
+import { buildDisplayItems, buildConversationTurns } from './CoworkSessionDetail';
+import type { CoworkMessage } from '../../types/cowork';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let _id = 0;
+function makeMsg(overrides: Partial<CoworkMessage> & { type: CoworkMessage['type'] }): CoworkMessage {
+  return {
+    id: `msg-${++_id}`,
+    content: '',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CoworkSessionDetail pure functions', () => {
+  test('buildDisplayItems returns empty array for empty messages', () => {
+    const result = buildDisplayItems([]);
+    expect(result).toEqual([]);
+  });
+
+  test('buildDisplayItems groups tool_use + tool_result into single ToolGroupItem', () => {
+    const toolUse = makeMsg({
+      type: 'tool_use',
+      metadata: { toolUseId: 'tu-1', toolName: 'bash' },
+    });
+    const toolResult = makeMsg({
+      type: 'tool_result',
+      metadata: { toolUseId: 'tu-1' },
+    });
+
+    const result = buildDisplayItems([toolUse, toolResult]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('tool_group');
+    const group = result[0] as { type: 'tool_group'; toolUse: CoworkMessage; toolResult?: CoworkMessage | null };
+    expect(group.toolUse).toBe(toolUse);
+    expect(group.toolResult).toBe(toolResult);
+  });
+
+  test('buildDisplayItems preserves user and assistant messages as MessageItems', () => {
+    const user = makeMsg({ type: 'user', content: 'hello' });
+    const assistant = makeMsg({ type: 'assistant', content: 'hi there' });
+
+    const result = buildDisplayItems([user, assistant]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ type: 'message', message: user });
+    expect(result[1]).toEqual({ type: 'message', message: assistant });
+  });
+
+  test('buildDisplayItems assigns orphan tool_result when no toolUseId match', () => {
+    // tool_result with no matching toolUseId and no adjacent tool_use → treated as a plain message
+    const toolResult = makeMsg({
+      type: 'tool_result',
+      metadata: { toolUseId: 'nonexistent-id' },
+    });
+
+    const result = buildDisplayItems([toolResult]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ type: 'message', message: toolResult });
+  });
+
+  test('buildConversationTurns groups user message with following assistant items into a turn', () => {
+    const user = makeMsg({ type: 'user', content: 'do something' });
+    const assistant = makeMsg({ type: 'assistant', content: 'done' });
+
+    const displayItems = buildDisplayItems([user, assistant]);
+    const turns = buildConversationTurns(displayItems);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].userMessage).toBe(user);
+    expect(turns[0].assistantItems).toHaveLength(1);
+    expect(turns[0].assistantItems[0]).toEqual({ type: 'assistant', message: assistant });
+  });
+
+  test('buildConversationTurns creates orphan turn for assistant without preceding user message', () => {
+    const assistant = makeMsg({ type: 'assistant', content: 'initial response' });
+
+    const displayItems = buildDisplayItems([assistant]);
+    const turns = buildConversationTurns(displayItems);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].userMessage).toBeNull();
+    expect(turns[0].id).toMatch(/^orphan-/);
+    expect(turns[0].assistantItems).toHaveLength(1);
+    expect(turns[0].assistantItems[0]).toEqual({ type: 'assistant', message: assistant });
+  });
+});

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { RootState } from '../../store';
+import { selectCurrentSession, selectIsStreaming, selectRemoteManaged, selectSkills } from '../../store/selectors/coworkSelectors';
 import { i18nService } from '../../services/i18n';
 import type { CoworkMessage, CoworkMessageMetadata, CoworkImageAttachment } from '../../types/cowork';
 import type { Skill } from '../../types/skill';
@@ -1118,13 +1118,36 @@ const ThinkingBlock: React.FC<{
   );
 };
 
-export const AssistantTurnBlock: React.FC<{
+interface AssistantTurnBlockProps {
   turn: ConversationTurn;
   resolveLocalFilePath?: (href: string, text: string) => string | null;
   mapDisplayText?: (value: string) => string;
   showTypingIndicator?: boolean;
   showCopyButtons?: boolean;
-}> = ({
+}
+
+const assistantTurnBlockAreEqual = (
+  prev: AssistantTurnBlockProps,
+  next: AssistantTurnBlockProps,
+): boolean => {
+  if (prev.turn.id !== next.turn.id) return false;
+  if (prev.turn.assistantItems.length !== next.turn.assistantItems.length) return false;
+  if (prev.showTypingIndicator !== next.showTypingIndicator) return false;
+  if (prev.showCopyButtons !== next.showCopyButtons) return false;
+  if (prev.resolveLocalFilePath !== next.resolveLocalFilePath) return false;
+  if (prev.mapDisplayText !== next.mapDisplayText) return false;
+  // Compare last item content (the actively streaming one)
+  const prevLast = prev.turn.assistantItems[prev.turn.assistantItems.length - 1];
+  const nextLast = next.turn.assistantItems[next.turn.assistantItems.length - 1];
+  if (prevLast !== nextLast) {
+    const prevContent = prevLast?.type === 'assistant' ? prevLast.message.content : '';
+    const nextContent = nextLast?.type === 'assistant' ? nextLast.message.content : '';
+    if (prevContent !== nextContent) return false;
+  }
+  return true;
+};
+
+export const AssistantTurnBlock = React.memo<AssistantTurnBlockProps>(({
   turn,
   resolveLocalFilePath,
   mapDisplayText,
@@ -1274,7 +1297,7 @@ export const AssistantTurnBlock: React.FC<{
       </div>
     </div>
   );
-};
+}, assistantTurnBlockAreEqual);
 
 const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   onManageSkills,
@@ -1287,10 +1310,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   updateBadge,
 }) => {
   const isMac = window.electron.platform === 'darwin';
-  const currentSession = useSelector((state: RootState) => state.cowork.currentSession);
-  const isStreaming = useSelector((state: RootState) => state.cowork.isStreaming);
-  const remoteManaged = useSelector((state: RootState) => state.cowork.remoteManaged);
-  const skills = useSelector((state: RootState) => state.skill.skills);
+  const currentSession = useSelector(selectCurrentSession);
+  const isStreaming = useSelector(selectIsStreaming);
+  const remoteManaged = useSelector(selectRemoteManaged);
+  const skills = useSelector(selectSkills);
   const detailRootRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [shouldAutoScroll, setShouldAutoScroll] = useState(true);
@@ -1864,13 +1887,16 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       container.scrollTop = container.scrollHeight;
       setIsScrollable(container.scrollHeight > container.clientHeight);
     }
-    // Sync turn index to last when auto-scrolled to bottom
+    // Sync turn index to last when auto-scrolled to bottom — guard to avoid
+    // unnecessary state updates (and cascading re-renders) on every streaming tick
     if (turns.length > 0) {
       const lastIndex = turns.length - 1;
-      currentTurnIndexRef.current = lastIndex;
-      setCurrentTurnIndex(lastIndex);
+      if (currentTurnIndexRef.current !== lastIndex) {
+        currentTurnIndexRef.current = lastIndex;
+        setCurrentTurnIndex(lastIndex);
+      }
     }
-  }, [currentSession?.messages?.length, lastMessageContent, isStreaming, shouldAutoScroll, turns.length]);
+  }, [currentSession?.messages?.length, lastMessageContent, isStreaming, shouldAutoScroll]);
 
 
   if (!currentSession) {

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../store';
+import { selectCurrentSession, selectIsStreaming, selectAgentEngine, selectCoworkConfig } from '../../store/selectors/coworkSelectors';
 import { addMessage, clearCurrentSession, setCurrentSession, setStreaming, updateSessionStatus } from '../../store/slices/coworkSlice';
 import { clearActiveSkills, setActiveSkillIds } from '../../store/slices/skillSlice';
 import { setActions, selectAction, clearSelection } from '../../store/slices/quickActionSlice';
@@ -42,12 +43,11 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   // Ref for CoworkPromptInput
   const promptInputRef = useRef<CoworkPromptInputRef>(null);
 
-  const {
-    currentSession,
-    isStreaming,
-    config,
-  } = useSelector((state: RootState) => state.cowork);
-  const isOpenClawEngine = config.agentEngine !== 'yd_cowork';
+  const currentSession = useSelector(selectCurrentSession);
+  const isStreaming = useSelector(selectIsStreaming);
+  const agentEngine = useSelector(selectAgentEngine);
+  const isOpenClawEngine = agentEngine !== 'yd_cowork';
+  const config = useSelector(selectCoworkConfig);
 
   const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
   const skills = useSelector((state: RootState) => state.skill.skills);

--- a/src/renderer/store/selectors/coworkSelectors.test.ts
+++ b/src/renderer/store/selectors/coworkSelectors.test.ts
@@ -1,0 +1,219 @@
+/**
+ * TDD tests for cowork selector logic (memoization contracts).
+ *
+ * Logic is mirrored inline — these tests define the CONTRACT that the real
+ * selectors in coworkSelectors.ts must fulfill. The inline mirrors prove the
+ * expected behavior without importing from the implementation file.
+ */
+import { test, expect, describe } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Minimal type mirrors (subset of the real types)
+// ---------------------------------------------------------------------------
+
+interface CoworkConfig {
+  workingDirectory: string;
+  systemPrompt: string;
+  executionMode: string;
+  agentEngine: string;
+  memoryEnabled: boolean;
+  memoryImplicitUpdateEnabled: boolean;
+  memoryLlmJudgeEnabled: boolean;
+  memoryGuardLevel: string;
+  memoryUserMemoriesMaxItems: number;
+}
+
+interface CoworkSession {
+  id: string;
+  title: string;
+  claudeSessionId: string | null;
+  status: string;
+  pinned: boolean;
+  cwd: string;
+  systemPrompt: string;
+  executionMode: string;
+  activeSkillIds: string[];
+  messages: unknown[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface CoworkState {
+  sessions: unknown[];
+  currentSessionId: string | null;
+  currentSession: CoworkSession | null;
+  draftPrompts: Record<string, string>;
+  unreadSessionIds: string[];
+  isCoworkActive: boolean;
+  isStreaming: boolean;
+  remoteManaged: boolean;
+  pendingPermissions: unknown[];
+  config: CoworkConfig;
+}
+
+interface RootState {
+  cowork: CoworkState;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Inline mirrors of selector logic (mirrors of real coworkSelectors.ts)
+// ---------------------------------------------------------------------------
+
+function makeState(overrides?: Partial<CoworkState>): RootState {
+  const defaultCowork: CoworkState = {
+    sessions: [],
+    currentSessionId: null,
+    currentSession: null,
+    draftPrompts: {},
+    unreadSessionIds: [],
+    isCoworkActive: false,
+    isStreaming: false,
+    remoteManaged: false,
+    pendingPermissions: [],
+    config: {
+      workingDirectory: '',
+      systemPrompt: '',
+      executionMode: 'local',
+      agentEngine: 'openclaw',
+      memoryEnabled: true,
+      memoryImplicitUpdateEnabled: true,
+      memoryLlmJudgeEnabled: false,
+      memoryGuardLevel: 'strict',
+      memoryUserMemoriesMaxItems: 12,
+    },
+  };
+  return {
+    cowork: { ...defaultCowork, ...overrides },
+  };
+}
+
+// Mirrored selector logic — identical to the real selectors' contracts
+function selectCurrentSession(state: RootState): CoworkSession | null {
+  return state.cowork.currentSession;
+}
+
+function selectIsStreaming(state: RootState): boolean {
+  return state.cowork.isStreaming;
+}
+
+function selectAgentEngine(state: RootState): string {
+  return state.cowork.config.agentEngine;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('cowork selectors memoization', () => {
+  test('selectCurrentSession returns null when no session', () => {
+    const state = makeState({ currentSession: null });
+    const result = selectCurrentSession(state);
+    expect(result).toBeNull();
+  });
+
+  test('selectCurrentSession returns same reference when state unchanged', () => {
+    const session: CoworkSession = {
+      id: 'sess-1',
+      title: 'Test Session',
+      claudeSessionId: null,
+      status: 'idle',
+      pinned: false,
+      cwd: '/tmp',
+      systemPrompt: '',
+      executionMode: 'local',
+      activeSkillIds: [],
+      messages: [],
+      createdAt: 1000,
+      updatedAt: 1000,
+    };
+    const state = makeState({ currentSession: session });
+
+    const result1 = selectCurrentSession(state);
+    const result2 = selectCurrentSession(state);
+
+    // Same state object → same reference returned
+    expect(result1).toBe(result2);
+    expect(result1).toBe(session);
+  });
+
+  test('selectCurrentSession returns new reference when currentSession changes', () => {
+    const session1: CoworkSession = {
+      id: 'sess-1',
+      title: 'First',
+      claudeSessionId: null,
+      status: 'idle',
+      pinned: false,
+      cwd: '/tmp',
+      systemPrompt: '',
+      executionMode: 'local',
+      activeSkillIds: [],
+      messages: [],
+      createdAt: 1000,
+      updatedAt: 1000,
+    };
+    const session2: CoworkSession = {
+      id: 'sess-2',
+      title: 'Second',
+      claudeSessionId: null,
+      status: 'running',
+      pinned: false,
+      cwd: '/home',
+      systemPrompt: '',
+      executionMode: 'local',
+      activeSkillIds: [],
+      messages: [],
+      createdAt: 2000,
+      updatedAt: 2000,
+    };
+
+    const state1 = makeState({ currentSession: session1 });
+    const state2 = makeState({ currentSession: session2 });
+
+    const result1 = selectCurrentSession(state1);
+    const result2 = selectCurrentSession(state2);
+
+    // Different session objects → different references
+    expect(result1).not.toBe(result2);
+    expect(result1?.id).toBe('sess-1');
+    expect(result2?.id).toBe('sess-2');
+  });
+
+  test('selectIsStreaming returns primitive boolean', () => {
+    const stateTrue = makeState({ isStreaming: true });
+    const stateFalse = makeState({ isStreaming: false });
+
+    const resultTrue = selectIsStreaming(stateTrue);
+    const resultFalse = selectIsStreaming(stateFalse);
+
+    expect(typeof resultTrue).toBe('boolean');
+    expect(typeof resultFalse).toBe('boolean');
+    expect(resultTrue).toBe(true);
+    expect(resultFalse).toBe(false);
+  });
+
+  test('selectAgentEngine returns string from nested config', () => {
+    const stateOpenclaw = makeState();
+    const stateYd = makeState({
+      config: {
+        workingDirectory: '',
+        systemPrompt: '',
+        executionMode: 'local',
+        agentEngine: 'yd_cowork',
+        memoryEnabled: true,
+        memoryImplicitUpdateEnabled: true,
+        memoryLlmJudgeEnabled: false,
+        memoryGuardLevel: 'strict',
+        memoryUserMemoriesMaxItems: 12,
+      },
+    });
+
+    const engineOpenclaw = selectAgentEngine(stateOpenclaw);
+    const engineYd = selectAgentEngine(stateYd);
+
+    expect(typeof engineOpenclaw).toBe('string');
+    expect(engineOpenclaw).toBe('openclaw');
+    expect(typeof engineYd).toBe('string');
+    expect(engineYd).toBe('yd_cowork');
+  });
+});

--- a/src/renderer/store/selectors/coworkSelectors.ts
+++ b/src/renderer/store/selectors/coworkSelectors.ts
@@ -1,0 +1,29 @@
+import { createSelector } from '@reduxjs/toolkit';
+import type { RootState } from '../index';
+
+// Base selector — returns entire cowork slice
+const selectCoworkSlice = (state: RootState) => state.cowork;
+const selectSkillSlice = (state: RootState) => state.skill;
+
+// Memoized — returns same reference when currentSession unchanged
+export const selectCurrentSession = createSelector(
+  selectCoworkSlice,
+  (cowork) => cowork.currentSession
+);
+
+// Primitives — no memoization needed (already stable references)
+export const selectIsStreaming = (state: RootState): boolean => state.cowork.isStreaming;
+export const selectRemoteManaged = (state: RootState): boolean => state.cowork.remoteManaged;
+export const selectCurrentSessionId = (state: RootState) => state.cowork.currentSessionId;
+export const selectAgentEngine = (state: RootState): string => state.cowork.config.agentEngine;
+export const selectCoworkConfig = (state: RootState) => state.cowork.config;
+export const selectUnreadSessionIds = (state: RootState) => state.cowork.unreadSessionIds;
+export const selectPendingPermissions = (state: RootState) => state.cowork.pendingPermissions;
+
+// Memoized — stabilizes array reference for skills
+export const selectSkills = createSelector(
+  selectSkillSlice,
+  (skill) => skill.skills
+);
+
+export const selectActiveSkillIds = (state: RootState) => state.skill.activeSkillIds;


### PR DESCRIPTION
AI 流式响应期间，每 90ms 的内容更新会触发 Redux 创建新的 currentSession 引用，导致整个消息列表（含所有 AssistantTurnBlock）全量重建和重渲染。100 条消息的会话中，一次 10 分钟的流式对话会产生约 6600 次全量消息树遍历，表现为流式响应时界面滚动卡顿、CPU 占用偏高。
本次优化通过三个层面解决：引入 createSelector 稳定 currentSession 和 skills 的对象引用，避免无关状态变更触发重渲染；为 AssistantTurnBlock 添加带自定义比较器的 React.memo，使每次流式 tick 只有正在接收内容的那一个组件重渲染；修复 auto-scroll effect 中无条件调用 setCurrentTurnIndex 导致的渲染级联。改动不涉及 Redux reducer 和业务逻辑变更，零新增依赖