### PR TITLE
fix(openclaw): default sandbox mode to off for auto execution mode

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -24,7 +24,7 @@ export type McpBridgeConfig = {
 const mapExecutionModeToSandboxMode = (mode: CoworkExecutionMode): 'off' | 'non-main' | 'all' => {
   switch (mode) {
     case 'sandbox': return 'all';
-    case 'auto': return 'non-main';
+    case 'auto': return 'off';
     case 'local':
     default: return 'off';
   }


### PR DESCRIPTION
Users without Docker installed were getting sandbox errors because auto mode mapped to non-main which requires Docker.