### PR TITLE
fix(installer): stop app before Windows uninstall

### DIFF
--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -11,8 +11,16 @@
 !macroend
 
 !macro customInit
-  ; Best-effort: terminate a running app instance before install/uninstall
+  ; Best-effort: terminate a running app instance before install
   ; to avoid NSIS "app cannot be closed" errors during upgrades.
+  nsExec::ExecToLog 'taskkill /IM "${APP_EXECUTABLE_FILENAME}" /F /T'
+  Pop $0
+  Sleep 800
+!macroend
+
+!macro customUnInit
+  ; Best-effort: terminate a running app instance before uninstall
+  ; so the uninstaller can fully remove the application.
   nsExec::ExecToLog 'taskkill /IM "${APP_EXECUTABLE_FILENAME}" /F /T'
   Pop $0
   Sleep 800

--- a/src/main/nsisInstallerScript.test.ts
+++ b/src/main/nsisInstallerScript.test.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import { expect, test } from 'vitest';
+
+const NSIS_SCRIPT_PATH = path.resolve(process.cwd(), 'scripts/nsis-installer.nsh');
+const TASKKILL_COMMAND = `nsExec::ExecToLog 'taskkill /IM "\${APP_EXECUTABLE_FILENAME}" /F /T'`;
+
+function getMacroBody(script: string, macroName: string): string | null {
+  const escapedName = macroName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`!macro ${escapedName}\\n([\\s\\S]*?)!macroend`);
+  const match = script.match(pattern);
+  return match?.[1] ?? null;
+}
+
+test('nsis script terminates a running app before both install and uninstall', () => {
+  const script = fs.readFileSync(NSIS_SCRIPT_PATH, 'utf8');
+
+  const installInitBody = getMacroBody(script, 'customInit');
+  const uninstallInitBody = getMacroBody(script, 'customUnInit');
+
+  expect(installInitBody).toBeTruthy();
+  expect(installInitBody).toContain(TASKKILL_COMMAND);
+
+  expect(uninstallInitBody).toBeTruthy();
+  expect(uninstallInitBody).toContain(TASKKILL_COMMAND);
+});


### PR DESCRIPTION
[问题]

Windows 卸载 LobsterAI 时，如果应用仍在运行，卸载完成后现有窗口和 IM 会话仍可继续工作，用户会误以为应用在卸载后仍然驻留。

[根因]

NSIS 安装脚本只在 customInit 中处理了安装/升级前的 taskkill，但卸载路径缺少 customUnInit 钩子，因此控制面板卸载不会在开始前结束正在运行的主进程。

[修复]

新增 customUnInit，在卸载开始前执行与安装前相同的 taskkill /F /T；同时补充回归测试，要求 customInit 和 customUnInit 都必须包含相同的进程终止命令，避免再次回归。

[复现路径]

1. 在 Windows 上启动 LobsterAI。

2. 保持应用窗口打开，从添加与删除程序中卸载 LobsterAI。

3. 修复前，应用窗口和 IM 能力仍继续工作；修复后，卸载开始前会先结束进程。

Closes #1173