### PR TITLE
fix(定时任务): 修复通知渠道过滤缺陷，升级渠道选择器显示体验

### DIFF
--- a/src/main/ipcHandlers/scheduledTask/helpers.ts
+++ b/src/main/ipcHandlers/scheduledTask/helpers.ts
@@ -12,6 +12,14 @@ export function initScheduledTaskHelpers(d: ScheduledTaskHelperDeps): void {
   deps = d;
 }
 
+/**
+ * List notification channels for scheduled tasks.
+ *
+ * Data source: IM Gateway config (same as Settings → IM 机器人).
+ * Channel-to-config-key mapping is resolved automatically via PlatformRegistry,
+ * so adding a new IM platform only requires updating PlatformRegistry — no
+ * changes needed here.
+ */
 export function listScheduledTaskChannels(): Array<{ value: string; label: string }> {
   const manager = deps?.getIMGatewayManager();
   const config = manager?.getConfig();
@@ -19,6 +27,7 @@ export function listScheduledTaskChannels(): Array<{ value: string; label: strin
     return [...PlatformRegistry.channelOptions()];
   }
 
+  // Collect enabled platform IDs from IM config
   const enabledConfigKeys = new Set<string>();
   const configEntries: Array<[string, unknown]> = Object.entries(
     config as unknown as Record<string, unknown>,
@@ -29,16 +38,13 @@ export function listScheduledTaskChannels(): Array<{ value: string; label: strin
     }
   }
 
+  // Filter channels by resolving channel → platform ID via PlatformRegistry
   return PlatformRegistry.channelOptions().filter((option) => {
-    if (option.value === 'dingtalk') {
-      return enabledConfigKeys.has('dingtalk');
+    const platform = PlatformRegistry.platformOfChannel(option.value);
+    if (platform) {
+      return enabledConfigKeys.has(platform);
     }
-    if (option.value === 'qqbot') {
-      return enabledConfigKeys.has('qq');
-    }
-    if (option.value === 'openclaw-weixin') {
-      return enabledConfigKeys.has('weixin');
-    }
+    // Unknown channel: keep if its value directly matches a config key
     return enabledConfigKeys.has(option.value);
   });
 }

--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -397,28 +397,112 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
     );
   };
 
+  const [channelDropdownOpen, setChannelDropdownOpen] = useState(false);
+  const channelDropdownRef = React.useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (channelDropdownRef.current && !channelDropdownRef.current.contains(event.target as Node)) {
+        setChannelDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const getChannelLogo = (channelValue: string): string | null => {
+    const platform = PlatformRegistry.platformOfChannel(channelValue);
+    if (platform) {
+      return PlatformRegistry.logo(platform);
+    }
+    return null;
+  };
+
+  const isChannelUnsupported = (channelValue: string): boolean => {
+    return channelValue === 'qqbot' || channelValue === 'netease-bee';
+  };
+
+  const getChannelDisplayLabel = (channelValue: string): string => {
+    if (channelValue === 'none') return i18nService.t('scheduledTasksFormNotifyChannelNone');
+    // Use i18n translation for platform name (e.g. weixin → '微信', feishu → '飞书')
+    const platform = PlatformRegistry.platformOfChannel(channelValue);
+    if (platform) {
+      const label = i18nService.t(platform) || PlatformRegistry.get(platform).label;
+      return isChannelUnsupported(channelValue) ? `${label} (${i18nService.t('scheduledTasksChannelUnsupported')})` : label;
+    }
+    const option = channelOptions.find(c => c.value === channelValue);
+    return option ? option.label : channelValue;
+  };
+
   const renderNotifyRow = () => {
+    const selectedLogo = getChannelLogo(form.notifyChannel);
+
     return (
       <div>
         <label className={labelClass}>{i18nService.t('scheduledTasksFormNotifyChannel')}</label>
         <div className="flex items-center gap-3">
-          <select
-            value={form.notifyChannel}
-            onChange={(event) => updateForm({ notifyChannel: event.target.value, notifyTo: '' })}
-            className={`${inputClass} ${showConversationSelector ? 'flex-1 min-w-0' : ''}`}
-          >
-            <option value="none">{i18nService.t('scheduledTasksFormNotifyChannelNone')}</option>
-            {channelOptions.map((channel) => {
-              const unsupported = channel.value === 'openclaw-weixin' || channel.value === 'qqbot' || channel.value === 'netease-bee';
-              return (
-                <option key={channel.value} value={channel.value} disabled={unsupported}>
-                  {unsupported
-                    ? `${channel.label} (${i18nService.t('scheduledTasksChannelUnsupported')})`
-                    : channel.label}
-                </option>
-              );
-            })}
-          </select>
+          <div className={`relative ${showConversationSelector ? 'flex-1 min-w-0' : 'w-full'}`} ref={channelDropdownRef}>
+            <button
+              type="button"
+              onClick={() => setChannelDropdownOpen(!channelDropdownOpen)}
+              className={`${inputClass} w-full flex items-center justify-between cursor-pointer`}
+            >
+              <span className="flex items-center gap-2 truncate">
+                {selectedLogo && (
+                  <img src={selectedLogo} alt="" className="w-5 h-5 object-contain rounded" />
+                )}
+                <span className="truncate">{getChannelDisplayLabel(form.notifyChannel)}</span>
+              </span>
+              <svg className={`w-4 h-4 ml-2 flex-shrink-0 transition-transform ${channelDropdownOpen ? 'rotate-180' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+
+            {channelDropdownOpen && (
+              <div className="absolute z-50 w-full mt-1 rounded-xl border border-border bg-surface shadow-lg overflow-hidden">
+                <div
+                  className="flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-surface-raised transition-colors"
+                  onClick={() => { updateForm({ notifyChannel: 'none', notifyTo: '' }); setChannelDropdownOpen(false); }}
+                >
+                  <span className="w-5 h-5" />
+                  <span className="text-sm text-foreground">{i18nService.t('scheduledTasksFormNotifyChannelNone')}</span>
+                </div>
+                {channelOptions.map((channel) => {
+                  const unsupported = isChannelUnsupported(channel.value);
+                  const logo = getChannelLogo(channel.value);
+                  const platform = PlatformRegistry.platformOfChannel(channel.value);
+                  const displayName = platform ? (i18nService.t(platform) || channel.label) : channel.label;
+                  return (
+                    <div
+                      key={channel.value}
+                      className={`flex items-center gap-2 px-3 py-2 transition-colors ${
+                        unsupported
+                          ? 'opacity-50 cursor-not-allowed'
+                          : 'cursor-pointer hover:bg-surface-raised'
+                      } ${form.notifyChannel === channel.value ? 'bg-surface-raised' : ''}`}
+                      onClick={() => {
+                        if (!unsupported) {
+                          updateForm({ notifyChannel: channel.value, notifyTo: '' });
+                          setChannelDropdownOpen(false);
+                        }
+                      }}
+                    >
+                      {logo ? (
+                        <img src={logo} alt={displayName} className="w-5 h-5 object-contain rounded" />
+                      ) : (
+                        <span className="w-5 h-5" />
+                      )}
+                      <span className={`text-sm ${unsupported ? 'text-foreground-secondary' : 'text-foreground'}`}>
+                        {unsupported
+                          ? `${displayName} (${i18nService.t('scheduledTasksChannelUnsupported')})`
+                          : displayName}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
           {showConversationSelector && (
             <select
               value={form.notifyTo}

--- a/src/renderer/components/scheduledTasks/utils.ts
+++ b/src/renderer/components/scheduledTasks/utils.ts
@@ -1,5 +1,6 @@
 import cronstrue from 'cronstrue/i18n';
 import { i18nService } from '../../services/i18n';
+import { PlatformRegistry } from '../../../shared/platform';
 import type {
   ScheduledTask,
   ScheduledTaskDelivery,
@@ -205,14 +206,27 @@ export function formatPayloadLabel(payload: ScheduledTaskPayload): string {
   return `${i18nService.t('scheduledTasksFormPayloadKindAgentTurn')} · ${payload.message}${timeoutLabel}`;
 }
 
+/**
+ * Resolve a channel name to a user-friendly display name via i18n + PlatformRegistry.
+ * e.g. 'feishu' → '飞书', 'openclaw-weixin' → '微信', 'moltbot-popo' → 'POPO'
+ */
+function resolveChannelDisplayName(channel: string): string {
+  const platform = PlatformRegistry.platformOfChannel(channel);
+  if (platform) {
+    return i18nService.t(platform) || PlatformRegistry.get(platform).label;
+  }
+  return channel;
+}
+
 export function formatDeliveryLabel(delivery: ScheduledTaskDelivery): string {
   if (delivery.mode === 'none' && !delivery.channel) {
     return i18nService.t('scheduledTasksFormDeliveryModeNone');
   }
 
   if (delivery.mode === 'none' && delivery.channel) {
+    const channelName = resolveChannelDisplayName(delivery.channel);
     const toLabel = delivery.to ? ` -> ${delivery.to}` : '';
-    return `${delivery.channel}${toLabel}`;
+    return `${channelName}${toLabel}`;
   }
 
   if (delivery.mode === 'webhook') {
@@ -221,9 +235,9 @@ export function formatDeliveryLabel(delivery: ScheduledTaskDelivery): string {
       : i18nService.t('scheduledTasksFormDeliveryModeWebhook');
   }
 
-  const channel = delivery.channel || 'last';
+  const channelName = delivery.channel ? resolveChannelDisplayName(delivery.channel) : 'last';
   const toLabel = delivery.to ? ` -> ${delivery.to}` : '';
-  return `${i18nService.t('scheduledTasksFormDeliveryModeAnnounce')} · ${channel}${toLabel}`;
+  return `${i18nService.t('scheduledTasksFormDeliveryModeAnnounce')} · ${channelName}${toLabel}`;
 }
 
 export type PlanType = 'once' | 'daily' | 'weekly' | 'monthly' | 'advanced';


### PR DESCRIPTION
## 问题背景
定时任务通知渠道选择器存在多个缺陷：
1. **POPO 和企业微信渠道不显示**：用户已在 IM 设置中启用，但定时任务中无法选择
2. **微信被错误标记为"暂不支持"**：实际插件已实现消息投递能力，属于遗留防御性代码
3. **渠道显示原始编码**：下拉框和任务详情均显示技术编码（如 `moltbot-popo`、`feishu`），用户无法识别

## 改动内容
### 修复渠道过滤机制
- 移除 5 个硬编码的 channel → config key if-else 映射
- 改为通过 `PlatformRegistry.platformOfChannel()` 自动解析
- **架构价值：** 新增 IM 平台只需更新 `PlatformRegistry`，定时任务自动适配，无需额外改动

### 升级通知渠道选择器
- 将原生 `<select>` 升级为自定义下拉组件
- 每个渠道选项显示平台 Logo + i18n 中文名称
- 修正"暂不支持"判定：移除 `openclaw-weixin`，仅保留真正不支持的 `qqbot` 和 `netease-bee`

### 问题截图
![77FE50752AA1](https://github.com/user-attachments/assets/600eeab2-5bb9-4907-917e-987b48de0f42)
<img width="829" height="368" alt="832b61905191" src="https://github.com/user-attachments/assets/18a4fc8e-c3f7-434c-bffc-d26953bc74d4" />

### 修复截图
![CCF196615F89](https://github.com/user-attachments/assets/169bb60f-f71e-4985-8de0-a1e9a124094b)
![21904B0014A7](https://github.com/user-attachments/assets/af11998c-eca3-4cf2-8f5f-2796b8cd46eb)


