### PR TITLE
[Bug] NIM 超大群消息中 teamTypeNum 硬编码错误导致群名无法正确获取

### DIFF
--- a/src/main/im/nimGateway.ts
+++ b/src/main/im/nimGateway.ts
@@ -914,7 +914,7 @@ export class NimGateway extends EventEmitter {
         : senderId;
       // For team messages, fetch the real group name via V2NIMTeamService.
       // conversationId format: {appId}|{type}|{teamId}, type=2 for team, 3 for superTeam.
-      const teamTypeNum = sessionType === 'superTeam' ? 2 : 1;
+      const teamTypeNum = sessionType === 'superTeam' ? 3 : 2;
       const groupName = isTeam
         ? await this.fetchTeamName(targetId, teamTypeNum, targetId)
         : undefined;


### PR DESCRIPTION
关联 Issue：#1200\r\n\r\n## 问题\r\n\r\n 第 917 行在调用  时， 的值与 V2NIM SDK 枚举不一致。\r\n\r\n同文件第 68-72 行注释已明确标注映射关系：\r\n\r\n\r\n但当前代码：\r\n\r\n\r\n-  传了 （team 的类型号）\r\n-  传了 （p2p 的类型号）\r\n\r\n## 影响\r\n\r\n云信超大群或普通群中 @机器人时， 以错误的类型号查询，SDK 返回空或 fallback， 显示为原始  而非真实群名。\r\n\r\n## 修复\r\n\r\n\r\n\r\n一行修改，与文件头部注释和 （第 68-72 行）的枚举定义保持一致。