### PR TITLE
chore(lint): remove unused eslint-disable directives

### DIFF
--- a/src/main/im/nimGateway.ts
+++ b/src/main/im/nimGateway.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { app } from 'electron';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const NIM = require('nim-web-sdk-ng/dist/nodejs/nim.js').default;
 import type { V2NIM } from 'nim-web-sdk-ng/dist/nodejs/nim';
 import {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1807,7 +1807,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private async loadGatewayClientCtor(clientEntryPath: string): Promise<GatewayClientCtor> {
     // Use require() with file path directly. TypeScript's CJS output downgrades
     // dynamic import() to require(), which doesn't support file:// URLs.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const loaded = require(clientEntryPath) as Record<string, unknown>;
     const direct = loaded.GatewayClient;
     if (typeof direct === 'function') {


### PR DESCRIPTION
## Summary

- Remove stale `eslint-disable` comments that no longer suppress any active rule
- Cherry-picked from #643 with conflict resolution (`xiaomifengGateway.ts` excluded as the file was already removed in the release branch)

## Changes

| File | Change |
|------|--------|
| `src/main/im/nimGateway.ts` | Remove unused `@typescript-eslint/no-require-imports` disable |
| `src/main/libs/agentEngine/openclawRuntimeAdapter.ts` | Remove unused `@typescript-eslint/no-var-requires` disable |

Supersedes #643 for the release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)