### PR TITLE
feat(cowork): 新增手动重试按钮，支持频繁请求等瞬时错误快速重试

### DIFF
--- a/src/common/coworkErrorClassify.ts
+++ b/src/common/coworkErrorClassify.ts
@@ -41,3 +41,24 @@ export function classifyErrorKey(error: string): string | null {
   }
   return null;
 }
+
+/**
+ * Error keys that are transient and safe to retry without user input changes.
+ * These errors are caused by server-side rate limits, network issues, or temporary failures.
+ */
+export const RETRYABLE_ERROR_KEYS = new Set([
+  'coworkErrorRateLimit',
+  'coworkErrorNetworkError',
+  'coworkErrorServerError',
+  'coworkErrorGatewayDisconnected',
+  'coworkErrorServiceRestart',
+  'coworkErrorGatewayDraining',
+  'coworkErrorUnknown',
+]);
+
+/**
+ * Returns true if the given i18n error key represents a retryable error.
+ */
+export function isRetryableErrorKey(key: string): boolean {
+  return RETRYABLE_ERROR_KEYS.has(key);
+}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -28,11 +28,13 @@ import WindowTitleBar from '../window/WindowTitleBar';
 import { getCompactFolderName } from '../../utils/path';
 import { getScheduledReminderDisplayText } from '../../../scheduledTask/reminderText';
 import DiffView, { extractDiffFromToolInput } from './DiffView';
+import { isRetryableErrorKey } from '../../../common/coworkErrorClassify';
 
 interface CoworkSessionDetailProps {
   onManageSkills?: () => void;
   onContinue: (prompt: string, skillPrompt?: string, imageAttachments?: CoworkImageAttachment[]) => boolean | void | Promise<boolean | void>;
   onStop: () => void;
+  onRetry?: () => void;
   onNavigateHome?: () => void;
   isSidebarCollapsed?: boolean;
   onToggleSidebar?: () => void;
@@ -1164,12 +1166,14 @@ export const AssistantTurnBlock: React.FC<{
   mapDisplayText?: (value: string) => string;
   showTypingIndicator?: boolean;
   showCopyButtons?: boolean;
+  onRetry?: () => void;
 }> = ({
   turn,
   resolveLocalFilePath,
   mapDisplayText,
   showTypingIndicator = false,
   showCopyButtons = true,
+  onRetry,
 }) => {
   const visibleAssistantItems = getVisibleAssistantItems(turn.assistantItems);
 
@@ -1182,6 +1186,9 @@ export const AssistantTurnBlock: React.FC<{
     const content = mapDisplayText ? mapDisplayText(normalizedContent) : normalizedContent;
     if (!content.trim()) return null;
 
+    const errorKey = typeof message.metadata?.errorKey === 'string' ? message.metadata.errorKey : null;
+    const showRetryButton = errorKey !== null && isRetryableErrorKey(errorKey) && !!onRetry;
+
     return (
       <div className="rounded-lg border border-border bg-background px-3 py-2">
         <div className="flex items-center gap-2">
@@ -1189,9 +1196,17 @@ export const AssistantTurnBlock: React.FC<{
             ? <ExclamationTriangleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
             : <InformationCircleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
           }
-          <div className="text-xs whitespace-pre-wrap text-secondary">
+          <div className="flex-1 text-xs whitespace-pre-wrap text-secondary">
             {content}
           </div>
+          {showRetryButton && (
+            <button
+              onClick={onRetry}
+              className="ml-2 flex-shrink-0 text-xs px-2 py-1 rounded-md border border-border text-secondary hover:text-foreground hover:border-foreground/40 hover:bg-surface-raised transition-colors"
+            >
+              {i18nService.t('coworkRetry')}
+            </button>
+          )}
         </div>
       </div>
     );
@@ -1324,6 +1339,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   onManageSkills,
   onContinue,
   onStop,
+  onRetry,
   onNavigateHome,
   isSidebarCollapsed,
   onToggleSidebar,
@@ -1942,6 +1958,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             resolveLocalFilePath={resolveLocalFilePath}
             showTypingIndicator
             showCopyButtons={!isStreaming}
+            onRetry={onRetry}
           />
         </div>
       );
@@ -1979,6 +1996,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 mapDisplayText={mapDisplayText}
                 showTypingIndicator={showTypingIndicator}
                 showCopyButtons={!isStreaming}
+                onRetry={isLastTurn ? onRetry : undefined}
               />
             </div>
           )}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -343,6 +343,15 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     await coworkService.stopSession(currentSession.id);
   };
 
+  const handleRetrySession = async () => {
+    if (!currentSession || isStreaming) return;
+    // Find the last user message to re-submit as a retry
+    const messages = currentSession.messages ?? [];
+    const lastUserMessage = [...messages].reverse().find(m => m.type === 'user');
+    if (!lastUserMessage) return;
+    await handleContinueSession(lastUserMessage.content);
+  };
+
   // Get selected quick action
   const selectedAction = React.useMemo(() => {
     return quickActions.find(action => action.id === selectedActionId);
@@ -500,6 +509,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
           onManageSkills={() => onShowSkills?.()}
           onContinue={handleContinueSession}
           onStop={handleStopSession}
+          onRetry={handleRetrySession}
           onNavigateHome={() => dispatch(clearCurrentSession())}
           isSidebarCollapsed={isSidebarCollapsed}
           onToggleSidebar={onToggleSidebar}

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -37,6 +37,17 @@ const classifyError = (error: string): string => {
   return key ? i18nService.t(key) : error;
 };
 
+const buildErrorMessage = (error: string, id?: string): { id: string; type: 'system'; content: string; timestamp: number; metadata: { error: string; errorKey: string | null } } => {
+  const errorKey = classifyErrorKey(error);
+  return {
+    id: id ?? `error-${Date.now()}`,
+    type: 'system' as const,
+    content: errorKey ? i18nService.t(errorKey) : error,
+    timestamp: Date.now(),
+    metadata: { error, errorKey },
+  };
+};
+
 class CoworkService {
   private streamListenerCleanups: Array<() => void> = [];
   private initialized = false;
@@ -149,12 +160,7 @@ class CoworkService {
       if (error) {
         store.dispatch(addMessage({
           sessionId,
-          message: {
-            id: `error-${Date.now()}`,
-            type: 'system',
-            content: classifyError(error),
-            timestamp: Date.now(),
-          },
+          message: buildErrorMessage(error),
         }));
       }
     });
@@ -306,17 +312,18 @@ class CoworkService {
       }
       // Show a user-visible error message in the session
       if (result.error) {
-        const errorContent = result.code === 'ENGINE_NOT_READY'
-          ? i18nService.t('coworkErrorEngineNotReady')
-          : classifyError(result.error);
+        const message = result.code === 'ENGINE_NOT_READY'
+          ? {
+            id: `error-${Date.now()}`,
+            type: 'system' as const,
+            content: i18nService.t('coworkErrorEngineNotReady'),
+            timestamp: Date.now(),
+            metadata: { error: result.error, errorKey: null },
+          }
+          : buildErrorMessage(result.error);
         store.dispatch(addMessage({
           sessionId: options.sessionId,
-          message: {
-            id: `error-${Date.now()}`,
-            type: 'system',
-            content: errorContent,
-            timestamp: Date.now(),
-          },
+          message,
         }));
       }
       console.error('Failed to continue session:', result.error);

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -552,6 +552,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionContinueFailed: '发送消息失败：{error}',
     coworkErrorEngineNotReady: 'AI 引擎正在启动中，请稍等几秒后重试。',
     coworkErrorUnknown: '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
+    coworkRetry: '重试',
 
     // Skills
     skills: '技能',
@@ -1740,6 +1741,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionContinueFailed: 'Failed to send message: {error}',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
     coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
+    coworkRetry: 'Retry',
 
     // Skills
     skills: 'Skills',


### PR DESCRIPTION
## 背景

当 Cowork 会话因请求频繁（429）、网络故障或服务端错误而中断时，用户只能手动重新输入上一条消息再次发送，体验较差。本 PR 在错误提示气泡中内联一个**重试**按钮，让用户一键重新发送最后一条消息。

## 变更内容

### 1. 错误分类模块扩展（`src/common/coworkErrorClassify.ts`）

新增 `RETRYABLE_ERROR_KEYS` 集合，定义属于**瞬时可重试**的错误类型：

| 错误 key | 触发场景 |
|---|---|
| `coworkErrorRateLimit` | 429 / rate limit / overloaded |
| `coworkErrorNetworkError` | ECONNREFUSED / ETIMEDOUT 等网络故障 |
| `coworkErrorServerError` | 500 / 502 / 503 服务端错误 |
| `coworkErrorGatewayDisconnected` | AI 引擎连接中断 |
| `coworkErrorServiceRestart` | AI 引擎重启中 |
| `coworkErrorGatewayDraining` | AI 引擎正在 draining |
| `coworkErrorUnknown` | 无法归类的未知错误 |

新增导出函数 `isRetryableErrorKey(key)` 供 UI 层判断。

> 鉴权失败、余额不足、输入过长、内容审核不通过等需要用户主动修改才能解决的错误**不在此列**，不显示重试按钮。

### 2. 错误消息构建（`src/renderer/services/cowork.ts`）

新增 `buildErrorMessage(error)` 工具函数，在 system 错误消息的 `metadata` 中同时写入：
- `metadata.error`：原始错误字符串
- `metadata.errorKey`：分类后的 i18n key（可为 `null`）

替换 `onStreamError` 和 `continueSession` 中原有的消息构建逻辑，使错误类型信息跟随消息持久化到 Redux store，UI 层无需重新解析原始错误字符串。

### 3. 重试按钮 UI（`src/renderer/components/cowork/CoworkSessionDetail.tsx`）

- `CoworkSessionDetailProps` 新增 `onRetry?: () => void` 可选属性
- `AssistantTurnBlock` 新增 `onRetry?: () => void` prop
- `renderSystemMessage` 更新判断逻辑：当 `metadata.errorKey` 属于可重试类型时，在错误气泡右侧渲染紧凑的"重试"按钮
- **仅最后一个对话轮**传入 `onRetry`（历史错误不显示重试按钮，避免重试过期的上下文）

效果示意：
<img width="574" height="300" alt="Xnip2026-04-01_15-50-41" src="https://github.com/user-attachments/assets/c173900b-650d-45ce-994d-6836034a28be" />

### 4. 重试逻辑（`src/renderer/components/cowork/CoworkView.tsx`）

新增 `handleRetrySession()`：
1. 从当前会话消息列表中找到最后一条 `type === 'user'` 的消息
2. 调用 `handleContinueSession(lastUserMessage.content)` 重新提交

### 5. 国际化（`src/renderer/services/i18n.ts`）

新增 `coworkRetry` 翻译键：
- 中文：`重试`
- 英文：`Retry`

## 测试方法

1. 启动开发环境：`npm run electron:dev`
2. 配置一个会触发 429 的 API Key（或在网络受限环境下发送消息）
3. 触发错误后，确认：
   - 频繁请求 / 网络错误 / 服务端错误 → 错误气泡右侧显示**重试**按钮
   - 鉴权失败 / 余额不足 → **不显示**重试按钮
   - 点击重试 → 自动重新发送最后一条用户消息，无需手动输入
   - 历史对话中的旧错误 → **不显示**重试按钮