### PR TITLE
fix(web-search): web-search-block-unsupported-chrome-flags

### DIFF
--- a/SKILLs/web-search/server/playwright/browser.ts
+++ b/SKILLs/web-search/server/playwright/browser.ts
@@ -79,8 +79,21 @@ function isDirectoryWritable(path: string): boolean {
   }
 }
 
+// Flags that are unsupported or cause Chrome to display a warning banner.
+// Chrome 130+ shows "You are using an unsupported command-line flag" for these.
+const BLOCKED_CHROME_FLAGS = [
+  '--disable-blink-features=AutomationControlled',
+];
+
 function resolveRuntimeChromeFlags(configFlags: string[] = []): string[] {
-  const runtimeFlags = [...configFlags];
+  const filtered = configFlags.filter((flag) => {
+    if (BLOCKED_CHROME_FLAGS.includes(flag)) {
+      console.warn(`[Browser] Ignoring unsupported Chrome flag: ${flag}`);
+      return false;
+    }
+    return true;
+  });
+  const runtimeFlags = [...filtered];
 
   if (process.platform === 'linux') {
     if (!isDirectoryWritable('/dev/shm')) {


### PR DESCRIPTION
根因
--disable-blink-features=AutomationControlled 不存在于 LobsterAI 代码中，来源是外部注入，常见场景：

来源	说明
残留的 Chrome user data 目录	之前有其他自动化工具（Selenium/puppeteer 脚本）在同一 user data dir 里写入了这个 flag
外部配置文件	web-search skill 的 chromeFlags 配置被用户/工具写入了该 flag
系统环境变量	极少数情况下通过 CHROMIUM_FLAGS 环境变量注入
Chrome 130+ 开始把该 flag 列为「不受支持」并主动弹出安全警告横幅，以前静默忽略。

修复内容