### PR TITLE
fix(model): allow up to 20 custom providers

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -29,7 +29,15 @@ import IMSettings from './im/IMSettings';
 import { imService } from '../services/im';
 import EmailSkillConfig from './skills/EmailSkillConfig';
 import { ProviderRegistry, resolveCodingPlanBaseUrl } from '../../shared/providers';
-import { defaultConfig, type AppConfig, getVisibleProviders, isCustomProvider, getCustomProviderDefaultName,getProviderDisplayName } from '../config';
+import {
+  CUSTOM_PROVIDER_KEYS,
+  defaultConfig,
+  type AppConfig,
+  getVisibleProviders,
+  isCustomProvider,
+  getCustomProviderDefaultName,
+  getProviderDisplayName,
+} from '../config';
 import {
   OpenAIIcon,
   DeepSeekIcon,
@@ -63,12 +71,6 @@ interface SettingsProps extends SettingsOpenOptions {
     disableUpdate?: boolean;
   } | null;
 }
-
-
-const CUSTOM_PROVIDER_KEYS = [
-  'custom_0', 'custom_1', 'custom_2', 'custom_3', 'custom_4',
-  'custom_5', 'custom_6', 'custom_7', 'custom_8', 'custom_9',
-] as const;
 
 const providerKeys = [
   'openai',

--- a/src/renderer/config.test.ts
+++ b/src/renderer/config.test.ts
@@ -1,9 +1,18 @@
 import { test, expect } from 'vitest';
 import {
+  CUSTOM_PROVIDER_KEYS,
+  CUSTOM_PROVIDER_MAX_COUNT,
   isCustomProvider,
   getCustomProviderDefaultName,
   getProviderDisplayName,
 } from './config';
+
+test('CUSTOM_PROVIDER_KEYS exposes 20 sparse custom provider slots', () => {
+  expect(CUSTOM_PROVIDER_MAX_COUNT).toBe(20);
+  expect(CUSTOM_PROVIDER_KEYS).toHaveLength(20);
+  expect(CUSTOM_PROVIDER_KEYS[0]).toBe('custom_0');
+  expect(CUSTOM_PROVIDER_KEYS[19]).toBe('custom_19');
+});
 
 test('isCustomProvider: custom_0 is custom', () => {
   expect(isCustomProvider('custom_0')).toBe(true);
@@ -43,6 +52,10 @@ test('getCustomProviderDefaultName: custom_1 -> Custom1', () => {
 
 test('getCustomProviderDefaultName: custom_42 -> Custom42', () => {
   expect(getCustomProviderDefaultName('custom_42')).toBe('Custom42');
+});
+
+test('getCustomProviderDefaultName: custom_19 -> Custom19', () => {
+  expect(getCustomProviderDefaultName('custom_19')).toBe('Custom19');
 });
 
 test('getProviderDisplayName: built-in provider capitalizes first letter', () => {

--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -302,6 +302,11 @@ export const CONFIG_KEYS = {
 // Provider lists derived from ProviderRegistry — single source of truth
 export const CHINA_PROVIDERS = [...ProviderRegistry.idsByRegion('china')] as const;
 export const GLOBAL_PROVIDERS = ProviderRegistry.idsByRegion('global');
+export const CUSTOM_PROVIDER_MAX_COUNT = 20;
+export const CUSTOM_PROVIDER_KEYS = Array.from(
+  { length: CUSTOM_PROVIDER_MAX_COUNT },
+  (_, index) => `custom_${index}`,
+) as ReadonlyArray<`custom_${number}`>;
 
 export const getVisibleProviders = (language: 'zh' | 'en'): readonly string[] => {
   if (language === 'zh') {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@shared': path.resolve(__dirname, './src/shared'),
+      '@': path.resolve(__dirname, './src/renderer'),
+    },
+  },
   test: {
     include: ['src/**/*.test.ts'],
     environment: 'node',


### PR DESCRIPTION
[Problem]
Users could only keep up to 10 custom model providers, which blocked switching to a new provider while preserving older custom configs.

[Root Cause]
The renderer kept the custom provider key list hard-coded in Settings and capped it at custom_0 through custom_9.

[Fix]
Move the custom provider key list into shared renderer config, raise the cap to 20, reuse the shared keys in Settings, and add tests for the new capacity and naming. Also add Vitest path aliases so the config tests can resolve shared imports.

[How To Verify]
1. eval "export PATH="/Users/leelei/.local/state/fnm_multishells/74509_1775033781206/bin":$PATH export FNM_MULTISHELL_PATH="/Users/leelei/.local/state/fnm_multishells/74509_1775033781206" export FNM_VERSION_FILE_STRATEGY="local"
export FNM_DIR="/Users/leelei/.local/share/fnm"
export FNM_LOGLEVEL="info"
export FNM_NODE_DIST_MIRROR="https://nodejs.org/dist" export FNM_COREPACK_ENABLED="false"
export FNM_RESOLVE_ENGINES="true"
export FNM_ARCH="arm64"
autoload -U add-zsh-hook
_fnm_autoload_hook () {
    if [[ -f .node-version || -f .nvmrc || -f package.json ]]; then
    fnm use --silent-if-unchanged
fi

}

add-zsh-hook chpwd _fnm_autoload_hook \
    && _fnm_autoload_hook

rehash" && /usr/local/bin/fnm use 24 >/dev/null && npm test -- src/renderer/config.test.ts
2. eval "export PATH="/Users/leelei/.local/state/fnm_multishells/74528_1775033781236/bin":$PATH export FNM_MULTISHELL_PATH="/Users/leelei/.local/state/fnm_multishells/74528_1775033781236" export FNM_VERSION_FILE_STRATEGY="local"
export FNM_DIR="/Users/leelei/.local/share/fnm"
export FNM_LOGLEVEL="info"
export FNM_NODE_DIST_MIRROR="https://nodejs.org/dist" export FNM_COREPACK_ENABLED="false"
export FNM_RESOLVE_ENGINES="true"
export FNM_ARCH="arm64"
autoload -U add-zsh-hook
_fnm_autoload_hook () {
    if [[ -f .node-version || -f .nvmrc || -f package.json ]]; then
    fnm use --silent-if-unchanged
fi

}

add-zsh-hook chpwd _fnm_autoload_hook \
    && _fnm_autoload_hook

rehash" && /usr/local/bin/fnm use 24 >/dev/null && ./node_modules/.bin/eslint src/renderer/components/Settings.tsx src/renderer/config.ts src/renderer/config.test.ts vitest.config.ts

Closes #1174