### PR TITLE
fix(im): always rebuild chat handler on setConfig to avoid stale imSe…

### DIFF
--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -348,10 +348,11 @@ export class IMGatewayManager extends EventEmitter {
     const previousConfig = this.imStore.getConfig();
     this.imStore.setConfig(config);
 
-    // Update chat handler if settings changed
-    if (config.settings) {
-      this.updateChatHandler();
-    }
+    // Always rebuild chat handler after any config change so it reads the
+    // latest imSettings (systemPrompt, skillsEnabled, platformAgentBindings).
+    // Previously only triggered when config.settings was present, which meant
+    // platform-specific saves (e.g. { dingtalk: ... }) never refreshed the handler.
+    this.updateChatHandler();
 
 
     // NIM now runs via OpenClaw; config sync is handled by IPC handler


### PR DESCRIPTION

setConfig only called updateChatHandler() when config.settings was present in the update payload. Platform-specific saves (e.g. saving DingTalk or Telegram credentials) pass { dingtalk: ... } without a settings key, so the chat handler was never refreshed.

As a result, changes to systemPrompt, skillsEnabled, or platformAgentBindings made before or alongside platform config saves would not take effect until the next app restart or a settings-only save.

Fix: call updateChatHandler() unconditionally on every setConfig, so the handler always reads the latest imSettings from the store. updateChatHandler() is a lightweight in-memory object swap with no I/O, so calling it on every config write has negligible overhead.