### PR TITLE
fix(ui): prevent modal from closing on drag-to-outside text selection

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import Modal from './common/Modal';
 import { configService } from '../services/config';
 import { apiService } from '../services/api';
 import { checkForAppUpdate } from '../services/appUpdate';
@@ -3613,10 +3614,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 modal-backdrop flex items-center justify-center"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
+    <Modal onClose={onClose} overlayClassName="fixed inset-0 z-50 modal-backdrop flex items-center justify-center">
       <div
         className="relative flex w-[900px] h-[80vh] rounded-2xl border-border border shadow-modal overflow-hidden modal-content"
         onClick={handleSettingsClick}
@@ -4003,7 +4001,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
             </div>
           )}
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
+import Modal from './common/Modal';
 import { useSelector } from 'react-redux';
 import { RootState } from '../store';
 import { agentService } from '../services/agent';
@@ -328,14 +329,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       )}
       {/* Batch Delete Confirmation Modal */}
       {showBatchDeleteConfirm && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => setShowBatchDeleteConfirm(false)}
-        >
-          <div
-            className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-xl overflow-hidden"
-            onClick={(e) => e.stopPropagation()}
-          >
+        <Modal onClose={() => setShowBatchDeleteConfirm(false)} className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-xl overflow-hidden">
             <div className="flex items-center gap-3 px-5 py-4">
               <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
                 <ExclamationTriangleIcon className="h-5 w-5 text-red-600 dark:text-red-500" />
@@ -363,8 +357,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                 {i18nService.t('batchDelete')} ({selectedIds.size})
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       )}
     </aside>
   );

--- a/src/renderer/components/agent/AgentCreateModal.tsx
+++ b/src/renderer/components/agent/AgentCreateModal.tsx
@@ -7,6 +7,7 @@ import { getVisibleIMPlatforms } from '../../utils/regionFilter';
 import type { IMPlatform, IMGatewayConfig } from '../../types/im';
 import AgentSkillSelector from './AgentSkillSelector';
 import EmojiPicker from './EmojiPicker';
+import Modal from '../common/Modal';
 
 type CreateTab = 'basic' | 'skills' | 'im';
 
@@ -117,11 +118,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
   ];
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
-      <div
-        className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-surface border border-border max-h-[80vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal isOpen={isOpen} onClose={onClose} className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-surface border border-border max-h-[80vh] flex flex-col">
         {/* Header: agent icon + name + close */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">
           <div className="flex items-center gap-2">
@@ -300,8 +297,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
             {creating ? (i18nService.t('creating') || 'Creating...') : (i18nService.t('create') || 'Create')}
           </button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/renderer/components/agent/AgentSettingsPanel.tsx
+++ b/src/renderer/components/agent/AgentSettingsPanel.tsx
@@ -12,6 +12,7 @@ import { getVisibleIMPlatforms } from '../../utils/regionFilter';
 import { PlatformRegistry } from '@shared/platform';
 import AgentSkillSelector from './AgentSkillSelector';
 import EmojiPicker from './EmojiPicker';
+import Modal from '../common/Modal';
 
 type SettingsTab = 'basic' | 'skills' | 'im';
 
@@ -143,11 +144,7 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
   ];
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
-      <div
-        className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-surface border border-border max-h-[80vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal onClose={onClose} className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-surface border border-border max-h-[80vh] flex flex-col">
         {/* Header: agent icon + name + close */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">
           <div className="flex items-center gap-2">
@@ -365,8 +362,7 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
             </button>
           </div>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/renderer/components/common/Modal.tsx
+++ b/src/renderer/components/common/Modal.tsx
@@ -1,0 +1,56 @@
+import React, { useRef } from 'react';
+
+interface ModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  className?: string;
+  overlayClassName?: string;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+  children: React.ReactNode;
+}
+
+/**
+ * Modal — A base modal overlay component with correct close-on-backdrop behavior.
+ *
+ * Only closes when the user clicks the backdrop directly (mousedown + mouseup both on backdrop).
+ * Dragging text from inside the modal to outside will NOT close the modal.
+ */
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  className,
+  overlayClassName,
+  onClick,
+  children,
+}) => {
+  const mouseDownOnBackdropRef = useRef(false);
+
+  if (isOpen === false) return null;
+
+  return (
+    <div
+      className={overlayClassName ?? 'fixed inset-0 z-50 flex items-center justify-center bg-black/50'}
+      onMouseDown={(e) => {
+        // Record whether mousedown started on the backdrop (not on modal content)
+        mouseDownOnBackdropRef.current = e.target === e.currentTarget;
+      }}
+      onClick={(e) => {
+        // Only close if both mousedown and click ended on the backdrop
+        if (e.target === e.currentTarget && mouseDownOnBackdropRef.current) {
+          mouseDownOnBackdropRef.current = false;
+          onClose();
+        }
+      }}
+    >
+      <div
+        className={className}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => { e.stopPropagation(); onClick?.(e); }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/renderer/components/cowork/CoworkSearchModal.tsx
+++ b/src/renderer/components/cowork/CoworkSearchModal.tsx
@@ -4,6 +4,7 @@ import SearchIcon from '../icons/SearchIcon';
 import { i18nService } from '../../services/i18n';
 import type { CoworkSessionSummary } from '../../types/cowork';
 import CoworkSessionList from './CoworkSessionList';
+import Modal from '../common/Modal';
 
 const emptySet = new Set<string>();
 
@@ -67,16 +68,15 @@ const CoworkSearchModal: React.FC<CoworkSearchModalProps> = ({
   if (!isOpen) return null;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center modal-backdrop p-6"
-      onClick={onClose}
+    <Modal
+      onClose={onClose}
+      overlayClassName="fixed inset-0 z-50 flex items-start justify-center modal-backdrop p-6"
+      className="modal-content w-full max-w-2xl mt-10 rounded-2xl border border-border bg-surface shadow-modal overflow-hidden"
     >
       <div
-        className="modal-content w-full max-w-2xl mt-10 rounded-2xl border border-border bg-surface shadow-modal overflow-hidden"
         role="dialog"
         aria-modal="true"
         aria-label={i18nService.t('search')}
-        onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-center gap-3 px-4 py-3 border-b border-border">
           <div className="relative flex-1">
@@ -120,7 +120,7 @@ const CoworkSearchModal: React.FC<CoworkSearchModalProps> = ({
           )}
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -29,6 +29,7 @@ import WindowTitleBar from '../window/WindowTitleBar';
 import { getCompactFolderName } from '../../utils/path';
 import { getScheduledReminderDisplayText } from '../../../scheduledTask/reminderText';
 import DiffView, { extractDiffFromToolInput } from './DiffView';
+import Modal from '../common/Modal';
 
 interface CoworkSessionDetailProps {
   onManageSkills?: () => void;
@@ -2262,14 +2263,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
       {/* Delete Confirmation Modal */}
       {showConfirmDelete && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
-          onClick={handleCancelDelete}
-        >
-          <div
-            className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden modal-content"
-            onClick={(e) => e.stopPropagation()}
-          >
+        <Modal onClose={handleCancelDelete} overlayClassName="fixed inset-0 z-50 flex items-center justify-center modal-backdrop" className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden modal-content">
             {/* Header */}
             <div className="flex items-center gap-3 px-5 py-4">
               <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
@@ -2302,11 +2296,8 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 {i18nService.t('deleteSession')}
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       )}
-
-      {/* Messages */}
       <div className="relative flex-1 min-h-0">
         <div
           ref={scrollContainerRef}

--- a/src/renderer/components/cowork/CoworkSessionItem.tsx
+++ b/src/renderer/components/cowork/CoworkSessionItem.tsx
@@ -6,6 +6,7 @@ import PencilSquareIcon from '../icons/PencilSquareIcon';
 import TrashIcon from '../icons/TrashIcon';
 import ListChecksIcon from '../icons/ListChecksIcon';
 import { i18nService } from '../../services/i18n';
+import Modal from '../common/Modal';
 
 interface CoworkSessionItemProps {
   session: CoworkSessionSummary;
@@ -427,14 +428,7 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
 
       {/* Delete Confirmation Modal */}
       {showConfirmDelete && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={handleCancelDelete}
-        >
-          <div
-            className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-xl overflow-hidden"
-            onClick={(e) => e.stopPropagation()}
-          >
+        <Modal onClose={handleCancelDelete} className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-xl overflow-hidden">
             {/* Header */}
             <div className="flex items-center gap-3 px-5 py-4">
               <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
@@ -467,8 +461,7 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
                 {i18nService.t('deleteSession')}
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       )}
     </div>
   );

--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -20,6 +20,7 @@ import { QRCodeSVG } from 'qrcode.react';
 import { ArrowPathIcon } from '@heroicons/react/24/outline';
 import { SchemaForm } from './SchemaForm';
 import type { UiHint } from './SchemaForm';
+import Modal from '../common/Modal';
 
 
 
@@ -3792,14 +3793,7 @@ const IMSettings: React.FC = () => {
         )}
 
         {connectivityModalPlatform && (
-          <div
-            className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
-            onClick={() => setConnectivityModalPlatform(null)}
-          >
-            <div
-              className="w-full max-w-2xl bg-surface rounded-2xl shadow-modal border border-border overflow-hidden"
-              onClick={(e) => e.stopPropagation()}
-            >
+          <Modal onClose={() => setConnectivityModalPlatform(null)} overlayClassName="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" className="w-full max-w-2xl bg-surface rounded-2xl shadow-modal border border-border overflow-hidden">
               <div className="px-4 py-3 border-b border-border flex items-center justify-between">
                 <div className="text-sm font-semibold text-foreground">
                   {`${i18nService.t(connectivityModalPlatform)} ${i18nService.t('imConnectivitySectionTitle')}`}
@@ -3868,8 +3862,7 @@ const IMSettings: React.FC = () => {
               <div className="px-4 py-3 border-t border-border flex items-center justify-end">
                 {renderConnectivityTestButton(connectivityModalPlatform)}
               </div>
-            </div>
-          </div>
+          </Modal>
         )}
       </div>
     </div>

--- a/src/renderer/components/mcp/McpManager.tsx
+++ b/src/renderer/components/mcp/McpManager.tsx
@@ -13,6 +13,7 @@ import { mcpRegistry, mcpCategories } from '../../data/mcpRegistry';
 import ErrorMessage from '../ErrorMessage';
 import Tooltip from '../ui/Tooltip';
 import McpServerFormModal from './McpServerFormModal';
+import Modal from '../common/Modal';
 
 const TRANSPORT_BADGE_COLORS: Record<string, string> = {
   stdio: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
@@ -672,14 +673,7 @@ const McpManager: React.FC = () => {
 
       {/* Delete confirmation modal */}
       {pendingDelete && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={handleCancelDelete}
-        >
-          <div
-            className="w-full max-w-sm mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-5"
-            onClick={(event) => event.stopPropagation()}
-          >
+        <Modal onClose={handleCancelDelete} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-sm mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-5">
             <div className="text-lg font-semibold text-foreground">
               {i18nService.t('deleteMcpServer')}
             </div>
@@ -709,8 +703,7 @@ const McpManager: React.FC = () => {
                 {i18nService.t('confirmDelete')}
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       )}
 
       {/* Edit / Registry-install form modal */}

--- a/src/renderer/components/mcp/McpServerFormModal.tsx
+++ b/src/renderer/components/mcp/McpServerFormModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { i18nService } from '../../services/i18n';
 import { McpServerConfig, McpServerFormData, McpRegistryEntry } from '../../types/mcp';
+import Modal from '../common/Modal';
 
 interface McpServerFormModalProps {
   isOpen: boolean;
@@ -218,14 +219,7 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
     : i18nService.t('saveMcpServer');
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={onClose}
-    >
-      <div
-        className="w-full max-w-lg mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6 max-h-[80vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal onClose={onClose} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-lg mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6 max-h-[80vh] overflow-y-auto">
         <div className="flex items-center justify-between mb-5">
           <div className="text-lg font-semibold text-foreground">
             {modalTitle}
@@ -434,8 +428,7 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
             </button>
           </div>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/renderer/components/skills/SkillSecurityReport.tsx
+++ b/src/renderer/components/skills/SkillSecurityReport.tsx
@@ -7,6 +7,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 import { i18nService } from '../../services/i18n';
+import Modal from '../common/Modal';
 
 interface SecurityFinding {
   dimension: string;
@@ -90,14 +91,7 @@ const SkillSecurityReport: React.FC<SkillSecurityReportProps> = ({
   }
 
   return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={() => onAction('cancel')}
-    >
-      <div
-        className="w-full max-w-xl mx-4 rounded-2xl bg-surface shadow-xl border border-border overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal onClose={() => onAction('cancel')} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-xl mx-4 rounded-2xl bg-surface shadow-xl border border-border overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">
           <div className="flex items-center gap-2.5">
@@ -212,8 +206,7 @@ const SkillSecurityReport: React.FC<SkillSecurityReportProps> = ({
             </button>
           </div>
         </div>
-      </div>
-    </div>,
+    </Modal>,
     document.body
   );
 };

--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import Modal from '../common/Modal';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   ArrowDownTrayIcon,
@@ -860,14 +861,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly }) => {
       )}
 
       {selectedMarketplaceSkill && createPortal(
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => setSelectedMarketplaceSkill(null)}
-        >
-          <div
-            className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6"
-            onClick={(event) => event.stopPropagation()}
-          >
+        <Modal onClose={() => setSelectedMarketplaceSkill(null)} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6">
             <div className="flex items-start justify-between mb-4">
               <div className="flex items-center gap-3 min-w-0">
                 <div className="w-9 h-9 rounded-lg bg-background flex items-center justify-center flex-shrink-0">
@@ -964,19 +958,11 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly }) => {
                 </button>
               ) : null;
             })()}
-          </div>
-        </div>
+        </Modal>
       , document.body)}
 
       {selectedSkill && createPortal(
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => setSelectedSkill(null)}
-        >
-          <div
-            className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6"
-            onClick={(event) => event.stopPropagation()}
-          >
+        <Modal onClose={() => setSelectedSkill(null)} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6">
             <div className="flex items-start justify-between mb-4">
               <div className="flex items-center gap-3 min-w-0">
                 <div className="w-9 h-9 rounded-lg bg-background flex items-center justify-center flex-shrink-0">
@@ -1081,19 +1067,11 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly }) => {
                 />
               </div>
             </div>
-          </div>
-        </div>
+        </Modal>
       , document.body)}
 
       {skillPendingDelete && createPortal(
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={handleCancelDeleteSkill}
-        >
-          <div
-            className="w-full max-w-sm mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-5"
-            onClick={(event) => event.stopPropagation()}
-          >
+        <Modal onClose={handleCancelDeleteSkill} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-sm mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-5">
             <div className="text-lg font-semibold text-foreground">
               {i18nService.t('deleteSkill')}
             </div>
@@ -1123,19 +1101,11 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly }) => {
                 {i18nService.t('confirmDelete')}
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       , document.body)}
 
       {isRemoteImportOpen && createPortal(
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => setIsRemoteImportOpen(false)}
-        >
-          <div
-            className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6"
-            onClick={(event) => event.stopPropagation()}
-          >
+        <Modal onClose={() => setIsRemoteImportOpen(false)} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6">
             <div className="flex items-start justify-between">
               <div className="text-lg font-semibold text-foreground">
                 {i18nService.t('remoteImportTitle')}
@@ -1201,8 +1171,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly }) => {
                 {isDownloadingSkill ? i18nService.t('importingSkill') : i18nService.t('importSkill')}
               </button>
             </div>
-          </div>
-        </div>
+        </Modal>
       , document.body)}
 
       {securityReport && (

--- a/src/renderer/components/update/AppUpdateModal.tsx
+++ b/src/renderer/components/update/AppUpdateModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { i18nService } from '../../services/i18n';
 import type { AppUpdateInfo, AppUpdateDownloadProgress } from '../../services/appUpdate';
+import Modal from '../common/Modal';
 
 export type UpdateModalState = 'info' | 'downloading' | 'installing' | 'error';
 
@@ -41,21 +42,8 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
   const currentLog = changeLog?.[lang] ?? { title: '', content: [] };
   const isDismissible = modalState === 'info' || modalState === 'error';
 
-  const handleBackdropClick = () => {
-    if (isDismissible) {
-      onCancel();
-    }
-  };
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
-      onClick={handleBackdropClick}
-    >
-      <div
-        className="modal-content w-full max-w-md mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal onClose={isDismissible ? onCancel : () => {}} overlayClassName="fixed inset-0 z-50 flex items-center justify-center modal-backdrop" className="modal-content w-full max-w-md mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden">
         {/* Info state - shows changelog and Update/Cancel buttons */}
         {modalState === 'info' && (
           <>
@@ -214,8 +202,7 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
             </div>
           </div>
         )}
-      </div>
-    </div>
+    </Modal>
   );
 };
 


### PR DESCRIPTION
## Summary
- Add shared `Modal` component that tracks mousedown origin to prevent accidental dismiss when dragging text outside
- Replace raw backdrop div + `stopPropagation` pattern across 13 files with the new `Modal` component
- Cherry-picked from #967 and adapted to `release/2026.04.01` class names (resolved 13 file conflicts)

## Test plan
- [ ] Open each modal, select text inside and drag outside — should NOT close
- [ ] Click backdrop — should still close normally
- [ ] Verify Settings, SkillsManager, MCP, Agent, Cowork, IM modals all open/close correctly

Co-Authored-By: gongzhi <gongzhi@corp.netease.com>