### PR TITLE
fix(scheduled-task): guard against NaN in scheduled task data from gateway

### DIFF
--- a/src/renderer/components/scheduledTasks/utils.ts
+++ b/src/renderer/components/scheduledTasks/utils.ts
@@ -182,6 +182,9 @@ export function formatScheduleLabel(schedule: Schedule): string {
 
   if (schedule.kind === 'every') {
     const everyMs = schedule.everyMs;
+    if (!Number.isFinite(everyMs) || everyMs <= 0) {
+      return `${i18nService.t('scheduledTasksScheduleEvery')} -`;
+    }
     if (everyMs % 86_400_000 === 0) {
       return `${i18nService.t('scheduledTasksScheduleEvery')} ${everyMs / 86_400_000} ${i18nService.t('scheduledTasksFormIntervalDays')}`;
     }
@@ -207,7 +210,7 @@ export function formatDateTime(date: Date): string {
 }
 
 export function formatDuration(ms: number | null): string {
-  if (ms === null) return '-';
+  if (ms === null || !Number.isFinite(ms)) return '-';
   if (ms < 1000) return `${ms}ms`;
   if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
   return `${Math.round(ms / 60_000)}m`;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1227,6 +1227,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormNotifyConversationNone: '无可用会话',
     scheduledTasksToggleWarningAtPast: '该任务的执行时间已过，启用后将不会运行',
     scheduledTasksToggleWarningExpired: '该任务已过期，启用后将不会运行',
+    scheduledTasksDataAnomalyWarning: '定时任务「{name}」存在异常数据，已自动修正显示，建议重新编辑该任务',
 
     // 隐私协议弹窗
     privacyDialogTitle: '网易有道LobsterAI服务协议',
@@ -2466,6 +2467,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormNotifyConversationNone: 'No conversations available',
     scheduledTasksToggleWarningAtPast: 'The execution time of this task has passed. It will not run after enabling',
     scheduledTasksToggleWarningExpired: 'This task has expired. It will not run after enabling',
+    scheduledTasksDataAnomalyWarning: 'Scheduled task "{name}" has abnormal data. Display has been auto-corrected. Consider re-editing this task',
 
     // Privacy dialog
     privacyDialogTitle: 'NetEase Youdao LobsterAI Terms of Service',

--- a/src/renderer/services/scheduledTask.ts
+++ b/src/renderer/services/scheduledTask.ts
@@ -14,12 +14,44 @@ import {
   appendAllRuns,
 } from '../store/slices/scheduledTaskSlice';
 import type {
+  ScheduledTask,
   ScheduledTaskChannelOption,
   ScheduledTaskConversationOption,
   ScheduledTaskInput,
   ScheduledTaskStatusEvent,
   ScheduledTaskRunEvent,
 } from '../../scheduledTask/types';
+import { i18nService } from './i18n';
+
+function showToast(message: string): void {
+  window.dispatchEvent(new CustomEvent('app:showToast', { detail: message }));
+}
+
+function hasTaskDataAnomaly(task: ScheduledTask): boolean {
+  if (task.schedule.kind === 'every') {
+    const ms = task.schedule.everyMs;
+    if (!Number.isFinite(ms) || ms <= 0) return true;
+  }
+  if (task.schedule.kind === 'at') {
+    const d = new Date(task.schedule.at);
+    if (!Number.isFinite(d.getTime())) return true;
+  }
+  const ts = task.state;
+  const nums = [ts.nextRunAtMs, ts.lastRunAtMs, ts.lastDurationMs, ts.runningAtMs];
+  for (const v of nums) {
+    if (v !== null && !Number.isFinite(v)) return true;
+  }
+  return false;
+}
+
+function checkTasksForAnomalies(tasks: ScheduledTask[]): void {
+  const anomalous = tasks.filter(hasTaskDataAnomaly);
+  if (anomalous.length === 0) return;
+
+  const name = anomalous[0].name;
+  const msg = i18nService.t('scheduledTasksDataAnomalyWarning').replace('{name}', name);
+  showToast(msg);
+}
 
 class ScheduledTaskService {
   private cleanupFns: (() => void)[] = [];
@@ -77,6 +109,7 @@ class ScheduledTaskService {
     try {
       const result = await api.list();
       if (result.success && result.tasks) {
+        checkTasksForAnomalies(result.tasks);
         store.dispatch(setTasks(result.tasks));
       }
     } catch (err: unknown) {
@@ -93,6 +126,10 @@ class ScheduledTaskService {
     try {
       const result = await api.create(input);
       if (result.success && result.task) {
+        if (hasTaskDataAnomaly(result.task)) {
+          const msg = i18nService.t('scheduledTasksDataAnomalyWarning').replace('{name}', result.task.name);
+          showToast(msg);
+        }
         store.dispatch(addTask(result.task));
       } else {
         throw new Error(result.error || 'Failed to create task');

--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -130,6 +130,25 @@ interface CronJobServiceDeps {
   ensureGatewayReady: () => Promise<void>;
 }
 
+/**
+ * Coerce a value to a finite number, returning `fallback` when the value is
+ * undefined, null, NaN, Infinity, or not a number at all.
+ * Used to guard against malformed Gateway responses that could surface NaN in the UI.
+ */
+function safeFiniteNumber(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return fallback;
+}
+
+/**
+ * Same as {@link safeFiniteNumber} but returns `null` when the value is absent
+ * instead of a numeric fallback.  Suitable for optional timestamp fields.
+ */
+function safeFiniteNumberOrNull(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return null;
+}
+
 function mapGatewayResultStatus(
   status?: GatewayStatusType,
 ): 'success' | 'error' | 'skipped' | null {
@@ -165,19 +184,24 @@ export function mapGatewaySchedule(schedule: GatewaySchedule): Schedule {
   switch (schedule.kind) {
     case ScheduleKind.At:
       return { kind: ScheduleKind.At, at: schedule.at };
-    case ScheduleKind.Every:
+    case ScheduleKind.Every: {
+      const everyMs = safeFiniteNumber(schedule.everyMs, 60_000);
+      const anchorMs = safeFiniteNumberOrNull(schedule.anchorMs);
       return {
         kind: ScheduleKind.Every,
-        everyMs: schedule.everyMs,
-        ...(typeof schedule.anchorMs === 'number' ? { anchorMs: schedule.anchorMs } : {}),
+        everyMs,
+        ...(anchorMs !== null ? { anchorMs } : {}),
       };
-    case ScheduleKind.Cron:
+    }
+    case ScheduleKind.Cron: {
+      const staggerMs = safeFiniteNumberOrNull(schedule.staggerMs);
       return {
         kind: ScheduleKind.Cron,
         expr: schedule.expr,
         ...(schedule.tz ? { tz: schedule.tz } : {}),
-        ...(typeof schedule.staggerMs === 'number' ? { staggerMs: schedule.staggerMs } : {}),
+        ...(staggerMs !== null ? { staggerMs } : {}),
       };
+    }
   }
 }
 
@@ -282,13 +306,13 @@ export function mapGatewayTaskState(
   }
 
   return {
-    nextRunAtMs: state.nextRunAtMs ?? null,
-    lastRunAtMs: state.lastRunAtMs ?? null,
+    nextRunAtMs: safeFiniteNumberOrNull(state.nextRunAtMs),
+    lastRunAtMs: safeFiniteNumberOrNull(state.lastRunAtMs),
     lastStatus,
     lastError: lastStatus === TaskStatus.Success ? null : (state.lastError ?? null),
-    lastDurationMs: state.lastDurationMs ?? null,
-    runningAtMs: state.runningAtMs ?? null,
-    consecutiveErrors: state.consecutiveErrors ?? 0,
+    lastDurationMs: safeFiniteNumberOrNull(state.lastDurationMs),
+    runningAtMs: safeFiniteNumberOrNull(state.runningAtMs),
+    consecutiveErrors: safeFiniteNumber(state.consecutiveErrors ?? 0, 0),
   };
 }
 
@@ -343,8 +367,8 @@ export function mapGatewayJob(job: GatewayJob): ScheduledTask {
     agentId: job.agentId ?? null,
     sessionKey: job.sessionKey ?? null,
     state: mapGatewayTaskState(job.state, delivery.mode),
-    createdAt: new Date(job.createdAtMs).toISOString(),
-    updatedAt: new Date(job.updatedAtMs).toISOString(),
+    createdAt: new Date(safeFiniteNumber(job.createdAtMs, Date.now())).toISOString(),
+    updatedAt: new Date(safeFiniteNumber(job.updatedAtMs, Date.now())).toISOString(),
   };
 }
 
@@ -367,15 +391,17 @@ export function mapGatewayRun(entry: GatewayRunLogEntry): ScheduledTaskRun {
     status = TaskStatus.Success;
   }
 
+  const tsMs = safeFiniteNumber(entry.runAtMs ?? entry.ts, Date.now());
+
   return {
     id: `${entry.jobId}-${entry.ts}`,
     taskId: entry.jobId,
     sessionId: entry.sessionId ?? null,
     sessionKey: entry.sessionKey ?? null,
     status,
-    startedAt: new Date(entry.runAtMs ?? entry.ts).toISOString(),
-    finishedAt: status === TaskStatus.Running ? null : new Date(entry.ts).toISOString(),
-    durationMs: entry.durationMs ?? null,
+    startedAt: new Date(tsMs).toISOString(),
+    finishedAt: status === TaskStatus.Running ? null : new Date(safeFiniteNumber(entry.ts, tsMs)).toISOString(),
+    durationMs: safeFiniteNumberOrNull(entry.durationMs),
     error: status === TaskStatus.Success ? null : (entry.error ?? null),
   };
 }


### PR DESCRIPTION
## Summary
- Cherry-pick of #530 onto release/2026.04.01, with conflict resolution
- 三层防御修复 Agent 通过 gateway API 创建定时任务时 UI 显示 NaN 的问题：
  1. **主进程映射层**：`safeFiniteNumber`/`safeFiniteNumberOrNull` 守卫所有 gateway 数值字段
  2. **渲染进程 service 层**：`hasTaskDataAnomaly` 检测 + toast 提示
  3. **UI 工具函数层**：`formatScheduleLabel`/`formatDuration` 增加 `Number.isFinite` 守卫

## Conflict resolution
- `cronJobService.ts`：保留 release 的 `ScheduleKind.*` 枚举、`TaskStatus.*`、`mapGatewayTaskState` 签名（含 `delivery.mode`）和 delivery error 抑制逻辑，合入 PR 的 safe number 守卫
- `i18n.ts`：保留 release 新增的隐私协议和 GitHub Copilot i18n keys，合入 anomaly warning key
- `scheduledTask.ts`：保留 release 的 import 路径（`../../scheduledTask/types`），合入 anomaly 检测函数

Closes #407

Co-Authored-By: leelei <liweicheng01@corp.netease.com>