### PR TITLE
fix(agent): AgentCreateModal 支持 Escape 键关闭，并在重新打开时重置表单

### DIFF
--- a/src/renderer/components/agent/AgentCreateModal.tsx
+++ b/src/renderer/components/agent/AgentCreateModal.tsx
@@ -42,15 +42,6 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
   const [imConfig, setImConfig] = useState<IMGatewayConfig | null>(null);
   const [boundPlatforms, setBoundPlatforms] = useState<Set<IMPlatform>>(new Set());
 
-  useEffect(() => {
-    if (!isOpen) return;
-    imService.loadConfig().then((cfg) => {
-      if (cfg) setImConfig(cfg);
-    });
-  }, [isOpen]);
-
-  if (!isOpen) return null;
-
   const resetForm = () => {
     setName('');
     setDescription('');
@@ -61,6 +52,26 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
     setActiveTab('basic');
     setBoundPlatforms(new Set());
   };
+
+  useEffect(() => {
+    if (!isOpen) return;
+    resetForm();
+    imService.loadConfig().then((cfg) => {
+      if (cfg) setImConfig(cfg);
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
 
   const handleCreate = async () => {
     if (!name.trim()) return;


### PR DESCRIPTION
## 问题描述

`AgentCreateModal` 存在两个 UX 一致性缺陷：

### 问题一：缺少 Escape 键关闭支持

项目中的其他 Modal（`McpServerFormModal` L194-199、`CoworkSearchModal`）均通过 `useEffect` 监听 `keydown` 事件实现 Escape 键关闭，但 `AgentCreateModal` 没有该逻辑，用户按 Escape 键无任何响应。

### 问题二：重新打开时显示上次残留数据

`resetForm()` 仅在**创建成功后**调用（`handleCreate` 内）。若用户打开弹窗 → 填写部分内容 → 关闭 → 再次打开，所有字段（名称、描述、系统提示词、身份、图标、技能列表、Tab、IM 绑定）均保留上次内容，与用户预期不符。

## 修改内容

**`src/renderer/components/agent/AgentCreateModal.tsx`**

1. 将 `resetForm()` 定义移至 `useEffect` 调用之前（避免 `const` 未提升导致的调用顺序问题）
2. 在 `isOpen` 监听的 `useEffect` 中，于加载 IM 配置**之前**先调用 `resetForm()`，确保每次打开都是干净状态
3. 新增独立 `useEffect` 监听 `keydown`，`Escape` 时调用 `onClose()`，并在 cleanup 中移除监听器

## 测试

- TypeScript 编译通过���无类型变更，仅调整函数顺序与新增 effect）
- 手动验证：打开弹窗填写内容 → 关闭 → 再次打开 → 字段已清空 ✓
- 手动验证：打开弹窗 → 按 Escape → 弹窗关闭 ✓