### PR TITLE
fix(scheduledTask): 修复定时任务首次执行结果不推送到 UI 的问题

### DIFF
--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -660,7 +660,7 @@ export class CronJobService {
 
         const lastRunAtMs = job.state.lastRunAtMs ?? 0;
         const previousRunAtMs = this.lastKnownRunAtMs.get(job.id) ?? 0;
-        if (lastRunAtMs > previousRunAtMs && previousRunAtMs > 0) {
+        if (this.firstPollDone && lastRunAtMs > previousRunAtMs) {
           try {
             const runs = await this.listRuns(job.id, 1, 0);
             if (runs[0]) {


### PR DESCRIPTION
## 问题描述

当定时任务**第一次执行**（此前从未运行过）时，UI 不会收到 `runUpdate` 实时通知。用户必须等到**第二次**执行才能看到结果推送。

### 根因

`cronJobService.ts` 中 `pollOnce()` 的运行更新检测条件：

```typescript
if (lastRunAtMs > previousRunAtMs && previousRunAtMs > 0) {
```

当任务从未运行过时，`previousRunAtMs` 始终为 `0`（首轮从缓存取的默认值），即使 `lastRunAtMs` 已变为实际时间戳，`&& previousRunAtMs > 0` 仍为 `false`，导致 `emitRunUpdate()` 被跳过。

### 复现步骤

1. 创建一个新的定时任务（从未执行过）
2. 等待任务触发执行
3. **预期**：UI 实时收到 `IpcChannel.RunUpdate` 通知
4. **实际**：无通知，必须手动刷新或等待第二次执行

### 与 PR #1108 的关系

PR #1108 修复的是 `pollOnce()` 的重入保护和幽灵事件问题，与本 PR 的 `previousRunAtMs > 0` 条件缺陷**正交且不冲突**。

## 修改内容

**`src/scheduledTask/cronJobService.ts`**（1 行改动）

```diff
- if (lastRunAtMs > previousRunAtMs && previousRunAtMs > 0) {
+ if (this.firstPollDone && lastRunAtMs > previousRunAtMs) {
```

- 用 `this.firstPollDone` 替代 `previousRunAtMs > 0` 作为守卫条件
- 首轮轮询不发送 `runUpdate`（避免将历史数据当作新事件推送），`emitFullRefresh` 已负责初始化 UI
- 第二轮起，`lastRunAtMs > previousRunAtMs` 即可正确检测新的执行完成——**包括首次执行**（`previousRunAtMs == 0` 的场景）

## 测试

- TypeScript 编译通过
- 逻辑验证：`firstPollDone` 在首轮结束后置 `true`（L686），`stopPolling()` 重置为 `false`（L623），与现有生命周期完全兼容