### PR TITLE
feat(main): AI 任务完成时闪烁任务栏/Dock 图标提醒用户

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -72,6 +72,7 @@ import { resolveEnterpriseConfigPath, syncEnterpriseConfig, mergeEnterpriseOpenc
 import { initLogger, getLogFilePath, getRecentMainLogEntries } from './logger';
 import { getCoworkLogPath } from './libs/coworkLogger';
 import { exportLogsZip } from './libs/logExport';
+import { requestWindowAttention } from './windowAttention';
 import { ensurePythonRuntimeReady } from './libs/pythonRuntime';
 import {
   applySystemProxyEnv,
@@ -1074,6 +1075,7 @@ const bindCoworkRuntimeForwarder = (): void => {
     windows.forEach((win) => {
       if (win.isDestroyed()) return;
       win.webContents.send('cowork:stream:complete', { sessionId, claudeSessionId });
+      requestWindowAttention(win);
     });
     // If session used a server model, notify renderer to refresh quota
     try {
@@ -1097,6 +1099,7 @@ const bindCoworkRuntimeForwarder = (): void => {
     windows.forEach((win) => {
       if (win.isDestroyed()) return;
       win.webContents.send('cowork:stream:error', { sessionId, error });
+      requestWindowAttention(win);
     });
   });
 
@@ -4166,7 +4169,13 @@ if (!gotTheLock) {
     mainWindow.on('unmaximize', forwardWindowState);
     mainWindow.on('enter-full-screen', forwardWindowState);
     mainWindow.on('leave-full-screen', forwardWindowState);
-    mainWindow.on('focus', forwardWindowState);
+    mainWindow.on('focus', () => {
+      forwardWindowState();
+      // Stop taskbar flashing when the user brings the window to front (Windows only).
+      if (process.platform === 'win32') {
+        mainWindow?.flashFrame(false);
+      }
+    });
     mainWindow.on('blur', forwardWindowState);
 
     // 等待内容加载完成后再显示窗口

--- a/src/main/windowAttention.ts
+++ b/src/main/windowAttention.ts
@@ -1,0 +1,21 @@
+import { app, BrowserWindow } from 'electron';
+
+/**
+ * Request the OS-level attention signal for the main window when the user
+ * cannot see it (minimized or unfocused).
+ *
+ * - Windows: flashes the taskbar icon orange until the window is focused.
+ * - macOS:   bounces the Dock icon once (informational, non-intrusive).
+ * - Linux:   no-op (no equivalent Electron API available).
+ */
+export function requestWindowAttention(win: BrowserWindow): void {
+  if (!win.isMinimized() && win.isFocused()) {
+    return;
+  }
+
+  if (process.platform === 'win32') {
+    win.flashFrame(true);
+  } else if (process.platform === 'darwin') {
+    app.dock?.bounce('informational');
+  }
+}


### PR DESCRIPTION
## 概述

AI 任务（Cowork 会话）完成或出错时，如果应用窗口不在前台（最小化或失去焦点），自动闪烁任务栏图标（Windows）或弹跳 Dock 图标（macOS）以提醒用户。

## 改动内容

### 新增文件
- **`src/main/windowAttention.ts`** — 封装跨平台窗口提醒逻辑：
  - Windows：调用 `win.flashFrame(true)` 闪烁任务栏图标
  - macOS：调用 `app.dock.bounce('informational')` 弹跳 Dock 图标一次
  - Linux：暂无等效 API，为 no-op
  - 仅在窗口最小化或失去焦点时触发

### 修改文件
- **`src/main/main.ts`**
  - 在 Cowork 流 `complete` 和 `error` 事件中调用 `requestWindowAttention()`，AI 任务完成或出错时提醒用户
  - 在窗口 `focus` 事件中调用 `mainWindow.flashFrame(false)`（仅 Windows），用户聚焦窗口后停止闪烁

## 测试

- [x] Windows：任务完成时任务栏图标闪烁橙色，点击窗口后停止
- [x] macOS：Dock 图标弹跳一次（informational 模式）
- [x] 窗口在前台时不触发任何闪烁
