### PR TITLE
feat(cowork): 增加对话框附件一键清除与输入框一键清空功能

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { PaperAirplaneIcon, StopIcon, FolderIcon } from '@heroicons/react/24/solid';
-import { PhotoIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { PhotoIcon, ExclamationTriangleIcon, BackspaceIcon } from '@heroicons/react/24/outline';
 import PaperClipIcon from '../icons/PaperClipIcon';
 import XMarkIcon from '../icons/XMarkIcon';
 import ModelSelector from '../ModelSelector';
@@ -614,6 +614,17 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                 </button>
               </div>
           ))}
+          {attachments.length >= 2 && !isStreaming && (
+            <button
+              type="button"
+              onClick={() => dispatch(clearDraftAttachments(draftKey))}
+              className="inline-flex items-center rounded-full px-2 py-1 text-xs text-secondary hover:text-foreground transition-colors"
+              title={i18nService.t('coworkClearAllAttachments')}
+              aria-label={i18nService.t('coworkClearAllAttachments')}
+            >
+              {i18nService.t('coworkClearAllAttachments')}
+            </button>
+          )}
         </div>
       )}
       {imageVisionHint && (
@@ -714,6 +725,17 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                 )}
               </div>
               <div className="flex items-center gap-2">
+                {value.trim().length > 0 && !isStreaming && !disabled && (
+                  <button
+                    type="button"
+                    onClick={() => { setValue(''); textareaRef.current?.focus(); }}
+                    className="p-2 rounded-xl text-secondary hover:text-foreground hover:bg-surface-raised transition-all active:scale-95"
+                    title={i18nService.t('coworkClearInput')}
+                    aria-label={i18nService.t('coworkClearInput')}
+                  >
+                    <BackspaceIcon className="h-5 w-5" />
+                  </button>
+                )}
                 {isStreaming ? (
                   <button
                     type="button"
@@ -764,6 +786,18 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                   <PaperClipIcon className="h-4 w-4" />
                 </button>
               </div>
+            )}
+
+            {value.trim().length > 0 && !isStreaming && !disabled && (
+              <button
+                type="button"
+                onClick={() => { setValue(''); textareaRef.current?.focus(); }}
+                className="flex-shrink-0 p-1.5 rounded-lg text-secondary hover:text-foreground hover:bg-surface-raised transition-all active:scale-95"
+                title={i18nService.t('coworkClearInput')}
+                aria-label={i18nService.t('coworkClearInput')}
+              >
+                <BackspaceIcon className="h-4 w-4" />
+              </button>
             )}
 
             {isStreaming ? (

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -511,6 +511,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkAddImage: '添加图片',
     coworkInputFileLabel: '输入文件',
     coworkAttachmentRemove: '移除',
+    coworkClearAllAttachments: '清除全部',
+    coworkClearInput: '清空输入',
     coworkShareSession: '分享',
     coworkExportImageInProgress: '正在导出图片...',
     coworkExportImageSuccess: '图片导出成功',
@@ -1207,7 +1209,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: 'User',
     login: 'Login',
     inDevelopment: 'In development',
-    
+
     // Settings
     settings: 'Settings',
     general: 'General',
@@ -1234,7 +1236,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: 'Color Themes',
     chinese: 'Chinese',
     english: 'English',
-    
+
     // API Settings
     apiKey: 'API Key',
     apiKeyPlaceholder: 'Enter your API Key',
@@ -1247,7 +1249,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: 'Current Model',
     availableModels: 'Available Models',
     modelSwitchHint: 'You can switch models in the chat interface',
-    
+
     // Model Provider Settings
     enabled: 'Enabled',
     disabled: 'Disabled',
@@ -1335,7 +1337,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: 'Passwords do not match',
     passwordTooShort: 'Password must be at least 4 characters',
     wrongPassword: 'Wrong password, please try again',
-    
+
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
     shortcutNotSet: 'Not set',
@@ -1371,14 +1373,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     planFree: 'Free',
     planAdvanced: 'Advanced',
     planPro: 'Pro',
-    
+
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',
-    
+
     // Loading State
     loading: 'Loading...',
-    
+
     // Sidebar
     conversations: 'Conversations',
     noConversations: 'No conversations',
@@ -1416,7 +1418,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: 'Work',
     folderIconCode: 'Code',
     folderIconIdea: 'Ideas',
-    
+
     // Chat Window
     sendMessage: 'Send Message',
     typeMessage: 'Type a message...',
@@ -1445,17 +1447,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: 'Up to 10 images',
     imageReadError: 'Failed to read image',
     imageInputNotSupported: 'Current model does not support images',
-    
+
     // Model Selection
     selectModel: 'Select Model',
-    
+
     // Error Messages
     errorOccurred: 'An error occurred',
     tryAgain: 'Please try again',
     networkError: 'Network error',
     apiKeyRequired: 'API Key Required',
     configureApiKey: 'Please configure your API key in settings',
-    
+
     // Initialization
     initializationError: 'Failed to initialize application. Please check your configuration.',
     apiKeyNotConfigured: 'API key not configured. Please set up your API key in settings.',
@@ -1699,6 +1701,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkAddImage: 'Add Image',
     coworkInputFileLabel: 'Input file',
     coworkAttachmentRemove: 'Remove',
+    coworkClearAllAttachments: 'Clear all',
+    coworkClearInput: 'Clear input',
     coworkShareSession: 'Share',
     coworkExportImageInProgress: 'Exporting image...',
     coworkExportImageSuccess: 'Image exported successfully',


### PR DESCRIPTION
## 背景

当用户在对话输入框中上传了多个文件附件时，只能逐一点击 ✕ 删除，操作繁琐；同样地，清空输入框的文字内容需要手动全选再删除，缺乏快捷入口。

## 改动内容

### 1. 附件一键清除全部
- 当已上传附件数量 ≥ 2 时，在附件 pill 列表末尾显示「清除全部」文字按钮
- 点击后一次性移除所有已上传附件（复用已有的 `clearDraftAttachments` action）
- Streaming 期间自动隐藏

### 2. 输入框一键清空
- 当输入框有内容且非 streaming/disabled 时，在**发送按钮旁**显示退格清除图标按钮（`BackspaceIcon` ⌫）
- 点击后立即清空输入内容并将焦点归还 textarea
- `isLarge`（大布局）与紧凑布局均已覆盖

### 3. i18n 支持
- 新增 `coworkClearAllAttachments`（中：清除全部 / 英：Clear all）
- 新增 `coworkClearInput`（中：清空输入 / 英：Clear input）

## 效果截图

### 变更前
<img width="1289" height="895" alt="0401-02" src="https://github.com/user-attachments/assets/db29fcc5-edce-4698-9f1a-260306468a63" />

### 变更后

<img width="1797" height="1026" alt="0401-03" src="https://github.com/user-attachments/assets/bd85d404-9e0a-4ec9-bfd4-3e65b9d2e91b" />



## 影响范围

| 文件 | 变更 |
|------|------|
| `src/renderer/components/cowork/CoworkPromptInput.tsx` | 新增「清除全部」附件按钮 + 「清空输入」图标按钮 |
| `src/renderer/services/i18n.ts` | 新增 4 条 i18n 文案（中英各 2 条） |

- ✅ 无新依赖
- ✅ 无 API 变更
- ✅ 无 BREAKING 变更