### PR TITLE
fix(scheduledTasks): 定时任务表单取消/返回时无未保存修改确认，用户填写的内容静默丢失

### DIFF
--- a/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../store';
 import { setViewMode, selectTask } from '../../store/slices/scheduledTaskSlice';
@@ -37,6 +37,13 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
   const selectedTask = selectedTaskId ? tasks.find((t) => t.id === selectedTaskId) ?? null : null;
   const [activeTab, setActiveTab] = useState<TabType>('tasks');
   const [deleteTaskInfo, setDeleteTaskInfo] = useState<{ id: string; name: string } | null>(null);
+  const isFormDirtyRef = useRef(false);
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
+  const pendingBackActionRef = useRef<(() => void) | null>(null);
+
+  const handleFormDirtyChange = useCallback((dirty: boolean) => {
+    isFormDirtyRef.current = dirty;
+  }, []);
 
   const handleRequestDelete = useCallback((taskId: string, taskName: string) => {
     setDeleteTaskInfo({ id: taskId, name: taskName });
@@ -63,6 +70,15 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
   }, []);
 
   const handleBackToList = () => {
+    if ((viewMode === 'create' || viewMode === 'edit') && isFormDirtyRef.current) {
+      pendingBackActionRef.current = () => {
+        isFormDirtyRef.current = false;
+        dispatch(selectTask(null));
+        dispatch(setViewMode('list'));
+      };
+      setShowLeaveConfirm(true);
+      return;
+    }
     dispatch(selectTask(null));
     dispatch(setViewMode('list'));
   };
@@ -175,6 +191,7 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
                 mode="create"
                 onCancel={handleBackToList}
                 onSaved={handleBackToList}
+                onDirtyChange={handleFormDirtyChange}
               />
             )}
             {viewMode === 'edit' && selectedTask && (
@@ -183,6 +200,7 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
                 task={selectedTask}
                 onCancel={() => dispatch(setViewMode('detail'))}
                 onSaved={() => dispatch(setViewMode('detail'))}
+                onDirtyChange={handleFormDirtyChange}
               />
             )}
             {viewMode === 'detail' && selectedTask && (
@@ -199,6 +217,45 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
           onConfirm={handleConfirmDelete}
           onCancel={handleCancelDelete}
         />
+      )}
+
+      {/* Unsaved changes confirmation overlay (back arrow) */}
+      {showLeaveConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35">
+          <div
+            role="dialog"
+            aria-modal="true"
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-sm rounded-2xl bg-background border-border border shadow-modal p-5"
+          >
+            <h4 className="text-sm font-semibold text-foreground mb-2">
+              {i18nService.t('taskFormUnsavedChanges')}
+            </h4>
+            <p className="text-sm text-secondary mb-4">
+              {i18nService.t('taskFormLeaveConfirm')}
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setShowLeaveConfirm(false)}
+                className="px-4 py-2 text-sm rounded-lg text-secondary hover:bg-surface-raised transition-colors border border-border"
+              >
+                {i18nService.t('taskFormStay')}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowLeaveConfirm(false);
+                  pendingBackActionRef.current?.();
+                  pendingBackActionRef.current = null;
+                }}
+                className="px-4 py-2 text-sm font-medium bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+              >
+                {i18nService.t('taskFormLeave')}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { scheduledTaskService } from '../../services/scheduledTask';
 import { i18nService } from '../../services/i18n';
 import type {
@@ -15,6 +15,7 @@ interface TaskFormProps {
   task?: ScheduledTask;
   onCancel: () => void;
   onSaved: () => void;
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
 interface FormState {
@@ -114,8 +115,10 @@ const WEEKDAY_KEYS = [
   'scheduledTasksFormWeekSat',
 ] as const;
 
-const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) => {
+const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved, onDirtyChange }) => {
   const [form, setForm] = useState<FormState>(() => createFormState(task));
+  const initialFormRef = useRef<string>(JSON.stringify(createFormState(task)));
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [channelOptions, setChannelOptions] = useState<ScheduledTaskChannelOption[]>(() => {
     const base: ScheduledTaskChannelOption[] = [];
     const savedChannel = task?.delivery.channel;
@@ -128,6 +131,20 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
   const [conversationsLoading, setConversationsLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const isDirty = JSON.stringify(form) !== initialFormRef.current;
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
+
+  const handleRequestCancel = () => {
+    if (isDirty) {
+      setShowLeaveConfirm(true);
+    } else {
+      onCancel();
+    }
+  };
 
   const isAdvanced = form.planType === 'advanced';
   const showConversationSelector = isIMChannel(form.notifyChannel);
@@ -483,7 +500,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
       <div className="flex items-center justify-end gap-3 pt-2">
         <button
           type="button"
-          onClick={onCancel}
+          onClick={handleRequestCancel}
           className="px-4 py-2 text-sm rounded-lg text-secondary hover:bg-surface-raised transition-colors"
         >
           {i18nService.t('cancel')}
@@ -501,6 +518,41 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
               : i18nService.t('scheduledTasksFormUpdate')}
         </button>
       </div>
+
+      {/* Unsaved changes confirmation overlay */}
+      {showLeaveConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35">
+          <div
+            role="dialog"
+            aria-modal="true"
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-sm rounded-2xl bg-background border-border border shadow-modal p-5"
+          >
+            <h4 className="text-sm font-semibold text-foreground mb-2">
+              {i18nService.t('taskFormUnsavedChanges')}
+            </h4>
+            <p className="text-sm text-secondary mb-4">
+              {i18nService.t('taskFormLeaveConfirm')}
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setShowLeaveConfirm(false)}
+                className="px-4 py-2 text-sm rounded-lg text-secondary hover:bg-surface-raised transition-colors border border-border"
+              >
+                {i18nService.t('taskFormStay')}
+              </button>
+              <button
+                type="button"
+                onClick={() => { setShowLeaveConfirm(false); onCancel(); }}
+                className="px-4 py-2 text-sm font-medium bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+              >
+                {i18nService.t('taskFormLeave')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1193,6 +1193,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     privacyDialogReject: '拒绝',
 
     'settings.enterprise.managed': '由企业统一管理',
+
+    // TaskForm unsaved changes confirmation
+    taskFormUnsavedChanges: '有未保存的修改',
+    taskFormLeaveConfirm: '离开后修改将丢失，确认离开吗？',
+    taskFormLeave: '离开',
+    taskFormStay: '继续编辑',
   },
   en: {
     // Common
@@ -2380,6 +2386,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     privacyDialogReject: 'Decline',
 
     'settings.enterprise.managed': 'Managed by enterprise',
+
+    // TaskForm unsaved changes confirmation
+    taskFormUnsavedChanges: 'Unsaved Changes',
+    taskFormLeaveConfirm: 'Your changes will be lost if you leave. Are you sure you want to leave?',
+    taskFormLeave: 'Leave',
+    taskFormStay: 'Keep Editing',
   }
 };
 


### PR DESCRIPTION
## 关联 Issue

Closes #1245

## 问题

在「定时任务」模块的新建/编辑表单中，用户填写内容后点击 Cancel 按钮或顶部返回箭头，系统直接丢弃所有修改返回列表页，没有任何确认提示。

## 修改内容

### TaskForm.tsx
- 通过 `useRef` 保存表单初始快照，用 JSON 序列化比较检测 dirty 状态
- 新增 `handleRequestCancel` 拦截 Cancel 按钮，dirty 时展示确认弹窗
- 新增 `onDirtyChange` 回调 prop，向父组件实时通知 dirty 状态
- 添加内联确认弹窗（继续编辑 / 离开）

### ScheduledTasksView.tsx
- 新增 `isFormDirtyRef` + `handleFormDirtyChange` 追踪子表单 dirty 状态
- 修改 `handleBackToList`：在 create/edit 模式下检测 dirty 状态，dirty 时展示确认弹窗
- 新增 `pendingBackActionRef` 存储确认后的跳转动作
- 添加内联确认弹窗（继续编辑 / 离开）
- 两处 `<TaskForm>` 均传入 `onDirtyChange`

### i18n.ts
- 新增 4 组中英文 key：`taskFormUnsavedChanges` / `taskFormLeaveConfirm` / `taskFormLeave` / `taskFormStay`

## 覆盖路径

| 触发方式 | create 模式 | edit 模式 |
|---------|------------|----------|
| Cancel 按钮 | ✅ TaskForm 内拦截 | ✅ TaskForm 内拦截 |
| 返回箭头 ← | ✅ ScheduledTasksView 拦截 | ✅ ScheduledTasksView 拦截 |
