### PR TITLE
[codex] fix openclaw model switch recovery after provider limits

### DIFF
--- a/docs/superpowers/plans/2026-04-01-issue-1240-model-switch-recovery.md
+++ b/docs/superpowers/plans/2026-04-01-issue-1240-model-switch-recovery.md
@@ -1,0 +1,222 @@
+# Issue 1240 Model Switch Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix issue #1240 so that after one provider/model is rate-limited, users can switch to another model or another Agent and immediately recover without restarting into a broken OpenClaw state.
+
+**Architecture:** Treat this as a configuration propagation bug in the OpenClaw path. The fix should make model changes restart or reload the running gateway when required, make per-Agent model selection real in generated `openclaw.json`, and migrate persisted session model references so old sessions do not stay pinned to the exhausted provider.
+
+**Tech Stack:** Electron main process, React renderer, SQLite config store, OpenClaw gateway config generation, Vitest.
+
+---
+
+## Current Evidence
+
+- Issue #1240 reports that after Volcengine Coding Plan is exhausted, switching to Gemini in other task windows still shows the same limit error.
+- [`src/renderer/components/ModelSelector.tsx`](/Users/leelei/.codex/worktrees/24fc/LobsterAI/src/renderer/components/ModelSelector.tsx) only changes Redux selected model.
+- [`src/renderer/App.tsx`](/Users/leelei/.codex/worktrees/24fc/LobsterAI/src/renderer/App.tsx) persists the selected model to `app_config`.
+- [`src/main/main.ts`](/Users/leelei/.codex/worktrees/24fc/LobsterAI/src/main/main.ts) handles `store:set('app_config')` by calling `syncOpenClawConfig({ restartGatewayIfRunning: false })`, so a running gateway can keep the old provider/model.
+- [`src/main/libs/openclawConfigSync.ts`](/Users/leelei/.codex/worktrees/24fc/LobsterAI/src/main/libs/openclawConfigSync.ts) writes only `agents.defaults.model.primary`; `buildAgentsList()` does not include `agent.model`, so switching to another Agent can still use the same default model.
+- [`src/main/libs/openclawConfigSync.ts`](/Users/leelei/.codex/worktrees/24fc/LobsterAI/src/main/libs/openclawConfigSync.ts) only migrates `agents/main/sessions/sessions.json` and only for a narrow `lobster -> providerId/model` case, so persisted sessions can stay pinned to the old provider.
+
+## Task 1: Lock Down The Regression With Tests
+
+**Files:**
+- Modify: `src/main/libs/openclawConfigSync.test.ts`
+- Create if needed: `src/main/libs/openclawConfigSync.sessionMigration.test.ts`
+- Create if needed: `src/main/main.appConfigSync.test.ts`
+
+- [ ] **Step 1: Add a regression test for per-Agent model emission**
+
+Create a test that mirrors config generation expectations:
+- main/default agent keeps `agents.defaults.model.primary`
+- non-main agent with `agent.model = 'gemini-2.5-flash'` emits its own model override in `agents.list`
+
+- [ ] **Step 2: Add a regression test for session-store migration**
+
+Cover both:
+- `agents/main/sessions/sessions.json`
+- `agents/<agentId>/sessions/sessions.json`
+
+Expected: sessions pinned to the old provider/model are rewritten to the newly selected provider/model when a global model switch happens.
+
+- [ ] **Step 3: Add a regression test for app_config model changes**
+
+Verify that changing `app_config.model.defaultModel` or `defaultModelProvider` results in a sync path that requests a gateway restart when the gateway is already running.
+
+- [ ] **Step 4: Run only the new focused tests first**
+
+Run:
+```bash
+npm test -- openclawConfigSync
+```
+
+Expected: the newly added regression cases fail before implementation.
+
+## Task 2: Make Agent-Level Model Switching Real
+
+**Files:**
+- Modify: `src/main/libs/openclawConfigSync.ts`
+- Modify if needed: `src/main/coworkStore.ts`
+- Modify if needed: `src/main/presetAgents.ts`
+
+- [ ] **Step 1: Add a helper that resolves an Agent's model into OpenClaw provider selection**
+
+Implement a small helper in [`src/main/libs/openclawConfigSync.ts`](/Users/leelei/.codex/worktrees/24fc/LobsterAI/src/main/libs/openclawConfigSync.ts) that:
+- accepts `agent.model`
+- resolves provider + model identity using the same provider metadata path as the default model
+- returns `model.primary` in OpenClaw format (`providerId/modelId`)
+
+- [ ] **Step 2: Emit per-Agent model overrides in `buildAgentsList()`**
+
+When `agent.model` is non-empty and resolvable, add:
+```json
+{
+  "id": "agent-id",
+  "model": { "primary": "provider/model" }
+}
+```
+
+Keep existing identity and skills behavior intact.
+
+- [ ] **Step 3: Decide fallback behavior**
+
+If `agent.model` is empty or invalid:
+- do not write a broken override
+- fall back to `agents.defaults.model.primary`
+- log one concise warning in English with the Agent id and bad model value
+
+## Task 3: Migrate Persisted Session Model References After A Switch
+
+**Files:**
+- Modify: `src/main/libs/openclawConfigSync.ts`
+- Add helper tests in: `src/main/libs/openclawConfigSync.test.ts`
+
+- [ ] **Step 1: Generalize session-store migration**
+
+Refactor `syncManagedSessionStore()` so it can iterate every relevant session store under:
+- `agents/main/sessions/sessions.json`
+- `agents/<agentId>/sessions/sessions.json`
+
+- [ ] **Step 2: Expand migration beyond the current `lobster` special case**
+
+When the selected default model/provider changes, rewrite stored session references that still point at the previous effective default model. This should update:
+- `entry.modelProvider`
+- `entry.model`
+- `entry.systemPromptReport.provider`
+- `entry.systemPromptReport.model`
+
+- [ ] **Step 3: Avoid corrupting intentionally pinned sessions**
+
+Only rewrite sessions that are effectively following the old default. Do not overwrite sessions that already point at a different explicit provider/model than the previous default.
+
+## Task 4: Restart The Running Gateway When Model/Provider Config Changes
+
+**Files:**
+- Modify: `src/main/main.ts`
+- Modify if needed: `src/renderer/App.tsx`
+
+- [ ] **Step 1: Detect app_config changes that affect OpenClaw runtime behavior**
+
+Inside the `store:set` handler for `app_config`, compare old vs new values and treat these as restart-relevant:
+- `model.defaultModel`
+- `model.defaultModelProvider`
+- provider enablement
+- provider API key
+- provider base URL
+- provider API format
+- provider `codingPlanEnabled`
+- provider model list changes
+
+- [ ] **Step 2: Restart only when runtime-affecting fields changed**
+
+Call:
+```ts
+syncOpenClawConfig({
+  reason: 'app-config-change',
+  restartGatewayIfRunning: runtimeAffectingChange,
+})
+```
+
+Do not restart for unrelated UI fields such as theme, language, or shortcuts.
+
+- [ ] **Step 3: Preserve the active-workload safety rule**
+
+Keep the existing deferred restart behavior in [`src/main/main.ts`](/Users/leelei/.codex/worktrees/24fc/LobsterAI/src/main/main.ts) so active sessions are not interrupted immediately. The expected behavior is:
+- config write happens when safe
+- if workloads are active, a deferred restart is scheduled
+- once workloads stop, the gateway restarts onto the new model/provider
+
+## Task 5: Reproduce And Harden The Startup Failure Path
+
+**Files:**
+- Modify if needed: `src/main/libs/openclawConfigSync.ts`
+- Modify if needed: `src/main/libs/openclawEngineManager.ts`
+- Modify if needed: `src/main/main.ts`
+
+- [ ] **Step 1: Reproduce issue #1240 startup failure locally**
+
+Use a local config sequence that mimics:
+1. start on a Coding Plan provider
+2. switch to Gemini while gateway is running
+3. restart the app
+
+Capture whether the failure comes from:
+- malformed generated `openclaw.json`
+- unsupported provider block for the selected model
+- stale session/config interaction during bootstrap
+
+- [ ] **Step 2: Add the smallest defensive fix once reproduction is confirmed**
+
+Possible acceptable fixes:
+- validate generated `openclaw.json` before replacing the old file
+- keep the previous known-good config if the new config is invalid
+- surface a precise startup error instead of leaving the app unable to boot
+
+- [ ] **Step 3: Avoid speculative hardening**
+
+Do not add fallback complexity unless the reproduction proves this path is real.
+
+## Task 6: Verify End-To-End Behavior
+
+**Files:**
+- Modify test files listed above
+
+- [ ] **Step 1: Run targeted tests**
+
+Run:
+```bash
+npm test -- openclawConfigSync
+```
+
+- [ ] **Step 2: Run touched main-process validation**
+
+Run:
+```bash
+npm run compile:electron
+```
+
+- [ ] **Step 3: Manual regression check in the app**
+
+Verify this exact flow:
+1. configure Volcengine Coding Plan as current model
+2. trigger a rate-limit style failure
+3. switch model in the chat UI to Gemini
+4. confirm a new Cowork session uses Gemini without app restart
+5. switch to another Agent/task window with its own configured model
+6. confirm that Agent uses its own model rather than the exhausted default
+7. restart the app and confirm startup succeeds with the regenerated config
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/main.ts src/main/libs/openclawConfigSync.ts src/main/libs/openclawConfigSync.test.ts
+git commit -m "fix(openclaw): recover model switching after provider limits"
+```
+
+## Notes For The Implementer
+
+- Prefer a small helper for comparing old/new `app_config` runtime fields instead of scattering JSON comparisons through [`src/main/main.ts`](/Users/leelei/.codex/worktrees/24fc/LobsterAI/src/main/main.ts).
+- Reuse existing provider resolution logic from [`src/main/libs/claudeSettings.ts`](/Users/leelei/.codex/worktrees/24fc/LobsterAI/src/main/libs/claudeSettings.ts) instead of inventing a second provider-matching path.
+- Keep all new log messages in English and follow the repository logging rules.
+- Do not change unrelated renderer UX unless reproduction proves the current UI creates misleading model-switch timing.

--- a/src/main/libs/openclawConfigSync.behavior.test.ts
+++ b/src/main/libs/openclawConfigSync.behavior.test.ts
@@ -1,0 +1,233 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { OpenClawProviderId, ProviderName } from '../../shared/providers';
+import type { Agent, CoworkConfig } from '../coworkStore';
+
+let mockHomeDir = '';
+let mockRawApiConfig: {
+  config: { apiKey: string; baseURL: string; model: string; apiType: 'anthropic' | 'openai' };
+  providerMetadata?: {
+    providerName: string;
+    codingPlanEnabled: boolean;
+    supportsImage?: boolean;
+    modelName?: string;
+  };
+} | { config: null; error?: string };
+let mockEnabledProviders: Array<{
+  providerName: string;
+  baseURL: string;
+  apiKey: string;
+  apiType: 'anthropic' | 'openai';
+  codingPlanEnabled: boolean;
+  models: Array<{ id: string; name?: string; supportsImage?: boolean }>;
+}> = [];
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => mockHomeDir,
+    getAppPath: () => process.cwd(),
+  },
+}));
+
+vi.mock('./claudeSettings', () => ({
+  resolveRawApiConfig: () => mockRawApiConfig,
+  resolveAllProviderApiKeys: () => ({}),
+  resolveAllEnabledProviderConfigs: () => mockEnabledProviders,
+  getAllServerModelMetadata: () => [],
+}));
+
+vi.mock('./openclawLocalExtensions', () => ({
+  hasBundledOpenClawExtension: () => false,
+}));
+
+vi.mock('./openclawTokenProxy', () => ({
+  getOpenClawTokenProxyPort: () => null,
+}));
+
+const { OpenClawConfigSync } = await import('./openclawConfigSync');
+
+const createCoworkConfig = (workspaceDir: string): CoworkConfig => ({
+  workingDirectory: workspaceDir,
+  systemPrompt: '',
+  executionMode: 'local',
+  agentEngine: 'openclaw',
+  memoryEnabled: true,
+  memoryImplicitUpdateEnabled: true,
+  memoryLlmJudgeEnabled: false,
+  memoryGuardLevel: 'standard',
+  memoryUserMemoriesMaxItems: 100,
+});
+
+const createSync = (tmpDir: string, agents: Agent[]) => {
+  const workspaceDir = path.join(tmpDir, 'workspace');
+  fs.mkdirSync(workspaceDir, { recursive: true });
+
+  return new OpenClawConfigSync({
+    engineManager: {
+      getConfigPath: () => path.join(tmpDir, 'openclaw.json'),
+      getStateDir: () => path.join(tmpDir, 'state'),
+    } as any,
+    getCoworkConfig: () => createCoworkConfig(workspaceDir),
+    getTelegramOpenClawConfig: () => null,
+    getDiscordOpenClawConfig: () => null,
+    getDingTalkConfig: () => null,
+    getFeishuConfig: () => null,
+    getQQConfig: () => null,
+    getWecomConfig: () => null,
+    getPopoConfig: () => null,
+    getNimConfig: () => null,
+    getNeteaseBeeChanConfig: () => null,
+    getWeixinConfig: () => null,
+    getIMSettings: () => null,
+    getMcpBridgeConfig: () => null,
+    getSkillsList: () => [],
+    getAgents: () => agents,
+  });
+};
+
+const readJson = (filePath: string): any => JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+describe('OpenClawConfigSync behavior', () => {
+  let tmpDir = '';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lobster-openclaw-sync-'));
+    mockHomeDir = path.join(tmpDir, 'home');
+    fs.mkdirSync(mockHomeDir, { recursive: true });
+    mockRawApiConfig = {
+      config: {
+        apiKey: 'sk-default',
+        baseURL: 'https://ark.cn-beijing.volces.com/api/v3',
+        model: 'doubao-seed-1-6-thinking',
+        apiType: 'openai',
+      },
+      providerMetadata: {
+        providerName: ProviderName.Volcengine,
+        codingPlanEnabled: true,
+      },
+    };
+    mockEnabledProviders = [
+      {
+        providerName: ProviderName.Volcengine,
+        baseURL: 'https://ark.cn-beijing.volces.com/api/v3',
+        apiKey: 'sk-volc',
+        apiType: 'openai',
+        codingPlanEnabled: true,
+        models: [{ id: 'doubao-seed-1-6-thinking', name: 'Doubao Thinking' }],
+      },
+      {
+        providerName: ProviderName.Gemini,
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        apiKey: 'sk-gemini',
+        apiType: 'openai',
+        codingPlanEnabled: false,
+        models: [{ id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash' }],
+      },
+    ];
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  test('writes per-agent model overrides into agents.list', () => {
+    const sync = createSync(tmpDir, [{
+      id: 'gemini-agent',
+      name: 'Gemini Agent',
+      description: '',
+      systemPrompt: '',
+      identity: '',
+      model: 'gemini-2.5-flash',
+      icon: '',
+      skillIds: [],
+      enabled: true,
+      isDefault: false,
+      source: 'custom',
+      presetId: '',
+      createdAt: 1,
+      updatedAt: 1,
+    }]);
+
+    const result = sync.sync('test-agent-model');
+
+    expect(result.ok).toBe(true);
+
+    const config = readJson(path.join(tmpDir, 'openclaw.json'));
+    const geminiAgent = config.agents.list.find((entry: { id: string }) => entry.id === 'gemini-agent');
+    expect(geminiAgent?.model?.primary).toBe(`${OpenClawProviderId.Google}/gemini-2.5-flash`);
+  });
+
+  test('migrates managed session stores for every agent workspace', () => {
+    const stateDir = path.join(tmpDir, 'state');
+    const mainSessionsDir = path.join(stateDir, 'agents', 'main', 'sessions');
+    const qaSessionsDir = path.join(stateDir, 'agents', 'qa-agent', 'sessions');
+    fs.mkdirSync(mainSessionsDir, { recursive: true });
+    fs.mkdirSync(qaSessionsDir, { recursive: true });
+
+    const sessionStore = {
+      'agent:main:lobsterai:session-1': {
+        modelProvider: 'lobster',
+        model: 'gemini-2.5-flash',
+        systemPromptReport: {
+          provider: 'lobster',
+          model: 'gemini-2.5-flash',
+        },
+      },
+    };
+    fs.writeFileSync(path.join(mainSessionsDir, 'sessions.json'), `${JSON.stringify(sessionStore, null, 2)}\n`);
+    fs.writeFileSync(path.join(qaSessionsDir, 'sessions.json'), `${JSON.stringify({
+      'agent:qa-agent:lobsterai:session-2': {
+        modelProvider: 'lobster',
+        model: 'gemini-2.5-flash',
+        systemPromptReport: {
+          provider: 'lobster',
+          model: 'gemini-2.5-flash',
+        },
+      },
+    }, null, 2)}\n`);
+
+    mockRawApiConfig = {
+      config: {
+        apiKey: 'sk-gemini',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        model: 'gemini-2.5-flash',
+        apiType: 'openai',
+      },
+      providerMetadata: {
+        providerName: ProviderName.Gemini,
+        codingPlanEnabled: false,
+      },
+    };
+
+    const sync = createSync(tmpDir, [{
+      id: 'qa-agent',
+      name: 'QA Agent',
+      description: '',
+      systemPrompt: '',
+      identity: '',
+      model: '',
+      icon: '',
+      skillIds: [],
+      enabled: true,
+      isDefault: false,
+      source: 'custom',
+      presetId: '',
+      createdAt: 1,
+      updatedAt: 1,
+    }]);
+
+    const result = sync.sync('test-session-migration');
+
+    expect(result.ok).toBe(true);
+
+    const mainStore = readJson(path.join(mainSessionsDir, 'sessions.json'));
+    const qaStore = readJson(path.join(qaSessionsDir, 'sessions.json'));
+
+    expect(mainStore['agent:main:lobsterai:session-1'].modelProvider).toBe(OpenClawProviderId.Google);
+    expect(qaStore['agent:qa-agent:lobsterai:session-2'].modelProvider).toBe(OpenClawProviderId.Google);
+  });
+});

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -1455,89 +1455,104 @@ export class OpenClawConfigSync {
     const shouldMigrateManagedModelRefs = !(
       selection.providerId === 'lobster' && selection.sessionModelId === selection.legacyModelId
     );
+    let changedAnyStore = false;
 
-    const sessionStorePath = path.join(
-      this.engineManager.getStateDir(),
-      'agents',
-      'main',
-      'sessions',
-      'sessions.json',
-    );
+    for (const sessionStorePath of this.collectManagedSessionStorePaths()) {
+      let storeContent = '';
+      try {
+        storeContent = fs.readFileSync(sessionStorePath, 'utf8');
+      } catch {
+        continue;
+      }
 
-    let storeContent = '';
+      let sessionStore: Record<string, unknown>;
+      try {
+        sessionStore = JSON.parse(storeContent) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+
+      let changed = false;
+      for (const [sessionKey, rawEntry] of Object.entries(sessionStore)) {
+        if (!rawEntry || typeof rawEntry !== 'object') {
+          continue;
+        }
+
+        const entry = rawEntry as Record<string, unknown>;
+        if (parseChannelSessionKey(sessionKey) !== null) {
+          // Channel (IM) sessions: set execSecurity to 'full' as a safety net
+          // so the gateway skips any approval flow for IM commands.
+          const execSecurity = typeof entry.execSecurity === 'string' ? entry.execSecurity.trim() : '';
+          if (execSecurity !== 'full') {
+            entry.execSecurity = 'full';
+            changed = true;
+          }
+          if (sessionSnapshotContainsDisabledManagedSkill(entry)) {
+            delete entry.skillsSnapshot;
+            changed = true;
+          }
+        }
+
+        if (!shouldMigrateManagedModelRefs || !(/^agent:[^:]+:lobsterai:/.test(sessionKey))) {
+          continue;
+        }
+
+        const entryProvider = typeof entry.modelProvider === 'string' ? entry.modelProvider.trim() : '';
+        const entryModel = typeof entry.model === 'string' ? entry.model.trim() : '';
+        if (entryProvider !== 'lobster' || entryModel !== selection.legacyModelId) {
+          continue;
+        }
+
+        entry.modelProvider = selection.providerId;
+        entry.model = selection.sessionModelId;
+        const systemPromptReport = entry.systemPromptReport;
+        if (systemPromptReport && typeof systemPromptReport === 'object') {
+          const report = systemPromptReport as Record<string, unknown>;
+          if (typeof report.provider === 'string' && report.provider.trim() === 'lobster') {
+            report.provider = selection.providerId;
+          }
+          if (typeof report.model === 'string' && report.model.trim() === selection.legacyModelId) {
+            report.model = selection.sessionModelId;
+          }
+        }
+        changed = true;
+      }
+
+      if (!changed) {
+        continue;
+      }
+
+      try {
+        this.atomicWriteFile(sessionStorePath, `${JSON.stringify(sessionStore, null, 2)}\n`);
+        changedAnyStore = true;
+      } catch (error) {
+        console.warn(
+          '[OpenClawConfigSync] Failed to update managed session store:',
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+
+    return changedAnyStore;
+  }
+
+  private collectManagedSessionStorePaths(): string[] {
+    const agentsDir = path.join(this.engineManager.getStateDir(), 'agents');
+    const discovered = new Set<string>([
+      path.join(agentsDir, 'main', 'sessions', 'sessions.json'),
+    ]);
+
     try {
-      storeContent = fs.readFileSync(sessionStorePath, 'utf8');
+      const entries = fs.readdirSync(agentsDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        discovered.add(path.join(agentsDir, entry.name, 'sessions', 'sessions.json'));
+      }
     } catch {
-      return false;
+      // Fresh installs may not have any agent session stores yet.
     }
 
-    let sessionStore: Record<string, unknown>;
-    try {
-      sessionStore = JSON.parse(storeContent) as Record<string, unknown>;
-    } catch {
-      return false;
-    }
-
-    let changed = false;
-    for (const [sessionKey, rawEntry] of Object.entries(sessionStore)) {
-      if (!rawEntry || typeof rawEntry !== 'object') {
-        continue;
-      }
-
-      const entry = rawEntry as Record<string, unknown>;
-      if (parseChannelSessionKey(sessionKey) !== null) {
-        // Channel (IM) sessions: set execSecurity to 'full' as a safety net
-        // so the gateway skips any approval flow for IM commands.
-        const execSecurity = typeof entry.execSecurity === 'string' ? entry.execSecurity.trim() : '';
-        if (execSecurity !== 'full') {
-          entry.execSecurity = 'full';
-          changed = true;
-        }
-        if (sessionSnapshotContainsDisabledManagedSkill(entry)) {
-          delete entry.skillsSnapshot;
-          changed = true;
-        }
-      }
-
-      if (!shouldMigrateManagedModelRefs || !(/^agent:[^:]+:lobsterai:/.test(sessionKey))) {
-        continue;
-      }
-
-      const entryProvider = typeof entry.modelProvider === 'string' ? entry.modelProvider.trim() : '';
-      const entryModel = typeof entry.model === 'string' ? entry.model.trim() : '';
-      if (entryProvider !== 'lobster' || entryModel !== selection.legacyModelId) {
-        continue;
-      }
-
-      entry.modelProvider = selection.providerId;
-      entry.model = selection.sessionModelId;
-      const systemPromptReport = entry.systemPromptReport;
-      if (systemPromptReport && typeof systemPromptReport === 'object') {
-        const report = systemPromptReport as Record<string, unknown>;
-        if (typeof report.provider === 'string' && report.provider.trim() === 'lobster') {
-          report.provider = selection.providerId;
-        }
-        if (typeof report.model === 'string' && report.model.trim() === selection.legacyModelId) {
-          report.model = selection.sessionModelId;
-        }
-      }
-      changed = true;
-    }
-
-    if (!changed) {
-      return false;
-    }
-
-    try {
-      this.atomicWriteFile(sessionStorePath, `${JSON.stringify(sessionStore, null, 2)}\n`);
-      return true;
-    } catch (error) {
-      console.warn(
-        '[OpenClawConfigSync] Failed to update managed session store:',
-        error instanceof Error ? error.message : String(error),
-      );
-      return false;
-    }
+    return Array.from(discovered);
   }
 
   /**
@@ -1685,6 +1700,11 @@ export class OpenClawConfigSync {
     for (const agent of agents) {
       if (agent.id === 'main' || !agent.enabled) continue;
 
+      const modelSelection = this.resolveAgentModelSelection(agent.model);
+      if (agent.model.trim() && !modelSelection) {
+        console.warn(`[OpenClawConfigSync] agent ${agent.id} has unresolved model "${agent.model.trim()}", falling back to defaults`);
+      }
+
       list.push({
         id: agent.id,
         // Omit `workspace` — OpenClaw defaults to {STATE_DIR}/workspace-{agentId}/
@@ -1698,10 +1718,51 @@ export class OpenClawConfigSync {
         // Per-agent skill whitelist: only when skillIds is non-empty.
         // OpenClaw's resolveAgentSkillsFilter() uses this to filter available skills.
         ...(agent.skillIds && agent.skillIds.length > 0 ? { skills: agent.skillIds } : {}),
+        ...(modelSelection ? {
+          model: {
+            primary: modelSelection.primaryModel,
+          },
+        } : {}),
       });
     }
 
     return list.length > 0 ? { list } : {};
+  }
+
+  private resolveAgentModelSelection(modelId: string): OpenClawProviderSelection | null {
+    const trimmedModelId = modelId.trim();
+    if (!trimmedModelId) return null;
+
+    const currentResolution = resolveRawApiConfig();
+    if (currentResolution.config?.model.trim() === trimmedModelId) {
+      return buildProviderSelection({
+        apiKey: currentResolution.config.apiKey,
+        baseURL: currentResolution.config.baseURL,
+        modelId: trimmedModelId,
+        apiType: currentResolution.config.apiType,
+        providerName: currentResolution.providerMetadata?.providerName,
+        codingPlanEnabled: currentResolution.providerMetadata?.codingPlanEnabled,
+        supportsImage: currentResolution.providerMetadata?.supportsImage,
+        modelName: currentResolution.providerMetadata?.modelName,
+      });
+    }
+
+    for (const providerConfig of resolveAllEnabledProviderConfigs()) {
+      const matchedModel = providerConfig.models.find((candidate) => candidate.id.trim() === trimmedModelId);
+      if (!matchedModel) continue;
+      return buildProviderSelection({
+        apiKey: providerConfig.apiKey,
+        baseURL: providerConfig.baseURL,
+        modelId: trimmedModelId,
+        apiType: providerConfig.apiType,
+        providerName: providerConfig.providerName,
+        codingPlanEnabled: providerConfig.codingPlanEnabled,
+        supportsImage: matchedModel.supportsImage,
+        modelName: matchedModel.name,
+      });
+    }
+
+    return null;
   }
 
   /**

--- a/src/main/libs/openclawRuntimeConfigChange.test.ts
+++ b/src/main/libs/openclawRuntimeConfigChange.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'vitest';
+import { hasOpenClawRuntimeAppConfigChanges } from './openclawRuntimeConfigChange';
+
+const baseConfig = {
+  language: 'zh',
+  theme: 'dark',
+  model: {
+    defaultModel: 'doubao-seed-1-6-thinking',
+    defaultModelProvider: 'volcengine',
+  },
+  providers: {
+    volcengine: {
+      enabled: true,
+      apiKey: 'sk-volc',
+      baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+      apiFormat: 'openai',
+      codingPlanEnabled: true,
+      models: [
+        { id: 'doubao-seed-1-6-thinking', name: 'Doubao Thinking' },
+      ],
+    },
+  },
+};
+
+describe('hasOpenClawRuntimeAppConfigChanges', () => {
+  test('returns false for unrelated UI-only changes', () => {
+    const nextConfig = {
+      ...baseConfig,
+      language: 'en',
+      theme: 'light',
+    };
+
+    expect(hasOpenClawRuntimeAppConfigChanges(baseConfig, nextConfig)).toBe(false);
+  });
+
+  test('returns true when default model changes', () => {
+    const nextConfig = {
+      ...baseConfig,
+      model: {
+        ...baseConfig.model,
+        defaultModel: 'gemini-2.5-flash',
+      },
+    };
+
+    expect(hasOpenClawRuntimeAppConfigChanges(baseConfig, nextConfig)).toBe(true);
+  });
+
+  test('returns true when default model provider changes', () => {
+    const nextConfig = {
+      ...baseConfig,
+      model: {
+        ...baseConfig.model,
+        defaultModelProvider: 'gemini',
+      },
+    };
+
+    expect(hasOpenClawRuntimeAppConfigChanges(baseConfig, nextConfig)).toBe(true);
+  });
+
+  test('returns true when provider runtime fields change', () => {
+    const nextConfig = {
+      ...baseConfig,
+      providers: {
+        ...baseConfig.providers,
+        volcengine: {
+          ...baseConfig.providers.volcengine,
+          apiKey: 'sk-new',
+        },
+      },
+    };
+
+    expect(hasOpenClawRuntimeAppConfigChanges(baseConfig, nextConfig)).toBe(true);
+  });
+
+  test('returns true when provider model list changes', () => {
+    const nextConfig = {
+      ...baseConfig,
+      providers: {
+        ...baseConfig.providers,
+        volcengine: {
+          ...baseConfig.providers.volcengine,
+          models: [
+            ...baseConfig.providers.volcengine.models,
+            { id: 'doubao-vision', name: 'Doubao Vision' },
+          ],
+        },
+      },
+    };
+
+    expect(hasOpenClawRuntimeAppConfigChanges(baseConfig, nextConfig)).toBe(true);
+  });
+});

--- a/src/main/libs/openclawRuntimeConfigChange.ts
+++ b/src/main/libs/openclawRuntimeConfigChange.ts
@@ -1,0 +1,60 @@
+type AppConfigLike = {
+  model?: {
+    defaultModel?: unknown;
+    defaultModelProvider?: unknown;
+  };
+  providers?: Record<string, {
+    enabled?: unknown;
+    apiKey?: unknown;
+    baseUrl?: unknown;
+    apiFormat?: unknown;
+    codingPlanEnabled?: unknown;
+    models?: Array<{
+      id?: unknown;
+      name?: unknown;
+      supportsImage?: unknown;
+    }>;
+  }>;
+};
+
+const asTrimmedString = (value: unknown): string => (
+  typeof value === 'string' ? value.trim() : ''
+);
+
+const normalizeAppConfigRuntimeSnapshot = (config: AppConfigLike | null | undefined) => {
+  const providers = Object.fromEntries(
+    Object.entries(config?.providers ?? {})
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([providerName, providerConfig]) => [
+        providerName,
+        {
+          enabled: providerConfig?.enabled === true,
+          apiKey: asTrimmedString(providerConfig?.apiKey),
+          baseUrl: asTrimmedString(providerConfig?.baseUrl),
+          apiFormat: asTrimmedString(providerConfig?.apiFormat),
+          codingPlanEnabled: providerConfig?.codingPlanEnabled === true,
+          models: (providerConfig?.models ?? []).map((model) => ({
+            id: asTrimmedString(model?.id),
+            name: asTrimmedString(model?.name),
+            supportsImage: model?.supportsImage === true,
+          })),
+        },
+      ])
+  );
+
+  return {
+    model: {
+      defaultModel: asTrimmedString(config?.model?.defaultModel),
+      defaultModelProvider: asTrimmedString(config?.model?.defaultModelProvider),
+    },
+    providers,
+  };
+};
+
+export function hasOpenClawRuntimeAppConfigChanges(
+  previousConfig: AppConfigLike | null | undefined,
+  nextConfig: AppConfigLike | null | undefined,
+): boolean {
+  return JSON.stringify(normalizeAppConfigRuntimeSnapshot(previousConfig))
+    !== JSON.stringify(normalizeAppConfigRuntimeSnapshot(nextConfig));
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -79,6 +79,7 @@ import {
   restoreOriginalProxyEnv,
   setSystemProxyEnabled,
 } from './libs/systemProxy';
+import { hasOpenClawRuntimeAppConfigChanges } from './libs/openclawRuntimeConfigChange';
 
 // 设置应用程序名称
 app.name = APP_NAME;
@@ -1702,12 +1703,14 @@ if (!gotTheLock) {
   });
 
   ipcMain.handle('store:set', async (_event, key, value) => {
+    const previousValue = key === 'app_config' ? getStore().get(key) : undefined;
     getStore().set(key, value);
     if (key === 'app_config') {
       refreshEndpointsTestMode(getStore());
+      const restartGatewayIfRunning = hasOpenClawRuntimeAppConfigChanges(previousValue, value);
       const syncResult = await syncOpenClawConfig({
         reason: 'app-config-change',
-        restartGatewayIfRunning: false,
+        restartGatewayIfRunning,
       });
       if (!syncResult.success) {
         console.error('[OpenClaw] Failed to sync config after app_config update:', syncResult.error);


### PR DESCRIPTION
## What changed
- detect runtime-relevant `app_config` model/provider changes and restart or defer-restart OpenClaw when needed
- emit per-agent `model.primary` into `openclaw.json` so switching Agents really switches models
- migrate managed session stores across all agent workspaces instead of only `main`
- add regression tests for agent model emission, session-store migration, and runtime config change detection

## Why
- provider rate limits could leave the running OpenClaw gateway pinned to the old model/provider even after the UI switched models
- custom Agents stored their own `model`, but that setting was not propagated into generated OpenClaw agent config
- persisted managed sessions outside the main agent could keep stale provider bindings

## Root cause
- `store:set('app_config')` always synced OpenClaw with `restartGatewayIfRunning: false`
- `buildAgentsList()` did not include per-agent model overrides
- `syncManagedSessionStore()` only rewrote `agents/main/sessions/sessions.json`

## Validation
- `npm test -- openclawConfigSync.behavior openclawRuntimeConfigChange`
- `npm run compile:electron`

Closes #1240