### PR TITLE
fix(openclaw): 修复使用阿里云 Qwen 时网关频繁重启的问题

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -821,6 +821,13 @@ export class OpenClawConfigSync {
     const hasMcpBridgePlugin = isBundledPluginAvailable('mcp-bridge');
     const hasAskUserPlugin = isBundledPluginAvailable('ask-user-question');
 
+    // Detect if any provider uses Qwen/Aliyun DashScope URLs — OpenClaw auto-injects
+    // qwen-portal-auth plugin for these, so we must declare it to prevent config diff loops.
+    const hasQwenProvider = Object.values(allProvidersMap).some((p) => {
+      const url = (p as { baseUrl?: string }).baseUrl || '';
+      return url.includes('dashscope.aliyuncs.com') || url.includes('aliyuncs.com/compatible-mode');
+    });
+
     const dingTalkConfig = this.getDingTalkConfig();
     // DingTalk runs through OpenClaw plugin but still needs the gateway HTTP endpoint (chatCompletions)
     const hasDingTalkOpenClaw = !!(dingTalkConfig?.enabled && dingTalkConfig.clientId);
@@ -933,6 +940,11 @@ export class OpenClawConfigSync {
             : {}),
           ...(hasAskUserPlugin
             ? { 'ask-user-question': { enabled: true } }
+            : {}),
+          // OpenClaw auto-injects qwen-portal-auth for Qwen/DashScope URLs; declare it
+          // explicitly so configSync doesn't remove it and trigger restart loops.
+          ...(hasQwenProvider
+            ? { 'qwen-portal-auth': { enabled: true } }
             : {}),
         };
 


### PR DESCRIPTION
## 问题描述
使用 LobsterAI Server 模式或自定义 Provider 连接阿里云 DashScope (Qwen) 时，OpenClaw 网关会每隔 15-20 秒自动重启，导致 AI 引擎频繁显示"正在启动网关..."。

## 根本原因
OpenClaw 网关检测到 `dashscope.aliyuncs.com` URL 后会自动注入 `qwen-portal-auth` 认证插件。但 LobsterAI 的配置同步模块没有声明这个插件，导致：
1. OpenClaw 写入 `qwen-portal-auth` 到 `plugins.entries`
2. ConfigSync 每次同步时没有这个插件配置
3. OpenClaw 检测到配置差异，触发网关重启
4. 重启后 OpenClaw 再次写入插件 → 循环往复

## 修复方案
在 `openclawConfigSync.ts` 中：
- 检测是否有 Provider 使用 DashScope/Qwen URL
- 如果是，显式声明 `qwen-portal-auth` 插件，保持配置一致