### PR TITLE
fix(cowork): 修复 DiffView 无法渲染——Edit 工具名匹配条件太窄，漏掉 Claude SDK 和 OpenClaw 的实际工具名

### DIFF
--- a/src/renderer/components/cowork/DiffView.tsx
+++ b/src/renderer/components/cowork/DiffView.tsx
@@ -336,7 +336,7 @@ export function extractDiffFromToolInput(
   if (!toolName || !toolInput) return null;
   const normalized = toolName.toLowerCase().replace(/[\s_]+/g, '');
 
-  if (normalized === 'edit' || normalized === 'editfile') {
+  if (normalized.includes('edit') && normalized !== 'multiedit') {
     const filePath = extractString(toolInput, ['file_path', 'path', 'filePath', 'target_file', 'targetFile']);
     const oldStr = extractString(toolInput, ['old_str', 'old_string', 'old_text', 'oldStr', 'oldText', 'search']);
     const newStr = extractString(toolInput, ['new_str', 'new_string', 'new_text', 'newStr', 'newText', 'replace']);


### PR DESCRIPTION
问题
Cowork 会话中 AI 调用 Edit 工具修改文件时，DiffView 组件始终不渲染，用户只能看到原始工具输入/输出文本，看不到可视化 diff 对比。

根因
extractDiffFromToolInput() 对工具名做标准化后，只匹配 'edit' 和 'editfile'。但实际环境中：

引擎	原始工具名	标准化后	匹配？
Claude SDK	str_replace_editor	strreplaceeditor	❌
Claude SDK	TextEditor	texteditor	❌
OpenClaw	file_editor	fileeditor	❌
OpenClaw	Edit	edit	✅
OpenClaw	MultiEdit	multiedit	✅
5 种已知工具名中只有 2 种能匹配，最常用的 str_replace_editor 恰好匹配不上。