### PR TITLE
feat(sidebar): 侧栏收缩后保留图标栏导航，支持tooltip提示和完整点击功能

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -691,7 +691,7 @@ const App: React.FC = () => {
           updateBadge={!isSidebarCollapsed ? updateBadge : null}
           hideLogin={enterpriseConfig?.ui?.login === 'hide'}
         />
-        <div className={`flex-1 min-w-0 py-1.5 pr-1.5 ${isSidebarCollapsed ? 'pl-1.5' : ''}`}>
+        <div className="flex-1 min-w-0 py-1.5 pr-1.5">
           <div className="relative h-full min-h-0 rounded-xl bg-background overflow-hidden">
             <EngineStartupOverlay />
             {mainView === 'skills' ? (

--- a/src/renderer/components/LoginButton.tsx
+++ b/src/renderer/components/LoginButton.tsx
@@ -221,7 +221,7 @@ const UserMenu: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   );
 };
 
-const LoginButton: React.FC = () => {
+const LoginButton: React.FC<{ iconOnly?: boolean }> = ({ iconOnly }) => {
   const { isLoggedIn, isLoading, user } = useSelector((state: RootState) => state.auth);
   const [showMenu, setShowMenu] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -254,6 +254,30 @@ const LoginButton: React.FC = () => {
 
   const phoneSuffix = user?.phone ? user.phone.slice(-4) : '';
 
+  const userIcon = isLoggedIn && user?.avatarUrl
+    ? <img src={user.avatarUrl} alt="" className="h-4 w-4 rounded-full" />
+    : <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4"><circle cx="12" cy="8" r="5" /><path d="M20 21a8 8 0 0 0-16 0" /></svg>;
+
+  const tooltipText = isLoggedIn
+    ? (user?.nickname || `****${phoneSuffix}`)
+    : i18nService.t('login');
+
+  if (iconOnly) {
+    return (
+      <div ref={containerRef} className="relative">
+        <button
+          type="button"
+          onClick={handleClick}
+          className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:text-foreground hover:bg-surface-raised transition-colors cursor-pointer"
+          title={tooltipText}
+        >
+          {userIcon}
+        </button>
+        {showMenu && <UserMenu onClose={() => setShowMenu(false)} />}
+      </div>
+    );
+  }
+
   return (
     <div ref={containerRef} className="relative">
       <button
@@ -261,20 +285,11 @@ const LoginButton: React.FC = () => {
         onClick={handleClick}
         className="inline-flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm font-medium text-secondary hover:text-foreground hover:bg-surface-raised transition-colors cursor-pointer"
       >
+        {userIcon}
         {isLoggedIn ? (
-          <>
-            {user?.avatarUrl ? (
-              <img src={user.avatarUrl} alt="" className="h-4 w-4 rounded-full" />
-            ) : (
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4"><circle cx="12" cy="8" r="5" /><path d="M20 21a8 8 0 0 0-16 0" /></svg>
-            )}
-            <span className="truncate max-w-[80px]">{user?.nickname || `****${phoneSuffix}`}</span>
-          </>
+          <span className="truncate max-w-[80px]">{user?.nickname || `****${phoneSuffix}`}</span>
         ) : (
-          <>
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4"><circle cx="12" cy="8" r="5" /><path d="M20 21a8 8 0 0 0-16 0" /></svg>
-            {i18nService.t('login')}
-          </>
+          i18nService.t('login')
         )}
       </button>
       {showMenu && <UserMenu onClose={() => setShowMenu(false)} />}

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -72,7 +72,6 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   useEffect(() => {
     if (!isCollapsed) return;
-    setIsSearchOpen(false);
     setIsBatchMode(false);
     setSelectedIds(new Set());
     setShowBatchDeleteConfirm(false);
@@ -139,11 +138,113 @@ const Sidebar: React.FC<SidebarProps> = ({
     handleExitBatchMode();
   }, [selectedIds, handleExitBatchMode]);
 
+  const collapsedIconBtnClass = (view?: string) =>
+    `h-8 w-8 inline-flex items-center justify-center rounded-lg transition-colors ${
+      view && activeView === view
+        ? 'bg-primary/10 text-primary hover:bg-primary/20'
+        : 'text-secondary hover:text-foreground hover:bg-surface-raised'
+    }`;
+
+  if (isCollapsed) {
+    return (
+      <aside
+        className="shrink-0 bg-surface-raised flex flex-col items-center w-12 sidebar-transition pt-3 pb-3"
+      >
+        {/* Expand toggle */}
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors mb-3"
+          title={i18nService.t('expand')}
+          aria-label={i18nService.t('expand')}
+        >
+          <SidebarToggleIcon className="h-4 w-4" isCollapsed={true} />
+        </button>
+        {/* Navigation icons */}
+        <div className="space-y-1 flex flex-col items-center">
+          <button
+            type="button"
+            onClick={onNewChat}
+            className={collapsedIconBtnClass('cowork')}
+            title={i18nService.t('newChat')}
+          >
+            <ComposeIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              onShowCowork();
+              setIsSearchOpen(true);
+            }}
+            className={collapsedIconBtnClass()}
+            title={i18nService.t('search')}
+          >
+            <SearchIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={onShowScheduledTasks}
+            className={collapsedIconBtnClass('scheduledTasks')}
+            title={i18nService.t('scheduledTasks')}
+          >
+            <ClockIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={onShowSkills}
+            className={collapsedIconBtnClass('skills')}
+            title={i18nService.t('skills')}
+          >
+            <PuzzleIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={onShowMcp}
+            className={collapsedIconBtnClass('mcp')}
+            title={i18nService.t('mcpServers')}
+          >
+            <ConnectorIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={onShowAgents}
+            className={collapsedIconBtnClass('agents')}
+            title={i18nService.t('myAgents')}
+          >
+            <UserGroupIcon className="h-4 w-4" />
+          </button>
+        </div>
+        {/* Spacer */}
+        <div className="flex-1" />
+        {/* User icon at bottom */}
+        {!hideLogin && <LoginButton iconOnly />}
+        {/* Settings icon at bottom */}
+        <button
+          type="button"
+          onClick={() => onShowSettings()}
+          className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:text-foreground hover:bg-surface-raised transition-colors"
+          title={i18nService.t('settings')}
+          aria-label={i18nService.t('settings')}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4"><path d="M14 17H5" /><path d="M19 7h-9" /><circle cx="17" cy="17" r="3" /><circle cx="7" cy="7" r="3" /></svg>
+        </button>
+        <CoworkSearchModal
+          isOpen={isSearchOpen}
+          onClose={() => setIsSearchOpen(false)}
+          sessions={filteredSessions}
+          currentSessionId={currentSessionId}
+          onSelectSession={handleSelectSession}
+          onDeleteSession={handleDeleteSession}
+          onTogglePin={handleTogglePin}
+          onRenameSession={handleRenameSession}
+        />
+      </aside>
+    );
+  }
+
   return (
     <aside
-      className={`shrink-0 bg-surface-raised flex flex-col sidebar-transition overflow-hidden ${
-        isCollapsed ? 'w-0' : 'w-60'
-      }`}
+      className="shrink-0 bg-surface-raised flex flex-col sidebar-transition overflow-hidden w-60"
     >
       <div className="pt-3 pb-3">
         <div className="draggable sidebar-header-drag h-8 flex items-center justify-between px-3">
@@ -154,9 +255,9 @@ const Sidebar: React.FC<SidebarProps> = ({
             type="button"
             onClick={onToggleCollapse}
             className="non-draggable h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-            aria-label={isCollapsed ? i18nService.t('expand') : i18nService.t('collapse')}
+            aria-label={i18nService.t('collapse')}
           >
-            <SidebarToggleIcon className="h-4 w-4" isCollapsed={isCollapsed} />
+            <SidebarToggleIcon className="h-4 w-4" isCollapsed={false} />
           </button>
         </div>
         <div className="mt-3 space-y-1 px-3">

--- a/src/renderer/components/agent/AgentsView.tsx
+++ b/src/renderer/components/agent/AgentsView.tsx
@@ -70,25 +70,6 @@ const AgentsView: React.FC<AgentsViewProps> = ({
       {/* Header */}
       <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border shrink-0">
         <div className="flex items-center space-x-3 h-8">
-          {isSidebarCollapsed && (
-            <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
-              <button
-                type="button"
-                onClick={onToggleSidebar}
-                className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                <SidebarToggleIcon className="h-4 w-4" isCollapsed={true} />
-              </button>
-              <button
-                type="button"
-                onClick={onNewChat}
-                className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                <ComposeIcon className="h-4 w-4" />
-              </button>
-              {updateBadge}
-            </div>
-          )}
           <h1 className="text-lg font-semibold text-foreground">
             {i18nService.t('myAgents')}
           </h1>

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -2160,25 +2160,6 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border bg-surface shrink-0">
         {/* Left side: Toggle buttons (when collapsed) + Title */}
         <div className="flex h-full items-center gap-2 min-w-0">
-          {isSidebarCollapsed && (
-            <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
-              <button
-                type="button"
-                onClick={onToggleSidebar}
-                className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                <SidebarToggleIcon className="h-4 w-4" isCollapsed={true} />
-              </button>
-              <button
-                type="button"
-                onClick={onNewChat}
-                className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                <ComposeIcon className="h-4 w-4" />
-              </button>
-              {updateBadge}
-            </div>
-          )}
           {isRenaming ? (
             <input
               ref={renameInputRef}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -463,25 +463,6 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   const homeHeader = (
     <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border shrink-0">
       <div className="non-draggable h-8 flex items-center">
-        {isSidebarCollapsed && (
-          <div className={`flex items-center gap-1 mr-2 ${isMac ? 'pl-[68px]' : ''}`}>
-            <button
-              type="button"
-              onClick={onToggleSidebar}
-              className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-            >
-              <SidebarToggleIcon className="h-4 w-4" isCollapsed={true} />
-            </button>
-            <button
-              type="button"
-              onClick={onNewChat}
-              className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-            >
-              <ComposeIcon className="h-4 w-4" />
-            </button>
-            {updateBadge}
-          </div>
-        )}
         <ModelSelector />
       </div>
       <div className="non-draggable flex items-center">

--- a/src/renderer/components/mcp/McpView.tsx
+++ b/src/renderer/components/mcp/McpView.tsx
@@ -18,25 +18,6 @@ const McpView: React.FC<McpViewProps> = ({ isSidebarCollapsed, onToggleSidebar, 
     <div className="flex-1 flex flex-col bg-background h-full">
       <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border shrink-0">
         <div className="flex items-center space-x-3 h-8">
-          {isSidebarCollapsed && (
-            <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
-              <button
-                type="button"
-                onClick={onToggleSidebar}
-                className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                <SidebarToggleIcon className="h-4 w-4" isCollapsed={true} />
-              </button>
-              <button
-                type="button"
-                onClick={onNewChat}
-                className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                <ComposeIcon className="h-4 w-4" />
-              </button>
-              {updateBadge}
-            </div>
-          )}
           <h1 className="text-lg font-semibold text-foreground">
             {i18nService.t('mcpServers')}
           </h1>

--- a/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
@@ -83,25 +83,6 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
       {/* Header */}
       <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border shrink-0">
         <div className="flex items-center space-x-3 h-8">
-          {isSidebarCollapsed && (
-            <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
-              <button
-                type="button"
-                onClick={onToggleSidebar}
-                className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                <SidebarToggleIcon className="h-4 w-4" isCollapsed={true} />
-              </button>
-              <button
-                type="button"
-                onClick={onNewChat}
-                className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                <ComposeIcon className="h-4 w-4" />
-              </button>
-              {updateBadge}
-            </div>
-          )}
           {viewMode !== 'list' && (
             <button
               onClick={handleBackToList}

--- a/src/renderer/components/skills/SkillsView.tsx
+++ b/src/renderer/components/skills/SkillsView.tsx
@@ -20,25 +20,6 @@ const SkillsView: React.FC<SkillsViewProps> = ({ isSidebarCollapsed, onToggleSid
     <div className="flex-1 flex flex-col bg-background h-full">
       <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border shrink-0">
         <div className="flex items-center space-x-3 h-8">
-          {isSidebarCollapsed && (
-            <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
-              <button
-                type="button"
-                onClick={onToggleSidebar}
-                className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                <SidebarToggleIcon className="h-4 w-4" isCollapsed={true} />
-              </button>
-              <button
-                type="button"
-                onClick={onNewChat}
-                className="h-8 w-8 inline-flex items-center justify-center rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                <ComposeIcon className="h-4 w-4" />
-              </button>
-              {updateBadge}
-            </div>
-          )}
           <h1 className="text-lg font-semibold text-foreground">
             {i18nService.t('skills')}
           </h1>


### PR DESCRIPTION
## 变更说明

### 问题
侧栏点击收缩后，整个侧栏完全消失（宽度变为 0），用户失去所有导航入口，只能通过各视图顶部的展开按钮恢复。体验不够直观，无法快速切换功能模块。

### 解决方案
收缩后保留一条 48px 宽的图标栏，显示各功能模块的图标按钮：

- **图标栏内容**：展开/收缩按钮、新建对话、搜索、定时任务、技能、MCP、智能体、用户头像、设置
- **Tooltip 提示**：每个图标 hover 显示功能名称（原生 title 属性）
- **保留点击功能**：所有图标按钮的点击行为与展开态完全一致
- **激活态高亮**：当前活跃视图对应图标有高亮样式
- **用户图标**：收缩态底部显示用户头像图标（LoginButton iconOnly 模式），点击可弹出用户菜单

### 附带优化
- 移除各视图头部在收缩态显示的 SidebarToggle + ComposeIcon 按钮（图标栏已提供这些入口，不再重复）
- 移除 App.tsx 中收缩态的额外左侧 padding

## 效果截图

### 变更前
<img width="1795" height="1174" alt="0401-05" src="https://github.com/user-attachments/assets/3c4e8a0e-18d9-4e2e-8f3f-61025096fa81" />

### 变更后
<img width="1799" height="1192" alt="0401-06" src="https://github.com/user-attachments/assets/7544d1c1-e7b7-487c-8422-957a7eda393a" />


### 改动文件
| 文件 | 改动 |
|---|---|
| `Sidebar.tsx` | 核心改动：收缩态条件渲染图标栏 |
| `LoginButton.tsx` | 新增 iconOnly prop 支持纯图标模式 |
| `App.tsx` | 移除收缩态 pl-1.5 条件 padding |
| `CoworkView.tsx` | 移除头部收缩态按钮 |
| `CoworkSessionDetail.tsx` | 移除头部收缩态按钮 |
| `SkillsView.tsx` | 移除头部收缩态按钮 |
| `McpView.tsx` | 移除头部收缩态按钮 |
| `AgentsView.tsx` | 移除头部收缩态按钮 |
| `ScheduledTasksView.tsx` | 移除头部收缩态按钮 |

### 测试建议
1. 点击收缩按钮 → 侧栏变为 48px 图标栏
2. hover 图标 → 显示 tooltip 功能名称
3. 点击图标 → 正确切换视图/执行操作
4. 当前视图图标高亮
5. 点击用户头像 → 弹出用户菜单
6. 点击展开按钮 → 恢复完整侧栏
7. 收缩态无会话列表、Agent列表、批量操作UI