### PR TITLE
fix(i18n): POPO IM 设置页面 4 处 placeholder 在中文情况下显示英文

### DIFF
--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -3499,7 +3499,7 @@ const IMSettings: React.FC = () => {
                 </div>
               </div>
               {popoConfig.aesKey && popoConfig.aesKey.length !== 32 && (
-                <p className="text-xs text-amber-500">AES Key {i18nService.t('lang') === 'zh' ? '需要为 32 个字符' : 'must be 32 characters'}（{i18nService.t('lang') === 'zh' ? '当前' : 'current'} {popoConfig.aesKey.length}）</p>
+                <p className="text-xs text-amber-500">AES Key {i18nService.t('imPopoAesKeyLengthWarning')}（{i18nService.t('imPopoAesKeyLengthCurrent')} {popoConfig.aesKey.length}）</p>
               )}
             </div>
 
@@ -3520,7 +3520,7 @@ const IMSettings: React.FC = () => {
                     value={popoConfig.webhookBaseUrl}
                     onChange={(e) => handlePopoChange({ webhookBaseUrl: e.target.value })}
                     onBlur={() => void handleSavePopoConfig()}
-                    placeholder={localIp ? `http://${localIp}` : (i18nService.t('lang') === 'zh' ? '外部域名（可选，不填则自动检测本机 IP）' : 'External domain (optional, auto-detects local IP)')}
+                    placeholder={localIp ? `http://${localIp}` : i18nService.t('imPopoWebhookPlaceholder')}
                     className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
                   />
                 </div>
@@ -3600,7 +3600,7 @@ const IMSettings: React.FC = () => {
                         }
                       }}
                       className="block flex-1 rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
-                      placeholder={i18nService.t('lang') === 'zh' ? '输入用户 ID 后回车添加' : 'Enter user ID and press Enter'}
+                      placeholder={i18nService.t('imPopoUserIdPlaceholder')}
                     />
                     <button
                       type="button"
@@ -3686,7 +3686,7 @@ const IMSettings: React.FC = () => {
                         }
                       }}
                       className="block flex-1 rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
-                      placeholder={i18nService.t('lang') === 'zh' ? '输入群组 ID 后回车添加' : 'Enter group ID and press Enter'}
+                      placeholder={i18nService.t('imPopoGroupIdPlaceholder')}
                     />
                     <button
                       type="button"

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -872,6 +872,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimQChatServerIdsHint: '指定要订阅的服务器 ID，多个用逗号分隔。留空则自动订阅所有已加入的服务器。',
     neteaseBeeChanClientIdPlaceholder: '小蜜蜂助理Client ID',
 
+    // IM 设置页面 - POPO 配置
+    imPopoAesKeyLengthWarning: 'AES Key 需要为 32 个字符',
+    imPopoAesKeyLengthCurrent: '当前',
+    imPopoWebhookPlaceholder: '外部域名（可选，不填则自动检测本机 IP）',
+    imPopoUserIdPlaceholder: '输入用户 ID 后回车添加',
+    imPopoGroupIdPlaceholder: '输入群组 ID 后回车添加',
+
     // IM 设置页面国际化
     imAdvancedSettings: '高级设置',
     imPairingApproval: '配对码审批',
@@ -2058,6 +2065,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimQChatServerIdsPlaceholder: 'Leave empty to auto-discover all joined servers',
     nimQChatServerIdsHint: 'Specify server IDs to subscribe, separated by commas. Leave empty to auto-subscribe all joined servers.',
     neteaseBeeChanClientIdPlaceholder: 'Netease Bee IM Client ID',
+
+    // IM settings page - POPO config
+    imPopoAesKeyLengthWarning: 'AES Key must be 32 characters',
+    imPopoAesKeyLengthCurrent: 'current',
+    imPopoWebhookPlaceholder: 'External domain (optional, auto-detects local IP)',
+    imPopoUserIdPlaceholder: 'Enter user ID and press Enter',
+    imPopoGroupIdPlaceholder: 'Enter group ID and press Enter',
 
     // IM settings page i18n
     imAdvancedSettings: 'Advanced Settings',


### PR DESCRIPTION
## Summary

- POPO IM 设置页面 4 处 placeholder/提示文字使用 `i18nService.t('lang') === 'zh'` 做语言判断，但 `lang` key 不存在于 i18n 翻译文件，`t('lang')` 始终返回字符串 `"lang"`，导致中文用户看到英文提示且出现中英括号混排
- 新增 5 个 i18n key，替换 4 处硬编码三元表达式为标准 `t()` 调用

## 问题

中文环境下进入 设置 → IM → POPO 配置区域，以下 4 处文字始终显示英文：
1. AES Key 长度校验警告显示 `must be 32 characters（current 3）` 而非 `需要为 32 个字符（当前 3）`
2. Webhook URL 输入框 placeholder 显示英文
3. 用户白名单输入框 placeholder 显示英文
4. 群组白名单输入框 placeholder 显示英文

## 修复

- 在 `src/renderer/services/i18n.ts` 新增 5 个 i18n key（zh + en 各 5 个）：`imPopoAesKeyLengthWarning`、`imPopoAesKeyLengthCurrent`、`imPopoWebhookPlaceholder`、`imPopoUserIdPlaceholder`、`imPopoGroupIdPlaceholder`
- 在 `src/renderer/components/im/IMSettings.tsx` 将 4 处 `i18nService.t('lang') === 'zh' ? ... : ...` 替换为 `i18nService.t('imPopo...')`

## 复现路径

设置 → IM → POPO → 输入非 32 位 AES Key / 查看 Webhook URL、用户白名单、群组白名单的 placeholder