### PR TITLE
feat(cowork): 为用户消息和AI消息添加区分背景色与气泡尖角

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -954,7 +954,7 @@ export const UserMessageItem: React.FC<{ message: CoworkMessage; skills: Skill[]
         <div className="pl-4 sm:pl-8 md:pl-12">
           <div className="flex items-start gap-3 flex-row-reverse">
             <div className="w-full min-w-0 flex flex-col items-end">
-              <div className="w-fit max-w-[42rem] rounded-2xl px-4 py-2.5 bg-surface text-foreground shadow-subtle">
+              <div className="chat-bubble-user w-fit max-w-[42rem] rounded-2xl px-4 py-2.5 bg-chat-user text-foreground shadow-subtle">
                 {message.content?.trim() && (
                   <MarkdownContent
                     content={message.content}
@@ -1253,7 +1253,7 @@ export const AssistantTurnBlock: React.FC<{
     <div className="px-4 py-2">
       <div className="max-w-3xl mx-auto">
         <div className="flex items-start gap-3">
-          <div className="flex-1 min-w-0 px-4 py-3 space-y-3">
+          <div className="chat-bubble-bot flex-1 min-w-0 px-4 py-3 space-y-3 bg-chat-bot rounded-2xl">
             {visibleAssistantItems.map((item, index) => {
               if (item.type === 'assistant') {
                 if (item.message.metadata?.isThinking) {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -68,6 +68,36 @@ blockquote {
   contain-intrinsic-size: 500px;
 }
 
+/* Chat bubble tail — user message (top-right corner) */
+.chat-bubble-user {
+  position: relative;
+}
+.chat-bubble-user::after {
+  content: '';
+  position: absolute;
+  top: 10px;
+  right: -6px;
+  width: 12px;
+  height: 12px;
+  background-color: var(--lobster-chat-user);
+  clip-path: polygon(0 0, 100% 0, 0 100%);
+}
+
+/* Chat bubble tail — bot message (top-left corner) */
+.chat-bubble-bot {
+  position: relative;
+}
+.chat-bubble-bot::before {
+  content: '';
+  position: absolute;
+  top: 10px;
+  left: -6px;
+  width: 12px;
+  height: 12px;
+  background-color: var(--lobster-chat-bot);
+  clip-path: polygon(100% 0, 100% 100%, 0 0);
+}
+
 :root {
   font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Inter', system-ui, 'Segoe UI', Roboto, sans-serif;
   line-height: 1.6;

--- a/src/renderer/theme/tailwind/plugin.cjs
+++ b/src/renderer/theme/tailwind/plugin.cjs
@@ -36,6 +36,12 @@ module.exports = plugin(function () {
           overlay:     'var(--lobster-surface-overlay)',
           inset:       'var(--lobster-surface-raised)',  // alias
         },
+        chat: {
+          user:              'var(--lobster-chat-user)',
+          'user-foreground': 'var(--lobster-chat-user-foreground)',
+          bot:               'var(--lobster-chat-bot)',
+          'bot-foreground':  'var(--lobster-chat-bot-foreground)',
+        },
         border: {
           DEFAULT:     'var(--lobster-border)',
           subtle:      'var(--lobster-border-subtle)',


### PR DESCRIPTION
## 改动说明

在 Cowork 对话视图中，用户消息和 AI 消息的背景色与页面背景几乎一致，难以快速区分。本 PR 为两类消息添加不同的浅色背景和气泡小尖角，提升对话的可读性和视觉层次感。

## 具体改动

### 1. 注册 Tailwind 颜色 Token
- 在 `plugin.cjs` 中注册 `chat.user`、`chat.bot` 等颜色条目，映射到已有的 `--lobster-chat-*` CSS 变量
- 全部 16 个主题已定义对应值，无需修改主题文件

### 2. 应用聊天气泡背景色
- 用户消息气泡：`bg-surface` → `bg-chat-user`（浅色主题下为淡蓝色）
- AI 回复区块：添加 `bg-chat-bot`（浅色主题下为浅灰色）+ `rounded-2xl` 圆角

### 3. 添加气泡小尖角
- 用户消息：右上角小三角尖角（`::after` 伪元素）
- AI 消息：左上角小三角尖角（`::before` 伪元素）
- 使用 `clip-path: polygon()` 实现，颜色跟随主题自动切换

## 涉及文件
- `src/renderer/theme/tailwind/plugin.cjs` — 新增 chat 颜色条目
- `src/renderer/components/cowork/CoworkSessionDetail.tsx` — 修改消息背景 class
- `src/renderer/index.css` — 添加气泡尖角伪元素样式

## 影响范围
- 纯视觉调整，不涉及逻辑或数据变更
- 仅影响 Cowork 对话视图，不影响 IM 频道等其他界面
- 文字颜色保持不变