### PR TITLE
fix(scheduled-task): 为必填字段添加红色星号标识

### DIFF
--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -451,7 +451,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
       </h2>
 
       <div>
-        <label className={labelClass}>{i18nService.t('scheduledTasksFormName')}</label>
+        <label className={labelClass}>{i18nService.t('scheduledTasksFormName')}<span className="text-red-400 text-xs ml-0.5">*</span></label>
         <input
           type="text"
           value={form.name}
@@ -464,7 +464,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
 
       <div>
         <label className={labelClass}>
-          {i18nService.t('scheduledTasksFormPayloadTextAgent')}
+          {i18nService.t('scheduledTasksFormPayloadTextAgent')}<span className="text-red-400 text-xs ml-0.5">*</span>
         </label>
         <textarea
           value={form.payloadText}


### PR DESCRIPTION
## 概述

定时任务创建/编辑表单中，为「任务标题」和「执行提示词」两个必填字段添加红色星号（*）标识，使用户在填写前即可感知必填要求。

## 问题

表单提交时会校验必填字段并报错，但 label 上没有任何必填标识，用户无法提前感知哪些字段必须填写，体验不友好。

## 修复

在两个必填字段的 label 后添加红色星号，样式对齐项目中 `McpServerFormModal` 的必填标识风格（`text-red-400 text-xs`）。

## 变更文件

| 文件 | 变更说明 |
|------|---------|
| `TaskForm.tsx` | 「任务标题」和「执行提示词」label 添加 `<span className="text-red-400 text-xs ml-0.5">*</span>` |

## 复现路径

1. 进入定时任务 → 新建任务
2. 观察表单各字段 label → 应在必填字段后显示红色星号
3. 不填写任何内容直接提交 → 报错字段与星号标记一致