### PR TITLE
ci: 添加 Dependabot、Welcome Bot 和 Stale Bot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      electron:
+        patterns:
+          - "electron*"
+      anthropic:
+        patterns:
+          - "@anthropic-ai/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,48 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Issues
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: |
+            This issue has been inactive for 60 days. It will be automatically closed in 14 days unless there is new activity.
+
+            If this issue is still relevant, please leave a comment or update it to keep it open. Thank you!
+          close-issue-message: |
+            This issue was automatically closed due to inactivity. Feel free to reopen it if the problem persists.
+
+          # Pull Requests
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: "stale"
+          stale-pr-message: |
+            This pull request has been inactive for 30 days. It will be automatically closed in 14 days unless there is new activity.
+
+            If you're still working on this, please leave a comment or push new commits to keep it open. Thank you!
+          close-pr-message: |
+            This pull request was automatically closed due to inactivity. Feel free to reopen it if you'd like to continue.
+
+          # Exempt labels
+          exempt-issue-labels: "pinned,security,bug,enhancement"
+          exempt-pr-labels: "pinned,security,work-in-progress,wip"
+
+          # Only label, don't close draft PRs
+          exempt-draft-pr: true
+
+          operations-per-run: 100

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,60 @@
+name: Welcome
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/first-interaction@2ec0f0fd78838633cd1c1342e4536d49ef72be54 # v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            👋 感谢你提交第一个 Issue！欢迎参与 LobsterAI 社区。
+
+            请确认已完成以下事项：
+            - 完整填写 Issue 模板
+            - 搜索已有 Issue，避免重复提交
+            - 提供复现步骤（Bug 类）
+
+            我们会尽快处理，感谢你的贡献！
+
+            ---
+
+            👋 Thanks for opening your first issue! We appreciate your contribution to LobsterAI.
+
+            Please make sure you've:
+            - Filled out the issue template completely
+            - Searched for existing issues to avoid duplicates
+            - Provided steps to reproduce (for bugs)
+
+            We'll review your issue as soon as possible.
+          pr-message: |
+            👋 感谢你提交第一个 Pull Request！欢迎参与 LobsterAI 社区。
+
+            请确认 PR 已满足以下要求：
+            - 遵循 [Conventional Commits](https://www.conventionalcommits.org/) 规范
+            - 包含清晰的变更说明
+            - UI 变更附上截图
+            - 通过所有 CI 检查
+
+            维护者会尽快 Review，感谢你的贡献！
+
+            ---
+
+            👋 Thanks for your first pull request to LobsterAI! We appreciate your contribution.
+
+            Please make sure your PR:
+            - Follows the [Conventional Commits](https://www.conventionalcommits.org/) spec
+            - Includes a clear description of the changes
+            - Has screenshots for UI changes
+            - Passes all CI checks
+
+            A maintainer will review your PR soon. Thank you! 🚀


### PR DESCRIPTION
## Summary

- 新增 `.github/dependabot.yml`：每周一检查 npm 和 GitHub Actions 依赖更新，electron / @anthropic-ai 分组处理；reviewer 由 CODEOWNERS 自动分配
- 新增 `.github/workflows/welcome.yml`：首次 PR/Issue 自动评论中英双语欢迎语，引导遵守贡献规范；action 锁定到 commit SHA
- 新增 `.github/workflows/stale.yml`：Issue 60 天、PR 30 天无活动自动标记 stale，再 14 天后关闭；`pinned`/`security`/`wip` 等标签豁免；cron 错开整点（`30 1 * * *` UTC）；action 锁定到 commit SHA

## Test plan

- [x] Dependabot 配置格式正确，依赖分组生效（下周一首次扫描）
- [x] Welcome Bot 对首次贡献者 PR/Issue 正常触发中英双语评论
- [x] Stale Bot 定时任务按预期标记不活跃 Issue/PR，豁免标签生效