### PR TITLE
fix(settings): 修复系统快捷键输入框因主题令牌缺失导致的置灰问题

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -448,10 +448,10 @@ const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void 
       onClick={() => setRecording(true)}
       onBlur={() => setRecording(false)}
       className={`w-36 rounded-xl border px-3 py-1.5 text-sm cursor-pointer select-none text-center outline-none transition-colors
-        dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset dark:text-claude-darkText text-claude-text
+        bg-surface-inset text-foreground
         ${recording
-          ? 'border-claude-accent ring-1 ring-claude-accent/30 dark:text-claude-darkTextSecondary text-claude-textSecondary'
-          : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
+          ? 'border-primary ring-1 ring-primary/30 text-secondary'
+          : 'border-border hover:border-primary/50'
         }`}
     >
       {value || i18nService.t('shortcutNotSet')}


### PR DESCRIPTION
## 问题描述

Settings 页面中的系统快捷键（ShortcutRecorder）组件在 14 主题系统重构后表现异常：输入框呈现灰色/不可见状态，用户无法正常交互。

## 原因分析

主题系统从硬编码 Tailwind 颜色类（如 `dark:bg-claude-darkSurfaceInset`、`text-claude-text`）迁移到 CSS 变量令牌（如 `bg-surface-inset`、`text-foreground`）后，ShortcutRecorder 组件未同步更新，导致样式类在新主题下无法解析，输入框背景和文字颜色丢失。

## 修复内容

- 将 `bg-claude-surfaceInset` / `dark:bg-claude-darkSurfaceInset` 替换为 `bg-surface-inset`
- 将 `text-claude-text` 替换为 `text-foreground`
- 将录制态 `border-claude-accent` / `text-claude-textSecondary` 替换为 `border-primary` / `text-secondary`
- 将悬停态 `hover:border-claude-accent/50` 替换为 `hover:border-primary/50`

## 影响范围

仅涉及 `src/renderer/components/Settings.tsx` 中的 `ShortcutRecorder` 子组件，无功能逻辑变更。