### PR TITLE
fix(memory): honor llm judge cache recency

### DIFF
--- a/src/main/libs/coworkMemoryJudge.test.ts
+++ b/src/main/libs/coworkMemoryJudge.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('./claudeSettings', () => ({
+  resolveCurrentApiConfig: () => ({
+    config: {
+      apiKey: 'test-key',
+      baseURL: 'https://example.com',
+      model: 'test-model',
+    },
+  }),
+}));
+
+describe('coworkMemoryJudge', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  test('evicts least recently used llm cache entry instead of oldest inserted entry', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        content: [{ text: '{"accepted":true,"confidence":0.91,"reason":"stable"}' }],
+      }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { judgeMemoryCandidate } = await import('./coworkMemoryJudge');
+
+    const buildInput = (index: number) => ({
+      text: `my name is cache-user-${index}`,
+      isExplicit: false,
+      guardLevel: 'strict' as const,
+      llmEnabled: true,
+    });
+
+    for (let index = 0; index < 256; index += 1) {
+      await judgeMemoryCandidate(buildInput(index));
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(256);
+
+    await judgeMemoryCandidate(buildInput(0));
+    expect(fetchMock).toHaveBeenCalledTimes(256);
+
+    await judgeMemoryCandidate(buildInput(256));
+    expect(fetchMock).toHaveBeenCalledTimes(257);
+
+    await judgeMemoryCandidate(buildInput(0));
+    expect(fetchMock).toHaveBeenCalledTimes(257);
+
+    await judgeMemoryCandidate(buildInput(1));
+    expect(fetchMock).toHaveBeenCalledTimes(258);
+  });
+});

--- a/src/main/libs/coworkMemoryJudge.ts
+++ b/src/main/libs/coworkMemoryJudge.ts
@@ -73,10 +73,15 @@ function getCachedLlmResult(key: string): MemoryJudgeResult | null {
     llmJudgeCache.delete(key);
     return null;
   }
+  llmJudgeCache.delete(key);
+  llmJudgeCache.set(key, cached);
   return cached.value;
 }
 
 function setCachedLlmResult(key: string, value: MemoryJudgeResult): void {
+  if (llmJudgeCache.has(key)) {
+    llmJudgeCache.delete(key);
+  }
   llmJudgeCache.set(key, { value, createdAt: Date.now() });
   while (llmJudgeCache.size > LLM_CACHE_MAX_SIZE) {
     const oldestKey = llmJudgeCache.keys().next().value;


### PR DESCRIPTION
## Summary

This PR fixes the LLM boundary-judge cache in `src/main/libs/coworkMemoryJudge.ts` so it behaves as a true LRU cache instead of evicting by plain `Map` insertion order.

It also adds a regression test that reproduces the issue described in `#1299` and verifies that frequently reused cache entries are no longer evicted incorrectly.

Closes #1299

## Problem

The issue report points out that the current cache eviction strategy is documented as LRU, but the implementation does not actually refresh recency on cache hit.

Before this change:

- cached LLM judge results were stored in a `Map`
- cache eviction removed the first key from `Map.keys()`
- cache hits returned the cached value directly
- the accessed entry was **not** moved to the tail of the `Map`

That means eviction followed **oldest inserted entry**, not **least recently used entry**.

## Reproduction

The bug can be reproduced with the following sequence:

1. Fill the LLM judge cache with 256 unique borderline inputs
2. Access the first cached input again so it becomes a hot entry logically
3. Insert a 257th unique input
4. Access the first input again

### Expected

- the first input should still be cached because it was just used
- the second input should be the one evicted as the true least recently used entry

### Actual before fix

- the first input was evicted anyway
- the cache behaved like FIFO-by-insertion-order for eviction
- this caused unnecessary repeated LLM requests for hot boundary cases

## Root Cause

The root cause is in the cache implementation inside `coworkMemoryJudge.ts`:

- `Map` preserves insertion order, not access recency
- `getCachedLlmResult()` returned the cached entry without updating its position
- `setCachedLlmResult()` evicted entries by removing the first inserted key

So although the code and analysis described the cache as LRU, its runtime behavior was not actually LRU.

## Solution

This PR implements the missing recency update behavior.

### Cache read path

In `getCachedLlmResult()`:

- keep the existing TTL expiration check
- when a cache entry is still valid, delete it and reinsert it into the `Map`
- this refreshes the entry as the most recently used item

### Cache write path

In `setCachedLlmResult()`:

- if the key already exists, delete it first
- then insert the new value
- continue evicting from the front of the `Map` when the cache exceeds `LLM_CACHE_MAX_SIZE`

With these two changes, the `Map` order now correctly represents LRU recency.

## Code Changes

### Updated

- `src/main/libs/coworkMemoryJudge.ts`

Specific changes:

- in `getCachedLlmResult()`:
  - refresh entry order on cache hit via `delete + set`
- in `setCachedLlmResult()`:
  - normalize update behavior for existing keys via `delete + set`
- keep the existing TTL-based invalidation behavior unchanged
- keep the existing max-size eviction behavior unchanged, but make it operate on real recency order

### Added

- `src/main/libs/coworkMemoryJudge.test.ts`

New regression coverage:

- fills the cache to its maximum size
- re-accesses the earliest inserted key
- inserts one additional key to force eviction
- verifies that:
  - the re-accessed key remains cached
  - the next true least recently used key is evicted
  - no extra fetch happens for the hot key after eviction pressure
  - one extra fetch does happen for the actual evicted key

## Why This Fix Is Safe

- the change is tightly scoped to the in-memory LLM judge cache
- no persistence, schema, IPC, or renderer behavior is affected
- TTL semantics remain unchanged
- cache size limit remains unchanged
- only cache recency bookkeeping is corrected

## Testing

### Regression test

Ran:

```powershell
.\node_modules\.bin\vitest.cmd run src/main/libs/coworkMemoryJudge.test.ts