### PR TITLE
fix(agent): reset form state when AgentCreateModal reopens

### DIFF
--- a/src/renderer/components/agent/AgentCreateModal.tsx
+++ b/src/renderer/components/agent/AgentCreateModal.tsx
@@ -44,6 +44,14 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
 
   useEffect(() => {
     if (!isOpen) return;
+    setName('');
+    setDescription('');
+    setSystemPrompt('');
+    setIdentity('');
+    setIcon('');
+    setSkillIds([]);
+    setActiveTab('basic');
+    setBoundPlatforms(new Set());
     imService.loadConfig().then((cfg) => {
       if (cfg) setImConfig(cfg);
     });


### PR DESCRIPTION
## Summary
- Fix stale form data persisting across AgentCreateModal open/close cycles
- Reset all form fields (name, description, system prompt, identity, icon, skills, IM bindings) when the modal opens

## Problem
The `AgentCreateModal` component is never unmounted — it uses `if (!isOpen) return null` to hide. This means React state (name, description, etc.) survives across open/close cycles. After cancelling a create or deleting an agent, reopening the create modal would show the previous form values.

## Solution
Call all state setters to reset form fields at the beginning of the `useEffect` that runs when `isOpen` becomes `true`, before loading IM config.

## Test plan
- [ ] Open create modal → fill in fields → Cancel → reopen → form should be empty
- [ ] Create an agent → delete it → open create modal → form should be empty
- [ ] Create an agent successfully → reopen create modal → form should be empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)