### PR TITLE
feat(cowork): isolate home-screen input draft per agent

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -88,6 +88,8 @@ interface CoworkPromptInputProps {
   showModelSelector?: boolean;
   onManageSkills?: () => void;
   sessionId?: string;
+  /** The current agent ID, used to isolate home-screen draft per agent */
+  agentId?: string;
   /** When true, hides attachment/skill buttons but keeps the input box visible (disabled) */
   remoteManaged?: boolean;
 }
@@ -107,13 +109,24 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       showModelSelector = false,
       onManageSkills,
       sessionId,
+      agentId,
       remoteManaged = false,
     } = props;
     const dispatch = useDispatch();
-    const draftKey = sessionId || '__home__';
+    const draftKey = sessionId || (agentId ? `__home__:${agentId}` : '__home__');
     const draftPrompt = useSelector((state: RootState) => state.cowork.draftPrompts[draftKey] || '');
     const attachments = useSelector((state: RootState) => state.cowork.draftAttachments[draftKey] || []) as CoworkAttachment[];
     const [value, setValue] = useState(draftPrompt);
+
+    // Sync local value when agent switches (draftKey changes)
+    const prevDraftKeyRef = React.useRef(draftKey);
+    useEffect(() => {
+      if (prevDraftKeyRef.current !== draftKey) {
+        prevDraftKeyRef.current = draftKey;
+        setValue(draftPrompt);
+      }
+    }, [draftKey, draftPrompt]);
+
     const [showFolderMenu, setShowFolderMenu] = useState(false);
     const [showFolderRequiredWarning, setShowFolderRequiredWarning] = useState(false);
     const [isDraggingFiles, setIsDraggingFiles] = useState(false);

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -550,6 +550,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
                 }}
                 showFolderSelector={true}
                 onManageSkills={() => onShowSkills?.()}
+                agentId={currentAgentId}
               />
             </div>
           </div>


### PR DESCRIPTION
# 问题
<img width="909" height="493" alt="截屏2026-04-02 16 49 11" src="https://github.com/user-attachments/assets/2497779c-2156-4599-9749-5a1f4d5a6e2b" />
<img width="930" height="519" alt="截屏2026-04-02 16 49 24" src="https://github.com/user-attachments/assets/21a6e464-5df7-459b-990f-86ddcf533d5a" />

多Agent应用场景，当 Agent A 上传 附件A+B，这时候用户切换Agent B，会把Agent A 草稿对话带过去，用户需要手动把消息清空。并且有可能在用户误操作情况下，导致 Agent B 去完成了本应该Agent A应该完成的任务，导致输出结果不佳。
如上图所示，股票助手去完成了内容助手应该完成的工作。
# 根因
切换Agent时仅做了sessionId的隔离，没有做AgentId的隔离
# 优化
切换 Agent A → 上传附件A + 输入了"帮我写个报告" → 切换 Agent B → 清空附件 + 输入框清空（B 的草稿为空）
切换回 Agent A → 恢复附件A + 输入框恢复"帮我写个报告"
每个 Agent 的草稿独立保存，互不干扰
已有的 sessionId 草稿逻辑不受影响