### PR TITLE
refactor(i18n): remove unused plan translation keys in renderer

### DIFF
--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -180,11 +180,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     authLearnMore: '了解更多',
     authValueAddedServices: '增值服务',
     authZeroCredits: '0积分',
-    planFree: '免费',
-    planStandard: '标准',
-    planAdvanced: '进阶',
-    planPro: '专业',
-    
+
     // 错误信息
     failedToLoadSettings: '加载设置失败',
     failedToSaveSettings: '保存设置失败',
@@ -1377,10 +1373,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     authLearnMore: 'Learn More',
     authValueAddedServices: 'Premium Services',
     authZeroCredits: '0 credits',
-    planFree: 'Free',
-    planAdvanced: 'Advanced',
-    planPro: 'Pro',
-    
+
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',


### PR DESCRIPTION
## Summary

- After investigating #1055, found that the renderer-side plan i18n keys (`planFree`, `planStandard`, `planAdvanced`, `planPro`) are not referenced by any component.
- The actual plan labels are served from the main process via `authPlanFree` / `authPlanStandard` in `main/i18n.ts`, which already have complete zh/en translations.
- This PR removes the dead entries from both zh and en locales to reduce confusion.

## Test plan

- [ ] Plan/subscription badges display correctly after login (click avatar → expand credits section) in both zh and en
- [ ] Build succeeds with no errors

Relates to #1055