### PR TITLE
fix(openclaw): correct NIM plugin id to match npm package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "optional": true
       },
       {
-        "id": "nim",
+        "id": "openclaw-nim",
         "npm": "openclaw-nim",
         "version": "0.3.1"
       },


### PR DESCRIPTION
处理因 nim 插件同步到 openclaw.json 中的名称不对，导致每次设置页面同步设置时都 openclaw 都需要重新加载 openclaw-nim 插件触发 gateway 重启。

## 重现方式

 - 设置中开启运行 IM 通道，随便输入一些信息保存
 - 关闭设置等 gateway 重启后再次打开设置
 - 任何设置都不更改直接保存

## 预期

 - Gateway 不重启

## 实际

 - Gateway 重启