### PR TITLE
style(renderer): 统一 Qwen/MiniMax 提供商认证 tab 样式与顺序

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -3130,7 +3130,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
                   {/* API Key mode */}
                   {!minimaxIsOAuthMode && (
-                    <div>
+                    <div className="min-h-[68px]">
                       <div className="flex items-center justify-between mb-1">
                         <label htmlFor="minimax-apiKey" className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
                           {i18nService.t('apiKey')}
@@ -3180,7 +3180,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
                   {/* OAuth mode */}
                   {minimaxIsOAuthMode && (
-                    <div className="space-y-2">
+                    <div className="space-y-2 min-h-[68px]">
                       {/* Already logged in */}
                       {minimaxOAuthPhase.kind === 'idle' && providers.minimax.apiKey && (
                         <div className="p-3 rounded-xl bg-green-500/10 border border-green-500/20 space-y-2">
@@ -3418,7 +3418,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
                       {/* API Key Tab */}
                       {qwenAuthTab === 'apikey' && (
-                        <div>
+                        <div className="min-h-[68px]">
                           <div className="flex items-center justify-between mb-1">
                             <label htmlFor="qwen-apiKey" className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
                               API Key
@@ -3468,7 +3468,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
                       {/* OAuth Tab */}
                       {qwenAuthTab === 'oauth' && (
-                        <div>
+                        <div className="min-h-[68px]">
                           <label className="block text-xs font-medium dark:text-claude-darkText text-claude-text mb-2">
                             {i18nService.t('qwenOAuthLoginFree')}
                           </label>


### PR DESCRIPTION
## Summary

- 统一 Qwen 和 MiniMax 提供商设置页认证 tab 的顺序：改为「OAuth 登录 | API Key」（OAuth 在左）
- 统一两个面板 tab 样式：Qwen 改为与 MiniMax 一致的 border+rounded-xl，active 态 bg-primary text-white
- 首次打开默认选中 OAuth tab（authType 未设置时视为 OAuth 模式）
- 修复切换认证 tab 时下方内容（API Base URL、API 格式等）发生跳动的问题：给两个 tab 内容区统一设置 min-h-[68px]

## Test plan
- [x] 编译通过
- [x] 打开 Qwen 提供商设置，确认默认显示 OAuth 登录 tab，样式与 MiniMax 一致
- [x] 切换 Qwen 的 OAuth ↔ API Key tab，确认下方内容不跳动
- [x] 打开 MiniMax 提供商设置，确认默认显示 OAuth tab
- [x] 切换 MiniMax 的 OAuth ↔ API Key tab，确认下方内容不跳动