### PR TITLE
功能增强：支持拖拽调整侧边栏宽度

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState, store } from './store';
 import Settings, { type SettingsOpenOptions } from './components/Settings';
-import Sidebar from './components/Sidebar';
+import Sidebar, { SIDEBAR_DEFAULT_WIDTH, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH } from './components/Sidebar';
 import Toast from './components/Toast';
 import WindowTitleBar from './components/window/WindowTitleBar';
 import { CoworkView } from './components/cowork';
@@ -41,6 +41,7 @@ const App: React.FC = () => {
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [, forceLanguageRefresh] = useState(0);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT_WIDTH);
   const [updateInfo, setUpdateInfo] = useState<AppUpdateInfo | null>(null);
   const [showUpdateModal, setShowUpdateModal] = useState(false);
   const [updateModalState, setUpdateModalState] = useState<'info' | 'downloading' | 'installing' | 'error'>('info');
@@ -260,6 +261,11 @@ const App: React.FC = () => {
 
   const handleToggleSidebar = useCallback(() => {
     setIsSidebarCollapsed((prev) => !prev);
+  }, []);
+
+  const handleSidebarWidthChange = useCallback((newWidth: number) => {
+    const clamped = Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, newWidth));
+    setSidebarWidth(clamped);
   }, []);
 
   const handleNewChat = useCallback(() => {
@@ -660,6 +666,8 @@ const App: React.FC = () => {
           onToggleCollapse={handleToggleSidebar}
           updateBadge={!isSidebarCollapsed ? updateBadge : null}
           hideLogin={enterpriseConfig?.ui?.login === 'hide'}
+          width={sidebarWidth}
+          onWidthChange={handleSidebarWidthChange}
         />
         <div className={`flex-1 min-w-0 py-1.5 pr-1.5 ${isSidebarCollapsed ? 'pl-1.5' : ''}`}>
           <div className="relative h-full min-h-0 rounded-xl bg-background overflow-hidden">

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '../store';
 import { agentService } from '../services/agent';
@@ -17,6 +17,10 @@ import TrashIcon from './icons/TrashIcon';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import UserGroupIcon from './icons/UserGroupIcon';
 
+export const SIDEBAR_MIN_WIDTH = 180;
+export const SIDEBAR_MAX_WIDTH = 480;
+export const SIDEBAR_DEFAULT_WIDTH = 240;
+
 interface SidebarProps {
   onShowSettings: () => void;
   onShowLogin?: () => void;
@@ -31,6 +35,8 @@ interface SidebarProps {
   onToggleCollapse: () => void;
   updateBadge?: React.ReactNode;
   hideLogin?: boolean;
+  width?: number;
+  onWidthChange?: (width: number) => void;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -46,6 +52,8 @@ const Sidebar: React.FC<SidebarProps> = ({
   onToggleCollapse,
   updateBadge,
   hideLogin,
+  width = SIDEBAR_DEFAULT_WIDTH,
+  onWidthChange,
 }) => {
   const currentAgentId = useSelector((state: RootState) => state.agent.currentAgentId);
   const sessions = useSelector((state: RootState) => state.cowork.sessions);
@@ -56,6 +64,42 @@ const Sidebar: React.FC<SidebarProps> = ({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [showBatchDeleteConfirm, setShowBatchDeleteConfirm] = useState(false);
   const isMac = window.electron.platform === 'darwin';
+
+  // Drag-to-resize state
+  const isDragging = useRef(false);
+  const dragStartX = useRef(0);
+  const dragStartWidth = useRef(width);
+
+  const handleDragStart = useCallback((e: React.MouseEvent) => {
+    if (isCollapsed) return;
+    e.preventDefault();
+    isDragging.current = true;
+    dragStartX.current = e.clientX;
+    dragStartWidth.current = width;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      if (!isDragging.current) return;
+      const delta = moveEvent.clientX - dragStartX.current;
+      const newWidth = Math.min(
+        SIDEBAR_MAX_WIDTH,
+        Math.max(SIDEBAR_MIN_WIDTH, dragStartWidth.current + delta)
+      );
+      onWidthChange?.(newWidth);
+    };
+
+    const handleMouseUp = () => {
+      isDragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  }, [isCollapsed, width, onWidthChange]);
 
   useEffect(() => {
     const handleSearch = () => {
@@ -139,10 +183,19 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   return (
     <aside
-      className={`shrink-0 bg-surface-raised flex flex-col sidebar-transition overflow-hidden ${
-        isCollapsed ? 'w-0' : 'w-60'
+      className={`relative shrink-0 bg-surface-raised flex flex-col sidebar-transition ${
+        isCollapsed ? 'w-0 overflow-hidden' : 'overflow-hidden'
       }`}
+      style={isCollapsed ? undefined : { width: `${width}px` }}
     >
+      {/* Drag handle */}
+      {!isCollapsed && onWidthChange && (
+        <div
+          className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize z-10 hover:bg-primary/30 active:bg-primary/50 transition-colors"
+          onMouseDown={handleDragStart}
+          title={i18nService.t('sidebarResizeHint')}
+        />
+      )}
       <div className="pt-3 pb-3">
         <div className="draggable sidebar-header-drag h-8 flex items-center justify-between px-3">
           <div className={`${isMac ? 'pl-[68px]' : ''}`}>

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -157,6 +157,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     loginNotAvailable: '登录功能暂未开放',
     collapse: '收起',
     expand: '展开',
+    sidebarResizeHint: '拖拽调整侧边栏宽度',
     featureInDevelopment: '正在开发中',
 
     // 认证相关
@@ -1346,6 +1347,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     loginNotAvailable: 'Login is not available yet',
     collapse: 'Collapse',
     expand: 'Expand',
+    sidebarResizeHint: 'Drag to resize sidebar',
     featureInDevelopment: 'In development',
 
     // Auth


### PR DESCRIPTION
## 关联 Issue

Closes #1314

## 变更内容

为侧边栏添加拖拽调整宽度功能，允许用户通过拖动侧边栏右侧边缘调整其宽度。

### 核心改动

**`src/renderer/components/Sidebar.tsx`**
- 新增 `width` 和 `onWidthChange` 可选 props
- 添加绝对定位拖拽手柄（1px 宽，hover 变色，cursor: col-resize）
- 鼠标按下时绑定全局 `mousemove`/`mouseup` 事件，拖拽结束自动清理
- 导出 `SIDEBAR_MIN_WIDTH`（180）、`SIDEBAR_MAX_WIDTH`（480）、`SIDEBAR_DEFAULT_WIDTH`（240）常量

**`src/renderer/App.tsx`**
- 添加 `sidebarWidth` state（默认 240px）
- 添加 `handleSidebarWidthChange` 回调并传入 Sidebar
- 宽度变更时做边界 clamp（180 ~ 480）

**`src/renderer/services/i18n.ts`**
- 新增 `sidebarResizeHint` 翻译键（中英文）

### 行为

- 侧边栏展开时，右侧出现 1px 宽的透明拖拽条
- 鼠标悬停时高亮显示（`bg-primary/30`），按下拖拽时更深（`bg-primary/50`）
- 拖拽宽度被限制在 [180px, 480px] 区间内
- 侧边栏收起时，手柄自动隐藏

## 测试

- 拖拽手柄可正常调整宽度，范围在 180px ~ 480px 间
- 松开鼠标后宽度保持
- 侧边栏收起时手柄不可见
- 拖拽期间 `user-select: none` 防止误选文本

## 截图

> 拖拽手柄位于侧边栏右边缘，宽 1px，hover 时以主色高亮