### PR TITLE
功能增强：侧边栏按钮显示键盘快捷键 kbd 提示

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -4,6 +4,9 @@ import { RootState } from '../store';
 import { agentService } from '../services/agent';
 import { coworkService } from '../services/cowork';
 import { i18nService } from '../services/i18n';
+import { configService } from '../services/config';
+import { defaultConfig } from '../config';
+import { formatShortcutLabels } from '../services/shortcuts';
 import CoworkSessionList from './cowork/CoworkSessionList';
 import CoworkSearchModal from './cowork/CoworkSearchModal';
 import LoginButton from './LoginButton';
@@ -16,6 +19,24 @@ import SidebarToggleIcon from './icons/SidebarToggleIcon';
 import TrashIcon from './icons/TrashIcon';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import UserGroupIcon from './icons/UserGroupIcon';
+
+/** Renders a row of small kbd-style labels for a keyboard shortcut. */
+const ShortcutBadge: React.FC<{ shortcut: string | undefined; isMac: boolean }> = ({ shortcut, isMac }) => {
+  const labels = formatShortcutLabels(shortcut, isMac);
+  if (labels.length === 0) return null;
+  return (
+    <span className="ml-auto flex items-center gap-0.5 opacity-50 group-hover:opacity-70 transition-opacity pointer-events-none">
+      {labels.map((label, i) => (
+        <kbd
+          key={i}
+          className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded text-[10px] font-mono font-medium bg-surface-raised border border-border text-secondary leading-none"
+        >
+          {label}
+        </kbd>
+      ))}
+    </span>
+  );
+};
 
 interface SidebarProps {
   onShowSettings: () => void;
@@ -56,6 +77,12 @@ const Sidebar: React.FC<SidebarProps> = ({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [showBatchDeleteConfirm, setShowBatchDeleteConfirm] = useState(false);
   const isMac = window.electron.platform === 'darwin';
+
+  // Derive active shortcuts (merge defaults + user overrides)
+  const activeShortcuts = (() => {
+    const config = configService.getConfig();
+    return { ...defaultConfig.shortcuts, ...(config.shortcuts ?? {}) } as Record<string, string>;
+  })();
 
   useEffect(() => {
     const handleSearch = () => {
@@ -161,7 +188,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           <button
             type="button"
             onClick={onNewChat}
-            className={`w-full inline-flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors ${
+            className={`group w-full inline-flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors ${
               activeView === 'cowork'
                 ? 'bg-primary/10 text-primary hover:bg-primary/20'
                 : 'text-secondary hover:text-foreground hover:bg-surface-raised'
@@ -169,6 +196,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           >
             <ComposeIcon className="h-4 w-4" />
             {i18nService.t('newChat')}
+            <ShortcutBadge shortcut={activeShortcuts.newChat} isMac={isMac} />
           </button>
           <button
             type="button"
@@ -176,10 +204,11 @@ const Sidebar: React.FC<SidebarProps> = ({
               onShowCowork();
               setIsSearchOpen(true);
             }}
-            className="w-full inline-flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm font-medium text-secondary hover:text-foreground hover:bg-surface-raised transition-colors"
+            className="group w-full inline-flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm font-medium text-secondary hover:text-foreground hover:bg-surface-raised transition-colors"
           >
             <SearchIcon className="h-4 w-4" />
             {i18nService.t('search')}
+            <ShortcutBadge shortcut={activeShortcuts.search} isMac={isMac} />
           </button>
           <button
             type="button"

--- a/src/renderer/services/shortcuts.ts
+++ b/src/renderer/services/shortcuts.ts
@@ -124,3 +124,35 @@ export const matchesShortcut = (event: KeyboardEvent, shortcut?: string): boolea
 
   return true;
 };
+
+/**
+ * Format a shortcut string into human-readable key labels.
+ * On macOS, Ctrl is rendered as ⌘ (meta/cmd); on other platforms as Ctrl.
+ * Returns an array of label strings, e.g. ['Ctrl', 'N'] or ['⌘', 'N'].
+ */
+export const formatShortcutLabels = (shortcut: string | undefined, isMac: boolean): string[] => {
+  const parsed = parseShortcut(shortcut);
+  if (!parsed) return [];
+
+  const parts: string[] = [];
+
+  if (parsed.commandOrControl) {
+    parts.push(isMac ? '⌘' : 'Ctrl');
+  } else if (parsed.ctrl) {
+    parts.push(isMac ? '⌃' : 'Ctrl');
+  }
+  if (parsed.alt) parts.push(isMac ? '⌥' : 'Alt');
+  if (parsed.shift) parts.push(isMac ? '⇧' : 'Shift');
+  if (parsed.meta && !parsed.commandOrControl) parts.push(isMac ? '⌘' : 'Win');
+
+  // Uppercase single characters; keep special keys as-is
+  const key = parsed.key;
+  if (key.length === 1) {
+    parts.push(key.toUpperCase());
+  } else {
+    // Capitalize first letter for display
+    parts.push(key.charAt(0).toUpperCase() + key.slice(1));
+  }
+
+  return parts;
+};


### PR DESCRIPTION
## 关联 Issue

Closes #1317

## 变更内容

为侧边栏的"新建任务"和"搜索"按钮添加键盘快捷键可视化提示（`<kbd>` 样式徽标）。

### 核心改动

**`src/renderer/services/shortcuts.ts`**
- 新增 `formatShortcutLabels(shortcut, isMac)` 函数
  - 解析快捷键字符串为显示友好的 string[] 标签
  - macOS 平台自动转换为 ⌘/⌥/⇧/⌃ 符号；其他平台显示 Ctrl/Alt/Shift

**`src/renderer/components/Sidebar.tsx`**
- 新增 `ShortcutBadge` 内部组件
  - 渲染一行 `<kbd>` 元素（圆角、边框、等宽字体）
  - 通过 `ml-auto` 右对齐，默认 50% 透明，hover 时提升至 70%（`group/group-hover` 控制）
- 在"新建任务"和"搜索"按钮上集成 `ShortcutBadge`
- 快捷键来源：`configService.getConfig().shortcuts`（合并用户自定义与默认值）
- 按钮新增 `group` 类名以支持 hover 联动

### 行为

| 按钮 | 默认快捷键 | macOS 显示 | 其他平台显示 |
|------|-----------|-----------|------------|
| 新建任务 | Ctrl+N | ⌘ N | Ctrl N |
| 搜索 | Ctrl+F | ⌘ F | Ctrl F |

快捷键显示随用户在设置中修改快捷键后自动更新。

## 测试

- 侧边栏展开时，"新建任务"和"搜索"按钮右侧显示对应的 kbd 标签
- macOS 下 Ctrl 显示为 ⌘，Windows/Linux 下显示为 Ctrl
- 进入设置修改快捷键后，下次渲染时 kbd 标签同步更新