### PR TITLE
功能增强：会话列表添加骨架屏加载状态，区分"加载中"与"空状态"

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -49,6 +49,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   const currentAgentId = useSelector((state: RootState) => state.agent.currentAgentId);
   const sessions = useSelector((state: RootState) => state.cowork.sessions);
+  const sessionsLoaded = useSelector((state: RootState) => state.cowork.sessionsLoaded);
   const filteredSessions = sessions.filter((s) => !s.agentId || s.agentId === currentAgentId);
   const currentSessionId = useSelector((state: RootState) => state.cowork.currentSessionId);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -250,18 +251,29 @@ const Sidebar: React.FC<SidebarProps> = ({
         <div className="px-3 pb-2 text-sm font-medium text-secondary">
           {i18nService.t('coworkHistory')}
         </div>
-        <CoworkSessionList
-          sessions={filteredSessions}
-          currentSessionId={currentSessionId}
-          isBatchMode={isBatchMode}
-          selectedIds={selectedIds}
-          onSelectSession={handleSelectSession}
-          onDeleteSession={handleDeleteSession}
-          onTogglePin={handleTogglePin}
-          onRenameSession={handleRenameSession}
-          onToggleSelection={handleToggleSelection}
-          onEnterBatchMode={handleEnterBatchMode}
-        />
+        {!sessionsLoaded ? (
+          <div className="space-y-2 px-1" aria-label={i18nService.t('loading')} aria-busy="true">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="p-3 rounded-lg">
+                <div className="skeleton h-3.5 rounded mb-2" style={{ width: `${65 + (i % 3) * 10}%` }} />
+                <div className="skeleton h-2.5 rounded" style={{ width: `${40 + (i % 4) * 8}%` }} />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <CoworkSessionList
+            sessions={filteredSessions}
+            currentSessionId={currentSessionId}
+            isBatchMode={isBatchMode}
+            selectedIds={selectedIds}
+            onSelectSession={handleSelectSession}
+            onDeleteSession={handleDeleteSession}
+            onTogglePin={handleTogglePin}
+            onRenameSession={handleRenameSession}
+            onToggleSelection={handleToggleSelection}
+            onEnterBatchMode={handleEnterBatchMode}
+          />
+        )}
       </div>
       <CoworkSearchModal
         isOpen={isSearchOpen}

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -17,6 +17,7 @@ export interface DraftAttachment {
 
 interface CoworkState {
   sessions: CoworkSessionSummary[];
+  sessionsLoaded: boolean;
   currentSessionId: string | null;
   currentSession: CoworkSession | null;
   draftPrompts: Record<string, string>;
@@ -32,6 +33,7 @@ interface CoworkState {
 
 const initialState: CoworkState = {
   sessions: [],
+  sessionsLoaded: false,
   currentSessionId: null,
   currentSession: null,
   draftPrompts: {},
@@ -114,6 +116,7 @@ const coworkSlice = createSlice({
 
     setSessions(state, action: PayloadAction<CoworkSessionSummary[]>) {
       state.sessions = action.payload;
+      state.sessionsLoaded = true;
       const validSessionIds = new Set(action.payload.map((session) => session.id));
       state.unreadSessionIds = state.unreadSessionIds.filter((id) => {
         return validSessionIds.has(id) && id !== state.currentSessionId;


### PR DESCRIPTION
## 关联 Issue

Closes #1319

## 变更内容

添加会话列表骨架屏（Skeleton Loading），解决应用启动时空状态闪烁问题。

### 核心改动

**`src/renderer/store/slices/coworkSlice.ts`**
- 在 `CoworkState` 接口中添加 `sessionsLoaded: boolean`（初始值 `false`）
- 在 `setSessions` reducer 中将其设为 `true`，确保首次数据到达后状态正确切换

**`src/renderer/components/Sidebar.tsx`**
- 从 Redux 读取 `state.cowork.sessionsLoaded`
- 当 `sessionsLoaded === false` 时，渲染 5 条骨架屏占位行（宽度错落）
- 骨架屏复用项目已有的 `.skeleton` CSS 类（shimmer 动画，无新增样式）
- `sessionsLoaded === true` 后正常渲染 `CoworkSessionList`
- 骨架屏区域添加 `aria-label` 和 `aria-busy="true"` 无障碍属性

### 行为

| 状态 | 显示内容 |
|------|---------|
| 应用启动、sessions 未到达 | 5 条骨架屏（shimmer 动画） |
| 首次 setSessions 后 | 正常会话列表 |
| setSessions 传入空数组 | 正常的"暂无历史记录"空状态 |

## 测试

- 应用启动时，侧边栏会话区域显示骨架屏动画
- 数据加载完成后，无闪烁地切换为真实列表或空状态
- 已有快照/集成测试不受影响（仅新增 slice 字段）