### PR TITLE
fix(settings): dismiss overlays when switching settings tabs (#1307)

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1591,6 +1591,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
       setNewModelId('');
       setNewModelSupportsImage(false);
       setModelFormError(null);
+      setIsTestResultModalOpen(false);
+      setTestResult(null);
+    }
+    if (tab !== 'coworkMemory' && showMemoryModal) {
+      resetCoworkMemoryEditor();
     }
     setActiveTab(tab);
   };


### PR DESCRIPTION
## Summary
Fixes a bug where the cowork memory editor modal or the model connection-test modal could remain mounted as a full-window `absolute inset-0` layer after navigating to another settings tab (e.g. **Models**). The UI looked read-only because clicks hit the semi-transparent overlay instead of the provider form.

## Changes
- When leaving the **Model** tab, close the connection test modal and clear its result state.
- When navigating away from **Cowork memory** while the memory CRUD modal is open, reset the memory editor (same as cancel).

## Issue
Closes https://github.com/netease-youdao/LobsterAI/issues/1307