### PR TITLE
fix(cowork): true LRU eviction for LLM memory judge cache (#1299)

### DIFF
--- a/src/main/libs/coworkMemoryJudge.ts
+++ b/src/main/libs/coworkMemoryJudge.ts
@@ -73,10 +73,16 @@ function getCachedLlmResult(key: string): MemoryJudgeResult | null {
     llmJudgeCache.delete(key);
     return null;
   }
+  // LRU: Map iteration order follows insertion; move this key to the end on hit.
+  llmJudgeCache.delete(key);
+  llmJudgeCache.set(key, cached);
   return cached.value;
 }
 
 function setCachedLlmResult(key: string, value: MemoryJudgeResult): void {
+  if (llmJudgeCache.has(key)) {
+    llmJudgeCache.delete(key);
+  }
   llmJudgeCache.set(key, { value, createdAt: Date.now() });
   while (llmJudgeCache.size > LLM_CACHE_MAX_SIZE) {
     const oldestKey = llmJudgeCache.keys().next().value;


### PR DESCRIPTION
## Summary
The LLM boundary-judge cache in `coworkMemoryJudge.ts` was documented as LRU but eviction used `Map` insertion order only. Cache hits did not move entries to the most-recent position, so hot keys could be evicted first once the cache filled.

## Changes
- On cache hit, delete and re-insert the entry so it becomes the newest in insertion order.
- On `set`, refresh position if the key already exists before trimming to `LLM_CACHE_MAX_SIZE`.

## Issue
Closes https://github.com/netease-youdao/LobsterAI/issues/1299