### PR TITLE
fix(cowork): narrow input-too-long error classification (#1298)

### DIFF
--- a/src/common/coworkErrorClassify.test.ts
+++ b/src/common/coworkErrorClassify.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from 'vitest';
+import { classifyErrorKey } from './coworkErrorClassify';
+
+test('input too long: max_tokens exceeded', () => {
+  expect(classifyErrorKey('max_tokens exceeded')).toBe('coworkErrorInputTooLong');
+});
+
+test('input too long: max_completion_tokens exceeded', () => {
+  expect(classifyErrorKey('max_completion_tokens exceeded for this model')).toBe(
+    'coworkErrorInputTooLong'
+  );
+});
+
+test('input too long: context length exceeded', () => {
+  expect(
+    classifyErrorKey("This model's maximum context length is 8192 tokens. context length exceeded")
+  ).toBe('coworkErrorInputTooLong');
+});
+
+test('does not classify bare max_tokens / unsupported param as input too long', () => {
+  expect(
+    classifyErrorKey("Unsupported parameter: 'max_tokens' is not supported with this model")
+  ).toBeNull();
+  expect(classifyErrorKey('max_tokens must be a positive integer')).toBeNull();
+});

--- a/src/common/coworkErrorClassify.ts
+++ b/src/common/coworkErrorClassify.ts
@@ -11,8 +11,12 @@ const ERROR_RULES: Array<[RegExp, string]> = [
   [/\b429\b|rate[_ ]limit|too many requests|overloaded|RESOURCE_EXHAUSTED/i, 'coworkErrorRateLimit'],
   // Billing: DeepSeek 402, OpenAI, OpenRouter, Qwen, StepFun
   [/insufficient.*(balance|quota|credits)|billing|quota[_ ]exceeded|Arrearage|account.*not.*in.*good.*standing|余额不足|\b402\b/i, 'coworkErrorInsufficientBalance'],
-  // Input too long: context length, HTTP 413, Qwen, payload too large
-  [/input.*too.*long|context.*length.*exceeded|range of input length|\b413\b|payload.*too.*large|request.*entity.*too.*large|max[_ ]tokens/i, 'coworkErrorInputTooLong'],
+  // Input too long: context length, HTTP 413, Qwen, payload too large.
+  // Avoid matching bare "max_tokens" (e.g. unsupported/invalid param messages) — require an exceed/limit sense.
+  [
+    /input.*too.*long|context.*length.*exceeded|range of input length|\b413\b|payload.*too.*large|request.*entity.*too.*large|max_tokens\s+exceeded|max_completion_tokens\s+exceeded|(?:exceed|exceeds|exceeded).{0,80}max[_ ]tokens|max[_ ]tokens.{0,80}(?:exceed|exceeds|exceeded)|total.{0,40}token.{0,40}exceed|context\s+(?:window|length).{0,40}exceed/i,
+    'coworkErrorInputTooLong',
+  ],
   // PDF processing failure
   [/could not process pdf/i, 'coworkErrorCouldNotProcessPdf'],
   // Model not found: standard, Qwen, Ollama


### PR DESCRIPTION
## Summary
Cowork errors were classified as `coworkErrorInputTooLong` whenever the upstream message contained `max_tokens`, including unrelated messages such as unsupported or invalid `max_tokens` parameters. That produced the misleading “input too long / context limit” UI even for very short user input.

## Changes
- Tighten the regex to match clear context/token **exceeded** patterns (and keep explicit cases like `max_tokens exceeded`, `max_completion_tokens exceeded`, Qwen-style ranges, HTTP 413, etc.).
- Add Vitest coverage for the regression.

## Issue
Closes https://github.com/netease-youdao/LobsterAI/issues/1298