### PR TITLE
fix(openclaw): reduce unnecessary gateway hard restarts

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -897,7 +897,7 @@ const clearDeferredRestart = () => {
 const executeDeferredGatewayRestart = async (reason: string) => {
   clearDeferredRestart();
   console.log(`[OpenClaw] executeDeferredGatewayRestart: performing deferred restart (reason: ${reason})`);
-  await syncOpenClawConfig({ reason: `deferred:${reason}`, restartGatewayIfRunning: true });
+  await syncOpenClawConfig({ reason: `deferred:${reason}` });
 };
 
 const scheduleDeferredGatewayRestart = (reason: string) => {
@@ -1301,10 +1301,10 @@ const refreshMcpBridge = (): Promise<{ tools: number; error?: string }> => {
       const toolCount = bridgeConfig?.tools.length ?? 0;
       console.log(`[McpBridge] refresh: ${toolCount} tools discovered`);
 
-      // 3. Sync openclaw.json and restart gateway if running
+      // 3. Sync openclaw.json — OpenClaw's file watcher will hot-reload;
+      // hard restart only happens when secret env vars change.
       const syncResult = await syncOpenClawConfig({
         reason: 'mcp-server-changed',
-        restartGatewayIfRunning: true,
       });
       if (!syncResult.success) {
         console.error('[McpBridge] refresh: config sync failed:', syncResult.error);
@@ -1351,7 +1351,6 @@ const getIMGatewayManager = () => {
         syncOpenClawConfig: async () => {
           await syncOpenClawConfig({
             reason: 'im-gateway-start',
-            restartGatewayIfRunning: true,
           });
         },
         ensureOpenClawGatewayConnected: async () => {
@@ -3226,7 +3225,6 @@ if (!gotTheLock) {
       if (shouldSyncOpenClawConfig) {
         const syncResult = await syncOpenClawConfig({
           reason: 'cowork-config-change',
-          restartGatewayIfRunning: true,
         });
         if (!syncResult.success && nextConfig.agentEngine === 'openclaw') {
           return {
@@ -3335,10 +3333,9 @@ if (!gotTheLock) {
     try {
       await syncOpenClawConfig({
         reason: 'im-config-change',
-        restartGatewayIfRunning: true,
       });
-      // After config sync (which may restart the gateway), ensure the runtime
-      // adapter's WebSocket client is connected so channel events are received.
+      // After config sync, ensure the runtime adapter's WebSocket client
+      // is connected so channel events are received.
       if (openClawRuntimeAdapter) {
         try {
           await openClawRuntimeAdapter.connectGatewayIfNeeded();
@@ -3541,11 +3538,8 @@ if (!gotTheLock) {
       if (!approved) {
         return { success: false, error: 'Pairing code not found or expired' };
       }
-      // Restart gateway so it reloads the updated allowFrom from disk
-      // (OpenClaw SDK caches allowFrom in memory)
       await syncOpenClawConfig({
         reason: `im-pairing-approval:${platform}`,
-        restartGatewayIfRunning: true,
       });
       return { success: true };
     } catch (error) {
@@ -4965,7 +4959,6 @@ if (!gotTheLock) {
     if (resolveCoworkAgentEngine() === 'openclaw') {
       const proxyResync = await syncOpenClawConfig({
         reason: 'proxy-ready',
-        restartGatewayIfRunning: true,
       });
       if (proxyResync.changed) {
         console.log('[Main] OpenClaw config updated after proxy ready, gateway will restart to pick up new config');

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -1922,11 +1922,31 @@ export class SkillManager {
     const primaryRoot = this.ensureSkillsRoot();
     const roots = this.getSkillRoots(primaryRoot);
 
-    const watchHandler = () => this.scheduleNotify();
+    // Root-level watch: only react to directory additions/removals (new/deleted skills).
+    const rootWatchHandler = (_event: string, filename: string | null) => {
+      if (!filename) { this.scheduleNotify(); return; }
+      // Ignore hidden files/dirs and known non-skill files
+      if (filename.startsWith('.')) return;
+      // Accept directory changes (new skill added/removed) and config file
+      if (filename === SKILLS_CONFIG_FILE) { this.scheduleNotify(); return; }
+      // For other filenames, check if it looks like a skill directory entry
+      // (no extension = likely a directory name)
+      if (!path.extname(filename)) { this.scheduleNotify(); }
+    };
+
+    // Skill-directory-level watch: only react to skill definition file changes.
+    const skillDirWatchHandler = (_event: string, filename: string | null) => {
+      if (!filename) { this.scheduleNotify(); return; }
+      if (filename === SKILL_FILE_NAME || filename === SKILLS_CONFIG_FILE) {
+        this.scheduleNotify();
+      }
+      // Ignore cache files, data files, and any other non-definition files.
+    };
+
     roots.forEach(root => {
       if (!fs.existsSync(root)) return;
       try {
-        this.watchers.push(fs.watch(root, watchHandler));
+        this.watchers.push(fs.watch(root, rootWatchHandler));
       } catch (error) {
         console.warn('[skills] Failed to watch skills root:', root, error);
       }
@@ -1934,7 +1954,7 @@ export class SkillManager {
       const skillDirs = listSkillDirs(root);
       skillDirs.forEach(dir => {
         try {
-          this.watchers.push(fs.watch(dir, watchHandler));
+          this.watchers.push(fs.watch(dir, skillDirWatchHandler));
         } catch (error) {
           console.warn('[skills] Failed to watch skill directory:', dir, error);
         }


### PR DESCRIPTION
 Summary

  - Remove restartGatewayIfRunning: true from all 7 syncOpenClawConfig call sites (MCP
  server change, IM config change, IM gateway start, cowork config change, IM pairing
  approval, proxy ready, deferred restart). Config changes to openclaw.json are now
  picked up by OpenClaw's built-in file watcher which hot-reloads or triggers SIGUSR1
  in-process restart as needed — no hard process kill required from LobsterAI side.
  - Hard restart (stopGateway + startGateway) now only triggers when
  secretEnvVarsChanged is true, since environment variables are fixed at process spawn
  time and cannot be hot-reloaded.
  - Filter fs.watch in SkillManager.startWatching() to only respond to skill definition
   files (SKILL.md, skills.config.json), ignoring cache/data files written by skills at
   runtime (e.g. news skill cache). Previously any file write in a skill directory
  triggered syncOpenClawConfig, adding unnecessary I/O overhead and risking accidental
  hard restarts when coinciding with token refresh.

  Background

  OpenClaw gateway has a sophisticated config reload system (config-reload-plan.ts)
  that classifies every config path change into one of three categories:
  - hot: in-process subsystem reload (channels, cron, hooks, heartbeat, browser)
  - restart: SIGUSR1 in-process restart (plugins, gateway, discovery)
  - none: no action needed — read dynamically at runtime (agents, tools, skills,
  bindings, etc.)

  Most config changes triggered by LobsterAI (model/provider switch, skill
  enable/disable, agent updates) fall into the none category in OpenClaw's reload plan.
   The previous restartGatewayIfRunning: true was unnecessarily killing and restarting
  the entire gateway process for changes that required no reload at all.

  Test plan

  - Change MCP server settings → verify gateway stays running (no restart in logs)
  - Change IM platform config (e.g. enable/disable Telegram) → verify gateway
  hot-reloads channel without full restart
  - Switch model provider → verify no gateway restart
  - Change API key → verify gateway hard restarts (secretEnvVars changed)
  - Install/enable/disable a skill → verify no unnecessary config sync triggered
  - Skill writes cache file at runtime → verify no skills-changed event in logs
  - Manual restart button → verify still works