### PR TITLE
功能增强：会话列表错误状态红点徽标

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionItem.tsx
+++ b/src/renderer/components/cowork/CoworkSessionItem.tsx
@@ -260,8 +260,9 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
   const deleteLabel = i18nService.t('deleteSession');
   const relativeTime = formatRelativeTime(session.updatedAt);
   const showRunningIndicator = session.status === 'running';
-  const showUnreadIndicator = !showRunningIndicator && hasUnread;
-  const showStatusIndicator = showRunningIndicator || showUnreadIndicator;
+  const showErrorIndicator = session.status === 'error';
+  const showUnreadIndicator = !showRunningIndicator && !showErrorIndicator && hasUnread;
+  const showStatusIndicator = showRunningIndicator || showErrorIndicator || showUnreadIndicator;
   const batchLabel = i18nService.t('batchOperations');
   const menuItems = useMemo(() => {
     const items = [
@@ -323,10 +324,20 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
             {/* Status indicator */}
             {showStatusIndicator && (
               <span
-                className={`block w-2 h-2 rounded-full bg-primary flex-shrink-0 ${
-                  showRunningIndicator ? 'shadow-[0_0_6px_rgba(59,130,246,0.5)] animate-pulse' : ''
+                className={`block w-2 h-2 rounded-full flex-shrink-0 ${
+                  showRunningIndicator
+                    ? 'bg-primary shadow-[0_0_6px_rgba(59,130,246,0.5)] animate-pulse'
+                    : showErrorIndicator
+                      ? 'bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.5)]'
+                      : 'bg-primary'
                 }`}
-                title={showRunningIndicator ? i18nService.t(statusLabels[session.status]) : undefined}
+                title={
+                  showRunningIndicator
+                    ? i18nService.t(statusLabels[session.status])
+                    : showErrorIndicator
+                      ? i18nService.t(statusLabels[session.status])
+                      : undefined
+                }
               />
             )}
             {isRenaming ? (


### PR DESCRIPTION
## 功能说明

为 Cowork 会话列表中 `error` 状态的会话添加红色圆点指示器，让用户能在侧边栏一眼识别出错会话。

## 关联 Issue

Closes #1330

## 改动内容

### `src/renderer/components/cowork/CoworkSessionItem.tsx`

扩展状态指示器逻辑：

**修改前**：只有 `running`（蓝色脉冲）和有未读消息（蓝色静态）两种状态有指示器

**修改后**：
- `running`：蓝色脉冲圆点（不变）
- `error`：**新增** 红色静态圆点，含淡红色光晕（`bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.5)]`）
- 有未读消息：蓝色静态圆点（仅在非 running、非 error 时显示）
- 优先级：running > error > unread

hover tooltip 同样展示状态文案（复用已有 `coworkStatusError` i18n 键），无需新增翻译。

## 截图

| 状态 | 指示器 |
|------|--------|
| running | 🔵 蓝色脉冲 |
| error | 🔴 红色静态（新增） |
| 有未读 | 🔵 蓝色静态 |
| 其他 | 无指示器 |

## 测试

- [x] error 状态：显示红色静态圆点，hover 显示「错误」tooltip
- [x] running 状态：蓝色脉冲，行为不变
- [x] 有未读且为 error 状态：只显示红点，不显示蓝点
- [x] idle/completed 无未读：无指示器，行为不变
