### PR TITLE
ci: lint only changed files in PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,16 +67,20 @@ jobs:
       - name: Lint changed files only
         env:
           BEFORE_SHA: ${{ github.event.before }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- '*.ts' '*.tsx')
-          else
+            FILES=$(git diff --name-only --diff-filter=ACMR origin/${BASE_REF}...HEAD -- '*.ts' '*.tsx')
+          elif [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
             FILES=$(git diff --name-only --diff-filter=ACMR ${BEFORE_SHA}...HEAD -- '*.ts' '*.tsx')
+          else
+            echo "BEFORE_SHA unavailable, falling back to HEAD~1"
+            FILES=$(git diff --name-only --diff-filter=ACMR HEAD~1 -- '*.ts' '*.tsx')
           fi
           if [ -n "$FILES" ]; then
             echo "Linting changed files:"
             echo "$FILES"
-            echo "$FILES" | xargs npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0
+            echo "$FILES" | xargs -d '\n' npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0
           else
             echo "No TypeScript files changed, skipping lint"
           fi


### PR DESCRIPTION
## Summary
- CI lint job 从全量扫描改为仅扫描 PR 变更的 `.ts`/`.tsx` 文件
- 添加 `fetch-depth: 0` 以支持跨分支 `git diff`
- 使用 `--diff-filter=ACMR` 排除已删除文件
- 无 ts/tsx 变更时自动跳过 lint
- push 事件回退到 `HEAD~1` 比较

## Why
全量 `npm run lint` 容易因其他人合入的代码产生冲突/误报，改为增量扫描减少不必要的 CI 失败。

Ref: #1234

## Test plan
- [x] 本地验证：无 ts/tsx 变更时正确跳过 lint
- [x] 本地验证：有 ts/tsx 变更时正确检出文件并传给 eslint
- [ ] CI 上提交 PR 触发实际验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)