### PR TITLE
【功能缺失】输入框支持 Up/Down 方向键回溯已发送历史

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -120,6 +120,10 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const [isAddingFile, setIsAddingFile] = useState(false);
     const [imageVisionHint, setImageVisionHint] = useState(false);
 
+    // Sent prompt history for Up/Down arrow navigation
+    const sentHistoryRef = useRef<string[]>([]);
+    const historyIndexRef = useRef(-1);
+
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const folderButtonRef = useRef<HTMLButtonElement>(null);
     const dragDepthRef = useRef(0);
@@ -269,6 +273,14 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     }
     const result = await onSubmit(finalPrompt, skillPrompt, imageAtts.length > 0 ? imageAtts : undefined);
     if (result === false) return;
+    // Record in history for Up/Down navigation (keep last 50, deduplicate adjacent)
+    if (trimmedValue) {
+      const prev = sentHistoryRef.current[0];
+      if (prev !== trimmedValue) {
+        sentHistoryRef.current = [trimmedValue, ...sentHistoryRef.current.slice(0, 49)];
+      }
+    }
+    historyIndexRef.current = -1;
     setValue('');
     dispatch(setDraftPrompt({ sessionId: draftKey, draft: '' }));
     dispatch(clearDraftAttachments(draftKey));
@@ -297,6 +309,64 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         // Shift+Enter already inserts newline natively; for Ctrl/Cmd/Alt+Enter, insert via execCommand to preserve undo history
         event.preventDefault();
         document.execCommand('insertText', false, '\n');
+      }
+    }
+
+    // Up/Down arrow keys to navigate sent prompt history (only when textarea is single-line or at boundary)
+    if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && !event.shiftKey && !event.ctrlKey && !event.metaKey) {
+      const history = sentHistoryRef.current;
+      if (history.length === 0) return;
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      if (event.key === 'ArrowUp') {
+        // Only navigate up when cursor is on the first line (or value is empty)
+        const cursorPos = textarea.selectionStart;
+        const textBeforeCursor = value.slice(0, cursorPos);
+        const isOnFirstLine = !textBeforeCursor.includes('\n');
+        if (!isOnFirstLine) return;
+
+        const nextIndex = historyIndexRef.current + 1;
+        if (nextIndex < history.length) {
+          event.preventDefault();
+          historyIndexRef.current = nextIndex;
+          const historyValue = history[nextIndex];
+          setValue(historyValue);
+          dispatch(setDraftPrompt({ sessionId: draftKey, draft: historyValue }));
+          // Move cursor to end after state update
+          requestAnimationFrame(() => {
+            if (textareaRef.current) {
+              const len = historyValue.length;
+              textareaRef.current.setSelectionRange(len, len);
+            }
+          });
+        }
+      } else {
+        // ArrowDown: navigate forward in history
+        const cursorPos = textarea.selectionStart;
+        const textAfterCursor = value.slice(cursorPos);
+        const isOnLastLine = !textAfterCursor.includes('\n');
+        if (!isOnLastLine) return;
+
+        event.preventDefault();
+        const prevIndex = historyIndexRef.current - 1;
+        if (prevIndex >= 0) {
+          historyIndexRef.current = prevIndex;
+          const historyValue = history[prevIndex];
+          setValue(historyValue);
+          dispatch(setDraftPrompt({ sessionId: draftKey, draft: historyValue }));
+          requestAnimationFrame(() => {
+            if (textareaRef.current) {
+              const len = historyValue.length;
+              textareaRef.current.setSelectionRange(len, len);
+            }
+          });
+        } else {
+          // Back to empty / current draft
+          historyIndexRef.current = -1;
+          setValue('');
+          dispatch(setDraftPrompt({ sessionId: draftKey, draft: '' }));
+        }
       }
     }
   };


### PR DESCRIPTION
## 关联 Issue

closes #1341

## 改动说明

在 `CoworkPromptInput.tsx` 中实现发送历史的 Up/Down 键导航：

1. 新增两个 `useRef`：
   - `sentHistoryRef`：存储已发送消息列表（最多 50 条，去重）
   - `historyIndexRef`：当前浏览位置（-1 = 最新/空白）

2. 在 `handleSubmit` 中发送成功后将当前内容追加到历史头部

3. 在 `handleKeyDown` 中处理 Up/Down 键：
   - Up：仅在光标位于第一行时触发，加载上一条历史
   - Down：仅在光标位于最后一行时触发，加载下一条历史或恢复空白
   - 历史导航后将光标移至行尾

## 改动文件

- `src/renderer/components/cowork/CoworkPromptInput.tsx`