### PR TITLE
fix(im): add real API validation for POPO connectivity test

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -170,9 +170,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // POPO
     imPopoFillWebhookCredentials: '请补全 appKey、appSecret、token 和 aesKey 后重新测试连通性。',
     imPopoFillWsCredentials: '请补全 appKey、appSecret 和 aesKey 后重新测试连通性。',
-    imPopoConfigReady: 'POPO 配置已就绪。',
+    imPopoAuthPassed: 'POPO 鉴权通过。',
+    imPopoAuthFailed: 'POPO 鉴权失败: {error}',
+    imPopoCheckCredentials: '请检查 appKey 和 appSecret 是否正确。',
     imPopoOpenClawHint: 'POPO 通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
-    imPopoConfigReadyOpenClaw: 'POPO 配置已就绪，通过 OpenClaw 运行。',
 
     'enterprise.updateBlocked': '版本更新由企业统一管理',
   },
@@ -331,9 +332,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // POPO
     imPopoFillWebhookCredentials: 'Please provide the appKey, appSecret, token, and aesKey and test connectivity again.',
     imPopoFillWsCredentials: 'Please provide the appKey, appSecret, and aesKey and test connectivity again.',
-    imPopoConfigReady: 'POPO configuration is ready.',
+    imPopoAuthPassed: 'POPO authentication passed.',
+    imPopoAuthFailed: 'POPO authentication failed: {error}',
+    imPopoCheckCredentials: 'Please check that the appKey and appSecret are correct.',
     imPopoOpenClawHint: 'POPO runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
-    imPopoConfigReadyOpenClaw: 'POPO configuration is ready, running via OpenClaw.',
 
     'enterprise.updateBlocked': 'Updates are managed by enterprise',
   },

--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -1546,12 +1546,57 @@ export class IMGatewayManager extends EventEmitter {
       return { platform, testedAt, verdict: 'fail', checks };
     }
 
-    // Check 2: Config completeness passes
-    checks.push({
-      code: 'auth_check',
-      level: 'pass',
-      message: t('imPopoConfigReady'),
-    });
+    // Check 2: API authentication probe
+    // Call POPO official API to verify credentials validity
+    try {
+      const tokenUrl = 'https://open.popo.netease.com/open-apis/robots/v1/token';
+      const response = await this.withTimeout(
+        fetchJsonWithTimeout<{ 
+          errcode?: number; 
+          errmsg?: string; 
+          data?: { 
+            accessToken?: string; 
+            accessExpiredAt?: number;
+            refreshToken?: string;
+            refreshExpiredAt?: number;
+          } 
+        }>(
+          tokenUrl,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              appKey: popoConfig.appKey,
+              appSecret: popoConfig.appSecret,
+            }),
+          },
+          CONNECTIVITY_TIMEOUT_MS
+        ),
+        CONNECTIVITY_TIMEOUT_MS,
+        t('imAuthProbeTimeout')
+      );
+
+      if (response.data?.accessToken) {
+        checks.push({
+          code: 'auth_check',
+          level: 'pass',
+          message: t('imPopoAuthPassed'),
+        });
+      } else {
+        const errorMsg = response.errmsg || `errcode ${response.errcode || 'unknown'}`;
+        throw new Error(errorMsg);
+      }
+    } catch (error: any) {
+      checks.push({
+        code: 'auth_check',
+        level: 'fail',
+        message: t('imPopoAuthFailed', { error: error.message }),
+        suggestion: t('imPopoCheckCredentials'),
+      });
+      return { platform, testedAt, verdict: 'fail', checks };
+    }
 
     // Check 3: OpenClaw Gateway running info
     checks.push({


### PR DESCRIPTION
## 🔗 关联 Issue

Fixes #1287

## 问题描述
POPO 连接测试无论填写什么凭据都显示"验证通过"，即使 appKey 和 appSecret 是错误的或随意填写的。

**问题根因:**
原代码只是检查配置字段是否非空，并没有真正调用 POPO API 验证凭据的有效性。

## 解决方案
添加真正的 API 调用，验证 appKey 和 appSecret 的有效性。