### PR TITLE
修复：Windows 上拖入 .pptx/.docx 文件无法添加附件的问题

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -475,6 +475,27 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         continue;
       }
 
+      // Virtual file from Windows drag (e.g., .pptx/.docx): size is 0 and path is empty
+      // because Windows Explorer uses CFSTR_FILEDESCRIPTOR instead of CF_HDROP.
+      // FileReader cannot read content, so open native file picker as fallback.
+      if (file.size === 0 && file.name) {
+        const ext = file.name.includes('.') ? file.name.split('.').pop()?.toLowerCase() : undefined;
+        try {
+          const result = await window.electron.dialog.selectFiles({
+            title: file.name,
+            filters: ext ? [{ name: ext.toUpperCase(), extensions: [ext] }] : undefined,
+          });
+          if (result.success && result.paths.length > 0) {
+            for (const filePath of result.paths) {
+              addAttachment(filePath);
+            }
+          }
+        } catch (error) {
+          console.error('Failed to open file picker for virtual file:', error);
+        }
+        continue;
+      }
+
       const stagedPath = await saveInlineFile(file);
       if (stagedPath) {
         addAttachment(stagedPath);
@@ -534,7 +555,15 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   const hasFileTransfer = (dataTransfer: DataTransfer | null): boolean => {
     if (!dataTransfer) return false;
     if (dataTransfer.files.length > 0) return true;
-    return Array.from(dataTransfer.types).includes('Files');
+    if (Array.from(dataTransfer.types).includes('Files')) return true;
+    // Fallback: check items for file-kind entries (handles Windows Office file drags
+    // where dataTransfer.types may not include 'Files' or files may be empty)
+    if (dataTransfer.items) {
+      for (let i = 0; i < dataTransfer.items.length; i++) {
+        if (dataTransfer.items[i].kind === 'file') return true;
+      }
+    }
+    return false;
   };
 
   const handleDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
@@ -571,7 +600,34 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     dragDepthRef.current = 0;
     setIsDraggingFiles(false);
     if (disabled || isStreaming) return;
-    void handleIncomingFiles(event.dataTransfer.files);
+    // Collect files from both dataTransfer.files and dataTransfer.items.
+    // On Windows, Office shell extensions (Word/PowerPoint preview handlers)
+    // can interfere with dataTransfer.files for certain file types (.docx, .pptx),
+    // leaving files only accessible via dataTransfer.items.
+    const fileSet = new Map<string, File>();
+    // Source 1: dataTransfer.files (standard path)
+    for (let i = 0; i < event.dataTransfer.files.length; i++) {
+      const file = event.dataTransfer.files[i];
+      const key = `${file.name}-${file.size}-${file.lastModified}`;
+      fileSet.set(key, file);
+    }
+    // Source 2: dataTransfer.items (fallback for Office files on Windows)
+    if (event.dataTransfer.items) {
+      for (let i = 0; i < event.dataTransfer.items.length; i++) {
+        const item = event.dataTransfer.items[i];
+        if (item.kind === 'file') {
+          const file = item.getAsFile();
+          if (file) {
+            const key = `${file.name}-${file.size}-${file.lastModified}`;
+            if (!fileSet.has(key)) {
+              fileSet.set(key, file);
+            }
+          }
+        }
+      }
+    }
+    const filesToProcess = Array.from(fileSet.values());
+    void handleIncomingFiles(filesToProcess);
   };
 
   const handlePaste = useCallback((event: React.ClipboardEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
## 问题描述

在 Windows 系统中，从文件管理器将 `.pptx` / `.docx` 文件拖入 CoworkPromptInput 输入框时，附件无法被添加（`.xlsx`、图片等其他文件类型拖入正常）。点击「添加附件」按钮上传则一切正常。

## 根因分析

Windows Explorer 对 `.pptx` / `.docx` 文件使用**虚拟文件描述符**（`CFSTR_FILEDESCRIPTOR`）进行拖拽传输，而非标准文件引用（`CF_HDROP`）。这导致 Chromium/Electron 渲染进程在 `drop` 事件中获取到的 File 对象为占位对象：
- `file.size === 0`（无文件内容）
- `file.path === ''`（无原生路径）
- `file.name` 和 `file.type` 正常

原有代码中 `handleIncomingFiles` 因 `nativePath` 为空而回退到 `saveInlineFile`，但 `FileReader.readAsDataURL` 无法从 size=0 的虚拟文件中读取内容，最终静默失败。

## 修复方案

### 1. 增强 `hasFileTransfer()` 检测
除检查 `dataTransfer.files` 和 `dataTransfer.types` 外，增加对 `dataTransfer.items` 的 `kind === 'file'` 检查，确保所有拖拽场景都能被正确识别。

### 2. 合并 files + items 双来源
`handleDrop` 中同时从 `dataTransfer.files` 和 `dataTransfer.items` 收集文件，按 `name+size+lastModified` 去重，确保不遗漏任何来源的文件。

### 3. 虚拟文件回退文件选择器
在 `handleIncomingFiles` 中检测虚拟文件（`size === 0` 且无 `path`），自动弹出系统文件选择器让用户重新选取该文件，选取成功后正常添加为附件。

## 影响范围

- **修改文件**：`src/renderer/components/cowork/CoworkPromptInput.tsx`（1 个文件，+58/-2）
- **不影响**：点击上传、粘贴上传、图片上传、非 Windows 平台
- **无 API/IPC/数据库变更**