### PR TITLE
feat(cowork): 权限弹窗添加 ESC 键关闭支持

### DIFF
--- a/src/renderer/components/cowork/CoworkPermissionModal.tsx
+++ b/src/renderer/components/cowork/CoworkPermissionModal.tsx
@@ -340,6 +340,17 @@ const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({
     });
   };
 
+  // Handle ESC key to close modal
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        handleDeny();
+      }
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, []);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop">
       <div className="modal-content w-full max-w-lg mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden">


### PR DESCRIPTION
## 问题
权限弹窗无法通过 ESC 键关闭，用户体验不佳

## 修复
在 CoworkPermissionModal 组件中添加键盘事件监听器：
- 当用户按下 ESC 键时调用 handleDeny() 关闭弹窗
- 添加 cleanup 函数确保组件卸载时移除监听器，避免内存泄漏

## 复现路径
1. 启动应用并开始 Cowork 会话
2. 触发需要权限的操作（如读取文件）
3. 权限弹窗出现时，按 ESC 键
4. 弹窗应该关闭（等同于点击拒绝）

## 改动
- 修改: src/renderer/components/cowork/CoworkPermissionModal.tsx