### PR TITLE
feat(cowork): 新建任务页面输入框工具栏增加模型选择器

### DIFF
--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -549,6 +549,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
                   await coworkService.updateConfig({ workingDirectory: dir });
                 }}
                 showFolderSelector={true}
+                showModelSelector={true}
                 onManageSkills={() => onShowSkills?.()}
               />
             </div>


### PR DESCRIPTION
## 修改原因

当前新建任务（Home 页面）时，模型选择器仅位于页面**顶部 Header 栏**，而用户实际操作的输入框在页面**中部偏下**的位置。两者距离较远，用户需要在切换模型和输入提示词之间频繁移动视线和鼠标，交互体验不佳。

## 修改内容

在 Home 页面的 `CoworkPromptInput` 输入框工具栏中**新增**一个模型选择器，与文件夹选择、附件上传、技能选择等按钮并排显示，方便用户在输入提示词时就近切换模型。

同时**保留**顶部 Header 栏原有的模型选择器，兼顾已有用户的使用习惯。

### 数据联动

两个模型选择器共享同一个 Redux store（`state.model.selectedModel`），在任意一处切换模型，另一处会自动同步更新，无需额外的联动逻辑。

## 具体改动

- `src/renderer/components/cowork/CoworkView.tsx`：为 Home 页面的 `CoworkPromptInput` 组件添加 `showModelSelector={true}` 属性

## 改动前后对比

| 位置 | 改动前 | 改动后 |
|------|--------|--------|
| 顶部 Header 栏 | 有模型选择器 | 有模型选择器（保持不变） |
| 输入框工具栏 | 无模型选择器 | **新增**模型选择器（下拉方向向上） |