### PR TITLE
fix(copilot): update default models to Free tier

### DIFF
--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -355,12 +355,10 @@ const PROVIDER_DEFINITIONS = [
     region: 'global',
     enPriority: 0,
     defaultModels: [
-      { id: 'gpt-5-mini', name: 'GPT-5-mini', supportsImage: true },
+      { id: 'gpt-5-mini', name: 'GPT-5 mini', supportsImage: true },
       { id: 'claude-haiku-4.5', name: 'Claude Haiku 4.5', supportsImage: true },
-      { id: 'claude-sonnet-4.6', name: 'Claude Sonnet 4.6', supportsImage: true },
-      { id: 'claude-sonnet-4.5', name: 'Claude Sonnet 4.5', supportsImage: true },
+      { id: 'gpt-4.1', name: 'GPT-4.1', supportsImage: true },
       { id: 'gpt-4o', name: 'GPT-4o', supportsImage: true },
-      { id: 'o3-mini', name: 'o3-mini', supportsImage: false },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Update GitHub Copilot default models to only include Free tier available models
- Remove paid-only models: Claude Sonnet 4.6, Claude Sonnet 4.5, o3-mini
- Keep/add Free tier models: GPT-5 mini, Claude Haiku 4.5, GPT-4.1, GPT-4o

## Test plan
- [ ] Verify the 4 default models show correctly for new users (no prior saved config)
- [ ] Verify existing users with saved config still see their custom models

🤖 Generated with [Claude Code](https://claude.com/claude-code)