### PR TITLE
修复会话中多文件选择只保留最后一个文件的问题

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.test.ts
+++ b/src/renderer/components/cowork/CoworkPromptInput.test.ts
@@ -1,0 +1,102 @@
+import { test, expect } from 'vitest';
+import { mergeAttachments } from './CoworkPromptInput';
+
+interface DraftAttachment {
+  path: string;
+  name: string;
+  isImage?: boolean;
+  dataUrl?: string;
+}
+
+test('single file: merges one file into empty list', () => {
+  const oneFile: DraftAttachment = {
+    path: '/path/to/file.txt',
+    name: 'file.txt',
+  };
+  const result = mergeAttachments([], [oneFile]);
+  expect(result).toHaveLength(1);
+  expect(result[0].path).toBe('/path/to/file.txt');
+  expect(result[0].name).toBe('file.txt');
+});
+
+test('multiple files: merges three files into empty list', () => {
+  const files: DraftAttachment[] = [
+    { path: '/path/a.txt', name: 'a.txt' },
+    { path: '/path/b.txt', name: 'b.txt' },
+    { path: '/path/c.txt', name: 'c.txt' },
+  ];
+  const result = mergeAttachments([], files);
+  expect(result).toHaveLength(3);
+  expect(result.map((f: DraftAttachment) => f.path)).toEqual([
+    '/path/a.txt',
+    '/path/b.txt',
+    '/path/c.txt',
+  ]);
+});
+
+test('append to existing: adds new file to existing list', () => {
+  const existing: DraftAttachment[] = [
+    { path: '/path/existing.txt', name: 'existing.txt' },
+  ];
+  const newFile: DraftAttachment[] = [
+    { path: '/path/new.txt', name: 'new.txt' },
+  ];
+  const result = mergeAttachments(existing, newFile);
+  expect(result).toHaveLength(2);
+  expect(result[0].path).toBe('/path/existing.txt');
+  expect(result[1].path).toBe('/path/new.txt');
+});
+
+test('cross-batch dedup: removes duplicate path from incoming batch', () => {
+  const existing: DraftAttachment[] = [
+    { path: 'a.txt', name: 'a.txt' },
+  ];
+  const incoming: DraftAttachment[] = [
+    { path: 'a.txt', name: 'a.txt' },
+    { path: 'b.txt', name: 'b.txt' },
+  ];
+  const result = mergeAttachments(existing, incoming);
+  expect(result).toHaveLength(2);
+  const paths = result.map((f: DraftAttachment) => f.path);
+  expect(paths).toContain('a.txt');
+  expect(paths).toContain('b.txt');
+  expect(paths.filter((p: string) => p === 'a.txt')).toHaveLength(1);
+});
+
+test('within-batch dedup: removes duplicate within incoming batch', () => {
+  const incoming: DraftAttachment[] = [
+    { path: 'a.txt', name: 'a.txt' },
+    { path: 'a.txt', name: 'a.txt' },
+  ];
+  const result = mergeAttachments([], incoming);
+  expect(result).toHaveLength(1);
+  expect(result[0].path).toBe('a.txt');
+});
+
+test('empty incoming: returns existing list unchanged', () => {
+  const existing: DraftAttachment[] = [
+    { path: '/path/file.txt', name: 'file.txt' },
+  ];
+  const result = mergeAttachments(existing, []);
+  expect(result).toHaveLength(1);
+  expect(result[0].path).toBe('/path/file.txt');
+});
+
+test('image metadata: preserves isImage flag and dataUrl', () => {
+  const imageFile: DraftAttachment = {
+    path: '/path/image.png',
+    name: 'image.png',
+    isImage: true,
+    dataUrl: 'data:image/png;base64,iVBORw0KGgo...',
+  };
+  const result = mergeAttachments([], [imageFile]);
+  expect(result).toHaveLength(1);
+  expect(result[0].isImage).toBe(true);
+  expect(result[0].dataUrl).toBe('data:image/png;base64,iVBORw0KGgo...');
+});
+
+test('empty both: returns empty array', () => {
+  const result = mergeAttachments([], []);
+  expect(result).toHaveLength(0);
+  expect(result).toEqual([]);
+});

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -51,6 +51,30 @@ const getSkillDirectoryFromPath = (skillPath: string): string => {
   return normalized.replace(/\/SKILL\.md$/i, '') || normalized;
 };
 
+export const mergeAttachments = (
+  existing: DraftAttachment[],
+  incoming: DraftAttachment[]
+): DraftAttachment[] => {
+  const seenPaths = new Set<string>();
+  const result: DraftAttachment[] = [];
+
+  for (const attachment of existing) {
+    if (!seenPaths.has(attachment.path)) {
+      seenPaths.add(attachment.path);
+      result.push(attachment);
+    }
+  }
+
+  for (const attachment of incoming) {
+    if (!seenPaths.has(attachment.path)) {
+      seenPaths.add(attachment.path);
+      result.push(attachment);
+    }
+  }
+
+  return result;
+};
+
 const buildInlinedSkillPrompt = (skill: Skill): string => {
   const skillDirectory = getSkillDirectoryFromPath(skill.skillPath);
   return [
@@ -329,34 +353,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   const selectedModel = useSelector((state: RootState) => state.model.selectedModel);
   const modelSupportsImage = !!selectedModel?.supportsImage;
 
-  const addAttachment = useCallback((filePath: string, imageInfo?: { isImage: boolean; dataUrl?: string }) => {
-    if (!filePath) return;
-    const current = attachments;
-    if (current.some((attachment) => attachment.path === filePath)) return;
-    dispatch(setDraftAttachments({
-      draftKey,
-      attachments: [...current, {
-        path: filePath,
-        name: getFileNameFromPath(filePath),
-        isImage: imageInfo?.isImage,
-        dataUrl: imageInfo?.dataUrl,
-      }],
-    }));
-  }, [attachments, dispatch, draftKey]);
 
-  const addImageAttachmentFromDataUrl = useCallback((name: string, dataUrl: string) => {
-    // Use the dataUrl as the unique key (no file path for inline images)
-    const pseudoPath = `inline:${name}:${Date.now()}`;
-    dispatch(setDraftAttachments({
-      draftKey,
-      attachments: [...attachments, {
-        path: pseudoPath,
-        name,
-        isImage: true,
-        dataUrl,
-      }],
-    }));
-  }, [attachments, dispatch, draftKey]);
 
   const fileToDataUrl = useCallback((file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
@@ -426,7 +423,9 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const files = Array.from(fileList ?? []);
     if (files.length === 0) return;
 
+    const newAttachments: DraftAttachment[] = [];
     let hasImageWithoutVision = false;
+
     for (const file of files) {
       const nativePath = getNativeFilePath(file);
 
@@ -442,24 +441,41 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
             try {
               const result = await window.electron.dialog.readFileAsDataUrl(nativePath);
               if (result.success && result.dataUrl) {
-                addAttachment(nativePath, { isImage: true, dataUrl: result.dataUrl });
+                newAttachments.push({
+                  path: nativePath,
+                  name: getFileNameFromPath(nativePath),
+                  isImage: true,
+                  dataUrl: result.dataUrl,
+                });
                 continue;
               }
             } catch (error) {
               console.error('Failed to read image as data URL:', error);
             }
             // Fallback: add as regular file attachment
-            addAttachment(nativePath);
+            newAttachments.push({
+              path: nativePath,
+              name: getFileNameFromPath(nativePath),
+            });
           } else {
             // No native path (clipboard/drag from browser) - read via FileReader
             try {
               const dataUrl = await fileToDataUrl(file);
-              addImageAttachmentFromDataUrl(file.name, dataUrl);
+              const pseudoPath = `inline:${file.name}:${Date.now()}`;
+              newAttachments.push({
+                path: pseudoPath,
+                name: file.name,
+                isImage: true,
+                dataUrl,
+              });
             } catch (error) {
               console.error('Failed to read image from clipboard:', error);
               const stagedPath = await saveInlineFile(file);
               if (stagedPath) {
-                addAttachment(stagedPath);
+                newAttachments.push({
+                  path: stagedPath,
+                  name: getFileNameFromPath(stagedPath),
+                });
               }
             }
           }
@@ -471,19 +487,34 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
 
       // Non-image file or model doesn't support images: use original flow
       if (nativePath) {
-        addAttachment(nativePath);
+        newAttachments.push({
+          path: nativePath,
+          name: getFileNameFromPath(nativePath),
+        });
         continue;
       }
 
       const stagedPath = await saveInlineFile(file);
       if (stagedPath) {
-        addAttachment(stagedPath);
+        newAttachments.push({
+          path: stagedPath,
+          name: getFileNameFromPath(stagedPath),
+        });
       }
     }
+
+    // Single batch dispatch
+    if (newAttachments.length > 0) {
+      dispatch(setDraftAttachments({
+        draftKey,
+        attachments: mergeAttachments(attachments, newAttachments),
+      }));
+    }
+
     if (hasImageWithoutVision) {
       setImageVisionHint(true);
     }
-  }, [addAttachment, addImageAttachmentFromDataUrl, disabled, fileToDataUrl, getNativeFilePath, isStreaming, modelSupportsImage, saveInlineFile]);
+  }, [attachments, disabled, fileToDataUrl, getNativeFilePath, isStreaming, modelSupportsImage, saveInlineFile, dispatch, draftKey]);
 
   const handleAddFile = useCallback(async () => {
     if (isAddingFile || disabled || isStreaming) return;
@@ -493,36 +524,54 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         title: i18nService.t('coworkAddFile'),
       });
       if (!result.success || result.paths.length === 0) return;
+
+      const newAttachments: DraftAttachment[] = [];
       let hasImageWithoutVision = false;
+
       for (const filePath of result.paths) {
         if (isImagePath(filePath)) {
           if (modelSupportsImage) {
             try {
               const readResult = await window.electron.dialog.readFileAsDataUrl(filePath);
               if (readResult.success && readResult.dataUrl) {
-                addAttachment(filePath, { isImage: true, dataUrl: readResult.dataUrl });
+                newAttachments.push({
+                  path: filePath,
+                  name: getFileNameFromPath(filePath),
+                  isImage: true,
+                  dataUrl: readResult.dataUrl,
+                });
                 continue;
               }
             } catch (error) {
               console.error('Failed to read image as data URL:', error);
-
             }
           } else {
             hasImageWithoutVision = true;
           }
         }
-        addAttachment(filePath);
+        newAttachments.push({
+          path: filePath,
+          name: getFileNameFromPath(filePath),
+        });
       }
+
+      // Single batch dispatch
+      if (newAttachments.length > 0) {
+        dispatch(setDraftAttachments({
+          draftKey,
+          attachments: mergeAttachments(attachments, newAttachments),
+        }));
+      }
+
       if (hasImageWithoutVision) {
         setImageVisionHint(true);
-
       }
     } catch (error) {
       console.error('Failed to select file:', error);
     } finally {
       setIsAddingFile(false);
     }
-  }, [addAttachment, isAddingFile, disabled, isStreaming, modelSupportsImage]);
+  }, [isAddingFile, disabled, isStreaming, modelSupportsImage, attachments, dispatch, draftKey]);
 
   const handleRemoveAttachment = useCallback((path: string) => {
     dispatch(setDraftAttachments({


### PR DESCRIPTION
## Summary

- 修复 Cowork 会话输入框中通过文件选择器或拖拽添加多个文件时，只保留最后一个文件的 bug
- 提取 `mergeAttachments` 纯函数用于批量合并附件（含路径级去重），并添加 8 个 Vitest 单元测试

## 问题

在 Cowork 会话输入框中，通过文件选择器选择多个文件或拖拽多个文件时，只有最后一个文件被保留在附件列表中，之前选择的文件被覆盖丢失。

## 根因

`addAttachment` 和 `addImageAttachmentFromDataUrl` 使用 `useCallback` 捕获了闭包中的 `attachments` 状态。当 `handleAddFile` / `handleIncomingFiles` 在循环中多次调用这些函数时，每次调用都读取同一份过期的 `attachments` 引用，导致每次 `dispatch(setDraftAttachments(...))` 都基于空数组追加，后面的 dispatch 覆盖前面的结果。

## 修复

1. 提取 `mergeAttachments` 纯函数，负责合并已有附件和新增附件（含路径级去重）
2. 重构 `handleAddFile` 和 `handleIncomingFiles`，在循环中收集所有新附件到本地数组，循环结束后通过 `mergeAttachments` 合并并单次 dispatch
3. 移除已无调用者的 `addAttachment` 和 `addImageAttachmentFromDataUrl` 函数
4. 添加 8 个 Vitest 单元测试覆盖合并/去重/元数据保留等场景

## 复现路径

1. 打开 Cowork 会话
2. 点击添加文件按钮
3. 在文件选择对话框中选择 3 个以上文件
4. 确认后观察附件列表
5. **修复前**: 只显示最后一个文件
6. **修复后**: 显示所有选中的文件

## 改动文件

- `src/renderer/components/cowork/CoworkPromptInput.tsx` — 修复核心逻辑
- `src/renderer/components/cowork/CoworkPromptInput.test.ts` — 新增单元测试