### PR TITLE
fix(scheduled-task): fix IM channel selector showing incomplete/wrong labels

### DIFF
--- a/src/main/ipcHandlers/scheduledTask/helpers.ts
+++ b/src/main/ipcHandlers/scheduledTask/helpers.ts
@@ -12,6 +12,22 @@ export function initScheduledTaskHelpers(d: ScheduledTaskHelperDeps): void {
   deps = d;
 }
 
+const MULTI_INSTANCE_CONFIG_KEYS = new Set(['dingtalk', 'feishu', 'qq']);
+
+function isConfigKeyEnabled(key: string, value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+
+  if (MULTI_INSTANCE_CONFIG_KEYS.has(key)) {
+    const instances = (value as { instances?: unknown[] }).instances;
+    if (!Array.isArray(instances) || instances.length === 0) return false;
+    return instances.some(
+      (inst) => inst && typeof inst === 'object' && (inst as { enabled?: boolean }).enabled,
+    );
+  }
+
+  return (value as { enabled?: boolean }).enabled === true;
+}
+
 export function listScheduledTaskChannels(): Array<{ value: string; label: string }> {
   const manager = deps?.getIMGatewayManager();
   const config = manager?.getConfig();
@@ -19,26 +35,17 @@ export function listScheduledTaskChannels(): Array<{ value: string; label: strin
     return [...PlatformRegistry.channelOptions()];
   }
 
-  const enabledConfigKeys = new Set<string>();
-  const configEntries: Array<[string, unknown]> = Object.entries(
-    config as unknown as Record<string, unknown>,
-  );
-  for (const [key, value] of configEntries) {
-    if (value && typeof value === 'object' && (value as { enabled?: boolean }).enabled) {
-      enabledConfigKeys.add(key);
+  const configRecord = config as unknown as Record<string, unknown>;
+
+  const enabledPlatforms = new Set<string>();
+  for (const [key, value] of Object.entries(configRecord)) {
+    if (isConfigKeyEnabled(key, value)) {
+      enabledPlatforms.add(key);
     }
   }
 
   return PlatformRegistry.channelOptions().filter((option) => {
-    if (option.value === 'dingtalk') {
-      return enabledConfigKeys.has('dingtalk');
-    }
-    if (option.value === 'qqbot') {
-      return enabledConfigKeys.has('qq');
-    }
-    if (option.value === 'openclaw-weixin') {
-      return enabledConfigKeys.has('weixin');
-    }
-    return enabledConfigKeys.has(option.value);
+    const platform = PlatformRegistry.platformOfChannel(option.value);
+    return platform !== undefined && enabledPlatforms.has(platform);
   });
 }

--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -130,7 +130,9 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
     const base: ScheduledTaskChannelOption[] = [];
     const savedChannel = task?.delivery.channel;
     if (savedChannel && isIMChannel(savedChannel) && !base.some((o) => o.value === savedChannel)) {
-      base.push({ value: savedChannel, label: savedChannel });
+      const platform = PlatformRegistry.platformOfChannel(savedChannel);
+      const label = platform ? PlatformRegistry.get(platform).label : savedChannel;
+      base.push({ value: savedChannel, label });
     }
     return base;
   });
@@ -500,7 +502,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
           >
             <option value="none">{i18nService.t('scheduledTasksFormNotifyChannelNone')}</option>
             {channelOptions.map((channel) => {
-              const unsupported = channel.value === 'openclaw-weixin' || channel.value === 'qqbot' || channel.value === 'netease-bee';
+              const unsupported = channel.value === 'openclaw-weixin' || channel.value === 'qqbot';
               return (
                 <option key={channel.value} value={channel.value} disabled={unsupported}>
                   {unsupported


### PR DESCRIPTION
- Use PlatformRegistry.platformOfChannel() for channel→config key mapping instead of hardcoded if-else, fixing WeCom and POPO never appearing
- Handle multi-instance enabled check for DingTalk/Feishu/QQ whose config has no top-level enabled field (check instances[].enabled instead)
- Resolve saved channel to platform label when editing tasks, preventing raw channel values like "wecom-openclaw-plugin" from showing in the dropdown
- Remove netease-bee from unsupported channel list