### PR TITLE
feat: 增强LobsterAI卸载时的用户体验，同EasyClaw卸载流程

### DIFF
--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -84,8 +84,58 @@
 
 !macro customUnInstall
   ; ─── Remove Windows Defender Exclusion on uninstall ───
-  ; Clean up the exclusion we added during installation.
   nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "try { Remove-MpPreference -ExclusionPath $\"$INSTDIR\resources\cfmind$\" -ErrorAction SilentlyContinue } catch {}"'
   Pop $0
   Pop $1
+
+  ; ─── Clean up AppData directories ───
+  ; electron-builder's deleteAppDataOnUninstall may not clean everything
+  ; Manually ensure LobsterAI folder in AppData/Roaming is removed
+  RMDir /r "$APPDATA\LobsterAI"
+  RMDir /r "$LOCALAPPDATA\LobsterAI"
+
+  ; ─── Force complete installation directory removal ───
+  Sleep 500
+  RMDir /r "$INSTDIR"
+!macroend
+
+; ─── Uninstaller initialization macro ───
+; This runs BEFORE any files are deleted, right when user clicks uninstall
+; Using customUnInit macro instead of un.onInit function to avoid conflict
+; with electron-builder's built-in uninstaller scripts
+!macro customUnInit
+  ; Check if app is running and prompt user
+  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "if (Get-Process -Name $\"${APP_FILENAME}$\" -ErrorAction SilentlyContinue) { exit 1 } else { exit 0 }"'
+  Pop $0
+  Pop $1
+  
+  ; Exit code 1 means process is running
+  StrCmp $0 "1" 0 Done
+  
+  ; App is running - show concise prompt
+  MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+    "LobsterAI 正在运行。$\r$\n点击【确定】关闭。" \
+    IDOK CloseApp IDCANCEL Cancel
+  
+  CloseApp:
+    ; User confirmed - close the application
+    nsExec::ExecToLog 'taskkill /IM "${PRODUCT_FILENAME}.exe" /F /T'
+    Pop $0
+    Sleep 1500
+    
+    ; Verify termination
+    nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "if (Get-Process -Name $\"${APP_FILENAME}$\" -ErrorAction SilentlyContinue) { exit 1 } else { exit 0 }"'
+    Pop $0
+    Pop $1
+    StrCmp $0 "1" 0 Done
+    
+    ; Still running - abort
+    MessageBox MB_OK|MB_ICONEXCLAMATION \
+      "无法关闭 LobsterAI,请手动关闭后重试。"
+    Abort
+  
+  Cancel:
+    Abort
+    
+  Done:
 !macroend


### PR DESCRIPTION
###  概述
- 改进 Windows NSIS 卸载程序，完整清理用户数据并优雅处理正在运行的应用

 ### 改动内容
 卸载清理增强
- **AppData 清理**：卸载时删除 `%APPDATA%\LobsterAI` 和 `%LOCALAPPDATA%\LobsterAI` 目录，因为 electron-builder 的 `deleteAppDataOnUninstall` 可能无法完全清理
- **强制目录删除**：确保安装目录 `$INSTDIR` 被完全移除
 运行检测（`customUnInit` 宏）
- 在卸载开始前检测 LobsterAI 是否正在运行
- 显示提示框询问用户是否关闭应用
- 用户确认后使用 `taskkill /F /T` 自动终止应用
- 验证进程是否成功终止，若无法关闭则中止卸载
- 避免卸载时出现"文件被占用"错误
 ### 背景
之前在 Windows 上卸载 LobsterAI 可能会：
1. 在 AppData 目录留下残留文件
2. 应用运行时卸载静默失败
3. 导致不完整的清理，需要手动删除
 ### 测试项
- [x] 在 Windows 上安装 LobsterAI
- [x] 应用关闭时运行卸载程序 - 验证完全清理
- [x] 应用运行时运行卸载程序 - 验证提示框出现且应用被关闭
- [x] 检查 AppData 文件夹是否被删除
- [x] 验证安装目录是否被完全移除

Closed #1173 