### PR TITLE
fix(sqlite): use atomic tmp+rename write to prevent database corruption

### DIFF
--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -54,6 +54,21 @@ export class SqliteStore {
     const SQL = await SqliteStore.sqlPromise;
 
     // Load existing database or create new one
+    // Clean up any leftover .tmp-* files from a previous crash that occurred
+    // between writeFileSync(tmpPath) and renameSync(tmpPath, dbPath).
+    const dbDir = path.dirname(dbPath);
+    const dbBasename = path.basename(dbPath);
+    try {
+      const entries = fs.readdirSync(dbDir);
+      for (const entry of entries) {
+        if (entry.startsWith(`${dbBasename}.tmp-`)) {
+          fs.rmSync(path.join(dbDir, entry), { force: true });
+        }
+      }
+    } catch {
+      // Non-fatal: orphaned tmp files are harmless beyond wasting disk space.
+    }
+
     let db: Database;
     if (fs.existsSync(dbPath)) {
       const buffer = fs.readFileSync(dbPath);
@@ -304,7 +319,13 @@ export class SqliteStore {
   save() {
     const data = this.db.export();
     const buffer = Buffer.from(data);
-    fs.writeFileSync(this.dbPath, buffer);
+    // Write to a temporary file first, then atomically rename it over the
+    // destination. On POSIX this is guaranteed atomic; on NTFS, MoveFileEx
+    // with MOVEFILE_REPLACE_EXISTING is also atomic for same-volume moves.
+    // This prevents a corrupt database file if the process is killed mid-write.
+    const tmpPath = `${this.dbPath}.tmp-${crypto.randomUUID()}`;
+    fs.writeFileSync(tmpPath, buffer);
+    fs.renameSync(tmpPath, this.dbPath);
   }
 
   onDidChange<T = unknown>(key: string, callback: (newValue: T | undefined, oldValue: T | undefined) => void) {


### PR DESCRIPTION
## 问题

关联 Issue：#1273

`SqliteStore.save()` 直接调用 `fs.writeFileSync()` 将整个数据库覆盖写入目标文件。如果进程在写入过程中被 kill 或系统崩溃，数据库文件会处于半写状态——**永久损坏，无法恢复**。

```typescript
// 修复前：非原子写入，进程崩溃时数据库文件损坏
save() {
  const data = this.db.export();
  const buffer = Buffer.from(data);
  fs.writeFileSync(this.dbPath, buffer);  // ← 危险
}
```

## 修复方案

将写入改为**原子的两步操作**：先写临时文件，再 `rename` 覆盖目标：

```typescript
// 修复后：原子写入
save() {
  const data = this.db.export();
  const buffer = Buffer.from(data);
  const tmpPath = `${this.dbPath}.tmp-${crypto.randomUUID()}`;
  fs.writeFileSync(tmpPath, buffer);   // 写临时文件
  fs.renameSync(tmpPath, this.dbPath); // 原子替换
}
```

- **POSIX**：`rename(2)` 由标准保证原子性
- **Windows NTFS**：同卷 `MoveFileEx` + `MOVEFILE_REPLACE_EXISTING` 也是原子操作

数据库文件永远不会处于可观察的中间状态。

## 额外：启动时清理孤立 tmp 文件

如果进程恰好在 `writeFileSync(tmpPath)` 之后、`renameSync` 之前崩溃，会留下孤立的 `.tmp-*` 文件。在 `create()` 中增加了启动时的清理逻辑，避免长期积累。

## 变更范围

仅修改 `src/main/sqliteStore.ts`，**无破坏性变更**：
- `save()` 的公共签名不变
- `getSaveFunction()` 返回的函数语义不变
- 所有调用方无需修改

## 与 #1273 的关系

本 PR 解决 #1273 中描述的**数据库损坏风险**（非原子写入）。

WASM 线性内存崩溃（`memory access out of bounds`）是独立问题，需要迁移至 `node:sqlite`，属于更大范围的重构，不在本 PR 范围内。PR #1193 中的 debounce 优化与本修复正交，可独立合并。