### PR TITLE
fix: 修复请求安全性问题

### DIFF
--- a/src/main/libs/openclawTokenProxy.ts
+++ b/src/main/libs/openclawTokenProxy.ts
@@ -67,10 +67,22 @@ export function getOpenClawTokenProxyPort(): number | null {
   return proxyPort;
 }
 
+const MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024; // 10 MB
+
 function collectRequestBody(req: http.IncomingMessage): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    let totalBytes = 0;
+
+    req.on('data', (chunk: Buffer) => {
+      totalBytes += chunk.byteLength;
+      if (totalBytes > MAX_REQUEST_BODY_BYTES) {
+        req.destroy();
+        reject(new Error(`Request body too large (limit: ${MAX_REQUEST_BODY_BYTES} bytes)`));
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on('end', () => resolve(Buffer.concat(chunks)));
     req.on('error', reject);
   });

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -21,8 +21,8 @@ export class ApiError extends Error {
   }
 }
 
-// 生成唯一的请求 ID
-const generateRequestId = () => `req_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+// 生成唯一的请求 ID（使用加密安全的 crypto.randomUUID()）
+const generateRequestId = () => `req_${crypto.randomUUID()}`;
 
 class ApiService {
   private config: ApiConfig | null = null;


### PR DESCRIPTION
[问题]
请求 ID 用于识别 SSE 流式请求，如果可被预测，攻击者可能订阅其他用户的数据流

[根因]
Math.random() 是伪随机数，不具备密码学安全性

[修复]
crypto.randomUUID() 生成符合 RFC 4122 的 UUID v4，由操作系统级 CSPRNG（加密安全伪随机数生成器）提供，不可预测