### PR TITLE
fix(cowork): keep all files from multi-select attachment picker (#1384)

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -9,7 +9,7 @@ import FolderSelectorPopover from './FolderSelectorPopover';
 import { SkillsButton, ActiveSkillBadge } from '../skills';
 import { i18nService } from '../../services/i18n';
 import { skillService } from '../../services/skill';
-import { RootState } from '../../store';
+import { RootState, store } from '../../store';
 import { setDraftPrompt, setDraftAttachments, clearDraftAttachments, type DraftAttachment } from '../../store/slices/coworkSlice';
 import { setSkills, toggleActiveSkill } from '../../store/slices/skillSlice';
 import { Skill } from '../../types/skill';
@@ -331,7 +331,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
 
   const addAttachment = useCallback((filePath: string, imageInfo?: { isImage: boolean; dataUrl?: string }) => {
     if (!filePath) return;
-    const current = attachments;
+    const current = (store.getState().cowork.draftAttachments[draftKey] || []) as CoworkAttachment[];
     if (current.some((attachment) => attachment.path === filePath)) return;
     dispatch(setDraftAttachments({
       draftKey,
@@ -342,21 +342,22 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         dataUrl: imageInfo?.dataUrl,
       }],
     }));
-  }, [attachments, dispatch, draftKey]);
+  }, [dispatch, draftKey]);
 
   const addImageAttachmentFromDataUrl = useCallback((name: string, dataUrl: string) => {
     // Use the dataUrl as the unique key (no file path for inline images)
     const pseudoPath = `inline:${name}:${Date.now()}`;
+    const current = (store.getState().cowork.draftAttachments[draftKey] || []) as CoworkAttachment[];
     dispatch(setDraftAttachments({
       draftKey,
-      attachments: [...attachments, {
+      attachments: [...current, {
         path: pseudoPath,
         name,
         isImage: true,
         dataUrl,
       }],
     }));
-  }, [attachments, dispatch, draftKey]);
+  }, [dispatch, draftKey]);
 
   const fileToDataUrl = useCallback((file: File): Promise<string> => {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Problem
Choosing multiple files in one dialog only showed the last file (#1384). `addAttachment` closed over the same `attachments` array for every synchronous call in the loop, so each dispatch replaced the list with a single new item.

## Fix
Read the current draft attachment list from `store.getState()` immediately before each append (same pattern as functional updates).

Closes https://github.com/netease-youdao/LobsterAI/issues/1384

Made with [Cursor](https://cursor.com)