### PR TITLE
feat(scheduledTasks): 定时任务创建界面时间控件优化

### DIFF
--- a/src/renderer/components/scheduledTasks/CustomSelect.tsx
+++ b/src/renderer/components/scheduledTasks/CustomSelect.tsx
@@ -1,0 +1,201 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { ChevronDownIcon } from '@heroicons/react/24/outline';
+
+interface SelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+interface CustomSelectProps {
+  value: string;
+  options: SelectOption[];
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const CustomSelect: React.FC<CustomSelectProps> = ({
+  value,
+  options,
+  onChange,
+  disabled = false,
+  className = '',
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const selectedOption = options.find((o) => o.value === value);
+  const selectedIndex = options.findIndex((o) => o.value === value);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+      requestAnimationFrame(() => {
+        const list = listRef.current;
+        if (!list) return;
+        const selected = list.querySelector('[aria-selected="true"]');
+        if (selected) {
+          (selected as HTMLElement).scrollIntoView({ block: 'nearest' });
+        }
+      });
+    }
+  }, [isOpen, selectedIndex]);
+
+  const scrollHighlightedIntoView = useCallback((index: number) => {
+    requestAnimationFrame(() => {
+      const list = listRef.current;
+      if (!list) return;
+      const items = list.querySelectorAll('[role="option"]');
+      if (items[index]) {
+        (items[index] as HTMLElement).scrollIntoView({ block: 'nearest' });
+      }
+    });
+  }, []);
+
+  const findNextEnabledIndex = (from: number, direction: 1 | -1): number => {
+    let idx = from;
+    while (idx >= 0 && idx < options.length) {
+      if (!options[idx].disabled) return idx;
+      idx += direction;
+    }
+    return -1;
+  };
+
+  const handleSelect = (opt: SelectOption) => {
+    if (opt.disabled) return;
+    onChange(opt.value);
+    setIsOpen(false);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (disabled) return;
+
+    if (!isOpen) {
+      if (event.key === 'ArrowDown' || event.key === ' ') {
+        event.preventDefault();
+        setIsOpen(true);
+        return;
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        setIsOpen(true);
+        return;
+      }
+      return;
+    }
+
+    switch (event.key) {
+      case 'Escape':
+        event.preventDefault();
+        setIsOpen(false);
+        break;
+      case 'ArrowDown': {
+        event.preventDefault();
+        const next = findNextEnabledIndex(highlightedIndex + 1, 1);
+        if (next !== -1) {
+          setHighlightedIndex(next);
+          scrollHighlightedIntoView(next);
+        }
+        break;
+      }
+      case 'ArrowUp': {
+        event.preventDefault();
+        const prev = findNextEnabledIndex(highlightedIndex - 1, -1);
+        if (prev !== -1) {
+          setHighlightedIndex(prev);
+          scrollHighlightedIntoView(prev);
+        }
+        break;
+      }
+      case 'Enter':
+      case ' ': {
+        event.preventDefault();
+        const opt = options[highlightedIndex];
+        if (opt && !opt.disabled) {
+          handleSelect(opt);
+        }
+        break;
+      }
+    }
+  };
+
+  const itemClass = (index: number, opt: SelectOption) => {
+    const base = 'px-3 py-2 cursor-pointer select-none truncate';
+
+    if (opt.disabled) {
+      return `${base} text-secondary opacity-50 cursor-not-allowed`;
+    }
+
+    if (opt.value === value) {
+      return `${base} bg-primary/10 text-primary font-medium`;
+    }
+
+    if (index === highlightedIndex) {
+      return `${base} bg-surface-raised text-foreground`;
+    }
+
+    return `${base} text-foreground hover:bg-surface-raised`;
+  };
+
+  return (
+    <div className={`relative ${className}`} ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => !disabled && setIsOpen((prev) => !prev)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        className={`flex items-center justify-between w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 ${
+          disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+        }`}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+      >
+        <span className="truncate">{selectedOption?.label || value}</span>
+        <ChevronDownIcon
+          className={`h-4 w-4 ml-2 text-secondary transition-transform ${isOpen ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="absolute z-50 w-full mt-1 rounded-lg border border-border bg-surface shadow-popover popover-enter">
+          <ul
+            ref={listRef}
+            className="py-1 max-h-60 overflow-y-auto text-sm"
+            role="listbox"
+          >
+            {options.map((opt, index) => (
+              <li
+                key={opt.value}
+                role="option"
+                aria-selected={opt.value === value}
+                className={itemClass(index, opt)}
+                onMouseEnter={() => {
+                  if (!opt.disabled) setHighlightedIndex(index);
+                }}
+                onClick={() => handleSelect(opt)}
+              >
+                {opt.label}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CustomSelect;

--- a/src/renderer/components/scheduledTasks/DatePicker.tsx
+++ b/src/renderer/components/scheduledTasks/DatePicker.tsx
@@ -50,7 +50,7 @@ const DateSegment: React.FC<DateSegmentProps> = ({ value, min, max, width, padLe
     if (selectedItem) {
       selectedItem.scrollIntoView({ block: 'center' });
     }
-  }, [isOpen]);
+  }, [isOpen, value]);
 
   const commitValue = useCallback((raw: string) => {
     const parsed = parseInt(raw, 10);
@@ -67,8 +67,12 @@ const DateSegment: React.FC<DateSegmentProps> = ({ value, min, max, width, padLe
     const raw = e.target.value.replace(/\D/g, '');
     if (raw.length <= padLength) {
       setInputValue(raw);
+      const parsed = parseInt(raw, 10);
+      if (!Number.isNaN(parsed) && parsed >= min && parsed <= max) {
+        onChange(parsed);
+      }
     }
-  }, [padLength]);
+  }, [padLength, min, max, onChange]);
 
   const handleFocus = useCallback(() => {
     setIsFocused(true);

--- a/src/renderer/components/scheduledTasks/DatePicker.tsx
+++ b/src/renderer/components/scheduledTasks/DatePicker.tsx
@@ -136,7 +136,8 @@ const DateSegment: React.FC<DateSegmentProps> = ({ value, min, max, width, padLe
           onFocus={handleFocus}
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
-          className={`${width} bg-transparent px-1 py-2 text-sm text-foreground text-center focus:outline-none`}
+          onClick={() => setIsOpen(true)}
+          className={`${width} bg-transparent px-1 py-2 text-sm text-foreground text-center focus:outline-none cursor-pointer`}
         />
         <button
           type="button"

--- a/src/renderer/components/scheduledTasks/DatePicker.tsx
+++ b/src/renderer/components/scheduledTasks/DatePicker.tsx
@@ -1,24 +1,27 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 
-interface TimePickerProps {
-  hour: number;
-  minute: number;
-  second?: number;
-  showSeconds?: boolean;
-  onChange: (values: { hour: number; minute: number; second?: number }) => void;
+interface DatePickerProps {
+  year: number;
+  month: number;
+  day: number;
+  onChange: (values: { year: number; month: number; day: number }) => void;
   className?: string;
 }
 
-interface SegmentProps {
+interface DateSegmentProps {
   value: number;
+  min: number;
   max: number;
+  width: string;
+  padLength: number;
+  options?: { value: number; label: string }[];
   onChange: (value: number) => void;
 }
 
-const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
+const DateSegment: React.FC<DateSegmentProps> = ({ value, min, max, width, padLength, options, onChange }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [inputValue, setInputValue] = useState(String(value).padStart(2, '0'));
+  const [inputValue, setInputValue] = useState(String(value).padStart(padLength, '0'));
   const [isFocused, setIsFocused] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -26,9 +29,9 @@ const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
 
   useEffect(() => {
     if (!isFocused) {
-      setInputValue(String(value).padStart(2, '0'));
+      setInputValue(String(value).padStart(padLength, '0'));
     }
-  }, [value, isFocused]);
+  }, [value, isFocused, padLength]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -52,20 +55,20 @@ const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
   const commitValue = useCallback((raw: string) => {
     const parsed = parseInt(raw, 10);
     if (!Number.isNaN(parsed)) {
-      const clamped = Math.max(0, Math.min(max, parsed));
+      const clamped = Math.max(min, Math.min(max, parsed));
       onChange(clamped);
-      setInputValue(String(clamped).padStart(2, '0'));
+      setInputValue(String(clamped).padStart(padLength, '0'));
     } else {
-      setInputValue(String(value).padStart(2, '0'));
+      setInputValue(String(value).padStart(padLength, '0'));
     }
-  }, [max, onChange, value]);
+  }, [min, max, onChange, value, padLength]);
 
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value.replace(/\D/g, '');
-    if (raw.length <= 2) {
+    if (raw.length <= padLength) {
       setInputValue(raw);
     }
-  }, []);
+  }, [padLength]);
 
   const handleFocus = useCallback(() => {
     setIsFocused(true);
@@ -80,37 +83,23 @@ const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'ArrowUp') {
       e.preventDefault();
-      const next = value >= max ? 0 : value + 1;
+      const next = value >= max ? min : value + 1;
       onChange(next);
-      setInputValue(String(next).padStart(2, '0'));
+      setInputValue(String(next).padStart(padLength, '0'));
     } else if (e.key === 'ArrowDown') {
       e.preventDefault();
-      const next = value <= 0 ? max : value - 1;
+      const next = value <= min ? max : value - 1;
       onChange(next);
-      setInputValue(String(next).padStart(2, '0'));
+      setInputValue(String(next).padStart(padLength, '0'));
     } else if (e.key === 'Enter') {
       e.preventDefault();
       commitValue(inputValue);
       setIsOpen((prev) => !prev);
     } else if (e.key === 'Escape') {
       setIsOpen(false);
-      setInputValue(String(value).padStart(2, '0'));
+      setInputValue(String(value).padStart(padLength, '0'));
     }
-  }, [value, max, onChange, inputValue, commitValue]);
-
-  const handleWheel = useCallback((e: React.WheelEvent) => {
-    if (isOpen) return;
-    e.preventDefault();
-    if (e.deltaY < 0) {
-      const next = value >= max ? 0 : value + 1;
-      onChange(next);
-      setInputValue(String(next).padStart(2, '0'));
-    } else {
-      const next = value <= 0 ? max : value - 1;
-      onChange(next);
-      setInputValue(String(next).padStart(2, '0'));
-    }
-  }, [isOpen, value, max, onChange]);
+  }, [value, min, max, onChange, padLength, inputValue, commitValue]);
 
   const handleToggleDropdown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -121,14 +110,15 @@ const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
 
   const handleSelectValue = useCallback((v: number) => {
     onChange(v);
-    setInputValue(String(v).padStart(2, '0'));
+    setInputValue(String(v).padStart(padLength, '0'));
     setIsOpen(false);
     inputRef.current?.focus();
-  }, [onChange]);
+  }, [onChange, padLength]);
 
-  const handleListWheel = useCallback((e: React.WheelEvent) => {
-    e.stopPropagation();
-  }, []);
+  const items = options || Array.from({ length: max - min + 1 }, (_, i) => ({
+    value: min + i,
+    label: String(min + i).padStart(padLength, '0'),
+  }));
 
   return (
     <div ref={containerRef} className="relative">
@@ -136,14 +126,13 @@ const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
         <input
           ref={inputRef}
           type="text"
-          maxLength={2}
+          maxLength={padLength}
           value={inputValue}
           onChange={handleInputChange}
           onFocus={handleFocus}
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
-          onWheel={handleWheel}
-          className="w-9 bg-transparent px-1 py-2 text-sm text-foreground text-center focus:outline-none"
+          className={`${width} bg-transparent px-1 py-2 text-sm text-foreground text-center focus:outline-none`}
         />
         <button
           type="button"
@@ -157,24 +146,23 @@ const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
       {isOpen && (
         <div
           ref={listRef}
-          onWheel={handleListWheel}
           className="absolute z-50 mt-1 w-full max-h-[200px] overflow-y-auto rounded-lg border border-border bg-surface shadow-popover popover-enter"
         >
-          {Array.from({ length: max + 1 }, (_, i) => (
+          {items.map((item) => (
             <div
-              key={i}
-              data-selected={i === value ? 'true' : undefined}
+              key={item.value}
+              data-selected={item.value === value ? 'true' : undefined}
               onMouseDown={(e) => {
                 e.preventDefault();
-                handleSelectValue(i);
+                handleSelectValue(item.value);
               }}
               className={`px-2 py-1.5 text-sm text-center cursor-pointer select-none ${
-                i === value
+                item.value === value
                   ? 'bg-primary/10 text-primary font-medium'
                   : 'text-foreground hover:bg-surface-raised'
               }`}
             >
-              {String(i).padStart(2, '0')}
+              {item.label}
             </div>
           ))}
         </div>
@@ -183,39 +171,83 @@ const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
   );
 };
 
-const TimePicker: React.FC<TimePickerProps> = ({
-  hour,
-  minute,
-  second = 0,
-  showSeconds = false,
+function daysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate();
+}
+
+const MONTH_OPTIONS = Array.from({ length: 12 }, (_, i) => ({
+  value: i + 1,
+  label: String(i + 1).padStart(2, '0'),
+}));
+
+const DatePicker: React.FC<DatePickerProps> = ({
+  year,
+  month,
+  day,
   onChange,
   className,
 }) => {
-  const handleHourChange = useCallback((newHour: number) => {
-    onChange({ hour: newHour, minute, ...(showSeconds ? { second } : {}) });
-  }, [minute, second, showSeconds, onChange]);
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const maxDay = daysInMonth(year, month);
 
-  const handleMinuteChange = useCallback((newMinute: number) => {
-    onChange({ hour, minute: newMinute, ...(showSeconds ? { second } : {}) });
-  }, [hour, second, showSeconds, onChange]);
+  const yearOptions = Array.from({ length: 10 }, (_, i) => ({
+    value: currentYear + i,
+    label: String(currentYear + i),
+  }));
 
-  const handleSecondChange = useCallback((newSecond: number) => {
-    onChange({ hour, minute, second: newSecond });
-  }, [hour, minute, onChange]);
+  const dayOptions = Array.from({ length: maxDay }, (_, i) => ({
+    value: i + 1,
+    label: String(i + 1).padStart(2, '0'),
+  }));
+
+  const handleYearChange = useCallback((newYear: number) => {
+    const newMaxDay = daysInMonth(newYear, month);
+    onChange({ year: newYear, month, day: Math.min(day, newMaxDay) });
+  }, [month, day, onChange]);
+
+  const handleMonthChange = useCallback((newMonth: number) => {
+    const newMaxDay = daysInMonth(year, newMonth);
+    onChange({ year, month: newMonth, day: Math.min(day, newMaxDay) });
+  }, [year, day, onChange]);
+
+  const handleDayChange = useCallback((newDay: number) => {
+    onChange({ year, month, day: newDay });
+  }, [year, month, onChange]);
 
   return (
     <div className={`flex items-center gap-1 ${className ?? ''}`}>
-      <TimeSegment value={hour} max={23} onChange={handleHourChange} />
-      <span className="text-sm text-secondary font-medium">:</span>
-      <TimeSegment value={minute} max={59} onChange={handleMinuteChange} />
-      {showSeconds && (
-        <>
-          <span className="text-sm text-secondary font-medium">:</span>
-          <TimeSegment value={second} max={59} onChange={handleSecondChange} />
-        </>
-      )}
+      <DateSegment
+        value={year}
+        min={currentYear}
+        max={currentYear + 9}
+        width="w-12"
+        padLength={4}
+        options={yearOptions}
+        onChange={handleYearChange}
+      />
+      <span className="text-sm text-secondary font-medium">/</span>
+      <DateSegment
+        value={month}
+        min={1}
+        max={12}
+        width="w-9"
+        padLength={2}
+        options={MONTH_OPTIONS}
+        onChange={handleMonthChange}
+      />
+      <span className="text-sm text-secondary font-medium">/</span>
+      <DateSegment
+        value={day}
+        min={1}
+        max={maxDay}
+        width="w-9"
+        padLength={2}
+        options={dayOptions}
+        onChange={handleDayChange}
+      />
     </div>
   );
 };
 
-export default TimePicker;
+export default DatePicker;

--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -9,6 +9,8 @@ import type {
 } from '../../../scheduledTask/types';
 import { formatScheduleLabel, type PlanType, scheduleToPlanInfo } from './utils';
 import { PlatformRegistry } from '@shared/platform';
+import CustomSelect from './CustomSelect';
+import TimePicker from './TimePicker';
 
 interface TaskFormProps {
   mode: 'create' | 'edit';
@@ -253,14 +255,6 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
   const labelClass = 'block text-sm font-medium text-foreground mb-1';
   const errorClass = 'text-xs text-red-500 mt-1';
 
-  const timeValue = `${String(form.hour).padStart(2, '0')}:${String(form.minute).padStart(2, '0')}`;
-  const handleTimeChange = (value: string) => {
-    const [h, m] = value.split(':').map(Number);
-    if (!Number.isNaN(h) && !Number.isNaN(m)) {
-      updateForm({ hour: h, minute: m });
-    }
-  };
-
   const renderScheduleRow = () => {
     if (isAdvanced) {
       return (
@@ -279,21 +273,21 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
     }
 
     const planSelect = (
-      <select
+      <CustomSelect
         value={form.planType}
-        onChange={(event) => updateForm({ planType: event.target.value as PlanType })}
-        className={`${inputClass} flex-1 min-w-0`}
-      >
-        <option value="once">{i18nService.t('scheduledTasksFormScheduleModeOnce')}</option>
-        <option value="daily">{i18nService.t('scheduledTasksFormScheduleModeDaily')}</option>
-        <option value="weekly">{i18nService.t('scheduledTasksFormScheduleModeWeekly')}</option>
-        <option value="monthly">{i18nService.t('scheduledTasksFormScheduleModeMonthly')}</option>
-      </select>
+        options={[
+          { value: 'once', label: i18nService.t('scheduledTasksFormScheduleModeOnce') },
+          { value: 'daily', label: i18nService.t('scheduledTasksFormScheduleModeDaily') },
+          { value: 'weekly', label: i18nService.t('scheduledTasksFormScheduleModeWeekly') },
+          { value: 'monthly', label: i18nService.t('scheduledTasksFormScheduleModeMonthly') },
+        ]}
+        onChange={(v) => updateForm({ planType: v as PlanType })}
+        className="flex-1 min-w-0"
+      />
     );
 
     if (form.planType === 'once') {
       const dateValue = `${form.year}-${String(form.month).padStart(2, '0')}-${String(form.day).padStart(2, '0')}`;
-      const fullTimeValue = `${timeValue}:${String(form.second).padStart(2, '0')}`;
       return (
         <div>
           <label className={labelClass}>{i18nService.t('scheduledTasksFormScheduleType')}</label>
@@ -308,19 +302,13 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
               }}
               className={`${inputClass} flex-1 min-w-0`}
             />
-            <input
-              type="time"
-              step="1"
-              value={fullTimeValue}
-              onChange={(e) => {
-                const parts = e.target.value.split(':').map(Number);
-                const patch: Partial<FormState> = {};
-                if (!Number.isNaN(parts[0])) patch.hour = parts[0];
-                if (!Number.isNaN(parts[1])) patch.minute = parts[1];
-                if (parts.length > 2 && !Number.isNaN(parts[2])) patch.second = parts[2];
-                updateForm(patch);
-              }}
-              className={`${inputClass} flex-1 min-w-0`}
+            <TimePicker
+              hour={form.hour}
+              minute={form.minute}
+              second={form.second}
+              showSeconds
+              onChange={(v) => updateForm({ hour: v.hour, minute: v.minute, second: v.second ?? form.second })}
+              className="flex-1 min-w-0"
             />
           </div>
         </div>
@@ -333,11 +321,11 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
           <label className={labelClass}>{i18nService.t('scheduledTasksFormScheduleType')}</label>
           <div className="flex items-center gap-3">
             {planSelect}
-            <input
-              type="time"
-              value={timeValue}
-              onChange={(e) => handleTimeChange(e.target.value)}
-              className={`${inputClass} flex-1 min-w-0`}
+            <TimePicker
+              hour={form.hour}
+              minute={form.minute}
+              onChange={(v) => updateForm({ hour: v.hour, minute: v.minute })}
+              className="flex-1 min-w-0"
             />
           </div>
         </div>
@@ -350,20 +338,20 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
           <label className={labelClass}>{i18nService.t('scheduledTasksFormScheduleType')}</label>
           <div className="flex items-center gap-3">
             {planSelect}
-            <select
-              value={form.weekday}
-              onChange={(e) => updateForm({ weekday: Number(e.target.value) })}
-              className={`${inputClass} flex-1 min-w-0`}
-            >
-              {WEEKDAY_KEYS.map((key, idx) => (
-                <option key={idx} value={idx}>{i18nService.t(key)}</option>
-              ))}
-            </select>
-            <input
-              type="time"
-              value={timeValue}
-              onChange={(e) => handleTimeChange(e.target.value)}
-              className={`${inputClass} flex-1 min-w-0`}
+            <CustomSelect
+              value={String(form.weekday)}
+              options={WEEKDAY_KEYS.map((key, idx) => ({
+                value: String(idx),
+                label: i18nService.t(key),
+              }))}
+              onChange={(v) => updateForm({ weekday: Number(v) })}
+              className="flex-1 min-w-0"
+            />
+            <TimePicker
+              hour={form.hour}
+              minute={form.minute}
+              onChange={(v) => updateForm({ hour: v.hour, minute: v.minute })}
+              className="flex-1 min-w-0"
             />
           </div>
         </div>
@@ -375,22 +363,20 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
         <label className={labelClass}>{i18nService.t('scheduledTasksFormScheduleType')}</label>
         <div className="flex items-center gap-3">
           {planSelect}
-          <select
-            value={form.monthDay}
-            onChange={(e) => updateForm({ monthDay: Number(e.target.value) })}
-            className={`${inputClass} flex-1 min-w-0`}
-          >
-            {Array.from({ length: 31 }, (_, i) => i + 1).map((d) => (
-              <option key={d} value={d}>
-                {d}{i18nService.t('scheduledTasksFormMonthDaySuffix')}
-              </option>
-            ))}
-          </select>
-          <input
-            type="time"
-            value={timeValue}
-            onChange={(e) => handleTimeChange(e.target.value)}
-            className={`${inputClass} flex-1 min-w-0`}
+          <CustomSelect
+            value={String(form.monthDay)}
+            options={Array.from({ length: 31 }, (_, i) => ({
+              value: String(i + 1),
+              label: `${i + 1}${i18nService.t('scheduledTasksFormMonthDaySuffix')}`,
+            }))}
+            onChange={(v) => updateForm({ monthDay: Number(v) })}
+            className="flex-1 min-w-0"
+          />
+          <TimePicker
+            hour={form.hour}
+            minute={form.minute}
+            onChange={(v) => updateForm({ hour: v.hour, minute: v.minute })}
+            className="flex-1 min-w-0"
           />
         </div>
       </div>
@@ -402,42 +388,41 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
       <div>
         <label className={labelClass}>{i18nService.t('scheduledTasksFormNotifyChannel')}</label>
         <div className="flex items-center gap-3">
-          <select
+          <CustomSelect
             value={form.notifyChannel}
-            onChange={(event) => updateForm({ notifyChannel: event.target.value, notifyTo: '' })}
-            className={`${inputClass} ${showConversationSelector ? 'flex-1 min-w-0' : ''}`}
-          >
-            <option value="none">{i18nService.t('scheduledTasksFormNotifyChannelNone')}</option>
-            {channelOptions.map((channel) => {
-              const unsupported = channel.value === 'openclaw-weixin' || channel.value === 'qqbot' || channel.value === 'netease-bee';
-              return (
-                <option key={channel.value} value={channel.value} disabled={unsupported}>
-                  {unsupported
+            options={[
+              { value: 'none', label: i18nService.t('scheduledTasksFormNotifyChannelNone') },
+              ...channelOptions.map((channel) => {
+                const unsupported = channel.value === 'openclaw-weixin' || channel.value === 'qqbot' || channel.value === 'netease-bee';
+                return {
+                  value: channel.value,
+                  label: unsupported
                     ? `${channel.label} (${i18nService.t('scheduledTasksChannelUnsupported')})`
-                    : channel.label}
-                </option>
-              );
-            })}
-          </select>
+                    : channel.label,
+                  disabled: unsupported,
+                };
+              }),
+            ]}
+            onChange={(v) => updateForm({ notifyChannel: v, notifyTo: '' })}
+            className={showConversationSelector ? 'flex-1 min-w-0' : ''}
+          />
           {showConversationSelector && (
-            <select
+            <CustomSelect
               value={form.notifyTo}
-              onChange={(event) => updateForm({ notifyTo: event.target.value })}
+              options={
+                conversationsLoading
+                  ? [{ value: '', label: i18nService.t('scheduledTasksFormNotifyConversationLoading') }]
+                  : conversations.length === 0
+                    ? [{ value: '', label: i18nService.t('scheduledTasksFormNotifyConversationNone') }]
+                    : conversations.map((conv) => ({
+                        value: conv.conversationId,
+                        label: conv.conversationId,
+                      }))
+              }
+              onChange={(v) => updateForm({ notifyTo: v })}
               disabled={conversationsLoading}
-              className={`${inputClass} flex-1 min-w-0`}
-            >
-              {conversationsLoading ? (
-                <option value="">{i18nService.t('scheduledTasksFormNotifyConversationLoading')}</option>
-              ) : conversations.length === 0 ? (
-                <option value="">{i18nService.t('scheduledTasksFormNotifyConversationNone')}</option>
-              ) : (
-                conversations.map((conv) => (
-                  <option key={conv.conversationId} value={conv.conversationId}>
-                    {conv.conversationId}
-                  </option>
-                ))
-              )}
-            </select>
+              className="flex-1 min-w-0"
+            />
           )}
         </div>
       </div>

--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -10,6 +10,7 @@ import type {
 import { formatScheduleLabel, type PlanType, scheduleToPlanInfo } from './utils';
 import { PlatformRegistry } from '@shared/platform';
 import CustomSelect from './CustomSelect';
+import DatePicker from './DatePicker';
 import TimePicker from './TimePicker';
 
 interface TaskFormProps {
@@ -287,20 +288,17 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
     );
 
     if (form.planType === 'once') {
-      const dateValue = `${form.year}-${String(form.month).padStart(2, '0')}-${String(form.day).padStart(2, '0')}`;
       return (
         <div>
           <label className={labelClass}>{i18nService.t('scheduledTasksFormScheduleType')}</label>
           <div className="flex items-center gap-3">
             {planSelect}
-            <input
-              type="date"
-              value={dateValue}
-              onChange={(e) => {
-                const [y, mo, d] = e.target.value.split('-').map(Number);
-                if (!Number.isNaN(y)) updateForm({ year: y, month: mo, day: d });
-              }}
-              className={`${inputClass} flex-1 min-w-0`}
+            <DatePicker
+              year={form.year}
+              month={form.month}
+              day={form.day}
+              onChange={(v) => updateForm({ year: v.year, month: v.month, day: v.day })}
+              className="flex-1 min-w-0"
             />
             <TimePicker
               hour={form.hour}

--- a/src/renderer/components/scheduledTasks/TimePicker.tsx
+++ b/src/renderer/components/scheduledTasks/TimePicker.tsx
@@ -47,7 +47,7 @@ const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
     if (selectedItem) {
       selectedItem.scrollIntoView({ block: 'center' });
     }
-  }, [isOpen]);
+  }, [isOpen, value]);
 
   const commitValue = useCallback((raw: string) => {
     const parsed = parseInt(raw, 10);
@@ -64,8 +64,12 @@ const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
     const raw = e.target.value.replace(/\D/g, '');
     if (raw.length <= 2) {
       setInputValue(raw);
+      const parsed = parseInt(raw, 10);
+      if (!Number.isNaN(parsed) && parsed >= 0 && parsed <= max) {
+        onChange(parsed);
+      }
     }
-  }, []);
+  }, [max, onChange]);
 
   const handleFocus = useCallback(() => {
     setIsFocused(true);

--- a/src/renderer/components/scheduledTasks/TimePicker.tsx
+++ b/src/renderer/components/scheduledTasks/TimePicker.tsx
@@ -147,7 +147,8 @@ const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           onWheel={handleWheel}
-          className="w-9 bg-transparent px-1 py-2 text-sm text-foreground text-center focus:outline-none"
+          onClick={() => setIsOpen(true)}
+          className="w-9 bg-transparent px-1 py-2 text-sm text-foreground text-center focus:outline-none cursor-pointer"
         />
         <button
           type="button"

--- a/src/renderer/components/scheduledTasks/TimePicker.tsx
+++ b/src/renderer/components/scheduledTasks/TimePicker.tsx
@@ -1,0 +1,215 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+
+interface TimePickerProps {
+  hour: number;
+  minute: number;
+  second?: number;
+  showSeconds?: boolean;
+  onChange: (values: { hour: number; minute: number; second?: number }) => void;
+  className?: string;
+}
+
+interface SegmentProps {
+  value: number;
+  max: number;
+  onChange: (value: number) => void;
+}
+
+const TimeSegment: React.FC<SegmentProps> = ({ value, max, onChange }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+        setIsEditing(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !listRef.current) return;
+    const selectedItem = listRef.current.querySelector('[data-selected="true"]');
+    if (selectedItem) {
+      selectedItem.scrollIntoView({ block: 'center' });
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const increment = useCallback(() => {
+    onChange(value >= max ? 0 : value + 1);
+  }, [value, max, onChange]);
+
+  const decrement = useCallback(() => {
+    onChange(value <= 0 ? max : value - 1);
+  }, [value, max, onChange]);
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    if (isOpen) return;
+    e.preventDefault();
+    if (e.deltaY < 0) {
+      increment();
+    } else {
+      decrement();
+    }
+  }, [isOpen, increment, decrement]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      increment();
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      decrement();
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      setIsOpen((prev) => !prev);
+    } else if (e.key === 'Escape') {
+      setIsOpen(false);
+    }
+  }, [increment, decrement]);
+
+  const handleClick = useCallback(() => {
+    if (!isEditing) {
+      setIsOpen((prev) => !prev);
+    }
+  }, [isEditing]);
+
+  const handleDoubleClick = useCallback(() => {
+    setIsOpen(false);
+    setIsEditing(true);
+  }, []);
+
+  const commitEdit = useCallback((raw: string) => {
+    setIsEditing(false);
+    const parsed = parseInt(raw, 10);
+    if (!Number.isNaN(parsed)) {
+      onChange(Math.max(0, Math.min(max, parsed)));
+    }
+  }, [max, onChange]);
+
+  const handleInputKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === 'Escape') {
+      e.preventDefault();
+      commitEdit(e.currentTarget.value);
+    }
+  }, [commitEdit]);
+
+  const handleInputBlur = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    commitEdit(e.currentTarget.value);
+  }, [commitEdit]);
+
+  const handleSelectValue = useCallback((v: number) => {
+    onChange(v);
+    setIsOpen(false);
+  }, [onChange]);
+
+  const handleListWheel = useCallback((e: React.WheelEvent) => {
+    e.stopPropagation();
+  }, []);
+
+  const display = String(value).padStart(2, '0');
+
+  if (isEditing) {
+    return (
+      <div ref={containerRef} className="relative">
+        <input
+          ref={inputRef}
+          type="text"
+          maxLength={2}
+          defaultValue={display}
+          onKeyDown={handleInputKeyDown}
+          onBlur={handleInputBlur}
+          className="w-12 rounded-lg border border-primary bg-surface px-1 py-2 text-sm text-foreground text-center focus:outline-none focus:ring-2 focus:ring-primary/50"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
+        onWheel={handleWheel}
+        onKeyDown={handleKeyDown}
+        className="w-12 rounded-lg border border-border bg-surface px-1 py-2 text-sm text-foreground text-center cursor-pointer hover:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/50 transition-colors"
+      >
+        {display}
+      </button>
+      {isOpen && (
+        <div
+          ref={listRef}
+          onWheel={handleListWheel}
+          className="absolute z-50 mt-1 w-16 max-h-[200px] overflow-y-auto rounded-lg border border-border bg-surface shadow-popover popover-enter"
+        >
+          {Array.from({ length: max + 1 }, (_, i) => (
+            <div
+              key={i}
+              data-selected={i === value ? 'true' : undefined}
+              onClick={() => handleSelectValue(i)}
+              className={`px-2 py-1.5 text-sm text-center cursor-pointer select-none ${
+                i === value
+                  ? 'bg-primary/10 text-primary font-medium'
+                  : 'text-foreground hover:bg-surface-raised'
+              }`}
+            >
+              {String(i).padStart(2, '0')}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const TimePicker: React.FC<TimePickerProps> = ({
+  hour,
+  minute,
+  second = 0,
+  showSeconds = false,
+  onChange,
+  className,
+}) => {
+  const handleHourChange = useCallback((newHour: number) => {
+    onChange({ hour: newHour, minute, ...(showSeconds ? { second } : {}) });
+  }, [minute, second, showSeconds, onChange]);
+
+  const handleMinuteChange = useCallback((newMinute: number) => {
+    onChange({ hour, minute: newMinute, ...(showSeconds ? { second } : {}) });
+  }, [hour, second, showSeconds, onChange]);
+
+  const handleSecondChange = useCallback((newSecond: number) => {
+    onChange({ hour, minute, second: newSecond });
+  }, [hour, minute, onChange]);
+
+  return (
+    <div className={`flex items-center gap-1 ${className ?? ''}`}>
+      <TimeSegment value={hour} max={23} onChange={handleHourChange} />
+      <span className="text-sm text-secondary font-medium">:</span>
+      <TimeSegment value={minute} max={59} onChange={handleMinuteChange} />
+      {showSeconds && (
+        <>
+          <span className="text-sm text-secondary font-medium">:</span>
+          <TimeSegment value={second} max={59} onChange={handleSecondChange} />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default TimePicker;


### PR DESCRIPTION
### 背景
定时任务创建界面存在两个交互问题
- 时间选择器：使用原生 <input type="time">，在 Electron（Chromium）中必须点击最右侧的时钟图标才能弹出系统时间选择器，无法直接点击数字区域进行选择或输入。
- 下拉选择器：周期类型（单次/每天/每周/每月）、星期、日期、通知渠道等均使用原生 select，其下拉面板样式由操作系统渲染，无法与应用的圆角、背景色、边框等主题风格对齐。
<img width="1151" height="702" alt="image" src="https://github.com/user-attachments/assets/d3a98466-2116-4548-a565-4eaa6786a3e0" />

### 改动内容
#### CustomSelect.tsx
- 替换所有原生 <select> 元素
- 点击触发器展开下拉面板，面板样式（rounded-lg、bg-surface、border-border、shadow-popover）与应用主题完全一致
- 支持键盘导航（↑↓ 选项、Enter 确认、Escape 关闭）
- 支持 disabled 选项（灰显且不可选）
- 选中项高亮（bg-primary/10），当前键盘焦点项区分高亮（bg-surface-raised）
- Chevron 图标打开时旋转 180°
#### TimePicker.tsx
- 替换所有原生 <input type="time"> 元素
- 显示为 [HH] : [MM] 或 [HH] : [MM] : [SS]（单次模式含秒）
- 点击数字输入框直接展开下拉滚动列表
- 支持直接键盘输入数字，失焦时自动校验并 clamp 到合法范围
- 输入数字时实时联动下拉列表选中项（自动滚动到对应位置）
- 支持鼠标滚轮在输入框上调值（到达边界自动回绕）
- 支持 ↑↓ 键逐步调值、Escape 关闭下拉
#### DatePicker.tsx
- 替换「单次」模式下的原生 <input type="date"> 元素
- 显示为 [YYYY] / [MM] / [DD] 三段独立输入框，交互方式与 TimePicker 一致
- 自动处理月份天数约束（如切换月份时日期超出范围自动 clamp）
- 年份下拉范围为当前年起 10 年
#### TaskForm.tsx
- 引入以上三个组件，替换原有的 6 处 <select> 和 4 处 <input type="time">、1 处 <input type="date">
- 移除不再需要的 timeValue 变量和 handleTimeChange 辅助函数
- 所有业务逻辑（buildScheduleInput、validate、handleSubmit、form state 管理）完全未改动

### 效果示意图
<img width="1163" height="637" alt="image" src="https://github.com/user-attachments/assets/118189a1-f805-4080-9638-6119bd402c12" />
