### PR TITLE
fix(scheduled-task): fallback notify channel list when IM filter is empty (#1329)

### DIFF
--- a/src/main/ipcHandlers/scheduledTask/helpers.ts
+++ b/src/main/ipcHandlers/scheduledTask/helpers.ts
@@ -29,7 +29,7 @@ export function listScheduledTaskChannels(): Array<{ value: string; label: strin
     }
   }
 
-  return PlatformRegistry.channelOptions().filter((option) => {
+  const filtered = PlatformRegistry.channelOptions().filter((option) => {
     if (option.value === 'dingtalk') {
       return enabledConfigKeys.has('dingtalk');
     }
@@ -41,4 +41,11 @@ export function listScheduledTaskChannels(): Array<{ value: string; label: strin
     }
     return enabledConfigKeys.has(option.value);
   });
+
+  // When IM config exists but nothing is enabled yet, filtering yields an empty list
+  // and the scheduled-task form only showed "do not notify" (#1329).
+  if (filtered.length === 0) {
+    return [...PlatformRegistry.channelOptions()];
+  }
+  return filtered;
 }


### PR DESCRIPTION
## Problem
With IM settings present but no platform toggled on, `listScheduledTaskChannels` returned `[]`, so the new-task notify dropdown had no IM entries (#1329).

## Fix
If the enabled-only filter is empty, return the same full `PlatformRegistry.channelOptions()` list as when config is missing. Unsupported channels remain disabled in the form where applicable.

Closes https://github.com/netease-youdao/LobsterAI/issues/1329

Made with [Cursor](https://cursor.com)