### PR TITLE
fix: OpenClaw Token Proxy 无请求体大小限制

### DIFF
--- a/src/main/libs/openclawTokenProxy.ts
+++ b/src/main/libs/openclawTokenProxy.ts
@@ -67,10 +67,23 @@ export function getOpenClawTokenProxyPort(): number | null {
   return proxyPort;
 }
 
+const MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024; // 10 MB
+
 function collectRequestBody(req: http.IncomingMessage): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    let totalBytes = 0;
+
+    req.on('data', (chunk: Buffer) => {
+      totalBytes += chunk.byteLength;
+      if (totalBytes > MAX_REQUEST_BODY_BYTES) {
+        req.destroy();
+        reject(new Error(`Request body too large (limit: ${MAX_REQUEST_BODY_BYTES} bytes)`));
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on('end', () => resolve(Buffer.concat(chunks)));
     req.on('error', reject);
   });


### PR DESCRIPTION
[问题]
没有对请求体大小做任何限制，恶意进程（或 OS 上的任何程序）可向本地代理发送超大请求导致内存耗尽（OOM）。尽管代理绑定到 127.0.0.1，但同机任何进程均可访问

[根因]
OpenClaw Token Proxy 无请求体大小限制

[修复]
在 collectRequestBody 函数前新增了常量 MAX_REQUEST_BODY_BYTES = 10MB，并在函数内部添加了实时字节计数和超限保护