### PR TITLE
fix: MCP Bridge Server 的 handleRequest 处理 Promise 返回

### DIFF
--- a/src/main/libs/mcpBridgeServer.ts
+++ b/src/main/libs/mcpBridgeServer.ts
@@ -107,7 +107,13 @@ export class McpBridgeServer {
 
     return new Promise((resolve, reject) => {
       const srv = http.createServer((req, res) => {
-        this.handleRequest(req, res);
+        this.handleRequest(req, res).catch((err) => {
+          log('ERROR', `Unhandled request error: ${err instanceof Error ? err.message : String(err)}`);
+          if (!res.headersSent) {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Internal server error' }));
+          }
+        });
       });
 
       srv.on('error', (err) => {


### PR DESCRIPTION
[问题]
MCP Bridge Server 的 handleRequest 忽略了 Promise 返回

[根因]
handleRequest 是 async 函数，但回调中没有 await，也没有 .catch()。如果函数内部抛出未捕获的 Promise rejection，会导致未处理的异步错误，在 Node.js 中可能崩溃或造成连接永远挂起

[修复]
处理 Promise 链式请求各种情况