### PR TITLE
  fix(sqlite): move migration completion flag inside transaction success path

### DIFF
--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -453,12 +453,11 @@ export class SqliteStore {
       }
 
       this.db.run('COMMIT;');
+      this.set(USER_MEMORIES_MIGRATION_KEY, '1');
     } catch (error) {
       this.db.run('ROLLBACK;');
       console.warn('Failed to migrate legacy MEMORY.md entries:', error);
     }
-
-    this.set(USER_MEMORIES_MIGRATION_KEY, '1');
   }
 
   private migrateFromElectronStore(userDataPath: string) {


### PR DESCRIPTION
  ## Summary
  - 将迁移完成标志 `USER_MEMORIES_MIGRATION_KEY` 的设置从 try-catch 块外移至 `COMMIT` 之后（try 块内），确保只有事务成功提交才标记迁移完成

  ## 修复内容


[问题]
migrateLegacyMemoryFileToUserMemories() 中，迁移完成标志
USER_MEMORIES_MIGRATION_KEY 在 try-catch 块之外被无条件设置。 当事务因异常回滚后，该标志仍然被写入，导致后续启动时
跳过迁移，MEMORY.md 中的历史记忆条目永远无法迁移到
user_memories 数据库表。

[根因]
`this.set(USER_MEMORIES_MIGRATION_KEY, '1')` 位于 try-catch 块之后，不受事务成功与否的约束。

[修复]
将完成标志的设置移至 COMMIT 之后、catch 之前（try 块内），
确保只有事务成功提交后才标记迁移完成。

[复现路径]
1. 准备一个包含多条记忆的 MEMORY.md 文件
2. 在迁移插入过程中模拟异常（如数据库约束冲突）
3. 观察事务回滚后 USER_MEMORIES_MIGRATION_KEY 仍被设为 '1'
4. 重启应用，迁移不再执行，记忆条目丢失

Closes #622