### PR TITLE
fix(im): 修复 NIM 群组类型枚举值映射错误

### DIFF
--- a/src/main/im/nimGateway.ts
+++ b/src/main/im/nimGateway.ts
@@ -914,7 +914,8 @@ export class NimGateway extends EventEmitter {
         : senderId;
       // For team messages, fetch the real group name via V2NIMTeamService.
       // conversationId format: {appId}|{type}|{teamId}, type=2 for team, 3 for superTeam.
-      const teamTypeNum = sessionType === 'superTeam' ? 2 : 1;
+      // V2NIMConversationType: 1=p2p, 2=team, 3=superTeam (matches parseConversationId above).
+      const teamTypeNum = sessionType === 'superTeam' ? 3 : 2;
       const groupName = isTeam
         ? await this.fetchTeamName(targetId, teamTypeNum, targetId)
         : undefined;


### PR DESCRIPTION
## 问题描述

在通过 NIM（网易云信）SDK 查询群组名称时，`teamTypeNum` 的取值与 `V2NIMTeamType` 枚举定义不符，导致普通群和超级大群的类型传参错误，无法正确获取群名称。

关联 Issue：#1200

### 错误原因

```typescript
// 修复前（错误）
const teamTypeNum = sessionType === 'superTeam' ? 2 : 1;

// V2NIMTeamType 实际定义：
// V2NIM_TEAM_TYPE_NORMAL    = 2（普通群）
// V2NIM_TEAM_TYPE_SUPER     = 3（超级大群）
```

原代码将普通群映射为 `1`、超级大群映射为 `2`，与 SDK 枚举定义完全错位。

## 修复方案

按照 `V2NIMTeamType` 枚举的实际定义修正映射关系：

```diff
- const teamTypeNum = sessionType === 'superTeam' ? 2 : 1;
+ const teamTypeNum = sessionType === 'superTeam' ? 3 : 2;
```

## 变更文件

- `src/main/im/nimGateway.ts`