### PR TITLE
fix(cron): 修复 pollOnce 重入并发与 stopPolling 幽灵事件

### DIFF
--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -395,6 +395,7 @@ export class CronJobService {
   private lastKnownStates: Map<string, string> = new Map();
   private lastKnownRunAtMs: Map<string, number> = new Map();
   private polling = false;
+  private pollRunning = false;
   private firstPollDone = false;
   /** Synchronous jobId → name cache, populated during polling. */
   private jobNameCache: Map<string, string> = new Map();
@@ -625,9 +626,18 @@ export class CronJobService {
 
   private async pollOnce(): Promise<void> {
     if (!this.polling) return;
+    // Reentrance guard: skip this tick if a previous poll is still in flight.
+    // This prevents concurrent writes to shared Maps when the gateway is slow
+    // and the 15 s interval fires before the previous call has finished.
+    if (this.pollRunning) return;
+    this.pollRunning = true;
 
     try {
       await this.ensureGatewayReady();
+      // Check sentinel after every await: stopPolling() may have been called
+      // while we were waiting, and the shared Maps have already been cleared.
+      if (!this.polling) return;
+
       const client = this.getGatewayClient();
       if (!client) return;
 
@@ -635,6 +645,8 @@ export class CronJobService {
         includeDisabled: true,
         limit: 200,
       });
+      if (!this.polling) return;
+
       const jobs = Array.isArray(result.jobs) ? result.jobs : [];
 
       // Refresh jobId → name cache for synchronous lookups (used by session naming).
@@ -663,6 +675,9 @@ export class CronJobService {
         if (lastRunAtMs > previousRunAtMs && previousRunAtMs > 0) {
           try {
             const runs = await this.listRuns(job.id, 1, 0);
+            // Guard again after the inner await: if polling stopped mid-loop,
+            // don't emit events against cleared state.
+            if (!this.polling) return;
             if (runs[0]) {
               const task = mapGatewayJob(job);
               this.emitRunUpdate({ ...runs[0], taskName: task.name });
@@ -688,6 +703,8 @@ export class CronJobService {
       }
     } catch (error) {
       console.warn('[CronJobService] Polling error:', error);
+    } finally {
+      this.pollRunning = false;
     }
   }
 


### PR DESCRIPTION
## 问题描述

`CronJobService.pollOnce()` 存在两个并发安全问题，会在特定条件下导致事件风暴或幽灵事件，关联 #1107。

### 问题一：重入并发

`startPolling()` 以 15 秒为间隔循环调用 `pollOnce()`。当 Gateway 响应较慢（超过 15 s）时，定时器会触发新一轮 `pollOnce()`，导致两个协程同时操作共享的 `lastKnownStates` / `lastKnownRunAtMs` Map，产生重复的 `statusUpdate` / `runUpdate` IPC 事件。

### 问题二：stopPolling 幽灵事件

`stopPolling()` 先将 `this.polling` 置为 `false` 并清空所有共享 Map，但此时可能有 `pollOnce()` 协程正处于 `await` 挂起状态。协程恢复后会读到已被清空的 Map，`previousRunAtMs` fallback 到 `0`，从而对所有历史记录不为空的任务触发 `runUpdate` 幽灵事件。

## 修复方案

1. **重入保护**：新增 `private pollRunning = false` 标志位。`pollOnce()` 入口检查该标志，若已有协程在执行则直接跳过本次 tick，`finally` 块中重置标志。

2. **停止哨兵检查**：在 `pollOnce()` 内每个 `await` 之后插入 `if (!this.polling) return`，确保 `stopPolling()` 调用后 in-flight 协程立即退出，不再操作已清空的 Map。

## 变更文件

- `src/scheduledTask/cronJobService.ts`

## Diff 摘要

```diff
 private polling = false;
+private pollRunning = false;
 private firstPollDone = false;

 private async pollOnce(): Promise<void> {
   if (!this.polling) return;
+  if (this.pollRunning) return;    // 重入保护
+  this.pollRunning = true;
   try {
     await this.ensureGatewayReady();
+    if (!this.polling) return;     // 哨兵检查
     ...
     const result = await client.request(...);
+    if (!this.polling) return;     // 哨兵检查
     ...
         const runs = await this.listRuns(...);
+        if (!this.polling) return; // 哨兵检查（内层 await）
     ...
   } catch (error) { ... }
+  } finally {
+    this.pollRunning = false;
+  }
 }
```