### PR TITLE
fix(scheduledTasks): 定时任务的"停止"IPC handler 实际上不执行任何操作，但返回 `{ success: true }`，导致前端误认为任务已成功停止，而实际上任务仍在运行。

### DIFF
--- a/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../store';
-import { setViewMode, selectTask } from '../../store/slices/scheduledTaskSlice';
+import { setViewMode, selectTask, setError } from '../../store/slices/scheduledTaskSlice';
 import { scheduledTaskService } from '../../services/scheduledTask';
 import { i18nService } from '../../services/i18n';
 import TaskList from './TaskList';
@@ -35,8 +35,15 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
   const selectedTaskId = useSelector((state: RootState) => state.scheduledTask.selectedTaskId);
   const tasks = useSelector((state: RootState) => state.scheduledTask.tasks);
   const selectedTask = selectedTaskId ? tasks.find((t) => t.id === selectedTaskId) ?? null : null;
+  const error = useSelector((state: RootState) => state.scheduledTask.error);
   const [activeTab, setActiveTab] = useState<TabType>('tasks');
   const [deleteTaskInfo, setDeleteTaskInfo] = useState<{ id: string; name: string } | null>(null);
+
+  useEffect(() => {
+    if (!error) return;
+    window.dispatchEvent(new CustomEvent('app:showToast', { detail: error }));
+    dispatch(setError(null));
+  }, [error, dispatch]);
 
   const handleRequestDelete = useCallback((taskId: string, taskName: string) => {
     setDeleteTaskInfo({ id: taskId, name: taskName });


### PR DESCRIPTION
## 问题描述

定时任务的所有操作（开关切换、创建、更新、删除、立即运行、加载）在失败时，服务层会调用 `store.dispatch(setError(...))` 将错误写入 Redux state。

然而，**没有任何 UI 组件读取 `state.scheduledTask.error`**，导致所有操作失败时用户完全得不到反馈。

### 影响的操作

| 操作 | 服务方法 | 失败时表现（修复前）|
|------|----------|-----------|
| 切换开关 | `toggleTask()` | 按钮回到原状，无提示 |
| 创建任务 | `createTask()` | 表单停止提交，无提示 |
| 更新任务 | `updateTaskById()` | 表单停止提交，无提示 |
| 删除任务 | `deleteTask()` | 删除弹窗关闭，无提示 |
| 立即运行 | `runManually()` | 无任何反馈 |
| 加载列表 | `loadTasks()` | 列表为空，无提示 |

### 复现步骤

1. 打开龙虾 → 定时任务页面
2. 断开网络或模拟 IPC 失败
3. 点击任意任务的启用/禁用开关
4. 预期：显示错误 Toast 提示
5. 实际（修复前）：按钮动画恢复，无任何提示

## 根本原因

`scheduledTask.ts` 服务层所有方法在 catch 块中调用：

```typescript
store.dispatch(setError(err instanceof Error ? err.message : String(err)));
```

但 `ScheduledTasksView.tsx` 及所有子组件从未订阅 `state.scheduledTask.error`，错误被写入 Redux 后无人消费。

## 修复方案

在 `ScheduledTasksView.tsx` 添加 `useEffect` 监听 error state，通过 `app:showToast` 事件转发给全局 Toast 组件，随后清空 error。

```typescript
const error = useSelector((state: RootState) => state.scheduledTask.error);

useEffect(() => {
  if (!error) return;
  window.dispatchEvent(new CustomEvent('app:showToast', { detail: error }));
  dispatch(setError(null));
}, [error, dispatch]);
```

`app:showToast` 是 App.tsx 已有的全局 Toast 事件机制（见 App.tsx:486-493），无需新增组件。

## 改动

**`src/renderer/components/scheduledTasks/ScheduledTasksView.tsx`** — 1 file, 8 insertions, 1 deletion

## 效果
当网络异常时
<img width="583" height="123" alt="image" src="https://github.com/user-attachments/assets/d87e49d0-6a64-4cec-a579-71b8505716bc" />

- 修改前，定时任务可操作，没有任何异常反馈
<img width="2066" height="498" alt="image" src="https://github.com/user-attachments/assets/102ea193-a819-4a70-9957-e9f4bafda7ed" />

- 修改后， 当定时任务操作失败时，屏幕中上方出现白色 Toast 通知卡片，显示 开关切换失败：网络连接异常，右侧有 × 关闭按钮。
<img width="1346" height="837" alt="image" src="https://github.com/user-attachments/assets/6ccf6eed-1f07-422b-b7e7-e61575bdef7c" />
