### PR TITLE
feat(cowork): 会话完成/报错时推送系统通知（窗口未聚焦时）

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -173,6 +173,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imPopoConfigReady: 'POPO 配置已就绪。',
     imPopoOpenClawHint: 'POPO 通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
     imPopoConfigReadyOpenClaw: 'POPO 配置已就绪，通过 OpenClaw 运行。',
+
+    // Session completion notifications
+    sessionNotificationCompleteTitle: 'LobsterAI',
+    sessionNotificationCompleteBody: '会话已完成：{title}',
+    sessionNotificationErrorTitle: 'LobsterAI',
+    sessionNotificationErrorBody: '会话出错：{title}',
   },
   en: {
     // Tray menu
@@ -332,6 +338,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imPopoConfigReady: 'POPO configuration is ready.',
     imPopoOpenClawHint: 'POPO runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
     imPopoConfigReadyOpenClaw: 'POPO configuration is ready, running via OpenClaw.',
+
+    // Session completion notifications
+    sessionNotificationCompleteTitle: 'LobsterAI',
+    sessionNotificationCompleteBody: 'Session completed: {title}',
+    sessionNotificationErrorTitle: 'LobsterAI',
+    sessionNotificationErrorBody: 'Session failed: {title}',
   },
 };
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, session, nativeTheme, dialog, shell, nativeImage, systemPreferences, Menu, protocol, net, powerMonitor, powerSaveBlocker } from 'electron';
+import { app, BrowserWindow, ipcMain, session, nativeTheme, dialog, shell, nativeImage, systemPreferences, Menu, protocol, net, powerMonitor, powerSaveBlocker, Notification } from 'electron';
 import type { WebContents } from 'electron';
 import path from 'path';
 import fs from 'fs';
@@ -568,6 +568,16 @@ let coworkRuntimeForwarderBound = false;
 let memoryMigrationDone = false;
 let preventSleepBlockerId: number | null = null;
 
+function sendSessionNotification(titleKey: string, bodyKey: string, sessionTitle: string): void {
+  if (!Notification.isSupported()) return;
+  if (mainWindow && !mainWindow.isDestroyed() && mainWindow.isFocused()) return;
+  new Notification({
+    title: t(titleKey),
+    body: t(bodyKey, { title: sessionTitle }),
+    silent: false,
+  }).show();
+}
+
 const initStore = async (): Promise<SqliteStore> => {
   if (!storeInitPromise) {
     if (!app.isReady()) {
@@ -1067,6 +1077,12 @@ const bindCoworkRuntimeForwarder = (): void => {
       if (win.isDestroyed()) return;
       win.webContents.send('cowork:stream:complete', { sessionId, claudeSessionId });
     });
+    try {
+      const sessionTitle = getCoworkStore().getSession(sessionId)?.title ?? sessionId;
+      sendSessionNotification('sessionNotificationCompleteTitle', 'sessionNotificationCompleteBody', sessionTitle);
+    } catch {
+      // ignore
+    }
     // If session used a server model, notify renderer to refresh quota
     try {
       const apiConfig = resolveCurrentApiConfig();
@@ -1090,6 +1106,12 @@ const bindCoworkRuntimeForwarder = (): void => {
       if (win.isDestroyed()) return;
       win.webContents.send('cowork:stream:error', { sessionId, error });
     });
+    try {
+      const sessionTitle = getCoworkStore().getSession(sessionId)?.title ?? sessionId;
+      sendSessionNotification('sessionNotificationErrorTitle', 'sessionNotificationErrorBody', sessionTitle);
+    } catch {
+      // ignore
+    }
   });
 
   coworkRuntimeForwarderBound = true;


### PR DESCRIPTION
## 背景

当 LobsterAI 会话在后台运行时（主窗口未聚焦），用户无法得知会话是否已完成或出错，必须手动切回窗口查看。这与 Claude Code、Cursor 等同类工具的体验存在明显差距。

## 功能

利用 Electron 原生 `Notification` API，在以下情况自动推送系统通知：
- 会话成功完成（`runtime.on('complete')`）
- 会话发生报错（`runtime.on('error')`）

触发条件：主窗口未聚焦（`!mainWindow.isFocused()`）时才推送，避免打扰正在操作的用户。通知标题为 `LobsterAI`，正文展示会话名称。支持中英文。

## 改动文件

- `src/main/main.ts`：新增 `sendSessionNotification()` 工具函数，在 complete/error 事件中调用
- `src/main/i18n.ts`：新增 4 个 i18n key（zh/en 各 2 个）

## 测试方式

1. 启动一个会话
2. 切换到其他应用（使主窗口失去焦点）
3. 等待会话完成 → 系统通知栏出现 "LobsterAI / 会话已完成：xxx"