### PR TITLE
feat(cowork): 会话运行期间自动阻止系统休眠

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -567,6 +567,23 @@ let openClawStatusForwarderBound = false;
 let coworkRuntimeForwarderBound = false;
 let memoryMigrationDone = false;
 let preventSleepBlockerId: number | null = null;
+let activeSessionCount = 0;
+let autoSleepBlockerId: number | null = null;
+
+function acquireAutoSleepBlock(): void {
+  activeSessionCount += 1;
+  if (activeSessionCount === 1 && autoSleepBlockerId === null) {
+    autoSleepBlockerId = powerSaveBlocker.start('prevent-app-suspension');
+  }
+}
+
+function releaseAutoSleepBlock(): void {
+  activeSessionCount = Math.max(0, activeSessionCount - 1);
+  if (activeSessionCount === 0 && autoSleepBlockerId !== null) {
+    powerSaveBlocker.stop(autoSleepBlockerId);
+    autoSleepBlockerId = null;
+  }
+}
 
 const initStore = async (): Promise<SqliteStore> => {
   if (!storeInitPromise) {
@@ -1062,6 +1079,7 @@ const bindCoworkRuntimeForwarder = (): void => {
   });
 
   runtime.on('complete', (sessionId: string, claudeSessionId: string | null) => {
+    releaseAutoSleepBlock();
     const windows = BrowserWindow.getAllWindows();
     windows.forEach((win) => {
       if (win.isDestroyed()) return;
@@ -1083,6 +1101,7 @@ const bindCoworkRuntimeForwarder = (): void => {
   });
 
   runtime.on('error', (sessionId: string, error: string) => {
+    releaseAutoSleepBlock();
     // Mark session as error in store so the .catch() fallback can detect duplicates.
     try { getCoworkStore().updateSession(sessionId, { status: 'error' }); } catch { /* ignore */ }
     const windows = BrowserWindow.getAllWindows();
@@ -2481,6 +2500,7 @@ if (!gotTheLock) {
 
       // Start the session asynchronously (skip initial user message since we already added it)
       const runtime = getCoworkEngineRouter();
+      acquireAutoSleepBlock();
       runtime.startSession(session.id, options.prompt, {
         skipInitialUserMessage: true,
         systemPrompt,
@@ -2571,6 +2591,7 @@ if (!gotTheLock) {
     try {
       const runtime = getCoworkEngineRouter();
       runtime.stopSession(sessionId);
+      releaseAutoSleepBlock();
       return { success: true };
     } catch (error) {
       return {


### PR DESCRIPTION
## 背景

用户将耗时任务交给 LobsterAI 运行后，若系统因无操作进入休眠/挂起，会话将被中断。对于长时间运行的 Agent 任务，这是显著的可靠性问题。

## 功能

利用 Electron `powerSaveBlocker` API，在会话运行期间自动阻止系统挂起（`prevent-app-suspension`）：
- 会话启动（`cowork:session:start` 成功）时 acquire
- 会话完成（`runtime.on('complete')`）、报错（`runtime.on('error')`）、手动停止（`cowork:session:stop`）时 release
- 使用引用计数（`activeSessionCount`）支持多个并发会话，最后一个会话结束才真正释放锁

## 改动文件

- `src/main/main.ts`：新增 `activeSessionCount`、`autoSleepBlockerId` 两个模块级变量，以及 `acquireAutoSleepBlock()` / `releaseAutoSleepBlock()` 两个工具函数；在 start/complete/error/stop 四个关键位置各调用一次

## 测试方式

1. 启动会话后，系统将不会进入睡眠（可在活动监视器查看 powerSaveBlocker 锁）
2. 会话完成/停止后，锁自动释放
3. 同时运行两个会话，第一个结束时系统不释放（引用计数 > 0），第二个结束后才释放