### PR TITLE
feat(cowork): StreamingActivityBar 右侧显示会话运行计时器

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1023,19 +1023,37 @@ const AssistantMessageItem: React.FC<{
 };
 
 // Streaming activity bar shown between messages and input
-const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ messages }) => {
-  // Walk messages backwards to find the latest tool_use without a paired tool_result
+const StreamingActivityBar: React.FC<{ messages: CoworkMessage[]; startedAt: number }> = ({ messages, startedAt }) => {
+  const [elapsed, setElapsed] = useState(() => Math.floor((Date.now() - startedAt) / 1000));
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [startedAt]);
+
+  const formatElapsed = (seconds: number): string => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    if (m > 0) {
+      return i18nService.getLanguage() === 'zh'
+        ? `已运行 ${m}m ${s}s`
+        : `${m}m ${s}s elapsed`;
+    }
+    return i18nService.getLanguage() === 'zh'
+      ? `已运行 ${s}s`
+      : `${s}s elapsed`;
+  };
+
   const getStatusText = (): string => {
-    const toolUseIds = new Set<string>();
     const toolResultIds = new Set<string>();
     for (const msg of messages) {
       const id = msg.metadata?.toolUseId;
-      if (typeof id === 'string') {
-        if (msg.type === 'tool_result') toolResultIds.add(id);
-        if (msg.type === 'tool_use') toolUseIds.add(id);
+      if (typeof id === 'string' && msg.type === 'tool_result') {
+        toolResultIds.add(id);
       }
     }
-    // Walk backwards to find latest unresolved tool_use
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i];
       if (msg.type === 'tool_use') {
@@ -1048,16 +1066,19 @@ const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ message
         }
       }
     }
-    return `${i18nService.t('coworkToolRunning')}`;
+    return i18nService.t('coworkToolRunning');
   };
 
   return (
     <div className="shrink-0 animate-fade-in px-4">
       <div className="max-w-3xl mx-auto">
         <div className="streaming-bar" />
-        <div className="py-1">
+        <div className="py-1 flex items-center justify-between">
           <span className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">
             {getStatusText()}
+          </span>
+          <span className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 tabular-nums">
+            {formatElapsed(elapsed)}
           </span>
         </div>
       </div>
@@ -2336,7 +2357,15 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       </div>
 
       {/* Streaming Activity Bar */}
-      {isStreaming && <StreamingActivityBar messages={currentSession.messages} />}
+      {isStreaming && (
+        <StreamingActivityBar
+          messages={currentSession.messages}
+          startedAt={
+            [...currentSession.messages].reverse().find(m => m.type === 'user')?.timestamp
+            ?? currentSession.createdAt
+          }
+        />
+      )}
 
       {/* Input Area */}
       <div className="p-4 shrink-0">


### PR DESCRIPTION
## 背景

会话运行时，用户无法直观感受当前任务已进行了多久，对于耗时任务缺乏进度感知。Claude Code 等工具均在 streaming 状态下展示实时计时器。

## 功能

在 `StreamingActivityBar`（流式响应状态栏）右侧新增秒级实时计时器：
- 格式：`42s elapsed` / `2m 5s elapsed`（中文：`已运行 42s` / `已运行 2m 5s`）
- 起始时间取最后一条 user 消息的 timestamp（若无则取 `session.createdAt`）
- 通过 `setInterval(1000)` 每秒刷新，组件卸载时自动清除
- 颜色略深于左侧状态文字（60% opacity），使用 `tabular-nums` 避免抖动

## 改动文件

- `src/renderer/components/cowork/CoworkSessionDetail.tsx`：
  - `StreamingActivityBar` 新增 `startedAt` prop
  - 新增 `elapsed` state + `useEffect` 计时逻辑
  - 新增 `formatElapsed()` 格式化函数
  - layout 改为 `flex justify-between`

## 测试方式

1. 启动会话后，状态栏左侧显示当前工具状态，右侧出现计时器
2. 计时器每秒递增，格式在 60s 后自动切换为 `Xm Ys`
3. 会话结束后，状态栏消失，计时器随之销毁