### PR TITLE
feat(cowork): 将已选技能标签移至输入框内顶部展示

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -645,6 +645,9 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
             {i18nService.t('coworkDropFileHint')}
           </div>
         )}
+        {!remoteManaged && (
+          <ActiveSkillBadge className="px-4 pt-2.5" />
+        )}
         {isLarge ? (
           <>
             <textarea
@@ -704,13 +707,10 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                   </button>
                 )}
                 {!remoteManaged && (
-                  <>
-                    <SkillsButton
-                      onSelectSkill={handleSelectSkill}
-                      onManageSkills={handleManageSkills}
-                    />
-                    <ActiveSkillBadge />
-                  </>
+                  <SkillsButton
+                    onSelectSkill={handleSelectSkill}
+                    onManageSkills={handleManageSkills}
+                  />
                 )}
               </div>
               <div className="flex items-center gap-2">

--- a/src/renderer/components/skills/ActiveSkillBadge.tsx
+++ b/src/renderer/components/skills/ActiveSkillBadge.tsx
@@ -6,7 +6,11 @@ import { RootState } from '../../store';
 import { toggleActiveSkill, clearActiveSkills } from '../../store/slices/skillSlice';
 import { i18nService } from '../../services/i18n';
 
-const ActiveSkillBadge: React.FC = () => {
+interface ActiveSkillBadgeProps {
+  className?: string;
+}
+
+const ActiveSkillBadge: React.FC<ActiveSkillBadgeProps> = ({ className }) => {
   const dispatch = useDispatch();
   const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
   const skills = useSelector((state: RootState) => state.skill.skills);
@@ -28,7 +32,7 @@ const ActiveSkillBadge: React.FC = () => {
   };
 
   return (
-    <div className="flex items-center gap-1.5 flex-wrap">
+    <div className={`flex items-center gap-1.5 flex-wrap${className ? ` ${className}` : ''}`}>
       {activeSkills.map(skill => (
         <div
           key={skill.id}

--- a/src/renderer/utils/regionFilter.ts
+++ b/src/renderer/utils/regionFilter.ts
@@ -2,8 +2,6 @@ import { PlatformRegistry } from '@shared/platform';
 
 /**
  * 根据语言获取可见的 IM 平台
- * zh: 仅显示 china 区域平台（Telegram/Discord 在国内需翻墙，中文模式下不展示）
- * en: 显示全部平台
  */
 export const getVisibleIMPlatforms = (language: 'zh' | 'en'): readonly string[] => {
   if (language === 'zh') {

--- a/src/renderer/utils/regionFilter.ts
+++ b/src/renderer/utils/regionFilter.ts
@@ -2,6 +2,8 @@ import { PlatformRegistry } from '@shared/platform';
 
 /**
  * 根据语言获取可见的 IM 平台
+ * zh: 仅显示 china 区域平台（Telegram/Discord 在国内需翻墙，中文模式下不展示）
+ * en: 显示全部平台
  */
 export const getVisibleIMPlatforms = (language: 'zh' | 'en'): readonly string[] => {
   if (language === 'zh') {


### PR DESCRIPTION
## 问题
已选的 Skills 标签显示在输入框底部工具栏内，与文件夹、附件等按钮混排，
当选中技能较多时布局拥挤，视觉层级不清晰。

## 改动
- 将 ActiveSkillBadge 从底部工具栏移入输入框大容器内，置于 textarea 上方
- 工具栏只保留 SkillsButton（技能选择按钮），布局更简洁
- ActiveSkillBadge 新增 className prop，支持外部控制间距
- regionFilter.ts 补充注释，说明中英文区分展示 IM 平台的设计意图
  （Telegram/Discord 在国内需翻墙，中文模式下不展示，属于故意为之）

## 效果
- 有已选技能时：标签展示在输入框顶部，多个自动换行，视觉上与输入框同属一个区域
- 无已选技能时：不渲染任何内容，不影响输入框高度