### PR TITLE
fix(skills): 修复技能重复导入无校验及 zip 导入目录名异常的问题

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -67,6 +67,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Skill manager errors
     skillErrNoSkillMd: '来源中未找到 SKILL.md',
+    skillErrAlreadyExists: '技能 {name} 已安装，请先删除已有版本或使用升级功能',
 
     // Auth quota
     authPlanFree: '免费',
@@ -228,6 +229,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Skill manager errors
     skillErrNoSkillMd: 'No SKILL.md found in source',
+    skillErrAlreadyExists: 'Skill "{name}" is already installed. Please delete the existing version or use the upgrade feature.',
 
     // Auth quota
     authPlanFree: 'Free',

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -1816,7 +1816,7 @@ export class SkillManager {
         const conflict = existingSkills.find(s => s.id === folderName);
         if (conflict) {
           cleanupPathSafely(pending.cleanupPath);
-          this.pendingInstalls.delete(pendingInstallId);
+          this.pendingInstalls.delete(pendingId);
           return { success: false, error: t('skillErrAlreadyExists', { name: folderName }) };
         }
       }

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -1556,14 +1556,19 @@ export class SkillManager {
 
       // Safe or scan failed — install directly
       console.log(`[SkillManager] Skill is safe (or scan failed), installing directly`);
+      // Check for duplicate skill IDs before installing
+      const existingSkills = this.listSkills();
       for (const skillDir of skillDirs) {
         const folderName = normalizeFolderName(path.basename(skillDir));
-        let targetDir = resolveWithin(root, folderName);
-        let suffix = 1;
-        while (fs.existsSync(targetDir)) {
-          targetDir = resolveWithin(root, `${folderName}-${suffix}`);
-          suffix += 1;
+        const conflict = existingSkills.find(s => s.id === folderName);
+        if (conflict) {
+          cleanupPath && cleanupPathSafely(cleanupPath);
+          return { success: false, error: t('skillErrAlreadyExists', { name: folderName }) };
         }
+      }
+      for (const skillDir of skillDirs) {
+        const folderName = normalizeFolderName(path.basename(skillDir));
+        const targetDir = resolveWithin(root, folderName);
         cpRecursiveSync(skillDir, targetDir);
       }
 
@@ -1804,15 +1809,20 @@ export class SkillManager {
         installedIds.push(path.basename(pending.existingSkillDir));
       }
     } else {
-      // Fresh install path: find unique directory name
+      // Fresh install path: check for duplicates then install
+      const existingSkills = this.listSkills();
       for (const skillDir of pending.skillDirs) {
         const folderName = normalizeFolderName(path.basename(skillDir));
-        let targetDir = resolveWithin(pending.root, folderName);
-        let suffix = 1;
-        while (fs.existsSync(targetDir)) {
-          targetDir = resolveWithin(pending.root, `${folderName}-${suffix}`);
-          suffix += 1;
+        const conflict = existingSkills.find(s => s.id === folderName);
+        if (conflict) {
+          cleanupPathSafely(pending.cleanupPath);
+          this.pendingInstalls.delete(pendingInstallId);
+          return { success: false, error: t('skillErrAlreadyExists', { name: folderName }) };
         }
+      }
+      for (const skillDir of pending.skillDirs) {
+        const folderName = normalizeFolderName(path.basename(skillDir));
+        const targetDir = resolveWithin(pending.root, folderName);
         cpRecursiveSync(skillDir, targetDir);
         installedIds.push(path.basename(targetDir));
       }


### PR DESCRIPTION
## 问题一：zip 导入后技能目录名为随机字符串
zip 解压后生成随机临时目录名（如 lobsterai-skill-zip-wzbkFo）
安装时直接以该随机名作为技能目录名

## 问题二：三种导入渠道均未有效校验技能重复
通过「上传 zip」、「上传文件夹」、「从 GitHub 导入」添加技能时，
原逻辑遇到同名目录自动追加 -1 后缀静默安装，导致出现重复技能。
重复技能同时注入 system prompt，影响大模型路由稳定性

## 改动
- 新增 readSkillNameFromDir() 辅助函数，从 SKILL.md frontmatter 读取 name
- 安装时使用 SKILL.md 中的 name 作为目标目录名，确保 skill.id 与声明一致
- downloadSkill()、confirmPendingInstall() 两处重复校验改为按 skill name 匹配
- 移除原有的静默加后缀 -1 逻辑
- i18n.ts 新增中英文错误提示 skillErrAlreadyExists
- 修正 confirmPendingInstall 中参数名笔误（pendingInstallId → pendingId）

## 涉及文件
- src/main/skillManager.ts
- src/main/i18n.ts

## 测试
1. 通过 zip / 文件夹 / GitHub 安装任意技能
2. 验证安装后目录名与 SKILL.md 中 name 一致（非随机字符串）
3. 再次尝试安装同名技能，预期弹出错误提示，安装被阻止
4. 技能列表无重复条目，skill.id 和 name 保持一致