### PR TITLE
fix(i18n): Agent 设置页面删除按钮及技能选择器显示英文

### DIFF
--- a/src/renderer/components/agent/AgentSettingsPanel.tsx
+++ b/src/renderer/components/agent/AgentSettingsPanel.tsx
@@ -315,18 +315,18 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
                 className="inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
               >
                 <TrashIcon className="h-4 w-4" />
-                {i18nService.t('delete') || 'Delete'}
+                {i18nService.t('deleteAgent')}
               </button>
             )}
             {showDeleteConfirm && (
               <div className="flex items-center gap-2">
-                <span className="text-xs text-red-500">{i18nService.t('confirmDelete') || 'Confirm?'}</span>
+                <span className="text-xs text-red-500">{i18nService.t('confirmDeleteAgent')}</span>
                 <button
                   type="button"
                   onClick={handleDelete}
                   className="px-2 py-1 text-xs font-medium rounded bg-red-500 text-white hover:bg-red-600"
                 >
-                  {i18nService.t('delete') || 'Delete'}
+                  {i18nService.t('deleteAgent')}
                 </button>
                 <button
                   type="button"

--- a/src/renderer/components/agent/AgentSkillSelector.tsx
+++ b/src/renderer/components/agent/AgentSkillSelector.tsx
@@ -65,7 +65,7 @@ const AgentSkillSelector: React.FC<AgentSkillSelectorProps> = ({ selectedSkillId
       <div className="flex-1 overflow-y-auto">
         {filteredSkills.length === 0 ? (
           <div className="px-3 py-3 text-sm text-secondary/50 text-center">
-            {enabledSkills.length === 0 ? 'No skills installed' : 'No matching skills'}
+            {enabledSkills.length === 0 ? i18nService.t('noSkillsInstalled') : i18nService.t('noMatchingSkills')}
           </div>
         ) : (
           filteredSkills.map((skill) => {

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -481,6 +481,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     agentIMNotConfiguredHint: '请先在 设置 > IM 机器人 中配置',
     agentIMBound: '已绑定',
     agentIMBindHint: '选择此 Agent 响应的 IM 渠道',
+    deleteAgent: '删除',
+    confirmDeleteAgent: '确认删除？',
+    noSkillsInstalled: '暂无已安装的技能',
+    noMatchingSkills: '没有匹配的技能',
     noPresetsAvailable: '所有预设已添加',
     creating: '创建中...',
 
@@ -1669,6 +1673,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     agentIMNotConfiguredHint: 'Please configure in Settings > IM Bots first',
     agentIMBound: 'Bound',
     agentIMBindHint: 'Select IM channels this Agent responds to',
+    deleteAgent: 'Delete',
+    confirmDeleteAgent: 'Confirm?',
+    noSkillsInstalled: 'No skills installed',
+    noMatchingSkills: 'No matching skills',
     noPresetsAvailable: 'All presets have been added',
     creating: 'Creating...',
 


### PR DESCRIPTION
[问题]
Agent 设置页面的删除按钮显示英文 "delete"，技能选择器搜索无结果时显示 "No matching skills"，未进行国际化。

[根因]
AgentSettingsPanel 中使用了不存在的 i18n key `delete`，fallback 到硬编码英文 "Delete"； AgentSkillSelector 中 "No skills installed" 和 "No matching skills" 直接硬编码英文字符串，未走 i18n。

[修复]
- 在 i18n.ts 中新增 `deleteAgent`、`confirmDeleteAgent`、`noSkillsInstalled`、`noMatchingSkills` 的中英文翻译
- AgentSettingsPanel 改用 `deleteAgent` / `confirmDeleteAgent` key
- AgentSkillSelector 改用 `noSkillsInstalled` / `noMatchingSkills` key

[复现路径]
1. 切换语言为中文
2. 点击"我的 Agent" -> 选择已有 Agent -> 查看底部删除按钮
3. 在 Agent 技能选择器中搜索不存在的技能名称

Closes #1434