### PR TITLE
fix(cowork): 修复切换会话时 focus-input 事件清除错误附件的问题

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -206,7 +206,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       window.removeEventListener('cowork:focus-input', handleFocusInput);
       if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
     };
-  }, []);
+  }, [dispatch, draftKey]);
 
   useEffect(() => {
     if (workingDirectory?.trim()) {


### PR DESCRIPTION
将 useEffect 依赖数组补充 dispatch 和 draftKey，
确保事件监听器始终引用当前会话的 draftKey。