### PR TITLE
fix(skills): 修复已停用技能仍被注入对话提示词的问题

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -228,7 +228,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     // Get active skills prompts and combine them
     const activeSkills = activeSkillIds
       .map(id => skills.find(s => s.id === id))
-      .filter((s): s is Skill => s !== undefined);
+      .filter((s): s is Skill => s !== undefined && s.enabled);
     const skillPrompt = activeSkills.length > 0
       ? activeSkills.map(buildInlinedSkillPrompt).join('\n\n')
       : undefined;

--- a/src/renderer/store/slices/skillSlice.test.ts
+++ b/src/renderer/store/slices/skillSlice.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for skillSlice reducers.
+ *
+ * Bug covered: a skill that is active (selected in the conversation input) but
+ * then disabled via the skill manager still appeared in activeSkillIds, so its
+ * prompt was injected into the next conversation turn even though the user had
+ * turned the skill off.
+ *
+ * Two reducers are responsible for the fix:
+ *  - `setSkills`  — called whenever the full skill list is refreshed from the
+ *    main process; must also evict any active IDs whose skill is now disabled.
+ *  - `toggleSkill` — called when the user flips the enable/disable switch;
+ *    must immediately remove the skill from activeSkillIds when disabling.
+ */
+import { test, expect } from 'vitest';
+import reducer, {
+  setSkills,
+  toggleSkill,
+  toggleActiveSkill,
+  deleteSkill,
+  clearActiveSkills,
+  setActiveSkillIds,
+} from './skillSlice';
+import type { Skill } from '../../types/skill';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeSkill = (id: string, enabled = true): Skill => ({
+  id,
+  name: `Skill ${id}`,
+  description: '',
+  enabled,
+  isOfficial: false,
+  isBuiltIn: false,
+  updatedAt: 0,
+  prompt: `prompt for ${id}`,
+  skillPath: `/skills/${id}`,
+});
+
+// ---------------------------------------------------------------------------
+// setSkills — existing behaviour (non-regression)
+// ---------------------------------------------------------------------------
+
+test('setSkills: removes activeSkillIds for skills that no longer exist', () => {
+  const initial = {
+    skills: [makeSkill('a'), makeSkill('b')],
+    activeSkillIds: ['a', 'b'],
+  };
+  const next = reducer(initial, setSkills([makeSkill('a')]));
+  expect(next.activeSkillIds).toEqual(['a']);
+  expect(next.activeSkillIds).not.toContain('b');
+});
+
+test('setSkills: keeps activeSkillIds that still exist and are enabled', () => {
+  const initial = {
+    skills: [makeSkill('a'), makeSkill('b')],
+    activeSkillIds: ['a', 'b'],
+  };
+  const next = reducer(initial, setSkills([makeSkill('a'), makeSkill('b')]));
+  expect(next.activeSkillIds).toEqual(['a', 'b']);
+});
+
+// ---------------------------------------------------------------------------
+// setSkills — bug fix: disabled skills must be evicted from activeSkillIds
+// ---------------------------------------------------------------------------
+
+test('setSkills: evicts activeSkillId when the refreshed skill list marks it disabled', () => {
+  const initial = {
+    skills: [makeSkill('a'), makeSkill('b')],
+    activeSkillIds: ['a', 'b'],
+  };
+  // Simulate a refresh where 'b' has been disabled externally
+  const next = reducer(initial, setSkills([makeSkill('a'), makeSkill('b', false)]));
+  expect(next.activeSkillIds).toContain('a');
+  expect(next.activeSkillIds).not.toContain('b');
+});
+
+test('setSkills: evicts multiple disabled skills at once', () => {
+  const initial = {
+    skills: [makeSkill('a'), makeSkill('b'), makeSkill('c')],
+    activeSkillIds: ['a', 'b', 'c'],
+  };
+  const next = reducer(initial, setSkills([
+    makeSkill('a', false),
+    makeSkill('b', false),
+    makeSkill('c'),
+  ]));
+  expect(next.activeSkillIds).toEqual(['c']);
+});
+
+test('setSkills: evicts all active IDs when all skills are disabled', () => {
+  const initial = {
+    skills: [makeSkill('a'), makeSkill('b')],
+    activeSkillIds: ['a', 'b'],
+  };
+  const next = reducer(initial, setSkills([makeSkill('a', false), makeSkill('b', false)]));
+  expect(next.activeSkillIds).toHaveLength(0);
+});
+
+test('setSkills: no-op on activeSkillIds when no skills are disabled or removed', () => {
+  const initial = {
+    skills: [makeSkill('x')],
+    activeSkillIds: ['x'],
+  };
+  const next = reducer(initial, setSkills([makeSkill('x')]));
+  expect(next.activeSkillIds).toEqual(['x']);
+});
+
+// ---------------------------------------------------------------------------
+// toggleSkill — bug fix: disabling removes skill from activeSkillIds
+// ---------------------------------------------------------------------------
+
+test('toggleSkill: removes skill from activeSkillIds when disabling', () => {
+  const initial = {
+    skills: [makeSkill('a'), makeSkill('b')],
+    activeSkillIds: ['a', 'b'],
+  };
+  const next = reducer(initial, toggleSkill('a'));
+  expect(next.skills.find(s => s.id === 'a')?.enabled).toBe(false);
+  expect(next.activeSkillIds).not.toContain('a');
+  expect(next.activeSkillIds).toContain('b');
+});
+
+test('toggleSkill: does NOT touch activeSkillIds when enabling a skill', () => {
+  const initial = {
+    skills: [makeSkill('a', false), makeSkill('b')],
+    activeSkillIds: ['b'],
+  };
+  const next = reducer(initial, toggleSkill('a'));
+  expect(next.skills.find(s => s.id === 'a')?.enabled).toBe(true);
+  // 'a' was not in activeSkillIds; enabling it should not auto-add it
+  expect(next.activeSkillIds).toEqual(['b']);
+});
+
+test('toggleSkill: skill not in activeSkillIds remains absent after disabling', () => {
+  const initial = {
+    skills: [makeSkill('a'), makeSkill('b')],
+    activeSkillIds: ['b'],
+  };
+  const next = reducer(initial, toggleSkill('a'));
+  expect(next.skills.find(s => s.id === 'a')?.enabled).toBe(false);
+  expect(next.activeSkillIds).toEqual(['b']);
+});
+
+test('toggleSkill: no-op when skill id does not exist', () => {
+  const initial = {
+    skills: [makeSkill('a')],
+    activeSkillIds: ['a'],
+  };
+  const next = reducer(initial, toggleSkill('nonexistent'));
+  expect(next.skills).toHaveLength(1);
+  expect(next.activeSkillIds).toEqual(['a']);
+});
+
+// ---------------------------------------------------------------------------
+// toggleActiveSkill — existing behaviour (non-regression)
+// ---------------------------------------------------------------------------
+
+test('toggleActiveSkill: adds id when not present', () => {
+  const initial = { skills: [makeSkill('a')], activeSkillIds: [] };
+  const next = reducer(initial, toggleActiveSkill('a'));
+  expect(next.activeSkillIds).toContain('a');
+});
+
+test('toggleActiveSkill: removes id when already present', () => {
+  const initial = { skills: [makeSkill('a')], activeSkillIds: ['a'] };
+  const next = reducer(initial, toggleActiveSkill('a'));
+  expect(next.activeSkillIds).not.toContain('a');
+});
+
+// ---------------------------------------------------------------------------
+// deleteSkill — existing behaviour (non-regression)
+// ---------------------------------------------------------------------------
+
+test('deleteSkill: removes skill from both lists', () => {
+  const initial = {
+    skills: [makeSkill('a'), makeSkill('b')],
+    activeSkillIds: ['a', 'b'],
+  };
+  const next = reducer(initial, deleteSkill('a'));
+  expect(next.skills.map(s => s.id)).not.toContain('a');
+  expect(next.activeSkillIds).not.toContain('a');
+  expect(next.activeSkillIds).toContain('b');
+});
+
+// ---------------------------------------------------------------------------
+// clearActiveSkills / setActiveSkillIds — existing behaviour
+// ---------------------------------------------------------------------------
+
+test('clearActiveSkills: empties activeSkillIds', () => {
+  const initial = { skills: [makeSkill('a')], activeSkillIds: ['a'] };
+  const next = reducer(initial, clearActiveSkills());
+  expect(next.activeSkillIds).toHaveLength(0);
+});
+
+test('setActiveSkillIds: replaces activeSkillIds', () => {
+  const initial = { skills: [makeSkill('a'), makeSkill('b')], activeSkillIds: ['a'] };
+  const next = reducer(initial, setActiveSkillIds(['b']));
+  expect(next.activeSkillIds).toEqual(['b']);
+});

--- a/src/renderer/store/slices/skillSlice.ts
+++ b/src/renderer/store/slices/skillSlice.ts
@@ -17,9 +17,9 @@ const skillSlice = createSlice({
   reducers: {
     setSkills: (state, action: PayloadAction<Skill[]>) => {
       state.skills = action.payload;
-      // Remove any active skill IDs that no longer exist
+      // Remove any active skill IDs that no longer exist or have been disabled
       state.activeSkillIds = state.activeSkillIds.filter(id =>
-        action.payload.some(skill => skill.id === id)
+        action.payload.some(skill => skill.id === id && skill.enabled)
       );
     },
     addSkill: (state, action: PayloadAction<Skill>) => {
@@ -39,6 +39,10 @@ const skillSlice = createSlice({
       const skill = state.skills.find(s => s.id === action.payload);
       if (skill) {
         skill.enabled = !skill.enabled;
+        // If the skill is being disabled, remove it from active selections
+        if (!skill.enabled) {
+          state.activeSkillIds = state.activeSkillIds.filter(id => id !== action.payload);
+        }
       }
     },
     toggleActiveSkill: (state, action: PayloadAction<string>) => {


### PR DESCRIPTION
## 问题背景
关联 Issue：#1439
用户在技能管理页面将技能停用后，该技能的提示词仍然会被注入到下一次对话中，
导致已关闭的技能依然可以被调用。
## 根本原因
技能的启用/停用状态（`skill.enabled`）与对话输入框的"已选技能"列表
（`activeSkillIds`）之间存在同步缺口，共有三处漏洞：
**漏洞 1 — `toggleSkill` reducer 未同步清理**
用户在技能管理页面关闭技能时，`toggleSkill` 只将 `skill.enabled` 置为
`false`，但没有将该技能从 `activeSkillIds` 中移除。下次发送消息时，该技能
仍被视为"已选中"，其提示词照常注入。
**漏洞 2 — `setSkills` 仅清理已删除的技能**
技能列表刷新时，`setSkills` 只移除"不再存在"的 ID，不移除"已被禁用"的 ID。
外部刷新后，已禁用技能的 ID 依然留在 `activeSkillIds` 中。
**漏洞 3 — `CoworkPromptInput` 缺少 `enabled` 校验**
构建对话提示词时，代码直接用 `activeSkillIds` 查找技能对象，
没有检查 `skill.enabled`，导致即使状态已过期也会将禁用技能的提示词注入。
## 修复方案
- **`skillSlice.ts` — `toggleSkill`**：关闭技能时立即从 `activeSkillIds`
  中移除（开启时不自动添加，行为不变）。
- **`skillSlice.ts` — `setSkills`**：过滤条件增加 `skill.enabled`，
  每次列表刷新都会同步清除已禁用技能的选中状态。
- **`CoworkPromptInput.tsx`**：构建 `activeSkills` 时增加
  `s.enabled` 兜底过滤，防止 `activeSkillIds` 存在脏数据时仍注入提示词。
## 变更文件
- `src/renderer/store/slices/skillSlice.ts` — 修复两处 reducer 逻辑
- `src/renderer/components/cowork/CoworkPromptInput.tsx` — 增加防御性过滤
- `src/renderer/store/slices/skillSlice.test.ts`（新增）— 15 个单元测试，
  覆盖 `toggleSkill` 和 `setSkills` 的禁用同步场景及非回归用例
## 测试结果
Test Files  1 passed (1)
Tests      15 passed (15)