### PR TITLE
fix(openclaw): align qqbot plugin id with manifest to prevent restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "version": "2026.3.8"
       },
       {
-        "id": "qqbot",
+        "id": "openclaw-qqbot",
         "npm": "@sliverp/qqbot",
         "version": "1.5.3"
       },

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -914,7 +914,7 @@ export class OpenClawConfigSync {
               const pluginEnabled = (() => {
                 if (id === 'dingtalk') return !!(dingTalkConfig?.enabled && dingTalkConfig.clientId);
                 if (id === 'feishu-openclaw-plugin') return !!(feishuConfig?.enabled && feishuConfig.appId);
-                if (id === 'qqbot') return !!(qqConfig?.enabled && qqConfig.appId);
+                if (id === 'openclaw-qqbot') return !!(qqConfig?.enabled && qqConfig.appId);
                 if (id === 'wecom-openclaw-plugin') return !!(wecomConfig?.enabled && wecomConfig.botId);
                 if (id === 'moltbot-popo') return !!(popoConfig?.enabled && popoConfig.appKey);
                 if (id === 'nim') return !!(nimConfig?.enabled && nimConfig.appKey && nimConfig.account && nimConfig.token);


### PR DESCRIPTION

The package.json declared the QQ bot plugin with id "qqbot", but the plugin manifest (openclaw.plugin.json) uses "openclaw-qqbot". This mismatch caused OpenClaw to detect a spurious config diff on every syncOpenClawConfig() call, triggering unnecessary SIGUSR1 gateway restarts — even when the actual config had not changed.

Rename the id in package.json to "openclaw-qqbot" and update the corresponding check in openclawConfigSync.ts.