### PR TITLE
fix(openclaw): align qqbot plugin id with manifest to prevent restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "version": "2026.3.8"
       },
       {
-        "id": "qqbot",
+        "id": "openclaw-qqbot",
         "npm": "@tencent-connect/openclaw-qqbot",
         "version": "1.6.4"
       },

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -937,7 +937,7 @@ export class OpenClawConfigSync {
               const pluginEnabled = (() => {
                 if (id === 'dingtalk') return dingTalkInstances.some(i => i.enabled && i.clientId);
                 if (id === 'feishu-openclaw-plugin') return feishuInstances.some(i => i.enabled && i.appId);
-                if (id === 'qqbot') return qqInstances.some(i => i.enabled && i.appId);
+                if (id === 'openclaw-qqbot') return qqInstances.some(i => i.enabled && i.appId);
                 if (id === 'wecom-openclaw-plugin') return !!(wecomConfig?.enabled && wecomConfig.botId);
                 if (id === 'moltbot-popo') return !!(popoConfig?.enabled && popoConfig.appKey);
                 if (id === 'nim') return !!(nimConfig?.enabled && nimConfig.appKey && nimConfig.account && nimConfig.token);


### PR DESCRIPTION


The package.json declared the QQ bot plugin with id "qqbot", but the plugin manifest (openclaw.plugin.json) uses "openclaw-qqbot". This mismatch caused OpenClaw to detect a spurious config diff on every syncOpenClawConfig() call, triggering unnecessary SIGUSR1 gateway restarts.

Rename the plugin id to "openclaw-qqbot" in package.json and update the corresponding check in openclawConfigSync.ts.