### PR TITLE
feat(scheduledTask): support per-bot conversation filtering in task form

### DIFF
--- a/src/main/im/imStore.ts
+++ b/src/main/im/imStore.ts
@@ -1166,15 +1166,34 @@ export class IMStore {
   }
 
   /**
-   * List all session mappings for a platform
+   * List all session mappings for a platform, optionally filtered by IM bot accountId.
+   *
+   * The accountId is encoded as the first colon-delimited segment of im_conversation_id
+   * (e.g. "c9c41984:direct:ou_xxx" → accountId "c9c41984"). This convention is used by
+   * multi-instance platforms (Feishu, DingTalk, QQ) while single-instance platforms
+   * use "default" as the prefix. Filtering by accountId therefore requires no schema
+   * migration and is fully backward-compatible with existing rows.
    */
-  listSessionMappings(platform?: Platform): IMSessionMapping[] {
-    const query = platform
-      ? 'SELECT im_conversation_id, platform, cowork_session_id, agent_id, created_at, last_active_at FROM im_session_mappings WHERE platform = ? ORDER BY last_active_at DESC'
-      : 'SELECT im_conversation_id, platform, cowork_session_id, agent_id, created_at, last_active_at FROM im_session_mappings ORDER BY last_active_at DESC';
-    const rows = platform
-      ? (this.db.prepare(query).all(platform) as SessionMappingRow[])
-      : (this.db.prepare(query).all() as SessionMappingRow[]);
+  listSessionMappings(platform?: Platform, accountId?: string): IMSessionMapping[] {
+    let query: string;
+    let params: unknown[];
+
+    if (platform && accountId) {
+      // Include direct conversations owned by this bot instance (prefix matches accountId)
+      // and all group conversations for the platform, since group membership per-bot
+      // is not yet stored — group: prefix is a temporary heuristic until im_account_id
+      // column is introduced.
+      query = "SELECT im_conversation_id, platform, cowork_session_id, agent_id, created_at, last_active_at FROM im_session_mappings WHERE platform = ? AND (im_conversation_id LIKE ? OR im_conversation_id LIKE 'group:%') ORDER BY last_active_at DESC";
+      params = [platform, `${accountId}:%`];
+    } else if (platform) {
+      query = 'SELECT im_conversation_id, platform, cowork_session_id, agent_id, created_at, last_active_at FROM im_session_mappings WHERE platform = ? ORDER BY last_active_at DESC';
+      params = [platform];
+    } else {
+      query = 'SELECT im_conversation_id, platform, cowork_session_id, agent_id, created_at, last_active_at FROM im_session_mappings ORDER BY last_active_at DESC';
+      params = [];
+    }
+
+    const rows = this.db.prepare(query).all(...params) as SessionMappingRow[];
     return rows.map(row => ({
       imConversationId: row.im_conversation_id,
       platform: row.platform as Platform,

--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -16,10 +16,11 @@ export interface ScheduledTaskHandlerDeps {
       getSessionMapping: (conversationId: string, platform: string) => {
         coworkSessionId: string;
       } | undefined;
-      listSessionMappings: (platform: string) => Array<{
+      listSessionMappings: (platform: string, agentId?: string) => Array<{
         imConversationId: string;
         platform: string;
         coworkSessionId: string;
+        agentId: string;
         lastActiveAt: string;
       }>;
     } | undefined;
@@ -220,29 +221,19 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
     }
   });
 
-  ipcMain.handle(ScheduledTaskIpc.ListChannelConversations, async (_event, channel: string) => {
+  ipcMain.handle(ScheduledTaskIpc.ListChannelConversations, async (_event, channel: string, accountId?: string) => {
     try {
-      console.log('[IPC][listChannelConversations] channel:', channel);
       const platform = PlatformRegistry.platformOfChannel(channel);
-      console.log('[IPC][listChannelConversations] resolved platform:', platform);
-      if (!platform) {
-        console.log('[IPC][listChannelConversations] no platform mapping, returning empty');
-        return { success: true, conversations: [] };
-      }
+      if (!platform) return { success: true, conversations: [] };
       const imStore = getIMGatewayManager()?.getIMStore();
-      if (!imStore) {
-        console.log('[IPC][listChannelConversations] no imStore available, returning empty');
-        return { success: true, conversations: [] };
-      }
-      const mappings = imStore.listSessionMappings(platform);
-      console.log('[IPC][listChannelConversations] found', mappings.length, 'session mappings for platform:', platform);
+      if (!imStore) return { success: true, conversations: [] };
+      const mappings = imStore.listSessionMappings(platform, accountId);
       const conversations = mappings.map((m) => ({
         conversationId: m.imConversationId,
         platform: m.platform,
         coworkSessionId: m.coworkSessionId,
         lastActiveAt: m.lastActiveAt,
       }));
-      console.log('[IPC][listChannelConversations] conversations:', JSON.stringify(conversations, null, 2));
       return { success: true, conversations };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Failed to list conversations' };

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -422,7 +422,7 @@ contextBridge.exposeInMainWorld('electron', {
 
     // Delivery channels
     listChannels: () => ipcRenderer.invoke(ScheduledTaskIpc.ListChannels),
-    listChannelConversations: (channel: string) => ipcRenderer.invoke(ScheduledTaskIpc.ListChannelConversations, channel),
+    listChannelConversations: (channel: string, accountId?: string) => ipcRenderer.invoke(ScheduledTaskIpc.ListChannelConversations, channel, accountId),
 
     // Stream event listeners
     onStatusUpdate: (callback: (data: any) => void) => {

--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -182,7 +182,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
 
     let cancelled = false;
     setConversationsLoading(true);
-    void scheduledTaskService.listChannelConversations(form.notifyChannel).then((result) => {
+    void scheduledTaskService.listChannelConversations(form.notifyChannel, form.notifyAccountId).then((result) => {
       if (cancelled) return;
       setConversations(result);
       setConversationsLoading(false);
@@ -196,7 +196,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
       cancelled = true;
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form.notifyChannel]);
+  }, [form.notifyChannel, form.notifyAccountId]);
 
   const updateForm = (patch: Partial<FormState>) => {
     setForm((current) => ({ ...current, ...patch }));

--- a/src/renderer/services/scheduledTask.ts
+++ b/src/renderer/services/scheduledTask.ts
@@ -267,12 +267,12 @@ class ScheduledTaskService {
     }
   }
 
-  async listChannelConversations(channel: string): Promise<ScheduledTaskConversationOption[]> {
+  async listChannelConversations(channel: string, accountId?: string): Promise<ScheduledTaskConversationOption[]> {
     const api = window.electron?.scheduledTasks;
     if (!api?.listChannelConversations) return [];
 
     try {
-      const result = await api.listChannelConversations(channel);
+      const result = await api.listChannelConversations(channel, accountId);
       return result.success && result.conversations ? result.conversations : [];
     } catch {
       return [];

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -485,7 +485,7 @@ interface IElectronAPI {
       channels?: import('../../scheduledTask/types').ScheduledTaskChannelOption[];
       error?: string;
     }>;
-    listChannelConversations?: (channel: string) => Promise<{
+    listChannelConversations?: (channel: string, accountId?: string) => Promise<{
       success: boolean;
       conversations?: import('../../scheduledTask/types').ScheduledTaskConversationOption[];
       error?: string;


### PR DESCRIPTION
## Summary

  - **refactor(scheduledTask)**: 将 create/update IPC handler 中重复的 announce 投递归一化逻辑（sessionTarget 设置、SystemEvent→AgentTurn 转换、IM subtype
  前缀剥离、DingTalk reply route priming）提取为共享 helper `applyAnnounceDeliveryNormalization`，消除代码重复；同时将高频 payload dump 日志从 info 降级为
  debug。

  - **feat(scheduledTask)**: 定时任务表单的会话选择器在多机器人场景下支持按机器人实例过滤。选择"飞书 · Bot A"时仅展示属于该机器人的单聊会话（通过
  `im_conversation_id` 前缀 LIKE 匹配），并同时展示该平台下全部群组会话（临时策略，待 `im_account_id` 字段落地后精确归属）。无 schema 变更，历史数据零迁移成本。

  ## Impact

  | 层次 | 文件 | 变更性质 |
  |------|------|----------|
  | 主进程 DB | `imStore.ts` | `listSessionMappings` 新增可选 `accountId` 参数，SQL 加 LIKE 前缀 + group OR 条件 |
  | 主进程 IPC | `handlers.ts` | `ListChannelConversations` handler 接收并转发 `accountId`；`ScheduledTaskHandlerDeps` 接口同步更新；提取 announce 归一化 helper |
  | 主进程桥接 | `preload.ts` | `listChannelConversations` 签名加 `accountId?: string` |
  | 渲染进程类型 | `electron.d.ts` | 同步更新类型声明 |
  | 渲染进程服务 | `scheduledTask.ts` | service 方法加 `accountId` 参数并透传 |
  | 渲染进程 UI | `TaskForm.tsx` | `useEffect` 依赖加入 `notifyAccountId`，调用时传参 |

  ## Known Limitations

  群组会话暂按"同平台全量展示"处理，不区分机器人归属。后续引入 `im_session_mappings.im_account_id` 字段后，可替换为精确过滤并通过迁移脚本回填历史群组数据。