### PR TITLE
[codex] fix long modal titles for issue 1435

### DIFF
--- a/src/renderer/components/agent/AgentCreateModal.tsx
+++ b/src/renderer/components/agent/AgentCreateModal.tsx
@@ -1,13 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import { agentService } from '../../services/agent';
-import { imService } from '../../services/im';
-import { i18nService } from '../../services/i18n';
 import { XMarkIcon } from '@heroicons/react/24/outline';
+import React, { useEffect, useState } from 'react';
+
+import { agentService } from '../../services/agent';
+import { i18nService } from '../../services/i18n';
+import { imService } from '../../services/im';
+import type { IMGatewayConfig, IMPlatform } from '../../types/im';
 import { getVisibleIMPlatforms } from '../../utils/regionFilter';
-import type { IMPlatform, IMGatewayConfig } from '../../types/im';
+import Modal from '../common/Modal';
+import { getTruncatedTitleState } from '../common/truncatedTitle';
+import Tooltip from '../ui/Tooltip';
 import AgentSkillSelector from './AgentSkillSelector';
 import EmojiPicker from './EmojiPicker';
-import Modal from '../common/Modal';
 
 type CreateTab = 'basic' | 'skills' | 'im';
 
@@ -45,7 +48,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
 
   useEffect(() => {
     if (!isOpen) return;
-    imService.loadConfig().then((cfg) => {
+    imService.loadConfig().then(cfg => {
       if (cfg) setImConfig(cfg);
     });
   }, [isOpen]);
@@ -108,7 +111,9 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
 
   const isPlatformConfigured = (platform: IMPlatform): boolean => {
     if (!imConfig) return false;
-    return (imConfig as unknown as Record<string, { enabled?: boolean }>)[platform]?.enabled === true;
+    return (
+      (imConfig as unknown as Record<string, { enabled?: boolean }>)[platform]?.enabled === true
+    );
   };
 
   const tabs: { key: CreateTab; label: string }[] = [
@@ -116,187 +121,209 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
     { key: 'skills', label: i18nService.t('agentTabSkills') || 'Skills' },
     { key: 'im', label: i18nService.t('agentTabIM') || 'IM Channels' },
   ];
+  const titleState = getTruncatedTitleState(name, i18nService.t('createAgent') || 'Create Agent');
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-surface border border-border max-h-[80vh] flex flex-col">
-        {/* Header: agent icon + name + close */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-          <div className="flex items-center gap-2">
-            <span className="text-xl">{icon || '🤖'}</span>
-            <h3 className="text-base font-semibold text-foreground">
-              {name || (i18nService.t('createAgent') || 'Create Agent')}
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-surface border border-border max-h-[80vh] flex flex-col"
+    >
+      {/* Header: agent icon + name + close */}
+      <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+        <div className="flex min-w-0 max-w-[80%] items-center gap-2">
+          <span className="text-xl">{icon || '🤖'}</span>
+          <Tooltip
+            content={titleState.tooltipContent}
+            disabled={!titleState.tooltipContent}
+            className="min-w-0 max-w-full flex-1"
+          >
+            <h3 className="block w-full truncate text-base font-semibold text-foreground">
+              {titleState.displayTitle}
             </h3>
-          </div>
-          <button type="button" onClick={onClose} className="p-1 rounded-lg hover:bg-surface-raised">
-            <XMarkIcon className="h-5 w-5 text-secondary" />
+          </Tooltip>
+        </div>
+        <button type="button" onClick={onClose} className="p-1 rounded-lg hover:bg-surface-raised">
+          <XMarkIcon className="h-5 w-5 text-secondary" />
+        </button>
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex border-b border-border px-5">
+        {tabs.map(tab => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setActiveTab(tab.key)}
+            className={`px-4 py-2.5 text-sm font-medium transition-colors relative ${
+              activeTab === tab.key ? 'text-primary' : 'text-secondary hover:text-foreground'
+            }`}
+          >
+            {tab.label}
+            {activeTab === tab.key && (
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-full" />
+            )}
           </button>
-        </div>
+        ))}
+      </div>
 
-        {/* Tab bar */}
-        <div className="flex border-b border-border px-5">
-          {tabs.map((tab) => (
-            <button
-              key={tab.key}
-              type="button"
-              onClick={() => setActiveTab(tab.key)}
-              className={`px-4 py-2.5 text-sm font-medium transition-colors relative ${
-                activeTab === tab.key
-                  ? 'text-primary'
-                  : 'text-secondary hover:text-foreground'
-              }`}
-            >
-              {tab.label}
-              {activeTab === tab.key && (
-                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-full" />
-              )}
-            </button>
-          ))}
-        </div>
-
-        {/* Tab content */}
-        <div className="px-5 py-4 overflow-y-auto flex-1 min-h-[300px]">
-          {activeTab === 'basic' && (
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-secondary mb-1">
-                  {i18nService.t('agentName') || 'Name'} *
-                </label>
-                <div className="flex gap-2">
-                  <EmojiPicker value={icon} onChange={setIcon} />
-                  <input
-                    type="text"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    placeholder={i18nService.t('agentNamePlaceholder') || 'Agent name'}
-                    className="flex-1 px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm"
-                    autoFocus
-                  />
-                </div>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-secondary mb-1">
-                  {i18nService.t('agentDescription') || 'Description'}
-                </label>
+      {/* Tab content */}
+      <div className="px-5 py-4 overflow-y-auto flex-1 min-h-[300px]">
+        {activeTab === 'basic' && (
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-secondary mb-1">
+                {i18nService.t('agentName') || 'Name'} *
+              </label>
+              <div className="flex gap-2">
+                <EmojiPicker value={icon} onChange={setIcon} />
                 <input
                   type="text"
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  placeholder={i18nService.t('agentDescriptionPlaceholder') || 'Brief description'}
-                  className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-secondary mb-1">
-                  {i18nService.t('systemPrompt') || 'System Prompt'}
-                </label>
-                <textarea
-                  value={systemPrompt}
-                  onChange={(e) => setSystemPrompt(e.target.value)}
-                  placeholder={i18nService.t('systemPromptPlaceholder') || 'Describe the agent\'s role and behavior...'}
-                  rows={4}
-                  className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm resize-none"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-secondary mb-1">
-                  {i18nService.t('agentIdentity') || 'Identity'}
-                </label>
-                <textarea
-                  value={identity}
-                  onChange={(e) => setIdentity(e.target.value)}
-                  rows={3}
-                  placeholder={i18nService.t('agentIdentityPlaceholder') || 'Identity description (IDENTITY.md)...'}
-                  className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm resize-none"
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                  placeholder={i18nService.t('agentNamePlaceholder') || 'Agent name'}
+                  className="flex-1 px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm"
+                  autoFocus
                 />
               </div>
             </div>
-          )}
-
-          {activeTab === 'skills' && (
-            <AgentSkillSelector selectedSkillIds={skillIds} onChange={setSkillIds} />
-          )}
-
-          {activeTab === 'im' && (
             <div>
-              <p className="text-xs text-secondary/60 mb-4">
-                {i18nService.t('agentIMBindHint') || 'Select IM channels this Agent responds to'}
-              </p>
-              <div className="space-y-1">
-                {IM_PLATFORMS
-                  .filter(({ key }) => (getVisibleIMPlatforms(i18nService.getLanguage()) as readonly string[]).includes(key))
-                  .map(({ key: platform, logo }) => {
-                  const configured = isPlatformConfigured(platform);
-                  const bound = boundPlatforms.has(platform);
-                  return (
-                    <div
-                      key={platform}
-                      className={`flex items-center justify-between px-3 py-2.5 rounded-lg transition-colors ${
-                        configured
-                          ? 'hover:bg-surface-raised cursor-pointer'
-                          : 'opacity-50'
-                      }`}
-                      onClick={() => configured && handleToggleIMBinding(platform)}
-                    >
-                      <div className="flex items-center gap-3">
-                        <div className="flex h-8 w-8 items-center justify-center">
-                          <img src={logo} alt={i18nService.t(platform)} className="w-6 h-6 object-contain rounded" />
-                        </div>
-                        <div>
-                          <div className="text-sm font-medium text-foreground">
-                            {i18nService.t(platform)}
-                          </div>
-                          {!configured && (
-                            <div className="text-xs text-secondary/50">
-                              {i18nService.t('agentIMNotConfiguredHint') || 'Please configure in Settings > IM Bots first'}
-                            </div>
-                          )}
-                        </div>
+              <label className="block text-sm font-medium text-secondary mb-1">
+                {i18nService.t('agentDescription') || 'Description'}
+              </label>
+              <input
+                type="text"
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                placeholder={i18nService.t('agentDescriptionPlaceholder') || 'Brief description'}
+                className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-secondary mb-1">
+                {i18nService.t('systemPrompt') || 'System Prompt'}
+              </label>
+              <textarea
+                value={systemPrompt}
+                onChange={e => setSystemPrompt(e.target.value)}
+                placeholder={
+                  i18nService.t('systemPromptPlaceholder') ||
+                  "Describe the agent's role and behavior..."
+                }
+                rows={4}
+                className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm resize-none"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-secondary mb-1">
+                {i18nService.t('agentIdentity') || 'Identity'}
+              </label>
+              <textarea
+                value={identity}
+                onChange={e => setIdentity(e.target.value)}
+                rows={3}
+                placeholder={
+                  i18nService.t('agentIdentityPlaceholder') ||
+                  'Identity description (IDENTITY.md)...'
+                }
+                className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm resize-none"
+              />
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'skills' && (
+          <AgentSkillSelector selectedSkillIds={skillIds} onChange={setSkillIds} />
+        )}
+
+        {activeTab === 'im' && (
+          <div>
+            <p className="text-xs text-secondary/60 mb-4">
+              {i18nService.t('agentIMBindHint') || 'Select IM channels this Agent responds to'}
+            </p>
+            <div className="space-y-1">
+              {IM_PLATFORMS.filter(({ key }) =>
+                (getVisibleIMPlatforms(i18nService.getLanguage()) as readonly string[]).includes(
+                  key,
+                ),
+              ).map(({ key: platform, logo }) => {
+                const configured = isPlatformConfigured(platform);
+                const bound = boundPlatforms.has(platform);
+                return (
+                  <div
+                    key={platform}
+                    className={`flex items-center justify-between px-3 py-2.5 rounded-lg transition-colors ${
+                      configured ? 'hover:bg-surface-raised cursor-pointer' : 'opacity-50'
+                    }`}
+                    onClick={() => configured && handleToggleIMBinding(platform)}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-8 w-8 items-center justify-center">
+                        <img
+                          src={logo}
+                          alt={i18nService.t(platform)}
+                          className="w-6 h-6 object-contain rounded"
+                        />
                       </div>
-                      <div className="flex items-center gap-2">
-                        {configured ? (
-                          <div
-                            className={`relative w-9 h-5 rounded-full transition-colors ${
-                              bound ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
-                            }`}
-                          >
-                            <div
-                              className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${
-                                bound ? 'translate-x-4' : 'translate-x-0.5'
-                              }`}
-                            />
+                      <div>
+                        <div className="text-sm font-medium text-foreground">
+                          {i18nService.t(platform)}
+                        </div>
+                        {!configured && (
+                          <div className="text-xs text-secondary/50">
+                            {i18nService.t('agentIMNotConfiguredHint') ||
+                              'Please configure in Settings > IM Bots first'}
                           </div>
-                        ) : (
-                          <span className="text-xs text-secondary/50">
-                            {i18nService.t('agentIMNotConfigured') || 'Not configured'}
-                          </span>
                         )}
                       </div>
                     </div>
-                  );
-                })}
-              </div>
+                    <div className="flex items-center gap-2">
+                      {configured ? (
+                        <div
+                          className={`relative w-9 h-5 rounded-full transition-colors ${
+                            bound ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
+                          }`}
+                        >
+                          <div
+                            className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${
+                              bound ? 'translate-x-4' : 'translate-x-0.5'
+                            }`}
+                          />
+                        </div>
+                      ) : (
+                        <span className="text-xs text-secondary/50">
+                          {i18nService.t('agentIMNotConfigured') || 'Not configured'}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
-          )}
-        </div>
+          </div>
+        )}
+      </div>
 
-        {/* Footer */}
-        <div className="flex justify-end gap-2 px-5 py-4 border-t border-border">
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-          >
-            {i18nService.t('cancel') || 'Cancel'}
-          </button>
-          <button
-            type="button"
-            onClick={handleCreate}
-            disabled={!name.trim() || creating}
-            className="px-4 py-2 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            {creating ? (i18nService.t('creating') || 'Creating...') : (i18nService.t('create') || 'Create')}
-          </button>
-        </div>
+      {/* Footer */}
+      <div className="flex justify-end gap-2 px-5 py-4 border-t border-border">
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
+        >
+          {i18nService.t('cancel') || 'Cancel'}
+        </button>
+        <button
+          type="button"
+          onClick={handleCreate}
+          disabled={!name.trim() || creating}
+          className="px-4 py-2 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {creating
+            ? i18nService.t('creating') || 'Creating...'
+            : i18nService.t('create') || 'Create'}
+        </button>
+      </div>
     </Modal>
   );
 };

--- a/src/renderer/components/agent/AgentSettingsPanel.tsx
+++ b/src/renderer/components/agent/AgentSettingsPanel.tsx
@@ -1,19 +1,22 @@
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import type { Platform } from '@shared/platform';
+import { PlatformRegistry } from '@shared/platform';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { RootState } from '../../store';
+
 import { agentService } from '../../services/agent';
-import { imService } from '../../services/im';
 import { i18nService } from '../../services/i18n';
-import { XMarkIcon } from '@heroicons/react/24/outline';
-import TrashIcon from '../icons/TrashIcon';
+import { imService } from '../../services/im';
+import { RootState } from '../../store';
 import type { Agent } from '../../types/agent';
-import type { Platform } from '@shared/platform';
 import type { IMGatewayConfig } from '../../types/im';
 import { getVisibleIMPlatforms } from '../../utils/regionFilter';
-import { PlatformRegistry } from '@shared/platform';
+import Modal from '../common/Modal';
+import { getTruncatedTitleState } from '../common/truncatedTitle';
+import TrashIcon from '../icons/TrashIcon';
+import Tooltip from '../ui/Tooltip';
 import AgentSkillSelector from './AgentSkillSelector';
 import EmojiPicker from './EmojiPicker';
-import Modal from '../common/Modal';
 
 type SettingsTab = 'basic' | 'skills' | 'im';
 
@@ -25,7 +28,11 @@ interface AgentSettingsPanelProps {
   onSwitchAgent?: (agentId: string) => void;
 }
 
-const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClose, onSwitchAgent }) => {
+const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({
+  agentId,
+  onClose,
+  onSwitchAgent,
+}) => {
   const currentAgentId = useSelector((state: RootState) => state.agent.currentAgentId);
   const agents = useSelector((state: RootState) => state.agent.agents);
   const imStatus = useSelector((state: RootState) => state.im.status);
@@ -49,7 +56,7 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
     if (!agentId) return;
     setActiveTab('basic');
     setShowDeleteConfirm(false);
-    window.electron?.agents?.get(agentId).then((a) => {
+    window.electron?.agents?.get(agentId).then(a => {
       if (a) {
         setAgent(a);
         setName(a.name);
@@ -61,7 +68,7 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
       }
     });
     // Load IM config and status for bindings
-    imService.loadConfig().then((cfg) => {
+    imService.loadConfig().then(cfg => {
       if (cfg) {
         setImConfig(cfg);
         const bindings = cfg.settings?.platformAgentBindings || {};
@@ -95,7 +102,7 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
       // Persist IM bindings if changed
       const bindingsChanged =
         boundKeys.size !== initialBoundKeys.size ||
-        [...boundKeys].some((k) => !initialBoundKeys.has(k));
+        [...boundKeys].some(k => !initialBoundKeys.has(k));
       if (bindingsChanged && imConfig) {
         const currentBindings = { ...(imConfig.settings?.platformAgentBindings || {}) };
         // Remove old bindings for this agent
@@ -163,7 +170,7 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
   /** Resolve agent name by id */
   const getAgentName = (aid: string): string | null => {
     if (!aid || aid === 'main') return null;
-    const agent = agents.find((a) => a.id === aid);
+    const agent = agents.find(a => a.id === aid);
     return agent?.name || aid;
   };
 
@@ -174,6 +181,10 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
     { key: 'skills', label: i18nService.t('agentTabSkills') || 'Skills' },
     { key: 'im', label: i18nService.t('agentTabIM') || 'IM Channels' },
   ];
+  const titleState = getTruncatedTitleState(
+    name,
+    i18nService.t('agentSettings') || 'Agent Settings',
+  );
 
   const renderToggle = (isOn: boolean) => (
     <div
@@ -203,14 +214,17 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
         >
           <div className="flex items-center gap-3">
             <div className="flex h-8 w-8 items-center justify-center">
-              <img src={logo} alt={i18nService.t(platform)} className="w-6 h-6 object-contain rounded" />
+              <img
+                src={logo}
+                alt={i18nService.t(platform)}
+                className="w-6 h-6 object-contain rounded"
+              />
             </div>
             <div>
-              <div className="text-sm font-medium text-foreground">
-                {i18nService.t(platform)}
-              </div>
+              <div className="text-sm font-medium text-foreground">{i18nService.t(platform)}</div>
               <div className="text-xs text-secondary/50">
-                {i18nService.t('agentIMNotConfiguredHint') || 'Please configure in Settings > IM Bots first'}
+                {i18nService.t('agentIMNotConfiguredHint') ||
+                  'Please configure in Settings > IM Bots first'}
               </div>
             </div>
           </div>
@@ -226,11 +240,13 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
         {/* Platform header */}
         <div className="flex items-center gap-3 px-3 py-2.5 bg-surface-raised">
           <div className="flex h-8 w-8 items-center justify-center">
-            <img src={logo} alt={i18nService.t(platform)} className="w-6 h-6 object-contain rounded" />
+            <img
+              src={logo}
+              alt={i18nService.t(platform)}
+              className="w-6 h-6 object-contain rounded"
+            />
           </div>
-          <span className="text-sm font-semibold text-foreground">
-            {i18nService.t(platform)}
-          </span>
+          <span className="text-sm font-semibold text-foreground">{i18nService.t(platform)}</span>
         </div>
         {/* Instance list */}
         {connectedInstances.map((inst: any, idx: number) => {
@@ -250,20 +266,17 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
             >
               <div className="flex items-center gap-2">
                 <span className="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0" />
-                <span className="text-sm text-foreground">
-                  {inst.instanceName}
-                </span>
+                <span className="text-sm text-foreground">{inst.instanceName}</span>
                 {boundToOther && otherAgentName && (
                   <span className="text-xs text-amber-600 dark:text-amber-400 bg-amber-500/10 px-1.5 py-0.5 rounded">
-                    {(i18nService.t('agentIMBoundToOther') || '→ {agent}').replace('{agent}', otherAgentName)}
+                    {(i18nService.t('agentIMBoundToOther') || '→ {agent}').replace(
+                      '{agent}',
+                      otherAgentName,
+                    )}
                   </span>
                 )}
               </div>
-              {boundToOther ? (
-                <div className="w-9 h-5" />
-              ) : (
-                renderToggle(isBound)
-              )}
+              {boundToOther ? <div className="w-9 h-5" /> : renderToggle(isBound)}
             </div>
           );
         })}
@@ -286,33 +299,45 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
         className={`flex items-center justify-between px-3 py-2.5 rounded-lg transition-colors ${
           configured && !boundToOther
             ? 'hover:bg-surface-raised cursor-pointer'
-            : boundToOther ? 'opacity-55' : 'opacity-50'
+            : boundToOther
+              ? 'opacity-55'
+              : 'opacity-50'
         }`}
         onClick={() => configured && !boundToOther && handleToggleIMBinding(platform)}
       >
         <div className="flex items-center gap-3">
           <div className="flex h-8 w-8 items-center justify-center">
-            <img src={logo} alt={i18nService.t(platform)} className="w-6 h-6 object-contain rounded" />
+            <img
+              src={logo}
+              alt={i18nService.t(platform)}
+              className="w-6 h-6 object-contain rounded"
+            />
           </div>
           <div>
-            <div className="text-sm font-medium text-foreground">
-              {i18nService.t(platform)}
-            </div>
+            <div className="text-sm font-medium text-foreground">{i18nService.t(platform)}</div>
             {!configured && (
               <div className="text-xs text-secondary/50">
-                {i18nService.t('agentIMNotConfiguredHint') || 'Please configure in Settings > IM Bots first'}
+                {i18nService.t('agentIMNotConfiguredHint') ||
+                  'Please configure in Settings > IM Bots first'}
               </div>
             )}
           </div>
           {boundToOther && otherAgentName && (
             <span className="text-xs text-amber-600 dark:text-amber-400 bg-amber-500/10 px-1.5 py-0.5 rounded">
-              {(i18nService.t('agentIMBoundToOther') || '→ {agent}').replace('{agent}', otherAgentName)}
+              {(i18nService.t('agentIMBoundToOther') || '→ {agent}').replace(
+                '{agent}',
+                otherAgentName,
+              )}
             </span>
           )}
         </div>
         <div className="flex items-center gap-2">
           {configured ? (
-            boundToOther ? <div className="w-9 h-5" /> : renderToggle(isBound)
+            boundToOther ? (
+              <div className="w-9 h-5" />
+            ) : (
+              renderToggle(isBound)
+            )
           ) : (
             <span className="text-xs text-secondary/50">
               {i18nService.t('agentIMNotConfigured') || 'Not configured'}
@@ -324,179 +349,193 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
   };
 
   return (
-    <Modal onClose={onClose} className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-surface border border-border max-h-[80vh] flex flex-col">
-        {/* Header: agent icon + name + close */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-          <div className="flex items-center gap-2">
-            <span className="text-xl">{icon || '🤖'}</span>
-            <h3 className="text-base font-semibold text-foreground">
-              {name || (i18nService.t('agentSettings') || 'Agent Settings')}
+    <Modal
+      onClose={onClose}
+      className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-surface border border-border max-h-[80vh] flex flex-col"
+    >
+      {/* Header: agent icon + name + close */}
+      <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+        <div className="flex min-w-0 max-w-[80%] items-center gap-2">
+          <span className="text-xl">{icon || '🤖'}</span>
+          <Tooltip
+            content={titleState.tooltipContent}
+            disabled={!titleState.tooltipContent}
+            className="min-w-0 max-w-full flex-1"
+          >
+            <h3 className="block w-full truncate text-base font-semibold text-foreground">
+              {titleState.displayTitle}
             </h3>
-          </div>
-          <button type="button" onClick={onClose} className="p-1 rounded-lg hover:bg-surface-raised">
-            <XMarkIcon className="h-5 w-5 text-secondary" />
+          </Tooltip>
+        </div>
+        <button type="button" onClick={onClose} className="p-1 rounded-lg hover:bg-surface-raised">
+          <XMarkIcon className="h-5 w-5 text-secondary" />
+        </button>
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex border-b border-border px-5">
+        {tabs.map(tab => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setActiveTab(tab.key)}
+            className={`px-4 py-2.5 text-sm font-medium transition-colors relative ${
+              activeTab === tab.key ? 'text-primary' : 'text-secondary hover:text-foreground'
+            }`}
+          >
+            {tab.label}
+            {activeTab === tab.key && (
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-full" />
+            )}
           </button>
-        </div>
+        ))}
+      </div>
 
-        {/* Tab bar */}
-        <div className="flex border-b border-border px-5">
-          {tabs.map((tab) => (
-            <button
-              key={tab.key}
-              type="button"
-              onClick={() => setActiveTab(tab.key)}
-              className={`px-4 py-2.5 text-sm font-medium transition-colors relative ${
-                activeTab === tab.key
-                  ? 'text-primary'
-                  : 'text-secondary hover:text-foreground'
-              }`}
-            >
-              {tab.label}
-              {activeTab === tab.key && (
-                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-full" />
-              )}
-            </button>
-          ))}
-        </div>
-
-        {/* Tab content */}
-        <div className="px-5 py-4 overflow-y-auto flex-1 min-h-[300px]">
-          {activeTab === 'basic' && (
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-secondary mb-1">
-                  {i18nService.t('agentName') || 'Name'}
-                </label>
-                <div className="flex gap-2">
-                  <EmojiPicker value={icon} onChange={setIcon} />
-                  <input
-                    type="text"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    className="flex-1 px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm"
-                  />
-                </div>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-secondary mb-1">
-                  {i18nService.t('agentDescription') || 'Description'}
-                </label>
+      {/* Tab content */}
+      <div className="px-5 py-4 overflow-y-auto flex-1 min-h-[300px]">
+        {activeTab === 'basic' && (
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-secondary mb-1">
+                {i18nService.t('agentName') || 'Name'}
+              </label>
+              <div className="flex gap-2">
+                <EmojiPicker value={icon} onChange={setIcon} />
                 <input
                   type="text"
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-secondary mb-1">
-                  {i18nService.t('systemPrompt') || 'System Prompt'}
-                </label>
-                <textarea
-                  value={systemPrompt}
-                  onChange={(e) => setSystemPrompt(e.target.value)}
-                  rows={4}
-                  className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm resize-none"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-secondary mb-1">
-                  {i18nService.t('agentIdentity') || 'Identity'}
-                </label>
-                <textarea
-                  value={identity}
-                  onChange={(e) => setIdentity(e.target.value)}
-                  rows={3}
-                  placeholder={i18nService.t('agentIdentityPlaceholder') || 'Identity description (IDENTITY.md)...'}
-                  className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm resize-none"
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                  className="flex-1 px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm"
                 />
               </div>
             </div>
-          )}
-
-          {activeTab === 'skills' && (
-            <AgentSkillSelector selectedSkillIds={skillIds} onChange={setSkillIds} />
-          )}
-
-          {activeTab === 'im' && (
             <div>
-              <p className="text-xs text-secondary/60 mb-4">
-                {i18nService.t('agentIMBindHint') || 'Select IM channels this Agent responds to'}
-              </p>
-              <div className="space-y-1">
-                {PlatformRegistry.platforms
-                  .filter((platform) => (getVisibleIMPlatforms(i18nService.getLanguage()) as readonly string[]).includes(platform))
-                  .map((platform) => {
-                    if (MULTI_INSTANCE_PLATFORMS.includes(platform)) {
-                      return renderMultiInstancePlatform(platform);
-                    }
-                    return renderSingleInstancePlatform(platform);
-                  })}
-              </div>
+              <label className="block text-sm font-medium text-secondary mb-1">
+                {i18nService.t('agentDescription') || 'Description'}
+              </label>
+              <input
+                type="text"
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm"
+              />
             </div>
-          )}
-        </div>
+            <div>
+              <label className="block text-sm font-medium text-secondary mb-1">
+                {i18nService.t('systemPrompt') || 'System Prompt'}
+              </label>
+              <textarea
+                value={systemPrompt}
+                onChange={e => setSystemPrompt(e.target.value)}
+                rows={4}
+                className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm resize-none"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-secondary mb-1">
+                {i18nService.t('agentIdentity') || 'Identity'}
+              </label>
+              <textarea
+                value={identity}
+                onChange={e => setIdentity(e.target.value)}
+                rows={3}
+                placeholder={
+                  i18nService.t('agentIdentityPlaceholder') ||
+                  'Identity description (IDENTITY.md)...'
+                }
+                className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm resize-none"
+              />
+            </div>
+          </div>
+        )}
 
-        {/* Footer */}
-        <div className="flex items-center justify-between px-5 py-4 border-t border-border">
+        {activeTab === 'skills' && (
+          <AgentSkillSelector selectedSkillIds={skillIds} onChange={setSkillIds} />
+        )}
+
+        {activeTab === 'im' && (
           <div>
-            {!isMainAgent && !showDeleteConfirm && (
+            <p className="text-xs text-secondary/60 mb-4">
+              {i18nService.t('agentIMBindHint') || 'Select IM channels this Agent responds to'}
+            </p>
+            <div className="space-y-1">
+              {PlatformRegistry.platforms
+                .filter(platform =>
+                  (getVisibleIMPlatforms(i18nService.getLanguage()) as readonly string[]).includes(
+                    platform,
+                  ),
+                )
+                .map(platform => {
+                  if (MULTI_INSTANCE_PLATFORMS.includes(platform)) {
+                    return renderMultiInstancePlatform(platform);
+                  }
+                  return renderSingleInstancePlatform(platform);
+                })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between px-5 py-4 border-t border-border">
+        <div>
+          {!isMainAgent && !showDeleteConfirm && (
+            <button
+              type="button"
+              onClick={() => setShowDeleteConfirm(true)}
+              className="inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+            >
+              <TrashIcon className="h-4 w-4" />
+              {i18nService.t('delete')}
+            </button>
+          )}
+          {showDeleteConfirm && (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-red-500">{i18nService.t('confirmDelete')}</span>
               <button
                 type="button"
-                onClick={() => setShowDeleteConfirm(true)}
-                className="inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                onClick={handleDelete}
+                className="px-2 py-1 text-xs font-medium rounded bg-red-500 text-white hover:bg-red-600"
               >
-                <TrashIcon className="h-4 w-4" />
                 {i18nService.t('delete')}
               </button>
-            )}
-            {showDeleteConfirm && (
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-red-500">{i18nService.t('confirmDelete')}</span>
-                <button
-                  type="button"
-                  onClick={handleDelete}
-                  className="px-2 py-1 text-xs font-medium rounded bg-red-500 text-white hover:bg-red-600"
-                >
-                  {i18nService.t('delete')}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setShowDeleteConfirm(false)}
-                  className="px-2 py-1 text-xs font-medium rounded text-secondary hover:bg-surface-raised"
-                >
-                  {i18nService.t('cancel')}
-                </button>
-              </div>
-            )}
-          </div>
-          <div className="flex gap-2">
-            {onSwitchAgent && agentId !== currentAgentId && (
               <button
                 type="button"
-                onClick={() => onSwitchAgent(agentId)}
-                className="px-4 py-2 text-sm font-medium rounded-lg border border-primary text-primary hover:bg-primary/10 transition-colors"
+                onClick={() => setShowDeleteConfirm(false)}
+                className="px-2 py-1 text-xs font-medium rounded text-secondary hover:bg-surface-raised"
               >
-                {i18nService.t('switchToAgent') || 'Use this Agent'}
+                {i18nService.t('cancel')}
               </button>
-            )}
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-            >
-              {i18nService.t('cancel') || 'Cancel'}
-            </button>
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={!name.trim() || saving}
-              className="px-4 py-2 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {saving ? (i18nService.t('saving') || 'Saving...') : (i18nService.t('save') || 'Save')}
-            </button>
-          </div>
+            </div>
+          )}
         </div>
+        <div className="flex gap-2">
+          {onSwitchAgent && agentId !== currentAgentId && (
+            <button
+              type="button"
+              onClick={() => onSwitchAgent(agentId)}
+              className="px-4 py-2 text-sm font-medium rounded-lg border border-primary text-primary hover:bg-primary/10 transition-colors"
+            >
+              {i18nService.t('switchToAgent') || 'Use this Agent'}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
+          >
+            {i18nService.t('cancel') || 'Cancel'}
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!name.trim() || saving}
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving ? i18nService.t('saving') || 'Saving...' : i18nService.t('save') || 'Save'}
+          </button>
+        </div>
+      </div>
     </Modal>
   );
 };

--- a/src/renderer/components/common/truncatedTitle.test.ts
+++ b/src/renderer/components/common/truncatedTitle.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest';
+
+import { getTruncatedTitleState } from './truncatedTitle';
+
+test('getTruncatedTitleState falls back to the default title when the name is blank', () => {
+  expect(getTruncatedTitleState('', 'Create Agent')).toEqual({
+    displayTitle: 'Create Agent',
+    tooltipContent: null,
+  });
+});
+
+test('getTruncatedTitleState trims the custom name and uses it for the tooltip', () => {
+  expect(getTruncatedTitleState('  A very long custom agent name  ', 'Create Agent')).toEqual({
+    displayTitle: 'A very long custom agent name',
+    tooltipContent: 'A very long custom agent name',
+  });
+});

--- a/src/renderer/components/common/truncatedTitle.ts
+++ b/src/renderer/components/common/truncatedTitle.ts
@@ -1,0 +1,23 @@
+export interface TruncatedTitleState {
+  displayTitle: string;
+  tooltipContent: string | null;
+}
+
+export const getTruncatedTitleState = (
+  title: string | null | undefined,
+  fallbackTitle: string,
+): TruncatedTitleState => {
+  const trimmedTitle = title?.trim() ?? '';
+
+  if (!trimmedTitle) {
+    return {
+      displayTitle: fallbackTitle,
+      tooltipContent: null,
+    };
+  }
+
+  return {
+    displayTitle: trimmedTitle,
+    tooltipContent: trimmedTitle,
+  };
+};

--- a/src/renderer/components/mcp/McpServerFormModal.tsx
+++ b/src/renderer/components/mcp/McpServerFormModal.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect,useState } from 'react';
+
 import { i18nService } from '../../services/i18n';
-import { McpServerConfig, McpServerFormData, McpRegistryEntry } from '../../types/mcp';
+import { McpRegistryEntry,McpServerConfig, McpServerFormData } from '../../types/mcp';
 import Modal from '../common/Modal';
+import Tooltip from '../ui/Tooltip';
 
 interface McpServerFormModalProps {
   isOpen: boolean;
@@ -43,22 +45,22 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
       setCommand(server.command || '');
       setArgsText((server.args || []).join('\n'));
       setEnvRows(
-        server.env
-          ? Object.entries(server.env).map(([key, value]) => ({ key, value }))
-          : []
+        server.env ? Object.entries(server.env).map(([key, value]) => ({ key, value })) : [],
       );
       setUrl(server.url || '');
       setHeaderRows(
         server.headers
           ? Object.entries(server.headers).map(([key, value]) => ({ key, value }))
-          : []
+          : [],
       );
     } else if (registryEntry) {
       // Registry install mode — pre-fill from template
       setName(registryEntry.name);
       const registryDescription =
-        (i18nService.getLanguage() === 'zh' ? registryEntry.description_zh : registryEntry.description_en)
-        || (registryEntry.descriptionKey ? i18nService.t(registryEntry.descriptionKey) : '');
+        (i18nService.getLanguage() === 'zh'
+          ? registryEntry.description_zh
+          : registryEntry.description_en) ||
+        (registryEntry.descriptionKey ? i18nService.t(registryEntry.descriptionKey) : '');
       setDescription(registryDescription);
       setTransportType(registryEntry.transportType);
       setCommand(registryEntry.command);
@@ -201,10 +203,12 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
 
   if (!isOpen) return null;
 
-  const inputClass = 'w-full px-3 py-2 text-sm rounded-xl bg-background text-foreground placeholder-secondary border border-border focus:outline-none focus:ring-2 focus:ring-primary';
+  const inputClass =
+    'w-full px-3 py-2 text-sm rounded-xl bg-background text-foreground placeholder-secondary border border-border focus:outline-none focus:ring-2 focus:ring-primary';
   const readOnlyInputClass = inputClass + ' opacity-60 cursor-not-allowed';
   const labelClass = 'text-xs font-semibold tracking-wide text-secondary';
-  const kvInputClass = 'flex-1 px-2 py-1.5 text-sm rounded-lg bg-background text-foreground border border-border focus:outline-none focus:ring-1 focus:ring-primary';
+  const kvInputClass =
+    'flex-1 px-2 py-1.5 text-sm rounded-lg bg-background text-foreground border border-border focus:outline-none focus:ring-1 focus:ring-primary';
 
   // Title
   const modalTitle = isEdit
@@ -214,220 +218,239 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
       : i18nService.t('addMcpServer');
 
   // Save button text
-  const saveText = isRegistry && !isEdit
-    ? i18nService.t('mcpInstall')
-    : i18nService.t('saveMcpServer');
+  const saveText =
+    isRegistry && !isEdit ? i18nService.t('mcpInstall') : i18nService.t('saveMcpServer');
 
   return (
-    <Modal onClose={onClose} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-lg mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6 max-h-[80vh] overflow-y-auto">
-        <div className="flex items-center justify-between mb-5">
-          <div className="text-lg font-semibold text-foreground">
+    <Modal
+      onClose={onClose}
+      overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="w-full max-w-lg mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6 max-h-[80vh] overflow-y-auto"
+    >
+      <div className="flex items-center justify-between mb-5">
+        <Tooltip
+          content={isRegistry ? modalTitle : null}
+          disabled={!isRegistry}
+          className="min-w-0 max-w-full flex-1"
+        >
+          <div className="block w-full truncate text-lg font-semibold text-foreground">
             {modalTitle}
           </div>
+        </Tooltip>
+      </div>
+
+      <div className="space-y-4">
+        {/* Name */}
+        <div className="space-y-1.5">
+          <label className={labelClass}>{i18nService.t('mcpServerName')}</label>
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder={i18nService.t('mcpServerNamePlaceholder')}
+            className={isRegistry ? readOnlyInputClass : inputClass}
+            readOnly={isRegistry}
+            autoFocus={!isRegistry}
+          />
         </div>
 
-        <div className="space-y-4">
-          {/* Name */}
-          <div className="space-y-1.5">
-            <label className={labelClass}>{i18nService.t('mcpServerName')}</label>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder={i18nService.t('mcpServerNamePlaceholder')}
-              className={isRegistry ? readOnlyInputClass : inputClass}
-              readOnly={isRegistry}
-              autoFocus={!isRegistry}
-            />
-          </div>
+        {/* Description */}
+        <div className="space-y-1.5">
+          <label className={labelClass}>{i18nService.t('mcpServerDescription')}</label>
+          <input
+            type="text"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder={i18nService.t('mcpServerDescriptionPlaceholder')}
+            className={inputClass}
+          />
+        </div>
 
-          {/* Description */}
-          <div className="space-y-1.5">
-            <label className={labelClass}>{i18nService.t('mcpServerDescription')}</label>
-            <input
-              type="text"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder={i18nService.t('mcpServerDescriptionPlaceholder')}
-              className={inputClass}
-            />
-          </div>
+        {/* Transport Type */}
+        <div className="space-y-1.5">
+          <label className={labelClass}>{i18nService.t('mcpTransportType')}</label>
+          <select
+            value={transportType}
+            onChange={e => setTransportType(e.target.value as 'stdio' | 'sse' | 'http')}
+            className={isRegistry ? readOnlyInputClass : inputClass}
+            disabled={isRegistry}
+          >
+            <option value="stdio">{i18nService.t('mcpTransportStdio')}</option>
+            <option value="sse">{i18nService.t('mcpTransportSse')}</option>
+            <option value="http">{i18nService.t('mcpTransportHttp')}</option>
+          </select>
+        </div>
 
-          {/* Transport Type */}
-          <div className="space-y-1.5">
-            <label className={labelClass}>{i18nService.t('mcpTransportType')}</label>
-            <select
-              value={transportType}
-              onChange={(e) => setTransportType(e.target.value as 'stdio' | 'sse' | 'http')}
-              className={isRegistry ? readOnlyInputClass : inputClass}
-              disabled={isRegistry}
-            >
-              <option value="stdio">{i18nService.t('mcpTransportStdio')}</option>
-              <option value="sse">{i18nService.t('mcpTransportSse')}</option>
-              <option value="http">{i18nService.t('mcpTransportHttp')}</option>
-            </select>
-          </div>
+        {/* stdio fields */}
+        {transportType === 'stdio' && (
+          <>
+            <div className="space-y-1.5">
+              <label className={labelClass}>{i18nService.t('mcpCommand')}</label>
+              <input
+                type="text"
+                value={command}
+                onChange={e => setCommand(e.target.value)}
+                placeholder={i18nService.t('mcpCommandPlaceholder')}
+                className={isRegistry ? readOnlyInputClass : inputClass}
+                readOnly={isRegistry}
+              />
+            </div>
 
-          {/* stdio fields */}
-          {transportType === 'stdio' && (
-            <>
-              <div className="space-y-1.5">
-                <label className={labelClass}>{i18nService.t('mcpCommand')}</label>
-                <input
-                  type="text"
-                  value={command}
-                  onChange={(e) => setCommand(e.target.value)}
-                  placeholder={i18nService.t('mcpCommandPlaceholder')}
-                  className={isRegistry ? readOnlyInputClass : inputClass}
-                  readOnly={isRegistry}
-                />
+            <div className="space-y-1.5">
+              <label className={labelClass}>{i18nService.t('mcpArgs')}</label>
+              <textarea
+                value={argsText}
+                onChange={e => setArgsText(e.target.value)}
+                placeholder={i18nService.t('mcpArgsPlaceholder')}
+                rows={3}
+                className={inputClass + ' resize-none'}
+                autoFocus={isRegistry}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <label className={labelClass}>
+                  {i18nService.t('mcpEnvVars')}
+                  {isRegistry && envRows.some(r => r.required) && (
+                    <span className="ml-2 text-[10px] text-red-400 font-normal">
+                      * {i18nService.t('mcpRequiredConfig')}
+                    </span>
+                  )}
+                </label>
+                <button
+                  type="button"
+                  onClick={handleAddEnvRow}
+                  className="text-xs text-primary hover:text-primary/80 transition-colors"
+                >
+                  + {i18nService.t('addKeyValue')}
+                </button>
               </div>
-
-              <div className="space-y-1.5">
-                <label className={labelClass}>{i18nService.t('mcpArgs')}</label>
-                <textarea
-                  value={argsText}
-                  onChange={(e) => setArgsText(e.target.value)}
-                  placeholder={i18nService.t('mcpArgsPlaceholder')}
-                  rows={3}
-                  className={inputClass + ' resize-none'}
-                  autoFocus={isRegistry}
-                />
-              </div>
-
-              <div className="space-y-1.5">
-                <div className="flex items-center justify-between">
-                  <label className={labelClass}>
-                    {i18nService.t('mcpEnvVars')}
-                    {isRegistry && envRows.some(r => r.required) && (
-                      <span className="ml-2 text-[10px] text-red-400 font-normal">
-                        * {i18nService.t('mcpRequiredConfig')}
-                      </span>
-                    )}
-                  </label>
-                  <button
-                    type="button"
-                    onClick={handleAddEnvRow}
-                    className="text-xs text-primary hover:text-primary/80 transition-colors"
-                  >
-                    + {i18nService.t('addKeyValue')}
-                  </button>
-                </div>
-                {envRows.map((row, index) => (
-                  <div key={index} className="flex items-center gap-2">
-                    <input
-                      type="text"
-                      value={row.key}
-                      onChange={(e) => handleUpdateEnvRow(index, 'key', e.target.value)}
-                      placeholder={i18nService.t('mcpHeaderKey')}
-                      className={row.required ? kvInputClass + ' opacity-60 cursor-not-allowed' : kvInputClass}
-                      readOnly={!!row.required}
-                    />
-                    <input
-                      type="text"
-                      value={row.value}
-                      onChange={(e) => handleUpdateEnvRow(index, 'value', e.target.value)}
-                      placeholder={row.required ? `${row.key} *` : i18nService.t('mcpHeaderValue')}
-                      className={kvInputClass}
-                      autoFocus={isRegistry && index === 0 && !!row.required}
-                    />
-                    {!row.required && (
-                      <button
-                        type="button"
-                        onClick={() => handleRemoveEnvRow(index)}
-                        className="p-1 text-secondary hover:text-red-500 dark:hover:text-red-400 transition-colors flex-shrink-0"
-                      >
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-                          <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
-                        </svg>
-                      </button>
-                    )}
-                    {row.required && (
-                      <span className="text-red-400 text-xs flex-shrink-0 w-4 text-center">*</span>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
-
-          {/* sse / http fields */}
-          {(transportType === 'sse' || transportType === 'http') && (
-            <>
-              <div className="space-y-1.5">
-                <label className={labelClass}>{i18nService.t('mcpUrl')}</label>
-                <input
-                  type="text"
-                  value={url}
-                  onChange={(e) => setUrl(e.target.value)}
-                  placeholder={i18nService.t('mcpUrlPlaceholder')}
-                  className={inputClass}
-                />
-              </div>
-
-              <div className="space-y-1.5">
-                <div className="flex items-center justify-between">
-                  <label className={labelClass}>{i18nService.t('mcpHeaders')}</label>
-                  <button
-                    type="button"
-                    onClick={handleAddHeaderRow}
-                    className="text-xs text-primary hover:text-primary/80 transition-colors"
-                  >
-                    + {i18nService.t('addKeyValue')}
-                  </button>
-                </div>
-                {headerRows.map((row, index) => (
-                  <div key={index} className="flex items-center gap-2">
-                    <input
-                      type="text"
-                      value={row.key}
-                      onChange={(e) => handleUpdateHeaderRow(index, 'key', e.target.value)}
-                      placeholder={i18nService.t('mcpHeaderKey')}
-                      className={kvInputClass}
-                    />
-                    <input
-                      type="text"
-                      value={row.value}
-                      onChange={(e) => handleUpdateHeaderRow(index, 'value', e.target.value)}
-                      placeholder={i18nService.t('mcpHeaderValue')}
-                      className={kvInputClass}
-                    />
+              {envRows.map((row, index) => (
+                <div key={index} className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={row.key}
+                    onChange={e => handleUpdateEnvRow(index, 'key', e.target.value)}
+                    placeholder={i18nService.t('mcpHeaderKey')}
+                    className={
+                      row.required ? kvInputClass + ' opacity-60 cursor-not-allowed' : kvInputClass
+                    }
+                    readOnly={!!row.required}
+                  />
+                  <input
+                    type="text"
+                    value={row.value}
+                    onChange={e => handleUpdateEnvRow(index, 'value', e.target.value)}
+                    placeholder={row.required ? `${row.key} *` : i18nService.t('mcpHeaderValue')}
+                    className={kvInputClass}
+                    autoFocus={isRegistry && index === 0 && !!row.required}
+                  />
+                  {!row.required && (
                     <button
                       type="button"
-                      onClick={() => handleRemoveHeaderRow(index)}
+                      onClick={() => handleRemoveEnvRow(index)}
                       className="p-1 text-secondary hover:text-red-500 dark:hover:text-red-400 transition-colors flex-shrink-0"
                     >
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        className="w-4 h-4"
+                      >
                         <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
                       </svg>
                     </button>
-                  </div>
-                ))}
+                  )}
+                  {row.required && (
+                    <span className="text-red-400 text-xs flex-shrink-0 w-4 text-center">*</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* sse / http fields */}
+        {(transportType === 'sse' || transportType === 'http') && (
+          <>
+            <div className="space-y-1.5">
+              <label className={labelClass}>{i18nService.t('mcpUrl')}</label>
+              <input
+                type="text"
+                value={url}
+                onChange={e => setUrl(e.target.value)}
+                placeholder={i18nService.t('mcpUrlPlaceholder')}
+                className={inputClass}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <label className={labelClass}>{i18nService.t('mcpHeaders')}</label>
+                <button
+                  type="button"
+                  onClick={handleAddHeaderRow}
+                  className="text-xs text-primary hover:text-primary/80 transition-colors"
+                >
+                  + {i18nService.t('addKeyValue')}
+                </button>
               </div>
-            </>
-          )}
+              {headerRows.map((row, index) => (
+                <div key={index} className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={row.key}
+                    onChange={e => handleUpdateHeaderRow(index, 'key', e.target.value)}
+                    placeholder={i18nService.t('mcpHeaderKey')}
+                    className={kvInputClass}
+                  />
+                  <input
+                    type="text"
+                    value={row.value}
+                    onChange={e => handleUpdateHeaderRow(index, 'value', e.target.value)}
+                    placeholder={i18nService.t('mcpHeaderValue')}
+                    className={kvInputClass}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveHeaderRow(index)}
+                    className="p-1 text-secondary hover:text-red-500 dark:hover:text-red-400 transition-colors flex-shrink-0"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                      className="w-4 h-4"
+                    >
+                      <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+                    </svg>
+                  </button>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
 
-          {error && (
-            <div className="text-xs text-red-500">{error}</div>
-          )}
+        {error && <div className="text-xs text-red-500">{error}</div>}
 
-          <div className="flex items-center justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-3 py-1.5 text-xs rounded-lg border border-border text-secondary hover:bg-surface-raised transition-colors"
-            >
-              {i18nService.t('cancel')}
-            </button>
-            <button
-              type="button"
-              onClick={handleSave}
-              className="px-3 py-1.5 text-xs rounded-lg bg-primary text-white hover:bg-primary/90 transition-colors"
-            >
-              {saveText}
-            </button>
-          </div>
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs rounded-lg border border-border text-secondary hover:bg-surface-raised transition-colors"
+          >
+            {i18nService.t('cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            className="px-3 py-1.5 text-xs rounded-lg bg-primary text-white hover:bg-primary/90 transition-colors"
+          >
+            {saveText}
+          </button>
         </div>
+      </div>
     </Modal>
   );
 };

--- a/src/renderer/components/scheduledTasks/RunSessionModal.tsx
+++ b/src/renderer/components/scheduledTasks/RunSessionModal.tsx
@@ -1,13 +1,16 @@
-import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react';
-import { XMarkIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
+import { ArrowPathIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
 import { i18nService } from '../../services/i18n';
-import type { CoworkSession, CoworkMessage } from '../../types/cowork';
+import type { CoworkSession } from '../../types/cowork';
+import { getTruncatedTitleState } from '../common/truncatedTitle';
 import {
-  buildDisplayItems,
-  buildConversationTurns,
-  UserMessageItem,
   AssistantTurnBlock,
+  buildConversationTurns,
+  buildDisplayItems,
+  UserMessageItem,
 } from '../cowork/CoworkSessionDetail';
+import Tooltip from '../ui/Tooltip';
 
 interface RunSessionModalProps {
   sessionId?: string | null;
@@ -26,44 +29,47 @@ const RunSessionModal: React.FC<RunSessionModalProps> = ({ sessionId, sessionKey
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cancelledRef = useRef(false);
 
-  const loadSession = useCallback(async (isRetry = false): Promise<boolean> => {
-    if (!isRetry) {
-      setLoading(true);
-      setError(null);
-    }
-
-    try {
-      let loadedSession: CoworkSession | null = null;
-
-      // 1. Try loading by local session ID first
-      if (sessionId) {
-        const result = await window.electron?.cowork?.getSession(sessionId);
-        if (result?.success && result.session) {
-          loadedSession = result.session;
-        }
-      }
-
-      // 2. If not found locally, try resolving via OpenClaw sessionKey
-      if (!loadedSession && sessionKey) {
-        const result = await window.electron?.scheduledTasks?.resolveSession(sessionKey);
-        if (result?.success && result.session) {
-          loadedSession = result.session;
-        }
-      }
-
-      if (cancelledRef.current) return false;
-
-      if (loadedSession) {
-        setSession(loadedSession);
-        setLoading(false);
+  const loadSession = useCallback(
+    async (isRetry = false): Promise<boolean> => {
+      if (!isRetry) {
+        setLoading(true);
         setError(null);
-        return true;
       }
-      return false;
-    } catch {
-      return false;
-    }
-  }, [sessionId, sessionKey]);
+
+      try {
+        let loadedSession: CoworkSession | null = null;
+
+        // 1. Try loading by local session ID first
+        if (sessionId) {
+          const result = await window.electron?.cowork?.getSession(sessionId);
+          if (result?.success && result.session) {
+            loadedSession = result.session;
+          }
+        }
+
+        // 2. If not found locally, try resolving via OpenClaw sessionKey
+        if (!loadedSession && sessionKey) {
+          const result = await window.electron?.scheduledTasks?.resolveSession(sessionKey);
+          if (result?.success && result.session) {
+            loadedSession = result.session;
+          }
+        }
+
+        if (cancelledRef.current) return false;
+
+        if (loadedSession) {
+          setSession(loadedSession);
+          setLoading(false);
+          setError(null);
+          return true;
+        }
+        return false;
+      } catch {
+        return false;
+      }
+    },
+    [sessionId, sessionKey],
+  );
 
   useEffect(() => {
     cancelledRef.current = false;
@@ -126,28 +132,37 @@ const RunSessionModal: React.FC<RunSessionModalProps> = ({ sessionId, sessionKey
     }
   };
 
-  const messages: CoworkMessage[] = session?.messages ?? [];
-  const displayItems = useMemo(() => buildDisplayItems(messages), [messages]);
+  const displayItems = useMemo(
+    () => buildDisplayItems(session?.messages ?? []),
+    [session?.messages],
+  );
   const turns = useMemo(() => buildConversationTurns(displayItems), [displayItems]);
+  const titleState = getTruncatedTitleState(
+    session?.title,
+    i18nService.t('scheduledTasksViewSession'),
+  );
 
   return (
-    <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center"
-      onClick={onClose}
-    >
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center" onClick={onClose}>
       {/* Backdrop */}
       <div className="absolute inset-0 bg-black/40 dark:bg-black/60" />
 
       {/* Modal */}
       <div
         className="relative w-full max-w-3xl mx-4 max-h-[80vh] flex flex-col rounded-2xl shadow-2xl bg-background border border-border overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
+        onClick={e => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle bg-surface/50 shrink-0">
-          <h3 className="text-sm font-semibold text-foreground truncate">
-            {session?.title || i18nService.t('scheduledTasksViewSession')}
-          </h3>
+          <Tooltip
+            content={titleState.tooltipContent}
+            disabled={!titleState.tooltipContent}
+            className="min-w-0 max-w-[80%] flex-1"
+          >
+            <h3 className="block w-full truncate text-sm font-semibold text-foreground">
+              {titleState.displayTitle}
+            </h3>
+          </Tooltip>
           <button
             type="button"
             onClick={onClose}
@@ -162,8 +177,21 @@ const RunSessionModal: React.FC<RunSessionModalProps> = ({ sessionId, sessionKey
           {loading && (
             <div className="flex flex-col items-center justify-center py-16 gap-3">
               <svg className="w-5 h-5 animate-spin text-secondary" viewBox="0 0 24 24" fill="none">
-                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" className="opacity-25" />
-                <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="4" strokeLinecap="round" className="opacity-75" />
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                  className="opacity-25"
+                />
+                <path
+                  d="M4 12a8 8 0 018-8"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                  strokeLinecap="round"
+                  className="opacity-75"
+                />
               </svg>
               <span className="text-sm text-secondary">
                 {retryCount > 0
@@ -197,14 +225,12 @@ const RunSessionModal: React.FC<RunSessionModalProps> = ({ sessionId, sessionKey
 
           {!loading && !error && turns.length > 0 && (
             <div className="py-2">
-              {turns.map((turn) => {
+              {turns.map(turn => {
                 const showAssistantBlock = turn.assistantItems.length > 0;
 
                 return (
                   <React.Fragment key={turn.id}>
-                    {turn.userMessage && (
-                      <UserMessageItem message={turn.userMessage} skills={[]} />
-                    )}
+                    {turn.userMessage && <UserMessageItem message={turn.userMessage} skills={[]} />}
                     {showAssistantBlock && (
                       <AssistantTurnBlock
                         turn={turn}

--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -1,18 +1,14 @@
 import { ArrowPathIcon } from '@heroicons/react/20/solid';
-import {
-  ArrowDownTrayIcon,
-  CheckCircleIcon,
-  XMarkIcon,
-} from '@heroicons/react/24/outline';
+import { ArrowDownTrayIcon, CheckCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { i18nService } from '../../services/i18n';
-import { compareVersions,resolveLocalizedText, skillService } from '../../services/skill';
+import { compareVersions, resolveLocalizedText, skillService } from '../../services/skill';
 import { RootState } from '../../store';
 import { setSkills } from '../../store/slices/skillSlice';
-import { MarketplaceSkill, MarketTag,Skill } from '../../types/skill';
+import { MarketplaceSkill, MarketTag, Skill } from '../../types/skill';
 import Modal from '../common/Modal';
 import ErrorMessage from '../ErrorMessage';
 import FolderOpenIcon from '../icons/FolderOpenIcon';
@@ -23,6 +19,7 @@ import PuzzleIcon from '../icons/PuzzleIcon';
 import SearchIcon from '../icons/SearchIcon';
 import TrashIcon from '../icons/TrashIcon';
 import UploadIcon from '../icons/UploadIcon';
+import Tooltip from '../ui/Tooltip';
 import SkillSecurityReport from './SkillSecurityReport';
 
 type SkillTab = 'installed' | 'marketplace';
@@ -30,13 +27,16 @@ type ImportSourceType = 'github' | 'clawhub';
 
 const importSourceTypes: ImportSourceType[] = ['github', 'clawhub'];
 
-const importTabConfig: Record<ImportSourceType, {
-  tabLabelKey: string;
-  descriptionKey: string;
-  urlLabelKey: string;
-  placeholderKey: string;
-  examplesKey: string;
-}> = {
+const importTabConfig: Record<
+  ImportSourceType,
+  {
+    tabLabelKey: string;
+    descriptionKey: string;
+    urlLabelKey: string;
+    placeholderKey: string;
+    examplesKey: string;
+  }
+> = {
   github: {
     tabLabelKey: 'githubTabLabel',
     descriptionKey: 'githubImportDescription',
@@ -75,7 +75,9 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
   const [activeMarketTag, setActiveMarketTag] = useState('all');
   const [isLoadingMarketplace, setIsLoadingMarketplace] = useState(false);
   const [installingSkillId, setInstallingSkillId] = useState<string | null>(null);
-  const [selectedMarketplaceSkill, setSelectedMarketplaceSkill] = useState<MarketplaceSkill | null>(null);
+  const [selectedMarketplaceSkill, setSelectedMarketplaceSkill] = useState<MarketplaceSkill | null>(
+    null,
+  );
   const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
   const [skillPendingDelete, setSkillPendingDelete] = useState<Skill | null>(null);
   const [isDeletingSkill, setIsDeletingSkill] = useState(false);
@@ -119,13 +121,15 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
   useEffect(() => {
     let isActive = true;
     setIsLoadingMarketplace(true);
-    skillService.fetchMarketplaceSkills().then((data) => {
+    skillService.fetchMarketplaceSkills().then(data => {
       if (!isActive) return;
       setMarketplaceSkills(data.skills);
       setMarketTags(data.tags);
       setIsLoadingMarketplace(false);
     });
-    return () => { isActive = false; };
+    return () => {
+      isActive = false;
+    };
   }, []);
 
   useEffect(() => {
@@ -190,8 +194,12 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
   const filteredSkills = useMemo(() => {
     const query = skillSearchQuery.toLowerCase();
     return skills.filter(skill => {
-      const matchesSearch = skill.name.toLowerCase().includes(query)
-        || skillService.getLocalizedSkillDescription(skill.id, skill.name, skill.description).toLowerCase().includes(query);
+      const matchesSearch =
+        skill.name.toLowerCase().includes(query) ||
+        skillService
+          .getLocalizedSkillDescription(skill.id, skill.name, skill.description)
+          .toLowerCase()
+          .includes(query);
       return matchesSearch;
     });
   }, [skills, skillSearchQuery]);
@@ -201,8 +209,10 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
     let results = marketplaceSkills;
     if (query) {
       results = results.filter(skill => {
-        return skill.name.toLowerCase().includes(query)
-          || resolveLocalizedText(skill.description).toLowerCase().includes(query);
+        return (
+          skill.name.toLowerCase().includes(query) ||
+          resolveLocalizedText(skill.description).toLowerCase().includes(query)
+        );
       });
     }
     if (activeMarketTag !== 'all') {
@@ -225,7 +235,9 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
       dispatch(setSkills(updatedSkills));
       setSkillActionError('');
     } catch (error) {
-      setSkillActionError(error instanceof Error ? error.message : i18nService.t('skillUpdateFailed'));
+      setSkillActionError(
+        error instanceof Error ? error.message : i18nService.t('skillUpdateFailed'),
+      );
     }
   };
 
@@ -267,14 +279,17 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
     setSkillActionError('');
     const result = await skillService.downloadSkill(trimmedSource);
     setIsDownloadingSkill(false);
-    console.log('[SkillsManager] downloadSkill result:', JSON.stringify({
-      success: result.success,
-      error: result.error,
-      hasAuditReport: !!result.auditReport,
-      pendingInstallId: result.pendingInstallId,
-      riskLevel: result.auditReport?.riskLevel,
-      findingsCount: result.auditReport?.findings?.length,
-    }));
+    console.log(
+      '[SkillsManager] downloadSkill result:',
+      JSON.stringify({
+        success: result.success,
+        error: result.error,
+        hasAuditReport: !!result.auditReport,
+        pendingInstallId: result.pendingInstallId,
+        riskLevel: result.auditReport?.riskLevel,
+        findingsCount: result.auditReport?.findings?.length,
+      }),
+    );
     if (!result.success) {
       setSkillActionError(result.error || i18nService.t('skillDownloadFailed'));
       return;
@@ -328,7 +343,9 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
       // Not installed → switch to marketplace tab and search
       setActiveTab('marketplace');
       setSkillSearchQuery('skill-creator');
-      window.dispatchEvent(new CustomEvent('app:showToast', { detail: i18nService.t('skillCreatorNotInstalled') }));
+      window.dispatchEvent(
+        new CustomEvent('app:showToast', { detail: i18nService.t('skillCreatorNotInstalled') }),
+      );
       return;
     }
 
@@ -336,7 +353,9 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
       // Installed but disabled → switch to installed tab and search
       setActiveTab('installed');
       setSkillSearchQuery('skill-creator');
-      window.dispatchEvent(new CustomEvent('app:showToast', { detail: i18nService.t('skillCreatorNotEnabled') }));
+      window.dispatchEvent(
+        new CustomEvent('app:showToast', { detail: i18nService.t('skillCreatorNotEnabled') }),
+      );
       return;
     }
 
@@ -371,7 +390,9 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
     await handleAddSkillFromSource(trimmed);
   };
 
-  const getSkillInstallStatus = (marketplaceSkill: MarketplaceSkill): 'not_installed' | 'installed' | 'update_available' => {
+  const getSkillInstallStatus = (
+    marketplaceSkill: MarketplaceSkill,
+  ): 'not_installed' | 'installed' | 'update_available' => {
     const installed = skills.find(s => s.id === marketplaceSkill.id);
     if (!installed) return 'not_installed';
     if (!marketplaceSkill.version) return 'installed';
@@ -527,16 +548,11 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
   return (
     <div className="space-y-4">
       <div>
-        <p className="text-sm text-secondary">
-          {i18nService.t('skillsDescription')}
-        </p>
+        <p className="text-sm text-secondary">{i18nService.t('skillsDescription')}</p>
       </div>
 
       {skillActionError && !isRemoteImportOpen && (
-        <ErrorMessage
-          message={skillActionError}
-          onClose={() => setSkillActionError('')}
-        />
+        <ErrorMessage message={skillActionError} onClose={() => setSkillActionError('')} />
       )}
 
       <div className="flex items-center gap-3">
@@ -546,7 +562,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
             type="text"
             placeholder={i18nService.t('searchSkills')}
             value={skillSearchQuery}
-            onChange={(e) => setSkillSearchQuery(e.target.value)}
+            onChange={e => setSkillSearchQuery(e.target.value)}
             className="w-full pl-9 pr-3 py-2 text-sm rounded-xl bg-surface text-foreground placeholder-secondary border border-border focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </div>
@@ -624,9 +640,11 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
               {skills.length}
             </span>
           )}
-          <div className={`absolute bottom-0 left-0 right-0 h-0.5 rounded-full transition-colors ${
-            activeTab === 'installed' ? 'bg-primary' : 'bg-transparent'
-          }`} />
+          <div
+            className={`absolute bottom-0 left-0 right-0 h-0.5 rounded-full transition-colors ${
+              activeTab === 'installed' ? 'bg-primary' : 'bg-transparent'
+            }`}
+          />
         </button>
         <button
           type="button"
@@ -638,9 +656,11 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
           }`}
         >
           {i18nService.t('skillMarketplace')}
-          <div className={`absolute bottom-0 left-0 right-0 h-0.5 rounded-full transition-colors ${
-            activeTab === 'marketplace' ? 'bg-primary' : 'bg-transparent'
-          }`} />
+          <div
+            className={`absolute bottom-0 left-0 right-0 h-0.5 rounded-full transition-colors ${
+              activeTab === 'marketplace' ? 'bg-primary' : 'bg-transparent'
+            }`}
+          />
         </button>
         {updatableSkills.length > 0 && (
           <div className="ml-auto pr-1 pb-1">
@@ -658,107 +678,122 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
       </div>
 
       {activeTab === 'installed' && (
-      <>
-      <div className="grid grid-cols-2 gap-3">
-        {filteredSkills.length === 0 ? (
-          <div className="col-span-2 text-center py-8 text-sm text-secondary">
-            {i18nService.t('noSkillsAvailable')}
-          </div>
-        ) : (
-          filteredSkills.map((skill) => (
-            <div
-              key={skill.id}
-              className="rounded-xl border border-border bg-surface p-3 transition-colors hover:border-primary cursor-pointer"
-              onClick={() => setSelectedSkill(skill)}
-            >
-              <div className="flex items-start justify-between mb-2">
-                <div className="flex items-center gap-2 min-w-0">
-                  <div className="w-7 h-7 rounded-lg bg-surface flex items-center justify-center flex-shrink-0">
-                    <PuzzleIcon className="h-4 w-4 text-secondary" />
-                  </div>
-                  <span className="text-sm font-medium text-foreground truncate">
-                    {skill.name}
-                  </span>
-                </div>
-                <div className="flex items-center gap-2 flex-shrink-0">
-                  {!readOnly && !skill.isBuiltIn && (
-                    <button
-                      type="button"
-                      onClick={(e) => { e.stopPropagation(); handleRequestDeleteSkill(skill); }}
-                      className="p-1 rounded-lg text-secondary hover:text-red-500 dark:hover:text-red-400 transition-colors"
-                      title={i18nService.t('deleteSkill')}
-                    >
-                      <TrashIcon className="h-4 w-4" />
-                    </button>
-                  )}
-                  <div
-                    className={`w-9 h-5 rounded-full flex items-center transition-colors flex-shrink-0 ${
-                      readOnly ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
-                    } ${
-                      skill.enabled ? 'bg-primary' : 'bg-border'
-                    }`}
-                    onClick={(e) => { e.stopPropagation(); if (!readOnly) handleToggleSkill(skill.id); }}
-                  >
-                    <div
-                      className={`w-3.5 h-3.5 rounded-full bg-white shadow-md transform transition-transform ${
-                        skill.enabled ? 'translate-x-[18px]' : 'translate-x-[3px]'
-                      }`}
-                    />
-                  </div>
-                </div>
+        <>
+          <div className="grid grid-cols-2 gap-3">
+            {filteredSkills.length === 0 ? (
+              <div className="col-span-2 text-center py-8 text-sm text-secondary">
+                {i18nService.t('noSkillsAvailable')}
               </div>
-
-              <p className="text-xs text-secondary line-clamp-2 mb-2">
-                {skillService.getLocalizedSkillDescription(skill.id, skill.name, skill.description)}
-              </p>
-
-              <div className="flex items-center justify-between text-[10px] text-secondary">
-                <div className="flex items-center gap-2">
-                {skill.isOfficial && (
-                  <>
-                    <span className="px-1.5 py-0.5 rounded bg-primary-muted text-primary font-medium">
-                      {i18nService.t('official')}
-                    </span>
-                    <span>·</span>
-                  </>
-                )}
-                {skill.version && (
-                  <>
-                    <span className="px-1.5 py-0.5 rounded bg-surface-raised font-medium">
-                      v{skill.version}
-                    </span>
-                    <span>·</span>
-                  </>
-                )}
-                <span>{formatSkillDate(skill.updatedAt)}</span>
-                </div>
-                {(() => {
-                  const mp = marketplaceSkills.find(m => m.id === skill.id);
-                  if (mp && mp.version && compareVersions(mp.version, skill.version || '0.0.0') > 0) {
-                    return (
-                      <button
-                        type="button"
-                        onClick={(e) => { e.stopPropagation(); handleUpgradeSkill(mp); }}
-                        disabled={upgradeState?.isActive === true}
-                        className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded-lg border border-emerald-500/30 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            ) : (
+              filteredSkills.map(skill => (
+                <div
+                  key={skill.id}
+                  className="rounded-xl border border-border bg-surface p-3 transition-colors hover:border-primary cursor-pointer"
+                  onClick={() => setSelectedSkill(skill)}
+                >
+                  <div className="flex items-start justify-between mb-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <div className="w-7 h-7 rounded-lg bg-surface flex items-center justify-center flex-shrink-0">
+                        <PuzzleIcon className="h-4 w-4 text-secondary" />
+                      </div>
+                      <span className="text-sm font-medium text-foreground truncate">
+                        {skill.name}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      {!readOnly && !skill.isBuiltIn && (
+                        <button
+                          type="button"
+                          onClick={e => {
+                            e.stopPropagation();
+                            handleRequestDeleteSkill(skill);
+                          }}
+                          className="p-1 rounded-lg text-secondary hover:text-red-500 dark:hover:text-red-400 transition-colors"
+                          title={i18nService.t('deleteSkill')}
+                        >
+                          <TrashIcon className="h-4 w-4" />
+                        </button>
+                      )}
+                      <div
+                        className={`w-9 h-5 rounded-full flex items-center transition-colors flex-shrink-0 ${
+                          readOnly ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+                        } ${skill.enabled ? 'bg-primary' : 'bg-border'}`}
+                        onClick={e => {
+                          e.stopPropagation();
+                          if (!readOnly) handleToggleSkill(skill.id);
+                        }}
                       >
-                        <ArrowPathIcon className="h-3.5 w-3.5" />
-                        {i18nService.t('skillUpgrade')}
-                      </button>
-                    );
-                  }
-                  return null;
-                })()}
-              </div>
-            </div>
-          ))
-        )}
-      </div>
-      </>
+                        <div
+                          className={`w-3.5 h-3.5 rounded-full bg-white shadow-md transform transition-transform ${
+                            skill.enabled ? 'translate-x-[18px]' : 'translate-x-[3px]'
+                          }`}
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <p className="text-xs text-secondary line-clamp-2 mb-2">
+                    {skillService.getLocalizedSkillDescription(
+                      skill.id,
+                      skill.name,
+                      skill.description,
+                    )}
+                  </p>
+
+                  <div className="flex items-center justify-between text-[10px] text-secondary">
+                    <div className="flex items-center gap-2">
+                      {skill.isOfficial && (
+                        <>
+                          <span className="px-1.5 py-0.5 rounded bg-primary-muted text-primary font-medium">
+                            {i18nService.t('official')}
+                          </span>
+                          <span>·</span>
+                        </>
+                      )}
+                      {skill.version && (
+                        <>
+                          <span className="px-1.5 py-0.5 rounded bg-surface-raised font-medium">
+                            v{skill.version}
+                          </span>
+                          <span>·</span>
+                        </>
+                      )}
+                      <span>{formatSkillDate(skill.updatedAt)}</span>
+                    </div>
+                    {(() => {
+                      const mp = marketplaceSkills.find(m => m.id === skill.id);
+                      if (
+                        mp &&
+                        mp.version &&
+                        compareVersions(mp.version, skill.version || '0.0.0') > 0
+                      ) {
+                        return (
+                          <button
+                            type="button"
+                            onClick={e => {
+                              e.stopPropagation();
+                              handleUpgradeSkill(mp);
+                            }}
+                            disabled={upgradeState?.isActive === true}
+                            className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded-lg border border-emerald-500/30 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            <ArrowPathIcon className="h-3.5 w-3.5" />
+                            {i18nService.t('skillUpgrade')}
+                          </button>
+                        );
+                      }
+                      return null;
+                    })()}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </>
       )}
 
-      {activeTab === 'marketplace' && (
-        isLoadingMarketplace ? (
+      {activeTab === 'marketplace' &&
+        (isLoadingMarketplace ? (
           <div className="text-center py-12 text-sm text-secondary">
             {i18nService.t('downloadingSkill')}
           </div>
@@ -777,7 +812,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                 >
                   {i18nService.t('skillCategoryAll')}
                 </button>
-                {marketTags.map((tag) => (
+                {marketTags.map(tag => (
                   <button
                     key={tag.id}
                     type="button"
@@ -799,113 +834,125 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
               </div>
             ) : (
               <div className="grid grid-cols-2 gap-3">
-                {filteredMarketplaceSkills.map((skill) => (
-              <div
-                key={skill.id}
-                className="rounded-xl border border-border bg-surface p-3 transition-colors hover:border-primary cursor-pointer"
-                onClick={() => setSelectedMarketplaceSkill(skill)}
-              >
-                <div className="flex items-start justify-between mb-2">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <div className="w-7 h-7 rounded-lg bg-surface flex items-center justify-center flex-shrink-0">
-                      <PuzzleIcon className="h-4 w-4 text-secondary" />
+                {filteredMarketplaceSkills.map(skill => (
+                  <div
+                    key={skill.id}
+                    className="rounded-xl border border-border bg-surface p-3 transition-colors hover:border-primary cursor-pointer"
+                    onClick={() => setSelectedMarketplaceSkill(skill)}
+                  >
+                    <div className="flex items-start justify-between mb-2">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <div className="w-7 h-7 rounded-lg bg-surface flex items-center justify-center flex-shrink-0">
+                          <PuzzleIcon className="h-4 w-4 text-secondary" />
+                        </div>
+                        <span className="text-sm font-medium text-foreground truncate">
+                          {skill.name}
+                        </span>
+                      </div>
+                      <div className="flex-shrink-0">
+                        {(() => {
+                          const status = getSkillInstallStatus(skill);
+                          if (status === 'update_available') {
+                            return (
+                              <button
+                                type="button"
+                                onClick={e => {
+                                  e.stopPropagation();
+                                  handleUpgradeSkill(skill);
+                                }}
+                                disabled={upgradeState?.isActive === true}
+                                className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded-lg border border-emerald-500/30 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                              >
+                                <ArrowPathIcon className="h-3.5 w-3.5" />
+                                {i18nService.t('skillUpgrade')}
+                              </button>
+                            );
+                          }
+                          if (status === 'installed') {
+                            return (
+                              <span className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded-lg text-green-600 dark:text-green-400 bg-green-500/10">
+                                <CheckCircleIcon className="h-3.5 w-3.5" />
+                                {i18nService.t('skillAlreadyInstalled')}
+                              </span>
+                            );
+                          }
+                          return !readOnly ? (
+                            <button
+                              type="button"
+                              onClick={e => {
+                                e.stopPropagation();
+                                handleInstallMarketplaceSkill(skill);
+                              }}
+                              disabled={installingSkillId !== null}
+                              className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded-lg bg-primary text-white hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              <ArrowDownTrayIcon className="h-3.5 w-3.5" />
+                              {installingSkillId === skill.id
+                                ? i18nService.t('skillInstalling')
+                                : i18nService.t('skillInstall')}
+                            </button>
+                          ) : null;
+                        })()}
+                      </div>
                     </div>
-                    <span className="text-sm font-medium text-foreground truncate">
-                      {skill.name}
-                    </span>
-                  </div>
-                  <div className="flex-shrink-0">
-                    {(() => {
-                      const status = getSkillInstallStatus(skill);
-                      if (status === 'update_available') {
-                        return (
-                          <button
-                            type="button"
-                            onClick={(e) => { e.stopPropagation(); handleUpgradeSkill(skill); }}
-                            disabled={upgradeState?.isActive === true}
-                            className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded-lg border border-emerald-500/30 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                          >
-                            <ArrowPathIcon className="h-3.5 w-3.5" />
-                            {i18nService.t('skillUpgrade')}
-                          </button>
-                        );
-                      }
-                      if (status === 'installed') {
-                        return (
-                          <span className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded-lg text-green-600 dark:text-green-400 bg-green-500/10">
-                            <CheckCircleIcon className="h-3.5 w-3.5" />
-                            {i18nService.t('skillAlreadyInstalled')}
-                          </span>
-                        );
-                      }
-                      return !readOnly ? (
-                        <button
-                          type="button"
-                          onClick={(e) => { e.stopPropagation(); handleInstallMarketplaceSkill(skill); }}
-                          disabled={installingSkillId !== null}
-                          className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded-lg bg-primary text-white hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          <ArrowDownTrayIcon className="h-3.5 w-3.5" />
-                          {installingSkillId === skill.id ? i18nService.t('skillInstalling') : i18nService.t('skillInstall')}
-                        </button>
-                      ) : null;
-                    })()}
-                  </div>
-                </div>
 
-                <p className="text-xs text-secondary line-clamp-2 mb-2">
-                  {resolveLocalizedText(skill.description)}
-                </p>
+                    <p className="text-xs text-secondary line-clamp-2 mb-2">
+                      {resolveLocalizedText(skill.description)}
+                    </p>
 
-                <div className="flex items-center gap-2 text-[10px] text-secondary">
-                  {skill.source?.from && (
-                    <>
-                      <span className="px-1.5 py-0.5 rounded bg-surface-raised font-medium">
-                        {skill.source.from}
-                      </span>
-                      <span>·</span>
-                    </>
-                  )}
-                  {skill.version && (
-                    <>
-                      {(() => {
-                        const installedVer = getInstalledVersion(skill.id);
-                        if (installedVer && compareVersions(skill.version, installedVer) > 0) {
-                          return (
-                            <span className="px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600 dark:text-amber-400 font-medium">
-                              v{installedVer} → v{skill.version}
-                            </span>
-                          );
-                        }
-                        return (
+                    <div className="flex items-center gap-2 text-[10px] text-secondary">
+                      {skill.source?.from && (
+                        <>
                           <span className="px-1.5 py-0.5 rounded bg-surface-raised font-medium">
-                            v{skill.version}
+                            {skill.source.from}
                           </span>
-                        );
-                      })()}
-                    </>
-                  )}
-                </div>
+                          <span>·</span>
+                        </>
+                      )}
+                      {skill.version && (
+                        <>
+                          {(() => {
+                            const installedVer = getInstalledVersion(skill.id);
+                            if (installedVer && compareVersions(skill.version, installedVer) > 0) {
+                              return (
+                                <span className="px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600 dark:text-amber-400 font-medium">
+                                  v{installedVer} → v{skill.version}
+                                </span>
+                              );
+                            }
+                            return (
+                              <span className="px-1.5 py-0.5 rounded bg-surface-raised font-medium">
+                                v{skill.version}
+                              </span>
+                            );
+                          })()}
+                        </>
+                      )}
+                    </div>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
             )}
           </>
-        )
-      )}
+        ))}
 
-      {selectedMarketplaceSkill && createPortal(
-        <Modal onClose={() => setSelectedMarketplaceSkill(null)} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6">
+      {selectedMarketplaceSkill &&
+        createPortal(
+          <Modal
+            onClose={() => setSelectedMarketplaceSkill(null)}
+            overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+            className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6"
+          >
             <div className="flex items-start justify-between mb-4">
-              <div className="flex items-center gap-3 min-w-0">
+              <div className="flex items-center gap-3 min-w-0 max-w-[80%]">
                 <div className="w-9 h-9 rounded-lg bg-background flex items-center justify-center flex-shrink-0">
                   <PuzzleIcon className="h-5 w-5 text-secondary" />
                 </div>
-                <div className="min-w-0">
-                  <div className="text-base font-semibold text-foreground truncate">
+                <Tooltip content={selectedMarketplaceSkill.name} className="min-w-0 flex-1">
+                  <div className="block w-full truncate text-base font-semibold text-foreground">
                     {selectedMarketplaceSkill.name}
                   </div>
-                </div>
+                </Tooltip>
               </div>
               <button
                 type="button"
@@ -923,7 +970,9 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
             <div className="space-y-2 mb-5">
               {selectedMarketplaceSkill.version && (
                 <div className="flex items-center text-xs">
-                  <span className="w-16 flex-shrink-0 text-secondary">{i18nService.t('skillDetailVersion')}</span>
+                  <span className="w-16 flex-shrink-0 text-secondary">
+                    {i18nService.t('skillDetailVersion')}
+                  </span>
                   <span className="px-1.5 py-0.5 rounded bg-surface-raised text-foreground font-medium">
                     v{selectedMarketplaceSkill.version}
                   </span>
@@ -931,7 +980,9 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
               )}
               {selectedMarketplaceSkill.source?.from && (
                 <div className="flex items-center text-xs">
-                  <span className="w-16 flex-shrink-0 text-secondary">{i18nService.t('skillDetailSource')}</span>
+                  <span className="w-16 flex-shrink-0 text-secondary">
+                    {i18nService.t('skillDetailSource')}
+                  </span>
                   <span className="px-1.5 py-0.5 rounded bg-surface-raised text-foreground font-medium">
                     {selectedMarketplaceSkill.source.from}
                   </span>
@@ -948,7 +999,10 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                   <button
                     type="button"
                     className="text-primary hover:underline break-all text-left"
-                    onClick={(e) => { e.stopPropagation(); window.electron.shell.openExternal(selectedMarketplaceSkill.source.url); }}
+                    onClick={e => {
+                      e.stopPropagation();
+                      window.electron.shell.openExternal(selectedMarketplaceSkill.source.url);
+                    }}
                   >
                     {selectedMarketplaceSkill.source.url}
                   </button>
@@ -968,7 +1022,8 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                     className="w-full py-2.5 rounded-xl bg-amber-500 text-white text-sm font-medium hover:bg-amber-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
                   >
                     <ArrowPathIcon className="h-4 w-4" />
-                    {i18nService.t('skillUpgrade')} v{installedVer} → v{selectedMarketplaceSkill.version}
+                    {i18nService.t('skillUpgrade')} v{installedVer} → v
+                    {selectedMarketplaceSkill.version}
                   </button>
                 );
               }
@@ -988,25 +1043,33 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                   className="w-full py-2.5 rounded-xl bg-primary text-white text-sm font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
                 >
                   <ArrowDownTrayIcon className="h-4 w-4" />
-                  {installingSkillId === selectedMarketplaceSkill.id ? i18nService.t('skillInstalling') : i18nService.t('skillInstall')}
+                  {installingSkillId === selectedMarketplaceSkill.id
+                    ? i18nService.t('skillInstalling')
+                    : i18nService.t('skillInstall')}
                 </button>
               ) : null;
             })()}
-        </Modal>
-      , document.body)}
+          </Modal>,
+          document.body,
+        )}
 
-      {selectedSkill && createPortal(
-        <Modal onClose={() => setSelectedSkill(null)} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6">
+      {selectedSkill &&
+        createPortal(
+          <Modal
+            onClose={() => setSelectedSkill(null)}
+            overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+            className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6"
+          >
             <div className="flex items-start justify-between mb-4">
-              <div className="flex items-center gap-3 min-w-0">
+              <div className="flex items-center gap-3 min-w-0 max-w-[80%]">
                 <div className="w-9 h-9 rounded-lg bg-background flex items-center justify-center flex-shrink-0">
                   <PuzzleIcon className="h-5 w-5 text-secondary" />
                 </div>
-                <div className="min-w-0">
-                  <div className="text-base font-semibold text-foreground truncate">
+                <Tooltip content={selectedSkill.name} className="min-w-0 flex-1">
+                  <div className="block w-full truncate text-base font-semibold text-foreground">
                     {selectedSkill.name}
                   </div>
-                </div>
+                </Tooltip>
               </div>
               <button
                 type="button"
@@ -1018,7 +1081,11 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
             </div>
 
             <p className="text-sm text-secondary mb-4">
-              {skillService.getLocalizedSkillDescription(selectedSkill.id, selectedSkill.name, selectedSkill.description)}
+              {skillService.getLocalizedSkillDescription(
+                selectedSkill.id,
+                selectedSkill.name,
+                selectedSkill.description,
+              )}
             </p>
 
             <div className="space-y-2 mb-5">
@@ -1028,7 +1095,9 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                   <>
                     {selectedSkill.isOfficial && (
                       <div className="flex items-center text-xs">
-                        <span className="w-16 flex-shrink-0 text-secondary">{i18nService.t('skillDetailSource')}</span>
+                        <span className="w-16 flex-shrink-0 text-secondary">
+                          {i18nService.t('skillDetailSource')}
+                        </span>
                         <span className="px-1.5 py-0.5 rounded bg-primary-muted text-primary font-medium">
                           {i18nService.t('official')}
                         </span>
@@ -1041,7 +1110,9 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                     )}
                     {!selectedSkill.isOfficial && mp?.source?.from && (
                       <div className="flex items-center text-xs">
-                        <span className="w-16 flex-shrink-0 text-secondary">{i18nService.t('skillDetailSource')}</span>
+                        <span className="w-16 flex-shrink-0 text-secondary">
+                          {i18nService.t('skillDetailSource')}
+                        </span>
                         <span className="px-1.5 py-0.5 rounded bg-surface-raised text-foreground font-medium">
                           {mp.source.from}
                         </span>
@@ -1058,7 +1129,10 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                         <button
                           type="button"
                           className="text-primary hover:underline break-all text-left"
-                          onClick={(e) => { e.stopPropagation(); window.electron.shell.openExternal(mp.source.url); }}
+                          onClick={e => {
+                            e.stopPropagation();
+                            window.electron.shell.openExternal(mp.source.url);
+                          }}
                         >
                           {mp.source.url}
                         </button>
@@ -1073,7 +1147,10 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
               {!readOnly && !selectedSkill.isBuiltIn ? (
                 <button
                   type="button"
-                  onClick={() => { setSelectedSkill(null); handleRequestDeleteSkill(selectedSkill); }}
+                  onClick={() => {
+                    setSelectedSkill(null);
+                    handleRequestDeleteSkill(selectedSkill);
+                  }}
                   className="inline-flex items-center gap-1.5 px-3 py-2 text-sm rounded-xl text-red-500 dark:text-red-400 hover:bg-red-500/10 transition-colors"
                 >
                   <TrashIcon className="h-4 w-4" />
@@ -1085,9 +1162,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
               <div
                 className={`w-9 h-5 rounded-full flex items-center transition-colors flex-shrink-0 ${
                   readOnly ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
-                } ${
-                  selectedSkill.enabled ? 'bg-primary' : 'bg-border'
-                }`}
+                } ${selectedSkill.enabled ? 'bg-primary' : 'bg-border'}`}
                 onClick={() => {
                   if (readOnly) return;
                   handleToggleSkill(selectedSkill.id);
@@ -1101,11 +1176,17 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                 />
               </div>
             </div>
-        </Modal>
-      , document.body)}
+          </Modal>,
+          document.body,
+        )}
 
-      {skillPendingDelete && createPortal(
-        <Modal onClose={handleCancelDeleteSkill} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-sm mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-5">
+      {skillPendingDelete &&
+        createPortal(
+          <Modal
+            onClose={handleCancelDeleteSkill}
+            overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+            className="w-full max-w-sm mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-5"
+          >
             <div className="text-lg font-semibold text-foreground">
               {i18nService.t('deleteSkill')}
             </div>
@@ -1113,9 +1194,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
               {i18nService.t('skillDeleteConfirm').replace('{name}', skillPendingDelete.name)}
             </p>
             {skillActionError && (
-              <div className="mt-3 text-xs text-red-500">
-                {skillActionError}
-              </div>
+              <div className="mt-3 text-xs text-red-500">{skillActionError}</div>
             )}
             <div className="mt-4 flex items-center justify-end gap-2">
               <button
@@ -1135,18 +1214,30 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                 {i18nService.t('confirmDelete')}
               </button>
             </div>
-        </Modal>
-      , document.body)}
+          </Modal>,
+          document.body,
+        )}
 
-      {isRemoteImportOpen && createPortal(
-        <Modal onClose={() => { setIsRemoteImportOpen(false); setSkillActionError(''); }} overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60" className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6">
+      {isRemoteImportOpen &&
+        createPortal(
+          <Modal
+            onClose={() => {
+              setIsRemoteImportOpen(false);
+              setSkillActionError('');
+            }}
+            overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+            className="w-full max-w-md mx-4 rounded-2xl bg-surface border border-border shadow-2xl p-6"
+          >
             <div className="flex items-start justify-between">
               <div className="text-lg font-semibold text-foreground">
                 {i18nService.t('remoteImportTitle')}
               </div>
               <button
                 type="button"
-                onClick={() => { setIsRemoteImportOpen(false); setSkillActionError(''); }}
+                onClick={() => {
+                  setIsRemoteImportOpen(false);
+                  setSkillActionError('');
+                }}
                 className="p-1.5 rounded-lg text-secondary hover:text-foreground hover:bg-surface-raised transition-colors"
               >
                 <XMarkIcon className="h-5 w-5" />
@@ -1154,15 +1245,17 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
             </div>
 
             <div className="mt-4 flex items-center gap-1 border-b border-border">
-              {importSourceTypes.map((type) => (
+              {importSourceTypes.map(type => (
                 <button
                   key={type}
                   type="button"
-                  onClick={() => { setImportTab(type); setSkillDownloadSource(''); setSkillActionError(''); }}
+                  onClick={() => {
+                    setImportTab(type);
+                    setSkillDownloadSource('');
+                    setSkillActionError('');
+                  }}
                   className={`px-3 py-1.5 text-sm font-medium transition-colors relative ${
-                    importTab === type
-                      ? 'text-foreground'
-                      : 'text-secondary hover:text-foreground'
+                    importTab === type ? 'text-foreground' : 'text-secondary hover:text-foreground'
                   }`}
                 >
                   {i18nService.t(importTabConfig[type].tabLabelKey)}
@@ -1184,29 +1277,28 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                 ref={importInputRef}
                 type="text"
                 value={skillDownloadSource}
-                onChange={(e) => setSkillDownloadSource(e.target.value)}
+                onChange={e => setSkillDownloadSource(e.target.value)}
                 placeholder={i18nService.t(importTabConfig[importTab].placeholderKey)}
                 className="w-full px-3 py-2.5 text-sm rounded-xl bg-background text-foreground placeholder-secondary border border-border focus:outline-none focus:ring-2 focus:ring-primary"
               />
               <p className="text-xs text-secondary">
                 {i18nService.t(importTabConfig[importTab].examplesKey)}
               </p>
-              {skillActionError && (
-                <div className="text-xs text-red-500">
-                  {skillActionError}
-                </div>
-              )}
+              {skillActionError && <div className="text-xs text-red-500">{skillActionError}</div>}
               <button
                 type="button"
                 onClick={handleImportFromDialog}
                 disabled={isDownloadingSkill || !skillDownloadSource.trim()}
                 className="w-full py-2.5 rounded-xl bg-primary text-white text-sm font-medium hover:bg-primary-hover transition-colors disabled:opacity-50"
               >
-                {isDownloadingSkill ? i18nService.t('importingSkill') : i18nService.t('importSkill')}
+                {isDownloadingSkill
+                  ? i18nService.t('importingSkill')
+                  : i18nService.t('importSkill')}
               </button>
             </div>
-        </Modal>
-      , document.body)}
+          </Modal>,
+          document.body,
+        )}
 
       {securityReport && (
         <SkillSecurityReport
@@ -1221,7 +1313,8 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
           <div className="w-full max-w-sm mx-4 rounded-2xl dark:bg-claude-darkSurface bg-claude-surface border dark:border-claude-darkBorder border-claude-border shadow-2xl p-6">
             <div className="text-center">
               <div className="text-sm font-medium dark:text-claude-darkText text-claude-text mb-4">
-                {i18nService.t('skillUpgrading')
+                {i18nService
+                  .t('skillUpgrading')
                   .replace('{current}', String(upgradeState.current))
                   .replace('{total}', String(upgradeState.total))}
               </div>
@@ -1234,7 +1327,8 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
               </div>
 
               <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary mb-4">
-                {i18nService.t('skillUpgradingCurrent')
+                {i18nService
+                  .t('skillUpgradingCurrent')
                   .replace('{name}', upgradeState.currentSkillName)
                   .replace('{version}', upgradeState.currentSkillVersion)}
               </div>
@@ -1242,7 +1336,9 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
               {upgradeState.total > 1 && (
                 <button
                   type="button"
-                  onClick={() => { upgradeCancelledRef.current = true; }}
+                  onClick={() => {
+                    upgradeCancelledRef.current = true;
+                  }}
                   className="px-4 py-1.5 text-xs rounded-lg border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkTextSecondary text-claude-textSecondary dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-colors"
                 >
                   {i18nService.t('skillUpgradeCancel')}


### PR DESCRIPTION
## What changed
- truncate long runtime titles in modal headers to keep dialogs stable
- show the full title in a hover tooltip when the text is clipped
- reuse one shared helper across agent, skill, MCP, and scheduled task modals

## Why
- issue #1435 reported that long custom agent names overflowed the create dialog header
- the same layout risk existed in a few other dialogs that render user or registry provided names

## Root cause
- these headers rendered dynamic titles directly without a shared width cap or overflow handling

## Validation
- `./node_modules/.bin/vitest run src/renderer/components/common/truncatedTitle.test.ts`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `./node_modules/.bin/eslint src/renderer/components/common/truncatedTitle.ts src/renderer/components/common/truncatedTitle.test.ts src/renderer/components/agent/AgentCreateModal.tsx src/renderer/components/agent/AgentSettingsPanel.tsx src/renderer/components/scheduledTasks/RunSessionModal.tsx src/renderer/components/skills/SkillsManager.tsx src/renderer/components/mcp/McpServerFormModal.tsx`

Closes #1435