### PR TITLE
fix(scheduled-tasks): 已删除的定时任务重启后作为幽灵会话重新出现

### DIFF
--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../scheduledTask/constants';
 import { PlatformRegistry } from '../../../shared/platform';
 import type { CronJobService } from '../../../scheduledTask/cronJobService';
+import type { ScheduledTaskMetaStore } from '../../../scheduledTask/metaStore';
 import { listScheduledTaskChannels } from './helpers';
 
 export interface ScheduledTaskHandlerDeps {
@@ -34,6 +35,10 @@ export interface ScheduledTaskHandlerDeps {
     getGatewayClient: () => unknown;
     fetchSessionByKey: (sessionKey: string) => Promise<unknown>;
   } | null;
+  /** Optional: clean up local cowork sessions spawned by a cron job. */
+  deleteCronSessions?: (jobId: string) => string[];
+  /** Optional: clean up orphaned task metadata. */
+  getMetaStore?: () => ScheduledTaskMetaStore | null;
 }
 
 /**
@@ -139,6 +144,29 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
   ipcMain.handle(ScheduledTaskIpc.Delete, async (_event, id: string) => {
     try {
       await getCronJobService().removeJob(id);
+
+      // Clean up local cowork sessions spawned by this cron job so they do not
+      // reappear as ghost entries after an app restart (fixes #1359).
+      if (deps.deleteCronSessions) {
+        try {
+          const deleted = deps.deleteCronSessions(id);
+          if (deleted.length > 0) {
+            console.log(`[IPC][scheduledTask:delete] cleaned up ${deleted.length} cron session(s) for job ${id}`);
+          }
+        } catch (cleanupError) {
+          console.warn('[IPC][scheduledTask:delete] session cleanup failed:', cleanupError);
+        }
+      }
+
+      // Remove orphaned task metadata.
+      if (deps.getMetaStore) {
+        try {
+          deps.getMetaStore()?.delete(id);
+        } catch (metaError) {
+          console.warn('[IPC][scheduledTask:delete] meta cleanup failed:', metaError);
+        }
+      }
+
       return { success: true, result: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Failed to delete task' };

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -644,6 +644,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     this.channelSessionSync = sync;
   }
 
+  getChannelSessionSync(): OpenClawChannelSessionSync | null {
+    return this.channelSessionSync;
+  }
+
   /**
    * Fetch session history from OpenClaw by sessionKey and return a transient
    * CoworkSession object (not persisted to local database).

--- a/src/main/libs/openclawChannelSessionSync.ts
+++ b/src/main/libs/openclawChannelSessionSync.ts
@@ -544,4 +544,25 @@ export class OpenClawChannelSessionSync {
       }
     }
   }
+
+  /**
+   * Delete all local cowork sessions that were created for the given cron job.
+   * This must be called when a scheduled task is deleted, so that the orphaned
+   * sessions do not reappear as ghost entries after an app restart.
+   *
+   * Returns the IDs of deleted sessions.
+   */
+  deleteCronSessionsByJobId(jobId: string): string[] {
+    const suffix = `cron:${jobId}`;
+    const deletedIds: string[] = [];
+    for (const [key, sessionId] of this.syncedSessionKeys.entries()) {
+      if (key === suffix || key.endsWith(`:${suffix}`)) {
+        this.coworkStore.deleteSession(sessionId);
+        this.syncedSessionKeys.delete(key);
+        this.rejectedKeys.delete(key);
+        deletedIds.push(sessionId);
+      }
+    }
+    return deletedIds;
+  }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3286,6 +3286,10 @@ if (!gotTheLock) {
     getCronJobService,
     getIMGatewayManager: () => getIMGatewayManager() as any,
     getOpenClawRuntimeAdapter: () => openClawRuntimeAdapter as any,
+    deleteCronSessions: (jobId: string) => {
+      const sync = openClawRuntimeAdapter?.getChannelSessionSync();
+      return sync ? sync.deleteCronSessionsByJobId(jobId) : [];
+    },
   });
 
   // ==================== Permissions IPC Handlers ====================


### PR DESCRIPTION
## 问题背景
关联 Issue：#1359
用户删除定时任务后操作成功，但重启应用后该任务又以空内容的幽灵会话形式
出现在会话列表中，反复删除反复出现。
## 根本原因
定时任务的删除流程存在数据清理缺口：
删除操作只调用了 `cron.remove`（OpenClaw 网关端），将网关侧的任务记录
移除。但定时任务每次执行时，`resolveOrCreateCronSession()` 会在本地
SQLite 的 `cowork_sessions` 表中创建一条关联会话记录。**删除任务时，
这条本地会话从未被清理。**
重启应用后，`listSessions()` 无差别地返回 `cowork_sessions` 中的所有
记录，孤儿会话因此重新出现在 UI 中。由于对应的网关任务已不存在，这些
会话没有任何消息内容，表现为「空的幽灵任务」。
**数据流链路：**
任务执行 → resolveOrCreateCronSession() → cowork_sessions 写入本地行
任务删除 → cron.remove → 网关端删除 ✓ / 本地会话未清理 ✗
应用重启 → listSessions() → 孤儿会话被加载 → 幽灵任务出现
## 修复方案
在删除任务的 IPC handler 中，`removeJob` 成功后增加本地会话清理步骤：
- **`openclawChannelSessionSync.ts`** — 新增 `deleteCronSessionsByJobId(jobId)`
  方法。遍历内存缓存 `syncedSessionKeys`，匹配 `cron:<jobId>` 及
  `agent:*:cron:<jobId>` 模式的 key，调用 `coworkStore.deleteSession()`
  删除对应的本地会话，并清理缓存条目。
- **`openclawRuntimeAdapter.ts`** — 新增 `getChannelSessionSync()` getter，
  使外部调用方可以访问 sync 实例。
- **`handlers.ts`** — `ScheduledTaskHandlerDeps` 接口新增可选回调
  `deleteCronSessions`；delete handler 在 `removeJob` 后调用该回调，
  用 try/catch 包裹以确保清理失败不阻断删除响应。
- **`main.ts`** — 注册 handler 时注入 `deleteCronSessions` 回调，
  委托给 `openClawRuntimeAdapter.getChannelSessionSync().deleteCronSessionsByJobId()`。
## 变更文件
- `src/main/libs/openclawChannelSessionSync.ts` — 新增 `deleteCronSessionsByJobId()`
- `src/main/libs/agentEngine/openclawRuntimeAdapter.ts` — 新增 `getChannelSessionSync()` getter
- `src/main/ipcHandlers/scheduledTask/handlers.ts` — 扩展 deps 接口，delete handler 增加清理逻辑
- `src/main/main.ts` — 注入 `deleteCronSessions` 回调
## 测试结果
Test Files  19 passed (22)
Tests      225 passed (225)