### PR TITLE
fix: Agent设置面板关闭时添加未保存确认，防止配置静默丢失

### DIFF
--- a/src/renderer/components/agent/AgentSettingsPanel.tsx
+++ b/src/renderer/components/agent/AgentSettingsPanel.tsx
@@ -4,26 +4,20 @@ import { RootState } from '../../store';
 import { agentService } from '../../services/agent';
 import { imService } from '../../services/im';
 import { i18nService } from '../../services/i18n';
-import { XMarkIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { ExclamationTriangleIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import TrashIcon from '../icons/TrashIcon';
 import type { Agent } from '../../types/agent';
-import type { IMPlatform, IMGatewayConfig } from '../../types/im';
+import type { Platform } from '@shared/platform';
+import type { IMGatewayConfig } from '../../types/im';
 import { getVisibleIMPlatforms } from '../../utils/regionFilter';
+import { PlatformRegistry } from '@shared/platform';
 import AgentSkillSelector from './AgentSkillSelector';
+import EmojiPicker from './EmojiPicker';
+import Modal from '../common/Modal';
 
 type SettingsTab = 'basic' | 'skills' | 'im';
 
-const IM_PLATFORMS: { key: IMPlatform; logo: string }[] = [
-  { key: 'dingtalk', logo: 'dingding.png' },
-  { key: 'feishu', logo: 'feishu.png' },
-  { key: 'qq', logo: 'qq_bot.jpeg' },
-  { key: 'telegram', logo: 'telegram.svg' },
-  { key: 'discord', logo: 'discord.svg' },
-  { key: 'nim', logo: 'nim.png' },
-  { key: 'xiaomifeng', logo: 'xiaomifeng.png' },
-  { key: 'weixin', logo: 'weixin.png' },
-  { key: 'wecom', logo: 'wecom.png' },
-  { key: 'popo', logo: 'popo.png' },
-];
+const MULTI_INSTANCE_PLATFORMS: Platform[] = ['dingtalk', 'feishu', 'qq'];
 
 interface AgentSettingsPanelProps {
   agentId: string | null;
@@ -33,6 +27,8 @@ interface AgentSettingsPanelProps {
 
 const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClose, onSwitchAgent }) => {
   const currentAgentId = useSelector((state: RootState) => state.agent.currentAgentId);
+  const agents = useSelector((state: RootState) => state.agent.agents);
+  const imStatus = useSelector((state: RootState) => state.im.status);
   const [, setAgent] = useState<Agent | null>(null);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -42,12 +38,16 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
   const [skillIds, setSkillIds] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const [activeTab, setActiveTab] = useState<SettingsTab>('basic');
+  const [initialValues, setInitialValues] = useState({
+    name: '', description: '', systemPrompt: '', identity: '', icon: '', skillIds: [] as string[],
+  });
 
-  // IM binding state
+  // IM binding state — keys are 'telegram' (single) or 'dingtalk:<instanceId>' (multi)
   const [imConfig, setImConfig] = useState<IMGatewayConfig | null>(null);
-  const [boundPlatforms, setBoundPlatforms] = useState<Set<IMPlatform>>(new Set());
-  const [initialBoundPlatforms, setInitialBoundPlatforms] = useState<Set<IMPlatform>>(new Set());
+  const [boundKeys, setBoundKeys] = useState<Set<string>>(new Set());
+  const [initialBoundKeys, setInitialBoundKeys] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (!agentId) return;
@@ -62,26 +62,50 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
         setIdentity(a.identity);
         setIcon(a.icon);
         setSkillIds(a.skillIds ?? []);
+        setInitialValues({
+          name: a.name, description: a.description, systemPrompt: a.systemPrompt,
+          identity: a.identity, icon: a.icon, skillIds: a.skillIds ?? [],
+        });
       }
     });
-    // Load IM config for bindings
+    // Load IM config and status for bindings
     imService.loadConfig().then((cfg) => {
       if (cfg) {
         setImConfig(cfg);
         const bindings = cfg.settings?.platformAgentBindings || {};
-        const bound = new Set<IMPlatform>();
-        for (const [platform, boundAgentId] of Object.entries(bindings)) {
+        const bound = new Set<string>();
+        for (const [key, boundAgentId] of Object.entries(bindings)) {
           if (boundAgentId === agentId) {
-            bound.add(platform as IMPlatform);
+            bound.add(key);
           }
         }
-        setBoundPlatforms(bound);
-        setInitialBoundPlatforms(new Set(bound));
+        setBoundKeys(bound);
+        setInitialBoundKeys(new Set(bound));
       }
     });
+    imService.loadStatus();
   }, [agentId]);
 
   if (!agentId) return null;
+
+  const isDirty = name !== initialValues.name || description !== initialValues.description ||
+    systemPrompt !== initialValues.systemPrompt || identity !== initialValues.identity ||
+    icon !== initialValues.icon ||
+    JSON.stringify([...skillIds].sort()) !== JSON.stringify([...initialValues.skillIds].sort()) ||
+    boundKeys.size !== initialBoundKeys.size || [...boundKeys].some((k) => !initialBoundKeys.has(k));
+
+  const handleClose = () => {
+    if (isDirty) {
+      setShowDiscardConfirm(true);
+    } else {
+      onClose();
+    }
+  };
+
+  const handleConfirmDiscard = () => {
+    setShowDiscardConfirm(false);
+    onClose();
+  };
 
   const handleSave = async () => {
     if (!name.trim()) return;
@@ -97,8 +121,8 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
       });
       // Persist IM bindings if changed
       const bindingsChanged =
-        boundPlatforms.size !== initialBoundPlatforms.size ||
-        [...boundPlatforms].some((p) => !initialBoundPlatforms.has(p));
+        boundKeys.size !== initialBoundKeys.size ||
+        [...boundKeys].some((k) => !initialBoundKeys.has(k));
       if (bindingsChanged && imConfig) {
         const currentBindings = { ...(imConfig.settings?.platformAgentBindings || {}) };
         // Remove old bindings for this agent
@@ -108,8 +132,8 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
           }
         }
         // Add new bindings
-        for (const platform of boundPlatforms) {
-          currentBindings[platform] = agentId;
+        for (const key of boundKeys) {
+          currentBindings[key] = agentId;
         }
         await imService.persistConfig({
           settings: { ...imConfig.settings, platformAgentBindings: currentBindings },
@@ -129,19 +153,45 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
     }
   };
 
-  const handleToggleIMBinding = (platform: IMPlatform) => {
-    const next = new Set(boundPlatforms);
-    if (next.has(platform)) {
-      next.delete(platform);
+  const handleToggleIMBinding = (key: string) => {
+    const next = new Set(boundKeys);
+    if (next.has(key)) {
+      next.delete(key);
     } else {
-      next.add(platform);
+      next.add(key);
     }
-    setBoundPlatforms(next);
+    setBoundKeys(next);
   };
 
-  const isPlatformConfigured = (platform: IMPlatform): boolean => {
+  /** Check if a multi-instance platform has any enabled+connected instances */
+  const getConnectedInstances = (platform: Platform) => {
+    if (!imConfig) return [];
+    const cfg = imConfig[platform] as any;
+    const instances = cfg?.instances;
+    if (!Array.isArray(instances)) return [];
+    const statusInstances = (imStatus as any)?.[platform]?.instances;
+    return instances.filter((inst: any) => {
+      if (!inst.enabled) return false;
+      const instStatus = Array.isArray(statusInstances)
+        ? statusInstances.find((s: any) => s.instanceId === inst.instanceId)
+        : null;
+      return instStatus?.connected === true;
+    });
+  };
+
+  const isPlatformConfigured = (platform: Platform): boolean => {
     if (!imConfig) return false;
-    return imConfig[platform]?.enabled === true;
+    if (MULTI_INSTANCE_PLATFORMS.includes(platform)) {
+      return getConnectedInstances(platform).length > 0;
+    }
+    return (imConfig[platform] as any)?.enabled === true;
+  };
+
+  /** Resolve agent name by id */
+  const getAgentName = (aid: string): string | null => {
+    if (!aid || aid === 'main') return null;
+    const agent = agents.find((a) => a.id === aid);
+    return agent?.name || aid;
   };
 
   const isMainAgent = agentId === 'main';
@@ -152,27 +202,171 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
     { key: 'im', label: i18nService.t('agentTabIM') || 'IM Channels' },
   ];
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+  const renderToggle = (isOn: boolean) => (
+    <div
+      className={`relative w-9 h-5 rounded-full transition-colors ${
+        isOn ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
+      }`}
+    >
       <div
-        className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-white dark:bg-claude-darkSurface border dark:border-claude-darkBorder border-claude-border max-h-[80vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
+        className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${
+          isOn ? 'translate-x-4' : 'translate-x-0.5'
+        }`}
+      />
+    </div>
+  );
+
+  const renderMultiInstancePlatform = (platform: Platform) => {
+    const connectedInstances = getConnectedInstances(platform);
+    const logo = PlatformRegistry.logo(platform);
+    const bindings = imConfig?.settings?.platformAgentBindings || {};
+
+    if (connectedInstances.length === 0) {
+      // No connected instances — show disabled row like single-instance unconfigured
+      return (
+        <div
+          key={platform}
+          className="flex items-center justify-between px-3 py-2.5 rounded-lg opacity-50"
+        >
+          <div className="flex items-center gap-3">
+            <div className="flex h-8 w-8 items-center justify-center">
+              <img src={logo} alt={i18nService.t(platform)} className="w-6 h-6 object-contain rounded" />
+            </div>
+            <div>
+              <div className="text-sm font-medium text-foreground">
+                {i18nService.t(platform)}
+              </div>
+              <div className="text-xs text-secondary/50">
+                {i18nService.t('agentIMNotConfiguredHint') || 'Please configure in Settings > IM Bots first'}
+              </div>
+            </div>
+          </div>
+          <span className="text-xs text-secondary/50">
+            {i18nService.t('agentIMNotConfigured') || 'Not configured'}
+          </span>
+        </div>
+      );
+    }
+
+    return (
+      <div key={platform} className="rounded-lg border border-border overflow-hidden">
+        {/* Platform header */}
+        <div className="flex items-center gap-3 px-3 py-2.5 bg-surface-raised">
+          <div className="flex h-8 w-8 items-center justify-center">
+            <img src={logo} alt={i18nService.t(platform)} className="w-6 h-6 object-contain rounded" />
+          </div>
+          <span className="text-sm font-semibold text-foreground">
+            {i18nService.t(platform)}
+          </span>
+        </div>
+        {/* Instance list */}
+        {connectedInstances.map((inst: any, idx: number) => {
+          const bindingKey = `${platform}:${inst.instanceId}`;
+          const isBound = boundKeys.has(bindingKey);
+          const otherAgentId = bindings[bindingKey];
+          const boundToOther = otherAgentId && otherAgentId !== agentId;
+          const otherAgentName = boundToOther ? getAgentName(otherAgentId) : null;
+
+          return (
+            <div
+              key={inst.instanceId}
+              className={`flex items-center justify-between px-3 py-2 pl-14 transition-colors cursor-pointer hover:bg-surface-raised ${
+                idx < connectedInstances.length - 1 ? 'border-b border-border-subtle' : ''
+              } ${boundToOther ? 'opacity-55' : ''}`}
+              onClick={() => !boundToOther && handleToggleIMBinding(bindingKey)}
+            >
+              <div className="flex items-center gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0" />
+                <span className="text-sm text-foreground">
+                  {inst.instanceName}
+                </span>
+                {boundToOther && otherAgentName && (
+                  <span className="text-xs text-amber-600 dark:text-amber-400 bg-amber-500/10 px-1.5 py-0.5 rounded">
+                    {(i18nService.t('agentIMBoundToOther') || '→ {agent}').replace('{agent}', otherAgentName)}
+                  </span>
+                )}
+              </div>
+              {boundToOther ? (
+                <div className="w-9 h-5" />
+              ) : (
+                renderToggle(isBound)
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderSingleInstancePlatform = (platform: Platform) => {
+    const logo = PlatformRegistry.logo(platform);
+    const configured = isPlatformConfigured(platform);
+    const isBound = boundKeys.has(platform);
+    const bindings = imConfig?.settings?.platformAgentBindings || {};
+    const otherAgentId = bindings[platform];
+    const boundToOther = configured && otherAgentId && otherAgentId !== agentId;
+    const otherAgentName = boundToOther ? getAgentName(otherAgentId) : null;
+
+    return (
+      <div
+        key={platform}
+        className={`flex items-center justify-between px-3 py-2.5 rounded-lg transition-colors ${
+          configured && !boundToOther
+            ? 'hover:bg-surface-raised cursor-pointer'
+            : boundToOther ? 'opacity-55' : 'opacity-50'
+        }`}
+        onClick={() => configured && !boundToOther && handleToggleIMBinding(platform)}
       >
+        <div className="flex items-center gap-3">
+          <div className="flex h-8 w-8 items-center justify-center">
+            <img src={logo} alt={i18nService.t(platform)} className="w-6 h-6 object-contain rounded" />
+          </div>
+          <div>
+            <div className="text-sm font-medium text-foreground">
+              {i18nService.t(platform)}
+            </div>
+            {!configured && (
+              <div className="text-xs text-secondary/50">
+                {i18nService.t('agentIMNotConfiguredHint') || 'Please configure in Settings > IM Bots first'}
+              </div>
+            )}
+          </div>
+          {boundToOther && otherAgentName && (
+            <span className="text-xs text-amber-600 dark:text-amber-400 bg-amber-500/10 px-1.5 py-0.5 rounded">
+              {(i18nService.t('agentIMBoundToOther') || '→ {agent}').replace('{agent}', otherAgentName)}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {configured ? (
+            boundToOther ? <div className="w-9 h-5" /> : renderToggle(isBound)
+          ) : (
+            <span className="text-xs text-secondary/50">
+              {i18nService.t('agentIMNotConfigured') || 'Not configured'}
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <Modal onClose={handleClose} className="w-full max-w-2xl mx-4 rounded-xl shadow-xl bg-surface border border-border max-h-[80vh] flex flex-col">
         {/* Header: agent icon + name + close */}
-        <div className="flex items-center justify-between px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
           <div className="flex items-center gap-2">
             <span className="text-xl">{icon || '🤖'}</span>
-            <h3 className="text-base font-semibold dark:text-claude-darkText text-claude-text">
+            <h3 className="text-base font-semibold text-foreground">
               {name || (i18nService.t('agentSettings') || 'Agent Settings')}
             </h3>
           </div>
-          <button type="button" onClick={onClose} className="p-1 rounded-lg hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover">
-            <XMarkIcon className="h-5 w-5 dark:text-claude-darkTextSecondary text-claude-textSecondary" />
+          <button type="button" onClick={handleClose} className="p-1 rounded-lg hover:bg-surface-raised">
+            <XMarkIcon className="h-5 w-5 text-secondary" />
           </button>
         </div>
 
         {/* Tab bar */}
-        <div className="flex border-b dark:border-claude-darkBorder border-claude-border px-5">
+        <div className="flex border-b border-border px-5">
           {tabs.map((tab) => (
             <button
               key={tab.key}
@@ -180,13 +374,13 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
               onClick={() => setActiveTab(tab.key)}
               className={`px-4 py-2.5 text-sm font-medium transition-colors relative ${
                 activeTab === tab.key
-                  ? 'text-claude-accent'
-                  : 'dark:text-claude-darkTextSecondary text-claude-textSecondary hover:text-claude-text dark:hover:text-claude-darkText'
+                  ? 'text-primary'
+                  : 'text-secondary hover:text-foreground'
               }`}
             >
               {tab.label}
               {activeTab === tab.key && (
-                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-claude-accent rounded-full" />
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-full" />
               )}
             </button>
           ))}
@@ -197,50 +391,43 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
           {activeTab === 'basic' && (
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary mb-1">
+                <label className="block text-sm font-medium text-secondary mb-1">
                   {i18nService.t('agentName') || 'Name'}
                 </label>
                 <div className="flex gap-2">
-                  <input
-                    type="text"
-                    value={icon}
-                    onChange={(e) => setIcon(e.target.value)}
-                    placeholder="🤖"
-                    className="w-12 px-2 py-2 text-center rounded-lg border dark:border-claude-darkBorder border-claude-border bg-transparent dark:text-claude-darkText text-claude-text text-lg"
-                    maxLength={4}
-                  />
+                  <EmojiPicker value={icon} onChange={setIcon} />
                   <input
                     type="text"
                     value={name}
                     onChange={(e) => setName(e.target.value)}
-                    className="flex-1 px-3 py-2 rounded-lg border dark:border-claude-darkBorder border-claude-border bg-transparent dark:text-claude-darkText text-claude-text text-sm"
+                    className="flex-1 px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm"
                   />
                 </div>
               </div>
               <div>
-                <label className="block text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary mb-1">
+                <label className="block text-sm font-medium text-secondary mb-1">
                   {i18nService.t('agentDescription') || 'Description'}
                 </label>
                 <input
                   type="text"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  className="w-full px-3 py-2 rounded-lg border dark:border-claude-darkBorder border-claude-border bg-transparent dark:text-claude-darkText text-claude-text text-sm"
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary mb-1">
+                <label className="block text-sm font-medium text-secondary mb-1">
                   {i18nService.t('systemPrompt') || 'System Prompt'}
                 </label>
                 <textarea
                   value={systemPrompt}
                   onChange={(e) => setSystemPrompt(e.target.value)}
                   rows={4}
-                  className="w-full px-3 py-2 rounded-lg border dark:border-claude-darkBorder border-claude-border bg-transparent dark:text-claude-darkText text-claude-text text-sm resize-none"
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm resize-none"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium dark:text-claude-darkTextSecondary text-claude-textSecondary mb-1">
+                <label className="block text-sm font-medium text-secondary mb-1">
                   {i18nService.t('agentIdentity') || 'Identity'}
                 </label>
                 <textarea
@@ -248,81 +435,37 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
                   onChange={(e) => setIdentity(e.target.value)}
                   rows={3}
                   placeholder={i18nService.t('agentIdentityPlaceholder') || 'Identity description (IDENTITY.md)...'}
-                  className="w-full px-3 py-2 rounded-lg border dark:border-claude-darkBorder border-claude-border bg-transparent dark:text-claude-darkText text-claude-text text-sm resize-none"
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-transparent text-foreground text-sm resize-none"
                 />
               </div>
             </div>
           )}
 
           {activeTab === 'skills' && (
-            <AgentSkillSelector selectedSkillIds={skillIds} onChange={setSkillIds} variant="expanded" />
+            <AgentSkillSelector selectedSkillIds={skillIds} onChange={setSkillIds} />
           )}
 
           {activeTab === 'im' && (
             <div>
-              <p className="text-xs dark:text-claude-darkTextSecondary/60 text-claude-textSecondary/60 mb-4">
+              <p className="text-xs text-secondary/60 mb-4">
                 {i18nService.t('agentIMBindHint') || 'Select IM channels this Agent responds to'}
               </p>
               <div className="space-y-1">
-                {IM_PLATFORMS
-                  .filter(({ key }) => (getVisibleIMPlatforms(i18nService.getLanguage()) as readonly string[]).includes(key))
-                  .map(({ key: platform, logo }) => {
-                  const configured = isPlatformConfigured(platform);
-                  const bound = boundPlatforms.has(platform);
-                  return (
-                    <div
-                      key={platform}
-                      className={`flex items-center justify-between px-3 py-2.5 rounded-lg transition-colors ${
-                        configured
-                          ? 'hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover cursor-pointer'
-                          : 'opacity-50'
-                      }`}
-                      onClick={() => configured && handleToggleIMBinding(platform)}
-                    >
-                      <div className="flex items-center gap-3">
-                        <div className="flex h-8 w-8 items-center justify-center">
-                          <img src={logo} alt={i18nService.t(platform)} className="w-6 h-6 object-contain rounded" />
-                        </div>
-                        <div>
-                          <div className="text-sm font-medium dark:text-claude-darkText text-claude-text">
-                            {i18nService.t(platform)}
-                          </div>
-                          {!configured && (
-                            <div className="text-xs dark:text-claude-darkTextSecondary/50 text-claude-textSecondary/50">
-                              {i18nService.t('agentIMNotConfiguredHint') || 'Please configure in Settings > IM Bots first'}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {configured ? (
-                          <div
-                            className={`relative w-9 h-5 rounded-full transition-colors ${
-                              bound ? 'bg-claude-accent' : 'bg-gray-300 dark:bg-gray-600'
-                            }`}
-                          >
-                            <div
-                              className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${
-                                bound ? 'translate-x-4' : 'translate-x-0.5'
-                              }`}
-                            />
-                          </div>
-                        ) : (
-                          <span className="text-xs dark:text-claude-darkTextSecondary/50 text-claude-textSecondary/50">
-                            {i18nService.t('agentIMNotConfigured') || 'Not configured'}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
+                {PlatformRegistry.platforms
+                  .filter((platform) => (getVisibleIMPlatforms(i18nService.getLanguage()) as readonly string[]).includes(platform))
+                  .map((platform) => {
+                    if (MULTI_INSTANCE_PLATFORMS.includes(platform)) {
+                      return renderMultiInstancePlatform(platform);
+                    }
+                    return renderSingleInstancePlatform(platform);
+                  })}
               </div>
             </div>
           )}
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between px-5 py-4 border-t dark:border-claude-darkBorder border-claude-border">
+        <div className="flex items-center justify-between px-5 py-4 border-t border-border">
           <div>
             {!isMainAgent && !showDeleteConfirm && (
               <button
@@ -331,25 +474,25 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
                 className="inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
               >
                 <TrashIcon className="h-4 w-4" />
-                {i18nService.t('delete') || 'Delete'}
+                {i18nService.t('delete')}
               </button>
             )}
             {showDeleteConfirm && (
               <div className="flex items-center gap-2">
-                <span className="text-xs text-red-500">{i18nService.t('confirmDelete') || 'Confirm?'}</span>
+                <span className="text-xs text-red-500">{i18nService.t('confirmDelete')}</span>
                 <button
                   type="button"
                   onClick={handleDelete}
                   className="px-2 py-1 text-xs font-medium rounded bg-red-500 text-white hover:bg-red-600"
                 >
-                  {i18nService.t('delete') || 'Delete'}
+                  {i18nService.t('delete')}
                 </button>
                 <button
                   type="button"
                   onClick={() => setShowDeleteConfirm(false)}
-                  className="px-2 py-1 text-xs font-medium rounded dark:text-claude-darkTextSecondary text-claude-textSecondary hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover"
+                  className="px-2 py-1 text-xs font-medium rounded text-secondary hover:bg-surface-raised"
                 >
-                  {i18nService.t('cancel') || 'Cancel'}
+                  {i18nService.t('cancel')}
                 </button>
               </div>
             )}
@@ -359,15 +502,15 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
               <button
                 type="button"
                 onClick={() => onSwitchAgent(agentId)}
-                className="px-4 py-2 text-sm font-medium rounded-lg border border-claude-accent text-claude-accent hover:bg-claude-accent/10 transition-colors"
+                className="px-4 py-2 text-sm font-medium rounded-lg border border-primary text-primary hover:bg-primary/10 transition-colors"
               >
                 {i18nService.t('switchToAgent') || 'Use this Agent'}
               </button>
             )}
             <button
               type="button"
-              onClick={onClose}
-              className="px-4 py-2 text-sm font-medium rounded-lg dark:text-claude-darkTextSecondary text-claude-textSecondary hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors"
+              onClick={handleClose}
+              className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
             >
               {i18nService.t('cancel') || 'Cancel'}
             </button>
@@ -375,14 +518,39 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
               type="button"
               onClick={handleSave}
               disabled={!name.trim() || saving}
-              className="px-4 py-2 text-sm font-medium rounded-lg bg-claude-accent text-white hover:bg-claude-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-4 py-2 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {saving ? (i18nService.t('saving') || 'Saving...') : (i18nService.t('save') || 'Save')}
             </button>
           </div>
         </div>
-      </div>
-    </div>
+
+        {showDiscardConfirm && (
+          <Modal onClose={() => setShowDiscardConfirm(false)} className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-xl overflow-hidden">
+            <div className="flex items-center gap-3 px-5 py-4">
+              <div className="p-2 rounded-full bg-amber-100 dark:bg-amber-900/30">
+                <ExclamationTriangleIcon className="h-5 w-5 text-amber-600 dark:text-amber-500" />
+              </div>
+              <h2 className="text-base font-semibold text-foreground">
+                {i18nService.t('discardChangesTitle') || 'Discard changes?'}
+              </h2>
+            </div>
+            <div className="px-5 pb-4">
+              <p className="text-sm text-secondary">
+                {i18nService.t('discardChangesMessage') || 'You have unsaved changes. Are you sure you want to discard them?'}
+              </p>
+            </div>
+            <div className="flex items-center justify-end gap-3 px-5 py-4 border-t border-border">
+              <button onClick={() => setShowDiscardConfirm(false)} className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors">
+                {i18nService.t('cancel') || 'Cancel'}
+              </button>
+              <button onClick={handleConfirmDiscard} className="px-4 py-2 text-sm font-medium rounded-lg bg-red-500 hover:bg-red-600 text-white transition-colors">
+                {i18nService.t('discard') || 'Discard'}
+              </button>
+            </div>
+          </Modal>
+        )}
+    </Modal>
   );
 };
 


### PR DESCRIPTION
## 关联Issue

Closes #1469

## 修改内容

为`AgentSettingsPanel`组件添加未保存更改确认机制：

- 新增`initialValues`状态跟踪，在加载Agent数据时记录各字段的初始值
- 新增`isDirty`计算，通过对比当前值与初始值判断是否有未保存的修改
- 新增`handleClose`方法替换直接调用`onClose`，当检测到有未保存更改时弹出确认对话框
- 覆盖所有关闭路径：X按钮、Cancel按钮、遮罩层点击
- 确认对话框提供"继续编辑"和"放弃更改"两个选项

## 修改文件

- `src/renderer/components/agent/AgentSettingsPanel.tsx`

## 测试

- 修改配置后关闭面板 -> 弹出确认对话框
- 未修改配置关闭面板 -> 直接关闭
- 保存后关闭面板 -> 直接关闭（initialValues已更新）