### PR TITLE
fix(cowork): scroll-friendly active skill chips in prompt bar

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -659,8 +659,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
               className={textareaClass}
               style={{ minHeight: `${minHeight}px` }}
             />
-            <div className="flex items-center justify-between px-4 pb-2 pt-1.5">
-              <div className="flex items-center gap-2 relative">
+            <div className="flex min-w-0 items-center justify-between gap-2 px-4 pb-2 pt-1.5">
+              <div className="relative flex min-w-0 flex-1 items-center gap-2 overflow-x-auto [scrollbar-width:thin]">
                 {showFolderSelector && (
                   <>
                     <div className="relative group">
@@ -706,6 +706,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                 {!remoteManaged && (
                   <>
                     <SkillsButton
+                      className="shrink-0"
                       onSelectSkill={handleSelectSkill}
                       onManageSkills={handleManageSkills}
                     />
@@ -713,7 +714,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                   </>
                 )}
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex shrink-0 items-center gap-2">
                 {isStreaming ? (
                   <button
                     type="button"

--- a/src/renderer/components/skills/ActiveSkillBadge.tsx
+++ b/src/renderer/components/skills/ActiveSkillBadge.tsx
@@ -28,11 +28,11 @@ const ActiveSkillBadge: React.FC = () => {
   };
 
   return (
-    <div className="flex items-center gap-1.5 flex-wrap">
+    <div className="flex max-w-full min-w-0 flex-nowrap items-center gap-1.5 overflow-x-auto [scrollbar-width:thin]">
       {activeSkills.map(skill => (
         <div
           key={skill.id}
-          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-lg bg-primary-muted border border-primary"
+          className="inline-flex shrink-0 items-center gap-1 px-2 py-0.5 rounded-lg bg-primary-muted border border-primary"
         >
           <PuzzleIcon className="h-3.5 w-3.5 text-primary" />
           <span className="text-xs font-medium text-primary max-w-[80px] truncate">
@@ -52,7 +52,7 @@ const ActiveSkillBadge: React.FC = () => {
         <button
           type="button"
           onClick={handleClearAll}
-          className="text-xs text-primary hover:text-primary-hover transition-colors"
+          className="shrink-0 text-xs text-primary hover:text-primary-hover transition-colors"
           title={i18nService.t('clearAllSkills')}
         >
           {i18nService.t('clearAll')}


### PR DESCRIPTION
## Summary
- `ActiveSkillBadge`: horizontal scroll, nowrap row, `shrink-0` chips.
- `CoworkPromptInput` toolbar: `min-w-0`, `flex-1`, `overflow-x-auto` on the left cluster; `shrink-0` on send/stop; `SkillsButton` `shrink-0`.

## Issue
Closes #1413

Made with [Cursor](https://cursor.com)