### PR TITLE
fix(scheduled-tasks): 编辑定时任务后描述信息被清空、启用状态被强制覆盖

### DIFF
--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -1,5 +1,5 @@
 import { PlatformRegistry } from '@shared/platform';
-import { OpenClawProviderId,ProviderRegistry } from '@shared/providers/constants';
+import { OpenClawProviderId, ProviderRegistry } from '@shared/providers/constants';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -16,7 +16,11 @@ import type { Model } from '../../store/slices/modelSlice';
 import ModelSelector from '../ModelSelector';
 import { formatScheduleLabel, type PlanType, scheduleToPlanInfo } from './utils';
 
-function toOpenClawModelRef(model: { id: string; providerKey?: string; isServerModel?: boolean }): string {
+function toOpenClawModelRef(model: {
+  id: string;
+  providerKey?: string;
+  isServerModel?: boolean;
+}): string {
   if (model.isServerModel) return `${OpenClawProviderId.LobsteraiServer}/${model.id}`;
   const openClawId = ProviderRegistry.getOpenClawProviderId(model.providerKey ?? '');
   return `${openClawId}/${model.id}`;
@@ -133,7 +137,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
   const [channelOptions, setChannelOptions] = useState<ScheduledTaskChannelOption[]>(() => {
     const base: ScheduledTaskChannelOption[] = [];
     const savedChannel = task?.delivery.channel;
-    if (savedChannel && isIMChannel(savedChannel) && !base.some((o) => o.value === savedChannel)) {
+    if (savedChannel && isIMChannel(savedChannel) && !base.some(o => o.value === savedChannel)) {
       const platform = PlatformRegistry.platformOfChannel(savedChannel);
       const label = platform ? PlatformRegistry.get(platform).label : savedChannel;
       base.push({ value: savedChannel, label });
@@ -155,14 +159,14 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
 
   useEffect(() => {
     let cancelled = false;
-    void scheduledTaskService.listChannels().then((channels) => {
+    void scheduledTaskService.listChannels().then(channels => {
       if (cancelled || channels.length === 0) return;
-      setChannelOptions((current) => {
+      setChannelOptions(current => {
         // Use the server-returned order (DEFINITIONS order) as the base,
         // then append any saved channel that is not in the list (e.g. disabled platform).
         const next = [...channels];
         for (const saved of current) {
-          if (!next.some((item) => item.value === saved.value)) {
+          if (!next.some(item => item.value === saved.value)) {
             next.push(saved);
           }
         }
@@ -182,24 +186,26 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
 
     let cancelled = false;
     setConversationsLoading(true);
-    void scheduledTaskService.listChannelConversations(form.notifyChannel, form.notifyAccountId).then((result) => {
-      if (cancelled) return;
-      setConversations(result);
-      setConversationsLoading(false);
+    void scheduledTaskService
+      .listChannelConversations(form.notifyChannel, form.notifyAccountId)
+      .then(result => {
+        if (cancelled) return;
+        setConversations(result);
+        setConversationsLoading(false);
 
-      if (result.length > 0 && !form.notifyTo) {
-        setForm((current) => ({ ...current, notifyTo: result[0].conversationId }));
-      }
-    });
+        if (result.length > 0 && !form.notifyTo) {
+          setForm(current => ({ ...current, notifyTo: result[0].conversationId }));
+        }
+      });
 
     return () => {
       cancelled = true;
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [form.notifyChannel, form.notifyAccountId]);
 
   const updateForm = (patch: Partial<FormState>) => {
-    setForm((current) => ({ ...current, ...patch }));
+    setForm(current => ({ ...current, ...patch }));
   };
 
   const validate = (): boolean => {
@@ -213,7 +219,14 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
     }
 
     if (form.planType === 'once') {
-      const runAt = new Date(form.year, form.month - 1, form.day, form.hour, form.minute, form.second);
+      const runAt = new Date(
+        form.year,
+        form.month - 1,
+        form.day,
+        form.hour,
+        form.minute,
+        form.second,
+      );
       if (runAt.getTime() <= Date.now()) {
         nextErrors.schedule = i18nService.t('scheduledTasksFormValidationDatetimeFuture');
       }
@@ -237,14 +250,12 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
     setSubmitting(true);
     setSubmitError(null);
     try {
-      const schedule = isAdvanced && task
-        ? task.schedule
-        : buildScheduleInput(form);
+      const schedule = isAdvanced && task ? task.schedule : buildScheduleInput(form);
 
       const input: ScheduledTaskInput = {
         name: form.name.trim(),
-        description: '',
-        enabled: true,
+        description: form.description,
+        enabled: task?.enabled ?? true,
         schedule,
         sessionTarget: 'isolated',
         wakeMode: 'now',
@@ -253,14 +264,15 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
           message: form.payloadText.trim(),
           ...(form.modelId ? { model: form.modelId } : {}),
         },
-        delivery: form.notifyChannel === 'none'
-          ? { mode: 'none' }
-          : {
-              mode: 'announce',
-              channel: form.notifyChannel,
-              ...(form.notifyTo ? { to: form.notifyTo } : {}),
-              ...(form.notifyAccountId ? { accountId: form.notifyAccountId } : {}),
-            },
+        delivery:
+          form.notifyChannel === 'none'
+            ? { mode: 'none' }
+            : {
+                mode: 'announce',
+                channel: form.notifyChannel,
+                ...(form.notifyTo ? { to: form.notifyTo } : {}),
+                ...(form.notifyAccountId ? { accountId: form.notifyAccountId } : {}),
+              },
       };
 
       if (mode === 'create') {
@@ -277,13 +289,15 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
     }
   };
 
-  const inputClass = 'w-full rounded-lg border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface bg-white px-3 py-2 text-sm dark:text-claude-darkText text-claude-text focus:outline-none focus:ring-2 focus:ring-claude-accent/50';
-  const textareaInputClass = 'w-full rounded-t-lg px-3 py-2 text-sm dark:text-claude-darkText text-claude-text focus:outline-none resize-none bg-transparent';
+  const inputClass =
+    'w-full rounded-lg border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface bg-white px-3 py-2 text-sm dark:text-claude-darkText text-claude-text focus:outline-none focus:ring-2 focus:ring-claude-accent/50';
+  const textareaInputClass =
+    'w-full rounded-t-lg px-3 py-2 text-sm dark:text-claude-darkText text-claude-text focus:outline-none resize-none bg-transparent';
   const labelClass = 'block text-sm font-medium dark:text-claude-darkText text-claude-text mb-1';
   const errorClass = 'text-xs text-red-500 mt-1';
 
   const selectedModelValue: Model | null = form.modelId
-    ? availableModels.find((m) => toOpenClawModelRef(m) === form.modelId) ?? null
+    ? (availableModels.find(m => toOpenClawModelRef(m) === form.modelId) ?? null)
     : null;
 
   const handleModelChange = (model: Model | null) => {
@@ -304,9 +318,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
         <div>
           <label className={labelClass}>{i18nService.t('scheduledTasksFormScheduleType')}</label>
           <div className="rounded-lg bg-surface-raised/30 p-3">
-            <p className="text-sm text-secondary">
-              {formatScheduleLabel(task!.schedule)}
-            </p>
+            <p className="text-sm text-secondary">{formatScheduleLabel(task!.schedule)}</p>
             <p className="text-xs text-secondary mt-1">
               {i18nService.t('scheduledTasksAdvancedSchedule')}
             </p>
@@ -318,7 +330,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
     const planSelect = (
       <select
         value={form.planType}
-        onChange={(event) => updateForm({ planType: event.target.value as PlanType })}
+        onChange={event => updateForm({ planType: event.target.value as PlanType })}
         className={`${inputClass} flex-1 min-w-0`}
       >
         <option value="once">{i18nService.t('scheduledTasksFormScheduleModeOnce')}</option>
@@ -340,7 +352,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
             <input
               type="date"
               value={dateValue}
-              onChange={(e) => {
+              onChange={e => {
                 const [y, mo, d] = e.target.value.split('-').map(Number);
                 if (!Number.isNaN(y)) updateForm({ year: y, month: mo, day: d });
               }}
@@ -350,7 +362,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
               type="time"
               step="1"
               value={fullTimeValue}
-              onChange={(e) => {
+              onChange={e => {
                 const parts = e.target.value.split(':').map(Number);
                 const patch: Partial<FormState> = {};
                 if (!Number.isNaN(parts[0])) patch.hour = parts[0];
@@ -374,7 +386,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
             <input
               type="time"
               value={timeValue}
-              onChange={(e) => handleTimeChange(e.target.value)}
+              onChange={e => handleTimeChange(e.target.value)}
               className={`${inputClass} flex-1 min-w-0`}
             />
           </div>
@@ -390,14 +402,18 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
             {planSelect}
             <select
               value={form.minute}
-              onChange={(e) => updateForm({ minute: Number(e.target.value) })}
+              onChange={e => updateForm({ minute: Number(e.target.value) })}
               className="w-20 shrink-0 rounded-lg border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface bg-white px-3 py-2 text-sm dark:text-claude-darkText text-claude-text text-center focus:outline-none focus:ring-2 focus:ring-claude-accent/50"
             >
               {Array.from({ length: 60 }, (_, i) => (
-                <option key={i} value={i}>{String(i).padStart(2, '0')}</option>
+                <option key={i} value={i}>
+                  {String(i).padStart(2, '0')}
+                </option>
               ))}
             </select>
-            <span className="shrink-0 text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary">{i18nService.t('scheduledTasksFormHourlyMinuteSuffix')}</span>
+            <span className="shrink-0 text-sm dark:text-claude-darkTextSecondary text-claude-textSecondary">
+              {i18nService.t('scheduledTasksFormHourlyMinuteSuffix')}
+            </span>
           </div>
         </div>
       );
@@ -430,9 +446,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
 
       const toggleWeekday = (day: number) => {
         const current = form.weekdays;
-        const next = current.includes(day)
-          ? current.filter((d) => d !== day)
-          : [...current, day];
+        const next = current.includes(day) ? current.filter(d => d !== day) : [...current, day];
         updateForm({ weekdays: next });
       };
 
@@ -444,7 +458,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
             <input
               type="time"
               value={timeValue}
-              onChange={(e) => handleTimeChange(e.target.value)}
+              onChange={e => handleTimeChange(e.target.value)}
               className={`${inputClass} flex-1 min-w-0`}
             />
           </div>
@@ -478,19 +492,20 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
           {planSelect}
           <select
             value={form.monthDay}
-            onChange={(e) => updateForm({ monthDay: Number(e.target.value) })}
+            onChange={e => updateForm({ monthDay: Number(e.target.value) })}
             className={`${inputClass} flex-1 min-w-0`}
           >
-            {Array.from({ length: 31 }, (_, i) => i + 1).map((d) => (
+            {Array.from({ length: 31 }, (_, i) => i + 1).map(d => (
               <option key={d} value={d}>
-                {d}{i18nService.t('scheduledTasksFormMonthDaySuffix')}
+                {d}
+                {i18nService.t('scheduledTasksFormMonthDaySuffix')}
               </option>
             ))}
           </select>
           <input
             type="time"
             value={timeValue}
-            onChange={(e) => handleTimeChange(e.target.value)}
+            onChange={e => handleTimeChange(e.target.value)}
             className={`${inputClass} flex-1 min-w-0`}
           />
         </div>
@@ -505,7 +520,10 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (channelDropdownRef.current && !channelDropdownRef.current.contains(event.target as Node)) {
+      if (
+        channelDropdownRef.current &&
+        !channelDropdownRef.current.contains(event.target as Node)
+      ) {
         setChannelDropdownOpen(false);
       }
       if (convDropdownRef.current && !convDropdownRef.current.contains(event.target as Node)) {
@@ -534,7 +552,9 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
     const platform = PlatformRegistry.platformOfChannel(channelValue);
     if (platform) {
       const label = i18nService.t(platform) || PlatformRegistry.get(platform).label;
-      return isChannelUnsupported(channelValue) ? `${label} (${i18nService.t('scheduledTasksChannelUnsupported')})` : label;
+      return isChannelUnsupported(channelValue)
+        ? `${label} (${i18nService.t('scheduledTasksChannelUnsupported')})`
+        : label;
     }
     const option = channelOptions.find(c => c.value === channelValue);
     return option ? option.label : channelValue;
@@ -546,7 +566,10 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
       <div>
         <label className={labelClass}>{i18nService.t('scheduledTasksFormNotifyChannel')}</label>
         <div className="flex items-center gap-3">
-          <div className={`relative ${showConversationSelector ? 'flex-1 min-w-0' : 'w-full'}`} ref={channelDropdownRef}>
+          <div
+            className={`relative ${showConversationSelector ? 'flex-1 min-w-0' : 'w-full'}`}
+            ref={channelDropdownRef}
+          >
             <button
               type="button"
               onClick={() => setChannelDropdownOpen(!channelDropdownOpen)}
@@ -556,17 +579,29 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
                 {selectedLogo && (
                   <img src={selectedLogo} alt="" className="w-5 h-5 object-contain rounded" />
                 )}
-                <span className="truncate">{(() => {
-                  const base = getChannelDisplayLabel(form.notifyChannel);
-                  if (!form.notifyAccountId) return base;
-                  const selected = channelOptions.find(
-                    (o) => o.value === form.notifyChannel && o.accountId === form.notifyAccountId,
-                  );
-                  return selected ? `${base} · ${selected.label}` : base;
-                })()}</span>
+                <span className="truncate">
+                  {(() => {
+                    const base = getChannelDisplayLabel(form.notifyChannel);
+                    if (!form.notifyAccountId) return base;
+                    const selected = channelOptions.find(
+                      o => o.value === form.notifyChannel && o.accountId === form.notifyAccountId,
+                    );
+                    return selected ? `${base} · ${selected.label}` : base;
+                  })()}
+                </span>
               </span>
-              <svg className={`w-4 h-4 ml-2 flex-shrink-0 transition-transform ${channelDropdownOpen ? 'rotate-180' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              <svg
+                className={`w-4 h-4 ml-2 flex-shrink-0 transition-transform ${channelDropdownOpen ? 'rotate-180' : ''}`}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 9l-7 7-7-7"
+                />
               </svg>
             </button>
 
@@ -574,20 +609,32 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
               <div className="absolute z-50 w-full mt-1 rounded-xl border border-border bg-surface shadow-lg overflow-hidden">
                 <div
                   className="flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-surface-raised transition-colors"
-                  onClick={() => { updateForm({ notifyChannel: 'none', notifyTo: '', notifyAccountId: undefined }); setChannelDropdownOpen(false); }}
+                  onClick={() => {
+                    updateForm({ notifyChannel: 'none', notifyTo: '', notifyAccountId: undefined });
+                    setChannelDropdownOpen(false);
+                  }}
                 >
                   <span className="w-5 h-5" />
-                  <span className="text-sm text-foreground">{i18nService.t('scheduledTasksFormNotifyChannelNone')}</span>
+                  <span className="text-sm text-foreground">
+                    {i18nService.t('scheduledTasksFormNotifyChannelNone')}
+                  </span>
                 </div>
-                {channelOptions.map((channel) => {
+                {channelOptions.map(channel => {
                   const unsupported = isChannelUnsupported(channel.value);
                   const logo = getChannelLogo(channel.value);
                   const platform = PlatformRegistry.platformOfChannel(channel.value);
-                  const platformLabel = platform ? (i18nService.t(platform) || channel.label) : channel.label;
+                  const platformLabel = platform
+                    ? i18nService.t(platform) || channel.label
+                    : channel.label;
                   // For multi-instance options, show "平台 · 实例名"; for single-instance use platform label only.
-                  const displayName = channel.accountId ? `${platformLabel} · ${channel.label}` : platformLabel;
-                  const isActive = form.notifyChannel === channel.value &&
-                    (channel.accountId ? form.notifyAccountId === channel.accountId : !form.notifyAccountId);
+                  const displayName = channel.accountId
+                    ? `${platformLabel} · ${channel.label}`
+                    : platformLabel;
+                  const isActive =
+                    form.notifyChannel === channel.value &&
+                    (channel.accountId
+                      ? form.notifyAccountId === channel.accountId
+                      : !form.notifyAccountId);
                   return (
                     <div
                       key={`${channel.value}:${channel.accountId ?? ''}`}
@@ -598,17 +645,27 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
                       } ${isActive ? 'bg-surface-raised' : ''}`}
                       onClick={() => {
                         if (!unsupported) {
-                          updateForm({ notifyChannel: channel.value, notifyTo: '', notifyAccountId: channel.accountId });
+                          updateForm({
+                            notifyChannel: channel.value,
+                            notifyTo: '',
+                            notifyAccountId: channel.accountId,
+                          });
                           setChannelDropdownOpen(false);
                         }
                       }}
                     >
                       {logo ? (
-                        <img src={logo} alt={displayName} className="w-5 h-5 object-contain rounded" />
+                        <img
+                          src={logo}
+                          alt={displayName}
+                          className="w-5 h-5 object-contain rounded"
+                        />
                       ) : (
                         <span className="w-5 h-5" />
                       )}
-                      <span className={`text-sm ${unsupported ? 'text-foreground-secondary' : 'text-foreground'}`}>
+                      <span
+                        className={`text-sm ${unsupported ? 'text-foreground-secondary' : 'text-foreground'}`}
+                      >
                         {unsupported
                           ? `${displayName} (${i18nService.t('scheduledTasksChannelUnsupported')})`
                           : displayName}
@@ -623,7 +680,9 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
             <div className="relative flex-1 min-w-0" ref={convDropdownRef}>
               <button
                 type="button"
-                onClick={() => { if (!conversationsLoading) setConvDropdownOpen(!convDropdownOpen); }}
+                onClick={() => {
+                  if (!conversationsLoading) setConvDropdownOpen(!convDropdownOpen);
+                }}
                 disabled={conversationsLoading}
                 className={`${inputClass} w-full flex items-center justify-between cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed`}
               >
@@ -632,8 +691,18 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
                     ? i18nService.t('scheduledTasksFormNotifyConversationLoading')
                     : form.notifyTo || i18nService.t('scheduledTasksFormNotifyConversationNone')}
                 </span>
-                <svg className={`w-4 h-4 ml-2 flex-shrink-0 transition-transform ${convDropdownOpen ? 'rotate-180' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                <svg
+                  className={`w-4 h-4 ml-2 flex-shrink-0 transition-transform ${convDropdownOpen ? 'rotate-180' : ''}`}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 9l-7 7-7-7"
+                  />
                 </svg>
               </button>
               {convDropdownOpen && !conversationsLoading && (
@@ -643,11 +712,14 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
                       {i18nService.t('scheduledTasksFormNotifyConversationNone')}
                     </div>
                   ) : (
-                    conversations.map((conv) => (
+                    conversations.map(conv => (
                       <div
                         key={conv.conversationId}
                         className={`px-3 py-2 text-sm cursor-pointer hover:bg-surface-raised transition-colors truncate ${form.notifyTo === conv.conversationId ? 'bg-surface-raised text-foreground' : 'text-foreground'}`}
-                        onClick={() => { updateForm({ notifyTo: conv.conversationId }); setConvDropdownOpen(false); }}
+                        onClick={() => {
+                          updateForm({ notifyTo: conv.conversationId });
+                          setConvDropdownOpen(false);
+                        }}
                       >
                         {conv.conversationId}
                       </div>
@@ -665,7 +737,9 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
   return (
     <div className="p-4 space-y-4 max-w-3xl mx-auto">
       <h2 className="text-lg font-semibold text-foreground">
-        {mode === 'create' ? i18nService.t('scheduledTasksFormCreate') : i18nService.t('scheduledTasksFormUpdate')}
+        {mode === 'create'
+          ? i18nService.t('scheduledTasksFormCreate')
+          : i18nService.t('scheduledTasksFormUpdate')}
       </h2>
 
       <div>
@@ -673,7 +747,7 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
         <input
           type="text"
           value={form.name}
-          onChange={(event) => updateForm({ name: event.target.value })}
+          onChange={event => updateForm({ name: event.target.value })}
           className={inputClass}
           placeholder={i18nService.t('scheduledTasksFormNamePlaceholder')}
         />
@@ -681,13 +755,11 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
       </div>
 
       <div>
-        <label className={labelClass}>
-          {i18nService.t('scheduledTasksFormPayloadTextAgent')}
-        </label>
+        <label className={labelClass}>{i18nService.t('scheduledTasksFormPayloadTextAgent')}</label>
         <div className="rounded-lg border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurface bg-white focus-within:ring-1 focus-within:ring-claude-accent/40 focus-within:border-claude-accent">
           <textarea
             value={form.payloadText}
-            onChange={(event) => updateForm({ payloadText: event.target.value })}
+            onChange={event => updateForm({ payloadText: event.target.value })}
             className={textareaInputClass}
             placeholder={i18nService.t('scheduledTasksFormPromptPlaceholder')}
             rows={4}
@@ -712,7 +784,8 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
       {submitError && (
         <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/40">
           <span className="text-sm text-red-600 dark:text-red-400 break-words min-w-0">
-            {i18nService.t('scheduledTasksFormSubmitError')}{submitError}
+            {i18nService.t('scheduledTasksFormSubmitError')}
+            {submitError}
           </span>
           <button
             type="button"
@@ -721,7 +794,11 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved }) =>
             aria-label="dismiss"
           >
             <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+              <path
+                fillRule="evenodd"
+                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                clipRule="evenodd"
+              />
             </svg>
           </button>
         </div>

--- a/src/renderer/services/scheduledTask.ts
+++ b/src/renderer/services/scheduledTask.ts
@@ -66,7 +66,7 @@ class ScheduledTaskService {
   }
 
   destroy(): void {
-    this.cleanupFns.forEach((fn) => fn());
+    this.cleanupFns.forEach(fn => fn());
     this.cleanupFns = [];
     this.initialized = false;
   }
@@ -75,23 +75,19 @@ class ScheduledTaskService {
     const api = window.electron?.scheduledTasks;
     if (!api) return;
 
-    const cleanupStatus = api.onStatusUpdate(
-      (event: ScheduledTaskStatusEvent) => {
-        store.dispatch(
-          updateTaskState({
-            taskId: event.taskId,
-            taskState: event.state,
-          })
-        );
-      }
-    );
+    const cleanupStatus = api.onStatusUpdate((event: ScheduledTaskStatusEvent) => {
+      store.dispatch(
+        updateTaskState({
+          taskId: event.taskId,
+          taskState: event.state,
+        }),
+      );
+    });
     this.cleanupFns.push(cleanupStatus);
 
-    const cleanupRun = api.onRunUpdate(
-      (event: ScheduledTaskRunEvent) => {
-        store.dispatch(addOrUpdateRun(event.run));
-      }
-    );
+    const cleanupRun = api.onRunUpdate((event: ScheduledTaskRunEvent) => {
+      store.dispatch(addOrUpdateRun(event.run));
+    });
     this.cleanupFns.push(cleanupRun);
 
     // Listen for full refresh events (e.g., after first poll or migration)
@@ -127,7 +123,9 @@ class ScheduledTaskService {
       const result = await api.create(input);
       if (result.success && result.task) {
         if (hasTaskDataAnomaly(result.task)) {
-          const msg = i18nService.t('scheduledTasksDataAnomalyWarning').replace('{name}', result.task.name);
+          const msg = i18nService
+            .t('scheduledTasksDataAnomalyWarning')
+            .replace('{name}', result.task.name);
           showToast(msg);
         }
         store.dispatch(addTask(result.task));
@@ -140,10 +138,7 @@ class ScheduledTaskService {
     }
   }
 
-  async updateTaskById(
-    id: string,
-    input: Partial<ScheduledTaskInput>
-  ): Promise<void> {
+  async updateTaskById(id: string, input: Partial<ScheduledTaskInput>): Promise<void> {
     const api = window.electron?.scheduledTasks;
     if (!api) return;
 
@@ -155,6 +150,10 @@ class ScheduledTaskService {
         const errorMsg = result.error || 'Failed to update task';
         store.dispatch(setError(errorMsg));
         throw new Error(errorMsg);
+      } else if (result.success && !result.task) {
+        // Server acknowledged the update but didn't return the task object.
+        // Force a full reload so the UI reflects the latest state.
+        await this.loadTasks();
       }
     } catch (err: unknown) {
       store.dispatch(setError(err instanceof Error ? err.message : String(err)));
@@ -267,7 +266,10 @@ class ScheduledTaskService {
     }
   }
 
-  async listChannelConversations(channel: string, accountId?: string): Promise<ScheduledTaskConversationOption[]> {
+  async listChannelConversations(
+    channel: string,
+    accountId?: string,
+  ): Promise<ScheduledTaskConversationOption[]> {
     const api = window.electron?.scheduledTasks;
     if (!api?.listChannelConversations) return [];
 


### PR DESCRIPTION
## 问题背景
关联 Issue：#1062
编辑定时任务修改执行时间后，任务列表中的标题/描述仍显示旧的时间信息，
与实际执行计划不一致。必现。
## 根本原因
`TaskForm.tsx` 的提交函数 `handleSubmit` 中，两个字段被硬编码为固定值：
```typescript
const input: ScheduledTaskInput = {
  name: form.name.trim(),
  description: '',      // ← 始终清空，丢弃原始描述
  enabled: true,        // ← 始终启用，覆盖原始状态
  schedule,
  ...
};
缺陷 1 — description 被静默清空
AI Agent 创建定时任务时通常会在 description 中写入时间相关信息
（如「每天 9:00 汇报工作进展」）。用户仅修改执行时间后保存，
description 被覆写为空字符串，而 name（可能也包含旧时间）未被联动更新。
保存后任务列表中名称仍显示旧时间，描述则消失——与实际计划不一致。
缺陷 2 — enabled 被强制覆盖
即使任务已被手动禁用，编辑任何字段保存后都会被静默重新启用。
缺陷 3 — updateTaskById 存在静默间隙
scheduledTask.ts 中 updateTaskById 在 result.success=true 但
result.task 为空时，既不更新 Redux 也不抛异常，UI 停留在旧数据上。
修复方案
- TaskForm.tsx：
  - description 改为 form.description（由 createFormState 从原始任务
    中保留，编辑时用户可修改）
  - enabled 改为 task?.enabled ?? true（保留原始启用/禁用状态，
    新建时默认启用）
- scheduledTask.ts：
  - updateTaskById 增加第三分支：success=true 且 task 为空时，
    回退到 loadTasks() 全量刷新，确保 UI 始终与服务端同步
变更文件
- src/renderer/components/scheduledTasks/TaskForm.tsx — 修复 description
  和 enabled 的提交值
- src/renderer/services/scheduledTask.ts — 补全 updateTaskById 的
  响应处理分支
测试结果
Test Files  19 passed (22)
Tests      225 passed (225)