### PR TITLE
fix(skills): enforce disabled skills in system prompts

### DIFF
--- a/src/main/im/imChatHandler.ts
+++ b/src/main/im/imChatHandler.ts
@@ -21,6 +21,7 @@ interface LLMConfig {
 export interface IMChatHandlerOptions {
   getLLMConfig: () => Promise<LLMConfig | null>;
   getSkillsPrompt?: () => Promise<string | null>;
+  getDisabledSkillsPolicyPrompt?: () => string | null;
   imSettings: IMSettings;
 }
 
@@ -29,6 +30,18 @@ export class IMChatHandler {
 
   constructor(options: IMChatHandlerOptions) {
     this.options = options;
+  }
+
+  private appendDisabledSkillsPolicy(systemPrompt: string): string {
+    const fn = this.options.getDisabledSkillsPolicyPrompt;
+    if (!fn) return systemPrompt;
+    try {
+      const policy = fn();
+      if (!policy?.trim()) return systemPrompt;
+      return systemPrompt ? `${systemPrompt}\n\n${policy}` : policy;
+    } catch {
+      return systemPrompt;
+    }
   }
 
   /**
@@ -51,6 +64,8 @@ export class IMChatHandler {
           : skillsPrompt;
       }
     }
+
+    systemPrompt = this.appendDisabledSkillsPolicy(systemPrompt);
 
     // Append IM media sending instruction
     const mediaInstruction = buildIMMediaInstruction(this.options.imSettings);
@@ -297,6 +312,8 @@ export class IMChatHandler {
           : skillsPrompt;
       }
     }
+
+    systemPrompt = this.appendDisabledSkillsPolicy(systemPrompt);
 
     // For now, use non-streaming and yield once
     // TODO: Implement actual streaming for better UX

--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -54,6 +54,7 @@ export interface IMCoworkHandlerOptions {
   coworkStore: CoworkStore;
   imStore: IMStore;
   getSkillsPrompt?: () => Promise<string | null>;
+  getDisabledSkillsPolicyPrompt?: () => string | null;
   detectScheduledTaskRequest?: IMScheduledTaskRequestDetector;
   createScheduledTask?: (params: {
     sessionId: string;
@@ -68,6 +69,7 @@ export class IMCoworkHandler extends EventEmitter {
   private coworkStore: CoworkStore;
   private imStore: IMStore;
   private getSkillsPrompt?: () => Promise<string | null>;
+  private getDisabledSkillsPolicyPrompt?: () => string | null;
   private detectScheduledTaskRequest?: IMScheduledTaskRequestDetector;
   private createScheduledTask?: (params: {
     sessionId: string;
@@ -95,6 +97,7 @@ export class IMCoworkHandler extends EventEmitter {
     this.coworkStore = options.coworkStore;
     this.imStore = options.imStore;
     this.getSkillsPrompt = options.getSkillsPrompt;
+    this.getDisabledSkillsPolicyPrompt = options.getDisabledSkillsPolicyPrompt;
     this.detectScheduledTaskRequest = options.detectScheduledTaskRequest;
     this.createScheduledTask = options.createScheduledTask;
     this.sendAsyncReply = options.sendAsyncReply;
@@ -393,6 +396,17 @@ export class IMCoworkHandler extends EventEmitter {
       const skillsPrompt = await this.getSkillsPrompt();
       if (skillsPrompt) {
         sections.push(skillsPrompt);
+      }
+    }
+
+    if (this.getDisabledSkillsPolicyPrompt) {
+      try {
+        const policy = this.getDisabledSkillsPolicyPrompt();
+        if (policy) {
+          sections.push(policy);
+        }
+      } catch {
+        // Non-critical
       }
     }
 

--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -89,6 +89,7 @@ export class IMGatewayManager extends EventEmitter {
   private coworkHandler: IMCoworkHandler | null = null;
   private getLLMConfig: (() => Promise<any>) | null = null;
   private getSkillsPrompt: (() => Promise<string | null>) | null = null;
+  private getDisabledSkillsPolicyPrompt: (() => string | null) | null = null;
   private ensureCoworkReady: (() => Promise<void>) | null = null;
   private isOpenClawEngine: (() => boolean) | null = null;
   private syncOpenClawConfig: (() => Promise<void>) | null = null;
@@ -184,9 +185,11 @@ export class IMGatewayManager extends EventEmitter {
   initialize(options: {
     getLLMConfig: () => Promise<any>;
     getSkillsPrompt?: () => Promise<string | null>;
+    getDisabledSkillsPolicyPrompt?: () => string | null;
   }): void {
     this.getLLMConfig = options.getLLMConfig;
     this.getSkillsPrompt = options.getSkillsPrompt ?? null;
+    this.getDisabledSkillsPolicyPrompt = options.getDisabledSkillsPolicyPrompt ?? null;
 
     // Set up message handlers for gateways
     this.setupMessageHandlers();
@@ -301,6 +304,7 @@ export class IMGatewayManager extends EventEmitter {
     this.chatHandler = new IMChatHandler({
       getLLMConfig: this.getLLMConfig,
       getSkillsPrompt: this.getSkillsPrompt || undefined,
+      getDisabledSkillsPolicyPrompt: this.getDisabledSkillsPolicyPrompt || undefined,
       imSettings,
     });
 
@@ -325,6 +329,7 @@ export class IMGatewayManager extends EventEmitter {
         coworkStore: this.coworkStore,
         imStore: this.imStore,
         getSkillsPrompt: this.getSkillsPrompt || undefined,
+        getDisabledSkillsPolicyPrompt: this.getDisabledSkillsPolicyPrompt || undefined,
         detectScheduledTaskRequest,
         createScheduledTask: this.createScheduledTask || undefined,
         sendAsyncReply: async (platform, conversationId, text) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1453,6 +1453,7 @@ const getIMGatewayManager = () => {
       getSkillsPrompt: async () => {
         return getSkillManager().buildAutoRoutingPrompt();
       },
+      getDisabledSkillsPolicyPrompt: () => getSkillManager().buildDisabledSkillsPolicyPrompt(),
     });
 
     // Forward IM events to renderer
@@ -1481,15 +1482,33 @@ const getIMGatewayManager = () => {
   return imGatewayManager;
 };
 
+const DISABLED_SKILLS_POLICY_MARKER = '## Disabled skills (LobsterAI policy)';
+
+function stripDisabledSkillsPolicyFromPrompt(text: string): string {
+  const idx = text.indexOf(DISABLED_SKILLS_POLICY_MARKER);
+  if (idx < 0) return text;
+  return text.slice(0, idx).trimEnd();
+}
+
 function mergeCoworkSystemPrompt(
   engine: CoworkAgentEngine,
   systemPrompt?: string,
 ): string | undefined {
+  const trimmed = stripDisabledSkillsPolicyFromPrompt(systemPrompt?.trim() || '');
   const sections = [
     buildScheduledTaskEnginePrompt(engine),
-    systemPrompt?.trim() || '',
+    trimmed,
   ].filter(Boolean);
-  return sections.length > 0 ? sections.join('\n\n') : undefined;
+  let merged = sections.length > 0 ? sections.join('\n\n') : undefined;
+  try {
+    const policy = getSkillManager().buildDisabledSkillsPolicyPrompt();
+    if (policy) {
+      merged = merged ? `${merged}\n\n${policy}` : policy;
+    }
+  } catch {
+    // SkillManager may be unavailable during unusual init ordering
+  }
+  return merged?.trim() || undefined;
 }
 
 // 获取正确的预加载脚本路径

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -1357,6 +1357,21 @@ export class SkillManager {
     ].join('\n');
   }
 
+  /**
+   * Markdown block appended to system prompts so the model does not read or follow skills
+   * the user disabled (still on disk for OpenClaw / routing edge cases).
+   */
+  buildDisabledSkillsPolicyPrompt(): string | null {
+    const disabled = this.listSkills().filter(s => !s.enabled);
+    if (disabled.length === 0) return null;
+    const lines = disabled.map(s => `- \`${s.id}\`: ${s.skillPath}`);
+    return [
+      '## Disabled skills (LobsterAI policy)',
+      'These skills are turned off in the app. Do not read their SKILL.md files at the paths below, do not follow their workflows, and refuse or redirect if the user asks you to use them.',
+      ...lines,
+    ].join('\n');
+  }
+
   setSkillEnabled(id: string, enabled: boolean): SkillRecord[] {
     const state = this.loadSkillStateMap();
     state[id] = { enabled };


### PR DESCRIPTION
## Summary
Users who turn off a skill in LobsterAI could still trigger it in cowork chat (routing text stripped on follow-up turns, files still on disk for OpenClaw). This change appends a **Disabled skills (LobsterAI policy)** block to merged cowork system prompts on every start/continue, listing disabled skill ids and SKILL.md paths and instructing the model not to read or follow them.

- `mergeCoworkSystemPrompt`: strip any previous policy block, then append a fresh one from `SkillManager.buildDisabledSkillsPolicyPrompt()`.
- IM cowork and IM chat fallback: same policy via `getDisabledSkillsPolicyPrompt` from the gateway initializer.

## Issue
Closes #1439