### PR TITLE
fix(cowork): 技能选择状态改为按会话独立管理

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -6,8 +6,8 @@ import { useDispatch,useSelector } from 'react-redux';
 import { i18nService } from '../../services/i18n';
 import { skillService } from '../../services/skill';
 import { RootState } from '../../store';
-import { addDraftAttachment, clearDraftAttachments, type DraftAttachment,setDraftAttachments, setDraftPrompt } from '../../store/slices/coworkSlice';
-import { setSkills, toggleActiveSkill } from '../../store/slices/skillSlice';
+import { addDraftAttachment, clearDraftAttachments, type DraftAttachment, setDraftAttachments, setDraftPrompt, toggleDraftActiveSkill } from '../../store/slices/coworkSlice';
+import { setSkills } from '../../store/slices/skillSlice';
 import { CoworkImageAttachment } from '../../types/cowork';
 import { Skill } from '../../types/skill';
 import { getCompactFolderName } from '../../utils/path';
@@ -154,7 +154,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     },
   }));
 
-  const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
+  const activeSkillIds = useSelector((state: RootState) => state.cowork.draftActiveSkillIds[draftKey] || []);
   const skills = useSelector((state: RootState) => state.skill.skills);
 
   const isLarge = size === 'large';
@@ -168,7 +168,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       dispatch(setSkills(loadedSkills));
     };
     loadSkills();
-  }, [dispatch]);
+  }, [dispatch, draftKey]);
 
   useEffect(() => {
     const unsubscribe = skillService.onSkillsChanged(async () => {
@@ -291,11 +291,11 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     dispatch(setDraftPrompt({ sessionId: draftKey, draft: '' }));
     dispatch(clearDraftAttachments(draftKey));
     setImageVisionHint(false);
-  }, [value, isStreaming, disabled, onSubmit, activeSkillIds, skills, attachments, showFolderSelector, workingDirectory, dispatch]);
+  }, [value, isStreaming, disabled, onSubmit, activeSkillIds, skills, attachments, showFolderSelector, workingDirectory, dispatch, draftKey]);
 
   const handleSelectSkill = useCallback((skill: Skill) => {
-    dispatch(toggleActiveSkill(skill.id));
-  }, [dispatch]);
+    dispatch(toggleDraftActiveSkill({ draftKey, skillId: skill.id }));
+  }, [dispatch, draftKey]);
 
   const handleManageSkills = useCallback(() => {
     if (onManageSkills) {
@@ -736,10 +736,11 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                 {!remoteManaged && (
                   <>
                     <SkillsButton
+                      draftKey={draftKey}
                       onSelectSkill={handleSelectSkill}
                       onManageSkills={handleManageSkills}
                     />
-                    <ActiveSkillBadge />
+                    <ActiveSkillBadge draftKey={draftKey} />
                   </>
                 )}
               </div>

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -14,7 +14,7 @@ import { getScheduledReminderDisplayText } from '../../../scheduledTask/reminder
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { RootState } from '../../store';
-import { setActiveSkillIds } from '../../store/slices/skillSlice';
+import { setDraftActiveSkillIds } from '../../store/slices/coworkSlice';
 import type { CoworkImageAttachment,CoworkMessage, CoworkMessageMetadata } from '../../types/cowork';
 import type { Skill } from '../../types/skill';
 import { getCompactFolderName } from '../../utils/path';
@@ -2014,14 +2014,14 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     // Restore image attachments (always call to clear previous attachments)
     const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ?? []) as CoworkImageAttachment[];
     ref.setImageAttachments(imageAttachments);
-    // Restore active skills
+    // Restore active skills for the current session
     const skillIds = (message.metadata as CoworkMessageMetadata)?.skillIds;
-    if (skillIds && skillIds.length > 0) {
-      dispatch(setActiveSkillIds(skillIds));
+    if (skillIds && skillIds.length > 0 && currentSession) {
+      dispatch(setDraftActiveSkillIds({ draftKey: currentSession.id, skillIds }));
     }
     // Focus the input
     ref.focus();
-  }, [dispatch]);
+  }, [dispatch, currentSession]);
 
   const messages = currentSession?.messages;
   const displayItems = useMemo(() => messages ? buildDisplayItems(messages) : [], [messages]);

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -1,23 +1,23 @@
-import React, { useEffect, useState, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import { RootState } from '../../store';
-import { addMessage, clearCurrentSession, setCurrentSession, setStreaming, updateSessionStatus } from '../../store/slices/coworkSlice';
-import { clearActiveSkills, setActiveSkillIds } from '../../store/slices/skillSlice';
-import { setActions, selectAction, clearSelection } from '../../store/slices/quickActionSlice';
+import { ShieldCheckIcon } from '@heroicons/react/24/outline';
+import React, { useEffect, useRef,useState } from 'react';
+import { useDispatch,useSelector } from 'react-redux';
+
 import { coworkService } from '../../services/cowork';
-import { skillService } from '../../services/skill';
-import { quickActionService } from '../../services/quickAction';
 import { i18nService } from '../../services/i18n';
+import { quickActionService } from '../../services/quickAction';
+import { skillService } from '../../services/skill';
+import { RootState } from '../../store';
+import { addMessage, clearCurrentSession, clearDraftActiveSkillIds,setCurrentSession, setDraftActiveSkillIds, setStreaming, updateSessionStatus } from '../../store/slices/coworkSlice';
+import { clearSelection,selectAction, setActions } from '../../store/slices/quickActionSlice';
+import type { CoworkImageAttachment, CoworkSession, OpenClawEngineStatus } from '../../types/cowork';
+import ComposeIcon from '../icons/ComposeIcon';
+import SidebarToggleIcon from '../icons/SidebarToggleIcon';
+import ModelSelector from '../ModelSelector';
+import { PromptPanel,QuickActionBar } from '../quick-actions';
+import type { SettingsOpenOptions } from '../Settings';
+import WindowTitleBar from '../window/WindowTitleBar';
 import CoworkPromptInput, { type CoworkPromptInputRef } from './CoworkPromptInput';
 import CoworkSessionDetail from './CoworkSessionDetail';
-import ModelSelector from '../ModelSelector';
-import SidebarToggleIcon from '../icons/SidebarToggleIcon';
-import ComposeIcon from '../icons/ComposeIcon';
-import { ShieldCheckIcon } from '@heroicons/react/24/outline';
-import WindowTitleBar from '../window/WindowTitleBar';
-import { QuickActionBar, PromptPanel } from '../quick-actions';
-import type { SettingsOpenOptions } from '../Settings';
-import type { CoworkSession, CoworkImageAttachment, OpenClawEngineStatus } from '../../types/cowork';
 
 export interface CoworkViewProps {
   onRequestAppSettings?: (options?: SettingsOpenOptions) => void;
@@ -54,7 +54,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   } = useSelector((state: RootState) => state.cowork);
   const isOpenClawEngine = config.agentEngine !== 'yd_cowork';
 
-  const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
+  const draftActiveSkillIds = useSelector((state: RootState) => state.cowork.draftActiveSkillIds);
   const skills = useSelector((state: RootState) => state.skill.skills);
   const quickActions = useSelector((state: RootState) => state.quickAction.actions);
   const selectedActionId = useSelector((state: RootState) => state.quickAction.selectedActionId);
@@ -203,7 +203,8 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       const now = Date.now();
 
       // Capture active skill IDs before clearing them
-      const sessionSkillIds = [...activeSkillIds];
+      const homeDraftKey = '__home__';
+      const sessionSkillIds = [...(draftActiveSkillIds[homeDraftKey] || [])];
 
       const tempSession: CoworkSession = {
         id: tempSessionId,
@@ -240,7 +241,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
 
       // Clear active skills and quick action selection after starting session
       // so they don't persist to next session
-      dispatch(clearActiveSkills());
+      dispatch(clearDraftActiveSkillIds(homeDraftKey));
       dispatch(clearSelection());
 
       // Combine skill prompt with system prompt.
@@ -328,11 +329,12 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       });
 
       // Capture active skill IDs before clearing
-      const sessionSkillIds = [...activeSkillIds];
+      const sessionDraftKey = currentSession.id;
+      const sessionSkillIds = [...(draftActiveSkillIds[sessionDraftKey] || [])];
 
       // Clear active skills after capturing so they don't persist to next message
       if (sessionSkillIds.length > 0) {
-        dispatch(clearActiveSkills());
+        dispatch(clearDraftActiveSkillIds(sessionDraftKey));
       }
 
       // Combine skill prompt with system prompt for continuation.
@@ -386,12 +388,16 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     if (action) {
       const targetSkill = skills.find(s => s.id === action.skillMapping);
       if (targetSkill) {
-        dispatch(setActiveSkillIds([targetSkill.id]));
+        const actionDraftKey = currentSession?.id || '__home__';
+        dispatch(setDraftActiveSkillIds({ draftKey: actionDraftKey, skillIds: [targetSkill.id] }));
       }
     }
   };
 
   // When the mapped skill is deactivated from input area, restore the QuickActionBar
+  const currentDraftKey = currentSession?.id || '__home__';
+  const activeSkillIds = draftActiveSkillIds[currentDraftKey] || [];
+
   useEffect(() => {
     if (!selectedActionId) return;
     const action = quickActions.find(a => a.id === selectedActionId);

--- a/src/renderer/components/skills/ActiveSkillBadge.tsx
+++ b/src/renderer/components/skills/ActiveSkillBadge.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import XMarkIcon from '../icons/XMarkIcon';
-import PuzzleIcon from '../icons/PuzzleIcon';
-import { RootState } from '../../store';
-import { toggleActiveSkill, clearActiveSkills } from '../../store/slices/skillSlice';
-import { i18nService } from '../../services/i18n';
+import { useDispatch,useSelector } from 'react-redux';
 
-const ActiveSkillBadge: React.FC = () => {
+import { i18nService } from '../../services/i18n';
+import { RootState } from '../../store';
+import { clearDraftActiveSkillIds,toggleDraftActiveSkill } from '../../store/slices/coworkSlice';
+import PuzzleIcon from '../icons/PuzzleIcon';
+import XMarkIcon from '../icons/XMarkIcon';
+
+interface ActiveSkillBadgeProps {
+  draftKey: string;
+  className?: string;
+}
+
+const ActiveSkillBadge: React.FC<ActiveSkillBadgeProps> = ({ draftKey, className }) => {
   const dispatch = useDispatch();
-  const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
+  const activeSkillIds = useSelector((state: RootState) => state.cowork.draftActiveSkillIds[draftKey] || []);
   const skills = useSelector((state: RootState) => state.skill.skills);
 
   const activeSkills = activeSkillIds
@@ -19,16 +25,16 @@ const ActiveSkillBadge: React.FC = () => {
 
   const handleRemoveSkill = (e: React.MouseEvent, skillId: string) => {
     e.stopPropagation();
-    dispatch(toggleActiveSkill(skillId));
+    dispatch(toggleDraftActiveSkill({ draftKey, skillId }));
   };
 
   const handleClearAll = (e: React.MouseEvent) => {
     e.stopPropagation();
-    dispatch(clearActiveSkills());
+    dispatch(clearDraftActiveSkillIds(draftKey));
   };
 
   return (
-    <div className="flex items-center gap-1.5 flex-wrap">
+    <div className={`flex items-center gap-1.5 flex-wrap${className ? ` ${className}` : ''}`}>
       {activeSkills.map(skill => (
         <div
           key={skill.id}

--- a/src/renderer/components/skills/SkillsButton.tsx
+++ b/src/renderer/components/skills/SkillsButton.tsx
@@ -1,15 +1,18 @@
 import React, { useRef, useState } from 'react';
+
+import { Skill } from '../../types/skill';
 import PuzzleIcon from '../icons/PuzzleIcon';
 import SkillsPopover from './SkillsPopover';
-import { Skill } from '../../types/skill';
 
 interface SkillsButtonProps {
+  draftKey: string;
   onSelectSkill: (skill: Skill) => void;
   onManageSkills: () => void;
   className?: string;
 }
 
 const SkillsButton: React.FC<SkillsButtonProps> = ({
+  draftKey,
   onSelectSkill,
   onManageSkills,
   className = '',
@@ -37,6 +40,7 @@ const SkillsButton: React.FC<SkillsButtonProps> = ({
         <PuzzleIcon className="h-5 w-5" />
       </button>
       <SkillsPopover
+        draftKey={draftKey}
         isOpen={isPopoverOpen}
         onClose={handleClosePopover}
         onSelectSkill={onSelectSkill}

--- a/src/renderer/components/skills/SkillsPopover.tsx
+++ b/src/renderer/components/skills/SkillsPopover.tsx
@@ -1,15 +1,17 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { useSelector } from 'react-redux';
 import { CheckIcon } from '@heroicons/react/24/outline';
-import SearchIcon from '../icons/SearchIcon';
-import PuzzleIcon from '../icons/PuzzleIcon';
-import Cog6ToothIcon from '../icons/Cog6ToothIcon';
+import React, { useEffect, useRef,useState } from 'react';
+import { useSelector } from 'react-redux';
+
 import { i18nService } from '../../services/i18n';
 import { skillService } from '../../services/skill';
 import { RootState } from '../../store';
 import { Skill } from '../../types/skill';
+import Cog6ToothIcon from '../icons/Cog6ToothIcon';
+import PuzzleIcon from '../icons/PuzzleIcon';
+import SearchIcon from '../icons/SearchIcon';
 
 interface SkillsPopoverProps {
+  draftKey: string;
   isOpen: boolean;
   onClose: () => void;
   onSelectSkill: (skill: Skill) => void;
@@ -18,6 +20,7 @@ interface SkillsPopoverProps {
 }
 
 const SkillsPopover: React.FC<SkillsPopoverProps> = ({
+  draftKey,
   isOpen,
   onClose,
   onSelectSkill,
@@ -29,7 +32,7 @@ const SkillsPopover: React.FC<SkillsPopoverProps> = ({
   const popoverRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const skills = useSelector((state: RootState) => state.skill.skills);
-  const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
+  const activeSkillIds = useSelector((state: RootState) => state.cowork.draftActiveSkillIds[draftKey] || []);
 
   // Filter enabled skills based on search query
   const filteredSkills = skills

--- a/src/renderer/services/agent.ts
+++ b/src/renderer/services/agent.ts
@@ -1,14 +1,13 @@
 import { store } from '../store';
 import {
+  addAgent,
+  removeAgent,
   setAgents,
   setCurrentAgentId,
   setLoading,
-  addAgent,
   updateAgent as updateAgentAction,
-  removeAgent,
 } from '../store/slices/agentSlice';
-import { setActiveSkillIds, clearActiveSkills } from '../store/slices/skillSlice';
-import { clearCurrentSession } from '../store/slices/coworkSlice';
+import { clearCurrentSession,clearDraftActiveSkillIds, setDraftActiveSkillIds } from '../store/slices/coworkSlice';
 import type { Agent, PresetAgent } from '../types/agent';
 
 class AgentService {
@@ -152,10 +151,11 @@ class AgentService {
     store.dispatch(setCurrentAgentId(agentId));
     store.dispatch(clearCurrentSession());
     const agent = store.getState().agent.agents.find((a) => a.id === agentId);
+    const homeDraftKey = '__home__';
     if (agent?.skillIds?.length) {
-      store.dispatch(setActiveSkillIds(agent.skillIds));
+      store.dispatch(setDraftActiveSkillIds({ draftKey: homeDraftKey, skillIds: agent.skillIds }));
     } else {
-      store.dispatch(clearActiveSkills());
+      store.dispatch(clearDraftActiveSkillIds(homeDraftKey));
     }
   }
 }

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -1,11 +1,12 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
 import type {
-  CoworkSession,
-  CoworkSessionSummary,
-  CoworkMessage,
   CoworkConfig,
+  CoworkMessage,
   CoworkPermissionRequest,
+  CoworkSession,
   CoworkSessionStatus,
+  CoworkSessionSummary,
 } from '../../types/cowork';
 import { removeSessionFromState, removeSessionsFromState } from './coworkDeleteState';
 
@@ -23,6 +24,8 @@ interface CoworkState {
   draftPrompts: Record<string, string>;
   /** Keyed by draftKey (sessionId or '__home__'), stores pending attachments */
   draftAttachments: Record<string, DraftAttachment[]>;
+  /** Keyed by draftKey (sessionId or '__home__'), stores per-session active skill selections */
+  draftActiveSkillIds: Record<string, string[]>;
   unreadSessionIds: string[];
   isCoworkActive: boolean;
   isStreaming: boolean;
@@ -37,6 +40,7 @@ const initialState: CoworkState = {
   currentSession: null,
   draftPrompts: {},
   draftAttachments: {},
+  draftActiveSkillIds: {},
   unreadSessionIds: [],
   isCoworkActive: false,
   isStreaming: false,
@@ -199,10 +203,14 @@ const coworkSlice = createSlice({
 
     deleteSession(state, action: PayloadAction<string>) {
       removeSessionFromState(state, action.payload);
+      delete state.draftActiveSkillIds[action.payload];
     },
 
     deleteSessions(state, action: PayloadAction<string[]>) {
       removeSessionsFromState(state, action.payload);
+      for (const id of action.payload) {
+        delete state.draftActiveSkillIds[id];
+      }
     },
 
     addMessage(state, action: PayloadAction<{ sessionId: string; message: CoworkMessage }>) {
@@ -332,6 +340,35 @@ const coworkSlice = createSlice({
     clearDraftAttachments(state, action: PayloadAction<string>) {
       delete state.draftAttachments[action.payload];
     },
+
+    setDraftActiveSkillIds(state, action: PayloadAction<{ draftKey: string; skillIds: string[] }>) {
+      const { draftKey, skillIds } = action.payload;
+      if (skillIds.length === 0) {
+        delete state.draftActiveSkillIds[draftKey];
+      } else {
+        state.draftActiveSkillIds[draftKey] = skillIds;
+      }
+    },
+
+    toggleDraftActiveSkill(state, action: PayloadAction<{ draftKey: string; skillId: string }>) {
+      const { draftKey, skillId } = action.payload;
+      const current = state.draftActiveSkillIds[draftKey] || [];
+      const index = current.indexOf(skillId);
+      if (index === -1) {
+        state.draftActiveSkillIds[draftKey] = [...current, skillId];
+      } else {
+        const updated = current.filter((_, i) => i !== index);
+        if (updated.length === 0) {
+          delete state.draftActiveSkillIds[draftKey];
+        } else {
+          state.draftActiveSkillIds[draftKey] = updated;
+        }
+      }
+    },
+
+    clearDraftActiveSkillIds(state, action: PayloadAction<string>) {
+      delete state.draftActiveSkillIds[action.payload];
+    },
   },
 });
 
@@ -344,6 +381,9 @@ export const {
   setDraftAttachments,
   addDraftAttachment,
   clearDraftAttachments,
+  setDraftActiveSkillIds,
+  toggleDraftActiveSkill,
+  clearDraftActiveSkillIds,
   addSession,
   updateSessionStatus,
   deleteSession,


### PR DESCRIPTION
## 问题
技能选择状态存储在全局 skillSlice.activeSkillIds 中，导致在一个会话中选择的技能切换到其他会话后仍然生效，体验不合理。

## 解决方案
将技能选择状态迁移到 coworkSlice.draftActiveSkillIds，以 draftKey（会话 ID 或 __home__）为键按会话独立存储，与现有的 draftPrompts、draftAttachments 保持一致的设计模式。

## 行为变化
每个会话拥有独立的技能选择，互不影响
切换会话时，技能选择随会话切换
新建会话页面（首页）有自己独立的技能选择
删除会话时自动清理对应的技能状态