### PR TITLE
feat:add exit setup

### DIFF
--- a/src/main/appConstants.ts
+++ b/src/main/appConstants.ts
@@ -1,3 +1,22 @@
 export const APP_NAME = 'LobsterAI';
 export const APP_ID = 'lobsterai';
 export const DB_FILENAME = 'lobsterai.sqlite';
+
+/** 点击关闭按钮时的行为（仅 Windows） */
+export const CloseButtonAction = {
+  MinimizeToTaskbar: 'minimize_to_taskbar',
+  QuitApp: 'quit_app',
+} as const;
+export type CloseButtonAction = typeof CloseButtonAction[keyof typeof CloseButtonAction];
+
+/** SQLite kv 存储键名 */
+export const KvKey = {
+  CloseButtonAction: 'closeButtonAction',
+  CloseButtonActionPromptShown: 'closeButtonActionPromptShown',
+} as const;
+
+/** IPC channel names for close-button-action feature */
+export const CloseButtonIpc = {
+  GetAction: 'app:getCloseButtonAction',
+  SetAction: 'app:setCloseButtonAction',
+} as const;

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -175,6 +175,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imPopoConfigReadyOpenClaw: 'POPO 配置已就绪，通过 OpenClaw 运行。',
 
     'enterprise.updateBlocked': '版本更新由企业统一管理',
+
+    // Close button action dialog
+    closeActionDialogTitle: '关闭行为设置',
+    closeActionDialogMessage: '点击关闭按钮时你希望执行什么操作？',
+    closeActionMinimize: '最小化',
+    closeActionQuit: '退出',
+    closeActionCancel: '取消',
   },
   en: {
     // Tray menu
@@ -336,6 +343,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imPopoConfigReadyOpenClaw: 'POPO configuration is ready, running via OpenClaw.',
 
     'enterprise.updateBlocked': 'Updates are managed by enterprise',
+
+    // Close button action dialog
+    closeActionDialogTitle: 'Close Behavior',
+    closeActionDialogMessage: 'What should happen when you click the close button?',
+    closeActionMinimize: 'Minimize',
+    closeActionQuit: 'Quit',
+    closeActionCancel: 'Cancel',
   },
 };
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -48,7 +48,7 @@ import {
 } from './libs/openclawChannelSessionSync';
 import { IMGatewayManager, IMGatewayConfig } from './im';
 import type { Platform } from './im/types';
-import { APP_NAME } from './appConstants';
+import { APP_NAME, CloseButtonAction, CloseButtonIpc, KvKey } from './appConstants';
 import { getSkillServiceManager } from './skillServices';
 import { createTray, destroyTray, updateTrayMenu } from './trayManager';
 import { setLanguage, t } from './i18n';
@@ -1513,6 +1513,12 @@ let mainWindow: BrowserWindow | null = null;
 
 let isQuitting = false;
 
+/** Unified quit entry point. Sets the quitting flag then delegates to app.quit(). */
+const requestAppQuit = (): void => {
+  isQuitting = true;
+  app.quit();
+};
+
 // 存储活跃的流式请求控制器
 const activeStreamControllers = new Map<string, AbortController>();
 let lastReloadAt = 0;
@@ -1848,6 +1854,33 @@ if (!gotTheLock) {
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to set prevent-sleep',
+      };
+    }
+  });
+
+  // Close button action IPC handlers (Windows only)
+  ipcMain.handle(CloseButtonIpc.GetAction, () => {
+    const store = getStore();
+    return {
+      action: store.get<string>(KvKey.CloseButtonAction) ?? CloseButtonAction.MinimizeToTaskbar,
+      promptShown: store.get<boolean>(KvKey.CloseButtonActionPromptShown) ?? false,
+    };
+  });
+
+  ipcMain.handle(CloseButtonIpc.SetAction, (_event, action: unknown) => {
+    if (
+      action !== CloseButtonAction.MinimizeToTaskbar &&
+      action !== CloseButtonAction.QuitApp
+    ) {
+      return { success: false, error: 'Invalid close button action value' };
+    }
+    try {
+      getStore().set(KvKey.CloseButtonAction, action);
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to set close button action',
       };
     }
   });
@@ -4102,9 +4135,49 @@ if (!gotTheLock) {
     mainWindow.on('close', (e) => {
       // In development, close should actually quit so `npm run electron:dev`
       // restarts from a clean process. In production we keep tray behavior.
-      if (mainWindow && !isQuitting && !isDev) {
+      if (isDev || isQuitting) {
+        return;
+      }
+      // macOS: always hide/minimize, never quit via the close button.
+      if (isMac) {
         e.preventDefault();
-        mainWindow.hide();
+        mainWindow?.hide();
+        return;
+      }
+      // Windows / Linux: check configured close-button action.
+      e.preventDefault();
+      const store = getStore();
+      const promptShown = store.get<boolean>(KvKey.CloseButtonActionPromptShown) ?? false;
+      if (!promptShown) {
+        // First time: show a native dialog asking the user what they prefer.
+        const btnMinimize = 0;
+        const btnQuit = 1;
+        dialog.showMessageBox({
+          type: 'question',
+          title: t('closeActionDialogTitle'),
+          message: t('closeActionDialogMessage'),
+          buttons: [t('closeActionMinimize'), t('closeActionQuit')],
+          defaultId: btnMinimize,
+          cancelId: btnMinimize,
+        }).then(({ response }) => {
+          const action = response === btnQuit
+            ? CloseButtonAction.QuitApp
+            : CloseButtonAction.MinimizeToTaskbar;
+          store.set(KvKey.CloseButtonAction, action);
+          store.set(KvKey.CloseButtonActionPromptShown, true);
+          if (action === CloseButtonAction.QuitApp) {
+            requestAppQuit();
+          } else {
+            mainWindow?.hide();
+          }
+        });
+        return;
+      }
+      const action = store.get<string>(KvKey.CloseButtonAction) ?? CloseButtonAction.MinimizeToTaskbar;
+      if (action === CloseButtonAction.QuitApp) {
+        requestAppQuit();
+      } else {
+        mainWindow?.hide();
       }
     });
 
@@ -4180,7 +4253,7 @@ if (!gotTheLock) {
       const initLang = getStore().get<{ language?: string }>('app_config')?.language;
       setLanguage(initLang === 'en' ? 'en' : 'zh');
       // 窗口就绪后创建系统托盘
-      createTray(() => mainWindow);
+      createTray(() => mainWindow, requestAppQuit);
 
       // Start cron polling after the window is ready.
       (async () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -303,6 +303,10 @@ contextBridge.exposeInMainWorld('electron', {
     get: () => ipcRenderer.invoke('app:getAutoLaunch'),
     set: (enabled: boolean) => ipcRenderer.invoke('app:setAutoLaunch', enabled),
   },
+  closeButtonAction: {
+    get: () => ipcRenderer.invoke('app:getCloseButtonAction'),
+    set: (action: string) => ipcRenderer.invoke('app:setCloseButtonAction', action),
+  },
   preventSleep: {
     get: () => ipcRenderer.invoke('app:getPreventSleep'),
     set: (enabled: boolean) => ipcRenderer.invoke('app:setPreventSleep', enabled),

--- a/src/main/trayManager.ts
+++ b/src/main/trayManager.ts
@@ -35,7 +35,7 @@ function getLabels(): { showWindow: string; newTask: string; settings: string; q
   };
 }
 
-function buildContextMenu(getWindow: () => BrowserWindow | null): Menu {
+function buildContextMenu(getWindow: () => BrowserWindow | null, onQuit?: () => void): Menu {
   const labels = getLabels();
 
   return Menu.buildFromTemplate([
@@ -76,13 +76,17 @@ function buildContextMenu(getWindow: () => BrowserWindow | null): Menu {
     {
       label: labels.quit,
       click: () => {
-        app.quit();
+        if (onQuit) {
+          onQuit();
+        } else {
+          app.quit();
+        }
       },
     },
   ]);
 }
 
-export function createTray(getWindow: () => BrowserWindow | null): Tray {
+export function createTray(getWindow: () => BrowserWindow | null, onQuit?: () => void): Tray {
   if (tray) {
     return tray;
   }
@@ -102,7 +106,7 @@ export function createTray(getWindow: () => BrowserWindow | null): Tray {
   tray = new Tray(icon);
   tray.setToolTip(APP_NAME);
 
-  contextMenu = buildContextMenu(getWindow);
+  contextMenu = buildContextMenu(getWindow, onQuit);
 
   clickHandler = () => {
     const win = getWindow();

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -471,6 +471,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
   const [isUpdatingAutoLaunch, setIsUpdatingAutoLaunch] = useState(false);
   const [preventSleep, setPreventSleepState] = useState(false);
   const [isUpdatingPreventSleep, setIsUpdatingPreventSleep] = useState(false);
+  const [closeButtonActionValue, setCloseButtonActionValue] = useState<'minimize_to_taskbar' | 'quit_app'>('minimize_to_taskbar');
+  const [isUpdatingCloseButtonAction, setIsUpdatingCloseButtonAction] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [noticeMessage, setNoticeMessage] = useState<string | null>(notice ?? null);
@@ -709,6 +711,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
       }).catch(err => {
         console.error('Failed to load prevent-sleep setting:', err);
       });
+
+      // Load close-button action setting (Windows only)
+      if (window.electron.platform === 'win32') {
+        window.electron.closeButtonAction.get().then(({ action }) => {
+          setCloseButtonActionValue(action as 'minimize_to_taskbar' | 'quit_app');
+        }).catch(err => {
+          console.error('Failed to load close-button-action setting:', err);
+        });
+      }
 
       // Set up providers based on saved config
       if (config.api) {
@@ -2282,6 +2293,42 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, onUpda
                 </button>
               </label>
             </div>
+
+            {/* Close button action Section (Windows only) */}
+            {window.electron.platform === 'win32' && (
+              <div className="flex items-center justify-between">
+                <h4 className="text-sm font-medium text-foreground">
+                  {i18nService.t('closeButtonAction')}
+                </h4>
+                <div className="w-[140px] shrink-0">
+                  <ThemedSelect
+                    id="closeButtonAction"
+                    value={closeButtonActionValue}
+                    onChange={async (value) => {
+                      if (isUpdatingCloseButtonAction) return;
+                      setIsUpdatingCloseButtonAction(true);
+                      try {
+                        const result = await window.electron.closeButtonAction.set(value);
+                        if (result.success) {
+                          setCloseButtonActionValue(value as 'minimize_to_taskbar' | 'quit_app');
+                        } else {
+                          setError(result.error || 'Failed to update close button action');
+                        }
+                      } catch (err) {
+                        console.error('Failed to set close-button action:', err);
+                        setError('Failed to update close button action');
+                      } finally {
+                        setIsUpdatingCloseButtonAction(false);
+                      }
+                    }}
+                    options={[
+                      { value: 'minimize_to_taskbar', label: i18nService.t('closeButtonActionMinimize') },
+                      { value: 'quit_app', label: i18nService.t('closeButtonActionQuit') },
+                    ]}
+                  />
+                </div>
+              </div>
+            )}
 
             {/* System proxy Section */}
             <div>

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -990,6 +990,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     useSystemProxyDescription: '开启后网络请求将跟随系统代理（保存后生效）',
     preventSleep: '防止休眠',
     preventSleepDescription: '防止系统在应用运行时进入睡眠模式',
+    closeButtonAction: '关闭主面板时',
+    closeButtonActionMinimize: '最小化',
+    closeButtonActionQuit: '退出',
 
     // 定时任务
     scheduledTasks: '定时任务',
@@ -2177,6 +2180,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     useSystemProxyDescription: 'When enabled, network requests follow system proxy settings (applies after Save)',
     preventSleep: 'Prevent Sleep',
     preventSleepDescription: 'Prevent the system from sleeping while the app is running',
+    closeButtonAction: 'When closing the window',
+    closeButtonActionMinimize: 'Minimize',
+    closeButtonActionQuit: 'Quit',
 
     // Scheduled Tasks
     scheduledTasks: 'Scheduled Tasks',

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -389,6 +389,10 @@ interface IElectronAPI {
     get: () => Promise<{ enabled: boolean }>;
     set: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;
   };
+  closeButtonAction: {
+    get: () => Promise<{ action: string; promptShown: boolean }>;
+    set: (action: string) => Promise<{ success: boolean; error?: string }>;
+  };
   preventSleep: {
     get: () => Promise<{ enabled: boolean }>;
     set: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
## 概述
为 Windows 平台新增「关闭主面板时」行为配置，用户可选择点击窗口关闭按钮时执行**最小化到任务栏**或**退出应用**。首次点击关闭按钮时会弹出原生对话框引导用户选择，后续按配置直接执行。macOS 不受影响，始终保持原有隐藏行为。


## 改动文件

### `src/main/appConstants.ts`
新增三个常量：
- `CloseButtonAction` — 枚举值 `minimize_to_taskbar` / `quit_app`
- `KvKey` — SQLite 存储键名 `closeButtonAction` / `closeButtonActionPromptShown`
- `CloseButtonIpc` — IPC channel 名 `app:getCloseButtonAction` / `app:setCloseButtonAction`

### `src/main/main.ts`
- 新增 `requestAppQuit()` 统一退出入口（设置 `isQuitting = true` 后调用 `app.quit()`）
- 重写 `mainWindow.on('close')` 事件处理：
  - dev 模式 / `isQuitting` → 直接放行（原逻辑不变）
  - macOS → 始终 `hide()`（原逻辑不变）
  - Windows 首次关闭 → 弹原生 `dialog.showMessageBox` 让用户选择，选择结果持久化
  - Windows 后续关闭 → 读取配置直接执行对应行为
- `createTray()` 调用传入 `requestAppQuit` 作为 quit 回调，统一退出链路
- 新增两个 IPC handler：`app:getCloseButtonAction` / `app:setCloseButtonAction`

### `src/main/trayManager.ts`
- `createTray()` / `buildContextMenu()` 增加可选 `onQuit` 回调参数，优先使用注入的退出函数，确保托盘 Quit 与关闭按钮走同一条退出链路

### `src/main/preload.ts`
新增 `closeButtonAction.get()` / `closeButtonAction.set()` 暴露给渲染进程

### `src/renderer/types/electron.d.ts`
新增 `closeButtonAction` 类型声明

### `src/main/i18n.ts`
中英文各新增 5 个弹窗文案键（`closeActionDialogTitle`、`closeActionDialogMessage`、`closeActionMinimize`、`closeActionQuit`、`closeActionCancel`）

### `src/renderer/services/i18n.ts`
中英文各新增 3 个设置页文案键（`closeButtonAction`、`closeButtonActionMinimize`、`closeButtonActionQuit`）

### `src/renderer/components/Settings.tsx`
- 新增 state：`closeButtonActionValue` / `isUpdatingCloseButtonAction`
- 初始化时加载配置（仅 Windows）
- 通用设置页新增「关闭主面板时」下拉选项（`ThemedSelect`，仅 Windows 显示），选择后实时持久化



