### PR TITLE
feat(cowork): 新增会话裁剪功能，防止长对话超出模型上下文窗口

### DIFF
--- a/src/main/libs/coworkRunner.ts
+++ b/src/main/libs/coworkRunner.ts
@@ -8,7 +8,13 @@ import type { PermissionResult } from '@anthropic-ai/claude-agent-sdk';
 import type { CoworkStore, CoworkMessage, CoworkExecutionMode } from '../coworkStore';
 import { getClaudeCodePath, getCurrentApiConfig } from './claudeSettings';
 import { loadClaudeSdk } from './claudeSdk';
-import { getElectronNodeRuntimePath, getEnhancedEnv, getEnhancedEnvWithTmpdir, getSkillsRoot } from './coworkUtil';
+import { shouldPruneSession, pruneMessages, getModelContextWindow } from './sessionPruning';
+import {
+  getElectronNodeRuntimePath,
+  getEnhancedEnv,
+  getEnhancedEnvWithTmpdir,
+  getSkillsRoot,
+} from './coworkUtil';
 import { coworkLog, getCoworkLogPath } from './coworkLogger';
 import { ensurePythonPipReady, ensurePythonRuntimeReady } from './pythonRuntime';
 import { isDeleteCommand, isDangerousCommand } from './commandSafety';
@@ -18,11 +24,19 @@ import { SCHEDULED_TASK_SWITCH_MESSAGE } from '../../scheduledTask/enginePrompt'
 import { z } from 'zod';
 
 const ATTACHMENT_LINE_RE = /^\s*(?:[-*]\s*)?(输入文件|input\s*file)\s*[:：]\s*(.+?)\s*$/i;
-const INFERRED_FILE_REFERENCE_RE = /([^\s"'`，。！？：:；;（）()\[\]{}<>《》【】]+?\.[A-Za-z][A-Za-z0-9]{0,7})/g;
-const INFERRED_FILE_SEARCH_IGNORE = new Set(['.git', 'node_modules', '.cowork-temp', '.idea', '.vscode']);
+const INFERRED_FILE_REFERENCE_RE =
+  /([^\s"'`，。！？：:；;（）()\[\]{}<>《》【】]+?\.[A-Za-z][A-Za-z0-9]{0,7})/g;
+const INFERRED_FILE_SEARCH_IGNORE = new Set([
+  '.git',
+  'node_modules',
+  '.cowork-temp',
+  '.idea',
+  '.vscode',
+]);
 const LOCAL_HISTORY_MAX_MESSAGES = 24;
 const LOCAL_HISTORY_MAX_TOTAL_CHARS = 32000;
 const LOCAL_HISTORY_MAX_MESSAGE_CHARS = 4000;
+const SESSION_PRUNING_THRESHOLD = 0.75; // Trigger pruning at 75% of context window
 const STREAM_UPDATE_THROTTLE_MS = 90;
 const STREAMING_TEXT_MAX_CHARS = 120_000;
 const STREAMING_THINKING_MAX_CHARS = 60_000;
@@ -57,67 +71,71 @@ const PERMISSION_RESPONSE_TIMEOUT_MS = 60_000;
 const DELETE_TOOL_NAMES = new Set(['delete', 'remove', 'unlink', 'rmdir']);
 const SAFETY_APPROVAL_ALLOW_OPTION = '允许本次操作';
 const SAFETY_APPROVAL_DENY_OPTION = '拒绝本次操作';
-const PYTHON_BASH_COMMAND_RE = /(?:^|[^\w.-])(?:python(?:3)?|py(?:\.exe)?|pip(?:3)?)(?:\s+-3)?(?:\s|$)|\.py(?:\s|$)/i;
-const PYTHON_PIP_BASH_COMMAND_RE = /(?:^|[^\w.-])(?:pip(?:3)?|python(?:3)?\s+-m\s+pip|py(?:\.exe)?\s+-m\s+pip)(?:\s|$)/i;
-const MEMORY_REQUEST_TAIL_SPLIT_RE = /[,，。]\s*(?:请|麻烦)?你(?:帮我|帮忙|给我|为我|看下|看一下|查下|查一下)|[,，。]\s*帮我|[,，。]\s*请帮我|[,，。]\s*(?:能|可以)不能?\s*帮我|[,，。]\s*你看|[,，。]\s*请你/i;
-const MEMORY_PROCEDURAL_TEXT_RE = /(执行以下命令|run\s+(?:the\s+)?following\s+command|\b(?:cd|npm|pnpm|yarn|node|python|bash|sh|git|curl|wget)\b|\$[A-Z_][A-Z0-9_]*|&&|--[a-z0-9-]+|\/tmp\/|\.sh\b|\.bat\b|\.ps1\b)/i;
+const PYTHON_BASH_COMMAND_RE =
+  /(?:^|[^\w.-])(?:python(?:3)?|py(?:\.exe)?|pip(?:3)?)(?:\s+-3)?(?:\s|$)|\.py(?:\s|$)/i;
+const PYTHON_PIP_BASH_COMMAND_RE =
+  /(?:^|[^\w.-])(?:pip(?:3)?|python(?:3)?\s+-m\s+pip|py(?:\.exe)?\s+-m\s+pip)(?:\s|$)/i;
+const MEMORY_REQUEST_TAIL_SPLIT_RE =
+  /[,，。]\s*(?:请|麻烦)?你(?:帮我|帮忙|给我|为我|看下|看一下|查下|查一下)|[,，。]\s*帮我|[,，。]\s*请帮我|[,，。]\s*(?:能|可以)不能?\s*帮我|[,，。]\s*你看|[,，。]\s*请你/i;
+const MEMORY_PROCEDURAL_TEXT_RE =
+  /(执行以下命令|run\s+(?:the\s+)?following\s+command|\b(?:cd|npm|pnpm|yarn|node|python|bash|sh|git|curl|wget)\b|\$[A-Z_][A-Z0-9_]*|&&|--[a-z0-9-]+|\/tmp\/|\.sh\b|\.bat\b|\.ps1\b)/i;
 const MEMORY_ASSISTANT_STYLE_TEXT_RE = /^(?:使用|use)\s+[A-Za-z0-9._-]+\s*(?:技能|skill)/i;
 const WINDOWS_HIDE_INIT_SCRIPT_NAME = 'windows_hide_init.cjs';
 const WINDOWS_HIDE_INIT_SCRIPT_CONTENT = [
-  '\'use strict\';',
+  "'use strict';",
   '',
-  'if (process.platform === \'win32\') {',
-  '  const childProcess = require(\'child_process\');',
+  "if (process.platform === 'win32') {",
+  "  const childProcess = require('child_process');",
   '',
   '  const addWindowsHide = (options) => {',
   '    if (options == null) return { windowsHide: true };',
-  '    if (typeof options !== \'object\') return options;',
-  '    if (Object.prototype.hasOwnProperty.call(options, \'windowsHide\')) return options;',
+  "    if (typeof options !== 'object') return options;",
+  "    if (Object.prototype.hasOwnProperty.call(options, 'windowsHide')) return options;",
   '    return { ...options, windowsHide: true };',
   '  };',
   '',
   '  const patch = (name, buildWrapper) => {',
   '    const original = childProcess[name];',
-  '    if (typeof original !== \'function\') return;',
+  "    if (typeof original !== 'function') return;",
   '    childProcess[name] = buildWrapper(original);',
   '  };',
   '',
-  '  patch(\'spawn\', (original) => function patchedSpawn(command, args, options) {',
+  "  patch('spawn', (original) => function patchedSpawn(command, args, options) {",
   '    if (Array.isArray(args) || args === undefined) {',
   '      return original.call(this, command, args, addWindowsHide(options));',
   '    }',
   '    return original.call(this, command, addWindowsHide(args));',
   '  });',
   '',
-  '  patch(\'spawnSync\', (original) => function patchedSpawnSync(command, args, options) {',
+  "  patch('spawnSync', (original) => function patchedSpawnSync(command, args, options) {",
   '    if (Array.isArray(args) || args === undefined) {',
   '      return original.call(this, command, args, addWindowsHide(options));',
   '    }',
   '    return original.call(this, command, addWindowsHide(args));',
   '  });',
   '',
-  '  patch(\'fork\', (original) => function patchedFork(modulePath, args, options) {',
+  "  patch('fork', (original) => function patchedFork(modulePath, args, options) {",
   '    if (Array.isArray(args) || args === undefined) {',
   '      return original.call(this, modulePath, args, addWindowsHide(options));',
   '    }',
   '    return original.call(this, modulePath, addWindowsHide(args));',
   '  });',
   '',
-  '  patch(\'exec\', (original) => function patchedExec(command, options, callback) {',
-  '    if (typeof options === \'function\' || options === undefined) {',
+  "  patch('exec', (original) => function patchedExec(command, options, callback) {",
+  "    if (typeof options === 'function' || options === undefined) {",
   '      return original.call(this, command, addWindowsHide(undefined), options);',
   '    }',
   '    return original.call(this, command, addWindowsHide(options), callback);',
   '  });',
   '',
-  '  patch(\'execFile\', (original) => function patchedExecFile(file, args, options, callback) {',
+  "  patch('execFile', (original) => function patchedExecFile(file, args, options, callback) {",
   '    if (Array.isArray(args) || args === undefined) {',
-  '      if (typeof options === \'function\' || options === undefined) {',
+  "      if (typeof options === 'function' || options === undefined) {",
   '        return original.call(this, file, args, addWindowsHide(undefined), options);',
   '      }',
   '      return original.call(this, file, args, addWindowsHide(options), callback);',
   '    }',
-  '    if (typeof args === \'function\' || args === undefined) {',
+  "    if (typeof args === 'function' || args === undefined) {",
   '      return original.call(this, file, addWindowsHide(undefined), args);',
   '    }',
   '    return original.call(this, file, addWindowsHide(args), options);',
@@ -136,9 +154,7 @@ function ensureWindowsChildProcessHideInitScript(): string | null {
     fs.mkdirSync(initDir, { recursive: true });
     const initScriptPath = path.join(initDir, WINDOWS_HIDE_INIT_SCRIPT_NAME);
 
-    const existing = fs.existsSync(initScriptPath)
-      ? fs.readFileSync(initScriptPath, 'utf8')
-      : '';
+    const existing = fs.existsSync(initScriptPath) ? fs.readFileSync(initScriptPath, 'utf8') : '';
     if (existing !== WINDOWS_HIDE_INIT_SCRIPT_CONTENT) {
       fs.writeFileSync(initScriptPath, WINDOWS_HIDE_INIT_SCRIPT_CONTENT, 'utf8');
     }
@@ -147,7 +163,7 @@ function ensureWindowsChildProcessHideInitScript(): string | null {
     coworkLog(
       'WARN',
       'runClaudeCodeLocal',
-      `Failed to prepare Windows child-process hide init script: ${error instanceof Error ? error.message : String(error)}`
+      `Failed to prepare Windows child-process hide init script: ${error instanceof Error ? error.message : String(error)}`,
     );
     return null;
   }
@@ -251,20 +267,24 @@ export class CoworkRunner extends EventEmitter {
     this.store = store;
   }
 
-  setMcpServerProvider(provider: () => Array<{
-    name: string;
-    transportType: string;
-    command?: string;
-    args?: string[];
-    env?: Record<string, string>;
-    url?: string;
-    headers?: Record<string, string>;
-  }>): void {
+  setMcpServerProvider(
+    provider: () => Array<{
+      name: string;
+      transportType: string;
+      command?: string;
+      args?: string[];
+      env?: Record<string, string>;
+      url?: string;
+      headers?: Record<string, string>;
+    }>,
+  ): void {
     this.mcpServerProvider = provider;
   }
 
   private isSessionStopRequested(sessionId: string, activeSession?: ActiveSession): boolean {
-    return this.stoppedSessions.has(sessionId) || Boolean(activeSession?.abortController.signal.aborted);
+    return (
+      this.stoppedSessions.has(sessionId) || Boolean(activeSession?.abortController.signal.aborted)
+    );
   }
 
   private applyTurnMemoryUpdatesForSession(sessionId: string): void {
@@ -278,8 +298,10 @@ export class CoworkRunner extends EventEmitter {
       return;
     }
 
-    const lastUser = [...session.messages].reverse().find((message) => message.type === 'user' && message.content?.trim());
-    const lastAssistant = [...session.messages].reverse().find((message) => {
+    const lastUser = [...session.messages]
+      .reverse()
+      .find(message => message.type === 'user' && message.content?.trim());
+    const lastAssistant = [...session.messages].reverse().find(message => {
       if (message.type !== 'assistant') return false;
       if (!message.content?.trim()) return false;
       if (message.metadata?.isThinking) return false;
@@ -291,7 +313,10 @@ export class CoworkRunner extends EventEmitter {
     }
 
     const key = `${sessionId}:${lastUser.id}:${lastAssistant.id}`;
-    if (this.lastTurnMemoryKeyBySession.get(sessionId) === key || this.turnMemoryQueueKeys.has(key)) {
+    if (
+      this.lastTurnMemoryKeyBySession.get(sessionId) === key ||
+      this.turnMemoryQueueKeys.has(key)
+    ) {
       return;
     }
     this.turnMemoryQueueKeys.add(key);
@@ -330,18 +355,28 @@ export class CoworkRunner extends EventEmitter {
             userMessageId: job.userMessageId,
             assistantMessageId: job.assistantMessageId,
           });
-          coworkLog('INFO', 'memory:turnUpdateAsync', 'Applied turn memory updates asynchronously', {
-            sessionId: job.sessionId,
-            queueSize: this.turnMemoryQueue.length,
-            latencyMs: Math.max(0, Date.now() - job.enqueuedAt),
-            ...result,
-          });
+          coworkLog(
+            'INFO',
+            'memory:turnUpdateAsync',
+            'Applied turn memory updates asynchronously',
+            {
+              sessionId: job.sessionId,
+              queueSize: this.turnMemoryQueue.length,
+              latencyMs: Math.max(0, Date.now() - job.enqueuedAt),
+              ...result,
+            },
+          );
         } catch (error) {
-          coworkLog('WARN', 'memory:turnUpdateAsync', 'Failed to apply turn memory updates asynchronously', {
-            sessionId: job.sessionId,
-            queueSize: this.turnMemoryQueue.length,
-            error: error instanceof Error ? error.message : String(error),
-          });
+          coworkLog(
+            'WARN',
+            'memory:turnUpdateAsync',
+            'Failed to apply turn memory updates asynchronously',
+            {
+              sessionId: job.sessionId,
+              queueSize: this.turnMemoryQueue.length,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
         } finally {
           this.lastTurnMemoryKeyBySession.set(job.sessionId, job.key);
           this.turnMemoryQueueKeys.delete(job.key);
@@ -386,9 +421,10 @@ export class CoworkRunner extends EventEmitter {
     let totalChars = 0;
     const lines: string[] = [];
     for (const memory of memories) {
-      const text = memory.text.length > MAX_ITEM_CHARS
-        ? memory.text.slice(0, MAX_ITEM_CHARS) + '...'
-        : memory.text;
+      const text =
+        memory.text.length > MAX_ITEM_CHARS
+          ? memory.text.slice(0, MAX_ITEM_CHARS) + '...'
+          : memory.text;
       const line = `- ${this.escapeXml(text)}`;
       if (totalChars + line.length > MAX_TOTAL_CHARS) break;
       lines.push(line);
@@ -397,27 +433,31 @@ export class CoworkRunner extends EventEmitter {
     return `<userMemories>\n${lines.join('\n')}\n</userMemories>`;
   }
 
-  private formatChatSearchOutput(records: Array<{
-    url: string;
-    updatedAt: number;
-    title: string;
-    human: string;
-    assistant: string;
-  }>): string {
+  private formatChatSearchOutput(
+    records: Array<{
+      url: string;
+      updatedAt: number;
+      title: string;
+      human: string;
+      assistant: string;
+    }>,
+  ): string {
     if (records.length === 0) {
       return 'No matching chats found.';
     }
 
-    return records.map((record) => {
-      const updatedAtIso = new Date(record.updatedAt || Date.now()).toISOString();
-      return [
-        `<chat url="${this.escapeXml(record.url)}" updated_at="${updatedAtIso}">`,
-        `Title: ${record.title || 'Untitled'}`,
-        `Human: ${(record.human || '').trim() || '(empty)'}`,
-        `Assistant: ${(record.assistant || '').trim() || '(empty)'}`,
-        '</chat>',
-      ].join('\n');
-    }).join('\n\n');
+    return records
+      .map(record => {
+        const updatedAtIso = new Date(record.updatedAt || Date.now()).toISOString();
+        return [
+          `<chat url="${this.escapeXml(record.url)}" updated_at="${updatedAtIso}">`,
+          `Title: ${record.title || 'Untitled'}`,
+          `Human: ${(record.human || '').trim() || '(empty)'}`,
+          `Assistant: ${(record.assistant || '').trim() || '(empty)'}`,
+          '</chat>',
+        ].join('\n');
+      })
+      .join('\n\n');
   }
 
   private formatMemoryUserEditsResult(input: {
@@ -449,9 +489,8 @@ export class CoworkRunner extends EventEmitter {
       return '';
     }
     const tailMatch = normalized.match(MEMORY_REQUEST_TAIL_SPLIT_RE);
-    const clipped = tailMatch?.index && tailMatch.index > 0
-      ? normalized.slice(0, tailMatch.index)
-      : normalized;
+    const clipped =
+      tailMatch?.index && tailMatch.index > 0 ? normalized.slice(0, tailMatch.index) : normalized;
     return clipped.replace(/[，,；;:\-]+$/, '').trim();
   }
 
@@ -461,10 +500,18 @@ export class CoworkRunner extends EventEmitter {
       return { ok: false, text: '', reason: 'text is required' };
     }
     if (isQuestionLikeMemoryText(text)) {
-      return { ok: false, text: '', reason: 'memory text looks like a question, not a durable fact' };
+      return {
+        ok: false,
+        text: '',
+        reason: 'memory text looks like a question, not a durable fact',
+      };
     }
     if (MEMORY_ASSISTANT_STYLE_TEXT_RE.test(text)) {
-      return { ok: false, text: '', reason: 'memory text looks like assistant workflow instruction' };
+      return {
+        ok: false,
+        text: '',
+        reason: 'memory text looks like assistant workflow instruction',
+      };
     }
     if (MEMORY_PROCEDURAL_TEXT_RE.test(text)) {
       return { ok: false, text: '', reason: 'memory text looks like command/procedural content' };
@@ -520,17 +567,21 @@ export class CoworkRunner extends EventEmitter {
         limit: args.limit ?? 20,
         offset: 0,
       });
-      const payload = entries.length === 0
-        ? 'memories=(empty)'
-        : entries
-          .map((entry) => `${entry.id} | ${entry.status} | explicit=${entry.isExplicit ? 1 : 0} | ${entry.text}`)
-          .join('\n');
+      const payload =
+        entries.length === 0
+          ? 'memories=(empty)'
+          : entries
+              .map(
+                entry =>
+                  `${entry.id} | ${entry.status} | explicit=${entry.isExplicit ? 1 : 0} | ${entry.text}`,
+              )
+              .join('\n');
       return {
         text: this.formatMemoryUserEditsResult({
           action: 'list',
           successCount: entries.length,
           failedCount: 0,
-          changedIds: entries.map((entry) => entry.id),
+          changedIds: entries.map(entry => entry.id),
           payload,
         }),
         isError: false,
@@ -831,7 +882,7 @@ export class CoworkRunner extends EventEmitter {
       maxStringChars?: number;
       maxKeys?: number;
       maxItems?: number;
-    } = {}
+    } = {},
   ): unknown {
     const maxDepth = options.maxDepth ?? TOOL_INPUT_PREVIEW_MAX_DEPTH;
     const maxStringChars = options.maxStringChars ?? TOOL_INPUT_PREVIEW_MAX_CHARS;
@@ -841,10 +892,10 @@ export class CoworkRunner extends EventEmitter {
 
     const visit = (current: unknown, depth: number): unknown => {
       if (
-        current === null
-        || typeof current === 'number'
-        || typeof current === 'boolean'
-        || typeof current === 'undefined'
+        current === null ||
+        typeof current === 'number' ||
+        typeof current === 'boolean' ||
+        typeof current === 'undefined'
       ) {
         return current;
       }
@@ -861,7 +912,7 @@ export class CoworkRunner extends EventEmitter {
         return '[truncated-depth]';
       }
       if (Array.isArray(current)) {
-        const sanitized = current.slice(0, maxItems).map((item) => visit(item, depth + 1));
+        const sanitized = current.slice(0, maxItems).map(item => visit(item, depth + 1));
         if (current.length > maxItems) {
           sanitized.push(`[truncated-items:${current.length - maxItems}]`);
         }
@@ -893,7 +944,7 @@ export class CoworkRunner extends EventEmitter {
     current: string,
     delta: string,
     maxChars: number,
-    isTruncated: boolean
+    isTruncated: boolean,
   ): { content: string; truncated: boolean; changed: boolean } {
     if (!delta || isTruncated) {
       return { content: current, truncated: isTruncated, changed: false };
@@ -915,7 +966,7 @@ export class CoworkRunner extends EventEmitter {
 
   private shouldEmitStreamingUpdate(
     lastEmitAt: number,
-    force = false
+    force = false,
   ): { emit: boolean; now: number } {
     const now = Date.now();
     if (force || now - lastEmitAt >= STREAM_UPDATE_THROTTLE_MS) {
@@ -929,9 +980,10 @@ export class CoworkRunner extends EventEmitter {
     if (!raw) {
       return null;
     }
-    const content = raw.length <= maxChars
-      ? raw
-      : `${raw.slice(0, maxChars)}\n...[truncated ${raw.length - maxChars} chars]`;
+    const content =
+      raw.length <= maxChars
+        ? raw
+        : `${raw.slice(0, maxChars)}\n...[truncated ${raw.length - maxChars} chars]`;
 
     let role: string = message.type;
     if (message.type === 'assistant' && message.metadata?.isThinking) {
@@ -944,7 +996,7 @@ export class CoworkRunner extends EventEmitter {
   private buildHistoryBlocks(
     messages: CoworkMessage[],
     currentPrompt: string,
-    limits: { maxMessages: number; maxTotalChars: number; maxMessageChars: number }
+    limits: { maxMessages: number; maxTotalChars: number; maxMessageChars: number },
   ): string[] {
     if (messages.length === 0) {
       return [];
@@ -954,9 +1006,9 @@ export class CoworkRunner extends EventEmitter {
     const trimmedCurrentPrompt = currentPrompt.trim();
     const last = history[history.length - 1];
     if (
-      trimmedCurrentPrompt
-      && last?.type === 'user'
-      && last.content.trim() === trimmedCurrentPrompt
+      trimmedCurrentPrompt &&
+      last?.type === 'user' &&
+      last.content.trim() === trimmedCurrentPrompt
     ) {
       history.pop();
     }
@@ -976,9 +1028,10 @@ export class CoworkRunner extends EventEmitter {
       if (nextTotal > limits.maxTotalChars) {
         if (selectedFromNewest.length === 0) {
           const raw = block.replace(/\u0000/g, '').trim();
-          const truncated = raw.length <= limits.maxTotalChars
-            ? raw
-            : `${raw.slice(0, limits.maxTotalChars)}\n...[truncated ${raw.length - limits.maxTotalChars} chars]`;
+          const truncated =
+            raw.length <= limits.maxTotalChars
+              ? raw
+              : `${raw.slice(0, limits.maxTotalChars)}\n...[truncated ${raw.length - limits.maxTotalChars} chars]`;
           if (truncated) {
             selectedFromNewest.push(truncated);
           }
@@ -996,14 +1049,52 @@ export class CoworkRunner extends EventEmitter {
   /**
    * Inject conversation history into a local-mode prompt when the session is
    * restarted after a stop (subprocess was killed, no SDK session to resume).
+   * Applies context-window-aware pruning to prevent token overflow.
    */
-  private injectLocalHistoryPrompt(sessionId: string, currentPrompt: string, effectivePrompt: string): string {
+  private injectLocalHistoryPrompt(
+    sessionId: string,
+    currentPrompt: string,
+    effectivePrompt: string,
+  ): string {
     const session = this.store.getSession(sessionId);
     if (!session) {
       return effectivePrompt;
     }
 
-    const historyBlocks = this.buildHistoryBlocks(session.messages, currentPrompt, {
+    // Check if we need aggressive pruning for context window management.
+    // Reserve 40% of context window for system prompt + model response.
+    const apiConfig = getCurrentApiConfig('local');
+    const modelId = apiConfig?.model || 'default';
+    const contextWindow = getModelContextWindow(modelId);
+    const historyTokenBudget = Math.floor(contextWindow * 0.6);
+
+    const pruneResult = pruneMessages(
+      session.messages.map(m => ({ content: m.content, type: m.type, id: m.id })),
+      historyTokenBudget,
+    );
+
+    if (pruneResult.wasPruned) {
+      console.log(
+        `[SessionPruning] session ${sessionId}: pruned ${pruneResult.prunedCount} of ` +
+          `${session.messages.length} messages to fit within ${historyTokenBudget} token budget`,
+      );
+    }
+
+    // Build history blocks from kept messages (either all or pruned subset)
+    const messagesToUse = pruneResult.wasPruned
+      ? pruneResult.keptMessages.map(
+          m =>
+            ({
+              id: m.id || '',
+              type: m.type || 'user',
+              content: m.content,
+              metadata: {},
+              createdAt: 0,
+            }) as CoworkMessage,
+        )
+      : session.messages;
+
+    const historyBlocks = this.buildHistoryBlocks(messagesToUse, currentPrompt, {
       maxMessages: LOCAL_HISTORY_MAX_MESSAGES,
       maxTotalChars: LOCAL_HISTORY_MAX_TOTAL_CHARS,
       maxMessageChars: LOCAL_HISTORY_MAX_MESSAGE_CHARS,
@@ -1012,8 +1103,12 @@ export class CoworkRunner extends EventEmitter {
       return effectivePrompt;
     }
 
+    const preamble = pruneResult.wasPruned
+      ? `The session was interrupted and restarted. ${pruneResult.prunedSummaryPrefix} Continue using the recent conversation history below.`
+      : 'The session was interrupted and restarted. Continue using the conversation history below.';
+
     return [
-      'The session was interrupted and restarted. Continue using the conversation history below.',
+      preamble,
       'Use this context for continuity and do not quote it unless necessary.',
       '<conversation_history>',
       ...historyBlocks,
@@ -1027,9 +1122,7 @@ export class CoworkRunner extends EventEmitter {
 
   private normalizeWorkspaceRoot(workspaceRoot: string, cwd: string): string {
     const fallbackRoot = path.resolve(cwd);
-    const normalizedRoot = workspaceRoot?.trim()
-      ? path.resolve(workspaceRoot)
-      : fallbackRoot;
+    const normalizedRoot = workspaceRoot?.trim() ? path.resolve(workspaceRoot) : fallbackRoot;
     try {
       return fs.realpathSync(normalizedRoot);
     } catch {
@@ -1048,11 +1141,7 @@ export class CoworkRunner extends EventEmitter {
   }
 
   private resolveHostWorkspaceFallback(workspaceRoot: string): string | null {
-    const candidates = [
-      workspaceRoot,
-      this.store.getConfig().workingDirectory,
-      process.cwd(),
-    ];
+    const candidates = [workspaceRoot, this.store.getConfig().workingDirectory, process.cwd()];
 
     for (const candidate of candidates) {
       const trimmed = typeof candidate === 'string' ? candidate.trim() : '';
@@ -1065,7 +1154,11 @@ export class CoworkRunner extends EventEmitter {
     return null;
   }
 
-  private resolveSessionCwdForExecution(sessionId: string, cwd: string, workspaceRoot: string): string {
+  private resolveSessionCwdForExecution(
+    sessionId: string,
+    cwd: string,
+    workspaceRoot: string,
+  ): string {
     const trimmed = cwd.trim();
     const directResolved = path.resolve(trimmed || workspaceRoot || process.cwd());
     if (this.isDirectory(directResolved)) {
@@ -1151,22 +1244,23 @@ export class CoworkRunner extends EventEmitter {
   private buildWorkspaceSafetyPrompt(
     workspaceRoot: string,
     cwd: string,
-    confirmationMode: 'modal' | 'text'
+    confirmationMode: 'modal' | 'text',
   ): string {
-    const confirmationRules = confirmationMode === 'text'
-      ? [
-          '- Confirmation channel: plain text only (no modal).',
-          '- Before any delete operation, ask for explicit text confirmation first.',
-          '- Wait for explicit confirmation text before proceeding.',
-          '- Do not use AskUserQuestion in this session.',
-        ]
-      : [
-          '- Confirmation channel: AskUserQuestion modal.',
-          '- For every delete operation, you must call AskUserQuestion before executing any tool action.',
-          '- A direct user instruction is not enough for safety confirmation; AskUserQuestion approval is still required.',
-          '- Never use normal assistant text as the confirmation channel in modal mode.',
-          '- Continue only when AskUserQuestion returns explicit allow.',
-        ];
+    const confirmationRules =
+      confirmationMode === 'text'
+        ? [
+            '- Confirmation channel: plain text only (no modal).',
+            '- Before any delete operation, ask for explicit text confirmation first.',
+            '- Wait for explicit confirmation text before proceeding.',
+            '- Do not use AskUserQuestion in this session.',
+          ]
+        : [
+            '- Confirmation channel: AskUserQuestion modal.',
+            '- For every delete operation, you must call AskUserQuestion before executing any tool action.',
+            '- A direct user instruction is not enough for safety confirmation; AskUserQuestion approval is still required.',
+            '- Never use normal assistant text as the confirmation channel in modal mode.',
+            '- Continue only when AskUserQuestion returns explicit allow.',
+          ];
 
     return [
       '## Workspace Safety Policy (Highest Priority)',
@@ -1184,7 +1278,7 @@ export class CoworkRunner extends EventEmitter {
     workspaceRoot: string,
     cwd: string,
     confirmationMode: 'modal' | 'text',
-    memoryEnabled: boolean
+    memoryEnabled: boolean,
   ): string {
     const safetyPrompt = this.buildWorkspaceSafetyPrompt(workspaceRoot, cwd, confirmationMode);
     const windowsEncodingPrompt = this.buildWindowsEncodingPrompt();
@@ -1200,11 +1294,17 @@ export class CoworkRunner extends EventEmitter {
       memoryRecallPrompt.push(
         '- User memories are injected as <userMemories> facts and should be treated as stable personal context.',
         '- Use `memory_user_edits` only when the user explicitly asks to remember, update, list, or delete memory facts.',
-        '- Never write transient conversation facts, news content, or source citations into user memory unless the user explicitly asks.'
+        '- Never write transient conversation facts, news content, or source citations into user memory unless the user explicitly asks.',
       );
     }
     const trimmedBasePrompt = baseSystemPrompt?.trim();
-    return [safetyPrompt, windowsEncodingPrompt, windowsBundledRuntimePrompt, memoryRecallPrompt.join('\n'), trimmedBasePrompt]
+    return [
+      safetyPrompt,
+      windowsEncodingPrompt,
+      windowsBundledRuntimePrompt,
+      memoryRecallPrompt.join('\n'),
+      trimmedBasePrompt,
+    ]
       .filter((section): section is string => Boolean(section?.trim()))
       .join('\n\n');
   }
@@ -1217,9 +1317,7 @@ export class CoworkRunner extends EventEmitter {
   private buildPromptPrefix(): string {
     const localTimePrompt = this.buildLocalTimeContextPrompt();
     const userMemoriesXml = this.buildUserMemoriesXml();
-    return [localTimePrompt, userMemoriesXml]
-      .filter((section) => section?.trim())
-      .join('\n\n');
+    return [localTimePrompt, userMemoriesXml].filter(section => section?.trim()).join('\n\n');
   }
 
   private extractToolCommand(toolInput: Record<string, unknown>): string {
@@ -1253,7 +1351,7 @@ export class CoworkRunner extends EventEmitter {
   private buildSafetyQuestionInput(
     question: string,
     requestedToolName: string,
-    requestedToolInput: Record<string, unknown>
+    requestedToolInput: Record<string, unknown>,
   ): Record<string, unknown> {
     return {
       questions: [
@@ -1302,7 +1400,7 @@ export class CoworkRunner extends EventEmitter {
 
     return rawAnswer
       .split('|||')
-      .map((value) => value.trim())
+      .map(value => value.trim())
       .filter(Boolean)
       .includes(SAFETY_APPROVAL_ALLOW_OPTION);
   }
@@ -1313,7 +1411,7 @@ export class CoworkRunner extends EventEmitter {
     activeSession: ActiveSession,
     question: string,
     requestedToolName: string,
-    requestedToolInput: Record<string, unknown>
+    requestedToolInput: Record<string, unknown>,
   ): Promise<boolean> {
     const request: PermissionRequest = {
       requestId: uuidv4(),
@@ -1336,7 +1434,7 @@ export class CoworkRunner extends EventEmitter {
     signal: AbortSignal,
     activeSession: ActiveSession,
     toolName: string,
-    toolInput: Record<string, unknown>
+    toolInput: Record<string, unknown>,
   ): Promise<PermissionResult | null> {
     // 1. Non-Bash delete tools (e.g. dedicated 'rm' tool) → delete confirmation
     if (this.isDeleteOperation(toolName, toolInput)) {
@@ -1346,7 +1444,7 @@ export class CoworkRunner extends EventEmitter {
         activeSession,
         '即将执行删除操作，是否允许？',
         toolName,
-        toolInput
+        toolInput,
       );
       if (!approved) {
         return { behavior: 'deny', message: 'Delete operation denied by user.' };
@@ -1367,7 +1465,7 @@ export class CoworkRunner extends EventEmitter {
           activeSession,
           question,
           toolName,
-          toolInput
+          toolInput,
         );
         if (!approved) {
           return { behavior: 'deny', message: 'Dangerous command denied by user.' };
@@ -1392,7 +1490,7 @@ export class CoworkRunner extends EventEmitter {
 
   private async ensureWindowsPythonRuntimeForCommand(
     sessionId: string,
-    command: string
+    command: string,
   ): Promise<{ ok: boolean; reason?: string }> {
     if (process.platform !== 'win32' || !this.isPythonRelatedBashCommand(command)) {
       return { ok: true };
@@ -1406,8 +1504,11 @@ export class CoworkRunner extends EventEmitter {
       return { ok: true };
     }
 
-    const reason = runtimeResult.error
-      || (isPipCommand ? 'Bundled Python pip environment is unavailable.' : 'Bundled Python runtime is unavailable.');
+    const reason =
+      runtimeResult.error ||
+      (isPipCommand
+        ? 'Bundled Python pip environment is unavailable.'
+        : 'Bundled Python runtime is unavailable.');
     const summary = this.truncateCommandPreview(command, 140);
     coworkLog('ERROR', 'python-runtime', 'Windows python command blocked: runtime unavailable', {
       sessionId,
@@ -1433,7 +1534,7 @@ export class CoworkRunner extends EventEmitter {
       workspaceRoot?: string;
       confirmationMode?: 'modal' | 'text';
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
-    } = {}
+    } = {},
   ): Promise<void> {
     this.stoppedSessions.delete(sessionId);
     const session = this.store.getSession(sessionId);
@@ -1466,7 +1567,11 @@ export class CoworkRunner extends EventEmitter {
     const preferredWorkspaceRoot = options.workspaceRoot?.trim()
       ? path.resolve(options.workspaceRoot)
       : this.inferWorkspaceRootFromSessionCwd(session.cwd);
-    const sessionCwd = this.resolveSessionCwdForExecution(sessionId, session.cwd, preferredWorkspaceRoot);
+    const sessionCwd = this.resolveSessionCwdForExecution(
+      sessionId,
+      session.cwd,
+      preferredWorkspaceRoot,
+    );
 
     // Store active session
     const activeSession: ActiveSession = {
@@ -1503,7 +1608,7 @@ export class CoworkRunner extends EventEmitter {
       this.normalizeWorkspaceRoot(activeSession.workspaceRoot, sessionCwd),
       sessionCwd,
       activeSession.confirmationMode,
-      this.store.getConfig().memoryEnabled
+      this.store.getConfig().memoryEnabled,
     );
 
     // Run claude-code using the SDK
@@ -1513,19 +1618,48 @@ export class CoworkRunner extends EventEmitter {
 
       // If the session already has messages (restarted after stop), inject
       // conversation history so the model retains context from prior turns.
+      // Apply session pruning if the context is approaching the model's limit.
       const currentSession = this.store.getSession(sessionId);
       if (currentSession && currentSession.messages.length > 0) {
+        const apiConfig = getCurrentApiConfig('local');
+        const modelId = apiConfig?.model || 'default';
+        const pruneCheck = shouldPruneSession(
+          currentSession.messages.map(m => ({ content: m.content, type: m.type })),
+          modelId,
+          effectiveSystemPrompt,
+          SESSION_PRUNING_THRESHOLD,
+        );
+        if (pruneCheck.needsPruning) {
+          console.log(
+            `[SessionPruning] session ${sessionId}: ${pruneCheck.estimatedTokens} estimated tokens ` +
+              `(${(pruneCheck.usageRatio * 100).toFixed(0)}% of ${pruneCheck.contextWindow} context window), pruning history`,
+          );
+        }
         effectivePrompt = this.injectLocalHistoryPrompt(sessionId, prompt, effectivePrompt);
       }
 
       setCoworkProxySessionId(sessionId);
-      await this.runClaudeCode(activeSession, effectivePrompt, sessionCwd, effectiveSystemPrompt, options.imageAttachments);
+      await this.runClaudeCode(
+        activeSession,
+        effectivePrompt,
+        sessionCwd,
+        effectiveSystemPrompt,
+        options.imageAttachments,
+      );
     } catch (error) {
       console.error('Cowork session error:', error);
     }
   }
 
-  async continueSession(sessionId: string, prompt: string, options: { systemPrompt?: string; skillIds?: string[]; imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }> } = {}): Promise<void> {
+  async continueSession(
+    sessionId: string,
+    prompt: string,
+    options: {
+      systemPrompt?: string;
+      skillIds?: string[];
+      imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
+    } = {},
+  ): Promise<void> {
     this.stoppedSessions.delete(sessionId);
     const activeSession = this.activeSessions.get(sessionId);
     if (!activeSession) {
@@ -1575,7 +1709,11 @@ export class CoworkRunner extends EventEmitter {
     if (!session) {
       throw new Error(`Session ${sessionId} not found`);
     }
-    const sessionCwd = this.resolveSessionCwdForExecution(sessionId, session.cwd, activeSession.workspaceRoot);
+    const sessionCwd = this.resolveSessionCwdForExecution(
+      sessionId,
+      session.cwd,
+      activeSession.workspaceRoot,
+    );
     if (session.cwd !== sessionCwd) {
       this.store.updateSession(sessionId, { cwd: sessionCwd });
     }
@@ -1589,7 +1727,7 @@ export class CoworkRunner extends EventEmitter {
     if (!options.skillIds?.length && baseSystemPrompt?.includes('<available_skills>')) {
       baseSystemPrompt = baseSystemPrompt.replace(
         /## Skills \(mandatory\)[\s\S]*?<\/available_skills>/,
-        '## Skills\nSkill already loaded for this session. Continue following its instructions.'
+        '## Skills\nSkill already loaded for this session. Continue following its instructions.',
       );
     }
 
@@ -1598,14 +1736,20 @@ export class CoworkRunner extends EventEmitter {
       this.normalizeWorkspaceRoot(activeSession.workspaceRoot, sessionCwd),
       sessionCwd,
       activeSession.confirmationMode,
-      this.store.getConfig().memoryEnabled
+      this.store.getConfig().memoryEnabled,
     );
 
     try {
       const promptPrefix = this.buildPromptPrefix();
       const effectivePrompt = promptPrefix ? `${promptPrefix}\n\n---\n\n${prompt}` : prompt;
       setCoworkProxySessionId(sessionId);
-      await this.runClaudeCode(activeSession, effectivePrompt, sessionCwd, effectiveSystemPrompt, options.imageAttachments);
+      await this.runClaudeCode(
+        activeSession,
+        effectivePrompt,
+        sessionCwd,
+        effectiveSystemPrompt,
+        options.imageAttachments,
+      );
     } catch (error) {
       console.error('Cowork continue error:', error);
     }
@@ -1664,7 +1808,7 @@ export class CoworkRunner extends EventEmitter {
     prompt: string,
     cwd: string,
     systemPrompt: string,
-    imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>
+    imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>,
   ): Promise<void> {
     const { sessionId, abortController } = activeSession;
     const config = this.store.getConfig();
@@ -1705,13 +1849,33 @@ export class CoworkRunner extends EventEmitter {
     let stderrTail = '';
 
     // Log MCP-relevant environment for debugging
-    coworkLog('INFO', 'runClaudeCodeLocal', `MCP env: isPackaged=${app.isPackaged}, platform=${process.platform}, arch=${process.arch}`);
-    coworkLog('INFO', 'runClaudeCodeLocal', `MCP env: LOBSTERAI_ELECTRON_PATH=${envVars.LOBSTERAI_ELECTRON_PATH || '(not set)'}`);
-    coworkLog('INFO', 'runClaudeCodeLocal', `MCP env: ELECTRON_RUN_AS_NODE=${envVars.ELECTRON_RUN_AS_NODE || '(not set)'}`);
-    coworkLog('INFO', 'runClaudeCodeLocal', `MCP env: NODE_PATH=${envVars.NODE_PATH || '(not set)'}`);
+    coworkLog(
+      'INFO',
+      'runClaudeCodeLocal',
+      `MCP env: isPackaged=${app.isPackaged}, platform=${process.platform}, arch=${process.arch}`,
+    );
+    coworkLog(
+      'INFO',
+      'runClaudeCodeLocal',
+      `MCP env: LOBSTERAI_ELECTRON_PATH=${envVars.LOBSTERAI_ELECTRON_PATH || '(not set)'}`,
+    );
+    coworkLog(
+      'INFO',
+      'runClaudeCodeLocal',
+      `MCP env: ELECTRON_RUN_AS_NODE=${envVars.ELECTRON_RUN_AS_NODE || '(not set)'}`,
+    );
+    coworkLog(
+      'INFO',
+      'runClaudeCodeLocal',
+      `MCP env: NODE_PATH=${envVars.NODE_PATH || '(not set)'}`,
+    );
     coworkLog('INFO', 'runClaudeCodeLocal', `MCP env: HOME=${envVars.HOME || '(not set)'}`);
     coworkLog('INFO', 'runClaudeCodeLocal', `MCP env: TMPDIR=${envVars.TMPDIR || '(not set)'}`);
-    coworkLog('INFO', 'runClaudeCodeLocal', `MCP env: LOBSTERAI_NPM_BIN_DIR=${envVars.LOBSTERAI_NPM_BIN_DIR || '(not set)'}`);
+    coworkLog(
+      'INFO',
+      'runClaudeCodeLocal',
+      `MCP env: LOBSTERAI_NPM_BIN_DIR=${envVars.LOBSTERAI_NPM_BIN_DIR || '(not set)'}`,
+    );
     coworkLog('INFO', 'runClaudeCodeLocal', `MCP env: claudeCodePath=${claudeCodePath}`);
     // Log full PATH split by delimiter
     const pathEntries = (envVars.PATH || '').split(path.delimiter);
@@ -1731,15 +1895,17 @@ export class CoworkRunner extends EventEmitter {
     // On Windows, check that git-bash is available before attempting to start.
     // Claude Code CLI requires git-bash for shell tool execution.
     if (process.platform === 'win32' && !envVars.CLAUDE_CODE_GIT_BASH_PATH) {
-      const bashResolutionDiagnostic = typeof envVars.LOBSTERAI_GIT_BASH_RESOLUTION_ERROR === 'string'
-        ? envVars.LOBSTERAI_GIT_BASH_RESOLUTION_ERROR.trim()
-        : '';
-      const errorMsg = 'Windows local execution requires a healthy Git Bash runtime, but no valid bash was resolved. '
-        + 'This may be caused by missing bundled PortableGit or a conflicting system bash that cannot run cygpath. '
-        + 'Please reinstall or upgrade to a correctly built version that includes resources/mingit. '
-        + 'Advanced fallback: set CLAUDE_CODE_GIT_BASH_PATH to your bash.exe path '
-        + '(e.g. C:\\Program Files\\Git\\bin\\bash.exe).'
-        + (bashResolutionDiagnostic ? ` Resolver diagnostic: ${bashResolutionDiagnostic}` : '');
+      const bashResolutionDiagnostic =
+        typeof envVars.LOBSTERAI_GIT_BASH_RESOLUTION_ERROR === 'string'
+          ? envVars.LOBSTERAI_GIT_BASH_RESOLUTION_ERROR.trim()
+          : '';
+      const errorMsg =
+        'Windows local execution requires a healthy Git Bash runtime, but no valid bash was resolved. ' +
+        'This may be caused by missing bundled PortableGit or a conflicting system bash that cannot run cygpath. ' +
+        'Please reinstall or upgrade to a correctly built version that includes resources/mingit. ' +
+        'Advanced fallback: set CLAUDE_CODE_GIT_BASH_PATH to your bash.exe path ' +
+        '(e.g. C:\\Program Files\\Git\\bin\\bash.exe).' +
+        (bashResolutionDiagnostic ? ` Resolver diagnostic: ${bashResolutionDiagnostic}` : '');
       coworkLog('ERROR', 'runClaudeCodeLocal', errorMsg);
       this.handleError(sessionId, errorMsg);
       this.clearPendingPermissions(sessionId);
@@ -1787,7 +1953,7 @@ export class CoworkRunner extends EventEmitter {
       canUseTool: async (
         toolName: string,
         toolInput: unknown,
-        { signal }: { signal: AbortSignal }
+        { signal }: { signal: AbortSignal },
       ): Promise<PermissionResult> => {
         if (abortController.signal.aborted || signal.aborted) {
           return { behavior: 'deny', message: 'Session aborted' };
@@ -1801,7 +1967,10 @@ export class CoworkRunner extends EventEmitter {
 
         if (resolvedName === 'Bash') {
           const command = this.extractToolCommand(resolvedInput);
-          const pythonRuntimeCheck = await this.ensureWindowsPythonRuntimeForCommand(sessionId, command);
+          const pythonRuntimeCheck = await this.ensureWindowsPythonRuntimeForCommand(
+            sessionId,
+            command,
+          );
           if (!pythonRuntimeCheck.ok) {
             const reason = pythonRuntimeCheck.reason || 'Python runtime unavailable.';
             this.addSystemMessage(sessionId, reason);
@@ -1823,7 +1992,7 @@ export class CoworkRunner extends EventEmitter {
             signal,
             activeSession,
             resolvedName,
-            resolvedInput
+            resolvedInput,
           );
           if (policyResult) {
             return policyResult;
@@ -1849,13 +2018,12 @@ export class CoworkRunner extends EventEmitter {
         }
 
         if (result.behavior === 'deny') {
-          return result.message
-            ? result
-            : { behavior: 'deny', message: 'Permission denied' };
+          return result.message ? result : { behavior: 'deny', message: 'Permission denied' };
         }
 
         const updatedInput = result.updatedInput ?? resolvedInput;
-        const hasAnswers = updatedInput && typeof updatedInput === 'object' && 'answers' in updatedInput;
+        const hasAnswers =
+          updatedInput && typeof updatedInput === 'object' && 'answers' in updatedInput;
         if (!hasAnswers) {
           return { behavior: 'deny', message: 'No answers provided' };
         }
@@ -1877,15 +2045,16 @@ export class CoworkRunner extends EventEmitter {
       }) => {
         const isPackagedDarwin = app.isPackaged && process.platform === 'darwin';
         const useElectronShim =
-          process.platform === 'win32'
-          || isPackagedDarwin
-          || spawnOptions.env?.LOBSTERAI_NODE_SHIM_ACTIVE === '1';
+          process.platform === 'win32' ||
+          isPackagedDarwin ||
+          spawnOptions.env?.LOBSTERAI_NODE_SHIM_ACTIVE === '1';
         const spawnEnv: NodeJS.ProcessEnv = {
           ...(spawnOptions.env ?? {}),
           ELECTRON_RUN_AS_NODE: '1',
         };
         if (useElectronShim) {
-          spawnEnv.LOBSTERAI_ELECTRON_PATH = spawnOptions.env?.LOBSTERAI_ELECTRON_PATH || electronNodeRuntimePath;
+          spawnEnv.LOBSTERAI_ELECTRON_PATH =
+            spawnOptions.env?.LOBSTERAI_ELECTRON_PATH || electronNodeRuntimePath;
         } else {
           delete spawnEnv.LOBSTERAI_ELECTRON_PATH;
         }
@@ -1893,26 +2062,38 @@ export class CoworkRunner extends EventEmitter {
         let command = spawnOptions.command || 'node';
         const normalizedCommand = command.trim().toLowerCase();
         const commandBaseName = path.basename(command).toLowerCase();
-        const isNodeLikeCommand = normalizedCommand === 'node'
-          || normalizedCommand === 'node.exe'
-          || commandBaseName === 'node'
-          || commandBaseName === 'node.exe'
-          || commandBaseName === 'node.cmd'
-          || normalizedCommand.endsWith('\\node.cmd')
-          || normalizedCommand.endsWith('/node.cmd');
+        const isNodeLikeCommand =
+          normalizedCommand === 'node' ||
+          normalizedCommand === 'node.exe' ||
+          commandBaseName === 'node' ||
+          commandBaseName === 'node.exe' ||
+          commandBaseName === 'node.cmd' ||
+          normalizedCommand.endsWith('\\node.cmd') ||
+          normalizedCommand.endsWith('/node.cmd');
         if (process.platform === 'win32' && isNodeLikeCommand) {
           command = electronNodeRuntimePath;
           spawnEnv.LOBSTERAI_ELECTRON_PATH = electronNodeRuntimePath;
-          coworkLog('INFO', 'runClaudeCodeLocal', `Rewrote Windows SDK command "${spawnOptions.command || 'node'}" to Electron runtime: ${electronNodeRuntimePath}`);
+          coworkLog(
+            'INFO',
+            'runClaudeCodeLocal',
+            `Rewrote Windows SDK command "${spawnOptions.command || 'node'}" to Electron runtime: ${electronNodeRuntimePath}`,
+          );
         } else if (isPackagedDarwin && isNodeLikeCommand) {
           command = electronNodeRuntimePath;
           spawnEnv.LOBSTERAI_ELECTRON_PATH = electronNodeRuntimePath;
-          coworkLog('INFO', 'runClaudeCodeLocal', `Rewrote packaged macOS SDK command "${spawnOptions.command || 'node'}" to Electron helper runtime: ${electronNodeRuntimePath}`);
+          coworkLog(
+            'INFO',
+            'runClaudeCodeLocal',
+            `Rewrote packaged macOS SDK command "${spawnOptions.command || 'node'}" to Electron helper runtime: ${electronNodeRuntimePath}`,
+          );
         }
 
         if (isPackagedDarwin && command && path.isAbsolute(command)) {
           const commandCandidates = new Set<string>([command, path.resolve(command)]);
-          const appExecCandidates = new Set<string>([process.execPath, path.resolve(process.execPath)]);
+          const appExecCandidates = new Set<string>([
+            process.execPath,
+            path.resolve(process.execPath),
+          ]);
           try {
             commandCandidates.add(fs.realpathSync.native(command));
           } catch {
@@ -1923,11 +2104,17 @@ export class CoworkRunner extends EventEmitter {
           } catch {
             // Ignore realpath resolution errors.
           }
-          const pointsToAppExecutable = Array.from(commandCandidates).some((candidate) => appExecCandidates.has(candidate));
+          const pointsToAppExecutable = Array.from(commandCandidates).some(candidate =>
+            appExecCandidates.has(candidate),
+          );
           if (pointsToAppExecutable) {
             command = electronNodeRuntimePath;
             spawnEnv.LOBSTERAI_ELECTRON_PATH = electronNodeRuntimePath;
-            coworkLog('WARN', 'runClaudeCodeLocal', 'SDK spawner command points to app executable; rewriting to Electron helper runtime');
+            coworkLog(
+              'WARN',
+              'runClaudeCodeLocal',
+              'SDK spawner command points to app executable; rewriting to Electron helper runtime',
+            );
           }
         }
         coworkLog('INFO', 'runClaudeCodeLocal', 'Using packaged custom SDK spawner', {
@@ -1936,15 +2123,19 @@ export class CoworkRunner extends EventEmitter {
         });
 
         const shouldInjectWindowsHideRequire =
-          process.platform === 'win32'
-          && Boolean(windowsHideInitScript)
-          && spawnOptions.args.length > 0
-          && /\.m?js$/i.test(path.basename(spawnOptions.args[0]));
+          process.platform === 'win32' &&
+          Boolean(windowsHideInitScript) &&
+          spawnOptions.args.length > 0 &&
+          /\.m?js$/i.test(path.basename(spawnOptions.args[0]));
         const effectiveSpawnArgs = shouldInjectWindowsHideRequire
           ? prependNodeRequireArg(spawnOptions.args, windowsHideInitScript as string)
           : spawnOptions.args;
         if (shouldInjectWindowsHideRequire) {
-          coworkLog('INFO', 'runClaudeCodeLocal', `Injected Windows hidden-subprocess preload: ${windowsHideInitScript}`);
+          coworkLog(
+            'INFO',
+            'runClaudeCodeLocal',
+            `Injected Windows hidden-subprocess preload: ${windowsHideInitScript}`,
+          );
         }
 
         const child = spawn(command, effectiveSpawnArgs, {
@@ -2022,7 +2213,7 @@ export class CoworkRunner extends EventEmitter {
                 },
               ],
             } as any;
-          }
+          },
         ),
         tool(
           'recent_chats',
@@ -2043,7 +2234,7 @@ export class CoworkRunner extends EventEmitter {
             return {
               content: [{ type: 'text', text }],
             } as any;
-          }
+          },
         ),
       ];
       if (config.memoryEnabled) {
@@ -2074,29 +2265,33 @@ export class CoworkRunner extends EventEmitter {
               try {
                 const result = this.runMemoryUserEditsTool(args);
                 return {
-                  content: [{
-                    type: 'text',
-                    text: result.text,
-                  }],
+                  content: [
+                    {
+                      type: 'text',
+                      text: result.text,
+                    },
+                  ],
                   isError: result.isError,
                 } as any;
               } catch (error) {
                 return {
-                  content: [{
-                    type: 'text',
-                    text: this.formatMemoryUserEditsResult({
-                      action: args.action,
-                      successCount: 0,
-                      failedCount: 1,
-                      changedIds: [],
-                      reason: error instanceof Error ? error.message : String(error),
-                    }),
-                  }],
+                  content: [
+                    {
+                      type: 'text',
+                      text: this.formatMemoryUserEditsResult({
+                        action: args.action,
+                        successCount: 0,
+                        failedCount: 1,
+                        changedIds: [],
+                        reason: error instanceof Error ? error.message : String(error),
+                      }),
+                    },
+                  ],
                   isError: true,
                 } as any;
               }
-            }
-          )
+            },
+          ),
         );
       }
       options.mcpServers = {
@@ -2112,114 +2307,168 @@ export class CoworkRunner extends EventEmitter {
       if (this.mcpServerProvider) {
         try {
           const enabledMcpServers = this.mcpServerProvider();
-          coworkLog('INFO', 'runClaudeCodeLocal', `MCP: ${enabledMcpServers.length} user-configured servers found`);
+          coworkLog(
+            'INFO',
+            'runClaudeCodeLocal',
+            `MCP: ${enabledMcpServers.length} user-configured servers found`,
+          );
           for (const server of enabledMcpServers) {
             const serverKey = server.name;
             // Skip if name conflicts with existing MCP servers (e.g., memory server)
-            if (options.mcpServers && serverKey in (options.mcpServers as Record<string, unknown>)) {
-              coworkLog('WARN', 'runClaudeCodeLocal', `MCP server name conflict: "${serverKey}", skipping user config`);
+            if (
+              options.mcpServers &&
+              serverKey in (options.mcpServers as Record<string, unknown>)
+            ) {
+              coworkLog(
+                'WARN',
+                'runClaudeCodeLocal',
+                `MCP server name conflict: "${serverKey}", skipping user config`,
+              );
               continue;
             }
             let serverConfig: Record<string, unknown>;
             switch (server.transportType) {
-              case 'stdio':
-                {
-                  const stdioCommand = server.command || '';
-                  let effectiveStdioCommand = stdioCommand;
-                  const stdioArgs = server.args || [];
-                  let effectiveStdioArgs = [...stdioArgs];
-                  let shouldInjectWindowsHideRequire = false;
-                  let stdioEnv = server.env && Object.keys(server.env).length > 0
-                    ? { ...server.env }
-                    : undefined;
+              case 'stdio': {
+                const stdioCommand = server.command || '';
+                let effectiveStdioCommand = stdioCommand;
+                const stdioArgs = server.args || [];
+                let effectiveStdioArgs = [...stdioArgs];
+                let shouldInjectWindowsHideRequire = false;
+                let stdioEnv =
+                  server.env && Object.keys(server.env).length > 0 ? { ...server.env } : undefined;
 
-                  if (process.platform === 'win32' && app.isPackaged && effectiveStdioCommand) {
-                    const normalizedCommand = effectiveStdioCommand.trim().toLowerCase();
-                    const npmBinDir = envVars.LOBSTERAI_NPM_BIN_DIR;
-                    const npxCliJs = npmBinDir ? path.join(npmBinDir, 'npx-cli.js') : '';
-                    const npmCliJs = npmBinDir ? path.join(npmBinDir, 'npm-cli.js') : '';
+                if (process.platform === 'win32' && app.isPackaged && effectiveStdioCommand) {
+                  const normalizedCommand = effectiveStdioCommand.trim().toLowerCase();
+                  const npmBinDir = envVars.LOBSTERAI_NPM_BIN_DIR;
+                  const npxCliJs = npmBinDir ? path.join(npmBinDir, 'npx-cli.js') : '';
+                  const npmCliJs = npmBinDir ? path.join(npmBinDir, 'npm-cli.js') : '';
 
-                    const withElectronNodeEnv = (base: Record<string, string> | undefined): Record<string, string> => ({
-                      ...(base || {}),
+                  const withElectronNodeEnv = (
+                    base: Record<string, string> | undefined,
+                  ): Record<string, string> => ({
+                    ...(base || {}),
+                    ELECTRON_RUN_AS_NODE: '1',
+                    LOBSTERAI_ELECTRON_PATH: electronNodeRuntimePath,
+                  });
+
+                  if (
+                    normalizedCommand === 'node' ||
+                    normalizedCommand === 'node.exe' ||
+                    normalizedCommand.endsWith('\\node.cmd') ||
+                    normalizedCommand.endsWith('/node.cmd')
+                  ) {
+                    effectiveStdioCommand = electronNodeRuntimePath;
+                    stdioEnv = withElectronNodeEnv(stdioEnv);
+                    shouldInjectWindowsHideRequire = true;
+                    coworkLog(
+                      'INFO',
+                      'runClaudeCodeLocal',
+                      `MCP "${serverKey}": rewrote stdio command "${stdioCommand}" to Electron runtime`,
+                    );
+                  } else if (
+                    (normalizedCommand === 'npx' ||
+                      normalizedCommand === 'npx.cmd' ||
+                      normalizedCommand.endsWith('\\npx.cmd') ||
+                      normalizedCommand.endsWith('/npx.cmd')) &&
+                    npxCliJs &&
+                    fs.existsSync(npxCliJs)
+                  ) {
+                    effectiveStdioCommand = electronNodeRuntimePath;
+                    effectiveStdioArgs = [npxCliJs, ...stdioArgs];
+                    stdioEnv = withElectronNodeEnv(stdioEnv);
+                    shouldInjectWindowsHideRequire = true;
+                    coworkLog(
+                      'INFO',
+                      'runClaudeCodeLocal',
+                      `MCP "${serverKey}": rewrote stdio command "${stdioCommand}" to Electron runtime + npx-cli.js`,
+                    );
+                  } else if (
+                    (normalizedCommand === 'npm' ||
+                      normalizedCommand === 'npm.cmd' ||
+                      normalizedCommand.endsWith('\\npm.cmd') ||
+                      normalizedCommand.endsWith('/npm.cmd')) &&
+                    npmCliJs &&
+                    fs.existsSync(npmCliJs)
+                  ) {
+                    effectiveStdioCommand = electronNodeRuntimePath;
+                    effectiveStdioArgs = [npmCliJs, ...stdioArgs];
+                    stdioEnv = withElectronNodeEnv(stdioEnv);
+                    shouldInjectWindowsHideRequire = true;
+                    coworkLog(
+                      'INFO',
+                      'runClaudeCodeLocal',
+                      `MCP "${serverKey}": rewrote stdio command "${stdioCommand}" to Electron runtime + npm-cli.js`,
+                    );
+                  }
+                }
+
+                if (
+                  process.platform === 'win32' &&
+                  shouldInjectWindowsHideRequire &&
+                  windowsHideInitScript
+                ) {
+                  effectiveStdioArgs = prependNodeRequireArg(
+                    effectiveStdioArgs,
+                    windowsHideInitScript,
+                  );
+                  coworkLog(
+                    'INFO',
+                    'runClaudeCodeLocal',
+                    `MCP "${serverKey}": injected Windows hidden-subprocess preload`,
+                  );
+                }
+
+                if (
+                  app.isPackaged &&
+                  process.platform === 'darwin' &&
+                  stdioCommand &&
+                  path.isAbsolute(stdioCommand)
+                ) {
+                  const commandCandidates = new Set<string>([
+                    stdioCommand,
+                    path.resolve(stdioCommand),
+                  ]);
+                  const appExecCandidates = new Set<string>([
+                    process.execPath,
+                    path.resolve(process.execPath),
+                    electronNodeRuntimePath,
+                    path.resolve(electronNodeRuntimePath),
+                  ]);
+
+                  try {
+                    commandCandidates.add(fs.realpathSync.native(stdioCommand));
+                  } catch {
+                    // Ignore realpath resolution errors.
+                  }
+
+                  try {
+                    appExecCandidates.add(fs.realpathSync.native(process.execPath));
+                  } catch {
+                    // Ignore realpath resolution errors.
+                  }
+                  try {
+                    appExecCandidates.add(fs.realpathSync.native(electronNodeRuntimePath));
+                  } catch {
+                    // Ignore realpath resolution errors.
+                  }
+
+                  const pointsToAppExecutable = Array.from(commandCandidates).some(candidate =>
+                    appExecCandidates.has(candidate),
+                  );
+                  if (pointsToAppExecutable) {
+                    effectiveStdioCommand = electronNodeRuntimePath;
+                    stdioEnv = {
+                      ...(stdioEnv || {}),
                       ELECTRON_RUN_AS_NODE: '1',
                       LOBSTERAI_ELECTRON_PATH: electronNodeRuntimePath,
-                    });
-
-                    if (
-                      normalizedCommand === 'node'
-                      || normalizedCommand === 'node.exe'
-                      || normalizedCommand.endsWith('\\node.cmd')
-                      || normalizedCommand.endsWith('/node.cmd')
-                    ) {
-                      effectiveStdioCommand = electronNodeRuntimePath;
-                      stdioEnv = withElectronNodeEnv(stdioEnv);
-                      shouldInjectWindowsHideRequire = true;
-                      coworkLog('INFO', 'runClaudeCodeLocal', `MCP "${serverKey}": rewrote stdio command "${stdioCommand}" to Electron runtime`);
-                    } else if (
-                      (normalizedCommand === 'npx' || normalizedCommand === 'npx.cmd' || normalizedCommand.endsWith('\\npx.cmd') || normalizedCommand.endsWith('/npx.cmd'))
-                      && npxCliJs
-                      && fs.existsSync(npxCliJs)
-                    ) {
-                      effectiveStdioCommand = electronNodeRuntimePath;
-                      effectiveStdioArgs = [npxCliJs, ...stdioArgs];
-                      stdioEnv = withElectronNodeEnv(stdioEnv);
-                      shouldInjectWindowsHideRequire = true;
-                      coworkLog('INFO', 'runClaudeCodeLocal', `MCP "${serverKey}": rewrote stdio command "${stdioCommand}" to Electron runtime + npx-cli.js`);
-                    } else if (
-                      (normalizedCommand === 'npm' || normalizedCommand === 'npm.cmd' || normalizedCommand.endsWith('\\npm.cmd') || normalizedCommand.endsWith('/npm.cmd'))
-                      && npmCliJs
-                      && fs.existsSync(npmCliJs)
-                    ) {
-                      effectiveStdioCommand = electronNodeRuntimePath;
-                      effectiveStdioArgs = [npmCliJs, ...stdioArgs];
-                      stdioEnv = withElectronNodeEnv(stdioEnv);
-                      shouldInjectWindowsHideRequire = true;
-                      coworkLog('INFO', 'runClaudeCodeLocal', `MCP "${serverKey}": rewrote stdio command "${stdioCommand}" to Electron runtime + npm-cli.js`);
-                    }
+                    };
+                    coworkLog(
+                      'WARN',
+                      'runClaudeCodeLocal',
+                      `MCP "${serverKey}": command points to app executable; rewriting command to Electron helper runtime`,
+                    );
                   }
-
-                  if (process.platform === 'win32' && shouldInjectWindowsHideRequire && windowsHideInitScript) {
-                    effectiveStdioArgs = prependNodeRequireArg(effectiveStdioArgs, windowsHideInitScript);
-                    coworkLog('INFO', 'runClaudeCodeLocal', `MCP "${serverKey}": injected Windows hidden-subprocess preload`);
-                  }
-
-                  if (app.isPackaged && process.platform === 'darwin' && stdioCommand && path.isAbsolute(stdioCommand)) {
-                    const commandCandidates = new Set<string>([stdioCommand, path.resolve(stdioCommand)]);
-                    const appExecCandidates = new Set<string>([
-                      process.execPath,
-                      path.resolve(process.execPath),
-                      electronNodeRuntimePath,
-                      path.resolve(electronNodeRuntimePath),
-                    ]);
-
-                    try {
-                      commandCandidates.add(fs.realpathSync.native(stdioCommand));
-                    } catch {
-                      // Ignore realpath resolution errors.
-                    }
-
-                    try {
-                      appExecCandidates.add(fs.realpathSync.native(process.execPath));
-                    } catch {
-                      // Ignore realpath resolution errors.
-                    }
-                    try {
-                      appExecCandidates.add(fs.realpathSync.native(electronNodeRuntimePath));
-                    } catch {
-                      // Ignore realpath resolution errors.
-                    }
-
-                    const pointsToAppExecutable = Array.from(commandCandidates).some((candidate) => appExecCandidates.has(candidate));
-                    if (pointsToAppExecutable) {
-                      effectiveStdioCommand = electronNodeRuntimePath;
-                      stdioEnv = {
-                        ...(stdioEnv || {}),
-                        ELECTRON_RUN_AS_NODE: '1',
-                        LOBSTERAI_ELECTRON_PATH: electronNodeRuntimePath,
-                      };
-                      coworkLog('WARN', 'runClaudeCodeLocal', `MCP "${serverKey}": command points to app executable; rewriting command to Electron helper runtime`);
-                    }
-                  }
+                }
 
                 serverConfig = {
                   type: 'stdio',
@@ -2227,9 +2476,17 @@ export class CoworkRunner extends EventEmitter {
                   args: effectiveStdioArgs,
                   env: stdioEnv && Object.keys(stdioEnv).length > 0 ? stdioEnv : undefined,
                 };
-                coworkLog('INFO', 'runClaudeCodeLocal', `MCP "${serverKey}": stdio command="${effectiveStdioCommand}", args=${JSON.stringify(effectiveStdioArgs)}`);
+                coworkLog(
+                  'INFO',
+                  'runClaudeCodeLocal',
+                  `MCP "${serverKey}": stdio command="${effectiveStdioCommand}", args=${JSON.stringify(effectiveStdioArgs)}`,
+                );
                 if (stdioEnv && Object.keys(stdioEnv).length > 0) {
-                  coworkLog('INFO', 'runClaudeCodeLocal', `MCP "${serverKey}": custom env vars: ${JSON.stringify(stdioEnv)}`);
+                  coworkLog(
+                    'INFO',
+                    'runClaudeCodeLocal',
+                    `MCP "${serverKey}": custom env vars: ${JSON.stringify(stdioEnv)}`,
+                  );
                 }
                 // Resolve command path to verify it's findable
                 if (effectiveStdioCommand) {
@@ -2237,7 +2494,7 @@ export class CoworkRunner extends EventEmitter {
                     coworkLog(
                       fs.existsSync(effectiveStdioCommand) ? 'INFO' : 'WARN',
                       'runClaudeCodeLocal',
-                      `MCP "${serverKey}": absolute command "${effectiveStdioCommand}" exists=${fs.existsSync(effectiveStdioCommand)}`
+                      `MCP "${serverKey}": absolute command "${effectiveStdioCommand}" exists=${fs.existsSync(effectiveStdioCommand)}`,
                     );
                   } else {
                     const whichCmd = process.platform === 'win32' ? 'where' : 'which';
@@ -2249,33 +2506,55 @@ export class CoworkRunner extends EventEmitter {
                         windowsHide: process.platform === 'win32',
                       });
                       if (resolveResult.status === 0 && resolveResult.stdout) {
-                        coworkLog('INFO', 'runClaudeCodeLocal', `MCP "${serverKey}": command "${effectiveStdioCommand}" resolves to: ${resolveResult.stdout.trim()}`);
+                        coworkLog(
+                          'INFO',
+                          'runClaudeCodeLocal',
+                          `MCP "${serverKey}": command "${effectiveStdioCommand}" resolves to: ${resolveResult.stdout.trim()}`,
+                        );
                       } else {
-                        coworkLog('WARN', 'runClaudeCodeLocal', `MCP "${serverKey}": command "${effectiveStdioCommand}" NOT FOUND in PATH (exit: ${resolveResult.status}, stderr: ${(resolveResult.stderr || '').trim()})`);
+                        coworkLog(
+                          'WARN',
+                          'runClaudeCodeLocal',
+                          `MCP "${serverKey}": command "${effectiveStdioCommand}" NOT FOUND in PATH (exit: ${resolveResult.status}, stderr: ${(resolveResult.stderr || '').trim()})`,
+                        );
                       }
                     } catch (e) {
-                      coworkLog('WARN', 'runClaudeCodeLocal', `MCP "${serverKey}": failed to resolve command "${effectiveStdioCommand}": ${e instanceof Error ? e.message : String(e)}`);
+                      coworkLog(
+                        'WARN',
+                        'runClaudeCodeLocal',
+                        `MCP "${serverKey}": failed to resolve command "${effectiveStdioCommand}": ${e instanceof Error ? e.message : String(e)}`,
+                      );
                     }
                   }
                 }
                 break;
-                }
+              }
               case 'sse':
                 serverConfig = {
                   type: 'sse',
                   url: server.url || '',
-                  headers: server.headers && Object.keys(server.headers).length > 0 ? server.headers : undefined,
+                  headers:
+                    server.headers && Object.keys(server.headers).length > 0
+                      ? server.headers
+                      : undefined,
                 };
                 break;
               case 'http':
                 serverConfig = {
                   type: 'http',
                   url: server.url || '',
-                  headers: server.headers && Object.keys(server.headers).length > 0 ? server.headers : undefined,
+                  headers:
+                    server.headers && Object.keys(server.headers).length > 0
+                      ? server.headers
+                      : undefined,
                 };
                 break;
               default:
-                coworkLog('WARN', 'runClaudeCodeLocal', `Unknown MCP transport type: "${server.transportType}", skipping`);
+                coworkLog(
+                  'WARN',
+                  'runClaudeCodeLocal',
+                  `Unknown MCP transport type: "${server.transportType}", skipping`,
+                );
                 continue;
             }
             options.mcpServers = {
@@ -2283,21 +2562,37 @@ export class CoworkRunner extends EventEmitter {
               [serverKey]: serverConfig,
             };
             userMcpServerCount += 1;
-            coworkLog('INFO', 'runClaudeCodeLocal', `Injected user MCP server: "${serverKey}" (${server.transportType})`);
+            coworkLog(
+              'INFO',
+              'runClaudeCodeLocal',
+              `Injected user MCP server: "${serverKey}" (${server.transportType})`,
+            );
           }
         } catch (error) {
-          coworkLog('WARN', 'runClaudeCodeLocal', `Failed to load user MCP servers: ${error instanceof Error ? error.message : String(error)}`);
+          coworkLog(
+            'WARN',
+            'runClaudeCodeLocal',
+            `Failed to load user MCP servers: ${error instanceof Error ? error.message : String(error)}`,
+          );
         }
       }
 
       // Log final MCP server config summary
       if (options.mcpServers) {
         const mcpKeys = Object.keys(options.mcpServers as Record<string, unknown>);
-        coworkLog('INFO', 'runClaudeCodeLocal', `MCP final config: ${mcpKeys.length} servers: [${mcpKeys.join(', ')}]`);
+        coworkLog(
+          'INFO',
+          'runClaudeCodeLocal',
+          `MCP final config: ${mcpKeys.length} servers: [${mcpKeys.join(', ')}]`,
+        );
         for (const key of mcpKeys) {
           const cfg = (options.mcpServers as Record<string, Record<string, unknown>>)[key];
           if (cfg && typeof cfg === 'object' && 'type' in cfg) {
-            coworkLog('INFO', 'runClaudeCodeLocal', `MCP server "${key}": type=${cfg.type}, command=${cfg.command || 'N/A'}, args=${JSON.stringify(cfg.args || [])}`);
+            coworkLog(
+              'INFO',
+              'runClaudeCodeLocal',
+              `MCP server "${key}": type=${cfg.type}, command=${cfg.command || 'N/A'}, args=${JSON.stringify(cfg.args || [])}`,
+            );
           }
         }
         // Dump full MCP config as JSON for complete debugging
@@ -2314,9 +2609,17 @@ export class CoworkRunner extends EventEmitter {
               }
             }
           }
-          coworkLog('INFO', 'runClaudeCodeLocal', `MCP full config dump: ${JSON.stringify(serializable, null, 2)}`);
+          coworkLog(
+            'INFO',
+            'runClaudeCodeLocal',
+            `MCP full config dump: ${JSON.stringify(serializable, null, 2)}`,
+          );
         } catch (e) {
-          coworkLog('WARN', 'runClaudeCodeLocal', `MCP config dump failed: ${e instanceof Error ? e.message : String(e)}`);
+          coworkLog(
+            'WARN',
+            'runClaudeCodeLocal',
+            `MCP config dump failed: ${e instanceof Error ? e.message : String(e)}`,
+          );
         }
       }
 
@@ -2365,15 +2668,23 @@ export class CoworkRunner extends EventEmitter {
       // Set up a startup timeout BEFORE calling query(): if no events arrive
       // within the timeout, abort. This covers both the query() call itself
       // (which spawns the subprocess) and the initial event wait.
-      const startupTimeoutMs = userMcpServerCount > 0
-        ? SDK_STARTUP_TIMEOUT_WITH_USER_MCP_MS
-        : SDK_STARTUP_TIMEOUT_MS;
-      coworkLog('INFO', 'runClaudeCodeLocal', `Using SDK startup timeout: ${startupTimeoutMs}ms (userMcpServers=${userMcpServerCount})`);
+      const startupTimeoutMs =
+        userMcpServerCount > 0 ? SDK_STARTUP_TIMEOUT_WITH_USER_MCP_MS : SDK_STARTUP_TIMEOUT_MS;
+      coworkLog(
+        'INFO',
+        'runClaudeCodeLocal',
+        `Using SDK startup timeout: ${startupTimeoutMs}ms (userMcpServers=${userMcpServerCount})`,
+      );
       startupTimer = setTimeout(() => {
-        coworkLog('ERROR', 'runClaudeCodeLocal', 'SDK startup timeout: no events received within timeout', {
-          timeoutMs: startupTimeoutMs,
-          userMcpServers: userMcpServerCount,
-        });
+        coworkLog(
+          'ERROR',
+          'runClaudeCodeLocal',
+          'SDK startup timeout: no events received within timeout',
+          {
+            timeoutMs: startupTimeoutMs,
+            userMcpServers: userMcpServerCount,
+          },
+        );
         if (!abortController.signal.aborted) {
           abortController.abort();
         }
@@ -2394,7 +2705,10 @@ export class CoworkRunner extends EventEmitter {
         }
         eventCount++;
         const eventPayload = event as Record<string, unknown> | null;
-        const eventType = eventPayload && typeof eventPayload === 'object' ? String(eventPayload.type ?? '') : typeof event;
+        const eventType =
+          eventPayload && typeof eventPayload === 'object'
+            ? String(eventPayload.type ?? '')
+            : typeof event;
         coworkLog('INFO', 'runClaudeCodeLocal', `Event #${eventCount}: type=${eventType}`);
         this.handleClaudeEvent(sessionId, event);
       }
@@ -2403,7 +2717,11 @@ export class CoworkRunner extends EventEmitter {
         clearTimeout(startupTimer);
         startupTimer = null;
       }
-      coworkLog('INFO', 'runClaudeCodeLocal', `Event iteration completed, total events: ${eventCount}`);
+      coworkLog(
+        'INFO',
+        'runClaudeCodeLocal',
+        `Event iteration completed, total events: ${eventCount}`,
+      );
 
       if (this.stoppedSessions.has(sessionId)) {
         this.store.updateSession(sessionId, { status: 'idle' });
@@ -2457,7 +2775,7 @@ export class CoworkRunner extends EventEmitter {
     prompt: string,
     cwd: string,
     systemPrompt: string,
-    imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>
+    imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>,
   ): Promise<void> {
     const { sessionId } = activeSession;
     if (this.isSessionStopRequested(sessionId, activeSession)) {
@@ -2479,7 +2797,13 @@ export class CoworkRunner extends EventEmitter {
 
     activeSession.executionMode = 'local';
     this.store.updateSession(sessionId, { executionMode: 'local' });
-    await this.runClaudeCodeLocal(activeSession, effectivePrompt, resolvedCwd, systemPrompt, imageAttachments);
+    await this.runClaudeCodeLocal(
+      activeSession,
+      effectivePrompt,
+      resolvedCwd,
+      systemPrompt,
+      imageAttachments,
+    );
   }
 
   private resolveAssistantEventError(payload: Record<string, unknown>): string | null {
@@ -2572,7 +2896,10 @@ export class CoworkRunner extends EventEmitter {
 
     if (eventType === 'result') {
       // Log token usage for observability
-      const usage = (payload.usage ?? (payload.result && typeof payload.result === 'object' ? (payload.result as Record<string, unknown>).usage : undefined)) as Record<string, unknown> | undefined;
+      const usage = (payload.usage ??
+        (payload.result && typeof payload.result === 'object'
+          ? (payload.result as Record<string, unknown>).usage
+          : undefined)) as Record<string, unknown> | undefined;
       if (usage) {
         coworkLog('INFO', 'tokenUsage', 'Turn token usage', {
           sessionId,
@@ -2587,17 +2914,13 @@ export class CoworkRunner extends EventEmitter {
       if (subtype !== 'success') {
         const errors = Array.isArray(payload.errors)
           ? payload.errors
-            .filter((error) => typeof error === 'string')
-            .map((error) => (error as string).trim())
-            .filter((error) => error && error.toLowerCase() !== 'unknown')
+              .filter(error => typeof error === 'string')
+              .map(error => (error as string).trim())
+              .filter(error => error && error.toLowerCase() !== 'unknown')
           : [];
         const payloadError = this.normalizeSdkError(payload.error);
         const errorMessage =
-          errors.length > 0
-            ? errors.join('\n')
-            : payloadError
-              ? payloadError
-              : 'Claude run failed';
+          errors.length > 0 ? errors.join('\n') : payloadError ? payloadError : 'Claude run failed';
         this.handleError(sessionId, errorMessage);
         return;
       }
@@ -2663,9 +2986,11 @@ export class CoworkRunner extends EventEmitter {
     // Persist any pending streaming content before applying fallback assistant parsing.
     // This prevents losing streamed text when assistant event arrives before stop events.
     const hadPendingTextStreaming =
-      activeSession.currentStreamingMessageId !== null || activeSession.currentStreamingContent !== '';
+      activeSession.currentStreamingMessageId !== null ||
+      activeSession.currentStreamingContent !== '';
     const hadPendingThinkingStreaming =
-      activeSession.currentStreamingThinkingMessageId !== null || activeSession.currentStreamingThinking !== '';
+      activeSession.currentStreamingThinkingMessageId !== null ||
+      activeSession.currentStreamingThinking !== '';
     if (hadPendingTextStreaming || hadPendingThinkingStreaming) {
       this.finalizeStreamingContent(activeSession);
     }
@@ -2723,7 +3048,11 @@ export class CoworkRunner extends EventEmitter {
       const record = block as Record<string, unknown>;
       const blockType = String(record.type ?? '');
 
-      if (blockType === 'thinking' && typeof record.thinking === 'string' && record.thinking.trim()) {
+      if (
+        blockType === 'thinking' &&
+        typeof record.thinking === 'string' &&
+        record.thinking.trim()
+      ) {
         if (hasStreamedThinking || hadPendingThinkingStreaming) {
           continue;
         }
@@ -2747,9 +3076,10 @@ export class CoworkRunner extends EventEmitter {
         flushTextParts();
         const toolName = String(record.name ?? 'unknown');
         const toolInputRaw = record.input ?? {};
-        const toolInput = toolInputRaw && typeof toolInputRaw === 'object'
-          ? (toolInputRaw as Record<string, unknown>)
-          : { value: toolInputRaw };
+        const toolInput =
+          toolInputRaw && typeof toolInputRaw === 'object'
+            ? (toolInputRaw as Record<string, unknown>)
+            : { value: toolInputRaw };
         const toolUseId = typeof record.id === 'string' ? record.id : null;
 
         const message = this.store.addMessage(sessionId, {
@@ -2789,7 +3119,7 @@ export class CoworkRunner extends EventEmitter {
   private handleStreamEvent(
     sessionId: string,
     activeSession: ActiveSession,
-    payload: Record<string, unknown>
+    payload: Record<string, unknown>,
   ): void {
     // SDKPartialAssistantMessage structure:
     // { type: 'stream_event', event: BetaRawMessageStreamEvent, ... }
@@ -2806,10 +3136,15 @@ export class CoworkRunner extends EventEmitter {
       const blockType = String(contentBlock.type ?? '');
       if (blockType === 'thinking') {
         // Start a new thinking message for streaming
-        const initialThinkingRaw = typeof contentBlock.thinking === 'string' ? contentBlock.thinking : '';
-        const initialThinking = this.truncateLargeContent(initialThinkingRaw, STREAMING_THINKING_MAX_CHARS);
+        const initialThinkingRaw =
+          typeof contentBlock.thinking === 'string' ? contentBlock.thinking : '';
+        const initialThinking = this.truncateLargeContent(
+          initialThinkingRaw,
+          STREAMING_THINKING_MAX_CHARS,
+        );
         activeSession.currentStreamingThinking = initialThinking;
-        activeSession.currentStreamingThinkingTruncated = initialThinking.length < initialThinkingRaw.length;
+        activeSession.currentStreamingThinkingTruncated =
+          initialThinking.length < initialThinkingRaw.length;
         activeSession.lastStreamingThinkingUpdateAt = 0;
         activeSession.currentStreamingBlockType = 'thinking';
 
@@ -2863,7 +3198,7 @@ export class CoworkRunner extends EventEmitter {
           activeSession.currentStreamingThinking,
           delta.thinking,
           STREAMING_THINKING_MAX_CHARS,
-          activeSession.currentStreamingThinkingTruncated
+          activeSession.currentStreamingThinkingTruncated,
         );
         activeSession.currentStreamingThinking = next.content;
         activeSession.currentStreamingThinkingTruncated = next.truncated;
@@ -2873,10 +3208,17 @@ export class CoworkRunner extends EventEmitter {
           if (!next.changed) {
             return;
           }
-          const streamTick = this.shouldEmitStreamingUpdate(activeSession.lastStreamingThinkingUpdateAt);
+          const streamTick = this.shouldEmitStreamingUpdate(
+            activeSession.lastStreamingThinkingUpdateAt,
+          );
           if (streamTick.emit) {
             activeSession.lastStreamingThinkingUpdateAt = streamTick.now;
-            this.emit('messageUpdate', sessionId, activeSession.currentStreamingThinkingMessageId, activeSession.currentStreamingThinking);
+            this.emit(
+              'messageUpdate',
+              sessionId,
+              activeSession.currentStreamingThinkingMessageId,
+              activeSession.currentStreamingThinking,
+            );
           }
         } else {
           // No thinking message yet, create one
@@ -2898,7 +3240,7 @@ export class CoworkRunner extends EventEmitter {
           activeSession.currentStreamingContent,
           delta.text,
           STREAMING_TEXT_MAX_CHARS,
-          activeSession.currentStreamingTextTruncated
+          activeSession.currentStreamingTextTruncated,
         );
         activeSession.currentStreamingContent = next.content;
         activeSession.currentStreamingTextTruncated = next.truncated;
@@ -2909,10 +3251,17 @@ export class CoworkRunner extends EventEmitter {
           if (!next.changed) {
             return;
           }
-          const streamTick = this.shouldEmitStreamingUpdate(activeSession.lastStreamingTextUpdateAt);
+          const streamTick = this.shouldEmitStreamingUpdate(
+            activeSession.lastStreamingTextUpdateAt,
+          );
           if (streamTick.emit) {
             activeSession.lastStreamingTextUpdateAt = streamTick.now;
-            this.emit('messageUpdate', sessionId, activeSession.currentStreamingMessageId, activeSession.currentStreamingContent);
+            this.emit(
+              'messageUpdate',
+              sessionId,
+              activeSession.currentStreamingMessageId,
+              activeSession.currentStreamingContent,
+            );
           }
         } else {
           // No message yet, create one
@@ -2936,12 +3285,20 @@ export class CoworkRunner extends EventEmitter {
 
       if (blockType === 'thinking') {
         // Finalize thinking message
-        if (activeSession.currentStreamingThinkingMessageId && activeSession.currentStreamingThinking) {
+        if (
+          activeSession.currentStreamingThinkingMessageId &&
+          activeSession.currentStreamingThinking
+        ) {
           this.updateMessageMerged(sessionId, activeSession.currentStreamingThinkingMessageId, {
             content: activeSession.currentStreamingThinking,
             metadata: { isStreaming: false },
           });
-          this.emit('messageUpdate', sessionId, activeSession.currentStreamingThinkingMessageId, activeSession.currentStreamingThinking);
+          this.emit(
+            'messageUpdate',
+            sessionId,
+            activeSession.currentStreamingThinkingMessageId,
+            activeSession.currentStreamingThinking,
+          );
         }
         activeSession.currentStreamingThinkingMessageId = null;
         activeSession.currentStreamingThinking = '';
@@ -2954,7 +3311,12 @@ export class CoworkRunner extends EventEmitter {
             content: activeSession.currentStreamingContent,
             metadata: { isStreaming: false },
           });
-          this.emit('messageUpdate', sessionId, activeSession.currentStreamingMessageId, activeSession.currentStreamingContent);
+          this.emit(
+            'messageUpdate',
+            sessionId,
+            activeSession.currentStreamingMessageId,
+            activeSession.currentStreamingContent,
+          );
         }
         activeSession.currentStreamingMessageId = null;
         activeSession.currentStreamingContent = '';
@@ -2969,12 +3331,20 @@ export class CoworkRunner extends EventEmitter {
     // Handle message_stop - ensure everything is finalized
     if (eventType === 'message_stop') {
       // Finalize any pending thinking message
-      if (activeSession.currentStreamingThinkingMessageId && activeSession.currentStreamingThinking) {
+      if (
+        activeSession.currentStreamingThinkingMessageId &&
+        activeSession.currentStreamingThinking
+      ) {
         this.updateMessageMerged(sessionId, activeSession.currentStreamingThinkingMessageId, {
           content: activeSession.currentStreamingThinking,
           metadata: { isStreaming: false },
         });
-        this.emit('messageUpdate', sessionId, activeSession.currentStreamingThinkingMessageId, activeSession.currentStreamingThinking);
+        this.emit(
+          'messageUpdate',
+          sessionId,
+          activeSession.currentStreamingThinkingMessageId,
+          activeSession.currentStreamingThinking,
+        );
       }
       activeSession.currentStreamingThinkingMessageId = null;
       activeSession.currentStreamingThinking = '';
@@ -2987,7 +3357,12 @@ export class CoworkRunner extends EventEmitter {
           content: activeSession.currentStreamingContent,
           metadata: { isStreaming: false },
         });
-        this.emit('messageUpdate', sessionId, activeSession.currentStreamingMessageId, activeSession.currentStreamingContent);
+        this.emit(
+          'messageUpdate',
+          sessionId,
+          activeSession.currentStreamingMessageId,
+          activeSession.currentStreamingContent,
+        );
       }
       activeSession.currentStreamingMessageId = null;
       activeSession.currentStreamingContent = '';
@@ -3007,7 +3382,12 @@ export class CoworkRunner extends EventEmitter {
         content: activeSession.currentStreamingThinking,
         metadata: { isStreaming: false },
       });
-      this.emit('messageUpdate', sessionId, activeSession.currentStreamingThinkingMessageId, activeSession.currentStreamingThinking);
+      this.emit(
+        'messageUpdate',
+        sessionId,
+        activeSession.currentStreamingThinkingMessageId,
+        activeSession.currentStreamingThinking,
+      );
     }
     activeSession.currentStreamingThinkingMessageId = null;
     activeSession.currentStreamingThinking = '';
@@ -3033,7 +3413,7 @@ export class CoworkRunner extends EventEmitter {
   private waitForPermissionResponse(
     sessionId: string,
     requestId: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<PermissionResult> {
     return new Promise(resolve => {
       let settled = false;
@@ -3084,10 +3464,7 @@ export class CoworkRunner extends EventEmitter {
   private addSystemMessage(sessionId: string, content: string): void {
     const session = this.store.getSession(sessionId);
     const lastMessage = session?.messages[session.messages.length - 1];
-    if (
-      lastMessage?.type === 'system'
-      && lastMessage.content.trim() === content.trim()
-    ) {
+    if (lastMessage?.type === 'system' && lastMessage.content.trim() === content.trim()) {
       return;
     }
     const message = this.store.addMessage(sessionId, {
@@ -3099,13 +3476,13 @@ export class CoworkRunner extends EventEmitter {
 
   private getMessageById(sessionId: string, messageId: string): CoworkMessage | undefined {
     const session = this.store.getSession(sessionId);
-    return session?.messages.find((message) => message.id === messageId);
+    return session?.messages.find(message => message.id === messageId);
   }
 
   private updateMessageMerged(
     sessionId: string,
     messageId: string,
-    updates: { content?: string; metadata?: CoworkMessage['metadata'] }
+    updates: { content?: string; metadata?: CoworkMessage['metadata'] },
   ): void {
     const existing = this.getMessageById(sessionId, messageId);
     const mergedMetadata = updates.metadata
@@ -3121,7 +3498,7 @@ export class CoworkRunner extends EventEmitter {
   private persistFinalResult(
     sessionId: string,
     activeSession: ActiveSession,
-    resultText: string
+    resultText: string,
   ): void {
     const safeResultText = this.truncateLargeContent(resultText, FINAL_RESULT_MAX_CHARS);
     const trimmed = safeResultText.trim();
@@ -3152,7 +3529,10 @@ export class CoworkRunner extends EventEmitter {
     // This catches the case where streaming is complete but hasAssistantTextOutput is set
     if (activeSession.hasAssistantTextOutput) {
       const session = this.store.getSession(sessionId);
-      const lastAssistant = session?.messages.slice().reverse().find((message) => message.type === 'assistant');
+      const lastAssistant = session?.messages
+        .slice()
+        .reverse()
+        .find(message => message.type === 'assistant');
       if (lastAssistant && lastAssistant.content?.trim() === trimmed) {
         // Content is the same, just update metadata
         this.updateMessageMerged(sessionId, lastAssistant.id, {
@@ -3163,7 +3543,10 @@ export class CoworkRunner extends EventEmitter {
     }
 
     const session = this.store.getSession(sessionId);
-    const lastAssistant = session?.messages.slice().reverse().find((message) => message.type === 'assistant');
+    const lastAssistant = session?.messages
+      .slice()
+      .reverse()
+      .find(message => message.type === 'assistant');
     const lastAssistantText = lastAssistant?.content?.trim() ?? '';
 
     // If the last assistant message is a streaming placeholder (empty or still marked streaming),
@@ -3201,7 +3584,7 @@ export class CoworkRunner extends EventEmitter {
 
     if (Array.isArray(value)) {
       const parts = value
-        .map((item) => {
+        .map(item => {
           if (typeof item === 'string') return item;
           if (item && typeof item === 'object') {
             const record = item as Record<string, unknown>;

--- a/src/main/libs/sessionPruning.test.ts
+++ b/src/main/libs/sessionPruning.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for session pruning utilities.
+ *
+ * Tests cover:
+ * - Token estimation for English, CJK, and mixed content
+ * - pruneMessages: sliding window strategy
+ * - shouldPruneSession: threshold detection
+ * - Model context window lookup
+ */
+import { test, expect, describe } from 'vitest';
+import {
+  estimateTokenCount,
+  estimateConversationTokens,
+  pruneMessages,
+  shouldPruneSession,
+  getModelContextWindow,
+  DEFAULT_CONTEXT_WINDOWS,
+} from './sessionPruning';
+
+// ---------------------------------------------------------------------------
+// estimateTokenCount
+// ---------------------------------------------------------------------------
+
+describe('estimateTokenCount', () => {
+  test('empty string returns 0', () => {
+    expect(estimateTokenCount('')).toBe(0);
+  });
+
+  test('pure English uses ~1 token per 3.5 chars', () => {
+    const text = 'Hello world this is a test sentence with many words';
+    const tokens = estimateTokenCount(text);
+    // text.length / 3.5 ≈ 14.6 → expect somewhere around 14-16
+    expect(tokens).toBeGreaterThan(10);
+    expect(tokens).toBeLessThan(25);
+  });
+
+  test('CJK characters use higher token density', () => {
+    const chinese = '这是一段中文文本用于测试词元估算';
+    const english = 'This is English text for testing token estimation';
+    const chineseTokens = estimateTokenCount(chinese);
+    const englishTokens = estimateTokenCount(english);
+    // CJK: 16 chars / 1.5 ≈ 11; English: 50 chars / 3.5 ≈ 14
+    // Both should give reasonable estimates
+    expect(chineseTokens).toBeGreaterThan(5);
+    expect(englishTokens).toBeGreaterThan(5);
+  });
+
+  test('mixed CJK and English text is handled', () => {
+    const mixed = '你好 Hello 世界 World';
+    const tokens = estimateTokenCount(mixed);
+    expect(tokens).toBeGreaterThan(3);
+  });
+
+  test('short string estimates correctly', () => {
+    expect(estimateTokenCount('Hi')).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// estimateConversationTokens
+// ---------------------------------------------------------------------------
+
+describe('estimateConversationTokens', () => {
+  test('empty messages returns 0', () => {
+    expect(estimateConversationTokens([])).toBe(0);
+  });
+
+  test('adds overhead per message', () => {
+    const singleMsg = estimateConversationTokens([{ content: 'hello' }]);
+    const twoMsgs = estimateConversationTokens([{ content: 'hello' }, { content: 'hello' }]);
+    // Two messages should be more than one (due to per-message overhead)
+    expect(twoMsgs).toBeGreaterThan(singleMsg);
+  });
+
+  test('includes system prompt in total', () => {
+    const withoutSystem = estimateConversationTokens([{ content: 'hello' }]);
+    const withSystem = estimateConversationTokens([{ content: 'hello' }], 'system prompt here');
+    expect(withSystem).toBeGreaterThan(withoutSystem);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneMessages
+// ---------------------------------------------------------------------------
+
+describe('pruneMessages', () => {
+  const makeMessages = (count: number, charsEach = 100) =>
+    Array.from({ length: count }, (_, i) => ({
+      id: `msg-${i}`,
+      content: 'x'.repeat(charsEach),
+      type: i % 2 === 0 ? 'user' : 'assistant',
+    }));
+
+  test('returns all messages when within budget', () => {
+    const messages = makeMessages(5, 10);
+    const result = pruneMessages(messages, 10_000);
+    expect(result.wasPruned).toBe(false);
+    expect(result.prunedCount).toBe(0);
+    expect(result.keptMessages).toHaveLength(5);
+  });
+
+  test('prunes oldest messages when over budget', () => {
+    // 20 messages × 100 chars each ≈ 20 × (100/3.5 + 4) ≈ 20 × 33 = 660 tokens
+    // Budget of 200 tokens should force pruning
+    const messages = makeMessages(20, 100);
+    const result = pruneMessages(messages, 200);
+    expect(result.wasPruned).toBe(true);
+    expect(result.prunedCount).toBeGreaterThan(0);
+    expect(result.keptMessages.length).toBeLessThan(20);
+  });
+
+  test('keeps most recent messages (not oldest)', () => {
+    const messages = [
+      { id: 'old', content: 'x'.repeat(1000), type: 'user' }, // ~290 tokens
+      { id: 'newer', content: 'x'.repeat(1000), type: 'assistant' }, // ~290 tokens
+      { id: 'newest', content: 'newest message short', type: 'user' }, // ~10 tokens
+    ];
+    // Budget = 200: enough to keep 'newest' (~10 tokens + 100 prefix reserve = 110)
+    // but not enough to also keep 'old' (~290 tokens)
+    const result = pruneMessages(messages, 200);
+    if (result.wasPruned) {
+      const keptIds = result.keptMessages.map(m => m.id);
+      expect(keptIds).toContain('newest');
+      expect(keptIds).not.toContain('old');
+    } else {
+      // If everything fits, test is inconclusive but not wrong
+      expect(result.keptMessages).toHaveLength(3);
+    }
+  });
+
+  test('pruned result includes summary prefix', () => {
+    const messages = makeMessages(50, 200);
+    const result = pruneMessages(messages, 300);
+    if (result.wasPruned) {
+      expect(result.prunedSummaryPrefix).toBeTruthy();
+      expect(result.prunedSummaryPrefix).toContain('omitted');
+    }
+  });
+
+  test('empty budget returns empty kept messages', () => {
+    const messages = makeMessages(5, 100);
+    const result = pruneMessages(messages, 0);
+    expect(result.wasPruned).toBe(true);
+    expect(result.keptMessages).toHaveLength(0);
+  });
+
+  test('empty messages list always returns no pruning', () => {
+    const result = pruneMessages([], 10_000);
+    expect(result.wasPruned).toBe(false);
+    expect(result.prunedCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldPruneSession
+// ---------------------------------------------------------------------------
+
+describe('shouldPruneSession', () => {
+  test('returns false when usage is below threshold', () => {
+    const messages = [{ content: 'hello', type: 'user' }];
+    const result = shouldPruneSession(messages, 'claude', undefined, 0.75);
+    expect(result.needsPruning).toBe(false);
+    expect(result.contextWindow).toBe(DEFAULT_CONTEXT_WINDOWS['claude']);
+  });
+
+  test('returns true when conversation is very long', () => {
+    // Simulate a very large conversation
+    const messages = Array.from({ length: 500 }, (_, i) => ({
+      content: 'x'.repeat(300),
+      type: i % 2 === 0 ? 'user' : 'assistant',
+    }));
+    // Default model with 128k context window
+    const result = shouldPruneSession(messages, 'unknown-model', undefined, 0.1);
+    expect(result.needsPruning).toBe(true);
+    expect(result.usageRatio).toBeGreaterThan(0.1);
+  });
+
+  test('includes system prompt in usage calculation', () => {
+    const messages = [{ content: 'hi', type: 'user' }];
+    const withoutSystem = shouldPruneSession(messages, 'claude');
+    const longSystem = 'x'.repeat(50_000);
+    const withSystem = shouldPruneSession(messages, 'claude', longSystem);
+    expect(withSystem.estimatedTokens).toBeGreaterThan(withoutSystem.estimatedTokens);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getModelContextWindow
+// ---------------------------------------------------------------------------
+
+describe('getModelContextWindow', () => {
+  test('recognizes claude models', () => {
+    expect(getModelContextWindow('claude-opus-4')).toBe(DEFAULT_CONTEXT_WINDOWS['claude']);
+  });
+
+  test('recognizes gpt-4 models', () => {
+    expect(getModelContextWindow('gpt-4o')).toBe(DEFAULT_CONTEXT_WINDOWS['gpt-4']);
+  });
+
+  test('recognizes deepseek models', () => {
+    expect(getModelContextWindow('deepseek-chat')).toBe(DEFAULT_CONTEXT_WINDOWS['deepseek']);
+  });
+
+  test('falls back to default for unknown models', () => {
+    expect(getModelContextWindow('unknown-mystery-model')).toBe(DEFAULT_CONTEXT_WINDOWS['default']);
+  });
+
+  test('all known model families have positive context windows', () => {
+    for (const [, window] of Object.entries(DEFAULT_CONTEXT_WINDOWS)) {
+      expect(window).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/main/libs/sessionPruning.ts
+++ b/src/main/libs/sessionPruning.ts
@@ -1,0 +1,203 @@
+/**
+ * Session pruning utilities for managing conversation context size.
+ *
+ * Provides token estimation and message pruning strategies to prevent
+ * context window overflow in long-running cowork sessions.
+ */
+
+/**
+ * Estimate token count from a string using character-based heuristics.
+ *
+ * These ratios are empirically derived from OpenAI's tiktoken and
+ * Anthropic's tokenizer behavior:
+ * - English/code: ~1 token per 4 characters (3.5-4.5 range)
+ * - CJK (Chinese/Japanese/Korean): ~1 token per 1.5 characters
+ * - Mixed content uses a weighted blend
+ *
+ * This is intentionally conservative (overestimates) to avoid hitting
+ * the actual limit.
+ */
+export function estimateTokenCount(text: string): number {
+  if (!text) return 0;
+
+  // Count CJK characters (Unicode ranges for common CJK)
+  let cjkChars = 0;
+  let nonCjkChars = 0;
+  for (const char of text) {
+    const code = char.codePointAt(0) ?? 0;
+    if (
+      (code >= 0x4e00 && code <= 0x9fff) || // CJK Unified Ideographs
+      (code >= 0x3400 && code <= 0x4dbf) || // CJK Extension A
+      (code >= 0x3000 && code <= 0x303f) || // CJK Punctuation
+      (code >= 0xff00 && code <= 0xffef) || // Fullwidth Forms
+      (code >= 0xac00 && code <= 0xd7af) // Korean Hangul
+    ) {
+      cjkChars++;
+    } else {
+      nonCjkChars++;
+    }
+  }
+
+  // CJK: ~1 token per 1.5 chars; non-CJK: ~1 token per 3.5 chars
+  const cjkTokens = Math.ceil(cjkChars / 1.5);
+  const nonCjkTokens = Math.ceil(nonCjkChars / 3.5);
+
+  return cjkTokens + nonCjkTokens;
+}
+
+/**
+ * Estimate the total token count of a conversation message array.
+ * Each message has role overhead (~4 tokens per message for role/formatting).
+ */
+export function estimateConversationTokens(
+  messages: Array<{ content: string; type?: string }>,
+  systemPrompt?: string,
+): number {
+  const MESSAGE_OVERHEAD = 4; // tokens per message for role/formatting
+  let total = 0;
+
+  if (systemPrompt) {
+    total += estimateTokenCount(systemPrompt) + MESSAGE_OVERHEAD;
+  }
+
+  for (const msg of messages) {
+    total += estimateTokenCount(msg.content) + MESSAGE_OVERHEAD;
+  }
+
+  return total;
+}
+
+export interface PruningResult {
+  /** Messages to keep (most recent, within budget) */
+  keptMessages: Array<{ content: string; type?: string; id?: string }>;
+  /** Number of messages that were pruned */
+  prunedCount: number;
+  /** Summary of pruned messages (if generated) */
+  prunedSummaryPrefix: string;
+  /** Whether pruning actually occurred */
+  wasPruned: boolean;
+}
+
+/**
+ * Default context window sizes by model family.
+ * Used when the actual context window is unknown.
+ */
+export const DEFAULT_CONTEXT_WINDOWS: Record<string, number> = {
+  claude: 200_000,
+  'gpt-4': 128_000,
+  'gpt-3.5': 16_000,
+  deepseek: 64_000,
+  qwen: 128_000,
+  gemini: 1_000_000,
+  default: 128_000,
+};
+
+/**
+ * Get the estimated context window for a model.
+ */
+export function getModelContextWindow(modelId: string): number {
+  const lower = modelId.toLowerCase();
+  for (const [prefix, window] of Object.entries(DEFAULT_CONTEXT_WINDOWS)) {
+    if (prefix !== 'default' && lower.includes(prefix)) {
+      return window;
+    }
+  }
+  return DEFAULT_CONTEXT_WINDOWS['default'];
+}
+
+/**
+ * Prune conversation messages to fit within a token budget.
+ *
+ * Strategy: sliding window — keep the most recent messages that fit
+ * within the budget. A brief prefix is prepended indicating that
+ * earlier context was compressed.
+ *
+ * @param messages       All messages in chronological order
+ * @param tokenBudget    Maximum tokens for the message history
+ * @param systemPrompt   System prompt (counted against the budget)
+ * @returns PruningResult with kept messages and metadata
+ */
+export function pruneMessages(
+  messages: Array<{ content: string; type?: string; id?: string }>,
+  tokenBudget: number,
+  systemPrompt?: string,
+): PruningResult {
+  const MESSAGE_OVERHEAD = 4;
+  const systemTokens = systemPrompt ? estimateTokenCount(systemPrompt) + MESSAGE_OVERHEAD : 0;
+
+  // Reserve space for the summary prefix message
+  const SUMMARY_PREFIX_BUDGET = 100;
+  const availableBudget = tokenBudget - systemTokens - SUMMARY_PREFIX_BUDGET;
+
+  if (availableBudget <= 0) {
+    return {
+      keptMessages: [],
+      prunedCount: messages.length,
+      prunedSummaryPrefix: '[Earlier conversation context was too large and has been omitted.]',
+      wasPruned: messages.length > 0,
+    };
+  }
+
+  // Check if all messages fit
+  const totalTokens = estimateConversationTokens(messages);
+  if (totalTokens <= availableBudget) {
+    return {
+      keptMessages: messages,
+      prunedCount: 0,
+      prunedSummaryPrefix: '',
+      wasPruned: false,
+    };
+  }
+
+  // Sliding window: keep most recent messages that fit
+  let usedTokens = 0;
+  let keepFromIndex = messages.length;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msgTokens = estimateTokenCount(messages[i].content) + MESSAGE_OVERHEAD;
+    if (usedTokens + msgTokens > availableBudget) break;
+    usedTokens += msgTokens;
+    keepFromIndex = i;
+  }
+
+  const keptMessages = messages.slice(keepFromIndex);
+  const prunedCount = keepFromIndex;
+
+  const prunedSummaryPrefix =
+    prunedCount > 0
+      ? `[This conversation had ${messages.length} messages. The earliest ${prunedCount} messages have been omitted to fit within the context window. The conversation continues from message ${keepFromIndex + 1}.]`
+      : '';
+
+  return {
+    keptMessages,
+    prunedCount,
+    prunedSummaryPrefix,
+    wasPruned: prunedCount > 0,
+  };
+}
+
+/**
+ * Determine if a session needs pruning based on estimated token usage.
+ *
+ * @param messages     All session messages
+ * @param modelId      Model identifier (for context window lookup)
+ * @param systemPrompt System prompt text
+ * @param threshold    Fraction of context window to trigger pruning (default 0.75)
+ */
+export function shouldPruneSession(
+  messages: Array<{ content: string; type?: string }>,
+  modelId: string,
+  systemPrompt?: string,
+  threshold = 0.75,
+): { needsPruning: boolean; estimatedTokens: number; contextWindow: number; usageRatio: number } {
+  const contextWindow = getModelContextWindow(modelId);
+  const estimatedTokens = estimateConversationTokens(messages, systemPrompt);
+  const usageRatio = estimatedTokens / contextWindow;
+
+  return {
+    needsPruning: usageRatio >= threshold,
+    estimatedTokens,
+    contextWindow,
+    usageRatio,
+  };
+}

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -18,7 +18,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: '用户',
     login: '登录',
     inDevelopment: '正在开发中',
-    
+
     // 设置
     settings: '设置',
     general: '通用',
@@ -45,7 +45,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: '主题色',
     chinese: '中文',
     english: 'English',
-    
+
     // API设置
     apiKey: 'API Key',
     apiKeyPlaceholder: '输入你的 API Key',
@@ -60,7 +60,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: '当前模型',
     availableModels: '可用模型列表',
     modelSwitchHint: '在聊天界面可以切换使用的模型',
-    
+
     // 模型提供商设置
     enabled: '已启用',
     disabled: '已禁用',
@@ -87,7 +87,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelSuffixSecure: '（安全）',
     codingPlanSubscriptionBadge: '订阅套餐',
     inputFileLabel: '输入文件',
-    imageVisionHint: '当前模型未启用图片输入，图片将以文件路径形式发送。若该模型本身支持图片理解，可在模型配置中开启图片输入选项。',
+    imageVisionHint:
+      '当前模型未启用图片输入，图片将以文件路径形式发送。若该模型本身支持图片理解，可在模型配置中开启图片输入选项。',
     copied: '已复制',
     copyrightHolder: '网易有道 版权所有',
     noModelsAvailable: '暂无可用模型',
@@ -168,7 +169,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: '两次输入的密码不一致',
     passwordTooShort: '密码长度至少为4位',
     wrongPassword: '密码错误，请检查后重试',
-    
+
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
     shortcutNotSet: '未设置',
@@ -190,7 +191,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     authLogout: '退出登录',
     authLoginRequired: '请先登录后再开始对话。',
     authLoginRequiredBtn: '登录',
-    authQuotaExhausted: '今日免费额度已用完。您可以登录 LobsterAI Portal 购买套餐或积分包继续使用，或在设置中配置自己的 API Key。',
+    authQuotaExhausted:
+      '今日免费额度已用完。您可以登录 LobsterAI Portal 购买套餐或积分包继续使用，或在设置中配置自己的 API Key。',
     authTopUpLink: '充值',
     authSettingsLink: '设置',
     authLoginToChat: '登录后即可开始聊天',
@@ -205,14 +207,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     planStandard: '标准',
     planAdvanced: '进阶',
     planPro: '专业',
-    
+
     // 错误信息
     failedToLoadSettings: '加载设置失败',
     failedToSaveSettings: '保存设置失败',
-    
+
     // 加载状态
     loading: '加载中...',
-    
+
     // 侧边栏
     conversations: '对话',
     noConversations: '暂无对话',
@@ -251,7 +253,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: '工作',
     folderIconCode: '代码',
     folderIconIdea: '灵感',
-    
+
     // 聊天窗口
     sendMessage: '发送消息',
     typeMessage: '询问任何问题...',
@@ -281,17 +283,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: '最多上传 10 张图片',
     imageReadError: '读取图片失败',
     imageInputNotSupported: '当前模型不支持图像输入',
-    
+
     // 模型选择
     selectModel: '选择模型',
-    
+
     // 错误提示
     errorOccurred: '发生错误',
     tryAgain: '请重试',
     networkError: '网络错误',
     apiKeyRequired: '需要设置API密钥',
     configureApiKey: '请在设置中配置您的API密钥',
-    
+
     // 初始化
     initializationError: '初始化应用程序失败。请检查您的配置。',
     apiKeyNotConfigured: 'API密钥未配置。请在设置中设置您的API密钥。',
@@ -320,7 +322,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelGroupUser: '自定义模型',
     modelSelectorNoModels: '请先在设置中配置模型',
     coworkApiConfigTitle: 'API 配置',
-    coworkApiConfigHint: '支持 Anthropic 兼容与 OpenAI 兼容协议（OpenAI 兼容通过本地转换服务接入）。',
+    coworkApiConfigHint:
+      '支持 Anthropic 兼容与 OpenAI 兼容协议（OpenAI 兼容通过本地转换服务接入）。',
     coworkAgentEngine: 'Agent 引擎',
     coworkAgentEngineOpenClaw: 'OpenClaw（默认）',
     coworkAgentEngineOpenClawHint: '个人 AI 助理',
@@ -333,7 +336,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkOpenClawInstallHint: 'OpenClaw 运行时已内置。切换到该引擎或启动任务时会自动拉起网关。',
     coworkOpenClawGoToSettingsInstall: '查看引擎设置',
     coworkOpenClawRestartGateway: '重新启动网关',
-    coworkOpenClawNotInstalledNotice: '未检测到内置 OpenClaw runtime（cfmind），请先执行打包前构建脚本。',
+    coworkOpenClawNotInstalledNotice:
+      '未检测到内置 OpenClaw runtime（cfmind），请先执行打包前构建脚本。',
     coworkOpenClawReadyNotice: 'OpenClaw runtime 已就绪。开始任务时会自动启动网关。',
     coworkOpenClawStarting: 'AI 引擎正在启动网关...',
     coworkOpenClawRunning: 'AI 引擎已就绪。',
@@ -353,7 +357,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryEnabledHint: 'OpenClaw 会自动索引 MEMORY.md 文件，为 Agent 提供长期记忆检索。',
     coworkMemoryFilePath: '记忆文件路径',
     coworkMemoryLlmJudgeEnabled: '启用 LLM 二级判定',
-    coworkMemoryLlmJudgeEnabledHint: '仅对规则边界样本调用模型复核，提升准确率（会增加少量 API 调用）。',
+    coworkMemoryLlmJudgeEnabledHint:
+      '仅对规则边界样本调用模型复核，提升准确率（会增加少量 API 调用）。',
     coworkMemoryLegacyNotice: '当前为 OpenClaw 引擎模式。本页功能仅对 Cowork 生效。',
     coworkMemoryAutoWrite: '自动写入记忆',
     coworkMemoryCaptureEachTurn: '启用隐式更新',
@@ -394,14 +399,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryEmbeddingEnabled: '启用本地 embedding 重排',
     coworkMemoryEmbeddingEnabledHint: '在词法检索基础上用本地向量相似度重排结果，提升召回质量',
     coworkMemoryEmbeddingModel: 'Embedding 模型',
-    coworkMemoryEmbeddingModelHint: '推荐 BAAI/bge-m3；可改为你已下载的其他 sentence-transformers 模型',
+    coworkMemoryEmbeddingModelHint:
+      '推荐 BAAI/bge-m3；可改为你已下载的其他 sentence-transformers 模型',
     coworkMemoryEmbeddingLocalModelPath: '本地模型目录（可选）',
     coworkMemoryEmbeddingLocalModelPathHint: '填写后优先加载本地目录；留空时按模型名加载',
     coworkMemoryEmbeddingAutoDownload: '允许自动下载模型',
     coworkMemoryEmbeddingAutoDownloadHint: '关闭后必须提供本地模型目录',
     coworkMemoryEmbeddingDownload: '下载 / 校验模型',
     coworkMemoryEmbeddingDownloading: '下载中...',
-    coworkMemoryEmbeddingDownloadHint: '手动触发模型下载（或校验本地模型目录），下载过程可能较慢，请等待进度完成',
+    coworkMemoryEmbeddingDownloadHint:
+      '手动触发模型下载（或校验本地模型目录），下载过程可能较慢，请等待进度完成',
     coworkMemoryEmbeddingDownloadSuccess: 'Embedding 模型已就绪',
     coworkMemoryEmbeddingDownloadFailed: 'Embedding 模型下载失败',
     coworkMemoryEmbeddingProgressPreparing: '准备下载任务',
@@ -480,10 +487,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     customCreate: '自定义创建',
     choosePreset: '选择预设',
     agentSettings: 'Agent 设置',
-     agentName: '名称',
-     agentNamePlaceholder: 'Agent 名称',
-     emojiPickerTitle: '选择图标',
-     emojiCustomInput: '或者直接输入 Emoji',
+    agentName: '名称',
+    agentNamePlaceholder: 'Agent 名称',
+    emojiPickerTitle: '选择图标',
+    emojiCustomInput: '或者直接输入 Emoji',
     agentDescription: '描述',
     agentDescriptionPlaceholder: '简短描述',
     agentIdentity: '身份',
@@ -569,13 +576,15 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noFolderSelected: '未选择文件夹',
     coworkSelectFolderFirst: '请选择任务目录后再提交',
     noRecentFolders: '暂无最近文件夹',
-    folderDriveRootNotAllowed: '不支持使用磁盘根目录作为工作目录，请选择一个子文件夹（例如 D:\\Projects）。',
+    folderDriveRootNotAllowed:
+      '不支持使用磁盘根目录作为工作目录，请选择一个子文件夹（例如 D:\\Projects）。',
     coworkOpenFolder: '打开文件夹',
 
     // Cowork 错误消息
     coworkErrorAuthInvalid: 'API 密钥无效或已过期，请在设置中检查并更新您的 API 密钥。',
     coworkErrorInsufficientBalance: 'API 余额不足，请充值后重试。',
-    coworkErrorInputTooLong: '输入内容过长，超出模型上下文限制，请缩短对话内容后重试。',
+    coworkErrorInputTooLong: '输入内容过长，超出模型上下文限制。系统将自动压缩历史对话后重试。',
+    sessionPruningNotice: '对话历史已自动压缩以适应模型上下文窗口，早期部分消息已被省略。',
     coworkErrorCouldNotProcessPdf: '无法处理 PDF 文件。请尝试将 PDF 转换为文本格式后重新发送。',
     coworkErrorModelNotFound: '请求的模型不存在或不可用，请在设置中检查模型配置。',
     coworkErrorGatewayDisconnected: 'AI 引擎连接中断，请重试。如果问题持续，请尝试重启应用。',
@@ -602,21 +611,24 @@ const translations: Record<LanguageType, Record<string, string>> = {
     remoteImport: '远程导入',
     remoteImportTitle: '远程导入',
     createSkillByChat: '通过对话创建',
-    skillCreatorPrompt: '使用你的skill-creator技能，来创建一个技能。首先，请询问我这个技能需要干什么。',
+    skillCreatorPrompt:
+      '使用你的skill-creator技能，来创建一个技能。首先，请询问我这个技能需要干什么。',
     skillCreatorNotInstalled: '请先安装 skill-creator 技能',
     skillCreatorNotEnabled: '请先启用 skill-creator 技能',
     githubTabLabel: 'GitHub',
     githubImportDescription: '支持仓库链接与子目录链接；若仓库内有多个技能，将自动全部导入。',
     githubImportUrlLabel: 'URL',
     githubSkillPlaceholder: '例如：owner/repo 或 GitHub tree/blob 链接',
-    githubImportExamples: '示例：owner/repo；https://github.com/owner/repo/tree/main/SKILLs/my-skill',
+    githubImportExamples:
+      '示例：owner/repo；https://github.com/owner/repo/tree/main/SKILLs/my-skill',
     clawhubTabLabel: 'ClawHub',
     clawhubImportDescription: '粘贴 clawhub.ai 的技能页面链接，将自动安装对应技能。',
     clawhubImportUrlLabel: 'ClawHub URL',
     clawhubSkillPlaceholder: '例如：https://clawhub.ai/skills/owner/skill-name',
     clawhubImportExamples: '示例：https://clawhub.ai/skills/owner/skill-name',
     importSourceMismatchClawhub: '请输入 clawhub.ai 的链接，或切换到 GitHub 标签页导入。',
-    importSourceMismatchGithub: '请输入 GitHub 链接或 owner/repo 格式，或切换到 ClawHub 标签页导入。',
+    importSourceMismatchGithub:
+      '请输入 GitHub 链接或 owner/repo 格式，或切换到 ClawHub 标签页导入。',
     importSkill: '导入',
     importingSkill: '导入中...',
     official: '官方',
@@ -775,7 +787,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpInstallFromUrl: '通过 URL 安装',
     mcpInstallFromUrlTitle: '通过 URL 安装 MCP',
     mcpInstallFromUrlPlaceholder: '输入 npm 包名或 URL',
-    mcpInstallFromUrlHint: '支持 npm 包名（如 @modelcontextprotocol/server-filesystem）、npx 命令或 HTTP/HTTPS URL',
+    mcpInstallFromUrlHint:
+      '支持 npm 包名（如 @modelcontextprotocol/server-filesystem）、npx 命令或 HTTP/HTTPS URL',
     mcpRequiredConfig: '必填配置',
     mcpOptionalConfig: '可选配置',
     mcpViewOnGithub: '在 GitHub 上查看',
@@ -886,15 +899,20 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imConnectivityCheckTitle_nim_p2p_only_hint: '云信私聊模式',
     imConnectivityCheckSuggestion_missing_credentials: '补全必填配置项后重试。',
     imConnectivityCheckSuggestion_auth_check: '核对平台凭证、应用权限和发布状态。',
-    imConnectivityCheckSuggestion_gateway_running: '若显示未启用，请点击对应 IM 渠道胶囊按钮启用；启用后确认网络可访问平台服务。',
+    imConnectivityCheckSuggestion_gateway_running:
+      '若显示未启用，请点击对应 IM 渠道胶囊按钮启用；启用后确认网络可访问平台服务。',
     imConnectivityCheckSuggestion_inbound_activity: '向机器人发一条测试消息；群聊场景请 @机器人。',
-    imConnectivityCheckSuggestion_outbound_activity: '检查机器人发消息权限、可见范围和会话回包权限。',
+    imConnectivityCheckSuggestion_outbound_activity:
+      '检查机器人发消息权限、可见范围和会话回包权限。',
     imConnectivityCheckSuggestion_platform_last_error: '根据错误提示修复后再重测。',
     imConnectivityCheckSuggestion_feishu_group_requires_mention: '在群聊中使用 @机器人 + 内容。',
-    imConnectivityCheckSuggestion_feishu_event_subscription_required: '在飞书后台开启 im.message.receive_v1 并发布版本。',
+    imConnectivityCheckSuggestion_feishu_event_subscription_required:
+      '在飞书后台开启 im.message.receive_v1 并发布版本。',
     imConnectivityCheckSuggestion_discord_group_requires_mention: '在频道中使用 @机器人 + 内容。',
-    imConnectivityCheckSuggestion_telegram_privacy_mode_hint: '在 @BotFather 调整 Privacy Mode 设置。',
-    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint: '确认机器人已加入目标会话并允许收发消息。',
+    imConnectivityCheckSuggestion_telegram_privacy_mode_hint:
+      '在 @BotFather 调整 Privacy Mode 设置。',
+    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint:
+      '确认机器人已加入目标会话并允许收发消息。',
     imConnectivityCheckSuggestion_nim_p2p_only_hint: '通过私聊方式向机器人账号发送消息。',
     nimAccountPlaceholder: '机器人账号ID',
     nimAccountHint: '在云信控制台"账号管理"中创建的 IM 账号 ID',
@@ -906,7 +924,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimAppKeyHint: '从云信控制台应用信息中获取',
     nimTokenHint: '为该账号生成的访问凭证（建议设置为长期有效）',
     nimAccountWhitelist: '白名单账号',
-    nimAccountWhitelistHint: '填写允许与机器人对话的云信账号，多个账号用逗号分隔。留空则不限制，响应所有账号的消息。',
+    nimAccountWhitelistHint:
+      '填写允许与机器人对话的云信账号，多个账号用逗号分隔。留空则不限制，响应所有账号的消息。',
     nimTeamPolicy: '群消息策略',
     nimTeamPolicyDisabled: '禁用 - 不响应群消息',
     nimTeamPolicyOpen: '开放 - 响应所有群的@消息',
@@ -918,7 +937,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimQChatEnabledHint: '订阅圈组消息，仅响应@机器人的消息',
     nimQChatServerIds: '圈组服务器 ID',
     nimQChatServerIdsPlaceholder: '留空自动发现所有已加入的服务器',
-    nimQChatServerIdsHint: '指定要订阅的服务器 ID，多个用逗号分隔。留空则自动订阅所有已加入的服务器。',
+    nimQChatServerIdsHint:
+      '指定要订阅的服务器 ID，多个用逗号分隔。留空则自动订阅所有已加入的服务器。',
     neteaseBeeChanClientIdPlaceholder: '小蜜蜂助理Client ID',
 
     // IM 设置页面国际化
@@ -1001,7 +1021,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     feishuBotCreateWizardOrManual: '或 手动填写、修改已有机器人信息',
     feishuBotCreateWizardOptionNew: '新建机器人',
     feishuBotCreateWizardOptionExisting: '关联已有机器人',
-    feishuBotCreateWizardQrcodeDesc: '使用飞书客户端扫描二维码，选择「一键创建飞书机器人」完成配置。',
+    feishuBotCreateWizardQrcodeDesc:
+      '使用飞书客户端扫描二维码，选择「一键创建飞书机器人」完成配置。',
     feishuBotCreateWizardQrcodeExpired: '二维码已过期，请点击刷新',
     feishuBotCreateWizardQrcodeRefresh: '刷新二维码',
     feishuBotCreateWizardVerify: '验证',
@@ -1159,7 +1180,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormValidationDatetimeFuture: '执行时间必须在未来',
     scheduledTasksFormValidationIntervalPositive: '间隔时间必须大于 0',
     scheduledTasksFormValidationCronRequired: '请输入 Cron 表达式',
-    scheduledTasksFormValidationPayloadMismatch: '主会话只能使用系统事件，隔离会话只能使用 Agent 对话',
+    scheduledTasksFormValidationPayloadMismatch:
+      '主会话只能使用系统事件，隔离会话只能使用 Agent 对话',
     scheduledTasksFormValidationWebhookRequired: '请输入 Webhook URL',
     scheduledTasksFormValidationTimeout: '超时秒数必须是大于等于 0 的整数',
     scheduledTasksFormSubmitError: '保存失败：',
@@ -1264,7 +1286,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormNotifyConversationNone: '无可用会话',
     scheduledTasksToggleWarningAtPast: '该任务的执行时间已过，启用后将不会运行',
     scheduledTasksToggleWarningExpired: '该任务已过期，启用后将不会运行',
-    scheduledTasksDataAnomalyWarning: '定时任务「{name}」存在异常数据，已自动修正显示，建议重新编辑该任务',
+    scheduledTasksDataAnomalyWarning:
+      '定时任务「{name}」存在异常数据，已自动修正显示，建议重新编辑该任务',
 
     // 隐私协议弹窗
     privacyDialogTitle: '网易有道LobsterAI服务协议',
@@ -1297,7 +1320,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: 'User',
     login: 'Login',
     inDevelopment: 'In development',
-    
+
     // Settings
     settings: 'Settings',
     general: 'General',
@@ -1324,7 +1347,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: 'Color Themes',
     chinese: 'Chinese',
     english: 'English',
-    
+
     // API Settings
     apiKey: 'API Key',
     apiKeyPlaceholder: 'Enter your API Key',
@@ -1339,7 +1362,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: 'Current Model',
     availableModels: 'Available Models',
     modelSwitchHint: 'You can switch models in the chat interface',
-    
+
     // Model Provider Settings
     enabled: 'Enabled',
     disabled: 'Disabled',
@@ -1355,10 +1378,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelNameAndIdRequired: 'Model name and model ID are required',
     modelIdExists: 'Model ID already exists. Use a different one',
     ollamaModelName: 'Model Name',
-    ollamaModelNameHint: 'Enter the name of a model installed in Ollama, e.g. qwen3:8b, lfm2:latest',
+    ollamaModelNameHint:
+      'Enter the name of a model installed in Ollama, e.g. qwen3:8b, lfm2:latest',
     ollamaModelNamePlaceholder: 'qwen3:8b',
     ollamaDisplayName: 'Display Name (optional)',
-    ollamaDisplayNameHint: 'Custom name shown in the model list. Leave empty to use the model name.',
+    ollamaDisplayNameHint:
+      'Custom name shown in the model list. Leave empty to use the model name.',
     ollamaDisplayNamePlaceholder: 'My Qwen3 Model',
     ollamaModelNameRequired: 'Model name is required',
     supportsImageInput: 'Supports image input',
@@ -1366,7 +1391,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelSuffixSecure: '(Secure)',
     codingPlanSubscriptionBadge: 'Subscription',
     inputFileLabel: 'Input Files',
-    imageVisionHint: 'Image input is not enabled for the current model. Images will be sent as file paths. If the model supports vision, you can enable image input in the model configuration.',
+    imageVisionHint:
+      'Image input is not enabled for the current model. Images will be sent as file paths. If the model supports vision, you can enable image input in the model configuration.',
     copied: 'Copied',
     copyrightHolder: 'NetEase Youdao. All rights reserved.',
     noModelsAvailable: 'No models available',
@@ -1382,9 +1408,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     apiFormatOpenAI: 'OpenAI Compatible',
     apiFormatHint: 'Select protocol compatibility: Anthropic Compatible or OpenAI Compatible',
     zhipuCodingPlanHint: 'When enabled, uses the GLM Coding Plan dedicated API endpoint',
-    zhipuCodingPlanEndpointHint: 'When using GLM Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
-    qwenCodingPlanHint: 'When enabled, uses the Alibaba Cloud Bailian Coding Plan dedicated API endpoint',
-    qwenCodingPlanEndpointHint: 'When using Coding Plan, you need a dedicated API Key (format: sk-sp-xxxxx)',
+    zhipuCodingPlanEndpointHint:
+      'When using GLM Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
+    qwenCodingPlanHint:
+      'When enabled, uses the Alibaba Cloud Bailian Coding Plan dedicated API endpoint',
+    qwenCodingPlanEndpointHint:
+      'When using Coding Plan, you need a dedicated API Key (format: sk-sp-xxxxx)',
     qwenOAuthTab: 'OAuth Login',
     qwenOAuthLogin: 'OAuth Login',
     qwenOAuthLoginFree: 'OAuth Login',
@@ -1397,12 +1426,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     qwenAuthMethod: 'Authentication Method',
     qwenApiKeyOptional: 'API Key (Optional)',
     qwenApiKeyPriority: 'sk-xxxxx (Traditional method, higher priority than OAuth)',
-    qwenAuthPriorityHint: '💡 Authentication Priority: API Key > OAuth. If both are configured, API Key will be used first.',
+    qwenAuthPriorityHint:
+      '💡 Authentication Priority: API Key > OAuth. If both are configured, API Key will be used first.',
     qwenOrUseApiKey: 'Or use API Key',
-    volcengineCodingPlanHint: 'When enabled, uses the Volcengine Coding Plan dedicated API endpoint',
-    volcengineCodingPlanEndpointHint: 'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
+    volcengineCodingPlanHint:
+      'When enabled, uses the Volcengine Coding Plan dedicated API endpoint',
+    volcengineCodingPlanEndpointHint:
+      'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
     moonshotCodingPlanHint: 'When enabled, uses the Moonshot Coding Plan dedicated API endpoint',
-    moonshotCodingPlanEndpointHint: 'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
+    moonshotCodingPlanEndpointHint:
+      'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
     minimaxOAuthTabApiKey: 'API Key',
     minimaxOAuthTabOAuth: 'OAuth',
     minimaxOAuthRegionLabel: 'Region',
@@ -1415,7 +1448,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     minimaxOAuthStatusSuccess: 'OAuth login successful',
     minimaxOAuthStatusError: 'OAuth login failed',
     minimaxOAuthUserCode: 'Authorization code',
-    minimaxOAuthOpenBrowserHint: 'Browser opened, please enter the authorization code and complete login',
+    minimaxOAuthOpenBrowserHint:
+      'Browser opened, please enter the authorization code and complete login',
     minimaxOAuthLoggedIn: 'Logged in via MiniMax OAuth',
     minimaxOAuthRelogin: 'Re-login',
     minimaxOAuthLogout: 'Log out',
@@ -1431,8 +1465,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     importProvidersFailed: 'Failed to import providers',
     exportProvidersFailed: 'Failed to export providers',
     invalidProvidersFile: 'Invalid providers file',
-    decryptProvidersFailed: 'Failed to decrypt API key. Make sure the file was exported on this device.',
-    decryptProvidersPartial: 'Some keys could not be decrypted. Existing keys were kept or left blank.',
+    decryptProvidersFailed:
+      'Failed to decrypt API key. Make sure the file was exported on this device.',
+    decryptProvidersPartial:
+      'Some keys could not be decrypted. Existing keys were kept or left blank.',
 
     // Password related
     password: 'Password',
@@ -1441,13 +1477,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     enterPasswordAgain: 'Enter password again',
     exportPasswordTitle: 'Set Export Password',
     importPasswordTitle: 'Enter Import Password',
-    exportPasswordHint: 'This password encrypts your API keys. Use the same password when importing.',
+    exportPasswordHint:
+      'This password encrypts your API keys. Use the same password when importing.',
     importPasswordHint: 'Enter the password you set when exporting',
     passwordRequired: 'Password is required',
     passwordMismatch: 'Passwords do not match',
     passwordTooShort: 'Password must be at least 4 characters',
     wrongPassword: 'Wrong password, please try again',
-    
+
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
     shortcutNotSet: 'Not set',
@@ -1469,7 +1506,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     authLogout: 'Log Out',
     authLoginRequired: 'Please log in to start a conversation.',
     authLoginRequiredBtn: 'Log In',
-    authQuotaExhausted: 'Daily free quota exhausted. Visit LobsterAI Portal to purchase a plan or credits, or configure your own API Key in Settings.',
+    authQuotaExhausted:
+      'Daily free quota exhausted. Visit LobsterAI Portal to purchase a plan or credits, or configure your own API Key in Settings.',
     authTopUpLink: 'Top Up',
     authSettingsLink: 'Settings',
     authLoginToChat: 'Log in to start chatting',
@@ -1483,14 +1521,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     planFree: 'Free',
     planAdvanced: 'Advanced',
     planPro: 'Pro',
-    
+
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',
-    
+
     // Loading State
     loading: 'Loading...',
-    
+
     // Sidebar
     conversations: 'Conversations',
     noConversations: 'No conversations',
@@ -1504,7 +1542,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noProjects: 'No projects',
     delete: 'Delete',
     confirmDelete: 'Confirm Delete',
-    confirmDeleteMessage: 'Are you sure you want to delete this conversation? This action cannot be undone.',
+    confirmDeleteMessage:
+      'Are you sure you want to delete this conversation? This action cannot be undone.',
     searchChats: 'Search Chats',
     searchConversations: 'Search tasks...',
     searchNoResults: 'No matching tasks',
@@ -1521,7 +1560,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     projectSettings: 'Project settings',
     projectNameLabel: 'Project name',
     deleteProject: 'Delete project',
-    confirmDeleteProject: 'Are you sure you want to delete this project? Chats in this project will be moved to your chat list. This action cannot be undone.',
+    confirmDeleteProject:
+      'Are you sure you want to delete this project? Chats in this project will be moved to your chat list. This action cannot be undone.',
     folderIconDefault: 'Default',
     folderIconHealth: 'Health',
     folderIconStudy: 'Study',
@@ -1529,7 +1569,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: 'Work',
     folderIconCode: 'Code',
     folderIconIdea: 'Ideas',
-    
+
     // Chat Window
     sendMessage: 'Send Message',
     typeMessage: 'Type a message...',
@@ -1539,7 +1579,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkReEdit: 'Re-edit',
     messageCopied: 'Message copied',
     clearConversation: 'Clear Conversation',
-    confirmClearConversation: 'Are you sure you want to clear the current conversation? This action cannot be undone.',
+    confirmClearConversation:
+      'Are you sure you want to clear the current conversation? This action cannot be undone.',
     today: 'Today',
     yesterday: 'Yesterday',
     daysAgo: 'days ago',
@@ -1559,17 +1600,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: 'Up to 10 images',
     imageReadError: 'Failed to read image',
     imageInputNotSupported: 'Current model does not support images',
-    
+
     // Model Selection
     selectModel: 'Select Model',
-    
+
     // Error Messages
     errorOccurred: 'An error occurred',
     tryAgain: 'Please try again',
     networkError: 'Network error',
     apiKeyRequired: 'API Key Required',
     configureApiKey: 'Please configure your API key in settings',
-    
+
     // Initialization
     initializationError: 'Failed to initialize application. Please check your configuration.',
     apiKeyNotConfigured: 'API key not configured. Please set up your API key in settings.',
@@ -1589,30 +1630,36 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkWorkingDirectoryHint: 'LobsterAI will execute commands in this directory',
     coworkSystemPrompt: 'System Prompt',
     coworkSystemPromptPlaceholder: 'Set custom instructions for LobsterAI...',
-    coworkSystemPromptHint: 'Optional system prompt to customize LobsterAI\'s behavior',
+    coworkSystemPromptHint: "Optional system prompt to customize LobsterAI's behavior",
     coworkModelSettingsRequired: 'Please configure models and API keys in Model Settings first.',
     coworkModelSettingsTitle: 'Model Settings',
-    coworkModelSettingsHint: 'LobsterAI uses the current model and provider configuration from Model Settings.',
+    coworkModelSettingsHint:
+      'LobsterAI uses the current model and provider configuration from Model Settings.',
     coworkModelSettingsAction: 'Go to Model Settings',
     modelGroupServer: 'Plan Models',
     modelGroupUser: 'Custom Models',
     modelSelectorNoModels: 'Please configure models in settings first',
     coworkApiConfigTitle: 'API Configuration',
-    coworkApiConfigHint: 'Supports Anthropic-compatible and OpenAI-compatible APIs (OpenAI compatibility is bridged by a local adapter).',
+    coworkApiConfigHint:
+      'Supports Anthropic-compatible and OpenAI-compatible APIs (OpenAI compatibility is bridged by a local adapter).',
     coworkAgentEngine: 'Agent Engine',
     coworkAgentEngineOpenClaw: 'OpenClaw (Default)',
     coworkAgentEngineOpenClawHint: 'Personal AI assistant',
     coworkAgentEngineClaudeLegacy: 'Cowork',
-    coworkAgentEngineClaudeLegacyHint: 'Built-in engine, ready out of the box, recommended for daily tasks.',
+    coworkAgentEngineClaudeLegacyHint:
+      'Built-in engine, ready out of the box, recommended for daily tasks.',
     coworkOpenClawInstall: 'Start OpenClaw',
     coworkOpenClawRetryInstall: 'Retry OpenClaw Startup',
     coworkOpenClawStart: 'Start OpenClaw',
     coworkOpenClawInstalling: 'Starting OpenClaw...',
-    coworkOpenClawInstallHint: 'OpenClaw runtime is bundled. Switching to this engine or starting a task will auto-start the gateway.',
+    coworkOpenClawInstallHint:
+      'OpenClaw runtime is bundled. Switching to this engine or starting a task will auto-start the gateway.',
     coworkOpenClawGoToSettingsInstall: 'View Engine Settings',
     coworkOpenClawRestartGateway: 'Restart Gateway',
-    coworkOpenClawNotInstalledNotice: 'Bundled OpenClaw runtime (cfmind) was not found. Build the runtime before packaging.',
-    coworkOpenClawReadyNotice: 'OpenClaw runtime is ready. The gateway will auto-start when you run a task.',
+    coworkOpenClawNotInstalledNotice:
+      'Bundled OpenClaw runtime (cfmind) was not found. Build the runtime before packaging.',
+    coworkOpenClawReadyNotice:
+      'OpenClaw runtime is ready. The gateway will auto-start when you run a task.',
     coworkOpenClawStarting: 'AI engine is starting the gateway...',
     coworkOpenClawRunning: 'AI engine is ready.',
     coworkOpenClawError: 'OpenClaw gateway failed to become healthy in time.',
@@ -1622,16 +1669,20 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkBootstrapIdentityTitle: 'Agent Identity',
     coworkBootstrapIdentityHint: 'Agent metadata (name, emoji, avatar, etc.)',
     coworkBootstrapUserTitle: 'User Profile',
-    coworkBootstrapUserHint: 'Information about yourself (name, preferences, etc.) that the Agent will remember.',
+    coworkBootstrapUserHint:
+      'Information about yourself (name, preferences, etc.) that the Agent will remember.',
     coworkBootstrapSoulTitle: 'Agent Persona',
-    coworkBootstrapSoulHint: 'Agent personality, tone, and behavior guidelines. The Agent will be instructed to follow this.',
+    coworkBootstrapSoulHint:
+      'Agent personality, tone, and behavior guidelines. The Agent will be instructed to follow this.',
     coworkBootstrapStoragePath: 'Storage path',
     coworkBootstrapSaveFailed: 'Failed to save agent settings',
     coworkMemoryEnabled: 'Enable user memories',
-    coworkMemoryEnabledHint: 'OpenClaw automatically indexes MEMORY.md for long-term memory retrieval by the Agent.',
+    coworkMemoryEnabledHint:
+      'OpenClaw automatically indexes MEMORY.md for long-term memory retrieval by the Agent.',
     coworkMemoryFilePath: 'Memory file path',
     coworkMemoryLlmJudgeEnabled: 'Enable LLM secondary judge',
-    coworkMemoryLlmJudgeEnabledHint: 'Only borderline rule cases are reviewed by the model for better accuracy (adds a small number of API calls).',
+    coworkMemoryLlmJudgeEnabledHint:
+      'Only borderline rule cases are reviewed by the model for better accuracy (adds a small number of API calls).',
     coworkMemoryLegacyNotice: 'OpenClaw engine mode is active. This page only applies to Cowork.',
     coworkMemoryAutoWrite: 'Auto-write memory',
     coworkMemoryCaptureEachTurn: 'Enable implicit updates',
@@ -1670,16 +1721,20 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryAdvancedShow: 'Show advanced settings',
     coworkMemoryAdvancedHide: 'Hide advanced settings',
     coworkMemoryEmbeddingEnabled: 'Enable local embedding rerank',
-    coworkMemoryEmbeddingEnabledHint: 'Rerank lexical hits with local vector similarity for better recall quality',
+    coworkMemoryEmbeddingEnabledHint:
+      'Rerank lexical hits with local vector similarity for better recall quality',
     coworkMemoryEmbeddingModel: 'Embedding model',
-    coworkMemoryEmbeddingModelHint: 'Recommended: BAAI/bge-m3. You can switch to any downloaded sentence-transformers model',
+    coworkMemoryEmbeddingModelHint:
+      'Recommended: BAAI/bge-m3. You can switch to any downloaded sentence-transformers model',
     coworkMemoryEmbeddingLocalModelPath: 'Local model path (optional)',
-    coworkMemoryEmbeddingLocalModelPathHint: 'If set, load model from this directory first; if empty, load by model id',
+    coworkMemoryEmbeddingLocalModelPathHint:
+      'If set, load model from this directory first; if empty, load by model id',
     coworkMemoryEmbeddingAutoDownload: 'Allow auto model download',
     coworkMemoryEmbeddingAutoDownloadHint: 'When disabled, you must provide a local model path',
     coworkMemoryEmbeddingDownload: 'Download / Validate model',
     coworkMemoryEmbeddingDownloading: 'Downloading...',
-    coworkMemoryEmbeddingDownloadHint: 'Manually trigger model download (or validate local path). This can take a while, wait for progress to finish',
+    coworkMemoryEmbeddingDownloadHint:
+      'Manually trigger model download (or validate local path). This can take a while, wait for progress to finish',
     coworkMemoryEmbeddingDownloadSuccess: 'Embedding model is ready',
     coworkMemoryEmbeddingDownloadFailed: 'Failed to download embedding model',
     coworkMemoryEmbeddingProgressPreparing: 'Preparing download task',
@@ -1690,11 +1745,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryEmbeddingProgressDone: 'Completed',
     coworkMemoryEmbeddingProgressError: 'Failed',
     coworkMemoryEmbeddingWeight: 'Semantic rerank weight',
-    coworkMemoryEmbeddingWeightHint: 'Range 0-1. Higher means more embedding influence. Recommended: 0.62',
+    coworkMemoryEmbeddingWeightHint:
+      'Range 0-1. Higher means more embedding influence. Recommended: 0.62',
     coworkConfigSaveFailed: 'Failed to save LobsterAI settings. Please try again.',
     coworkApiProviderModel: 'Select from provider models',
     coworkApiProviderModelCustom: 'Custom',
-    coworkApiProviderModelHint: 'Only shows enabled providers with configured API key and base URL.',
+    coworkApiProviderModelHint:
+      'Only shows enabled providers with configured API key and base URL.',
     coworkApiBaseUrl: 'API Base URL',
     coworkApiKey: 'API Key',
     coworkApiModel: 'Model Name',
@@ -1724,9 +1781,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkTodoPending: 'pending',
     coworkTodoUntitled: 'Untitled todo',
     coworkTodoUnknownStatus: 'Unknown status',
-    coworkDangerousOperation: 'Warning: This operation may modify files or execute system commands. Please review carefully.',
-    coworkDestructiveOperation: 'Destructive operation: This command may cause irreversible data loss. Please confirm carefully.',
-    coworkCautionOperation: 'Caution: This command may modify files or system state. Please review carefully.',
+    coworkDangerousOperation:
+      'Warning: This operation may modify files or execute system commands. Please review carefully.',
+    coworkDestructiveOperation:
+      'Destructive operation: This command may cause irreversible data loss. Please confirm carefully.',
+    coworkCautionOperation:
+      'Caution: This command may modify files or system state. Please review carefully.',
     dangerReasonRecursiveDelete: 'Recursive file deletion',
     dangerReasonGitForcePush: 'Git force push',
     dangerReasonGitResetHard: 'Git hard reset',
@@ -1758,16 +1818,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     customCreate: 'Custom Create',
     choosePreset: 'Choose Preset',
     agentSettings: 'Agent Settings',
-     agentName: 'Name',
-     agentNamePlaceholder: 'Agent name',
-     emojiPickerTitle: 'Choose icon',
-     emojiCustomInput: 'Or type an emoji',
+    agentName: 'Name',
+    agentNamePlaceholder: 'Agent name',
+    emojiPickerTitle: 'Choose icon',
+    emojiCustomInput: 'Or type an emoji',
     agentDescription: 'Description',
     agentDescriptionPlaceholder: 'Brief description',
     agentIdentity: 'Identity',
     agentIdentityPlaceholder: 'Identity description (IDENTITY.md)...',
     agentSkills: 'Skills',
-    agentSkillsHint: 'Select skills available to this Agent. Leave empty to use all enabled skills.',
+    agentSkillsHint:
+      'Select skills available to this Agent. Leave empty to use all enabled skills.',
     agentSkillsSearch: 'Search skills...',
     agentSkillsNone: 'Click to select skills',
     agentsSubtitle: 'Custom personas and skill sets for your AI agents',
@@ -1790,11 +1851,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     coworkNewSession: 'New Session',
     coworkContinuePlaceholder: 'Continue the conversation...',
-    coworkRemoteManagedPlaceholder: 'This session was created via IM. Please use the corresponding IM platform.',
+    coworkRemoteManagedPlaceholder:
+      'This session was created via IM. Please use the corresponding IM platform.',
     aiGeneratedDisclaimer: 'Content generated by AI, for reference only.',
     updateAvailablePill: 'New update',
     updateAvailableTitle: 'New version available',
-    updateAvailableMessage: 'A new version is available. Please download it from the official website and install over the current version.',
+    updateAvailableMessage:
+      'A new version is available. Please download it from the official website and install over the current version.',
     updateAvailableConfirm: 'Update Now',
     updateAvailableCancel: 'Cancel',
     updateOpenFailed: 'Failed to open download page',
@@ -1833,13 +1896,15 @@ const translations: Record<LanguageType, Record<string, string>> = {
     deleteSession: 'Delete Task',
     turnIndex: 'Turn index',
     deleteTaskConfirmTitle: 'Confirm Deletion',
-    deleteTaskConfirmMessage: 'This action cannot be undone. All messages in this task will be permanently deleted.',
+    deleteTaskConfirmMessage:
+      'This action cannot be undone. All messages in this task will be permanently deleted.',
     batchOperations: 'Batch Operations',
     batchSelectAll: 'Select All',
     batchDelete: 'Delete',
     batchCancel: 'Cancel',
     batchDeleteConfirmTitle: 'Confirm Batch Deletion',
-    batchDeleteConfirmMessage: 'Are you sure you want to delete {count} selected tasks? This action cannot be undone.',
+    batchDeleteConfirmMessage:
+      'Are you sure you want to delete {count} selected tasks? This action cannot be undone.',
     back: 'Back',
     browse: 'Browse',
     addFolder: 'Add Folder',
@@ -1847,26 +1912,37 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noFolderSelected: 'No folder selected',
     coworkSelectFolderFirst: 'Please select a task folder before submitting',
     noRecentFolders: 'No recent folders',
-    folderDriveRootNotAllowed: 'Drive root directories are not supported as working directories. Please select a subfolder (e.g. D:\\Projects).',
+    folderDriveRootNotAllowed:
+      'Drive root directories are not supported as working directories. Please select a subfolder (e.g. D:\\Projects).',
     coworkOpenFolder: 'Open folder',
 
     // Cowork error messages
-    coworkErrorAuthInvalid: 'Invalid or expired API key. Please check and update your API key in settings.',
+    coworkErrorAuthInvalid:
+      'Invalid or expired API key. Please check and update your API key in settings.',
     coworkErrorInsufficientBalance: 'Insufficient API balance. Please top up and try again.',
-    coworkErrorInputTooLong: 'Input too long, exceeding model context limit. Please shorten the conversation and try again.',
-    coworkErrorCouldNotProcessPdf: 'Unable to process the PDF file. Please try converting the PDF to text format and resend.',
-    coworkErrorModelNotFound: 'The requested model does not exist or is unavailable. Please check the model configuration in settings.',
-    coworkErrorGatewayDisconnected: 'AI engine connection lost. Please retry. If the issue persists, try restarting the app.',
+    coworkErrorInputTooLong:
+      'Input too long, exceeding model context limit. The system will automatically compress conversation history and retry.',
+    sessionPruningNotice:
+      'Conversation history has been automatically compressed to fit the model context window. Some earlier messages have been omitted.',
+    coworkErrorCouldNotProcessPdf:
+      'Unable to process the PDF file. Please try converting the PDF to text format and resend.',
+    coworkErrorModelNotFound:
+      'The requested model does not exist or is unavailable. Please check the model configuration in settings.',
+    coworkErrorGatewayDisconnected:
+      'AI engine connection lost. Please retry. If the issue persists, try restarting the app.',
     coworkErrorServiceRestart: 'AI engine is restarting. Please try again later.',
     coworkErrorGatewayDraining: 'AI engine is restarting. Please wait a moment and try again.',
-    coworkErrorNetworkError: 'Network connection failed. Please check your network settings and try again.',
+    coworkErrorNetworkError:
+      'Network connection failed. Please check your network settings and try again.',
     coworkErrorRateLimit: 'Too many requests. Please try again later.',
-    coworkErrorContentFiltered: 'Content did not pass the safety review. Please modify and try again.',
+    coworkErrorContentFiltered:
+      'Content did not pass the safety review. Please modify and try again.',
     coworkErrorServerError: 'Server error occurred. Please try again later.',
     coworkErrorSessionStartFailed: 'Failed to start session: {error}',
     coworkErrorSessionContinueFailed: 'Failed to send message: {error}',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
-    coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
+    coworkErrorUnknown:
+      'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
 
     // Skills
     skills: 'Skills',
@@ -1880,21 +1956,26 @@ const translations: Record<LanguageType, Record<string, string>> = {
     remoteImport: 'Remote Import',
     remoteImportTitle: 'Remote Import',
     createSkillByChat: 'Create via Conversation',
-    skillCreatorPrompt: 'Use your skill-creator skill to create a new skill. First, please ask me what this skill should do.',
+    skillCreatorPrompt:
+      'Use your skill-creator skill to create a new skill. First, please ask me what this skill should do.',
     skillCreatorNotInstalled: 'Please install the skill-creator skill first',
     skillCreatorNotEnabled: 'Please enable the skill-creator skill first',
     githubTabLabel: 'GitHub',
-    githubImportDescription: 'Supports both repository and subdirectory links. If a repo contains multiple skills, all will be imported.',
+    githubImportDescription:
+      'Supports both repository and subdirectory links. If a repo contains multiple skills, all will be imported.',
     githubImportUrlLabel: 'URL',
     githubSkillPlaceholder: 'e.g. owner/repo or a GitHub tree/blob URL',
-    githubImportExamples: 'Examples: owner/repo; https://github.com/owner/repo/tree/main/SKILLs/my-skill',
+    githubImportExamples:
+      'Examples: owner/repo; https://github.com/owner/repo/tree/main/SKILLs/my-skill',
     clawhubTabLabel: 'ClawHub',
-    clawhubImportDescription: 'Paste a clawhub.ai skill page URL to automatically install the skill.',
+    clawhubImportDescription:
+      'Paste a clawhub.ai skill page URL to automatically install the skill.',
     clawhubImportUrlLabel: 'ClawHub URL',
     clawhubSkillPlaceholder: 'e.g. https://clawhub.ai/skills/owner/skill-name',
     clawhubImportExamples: 'Example: https://clawhub.ai/skills/owner/skill-name',
     importSourceMismatchClawhub: 'Please enter a clawhub.ai URL, or switch to the GitHub tab.',
-    importSourceMismatchGithub: 'Please enter a GitHub URL or owner/repo, or switch to the ClawHub tab.',
+    importSourceMismatchGithub:
+      'Please enter a GitHub URL or owner/repo, or switch to the ClawHub tab.',
     importSkill: 'Import',
     importingSkill: 'Importing...',
     official: 'Official',
@@ -2006,7 +2087,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // MCP Servers
     mcpServers: 'MCP',
-    mcpDescription: 'Configure and manage MCP (Model Context Protocol) servers to extend your agent\'s tool capabilities',
+    mcpDescription:
+      "Configure and manage MCP (Model Context Protocol) servers to extend your agent's tool capabilities",
     searchMcpServers: 'Search MCP servers',
     addMcpServer: 'Custom',
     editMcpServer: 'Edit MCP Server',
@@ -2053,7 +2135,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpInstallFromUrl: 'Install from URL',
     mcpInstallFromUrlTitle: 'Install MCP from URL',
     mcpInstallFromUrlPlaceholder: 'Enter npm package name or URL',
-    mcpInstallFromUrlHint: 'Supports npm package names (e.g. @modelcontextprotocol/server-filesystem), npx commands, or HTTP/HTTPS URLs',
+    mcpInstallFromUrlHint:
+      'Supports npm package names (e.g. @modelcontextprotocol/server-filesystem), npx commands, or HTTP/HTTPS URLs',
     mcpRequiredConfig: 'Required Configuration',
     mcpOptionalConfig: 'Optional Configuration',
     mcpViewOnGithub: 'View on GitHub',
@@ -2069,7 +2152,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpDesc_github: 'GitHub platform integration: repos, issues, PRs, Actions management',
     mcpDesc_gitlab: 'GitLab API integration: project management, merge requests, pipelines',
     mcpDesc_context7: 'Up-to-date library documentation and code examples for AI coding',
-    mcpDesc_google_drive: 'Google Drive file access and search with auto-export for Workspace files',
+    mcpDesc_google_drive:
+      'Google Drive file access and search with auto-export for Workspace files',
     mcpDesc_gmail: 'Gmail management: read, send, search emails with auto authentication',
     mcpDesc_google_calendar: 'Google Calendar management: create, query, update calendar events',
     mcpDesc_notion: 'Notion API: search, create/update pages, manage databases',
@@ -2077,7 +2161,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpDesc_todoist: 'Task management: create, update, complete and organize to-do items',
     mcpDesc_playwright: 'Advanced browser automation supporting Chromium/Firefox/WebKit',
     mcpDesc_canva: 'Canva design platform: create and manage designs, template operations',
-    mcpDesc_firecrawl: 'Web scraping and data extraction: batch processing, structured extraction and content analysis',
+    mcpDesc_firecrawl:
+      'Web scraping and data extraction: batch processing, structured extraction and content analysis',
     mcpDesc_fetch: 'Web content fetching and HTML-to-markdown conversion for LLM consumption',
 
     // Email Skill Config
@@ -2091,13 +2176,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     emailPasswordPlaceholder: 'Password or app-specific password',
     emailAdvancedSettings: 'Advanced Settings',
     emailAllowInsecureCert: 'Allow insecure certificates',
-    emailAllowInsecureCertHint: 'Skip TLS certificate verification, useful when proxy/VPN causes self-signed certificate errors',
+    emailAllowInsecureCertHint:
+      'Skip TLS certificate verification, useful when proxy/VPN causes self-signed certificate errors',
     emailMailbox: 'Default Mailbox',
     emailConfigSaved: 'Email configuration saved',
     emailConfigError: 'Failed to save configuration',
     emailHintGmail: 'If 2FA is enabled, use an App Password instead of your account password',
-    emailHint163: 'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
-    emailHintQQ: 'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
+    emailHint163:
+      'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
+    emailHintQQ:
+      'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
 
     // File operations
     openFile: 'Open File',
@@ -2118,12 +2206,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nim: 'NetEase IM',
     'netease-bee': 'Netease Bee',
     weixin: 'WeChat',
-    wecom: 'WeCom',    popo: 'POPO',
+    wecom: 'WeCom',
+    popo: 'POPO',
     connected: 'Connected',
     disconnected: 'Disconnected',
     imAgentBinding: 'Responding Agent',
     imAgentBindingDefault: 'Default (main)',
-    imAgentBindingHint: 'Select the Agent that responds to messages on this platform. Different Agents have different personas and skill configurations.',
+    imAgentBindingHint:
+      'Select the Agent that responds to messages on this platform. Different Agents have different personas and skill configurations.',
     kickedByOtherClient: 'Account logged in elsewhere',
     starting: 'Starting',
     start: 'Start',
@@ -2156,23 +2246,35 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imConnectivityCheckTitle_outbound_activity: 'Outbound Message Activity',
     imConnectivityCheckTitle_platform_last_error: 'Recent Platform Error',
     imConnectivityCheckTitle_feishu_group_requires_mention: 'Feishu Group Trigger Rule',
-    imConnectivityCheckTitle_feishu_event_subscription_required: 'Feishu Event Subscription Requirement',
+    imConnectivityCheckTitle_feishu_event_subscription_required:
+      'Feishu Event Subscription Requirement',
     imConnectivityCheckTitle_discord_group_requires_mention: 'Discord Group Trigger Rule',
     imConnectivityCheckTitle_telegram_privacy_mode_hint: 'Telegram Privacy Mode',
     imConnectivityCheckTitle_dingtalk_bot_membership_hint: 'DingTalk Conversation Permission',
     imConnectivityCheckTitle_nim_p2p_only_hint: 'NetEase IM P2P Mode',
     imConnectivityCheckSuggestion_missing_credentials: 'Fill required credentials and test again.',
-    imConnectivityCheckSuggestion_auth_check: 'Verify credentials, permissions, and app release status.',
-    imConnectivityCheckSuggestion_gateway_running: 'If disabled, click the IM channel pill to enable it, then verify platform endpoints are reachable.',
-    imConnectivityCheckSuggestion_inbound_activity: 'Send a test message to the bot; mention it in group chats.',
-    imConnectivityCheckSuggestion_outbound_activity: 'Check bot send permissions and conversation reply scope.',
-    imConnectivityCheckSuggestion_platform_last_error: 'Fix the reported error and run diagnostics again.',
-    imConnectivityCheckSuggestion_feishu_group_requires_mention: 'Use @bot plus your message in group chats.',
-    imConnectivityCheckSuggestion_feishu_event_subscription_required: 'Enable im.message.receive_v1 and publish app version.',
-    imConnectivityCheckSuggestion_discord_group_requires_mention: 'Use @bot plus your message in channels.',
-    imConnectivityCheckSuggestion_telegram_privacy_mode_hint: 'Review Privacy Mode in @BotFather settings.',
-    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint: 'Ensure the bot is in the target conversation with send/receive rights.',
-    imConnectivityCheckSuggestion_nim_p2p_only_hint: 'Send messages via direct chat to the bot account.',
+    imConnectivityCheckSuggestion_auth_check:
+      'Verify credentials, permissions, and app release status.',
+    imConnectivityCheckSuggestion_gateway_running:
+      'If disabled, click the IM channel pill to enable it, then verify platform endpoints are reachable.',
+    imConnectivityCheckSuggestion_inbound_activity:
+      'Send a test message to the bot; mention it in group chats.',
+    imConnectivityCheckSuggestion_outbound_activity:
+      'Check bot send permissions and conversation reply scope.',
+    imConnectivityCheckSuggestion_platform_last_error:
+      'Fix the reported error and run diagnostics again.',
+    imConnectivityCheckSuggestion_feishu_group_requires_mention:
+      'Use @bot plus your message in group chats.',
+    imConnectivityCheckSuggestion_feishu_event_subscription_required:
+      'Enable im.message.receive_v1 and publish app version.',
+    imConnectivityCheckSuggestion_discord_group_requires_mention:
+      'Use @bot plus your message in channels.',
+    imConnectivityCheckSuggestion_telegram_privacy_mode_hint:
+      'Review Privacy Mode in @BotFather settings.',
+    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint:
+      'Ensure the bot is in the target conversation with send/receive rights.',
+    imConnectivityCheckSuggestion_nim_p2p_only_hint:
+      'Send messages via direct chat to the bot account.',
     nimAccountPlaceholder: 'Bot account ID',
     nimAccountHint: 'IM account ID (accid) created in NetEase IM console account management',
     nimCredentialsGuide: 'How to obtain NetEase IM credentials:',
@@ -2183,7 +2285,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimAppKeyHint: 'Obtain from app information in NetEase IM console',
     nimTokenHint: 'Access credential generated for this account (long-term validity recommended)',
     nimAccountWhitelist: 'Account Whitelist',
-    nimAccountWhitelistHint: 'Enter NIM accounts allowed to chat with the bot, separated by commas. Leave empty to allow all accounts.',
+    nimAccountWhitelistHint:
+      'Enter NIM accounts allowed to chat with the bot, separated by commas. Leave empty to allow all accounts.',
     nimTeamPolicy: 'Team Message Policy',
     nimTeamPolicyDisabled: 'Disabled - Do not respond to team messages',
     nimTeamPolicyOpen: 'Open - Respond to @mentions in all teams',
@@ -2195,7 +2298,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimQChatEnabledHint: 'Subscribe to QChat messages, only responds to @mentions',
     nimQChatServerIds: 'QChat Server IDs',
     nimQChatServerIdsPlaceholder: 'Leave empty to auto-discover all joined servers',
-    nimQChatServerIdsHint: 'Specify server IDs to subscribe, separated by commas. Leave empty to auto-subscribe all joined servers.',
+    nimQChatServerIdsHint:
+      'Specify server IDs to subscribe, separated by commas. Leave empty to auto-subscribe all joined servers.',
     neteaseBeeChanClientIdPlaceholder: 'Netease Bee IM Client ID',
 
     // IM settings page i18n
@@ -2208,12 +2312,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imDebugMode: 'Debug Mode',
     imSessionTimeout: 'Session Timeout (min, deprecated)',
     imSeparateSessionByConversation: 'Separate Session by Conversation',
-    imSeparateSessionByConversationDesc: 'Maintain independent sessions for DMs, groups, and different groups',
+    imSeparateSessionByConversationDesc:
+      'Maintain independent sessions for DMs, groups, and different groups',
     imGroupSessionScope: 'Group Session Scope',
     imGroupSessionScopeGroup: 'Shared in group',
     imGroupSessionScopeGroupSender: 'Per user in group',
     imSharedMemoryAcrossConversations: 'Share Memory Across Conversations',
-    imSharedMemoryAcrossConversationsDesc: 'Share memory across different conversations (isolated by default)',
+    imSharedMemoryAcrossConversationsDesc:
+      'Share memory across different conversations (isolated by default)',
     imGatewayBaseUrl: 'Custom Gateway URL',
     imGatewayBaseUrlPlaceholder: 'e.g. https://proxy.example.com',
     imSendThinkingMessage: 'Send "thinking" message',
@@ -2266,19 +2372,25 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imWecomQuickSetupSuccess: 'Bot created successfully, credentials auto-filled',
     imWecomQuickSetupError: 'Creation failed',
     imViewGuide: 'Setup Manual',
-    imDingtalkGuideStep1: 'Go to DingTalk Open Platform, create or pick an enterprise app under "App Development > Bot"',
-    imDingtalkGuideStep2: 'Copy the Client ID (AppKey) and Client Secret (AppSecret) from the credentials page',
-    imDingtalkGuideStep3: 'Turn on the "Bot" capability and enter Client ID and Client Secret below',
+    imDingtalkGuideStep1:
+      'Go to DingTalk Open Platform, create or pick an enterprise app under "App Development > Bot"',
+    imDingtalkGuideStep2:
+      'Copy the Client ID (AppKey) and Client Secret (AppSecret) from the credentials page',
+    imDingtalkGuideStep3:
+      'Turn on the "Bot" capability and enter Client ID and Client Secret below',
     imDingtalkGuideStep4: 'Once saved, the bot will auto-connect via Stream mode',
     imFeishuGuideStep1: 'Enter the Feishu bot App ID and App Secret below to complete setup',
-    imFeishuGuideStep2: 'App credentials are available on the Feishu Open Platform. See the setup manual for details.',
+    imFeishuGuideStep2:
+      'App credentials are available on the Feishu Open Platform. See the setup manual for details.',
     feishuBotCreateWizardTitle: 'Create Bot',
     feishuBotCreateWizardScanBtn: 'Scan QR Code to Create Bot',
-    feishuBotCreateWizardScanHint: 'Scan the QR code with your Feishu app to create and configure a bot in one step',
+    feishuBotCreateWizardScanHint:
+      'Scan the QR code with your Feishu app to create and configure a bot in one step',
     feishuBotCreateWizardOrManual: 'or manually enter / edit bot credentials',
     feishuBotCreateWizardOptionNew: 'Create a new bot',
     feishuBotCreateWizardOptionExisting: 'Use an existing bot',
-    feishuBotCreateWizardQrcodeDesc: 'Scan the QR code with your Feishu app and select "One-click create Feishu bot" to complete setup.',
+    feishuBotCreateWizardQrcodeDesc:
+      'Scan the QR code with your Feishu app and select "One-click create Feishu bot" to complete setup.',
     feishuBotCreateWizardQrcodeExpired: 'QR code expired, please refresh',
     feishuBotCreateWizardQrcodeRefresh: 'Refresh QR Code',
     feishuBotCreateWizardVerify: 'Verify',
@@ -2320,8 +2432,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imTelegramGuideStep4: 'Paste the token into the field below',
     imDiscordGuideStep1: 'Open Discord Developer Portal and create a new application',
     imDiscordGuideStep2: 'Under the Bot section, add a bot and copy its token',
-    imDiscordGuideStep3: 'Under Bot – Privileged Gateway Intents, enable Message Content and Server Members intents',
-    imDiscordGuideStep4: 'In the OAuth2 URL Generator, select "bot" and "applications.commands" with messaging permissions',
+    imDiscordGuideStep3:
+      'Under Bot – Privileged Gateway Intents, enable Message Content and Server Members intents',
+    imDiscordGuideStep4:
+      'In the OAuth2 URL Generator, select "bot" and "applications.commands" with messaging permissions',
     imDiscordGuideStep5: 'Invite the bot to your server using the generated URL',
     imDiscordGuideStep6: 'Paste the bot token into the field below',
 
@@ -2329,7 +2443,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     autoLaunch: 'Launch at Login',
     autoLaunchDescription: 'Automatically start the app when you log in',
     useSystemProxy: 'Use System Proxy',
-    useSystemProxyDescription: 'When enabled, network requests follow system proxy settings (applies after Save)',
+    useSystemProxyDescription:
+      'When enabled, network requests follow system proxy settings (applies after Save)',
     preventSleep: 'Prevent Sleep',
     preventSleepDescription: 'Prevent the system from sleeping while the app is running',
 
@@ -2436,13 +2551,15 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormValidationDatetimeFuture: 'Execution time must be in the future',
     scheduledTasksFormValidationIntervalPositive: 'Interval must be greater than 0',
     scheduledTasksFormValidationCronRequired: 'Cron expression is required',
-    scheduledTasksFormValidationPayloadMismatch: 'Main sessions require system events, isolated sessions require agent turns',
+    scheduledTasksFormValidationPayloadMismatch:
+      'Main sessions require system events, isolated sessions require agent turns',
     scheduledTasksFormValidationWebhookRequired: 'Webhook URL is required',
     scheduledTasksFormValidationTimeout: 'Timeout must be an integer greater than or equal to 0',
     scheduledTasksFormSubmitError: 'Save failed: ',
     scheduledTasksEdit: 'Edit',
     scheduledTasksDelete: 'Delete',
-    scheduledTasksDeleteConfirm: 'Are you sure you want to delete task "{name}"? This cannot be undone.',
+    scheduledTasksDeleteConfirm:
+      'Are you sure you want to delete task "{name}"? This cannot be undone.',
     scheduledTasksRun: 'Run Now',
     scheduledTasksStop: 'Stop',
     scheduledTasksEnabled: 'Enabled',
@@ -2539,13 +2656,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormNotifyConversationPlaceholder: 'Select target conversation',
     scheduledTasksFormNotifyConversationLoading: 'Loading conversations...',
     scheduledTasksFormNotifyConversationNone: 'No conversations available',
-    scheduledTasksToggleWarningAtPast: 'The execution time of this task has passed. It will not run after enabling',
+    scheduledTasksToggleWarningAtPast:
+      'The execution time of this task has passed. It will not run after enabling',
     scheduledTasksToggleWarningExpired: 'This task has expired. It will not run after enabling',
-    scheduledTasksDataAnomalyWarning: 'Scheduled task "{name}" has abnormal data. Display has been auto-corrected. Consider re-editing this task',
+    scheduledTasksDataAnomalyWarning:
+      'Scheduled task "{name}" has abnormal data. Display has been auto-corrected. Consider re-editing this task',
 
     // Privacy dialog
     privacyDialogTitle: 'NetEase Youdao LobsterAI Terms of Service',
-    privacyDialogDesc: 'Before using NetEase Youdao LobsterAI, please carefully read the {link} and confirm.',
+    privacyDialogDesc:
+      'Before using NetEase Youdao LobsterAI, please carefully read the {link} and confirm.',
     privacyDialogLinkText: 'NetEase Youdao LobsterAI Terms of Service',
     privacyDialogAccept: 'I have read and agree',
     privacyDialogReject: 'Decline',
@@ -2553,25 +2673,26 @@ const translations: Record<LanguageType, Record<string, string>> = {
     githubCopilotSignIn: 'Sign in with GitHub',
     githubCopilotSignOut: 'Sign Out',
     githubCopilotRequesting: 'Requesting device code...',
-    githubCopilotEnterCode: 'Open the link below in your browser and enter the device code to authorize:',
+    githubCopilotEnterCode:
+      'Open the link below in your browser and enter the device code to authorize:',
     githubCopilotWaiting: 'Waiting for authorization...',
     githubCopilotConnected: 'Connected',
     githubCopilotNoSubscription: 'You do not have an active GitHub Copilot subscription',
     copy: 'Copy',
 
     'settings.enterprise.managed': 'Managed by enterprise',
-  }
+  },
 };
 
 class I18nService {
   private currentLanguage: LanguageType = 'zh';
   private listeners = new Set<() => void>();
-  
+
   constructor() {
     // 默认使用中文
     this.currentLanguage = 'zh';
   }
-  
+
   // 初始化语言设置
   async initialize(): Promise<void> {
     try {
@@ -2591,7 +2712,7 @@ class I18nService {
           this.currentLanguage = config.language;
           configService.updateConfig({
             ...config,
-            language_initialized: true
+            language_initialized: true,
           });
         } else {
           // 新用户或使用默认中文的旧用户:检测系统语言
@@ -2599,7 +2720,9 @@ class I18nService {
             const systemLocale = await window.electron.appInfo.getSystemLocale();
             const defaultLanguage = this.inferLanguageFromLocale(systemLocale);
 
-            console.log(`[i18n] First run detected. System locale: ${systemLocale}, default language: ${defaultLanguage}`);
+            console.log(
+              `[i18n] First run detected. System locale: ${systemLocale}, default language: ${defaultLanguage}`,
+            );
 
             this.currentLanguage = defaultLanguage;
 
@@ -2607,7 +2730,7 @@ class I18nService {
             configService.updateConfig({
               ...config,
               language: defaultLanguage,
-              language_initialized: true
+              language_initialized: true,
             });
           } catch (error) {
             console.error('Failed to get system locale:', error);
@@ -2616,7 +2739,7 @@ class I18nService {
             configService.updateConfig({
               ...config,
               language: 'en',
-              language_initialized: true
+              language_initialized: true,
             });
           }
         }
@@ -2629,7 +2752,7 @@ class I18nService {
           this.currentLanguage = 'en';
           configService.updateConfig({
             ...config,
-            language: 'en'
+            language: 'en',
           });
         }
       }
@@ -2648,7 +2771,7 @@ class I18nService {
     }
     return 'en'; // 默认英文 (包括 zh-TW, zh-HK, en-*, 以及其他所有语言)
   }
-  
+
   // 设置语言
   setLanguage(language: LanguageType, options: { persist?: boolean } = {}): void {
     const { persist = true } = options;
@@ -2656,7 +2779,7 @@ class I18nService {
     this.currentLanguage = language;
 
     if (hasChanged) {
-      this.listeners.forEach((listener) => listener());
+      this.listeners.forEach(listener => listener());
     }
 
     if (!persist) {
@@ -2668,18 +2791,18 @@ class I18nService {
       const config = configService.getConfig();
       configService.updateConfig({
         ...config,
-        language
+        language,
       });
     } catch (error) {
       console.error('Failed to save language setting:', error);
     }
   }
-  
+
   // 获取当前语言
   getLanguage(): LanguageType {
     return this.currentLanguage;
   }
-  
+
   // 获取翻译文本
   t(key: string): string {
     const translation = translations[this.currentLanguage][key];
@@ -2700,4 +2823,4 @@ class I18nService {
   }
 }
 
-export const i18nService = new I18nService(); 
+export const i18nService = new I18nService();


### PR DESCRIPTION
## 功能背景
长时间运行的 Cowork 会话会不断积累对话历史，当内容超出模型的上下文窗口限制时，
触发不可恢复的「输入过长」错误。用户此前只能删除会话重新开始，丢失所有上下文。
对标 OpenClaw 的 Session Pruning 能力，本次为 LobsterAI 引入自动会话裁剪机制。
## 根本原因
`coworkRunner.ts` 在会话重启后注入历史时（`injectLocalHistoryPrompt`），
使用固定的字符数上限（32000 chars / 24 条消息）进行截断。该策略与模型实际
的 token 上下文窗口脱节：
- 无 token 估算能力，不知道当前对话还剩多少空间
- 固定字符限制无法适配不同上下文窗口（claude 200k vs gpt-3.5 16k）
- 历史注入时不区分「消息在预算内」vs「消息已超出上下文」
当会话超长时系统直接报错，既无提示也无自动恢复。
## 实现方案
### 新文件：`src/main/libs/sessionPruning.ts`
**Token 估算**（无需外部 tokenizer 库）：
- 英文/代码：~1 token / 3.5 字符
- 中日韩字符：~1 token / 1.5 字符
- 每条消息额外 4 token 的格式开销（role/分隔符）
**滑动窗口裁剪策略**：
所有消息（按时间排序）
      │
      ▼
从最新消息向前累加 token 估算
      │
      ├── token 预算充足 → 继续向前包含消息
      │
      └── 超出预算 → 停止，保留已累加的最近消息
                    + 前缀注明省略了多少条早期消息
为系统提示 + 模型响应预留 40% 上下文空间，历史注入最多使用 60%。
**上下文窗口注册表**（`DEFAULT_CONTEXT_WINDOWS`）：
| 模型家族 | 上下文窗口 |
|---|---|
| claude | 200,000 tokens |
| gpt-4 | 128,000 tokens |
| gpt-3.5 | 16,000 tokens |
| deepseek | 64,000 tokens |
| qwen | 128,000 tokens |
| gemini | 1,000,000 tokens |
| 默认 | 128,000 tokens |
### 集成：`src/main/libs/coworkRunner.ts`
- 新增 `SESSION_PRUNING_THRESHOLD = 0.75` 常量
- `injectLocalHistoryPrompt()` 在构建历史块前先调用 `pruneMessages()`
- 超出预算的旧消息被省略，历史前缀改为：
  `"会话已重启。[此对话共 N 条消息，最早 M 条已省略以适应上下文窗口。]
  以下是近期对话历史..."`
- 在 `startSession()` 中增加主动裁剪检查，当估算 token 超过阈值时打印日志
### `src/renderer/services/i18n.ts`
- 更新 `coworkErrorInputTooLong`（中/英）：从「请手动缩短」改为「系统将自动压缩历史」
- 新增 `sessionPruningNotice` 键，用于 UI 通知（中/英）
## 变更文件
- `src/main/libs/sessionPruning.ts`（新增）— 核心裁剪工具函数
- `src/main/libs/sessionPruning.test.ts`（新增）— 22 个单元测试
- `src/main/libs/coworkRunner.ts` — 集成裁剪逻辑
- `src/renderer/services/i18n.ts` — 更新错误提示文案
## 设计决策
| 决策 | 理由 |
|---|---|
| 字符启发式而非真实 tokenizer | 无需引入 tiktoken 等依赖，估算结果有意保守（略微高估）以留安全余量 |
| 阈值设为 75% | 提前裁剪，给系统提示 + 当前请求 + 模型响应预留足够空间 |
| 历史使用 60% 预算 | 其余 40% 留给系统提示、当前请求和模型输出 |
| OpenClaw 引擎不需裁剪 | OpenClaw 网关自身管理 byte-bounded 上下文窗口，LobsterAI 不需干预 |
| 保留最新消息 | 最近的对话比早期消息更有上下文相关性 |
## 测试结果
Test Files  1 passed (1)
Tests      22 passed (22)