### PR TITLE
禁用技能后仍保留在activeSkillIds中，对话中继续被调用

### DIFF
--- a/src/renderer/store/slices/skillSlice.ts
+++ b/src/renderer/store/slices/skillSlice.ts
@@ -17,9 +17,9 @@ const skillSlice = createSlice({
   reducers: {
     setSkills: (state, action: PayloadAction<Skill[]>) => {
       state.skills = action.payload;
-      // Remove any active skill IDs that no longer exist
+      // Remove any active skill IDs that no longer exist or are now disabled
       state.activeSkillIds = state.activeSkillIds.filter(id =>
-        action.payload.some(skill => skill.id === id)
+        action.payload.some(skill => skill.id === id && skill.enabled)
       );
     },
     addSkill: (state, action: PayloadAction<Skill>) => {


### PR DESCRIPTION
## 问题描述

在技能管理器中将某个技能禁用后，该技能的 ID 仍然保留在 `activeSkillIds` 中，导致已禁用的技能在下次对话时依然被注入到提示词中持续生效。

## 修复方案

修改 `src/renderer/store/slices/skillSlice.ts` 中 `setSkills` reducer 的过滤逻辑，在清理 `activeSkillIds` 时同时检查技能是否 `enabled`：

```ts
// 修复前：只检查技能是否存在
state.activeSkillIds = state.activeSkillIds.filter(id =>
  action.payload.some(skill => skill.id === id)
);

// 修复后：同时检查技能是否启用
state.activeSkillIds = state.activeSkillIds.filter(id =>
  action.payload.some(skill => skill.id === id && skill.enabled)
);
```

## 影响范围

仅修改 `skillSlice.ts` 一行过滤条件，影响范围极小。禁用技能后可立即从活跃列表中移除，对话不再注入已停用技能。

关联 Issue: #1500