### PR TITLE
feat(settings): 为 Agent 引导文件编辑器引入富文本 Markdown 编辑器

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@nodesecure/js-x-ray": "^14.2.0",
     "@reduxjs/toolkit": "^2.2.1",
     "@types/uuid": "^10.0.0",
+    "@uiw/react-md-editor": "^4.1.0",
     "@wecom/wecom-aibot-sdk": "^0.1.0",
     "better-sqlite3": "^12.8.0",
     "bufferutil": "^4.1.0",

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1,56 +1,94 @@
-import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import Modal from './common/Modal';
-import { configService } from '../services/config';
-import { apiService } from '../services/api';
-import { checkForAppUpdate } from '../services/appUpdate';
-import type { AppUpdateInfo } from '../services/appUpdate';
-import { themeService } from '../services/theme';
-import { i18nService, LanguageType } from '../services/i18n';
-import { decryptSecret, encryptWithPassword, decryptWithPassword, EncryptedPayload, PasswordEncryptedPayload } from '../services/encryption';
-import { coworkService } from '../services/cowork';
-import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
-import ErrorMessage from './ErrorMessage';
-import { XMarkIcon, Cog6ToothIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, EnvelopeIcon, CpuChipIcon, InformationCircleIcon, UserCircleIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
-import PlusCircleIcon from './icons/PlusCircleIcon';
-import TrashIcon from './icons/TrashIcon';
-import PencilIcon from './icons/PencilIcon';
-import BrainIcon from './icons/BrainIcon';
+import {
+  ArrowTopRightOnSquareIcon,
+  ChatBubbleLeftIcon,
+  CheckCircleIcon,
+  Cog6ToothIcon,
+  CpuChipIcon,
+  CubeIcon,
+  EnvelopeIcon,
+  FolderOpenIcon,
+  InformationCircleIcon,
+  SignalIcon,
+  UserCircleIcon,
+  XCircleIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { setAvailableModels } from '../store/slices/modelSlice';
+
+import { ProviderRegistry, resolveCodingPlanBaseUrl } from '../../shared/providers';
+import {
+  type AppConfig,
+  defaultConfig,
+  getCustomProviderDefaultName,
+  getProviderDisplayName,
+  getVisibleProviders,
+  isCustomProvider,
+} from '../config';
+import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
+import { apiService } from '../services/api';
+import type { AppUpdateInfo } from '../services/appUpdate';
+import { checkForAppUpdate } from '../services/appUpdate';
+import { configService } from '../services/config';
+import { coworkService } from '../services/cowork';
+import {
+  decryptSecret,
+  decryptWithPassword,
+  EncryptedPayload,
+  encryptWithPassword,
+  PasswordEncryptedPayload,
+} from '../services/encryption';
+import { i18nService, LanguageType } from '../services/i18n';
+import { imService } from '../services/im';
+import { themeService } from '../services/theme';
 import { RootState } from '../store';
-import ThemedSelect from './ui/ThemedSelect';
+import { setAvailableModels } from '../store/slices/modelSlice';
 import type {
   CoworkAgentEngine,
-  OpenClawEngineStatus,
-  CoworkUserMemoryEntry,
   CoworkMemoryStats,
+  CoworkUserMemoryEntry,
+  OpenClawEngineStatus,
 } from '../types/cowork';
-import IMSettings from './im/IMSettings';
-import { imService } from '../services/im';
-import EmailSkillConfig from './skills/EmailSkillConfig';
-import { ProviderRegistry, resolveCodingPlanBaseUrl } from '../../shared/providers';
-import { defaultConfig, type AppConfig, getVisibleProviders, isCustomProvider, getCustomProviderDefaultName,getProviderDisplayName } from '../config';
+import MarkdownEditor from './common/MarkdownEditor';
+import Modal from './common/Modal';
+import ErrorMessage from './ErrorMessage';
+import BrainIcon from './icons/BrainIcon';
+import PencilIcon from './icons/PencilIcon';
+import PlusCircleIcon from './icons/PlusCircleIcon';
 import {
-  OpenAIIcon,
+  AnthropicIcon,
+  CustomProviderIcon,
   DeepSeekIcon,
   GeminiIcon,
-  AnthropicIcon,
-  MoonshotIcon,
-  ZhipuIcon,
+  GitHubCopilotIcon,
   MiniMaxIcon,
-  YouDaoZhiYunIcon,
+  MoonshotIcon,
+  OllamaIcon,
+  OpenAIIcon,
+  OpenRouterIcon,
   QwenIcon,
-  XiaomiIcon,
   StepfunIcon,
   VolcengineIcon,
-  OpenRouterIcon,
-  OllamaIcon,
-  GitHubCopilotIcon,
-  CustomProviderIcon,
+  XiaomiIcon,
+  YouDaoZhiYunIcon,
+  ZhipuIcon,
 } from './icons/providers';
+import TrashIcon from './icons/TrashIcon';
+import IMSettings from './im/IMSettings';
+import EmailSkillConfig from './skills/EmailSkillConfig';
+import ThemedSelect from './ui/ThemedSelect';
 
-type TabType = 'general'| 'coworkAgentEngine' | 'model' | 'coworkMemory' | 'coworkAgent' | 'shortcuts' | 'im' | 'email' | 'about';
+type TabType =
+  | 'general'
+  | 'coworkAgentEngine'
+  | 'model'
+  | 'coworkMemory'
+  | 'coworkAgent'
+  | 'shortcuts'
+  | 'im'
+  | 'email'
+  | 'about';
 
 export type SettingsOpenOptions = {
   initialTab?: TabType;
@@ -68,10 +106,17 @@ interface SettingsProps extends SettingsOpenOptions {
   } | null;
 }
 
-
 const CUSTOM_PROVIDER_KEYS = [
-  'custom_0', 'custom_1', 'custom_2', 'custom_3', 'custom_4',
-  'custom_5', 'custom_6', 'custom_7', 'custom_8', 'custom_9',
+  'custom_0',
+  'custom_1',
+  'custom_2',
+  'custom_3',
+  'custom_4',
+  'custom_5',
+  'custom_6',
+  'custom_7',
+  'custom_8',
+  'custom_9',
 ] as const;
 
 const providerKeys = [
@@ -162,37 +207,69 @@ const providerMeta: Record<ProviderType, { label: string; icon: React.ReactNode 
   openrouter: { label: 'OpenRouter', icon: <OpenRouterIcon /> },
   'github-copilot': { label: 'GitHub Copilot', icon: <GitHubCopilotIcon /> },
   ollama: { label: 'Ollama', icon: <OllamaIcon /> },
-  ...Object.fromEntries(
-    CUSTOM_PROVIDER_KEYS.map(key => [key, { label: getCustomProviderDefaultName(key), icon: <CustomProviderIcon /> }])
-  ) as Record<(typeof CUSTOM_PROVIDER_KEYS)[number], { label: string; icon: React.ReactNode }>,
+  ...(Object.fromEntries(
+    CUSTOM_PROVIDER_KEYS.map(key => [
+      key,
+      { label: getCustomProviderDefaultName(key), icon: <CustomProviderIcon /> },
+    ]),
+  ) as Record<(typeof CUSTOM_PROVIDER_KEYS)[number], { label: string; icon: React.ReactNode }>),
 };
 
 const providerLinks: Partial<Record<ProviderType, { website: string; apiKey?: string }>> = {
-  openai:       { website: 'https://platform.openai.com',              apiKey: 'https://platform.openai.com/api-keys' },
-  gemini:       { website: 'https://aistudio.google.com',              apiKey: 'https://aistudio.google.com/apikey' },
-  anthropic:    { website: 'https://console.anthropic.com',            apiKey: 'https://console.anthropic.com/settings/keys' },
-  deepseek:     { website: 'https://platform.deepseek.com',            apiKey: 'https://platform.deepseek.com/api_keys' },
-  moonshot:     { website: 'https://platform.moonshot.cn',             apiKey: 'https://platform.moonshot.cn/console/api-keys' },
-  zhipu:        { website: 'https://open.bigmodel.cn',                 apiKey: 'https://open.bigmodel.cn/usercenter/apikeys' },
-  minimax:      { website: 'https://platform.minimaxi.com',            apiKey: 'https://platform.minimaxi.com/user-center/basic-information/interface-key' },
-  volcengine:   { website: 'https://console.volcengine.com/ark',       apiKey: 'https://console.volcengine.com/ark' },
-  qwen:         { website: 'https://dashscope.console.aliyun.com',     apiKey: 'https://dashscope.console.aliyun.com/apiKey' },
-  youdaozhiyun: { website: 'https://ai.youdao.com',                    apiKey: 'https://ai.youdao.com/console' },
-  stepfun:      { website: 'https://platform.stepfun.com',             apiKey: 'https://platform.stepfun.com/interface-key' },
-  xiaomi:       { website: 'https://dev.mi.com/platform',              apiKey: 'https://dev.mi.com/platform' },
-  openrouter:   { website: 'https://openrouter.ai',                    apiKey: 'https://openrouter.ai/keys' },
-  ollama:       { website: 'https://ollama.com' },
+  openai: {
+    website: 'https://platform.openai.com',
+    apiKey: 'https://platform.openai.com/api-keys',
+  },
+  gemini: { website: 'https://aistudio.google.com', apiKey: 'https://aistudio.google.com/apikey' },
+  anthropic: {
+    website: 'https://console.anthropic.com',
+    apiKey: 'https://console.anthropic.com/settings/keys',
+  },
+  deepseek: {
+    website: 'https://platform.deepseek.com',
+    apiKey: 'https://platform.deepseek.com/api_keys',
+  },
+  moonshot: {
+    website: 'https://platform.moonshot.cn',
+    apiKey: 'https://platform.moonshot.cn/console/api-keys',
+  },
+  zhipu: {
+    website: 'https://open.bigmodel.cn',
+    apiKey: 'https://open.bigmodel.cn/usercenter/apikeys',
+  },
+  minimax: {
+    website: 'https://platform.minimaxi.com',
+    apiKey: 'https://platform.minimaxi.com/user-center/basic-information/interface-key',
+  },
+  volcengine: {
+    website: 'https://console.volcengine.com/ark',
+    apiKey: 'https://console.volcengine.com/ark',
+  },
+  qwen: {
+    website: 'https://dashscope.console.aliyun.com',
+    apiKey: 'https://dashscope.console.aliyun.com/apiKey',
+  },
+  youdaozhiyun: { website: 'https://ai.youdao.com', apiKey: 'https://ai.youdao.com/console' },
+  stepfun: {
+    website: 'https://platform.stepfun.com',
+    apiKey: 'https://platform.stepfun.com/interface-key',
+  },
+  xiaomi: { website: 'https://dev.mi.com/platform', apiKey: 'https://dev.mi.com/platform' },
+  openrouter: { website: 'https://openrouter.ai', apiKey: 'https://openrouter.ai/keys' },
+  ollama: { website: 'https://ollama.com' },
 };
 
-const providerRequiresApiKey = (provider: ProviderType) => provider !== 'ollama' && provider !== 'github-copilot';
-const normalizeBaseUrl = (baseUrl: string): string => baseUrl.trim().replace(/\/+$/, '').toLowerCase();
-const normalizeApiFormat = (value: unknown): 'anthropic' | 'openai' => (
-  value === 'openai' ? 'openai' : 'anthropic'
-);
+const providerRequiresApiKey = (provider: ProviderType) =>
+  provider !== 'ollama' && provider !== 'github-copilot';
+const normalizeBaseUrl = (baseUrl: string): string =>
+  baseUrl.trim().replace(/\/+$/, '').toLowerCase();
+const normalizeApiFormat = (value: unknown): 'anthropic' | 'openai' =>
+  value === 'openai' ? 'openai' : 'anthropic';
 const ABOUT_CONTACT_EMAIL = 'lobsterai.project@rd.netease.com';
 const ABOUT_USER_MANUAL_URL = 'https://lobsterai.youdao.com/#/docs/lobsterai_user_manual';
 const ABOUT_USER_COMMUNITY_URL = 'https://lobsterai.youdao.com/#/about';
-const ABOUT_SERVICE_TERMS_URL = 'https://c.youdao.com/dict/hardware/lobsterai/lobsterai_service.html';
+const ABOUT_SERVICE_TERMS_URL =
+  'https://c.youdao.com/dict/hardware/lobsterai/lobsterai_service.html';
 
 // MiniMax Portal OAuth constants
 const MINIMAX_OAUTH_CLIENT_ID = '78257093-7e40-4613-99e0-527b14b39113';
@@ -213,19 +290,29 @@ type MiniMaxOAuthPhase =
   | { kind: 'success' }
   | { kind: 'error'; message: string };
 
-async function generateMiniMaxPkce(): Promise<{ verifier: string; challenge: string; state: string }> {
+async function generateMiniMaxPkce(): Promise<{
+  verifier: string;
+  challenge: string;
+  state: string;
+}> {
   const verifierArray = new Uint8Array(32);
   crypto.getRandomValues(verifierArray);
   const verifier = btoa(String.fromCharCode(...verifierArray))
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
   const encoded = new TextEncoder().encode(verifier);
   const digest = await crypto.subtle.digest('SHA-256', encoded);
   const challenge = btoa(String.fromCharCode(...new Uint8Array(digest)))
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
   const stateArray = new Uint8Array(16);
   crypto.getRandomValues(stateArray);
   const state = btoa(String.fromCharCode(...stateArray))
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
   return { verifier, challenge, state };
 }
 
@@ -263,7 +350,9 @@ const copyTextToClipboard = async (text: string): Promise<boolean> => {
   }
 };
 
-const getFixedApiFormatForProvider = (provider: string): 'anthropic' | 'openai' | 'gemini' | null => {
+const getFixedApiFormatForProvider = (
+  provider: string,
+): 'anthropic' | 'openai' | 'gemini' | null => {
   if (provider === 'openai' || provider === 'stepfun') {
     return 'openai';
   }
@@ -284,15 +373,16 @@ const getFixedApiFormatForProvider = (provider: string): 'anthropic' | 'openai' 
   }
   return null;
 };
-const getEffectiveApiFormat = (provider: string, value: unknown): 'anthropic' | 'openai' | 'gemini' => (
-  getFixedApiFormatForProvider(provider) ?? normalizeApiFormat(value)
-);
-const shouldShowApiFormatSelector = (provider: string): boolean => (
-  getFixedApiFormatForProvider(provider) === null
-);
+const getEffectiveApiFormat = (
+  provider: string,
+  value: unknown,
+): 'anthropic' | 'openai' | 'gemini' =>
+  getFixedApiFormatForProvider(provider) ?? normalizeApiFormat(value);
+const shouldShowApiFormatSelector = (provider: string): boolean =>
+  getFixedApiFormatForProvider(provider) === null;
 const getProviderDefaultBaseUrl = (
   provider: ProviderType,
-  apiFormat: 'anthropic' | 'openai' | 'gemini'
+  apiFormat: 'anthropic' | 'openai' | 'gemini',
 ): string | null => {
   if (apiFormat === 'gemini') return null;
   return ProviderRegistry.getSwitchableBaseUrl(provider, apiFormat) ?? null;
@@ -300,20 +390,28 @@ const getProviderDefaultBaseUrl = (
 const resolveBaseUrl = (
   provider: ProviderType,
   baseUrl: string,
-  apiFormat: 'anthropic' | 'openai' | 'gemini'
+  apiFormat: 'anthropic' | 'openai' | 'gemini',
 ): string => {
   if (baseUrl.trim()) {
-    if (shouldAutoSwitchProviderBaseUrl(provider, baseUrl) && (apiFormat === 'anthropic' || apiFormat === 'openai')) {
+    if (
+      shouldAutoSwitchProviderBaseUrl(provider, baseUrl) &&
+      (apiFormat === 'anthropic' || apiFormat === 'openai')
+    ) {
       const switchedUrl = ProviderRegistry.getSwitchableBaseUrl(provider, apiFormat);
       if (switchedUrl) return switchedUrl;
     }
     return baseUrl;
   }
-  return getProviderDefaultBaseUrl(provider, apiFormat)
-    || defaultConfig.providers?.[provider]?.baseUrl
-    || '';
+  return (
+    getProviderDefaultBaseUrl(provider, apiFormat) ||
+    defaultConfig.providers?.[provider]?.baseUrl ||
+    ''
+  );
 };
-const shouldAutoSwitchProviderBaseUrl = (provider: ProviderType, currentBaseUrl: string): boolean => {
+const shouldAutoSwitchProviderBaseUrl = (
+  provider: ProviderType,
+  currentBaseUrl: string,
+): boolean => {
   const anthropicUrl = ProviderRegistry.getSwitchableBaseUrl(provider, 'anthropic');
   const openaiUrl = ProviderRegistry.getSwitchableBaseUrl(provider, 'openai');
   if (!anthropicUrl && !openaiUrl) {
@@ -322,8 +420,8 @@ const shouldAutoSwitchProviderBaseUrl = (provider: ProviderType, currentBaseUrl:
 
   const normalizedCurrent = normalizeBaseUrl(currentBaseUrl);
   return (
-    (anthropicUrl ? normalizedCurrent === normalizeBaseUrl(anthropicUrl) : false)
-    || (openaiUrl ? normalizedCurrent === normalizeBaseUrl(openaiUrl) : false)
+    (anthropicUrl ? normalizedCurrent === normalizeBaseUrl(anthropicUrl) : false) ||
+    (openaiUrl ? normalizedCurrent === normalizeBaseUrl(openaiUrl) : false)
   );
 };
 const buildOpenAICompatibleChatCompletionsUrl = (baseUrl: string, provider: string): string => {
@@ -335,15 +433,14 @@ const buildOpenAICompatibleChatCompletionsUrl = (baseUrl: string, provider: stri
     return normalized;
   }
 
-  const isGeminiLike = provider === 'gemini' || normalized.includes('generativelanguage.googleapis.com');
+  const isGeminiLike =
+    provider === 'gemini' || normalized.includes('generativelanguage.googleapis.com');
   if (isGeminiLike) {
     if (normalized.endsWith('/v1beta/openai') || normalized.endsWith('/v1/openai')) {
       return `${normalized}/chat/completions`;
     }
     if (normalized.endsWith('/v1beta') || normalized.endsWith('/v1')) {
-      const betaBase = normalized.endsWith('/v1')
-        ? `${normalized.slice(0, -3)}v1beta`
-        : normalized;
+      const betaBase = normalized.endsWith('/v1') ? `${normalized.slice(0, -3)}v1beta` : normalized;
       return `${betaBase}/openai/chat/completions`;
     }
     return `${normalized}/v1beta/openai/chat/completions`;
@@ -372,9 +469,7 @@ const buildOpenAIResponsesUrl = (baseUrl: string): string => {
   }
   return `${normalized}/v1/responses`;
 };
-const shouldUseOpenAIResponsesForProvider = (provider: string): boolean => (
-  provider === 'openai'
-);
+const shouldUseOpenAIResponsesForProvider = (provider: string): boolean => provider === 'openai';
 const shouldUseMaxCompletionTokensForOpenAI = (provider: string, modelId?: string): boolean => {
   if (provider !== 'openai') {
     return false;
@@ -383,10 +478,12 @@ const shouldUseMaxCompletionTokensForOpenAI = (provider: string, modelId?: strin
   const resolvedModel = normalizedModel.includes('/')
     ? normalizedModel.slice(normalizedModel.lastIndexOf('/') + 1)
     : normalizedModel;
-  return resolvedModel.startsWith('gpt-5')
-    || resolvedModel.startsWith('o1')
-    || resolvedModel.startsWith('o3')
-    || resolvedModel.startsWith('o4');
+  return (
+    resolvedModel.startsWith('gpt-5') ||
+    resolvedModel.startsWith('o1') ||
+    resolvedModel.startsWith('o3') ||
+    resolvedModel.startsWith('o4')
+  );
 };
 const CONNECTIVITY_TEST_TOKEN_BUDGET = 64;
 
@@ -405,7 +502,7 @@ const getDefaultProviders = (): ProvidersConfig => {
           supportsImage: model.supportsImage ?? false,
         })),
       },
-    ])
+    ]),
   ) as ProvidersConfig;
 };
 
@@ -448,16 +545,26 @@ const formatShortcutFromEvent = (e: React.KeyboardEvent): string | null => {
   if (e.shiftKey) parts.push('Shift');
 
   const keyMap: Record<string, string> = {
-    ArrowUp: 'Up', ArrowDown: 'Down', ArrowLeft: 'Left', ArrowRight: 'Right',
-    ' ': 'Space', Escape: 'Esc', Enter: 'Enter', Backspace: 'Backspace',
-    Delete: 'Delete', Tab: 'Tab',
+    ArrowUp: 'Up',
+    ArrowDown: 'Down',
+    ArrowLeft: 'Left',
+    ArrowRight: 'Right',
+    ' ': 'Space',
+    Escape: 'Esc',
+    Enter: 'Enter',
+    Backspace: 'Backspace',
+    Delete: 'Delete',
+    Tab: 'Tab',
   };
   const key = keyMap[e.key] ?? (e.key.length === 1 ? e.key.toUpperCase() : e.key);
   parts.push(key);
   return parts.join('+');
 };
 
-const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void }> = ({ value, onChange }) => {
+const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void }> = ({
+  value,
+  onChange,
+}) => {
   const [recording, setRecording] = useState(false);
   const divRef = useRef<HTMLDivElement>(null);
 
@@ -465,10 +572,20 @@ const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void 
     if (!recording) return;
     e.preventDefault();
     e.stopPropagation();
-    if (e.key === 'Escape') { setRecording(false); return; }
-    if (e.key === 'Delete' || e.key === 'Backspace') { onChange(''); setRecording(false); return; }
+    if (e.key === 'Escape') {
+      setRecording(false);
+      return;
+    }
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      onChange('');
+      setRecording(false);
+      return;
+    }
     const shortcut = formatShortcutFromEvent(e);
-    if (shortcut) { onChange(shortcut); setRecording(false); }
+    if (shortcut) {
+      onChange(shortcut);
+      setRecording(false);
+    }
   };
 
   useEffect(() => {
@@ -490,9 +607,10 @@ const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void 
       onBlur={() => setRecording(false)}
       className={`w-36 rounded-xl border px-3 py-1.5 text-sm cursor-pointer select-none text-center outline-none transition-colors
         dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset dark:text-claude-darkText text-claude-text
-        ${recording
-          ? 'border-claude-accent ring-1 ring-claude-accent/30 dark:text-claude-darkTextSecondary text-claude-textSecondary'
-          : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
+        ${
+          recording
+            ? 'border-claude-accent ring-1 ring-claude-accent/30 dark:text-claude-darkTextSecondary text-claude-textSecondary'
+            : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
         }`}
     >
       {value || i18nService.t('shortcutNotSet')}
@@ -500,7 +618,15 @@ const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void 
   );
 };
 
-const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, noticeI18nKey, noticeExtra, onUpdateFound, enterpriseConfig }) => {
+const Settings: React.FC<SettingsProps> = ({
+  onClose,
+  initialTab,
+  notice,
+  noticeI18nKey,
+  noticeExtra,
+  onUpdateFound,
+  enterpriseConfig,
+}) => {
   const dispatch = useDispatch();
   // 状态
   const [activeTab, setActiveTab] = useState<TabType>(initialTab ?? 'general');
@@ -546,17 +672,21 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   // Add state for providers configuration
   const [providers, setProviders] = useState<ProvidersConfig>(() => getDefaultProviders());
 
-
   // authType defaults to undefined on first open, which should behave as OAuth mode
   const minimaxIsOAuthMode = providers.minimax.authType !== 'apikey';
-  const isBaseUrlLocked = (activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled) || (activeProvider === 'qwen' && providers.qwen.codingPlanEnabled) || (activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled) || (activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled) || (activeProvider === 'minimax' && minimaxIsOAuthMode);
-  
+  const isBaseUrlLocked =
+    (activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled) ||
+    (activeProvider === 'qwen' && providers.qwen.codingPlanEnabled) ||
+    (activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled) ||
+    (activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled) ||
+    (activeProvider === 'minimax' && minimaxIsOAuthMode);
+
   // 创建引用来确保内容区域的滚动
   const contentRef = useRef<HTMLDivElement>(null);
   const importInputRef = useRef<HTMLInputElement>(null);
   const emailCopiedTimerRef = useRef<number | null>(null);
   const updateCheckTimerRef = useRef<number | null>(null);
-  
+
   // 快捷键设置
   const [shortcuts, setShortcuts] = useState({
     newChat: 'Ctrl+N',
@@ -565,7 +695,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   });
 
   // GitHub Copilot device code auth state
-  const [copilotAuthStatus, setCopilotAuthStatus] = useState<'idle' | 'requesting' | 'awaiting_user' | 'polling' | 'authenticated' | 'error'>('idle');
+  const [copilotAuthStatus, setCopilotAuthStatus] = useState<
+    'idle' | 'requesting' | 'awaiting_user' | 'polling' | 'authenticated' | 'error'
+  >('idle');
   const [copilotUserCode, setCopilotUserCode] = useState('');
   const [copilotVerificationUri, setCopilotVerificationUri] = useState('');
   const [copilotGithubUser, setCopilotGithubUser] = useState('');
@@ -587,7 +719,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [testMode, setTestMode] = useState(false);
   const [logoClickCount, setLogoClickCount] = useState(0);
   const [testModeUnlocked, setTestModeUnlocked] = useState(false);
-  const [updateCheckStatus, setUpdateCheckStatus] = useState<'idle' | 'checking' | 'upToDate' | 'error'>('idle');
+  const [updateCheckStatus, setUpdateCheckStatus] = useState<
+    'idle' | 'checking' | 'upToDate' | 'error'
+  >('idle');
 
   useEffect(() => {
     window.electron.appInfo.getVersion().then(setAppVersion);
@@ -682,7 +816,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         setNoticeMessage(i18nService.t('aboutExportLogsSuccess'));
       }
     } catch (exportError) {
-      setError(exportError instanceof Error ? exportError.message : i18nService.t('aboutExportLogsFailed'));
+      setError(
+        exportError instanceof Error ? exportError.message : i18nService.t('aboutExportLogsFailed'),
+      );
     } finally {
       setIsExportingLogs(false);
     }
@@ -690,9 +826,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   const coworkConfig = useSelector((state: RootState) => state.cowork.config);
 
-  const [coworkAgentEngine, setCoworkAgentEngine] = useState<CoworkAgentEngine>(coworkConfig.agentEngine || 'openclaw');
-  const [coworkMemoryEnabled, setCoworkMemoryEnabled] = useState<boolean>(coworkConfig.memoryEnabled ?? true);
-  const [coworkMemoryLlmJudgeEnabled, setCoworkMemoryLlmJudgeEnabled] = useState<boolean>(coworkConfig.memoryLlmJudgeEnabled ?? false);
+  const [coworkAgentEngine, setCoworkAgentEngine] = useState<CoworkAgentEngine>(
+    coworkConfig.agentEngine || 'openclaw',
+  );
+  const [coworkMemoryEnabled, setCoworkMemoryEnabled] = useState<boolean>(
+    coworkConfig.memoryEnabled ?? true,
+  );
+  const [coworkMemoryLlmJudgeEnabled, setCoworkMemoryLlmJudgeEnabled] = useState<boolean>(
+    coworkConfig.memoryLlmJudgeEnabled ?? false,
+  );
   const [coworkMemoryEntries, setCoworkMemoryEntries] = useState<CoworkUserMemoryEntry[]>([]);
   const [coworkMemoryStats, setCoworkMemoryStats] = useState<CoworkMemoryStats | null>(null);
   const [coworkMemoryListLoading, setCoworkMemoryListLoading] = useState<boolean>(false);
@@ -704,34 +846,39 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [bootstrapUser, setBootstrapUser] = useState<string>('');
   const [bootstrapSoul, setBootstrapSoul] = useState<string>('');
   const [bootstrapLoaded, setBootstrapLoaded] = useState<boolean>(false);
-  const [openClawEngineStatus, setOpenClawEngineStatus] = useState<OpenClawEngineStatus | null>(null);
+  const [bootstrapLoading, setBootstrapLoading] = useState<boolean>(false);
+  const [bootstrapActiveFile, setBootstrapActiveFile] = useState<'identity' | 'soul' | 'user'>(
+    'identity',
+  );
+  const [openClawEngineStatus, setOpenClawEngineStatus] = useState<OpenClawEngineStatus | null>(
+    null,
+  );
 
   useEffect(() => {
     setCoworkAgentEngine(coworkConfig.agentEngine || 'openclaw');
     setCoworkMemoryEnabled(coworkConfig.memoryEnabled ?? true);
     setCoworkMemoryLlmJudgeEnabled(coworkConfig.memoryLlmJudgeEnabled ?? false);
-  }, [
-    coworkConfig.agentEngine,
-    coworkConfig.memoryEnabled,
-    coworkConfig.memoryLlmJudgeEnabled,
-  ]);
+  }, [coworkConfig.agentEngine, coworkConfig.memoryEnabled, coworkConfig.memoryLlmJudgeEnabled]);
 
-  useEffect(() => () => {
-    if (emailCopiedTimerRef.current != null) {
-      window.clearTimeout(emailCopiedTimerRef.current);
-    }
-    if (updateCheckTimerRef.current != null) {
-      window.clearTimeout(updateCheckTimerRef.current);
-    }
-  }, []);
+  useEffect(
+    () => () => {
+      if (emailCopiedTimerRef.current != null) {
+        window.clearTimeout(emailCopiedTimerRef.current);
+      }
+      if (updateCheckTimerRef.current != null) {
+        window.clearTimeout(updateCheckTimerRef.current);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     let active = true;
-    void coworkService.getOpenClawEngineStatus().then((status) => {
+    void coworkService.getOpenClawEngineStatus().then(status => {
       if (!active || !status) return;
       setOpenClawEngineStatus(status);
     });
-    const unsubscribe = coworkService.onOpenClawEngineStatus((status) => {
+    const unsubscribe = coworkService.onOpenClawEngineStatus(status => {
       if (!active) return;
       setOpenClawEngineStatus(status);
     });
@@ -744,7 +891,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   useEffect(() => {
     try {
       const config = configService.getConfig();
-      
+
       // Set general settings
       initialThemeRef.current = config.theme;
       initialLanguageRef.current = config.language;
@@ -756,18 +903,24 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       if (savedTestMode) setTestModeUnlocked(true);
 
       // Load auto-launch setting
-      window.electron.autoLaunch.get().then(({ enabled }) => {
-        setAutoLaunchState(enabled);
-      }).catch(err => {
-        console.error('Failed to load auto-launch setting:', err);
-      });
+      window.electron.autoLaunch
+        .get()
+        .then(({ enabled }) => {
+          setAutoLaunchState(enabled);
+        })
+        .catch(err => {
+          console.error('Failed to load auto-launch setting:', err);
+        });
 
       // Load prevent-sleep setting
-      window.electron.preventSleep.get().then(({ enabled }) => {
-        setPreventSleepState(enabled);
-      }).catch(err => {
-        console.error('Failed to load prevent-sleep setting:', err);
-      });
+      window.electron.preventSleep
+        .get()
+        .then(({ enabled }) => {
+          setPreventSleepState(enabled);
+        })
+        .catch(err => {
+          console.error('Failed to load prevent-sleep setting:', err);
+        });
 
       // Set up providers based on saved config
       if (config.api) {
@@ -782,8 +935,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.openai,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('deepseek')) {
           setActiveProvider('deepseek');
@@ -793,10 +946,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.deepseek,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
-        } else if (normalizedApiBaseUrl.includes('moonshot.ai') || normalizedApiBaseUrl.includes('moonshot.cn')) {
+        } else if (
+          normalizedApiBaseUrl.includes('moonshot.ai') ||
+          normalizedApiBaseUrl.includes('moonshot.cn')
+        ) {
           setActiveProvider('moonshot');
           setProviders(prev => ({
             ...prev,
@@ -804,8 +960,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.moonshot,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('bigmodel.cn')) {
           setActiveProvider('zhipu');
@@ -815,8 +971,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.zhipu,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('minimax')) {
           setActiveProvider('minimax');
@@ -826,8 +982,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.minimax,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('openapi.youdao.com')) {
           setActiveProvider('youdaozhiyun');
@@ -837,8 +993,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.youdaozhiyun,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('dashscope')) {
           setActiveProvider('qwen');
@@ -848,8 +1004,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.qwen,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('stepfun')) {
           setActiveProvider('stepfun');
@@ -859,8 +1015,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.stepfun,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('openrouter.ai')) {
           setActiveProvider('openrouter');
@@ -870,8 +1026,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.openrouter,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('googleapis')) {
           setActiveProvider('gemini');
@@ -881,8 +1037,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.gemini,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('anthropic')) {
           setActiveProvider('anthropic');
@@ -892,10 +1048,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.anthropic,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
-        } else if (normalizedApiBaseUrl.includes('ollama') || normalizedApiBaseUrl.includes('11434')) {
+        } else if (
+          normalizedApiBaseUrl.includes('ollama') ||
+          normalizedApiBaseUrl.includes('11434')
+        ) {
           setActiveProvider('ollama');
           setProviders(prev => ({
             ...prev,
@@ -903,24 +1062,26 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.ollama,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         }
       }
-      
+
       // Load provider-specific configurations if available
       // 合并已保存的配置和默认配置，确保新添加的 provider 能被显示
       if (config.providers) {
         setProviders(prev => {
           const merged = {
-            ...prev,  // 保留默认的 providers（包括新添加的 anthropic）
-            ...config.providers,  // 覆盖已保存的配置
+            ...prev, // 保留默认的 providers（包括新添加的 anthropic）
+            ...config.providers, // 覆盖已保存的配置
           };
 
           // After merging, find the first enabled provider to set as activeProvider
           // This ensures we don't use stale activeProvider from old config.api.baseUrl
-          const firstEnabledProvider = providerKeys.find(providerKey => merged[providerKey]?.enabled);
+          const firstEnabledProvider = providerKeys.find(
+            providerKey => merged[providerKey]?.enabled,
+          );
           if (firstEnabledProvider) {
             setActiveProvider(firstEnabledProvider);
           }
@@ -932,7 +1093,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 // Fix corrupted model IDs from previous OAuth mutation bug
                 if (providerKey === 'qwen' && (id === 'vision-model' || id === 'coder-model')) {
                   const defaultModel = defaultConfig.providers?.qwen?.models?.[idx];
-                  id = defaultModel?.id || (model.supportsImage ? 'qwen3.5-plus' : 'qwen3-coder-plus');
+                  id =
+                    defaultModel?.id || (model.supportsImage ? 'qwen3.5-plus' : 'qwen3-coder-plus');
                 }
                 return {
                   ...model,
@@ -944,15 +1106,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 providerKey,
                 {
                   ...providerConfig,
-                  apiFormat: getEffectiveApiFormat(providerKey, (providerConfig as ProviderConfig).apiFormat),
+                  apiFormat: getEffectiveApiFormat(
+                    providerKey,
+                    (providerConfig as ProviderConfig).apiFormat,
+                  ),
                   models,
                 },
               ];
-            })
+            }),
           ) as ProvidersConfig;
         });
       }
-      
+
       // 加载快捷键设置
       if (config.shortcuts) {
         setShortcuts(prev => ({
@@ -1132,9 +1297,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         const def = ProviderRegistry.get(provider);
         if (def?.codingPlanSupported) {
           const enabled = value === 'true';
-          const nextModels = enabled && def.codingPlanModels
-            ? def.codingPlanModels.map(m => ({ ...m }))
-            : def.defaultModels.map(m => ({ ...m }));
+          const nextModels =
+            enabled && def.codingPlanModels
+              ? def.codingPlanModels.map(m => ({ ...m }))
+              : def.defaultModels.map(m => ({ ...m }));
           return {
             ...prev,
             [provider]: {
@@ -1161,7 +1327,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     setMinimaxOAuthPhase({ kind: 'requesting_code' });
 
     const codeEndpoint = region === 'cn' ? MINIMAX_CODE_ENDPOINT_CN : MINIMAX_CODE_ENDPOINT_GLOBAL;
-    const tokenEndpoint = region === 'cn' ? MINIMAX_TOKEN_ENDPOINT_CN : MINIMAX_TOKEN_ENDPOINT_GLOBAL;
+    const tokenEndpoint =
+      region === 'cn' ? MINIMAX_TOKEN_ENDPOINT_CN : MINIMAX_TOKEN_ENDPOINT_GLOBAL;
     const defaultBaseUrl = region === 'cn' ? MINIMAX_BASE_URL_CN : MINIMAX_BASE_URL_GLOBAL;
 
     try {
@@ -1181,7 +1348,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
-          'Accept': 'application/json',
+          Accept: 'application/json',
         },
         body: codeBody,
       });
@@ -1200,7 +1367,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       };
 
       if (!codePayload.user_code || !codePayload.verification_uri) {
-        throw new Error(codePayload.error ?? 'MiniMax OAuth returned incomplete authorization payload');
+        throw new Error(
+          codePayload.error ?? 'MiniMax OAuth returned incomplete authorization payload',
+        );
       }
 
       if (codePayload.state !== state) {
@@ -1209,7 +1378,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       try {
         await window.electron.shell.openExternal(codePayload.verification_uri);
-      } catch { /* ignore: user can open manually */ }
+      } catch {
+        /* ignore: user can open manually */
+      }
 
       setMinimaxOAuthPhase({
         kind: 'pending',
@@ -1218,7 +1389,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       });
 
       let pollIntervalMs = codePayload.interval ?? 2000;
-      const expireTimeMs = codePayload.expired_in ?? (Date.now() + 5 * 60 * 1000);
+      const expireTimeMs = codePayload.expired_in ?? Date.now() + 5 * 60 * 1000;
 
       while (Date.now() < expireTimeMs) {
         if (minimaxOAuthCancelRef.current) {
@@ -1245,7 +1416,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           method: 'POST',
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
-            'Accept': 'application/json',
+            Accept: 'application/json',
           },
           body: tokenBody,
         });
@@ -1326,13 +1497,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     setMinimaxOAuthPhase({ kind: 'idle' });
   };
 
-  const hasCoworkConfigChanges = coworkAgentEngine !== coworkConfig.agentEngine
-    || coworkMemoryEnabled !== coworkConfig.memoryEnabled
-    || coworkMemoryLlmJudgeEnabled !== coworkConfig.memoryLlmJudgeEnabled;
+  const hasCoworkConfigChanges =
+    coworkAgentEngine !== coworkConfig.agentEngine ||
+    coworkMemoryEnabled !== coworkConfig.memoryEnabled ||
+    coworkMemoryLlmJudgeEnabled !== coworkConfig.memoryLlmJudgeEnabled;
   const isOpenClawAgentEngine = coworkAgentEngine === 'openclaw';
 
   const openClawProgressPercent = useMemo(() => {
-    if (typeof openClawEngineStatus?.progressPercent !== 'number' || !Number.isFinite(openClawEngineStatus.progressPercent)) {
+    if (
+      typeof openClawEngineStatus?.progressPercent !== 'number' ||
+      !Number.isFinite(openClawEngineStatus.progressPercent)
+    ) {
       return null;
     }
     return Math.max(0, Math.min(100, Math.round(openClawEngineStatus.progressPercent)));
@@ -1380,9 +1555,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     } finally {
       setCoworkMemoryListLoading(false);
     }
-  }, [
-    coworkMemoryQuery,
-  ]);
+  }, [coworkMemoryQuery]);
 
   useEffect(() => {
     if (activeTab !== 'coworkMemory') return;
@@ -1398,15 +1571,16 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     const TEMPLATE_MARKERS = [
       'Fill this in during your first conversation',
       "You're not a chatbot. You're becoming someone",
-      'Learn about the person you\'re helping',
+      "Learn about the person you're helping",
     ];
-    if (TEMPLATE_MARKERS.some((m) => content.includes(m))) return '';
+    if (TEMPLATE_MARKERS.some(m => content.includes(m))) return '';
     return content;
   };
 
   useEffect(() => {
     if (activeTab !== 'coworkAgent') return;
     if (!bootstrapLoaded) {
+      setBootstrapLoading(true);
       void (async () => {
         const [identity, user, soul] = await Promise.all([
           coworkService.readBootstrapFile('IDENTITY.md'),
@@ -1417,6 +1591,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         setBootstrapUser(stripDefaultTemplate(user));
         setBootstrapSoul(stripDefaultTemplate(soul));
         setBootstrapLoaded(true);
+        setBootstrapLoading(false);
       })();
     }
   }, [activeTab, bootstrapLoaded]);
@@ -1446,7 +1621,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       resetCoworkMemoryEditor();
       await loadCoworkMemoryData();
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : i18nService.t('coworkMemoryCrudSaveFailed'));
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : i18nService.t('coworkMemoryCrudSaveFailed'),
+      );
     } finally {
       setCoworkMemoryListLoading(false);
     }
@@ -1467,7 +1646,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       }
       await loadCoworkMemoryData();
     } catch (deleteError) {
-      setError(deleteError instanceof Error ? deleteError.message : i18nService.t('coworkMemoryCrudDeleteFailed'));
+      setError(
+        deleteError instanceof Error
+          ? deleteError.message
+          : i18nService.t('coworkMemoryCrudDeleteFailed'),
+      );
     } finally {
       setCoworkMemoryListLoading(false);
     }
@@ -1499,8 +1682,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       ...prev,
       [provider]: {
         ...prev[provider],
-        enabled: !prev[provider].enabled
-      }
+        enabled: !prev[provider].enabled,
+      },
     }));
   };
 
@@ -1539,7 +1722,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       // Step 2: Poll for token
       setCopilotAuthStatus('polling');
-      const result = await window.electron.githubCopilot.pollForToken(deviceCode, interval, expiresIn);
+      const result = await window.electron.githubCopilot.pollForToken(
+        deviceCode,
+        interval,
+        expiresIn,
+      );
 
       if (result.success && result.token) {
         setCopilotGithubUser(result.githubUser || '');
@@ -1606,15 +1793,19 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             {
               ...providerConfig,
               apiFormat,
-              baseUrl: resolveBaseUrl(providerKey as ProviderType, providerConfig.baseUrl, apiFormat),
+              baseUrl: resolveBaseUrl(
+                providerKey as ProviderType,
+                providerConfig.baseUrl,
+                apiFormat,
+              ),
             },
           ];
-        })
+        }),
       ) as ProvidersConfig;
 
       // Find the first enabled provider to use as the primary API
       const firstEnabledProvider = Object.entries(normalizedProviders).find(
-        ([_, config]) => config.enabled
+        ([_, config]) => config.enabled,
       );
 
       const primaryProvider = firstEnabledProvider
@@ -1663,7 +1854,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       });
 
       // 更新 Redux store 中的可用模型列表
-      const allModels: { id: string; name: string; provider?: string; providerKey?: string; supportsImage?: boolean }[] = [];
+      const allModels: {
+        id: string;
+        name: string;
+        provider?: string;
+        providerKey?: string;
+        supportsImage?: boolean;
+      }[] = [];
       Object.entries(normalizedProviders).forEach(([providerName, config]) => {
         if (config.enabled && config.models) {
           config.models.forEach(model => {
@@ -1734,7 +1931,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const handleShortcutChange = (key: keyof typeof shortcuts, value: string) => {
     setShortcuts(prev => ({
       ...prev,
-      [key]: value
+      [key]: value,
     }));
   };
 
@@ -1766,17 +1963,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   const handleDeleteModel = (modelId: string) => {
     if (!providers[activeProvider].models) return;
-    
-    const updatedModels = providers[activeProvider].models.filter(
-      model => model.id !== modelId
-    );
-    
+
+    const updatedModels = providers[activeProvider].models.filter(model => model.id !== modelId);
+
     setProviders(prev => ({
       ...prev,
       [activeProvider]: {
         ...prev[activeProvider],
-        models: updatedModels
-      }
+        models: updatedModels,
+      },
     }));
   };
 
@@ -1798,13 +1993,16 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     }
 
     // For Ollama, auto-fill display name from modelId if not provided
-    const modelName = activeProvider === 'ollama'
-      ? (newModelName.trim() && newModelName.trim() !== modelId ? newModelName.trim() : modelId)
-      : newModelName.trim();
+    const modelName =
+      activeProvider === 'ollama'
+        ? newModelName.trim() && newModelName.trim() !== modelId
+          ? newModelName.trim()
+          : modelId
+        : newModelName.trim();
 
     const currentModels = providers[activeProvider].models ?? [];
     const duplicateModel = currentModels.find(
-      model => model.id === modelId && (!isEditingModel || model.id !== editingModelId)
+      model => model.id === modelId && (!isEditingModel || model.id !== editingModelId),
     );
     if (duplicateModel) {
       setModelFormError(i18nService.t('modelIdExists'));
@@ -1816,16 +2014,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       name: modelName,
       supportsImage: newModelSupportsImage,
     };
-    const updatedModels = isEditingModel && editingModelId
-      ? currentModels.map(model => (model.id === editingModelId ? nextModel : model))
-      : [...currentModels, nextModel];
+    const updatedModels =
+      isEditingModel && editingModelId
+        ? currentModels.map(model => (model.id === editingModelId ? nextModel : model))
+        : [...currentModels, nextModel];
 
     setProviders(prev => ({
       ...prev,
       [activeProvider]: {
         ...prev[activeProvider],
-        models: updatedModels
-      }
+        models: updatedModels,
+      },
     }));
 
     setIsAddingModel(false);
@@ -1861,7 +2060,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   const showTestResultModal = (
     result: Omit<ProviderConnectionTestResult, 'provider'>,
-    provider: ProviderType
+    provider: ProviderType,
   ) => {
     setTestResult({
       ...result,
@@ -1879,11 +2078,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     setTestResult(null);
 
     // Check if provider has valid authentication (API Key or OAuth for Qwen)
-    const hasValidAuth = providerConfig.apiKey || 
+    const hasValidAuth =
+      providerConfig.apiKey ||
       (testingProvider === 'qwen' && (providerConfig as any).oauthCredentials);
-    
+
     if (providerRequiresApiKey(testingProvider) && !hasValidAuth) {
-      showTestResultModal({ success: false, message: i18nService.t('apiKeyRequired') }, testingProvider);
+      showTestResultModal(
+        { success: false, message: i18nService.t('apiKeyRequired') },
+        testingProvider,
+      );
       setIsTesting(false);
       return;
     }
@@ -1891,7 +2094,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     // 获取第一个可用模型 - use a shallow copy to avoid mutating state
     const originalModel = providerConfig.models?.[0];
     if (!originalModel) {
-      showTestResultModal({ success: false, message: i18nService.t('noModelsConfigured') }, testingProvider);
+      showTestResultModal(
+        { success: false, message: i18nService.t('noModelsConfigured') },
+        testingProvider,
+      );
       setIsTesting(false);
       return;
     }
@@ -1901,16 +2107,28 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     try {
       let response: Awaited<ReturnType<typeof window.electron.api.fetch>>;
       // Apply Coding Plan endpoint switch
-      let effectiveBaseUrl = resolveBaseUrl(testingProvider, providerConfig.baseUrl, getEffectiveApiFormat(testingProvider, providerConfig.apiFormat));
+      let effectiveBaseUrl = resolveBaseUrl(
+        testingProvider,
+        providerConfig.baseUrl,
+        getEffectiveApiFormat(testingProvider, providerConfig.apiFormat),
+      );
       let effectiveApiFormat = getEffectiveApiFormat(testingProvider, providerConfig.apiFormat);
-      
+
       // Handle Coding Plan endpoint switch for supported providers
-      if ((providerConfig as { codingPlanEnabled?: boolean }).codingPlanEnabled && (effectiveApiFormat === 'anthropic' || effectiveApiFormat === 'openai')) {
-        const resolved = resolveCodingPlanBaseUrl(testingProvider, true, effectiveApiFormat, effectiveBaseUrl);
+      if (
+        (providerConfig as { codingPlanEnabled?: boolean }).codingPlanEnabled &&
+        (effectiveApiFormat === 'anthropic' || effectiveApiFormat === 'openai')
+      ) {
+        const resolved = resolveCodingPlanBaseUrl(
+          testingProvider,
+          true,
+          effectiveApiFormat,
+          effectiveBaseUrl,
+        );
         effectiveBaseUrl = resolved.baseUrl;
         effectiveApiFormat = resolved.effectiveFormat;
       }
-      
+
       let normalizedBaseUrl = effectiveBaseUrl.replace(/\/+$/, '');
 
       // Determine effective API key
@@ -1965,11 +2183,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           headers.Authorization = `Bearer ${effectiveApiKey}`;
         }
         if (testingProvider === 'github-copilot') {
-                  headers['Copilot-Integration-Id'] = 'vscode-chat';
-                  headers['Editor-Version'] = 'vscode/1.96.2';
-                  headers['Editor-Plugin-Version'] = 'copilot-chat/0.26.7';
-                  headers['User-Agent'] = 'GitHubCopilotChat/0.26.7';
-                  headers['Openai-Intent'] = 'conversation-panel';
+          headers['Copilot-Integration-Id'] = 'vscode-chat';
+          headers['Editor-Version'] = 'vscode/1.96.2';
+          headers['Editor-Plugin-Version'] = 'copilot-chat/0.26.7';
+          headers['User-Agent'] = 'GitHubCopilotChat/0.26.7';
+          headers['Openai-Intent'] = 'conversation-panel';
         }
         const openAIRequestBody: Record<string, unknown> = useResponsesApi
           ? {
@@ -1981,7 +2199,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               model: firstModel.id,
               messages: [{ role: 'user', content: 'Hi' }],
             };
-        if (!useResponsesApi && shouldUseMaxCompletionTokensForOpenAI(testingProvider, firstModel.id)) {
+        if (
+          !useResponsesApi &&
+          shouldUseMaxCompletionTokensForOpenAI(testingProvider, firstModel.id)
+        ) {
           openAIRequestBody.max_completion_tokens = CONNECTIVITY_TEST_TOKEN_BUDGET;
         } else {
           if (!useResponsesApi) {
@@ -1998,23 +2219,38 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       if (response.ok) {
         enableProvider(testingProvider);
-        showTestResultModal({ success: true, message: i18nService.t('connectionSuccess') }, testingProvider);
+        showTestResultModal(
+          { success: true, message: i18nService.t('connectionSuccess') },
+          testingProvider,
+        );
       } else {
         const data = response.data || {};
         // 提取错误信息
-        const errorMessage = data.error?.message || data.message || `${i18nService.t('connectionFailed')}: ${response.status}`;
-        if (typeof errorMessage === 'string' && errorMessage.toLowerCase().includes('model output limit was reached')) {
+        const errorMessage =
+          data.error?.message ||
+          data.message ||
+          `${i18nService.t('connectionFailed')}: ${response.status}`;
+        if (
+          typeof errorMessage === 'string' &&
+          errorMessage.toLowerCase().includes('model output limit was reached')
+        ) {
           enableProvider(testingProvider);
-          showTestResultModal({ success: true, message: i18nService.t('connectionSuccess') }, testingProvider);
+          showTestResultModal(
+            { success: true, message: i18nService.t('connectionSuccess') },
+            testingProvider,
+          );
           return;
         }
         showTestResultModal({ success: false, message: errorMessage }, testingProvider);
       }
     } catch (err) {
-      showTestResultModal({
-        success: false,
-        message: err instanceof Error ? err.message : i18nService.t('connectionFailed'),
-      }, testingProvider);
+      showTestResultModal(
+        {
+          success: false,
+          message: err instanceof Error ? err.message : i18nService.t('connectionFailed'),
+        },
+        testingProvider,
+      );
     } finally {
       setIsTesting(false);
     }
@@ -2036,7 +2272,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             models: providerConfig.models,
           },
         ] as const;
-      })
+      }),
     );
 
     return {
@@ -2153,9 +2389,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             hadDecryptFailure = true;
             console.warn(`Failed to decrypt provider key for ${providerKey}`, error);
           }
-        } else if (typeof providerData.apiKeyEncrypted === 'string' && typeof providerData.apiKeyIv === 'string') {
+        } else if (
+          typeof providerData.apiKeyEncrypted === 'string' &&
+          typeof providerData.apiKeyIv === 'string'
+        ) {
           try {
-            apiKey = await decryptSecret({ encrypted: providerData.apiKeyEncrypted, iv: providerData.apiKeyIv });
+            apiKey = await decryptSecret({
+              encrypted: providerData.apiKeyEncrypted,
+              iv: providerData.apiKeyIv,
+            });
           } catch (error) {
             hadDecryptFailure = true;
             console.warn(`Failed to decrypt provider key for ${providerKey}`, error);
@@ -2165,11 +2407,23 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         const models = normalizeModels(providerData.models);
 
         providerUpdates[providerKey] = {
-          enabled: typeof providerData.enabled === 'boolean' ? providerData.enabled : providers[providerKey].enabled,
+          enabled:
+            typeof providerData.enabled === 'boolean'
+              ? providerData.enabled
+              : providers[providerKey].enabled,
           apiKey: apiKey ?? providers[providerKey].apiKey,
-          baseUrl: typeof providerData.baseUrl === 'string' ? providerData.baseUrl : providers[providerKey].baseUrl,
-          apiFormat: getEffectiveApiFormat(providerKey, providerData.apiFormat ?? providers[providerKey].apiFormat),
-          codingPlanEnabled: typeof providerData.codingPlanEnabled === 'boolean' ? providerData.codingPlanEnabled : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
+          baseUrl:
+            typeof providerData.baseUrl === 'string'
+              ? providerData.baseUrl
+              : providers[providerKey].baseUrl,
+          apiFormat: getEffectiveApiFormat(
+            providerKey,
+            providerData.apiFormat ?? providers[providerKey].apiFormat,
+          ),
+          codingPlanEnabled:
+            typeof providerData.codingPlanEnabled === 'boolean'
+              ? providerData.codingPlanEnabled
+              : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
           models: models ?? providers[providerKey].models,
         };
       }
@@ -2196,8 +2450,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       }
     } catch (err) {
       console.error('Failed to import providers:', err);
-      const isDecryptError = err instanceof Error
-        && (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
+      const isDecryptError =
+        err instanceof Error &&
+        (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
       const message = isDecryptError
         ? i18nService.t('decryptProvidersFailed')
         : i18nService.t('importProvidersFailed');
@@ -2243,11 +2498,23 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         const models = normalizeModels(providerData.models);
 
         providerUpdates[providerKey] = {
-          enabled: typeof providerData.enabled === 'boolean' ? providerData.enabled : providers[providerKey].enabled,
+          enabled:
+            typeof providerData.enabled === 'boolean'
+              ? providerData.enabled
+              : providers[providerKey].enabled,
           apiKey: apiKey ?? providers[providerKey].apiKey,
-          baseUrl: typeof providerData.baseUrl === 'string' ? providerData.baseUrl : providers[providerKey].baseUrl,
-          apiFormat: getEffectiveApiFormat(providerKey, providerData.apiFormat ?? providers[providerKey].apiFormat),
-          codingPlanEnabled: typeof providerData.codingPlanEnabled === 'boolean' ? providerData.codingPlanEnabled : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
+          baseUrl:
+            typeof providerData.baseUrl === 'string'
+              ? providerData.baseUrl
+              : providers[providerKey].baseUrl,
+          apiFormat: getEffectiveApiFormat(
+            providerKey,
+            providerData.apiFormat ?? providers[providerKey].apiFormat,
+          ),
+          codingPlanEnabled:
+            typeof providerData.codingPlanEnabled === 'boolean'
+              ? providerData.codingPlanEnabled
+              : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
           models: models ?? providers[providerKey].models,
         };
       }
@@ -2259,7 +2526,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       // Check if any key was successfully decrypted
       const anyKeyDecrypted = Object.entries(providerUpdates).some(
-        ([key, update]) => update?.apiKey && update.apiKey !== providers[key]?.apiKey
+        ([key, update]) => update?.apiKey && update.apiKey !== providers[key]?.apiKey,
       );
 
       if (!anyKeyDecrypted && hadDecryptFailure) {
@@ -2285,8 +2552,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       }
     } catch (err) {
       console.error('Failed to import providers:', err);
-      const isDecryptError = err instanceof Error
-        && (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
+      const isDecryptError =
+        err instanceof Error &&
+        (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
       const message = isDecryptError
         ? i18nService.t('decryptProvidersFailed')
         : i18nService.t('importProvidersFailed');
@@ -2299,15 +2567,69 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   // 渲染标签页
   const sidebarTabs: { key: TabType; label: string; icon: React.ReactNode }[] = useMemo(() => {
     const allTabs = [
-      { key: 'general' as TabType,        label: i18nService.t('general'),        icon: <Cog6ToothIcon className="h-5 w-5" /> },
-      { key: 'coworkAgentEngine' as TabType, label: i18nService.t('coworkAgentEngine'), icon: <CpuChipIcon className="h-5 w-5" /> },
-      { key: 'model' as TabType,          label: i18nService.t('model'),          icon: <CubeIcon className="h-5 w-5" /> },
-      { key: 'im' as TabType,             label: i18nService.t('imBot'),          icon: <ChatBubbleLeftIcon className="h-5 w-5" /> },
-      { key: 'email' as TabType,          label: i18nService.t('emailTab'),       icon: <EnvelopeIcon className="h-5 w-5" /> },
-      { key: 'coworkMemory' as TabType,   label: i18nService.t('coworkMemoryTitle'), icon: <BrainIcon className="h-5 w-5" /> },
-      { key: 'coworkAgent' as TabType,    label: i18nService.t('coworkAgentTab'),    icon: <UserCircleIcon className="h-5 w-5" /> },
-      { key: 'shortcuts' as TabType,      label: i18nService.t('shortcuts'),      icon: <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-5 w-5"><rect x="2" y="4" width="20" height="14" rx="2" /><line x1="6" y1="8" x2="8" y2="8" /><line x1="10" y1="8" x2="12" y2="8" /><line x1="14" y1="8" x2="16" y2="8" /><line x1="6" y1="12" x2="8" y2="12" /><line x1="10" y1="12" x2="14" y2="12" /><line x1="16" y1="12" x2="18" y2="12" /><line x1="8" y1="15.5" x2="16" y2="15.5" /></svg> },
-      { key: 'about' as TabType,          label: i18nService.t('about'),          icon: <InformationCircleIcon className="h-5 w-5" /> },
+      {
+        key: 'general' as TabType,
+        label: i18nService.t('general'),
+        icon: <Cog6ToothIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'coworkAgentEngine' as TabType,
+        label: i18nService.t('coworkAgentEngine'),
+        icon: <CpuChipIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'model' as TabType,
+        label: i18nService.t('model'),
+        icon: <CubeIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'im' as TabType,
+        label: i18nService.t('imBot'),
+        icon: <ChatBubbleLeftIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'email' as TabType,
+        label: i18nService.t('emailTab'),
+        icon: <EnvelopeIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'coworkMemory' as TabType,
+        label: i18nService.t('coworkMemoryTitle'),
+        icon: <BrainIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'coworkAgent' as TabType,
+        label: i18nService.t('coworkAgentTab'),
+        icon: <UserCircleIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'shortcuts' as TabType,
+        label: i18nService.t('shortcuts'),
+        icon: (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="h-5 w-5"
+          >
+            <rect x="2" y="4" width="20" height="14" rx="2" />
+            <line x1="6" y1="8" x2="8" y2="8" />
+            <line x1="10" y1="8" x2="12" y2="8" />
+            <line x1="14" y1="8" x2="16" y2="8" />
+            <line x1="6" y1="12" x2="8" y2="12" />
+            <line x1="10" y1="12" x2="14" y2="12" />
+            <line x1="16" y1="12" x2="18" y2="12" />
+            <line x1="8" y1="15.5" x2="16" y2="15.5" />
+          </svg>
+        ),
+      },
+      {
+        key: 'about' as TabType,
+        label: i18nService.t('about'),
+        icon: <InformationCircleIcon className="h-5 w-5" />,
+      },
     ];
     // Filter out tabs hidden by enterprise config
     // Filter out tabs with 'hide' action in enterprise config
@@ -2324,27 +2646,25 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   }, [activeTab, sidebarTabs]);
 
   const renderTabContent = () => {
-    switch(activeTab) {
+    switch (activeTab) {
       case 'general':
         return (
           <div className="space-y-8">
             {/* Language Section */}
             <div className="flex items-center justify-between">
-              <h4 className="text-sm font-medium text-foreground">
-                {i18nService.t('language')}
-              </h4>
+              <h4 className="text-sm font-medium text-foreground">{i18nService.t('language')}</h4>
               <div className="w-[140px] shrink-0">
                 <ThemedSelect
                   id="language"
                   value={language}
-                  onChange={(value) => {
+                  onChange={value => {
                     const nextLanguage = value as LanguageType;
                     setLanguage(nextLanguage);
                     i18nService.setLanguage(nextLanguage, { persist: false });
                   }}
                   options={[
                     { value: 'zh', label: i18nService.t('chinese') },
-                    { value: 'en', label: i18nService.t('english') }
+                    { value: 'en', label: i18nService.t('english') },
                   ]}
                 />
               </div>
@@ -2384,11 +2704,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   disabled={isUpdatingAutoLaunch}
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                     isUpdatingAutoLaunch ? 'opacity-50 cursor-not-allowed' : ''
-                  } ${
-                    autoLaunch
-                      ? 'bg-primary'
-                      : 'bg-gray-300 dark:bg-gray-600'
-                  }`}
+                  } ${autoLaunch ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'}`}
                 >
                   <span
                     className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
@@ -2433,11 +2749,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   disabled={isUpdatingPreventSleep}
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                     isUpdatingPreventSleep ? 'opacity-50 cursor-not-allowed' : ''
-                  } ${
-                    preventSleep
-                      ? 'bg-primary'
-                      : 'bg-gray-300 dark:bg-gray-600'
-                  }`}
+                  } ${preventSleep ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'}`}
                 >
                   <span
                     className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
@@ -2462,12 +2774,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   role="switch"
                   aria-checked={useSystemProxy}
                   onClick={() => {
-                    setUseSystemProxy((prev) => !prev);
+                    setUseSystemProxy(prev => !prev);
                   }}
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
-                    useSystemProxy
-                      ? 'bg-primary'
-                      : 'bg-gray-300 dark:bg-gray-600'
+                    useSystemProxy ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
                   }`}
                 >
                   <span
@@ -2481,13 +2791,16 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
             {/* Appearance Section — mode selector + theme gallery */}
             <div>
-              <h4 className="text-sm font-medium mb-3" style={{ color: 'var(--lobster-text-primary)' }}>
+              <h4
+                className="text-sm font-medium mb-3"
+                style={{ color: 'var(--lobster-text-primary)' }}
+              >
                 {i18nService.t('appearance')}
               </h4>
 
               {/* Level 1: Mode selector */}
               <div className="grid grid-cols-3 gap-3 mb-4">
-                {(['light', 'dark', 'system'] as const).map((mode) => {
+                {(['light', 'dark', 'system'] as const).map(mode => {
                   const isSelected = theme === mode;
                   return (
                     <button
@@ -2500,11 +2813,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       }}
                       className="flex flex-col items-center rounded-xl border-2 p-3 transition-colors cursor-pointer"
                       style={{
-                        borderColor: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-border)',
+                        borderColor: isSelected
+                          ? 'var(--lobster-primary)'
+                          : 'var(--lobster-border)',
                         backgroundColor: isSelected ? 'var(--lobster-primary-muted)' : undefined,
                       }}
                     >
-                      <svg viewBox="0 0 120 80" className="w-full h-auto rounded-md mb-2 overflow-hidden" xmlns="http://www.w3.org/2000/svg">
+                      <svg
+                        viewBox="0 0 120 80"
+                        className="w-full h-auto rounded-md mb-2 overflow-hidden"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
                         {mode === 'light' && (
                           <>
                             <rect width="120" height="80" fill="#F8F9FB" />
@@ -2585,7 +2904,14 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           </>
                         )}
                       </svg>
-                      <span className="text-xs font-medium" style={{ color: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-text-primary)' }}>
+                      <span
+                        className="text-xs font-medium"
+                        style={{
+                          color: isSelected
+                            ? 'var(--lobster-primary)'
+                            : 'var(--lobster-text-primary)',
+                        }}
+                      >
                         {i18nService.t(mode)}
                       </span>
                     </button>
@@ -2594,13 +2920,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               </div>
 
               {/* Theme color gallery — all themes */}
-              <h4 className="text-sm font-medium mb-3 mt-5" style={{ color: 'var(--lobster-text-primary)' }}>
+              <h4
+                className="text-sm font-medium mb-3 mt-5"
+                style={{ color: 'var(--lobster-text-primary)' }}
+              >
                 {i18nService.t('themeColor')}
               </h4>
               {(() => {
                 const allThemes = themeService.getAllThemes();
-                const classicThemes = allThemes.filter(t => t.meta.id === 'classic-light' || t.meta.id === 'classic-dark');
-                const otherThemes = allThemes.filter(t => t.meta.id !== 'classic-light' && t.meta.id !== 'classic-dark');
+                const classicThemes = allThemes.filter(
+                  t => t.meta.id === 'classic-light' || t.meta.id === 'classic-dark',
+                );
+                const otherThemes = allThemes.filter(
+                  t => t.meta.id !== 'classic-light' && t.meta.id !== 'classic-dark',
+                );
                 const renderTile = (t: import('../theme').ThemeDefinition) => {
                   const isSelected = themeId === t.meta.id;
                   const [bg, c1, c2, c3] = t.meta.preview;
@@ -2615,18 +2948,31 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       }}
                       className="flex flex-col items-center rounded-xl border-2 p-2 transition-colors cursor-pointer"
                       style={{
-                        borderColor: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-border)',
+                        borderColor: isSelected
+                          ? 'var(--lobster-primary)'
+                          : 'var(--lobster-border)',
                         backgroundColor: isSelected ? 'var(--lobster-primary-muted)' : undefined,
                       }}
                     >
-                      <svg viewBox="0 0 80 48" className="w-full h-auto rounded-md mb-1.5 overflow-hidden" xmlns="http://www.w3.org/2000/svg">
+                      <svg
+                        viewBox="0 0 80 48"
+                        className="w-full h-auto rounded-md mb-1.5 overflow-hidden"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
                         <rect width="80" height="48" fill={bg} />
                         <rect x="4" y="6" width="20" height="36" rx="3" fill={c1} opacity="0.7" />
                         <rect x="28" y="6" width="48" height="36" rx="3" fill={c2} opacity="0.5" />
                         <circle cx="52" cy="24" r="8" fill={c3} opacity="0.8" />
                         <rect x="32" y="34" width="40" height="4" rx="2" fill={c1} opacity="0.6" />
                       </svg>
-                      <span className="text-[10px] font-medium truncate w-full text-center" style={{ color: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-text-primary)' }}>
+                      <span
+                        className="text-[10px] font-medium truncate w-full text-center"
+                        style={{
+                          color: isSelected
+                            ? 'var(--lobster-primary)'
+                            : 'var(--lobster-text-primary)',
+                        }}
+                      >
                         {t.meta.name}
                       </span>
                     </button>
@@ -2637,9 +2983,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <div className="grid grid-cols-2 gap-3 mb-3">
                       {classicThemes.map(renderTile)}
                     </div>
-                    <div className="grid grid-cols-4 gap-3">
-                      {otherThemes.map(renderTile)}
-                    </div>
+                    <div className="grid grid-cols-4 gap-3">{otherThemes.map(renderTile)}</div>
                   </>
                 );
               })()}
@@ -2655,12 +2999,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           <div className="space-y-6">
             <div className="space-y-3">
               <div className="flex items-start gap-3 rounded-xl border px-3 py-2 text-sm border-border">
-                <input
-                  type="radio"
-                  checked={true}
-                  readOnly
-                  className="mt-1"
-                />
+                <input type="radio" checked={true} readOnly className="mt-1" />
                 <span>
                   <span className="block font-medium text-foreground">
                     {i18nService.t('coworkAgentEngineOpenClaw')}
@@ -2676,9 +3015,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="text-xs text-secondary">
                   {i18nService.t('coworkOpenClawInstallHint')}
                 </div>
-                <div className={`rounded-xl border px-4 py-3 text-sm ${openClawEngineStatus?.phase === 'error'
-                  ? 'border-red-300 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300'
-                  : 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-300'}`}
+                <div
+                  className={`rounded-xl border px-4 py-3 text-sm ${
+                    openClawEngineStatus?.phase === 'error'
+                      ? 'border-red-300 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300'
+                      : 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-300'
+                  }`}
                 >
                   <div className="flex items-center justify-between gap-3">
                     <div>
@@ -2748,24 +3090,25 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <input
                 type="text"
                 value={coworkMemoryQuery}
-                onChange={(event) => setCoworkMemoryQuery(event.target.value)}
+                onChange={event => setCoworkMemoryQuery(event.target.value)}
                 placeholder={i18nService.t('coworkMemorySearchPlaceholder')}
                 className="w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface"
               />
 
               <div className="rounded-lg border border-border">
                 {coworkMemoryListLoading ? (
-                  <div className="px-3 py-3 text-xs text-secondary">
-                    {i18nService.t('loading')}
-                  </div>
+                  <div className="px-3 py-3 text-xs text-secondary">{i18nService.t('loading')}</div>
                 ) : coworkMemoryEntries.length === 0 ? (
                   <div className="px-3 py-3 text-xs text-secondary">
                     {i18nService.t('coworkMemoryEmpty')}
                   </div>
                 ) : (
                   <div className="divide-y divide-border">
-                    {coworkMemoryEntries.map((entry) => (
-                      <div key={entry.id} className="px-3 py-3 text-xs hover:bg-surface-raised transition-colors">
+                    {coworkMemoryEntries.map(entry => (
+                      <div
+                        key={entry.id}
+                        className="px-3 py-3 text-xs hover:bg-surface-raised transition-colors"
+                      >
                         <div className="flex items-start justify-between gap-3">
                           <div className="flex-1 min-w-0">
                             <div className="font-medium text-foreground break-words">
@@ -2782,7 +3125,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                             </button>
                             <button
                               type="button"
-                              onClick={() => { void handleDeleteCoworkMemoryEntry(entry); }}
+                              onClick={() => {
+                                void handleDeleteCoworkMemoryEntry(entry);
+                              }}
                               className="rounded border px-2 py-1 text-red-500 border-border hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-60 transition-colors"
                               disabled={coworkMemoryListLoading}
                             >
@@ -2796,7 +3141,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 )}
               </div>
             </div>
-
           </div>
         );
 
@@ -2842,7 +3186,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 const missingApiKey = providerRequiresApiKey(providerKey) && !config.apiKey.trim();
                 const canToggleProvider = config.enabled || !missingApiKey;
                 const displayLabel = isCustom
-                  ? ((config as ProviderConfig).displayName || getCustomProviderDefaultName(provider))
+                  ? (config as ProviderConfig).displayName || getCustomProviderDefaultName(provider)
                   : (providerInfo?.label ?? getProviderDisplayName(provider));
                 return (
                   <div
@@ -2861,11 +3205,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         </span>
                       </div>
                       <div className="flex flex-col min-w-0">
-                        <span className={`text-sm font-medium truncate ${
-                          activeProvider === provider
-                            ? 'text-primary'
-                            : 'text-foreground'
-                        }`}>
+                        <span
+                          className={`text-sm font-medium truncate ${
+                            activeProvider === provider ? 'text-primary' : 'text-foreground'
+                          }`}
+                        >
                           {displayLabel}
                         </span>
                         {isCustom && (
@@ -2880,13 +3224,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         <button
                           type="button"
                           className="opacity-0 group-hover:opacity-100 transition-opacity text-claude-secondaryText hover:text-red-500 dark:text-claude-darkSecondaryText dark:hover:text-red-400 p-0.5"
-                          onClick={(e) => {
+                          onClick={e => {
                             e.stopPropagation();
                             handleDeleteCustomProvider(providerKey);
                           }}
                           title={i18nService.t('deleteCustomProvider')}
                         >
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                            className="w-3.5 h-3.5"
+                          >
                             <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
                           </svg>
                         </button>
@@ -2898,7 +3247,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         } ${
                           canToggleProvider ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'
                         }`}
-                        onClick={(e) => {
+                        onClick={e => {
                           e.stopPropagation();
                           if (!canToggleProvider) {
                             return;
@@ -2918,13 +3267,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               })}
               {/* Add Custom Provider Button */}
               {CUSTOM_PROVIDER_KEYS.some(k => !providers[k]) && (
-              <button
-                type="button"
-                onClick={handleAddCustomProvider}
-                className="w-full flex items-center justify-center p-2 rounded-xl border border-dashed border-claude-border dark:border-claude-darkBorder text-claude-secondaryText dark:text-claude-darkSecondaryText hover:border-claude-accent hover:text-claude-accent transition-colors text-sm"
-              >
-                {i18nService.t('addCustomProvider')}
-              </button>
+                <button
+                  type="button"
+                  onClick={handleAddCustomProvider}
+                  className="w-full flex items-center justify-center p-2 rounded-xl border border-dashed border-claude-border dark:border-claude-darkBorder text-claude-secondaryText dark:text-claude-darkSecondaryText hover:border-claude-accent hover:text-claude-accent transition-colors text-sm"
+                >
+                  {i18nService.t('addCustomProvider')}
+                </button>
               )}
             </div>
 
@@ -2934,14 +3283,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center gap-1.5">
                   <h3 className="text-base font-medium text-foreground">
                     {isCustomProvider(activeProvider)
-                      ? ((providers[activeProvider] as ProviderConfig)?.displayName || getCustomProviderDefaultName(activeProvider))
-                      : (providerMeta[activeProvider]?.label ?? getProviderDisplayName(activeProvider))
-                    } {i18nService.t('providerSettings')}
+                      ? (providers[activeProvider] as ProviderConfig)?.displayName ||
+                        getCustomProviderDefaultName(activeProvider)
+                      : (providerMeta[activeProvider]?.label ??
+                        getProviderDisplayName(activeProvider))}{' '}
+                    {i18nService.t('providerSettings')}
                   </h3>
                   {providerLinks[activeProvider]?.website && (
                     <button
                       type="button"
-                      onClick={() => void window.electron.shell.openExternal(providerLinks[activeProvider]!.website)}
+                      onClick={() =>
+                        void window.electron.shell.openExternal(
+                          providerLinks[activeProvider]!.website,
+                        )
+                      }
                       className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                       title={i18nService.t('visitOfficialSite')}
                       aria-label={i18nService.t('visitOfficialSite')}
@@ -2957,7 +3312,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       : 'bg-red-500/20 text-red-600 dark:text-red-400'
                   }`}
                 >
-                  {providers[activeProvider].enabled ? i18nService.t('providerStatusOn') : i18nService.t('providerStatusOff')}
+                  {providers[activeProvider].enabled
+                    ? i18nService.t('providerStatusOn')
+                    : i18nService.t('providerStatusOff')}
                 </div>
               </div>
 
@@ -2969,7 +3326,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <div className="flex rounded-xl overflow-hidden border border-border mb-3">
                       <button
                         type="button"
-                        onClick={() => setProviders(prev => ({ ...prev, minimax: { ...prev.minimax, authType: 'oauth' } }))}
+                        onClick={() =>
+                          setProviders(prev => ({
+                            ...prev,
+                            minimax: { ...prev.minimax, authType: 'oauth' },
+                          }))
+                        }
                         className={`flex-1 py-1.5 text-xs font-medium transition-colors ${minimaxIsOAuthMode ? 'bg-primary text-white' : 'text-secondary hover:bg-surface-raised'}`}
                       >
                         {i18nService.t('minimaxOAuthTabOAuth')}
@@ -2977,7 +3339,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       <button
                         type="button"
                         onClick={() => {
-                          setProviders(prev => ({ ...prev, minimax: { ...prev.minimax, authType: 'apikey' } }));
+                          setProviders(prev => ({
+                            ...prev,
+                            minimax: { ...prev.minimax, authType: 'apikey' },
+                          }));
                           setMinimaxOAuthPhase({ kind: 'idle' });
                         }}
                         className={`flex-1 py-1.5 text-xs font-medium transition-colors ${!minimaxIsOAuthMode ? 'bg-primary text-white' : 'text-secondary hover:bg-surface-raised'}`}
@@ -2991,13 +3356,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {!minimaxIsOAuthMode && (
                     <div className="min-h-[68px]">
                       <div className="flex items-center justify-between mb-1">
-                        <label htmlFor="minimax-apiKey" className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
+                        <label
+                          htmlFor="minimax-apiKey"
+                          className="block text-xs font-medium dark:text-claude-darkText text-claude-text"
+                        >
                           {i18nService.t('apiKey')}
                         </label>
                         {providerLinks.minimax?.apiKey && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks.minimax!.apiKey!)}
+                            onClick={() =>
+                              void window.electron.shell.openExternal(
+                                providerLinks.minimax!.apiKey!,
+                              )
+                            }
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -3005,34 +3377,44 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         )}
                       </div>
                       <div className="relative">
-                      <input
-                        type={showApiKey ? 'text' : 'password'}
-                        id="minimax-apiKey"
-                        value={providers.minimax.apiKey}
-                        onChange={(e) => handleProviderConfigChange('minimax', 'apiKey', e.target.value)}
-                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-xs"
-                        placeholder={i18nService.t('apiKeyPlaceholder')}
-                      />
-                      <div className="absolute right-2 inset-y-0 flex items-center gap-1">
-                        {providers.minimax.apiKey && (
+                        <input
+                          type={showApiKey ? 'text' : 'password'}
+                          id="minimax-apiKey"
+                          value={providers.minimax.apiKey}
+                          onChange={e =>
+                            handleProviderConfigChange('minimax', 'apiKey', e.target.value)
+                          }
+                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-xs"
+                          placeholder={i18nService.t('apiKeyPlaceholder')}
+                        />
+                        <div className="absolute right-2 inset-y-0 flex items-center gap-1">
+                          {providers.minimax.apiKey && (
+                            <button
+                              type="button"
+                              onClick={() => handleProviderConfigChange('minimax', 'apiKey', '')}
+                              className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
+                              title={i18nService.t('clear') || 'Clear'}
+                            >
+                              <XCircleIconSolid className="h-4 w-4" />
+                            </button>
+                          )}
                           <button
                             type="button"
-                            onClick={() => handleProviderConfigChange('minimax', 'apiKey', '')}
+                            onClick={() => setShowApiKey(!showApiKey)}
                             className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                            title={i18nService.t('clear') || 'Clear'}
+                            title={
+                              showApiKey
+                                ? i18nService.t('hide') || 'Hide'
+                                : i18nService.t('show') || 'Show'
+                            }
                           >
-                            <XCircleIconSolid className="h-4 w-4" />
+                            {showApiKey ? (
+                              <EyeIcon className="h-4 w-4" />
+                            ) : (
+                              <EyeSlashIcon className="h-4 w-4" />
+                            )}
                           </button>
-                        )}
-                        <button
-                          type="button"
-                          onClick={() => setShowApiKey(!showApiKey)}
-                          className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                          title={showApiKey ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
-                        >
-                          {showApiKey ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
-                        </button>
-                      </div>
+                        </div>
                       </div>
                     </div>
                   )}
@@ -3127,7 +3509,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           </div>
                           <a
                             href={minimaxOAuthPhase.verificationUri}
-                            onClick={(e) => { e.preventDefault(); void window.electron.shell.openExternal(minimaxOAuthPhase.verificationUri); }}
+                            onClick={e => {
+                              e.preventDefault();
+                              void window.electron.shell.openExternal(
+                                minimaxOAuthPhase.verificationUri,
+                              );
+                            }}
                             className="block text-[11px] text-primary underline truncate"
                           >
                             {minimaxOAuthPhase.verificationUri}
@@ -3193,13 +3580,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {activeProvider !== 'qwen' && (
                     <div>
                       <div className="flex items-center justify-between mb-1">
-                        <label htmlFor={`${activeProvider}-apiKey`} className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
+                        <label
+                          htmlFor={`${activeProvider}-apiKey`}
+                          className="block text-xs font-medium dark:text-claude-darkText text-claude-text"
+                        >
                           {i18nService.t('apiKey')}
                         </label>
                         {providerLinks[activeProvider]?.apiKey && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks[activeProvider]!.apiKey!)}
+                            onClick={() =>
+                              void window.electron.shell.openExternal(
+                                providerLinks[activeProvider]!.apiKey!,
+                              )
+                            }
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -3211,7 +3605,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           type={showApiKey ? 'text' : 'password'}
                           id={`${activeProvider}-apiKey`}
                           value={providers[activeProvider].apiKey}
-                          onChange={(e) => handleProviderConfigChange(activeProvider, 'apiKey', e.target.value)}
+                          onChange={e =>
+                            handleProviderConfigChange(activeProvider, 'apiKey', e.target.value)
+                          }
                           className="block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-16 text-xs"
                           placeholder={i18nService.t('apiKeyPlaceholder')}
                         />
@@ -3219,7 +3615,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           {providers[activeProvider].apiKey && (
                             <button
                               type="button"
-                              onClick={() => handleProviderConfigChange(activeProvider, 'apiKey', '')}
+                              onClick={() =>
+                                handleProviderConfigChange(activeProvider, 'apiKey', '')
+                              }
                               className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
                               title={i18nService.t('clear') || 'Clear'}
                             >
@@ -3230,9 +3628,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                             type="button"
                             onClick={() => setShowApiKey(!showApiKey)}
                             className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                            title={showApiKey ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                            title={
+                              showApiKey
+                                ? i18nService.t('hide') || 'Hide'
+                                : i18nService.t('show') || 'Show'
+                            }
                           >
-                            {showApiKey ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                            {showApiKey ? (
+                              <EyeIcon className="h-4 w-4" />
+                            ) : (
+                              <EyeSlashIcon className="h-4 w-4" />
+                            )}
                           </button>
                         </div>
                       </div>
@@ -3243,13 +3649,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {activeProvider === 'qwen' && (
                     <div>
                       <div className="flex items-center justify-between mb-1">
-                        <label htmlFor="qwen-apiKey" className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
+                        <label
+                          htmlFor="qwen-apiKey"
+                          className="block text-xs font-medium dark:text-claude-darkText text-claude-text"
+                        >
                           API Key
                         </label>
                         {providerLinks.qwen?.apiKey && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks.qwen!.apiKey!)}
+                            onClick={() =>
+                              void window.electron.shell.openExternal(providerLinks.qwen!.apiKey!)
+                            }
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -3261,7 +3672,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           type={showApiKey ? 'text' : 'password'}
                           id="qwen-apiKey"
                           value={providers.qwen.apiKey}
-                          onChange={(e) => handleProviderConfigChange('qwen', 'apiKey', e.target.value)}
+                          onChange={e =>
+                            handleProviderConfigChange('qwen', 'apiKey', e.target.value)
+                          }
                           className="block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-16 text-xs"
                           placeholder={i18nService.t('apiKeyPlaceholder')}
                         />
@@ -3280,9 +3693,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                             type="button"
                             onClick={() => setShowApiKey(!showApiKey)}
                             className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                            title={showApiKey ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                            title={
+                              showApiKey
+                                ? i18nService.t('hide') || 'Hide'
+                                : i18nService.t('show') || 'Show'
+                            }
                           >
-                            {showApiKey ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                            {showApiKey ? (
+                              <EyeIcon className="h-4 w-4" />
+                            ) : (
+                              <EyeSlashIcon className="h-4 w-4" />
+                            )}
                           </button>
                         </div>
                       </div>
@@ -3297,27 +3718,39 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     {i18nService.t('githubCopilotAuth')}
                   </label>
 
-                  {(copilotAuthStatus === 'idle' || copilotAuthStatus === 'error') && !providers['github-copilot'].apiKey && (
-                    <div className="space-y-2">
-                      <button
-                        type="button"
-                        onClick={handleCopilotSignIn}
-                        className="flex items-center gap-2 px-4 py-2 rounded-xl bg-claude-accent text-white text-xs font-medium hover:bg-claude-accent/90 transition-colors"
-                      >
-                        <GitHubCopilotIcon className="w-4 h-4" />
-                        {i18nService.t('githubCopilotSignIn')}
-                      </button>
-                      {copilotError && (
-                        <p className="text-xs text-red-500 dark:text-red-400">{copilotError}</p>
-                      )}
-                    </div>
-                  )}
+                  {(copilotAuthStatus === 'idle' || copilotAuthStatus === 'error') &&
+                    !providers['github-copilot'].apiKey && (
+                      <div className="space-y-2">
+                        <button
+                          type="button"
+                          onClick={handleCopilotSignIn}
+                          className="flex items-center gap-2 px-4 py-2 rounded-xl bg-claude-accent text-white text-xs font-medium hover:bg-claude-accent/90 transition-colors"
+                        >
+                          <GitHubCopilotIcon className="w-4 h-4" />
+                          {i18nService.t('githubCopilotSignIn')}
+                        </button>
+                        {copilotError && (
+                          <p className="text-xs text-red-500 dark:text-red-400">{copilotError}</p>
+                        )}
+                      </div>
+                    )}
 
                   {copilotAuthStatus === 'requesting' && (
                     <div className="flex items-center gap-2 text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
                       <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                        />
                       </svg>
                       {i18nService.t('githubCopilotRequesting')}
                     </div>
@@ -3354,8 +3787,19 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       <div className="flex items-center gap-3">
                         <div className="flex items-center gap-2 text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
                           <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
-                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                            <circle
+                              className="opacity-25"
+                              cx="12"
+                              cy="12"
+                              r="10"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                            />
+                            <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                            />
                           </svg>
                           {i18nService.t('githubCopilotWaiting')}
                         </div>
@@ -3370,38 +3814,46 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     </div>
                   )}
 
-                  {(copilotAuthStatus === 'authenticated' || providers['github-copilot'].apiKey) && copilotAuthStatus !== 'requesting' && copilotAuthStatus !== 'awaiting_user' && copilotAuthStatus !== 'polling' && (
-                    <div className="flex items-center justify-between p-3 rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset border border-claude-border dark:border-claude-darkBorder">
-                      <div className="flex items-center gap-2">
-                        <div className="w-2 h-2 rounded-full bg-green-500" />
-                        <span className="text-xs dark:text-claude-darkText text-claude-text">
-                          {copilotGithubUser
-                            ? `${i18nService.t('githubCopilotConnected')} @${copilotGithubUser}`
-                            : i18nService.t('githubCopilotConnected')}
-                        </span>
+                  {(copilotAuthStatus === 'authenticated' || providers['github-copilot'].apiKey) &&
+                    copilotAuthStatus !== 'requesting' &&
+                    copilotAuthStatus !== 'awaiting_user' &&
+                    copilotAuthStatus !== 'polling' && (
+                      <div className="flex items-center justify-between p-3 rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset border border-claude-border dark:border-claude-darkBorder">
+                        <div className="flex items-center gap-2">
+                          <div className="w-2 h-2 rounded-full bg-green-500" />
+                          <span className="text-xs dark:text-claude-darkText text-claude-text">
+                            {copilotGithubUser
+                              ? `${i18nService.t('githubCopilotConnected')} @${copilotGithubUser}`
+                              : i18nService.t('githubCopilotConnected')}
+                          </span>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={handleCopilotSignOut}
+                          className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-red-500 transition-colors"
+                        >
+                          {i18nService.t('githubCopilotSignOut')}
+                        </button>
                       </div>
-                      <button
-                        type="button"
-                        onClick={handleCopilotSignOut}
-                        className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-red-500 transition-colors"
-                      >
-                        {i18nService.t('githubCopilotSignOut')}
-                      </button>
-                    </div>
-                  )}
+                    )}
                 </div>
               )}
 
               {isCustomProvider(activeProvider) && (
                 <div>
-                  <label htmlFor={`${activeProvider}-displayName`} className="block text-xs font-medium dark:text-claude-darkText text-claude-text mb-1">
+                  <label
+                    htmlFor={`${activeProvider}-displayName`}
+                    className="block text-xs font-medium dark:text-claude-darkText text-claude-text mb-1"
+                  >
                     {i18nService.t('customDisplayName')}
                   </label>
                   <input
                     type="text"
                     id={`${activeProvider}-displayName`}
                     value={(providers[activeProvider] as ProviderConfig)?.displayName ?? ''}
-                    onChange={(e) => handleProviderConfigChange(activeProvider, 'displayName', e.target.value)}
+                    onChange={e =>
+                      handleProviderConfigChange(activeProvider, 'displayName', e.target.value)
+                    }
                     className="block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-xs"
                     placeholder={i18nService.t('customDisplayNamePlaceholder')}
                   />
@@ -3409,146 +3861,184 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               )}
 
               {!(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
-              <div>
-                <label htmlFor={`${activeProvider}-baseUrl`} className="block text-xs font-medium text-foreground mb-1">
-                  {i18nService.t('baseUrl')}
-                </label>
-                <div className="relative">
-                  <input
-                    type="text"
-                    id={`${activeProvider}-baseUrl`}
-                    value={
-                      (() => {
+                <div>
+                  <label
+                    htmlFor={`${activeProvider}-baseUrl`}
+                    className="block text-xs font-medium text-foreground mb-1"
+                  >
+                    {i18nService.t('baseUrl')}
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      id={`${activeProvider}-baseUrl`}
+                      value={(() => {
                         // Coding plan override: delegate to ProviderRegistry (50e20b76)
-                        const fmt = getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat);
+                        const fmt = getEffectiveApiFormat(
+                          activeProvider,
+                          providers[activeProvider].apiFormat,
+                        );
                         if (fmt !== 'gemini') {
-                          const cpUrl = (providers[activeProvider] as { codingPlanEnabled?: boolean }).codingPlanEnabled
+                          const cpUrl = (
+                            providers[activeProvider] as { codingPlanEnabled?: boolean }
+                          ).codingPlanEnabled
                             ? ProviderRegistry.getCodingPlanUrl(activeProvider, fmt)
                             : undefined;
                           if (cpUrl) return cpUrl;
                         }
                         return providers[activeProvider].baseUrl;
-                      })()
-                    }
-                    onChange={(e) => handleProviderConfigChange(activeProvider, 'baseUrl', e.target.value)}
-                    disabled={isBaseUrlLocked}
-                    className={`block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-8 text-xs ${isBaseUrlLocked ? 'opacity-50 cursor-not-allowed' : ''}`}
-                    placeholder={
-                      activeProvider === 'qwen'
-                        ? 'https://dashscope.aliyuncs.com/apps/anthropic'
-                        : getProviderDefaultBaseUrl(activeProvider, getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat)) || defaultConfig.providers?.[activeProvider]?.baseUrl || i18nService.t('baseUrlPlaceholder')
-                    }
-                  />
-                  {providers[activeProvider].baseUrl && !isBaseUrlLocked && (
-                    <div className="absolute right-2 inset-y-0 flex items-center">
-                      <button
-                        type="button"
-                        onClick={() => handleProviderConfigChange(activeProvider, 'baseUrl', '')}
-                        className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                        title={i18nService.t('clear') || 'Clear'}
-                      >
-                        <XCircleIconSolid className="h-4 w-4" />
-                      </button>
+                      })()}
+                      onChange={e =>
+                        handleProviderConfigChange(activeProvider, 'baseUrl', e.target.value)
+                      }
+                      disabled={isBaseUrlLocked}
+                      className={`block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-8 text-xs ${isBaseUrlLocked ? 'opacity-50 cursor-not-allowed' : ''}`}
+                      placeholder={
+                        activeProvider === 'qwen'
+                          ? 'https://dashscope.aliyuncs.com/apps/anthropic'
+                          : getProviderDefaultBaseUrl(
+                              activeProvider,
+                              getEffectiveApiFormat(
+                                activeProvider,
+                                providers[activeProvider].apiFormat,
+                              ),
+                            ) ||
+                            defaultConfig.providers?.[activeProvider]?.baseUrl ||
+                            i18nService.t('baseUrlPlaceholder')
+                      }
+                    />
+                    {providers[activeProvider].baseUrl && !isBaseUrlLocked && (
+                      <div className="absolute right-2 inset-y-0 flex items-center">
+                        <button
+                          type="button"
+                          onClick={() => handleProviderConfigChange(activeProvider, 'baseUrl', '')}
+                          className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
+                          title={i18nService.t('clear') || 'Clear'}
+                        >
+                          <XCircleIconSolid className="h-4 w-4" />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  {isCustomProvider(activeProvider) && (
+                    <div className="mt-1.5 space-y-0.5 text-[11px] text-secondary">
+                      <p>
+                        <span className="text-sm text-muted mr-1">•</span>
+                        {i18nService.t('baseUrlHint1')}
+                        <code className="ml-1 text-primary break-all">
+                          {i18nService.t('baseUrlHintExample1')}
+                        </code>
+                      </p>
+                      <p>
+                        <span className="text-sm text-muted mr-1">•</span>
+                        {i18nService.t('baseUrlHint2')}
+                        <code className="ml-1 text-primary break-all">
+                          {i18nService.t('baseUrlHintExample2')}
+                        </code>
+                      </p>
+                    </div>
+                  )}
+                  {/* GLM Coding Plan 提示 */}
+                  {activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">GLM Coding Plan:</span>{' '}
+                        {i18nService.t('zhipuCodingPlanEndpointHint')}
+                      </p>
+                    </div>
+                  )}
+                  {/* Qwen Coding Plan 提示 */}
+                  {activeProvider === 'qwen' && providers.qwen.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">Coding Plan:</span>{' '}
+                        {i18nService.t('qwenCodingPlanEndpointHint')}
+                      </p>
+                    </div>
+                  )}
+                  {/* Volcengine Coding Plan 提示 */}
+                  {activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">Coding Plan:</span>{' '}
+                        {i18nService.t('volcengineCodingPlanEndpointHint')}
+                      </p>
+                    </div>
+                  )}
+                  {/* Moonshot Coding Plan 提示 */}
+                  {activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">Coding Plan:</span>{' '}
+                        {i18nService.t('moonshotCodingPlanEndpointHint')}
+                      </p>
                     </div>
                   )}
                 </div>
-                {isCustomProvider(activeProvider) && (
-                <div className="mt-1.5 space-y-0.5 text-[11px] text-secondary">
-                  <p>
-                    <span className="text-sm text-muted mr-1">•</span>
-                    {i18nService.t('baseUrlHint1')}
-                    <code className="ml-1 text-primary break-all">{i18nService.t('baseUrlHintExample1')}</code>
-                  </p>
-                  <p>
-                    <span className="text-sm text-muted mr-1">•</span>
-                    {i18nService.t('baseUrlHint2')}
-                    <code className="ml-1 text-primary break-all">{i18nService.t('baseUrlHintExample2')}</code>
-                  </p>
-                </div>
-                )}
-                {/* GLM Coding Plan 提示 */}
-                {activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">GLM Coding Plan:</span> {i18nService.t('zhipuCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-                {/* Qwen Coding Plan 提示 */}
-                {activeProvider === 'qwen' && providers.qwen.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">Coding Plan:</span> {i18nService.t('qwenCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-                {/* Volcengine Coding Plan 提示 */}
-                {activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">Coding Plan:</span> {i18nService.t('volcengineCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-                {/* Moonshot Coding Plan 提示 */}
-                {activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">Coding Plan:</span> {i18nService.t('moonshotCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-              </div>
               )}
 
               {/* API 格式选择器 */}
-              {shouldShowApiFormatSelector(activeProvider) && !(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
-                <div>
-                  <label htmlFor={`${activeProvider}-apiFormat`} className="block text-xs font-medium text-foreground mb-1">
-                    {i18nService.t('apiFormat')}
-                  </label>
-                  <div className="flex items-center space-x-4">
-                    <label className="flex items-center">
-                      <input
-                        type="radio"
-                        name={`${activeProvider}-apiFormat`}
-                        value="anthropic"
-                        checked={getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat) !== 'openai'}
-                        onChange={() => handleProviderConfigChange(activeProvider, 'apiFormat', 'anthropic')}
-                        className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
-                      />
-                      <span className="ml-2 text-xs text-foreground">
-                        {i18nService.t('apiFormatNative')}
-                      </span>
+              {shouldShowApiFormatSelector(activeProvider) &&
+                !(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
+                  <div>
+                    <label
+                      htmlFor={`${activeProvider}-apiFormat`}
+                      className="block text-xs font-medium text-foreground mb-1"
+                    >
+                      {i18nService.t('apiFormat')}
                     </label>
-                    <label className="flex items-center">
-                      <input
-                        type="radio"
-                        name={`${activeProvider}-apiFormat`}
-                        value="openai"
-                        checked={getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat) === 'openai'}
-                        onChange={() => handleProviderConfigChange(activeProvider, 'apiFormat', 'openai')}
-                        className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
-                      />
-                      <span className="ml-2 text-xs text-foreground">
-                        {i18nService.t('apiFormatOpenAI')}
-                      </span>
-                    </label>
+                    <div className="flex items-center space-x-4">
+                      <label className="flex items-center">
+                        <input
+                          type="radio"
+                          name={`${activeProvider}-apiFormat`}
+                          value="anthropic"
+                          checked={
+                            getEffectiveApiFormat(
+                              activeProvider,
+                              providers[activeProvider].apiFormat,
+                            ) !== 'openai'
+                          }
+                          onChange={() =>
+                            handleProviderConfigChange(activeProvider, 'apiFormat', 'anthropic')
+                          }
+                          className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
+                        />
+                        <span className="ml-2 text-xs text-foreground">
+                          {i18nService.t('apiFormatNative')}
+                        </span>
+                      </label>
+                      <label className="flex items-center">
+                        <input
+                          type="radio"
+                          name={`${activeProvider}-apiFormat`}
+                          value="openai"
+                          checked={
+                            getEffectiveApiFormat(
+                              activeProvider,
+                              providers[activeProvider].apiFormat,
+                            ) === 'openai'
+                          }
+                          onChange={() =>
+                            handleProviderConfigChange(activeProvider, 'apiFormat', 'openai')
+                          }
+                          className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
+                        />
+                        <span className="ml-2 text-xs text-foreground">
+                          {i18nService.t('apiFormatOpenAI')}
+                        </span>
+                      </label>
+                    </div>
+                    <p className="mt-1 text-xs text-secondary">{i18nService.t('apiFormatHint')}</p>
                   </div>
-                  <p className="mt-1 text-xs text-secondary">
-                    {i18nService.t('apiFormatHint')}
-                  </p>
-                </div>
-              )}
+                )}
 
               {/* GLM Coding Plan 开关 (仅 Zhipu) */}
               {activeProvider === 'zhipu' && (
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        GLM Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">GLM Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         Beta
                       </span>
@@ -3561,7 +4051,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.zhipu.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('zhipu', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'zhipu',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3574,9 +4070,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         {i18nService.t('codingPlanSubscriptionBadge')}
                       </span>
@@ -3589,7 +4083,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.qwen.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('qwen', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'qwen',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3602,9 +4102,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         Beta
                       </span>
@@ -3617,7 +4115,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.volcengine.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('volcengine', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'volcengine',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3630,9 +4134,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         Beta
                       </span>
@@ -3645,7 +4147,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.moonshot.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('moonshot', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'moonshot',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3655,17 +4163,22 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
               {/* 测试连接按钮 */}
               {!(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
-              <div className="flex items-center space-x-3">
-                <button
-                  type="button"
-                  onClick={handleTestConnection}
-                  disabled={isTesting || (providerRequiresApiKey(activeProvider) && !providers[activeProvider].apiKey && !(activeProvider === 'qwen' && (providers.qwen as any).oauthCredentials))}
-                  className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-xl border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
-                >
-                  <SignalIcon className="h-3.5 w-3.5 mr-1.5" />
-                  {isTesting ? i18nService.t('testing') : i18nService.t('testConnection')}
-                </button>
-              </div>
+                <div className="flex items-center space-x-3">
+                  <button
+                    type="button"
+                    onClick={handleTestConnection}
+                    disabled={
+                      isTesting ||
+                      (providerRequiresApiKey(activeProvider) &&
+                        !providers[activeProvider].apiKey &&
+                        !(activeProvider === 'qwen' && (providers.qwen as any).oauthCredentials))
+                    }
+                    className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-xl border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
+                  >
+                    <SignalIcon className="h-3.5 w-3.5 mr-1.5" />
+                    {isTesting ? i18nService.t('testing') : i18nService.t('testConnection')}
+                  </button>
+                </div>
               )}
 
               <div>
@@ -3694,7 +4207,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         <div className="flex items-center gap-1.5 min-w-0 flex-1">
                           <div className="w-1.5 h-1.5 shrink-0 rounded-full bg-green-400"></div>
                           <div className="min-w-0">
-                            <div className="text-foreground font-medium text-[11px] truncate">{model.name}</div>
+                            <div className="text-foreground font-medium text-[11px] truncate">
+                              {model.name}
+                            </div>
                             <div className="text-[10px] text-secondary truncate">{model.id}</div>
                           </div>
                         </div>
@@ -3706,7 +4221,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           )}
                           <button
                             type="button"
-                            onClick={() => handleEditModel(model.id, model.name, model.supportsImage)}
+                            onClick={() =>
+                              handleEditModel(model.id, model.name, model.supportsImage)
+                            }
                             className="p-0.5 text-secondary hover:text-primary opacity-0 group-hover:opacity-100 transition-opacity"
                           >
                             <PencilIcon className="h-3.5 w-3.5" />
@@ -3723,9 +4240,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     </div>
                   ))}
 
-                  {(!providers[activeProvider].models || providers[activeProvider].models.length === 0) && (
+                  {(!providers[activeProvider].models ||
+                    providers[activeProvider].models.length === 0) && (
                     <div className="bg-surface p-2.5 rounded-xl border border-border-subtle text-center">
-                      <p className="text-[11px] text-secondary">{i18nService.t('noModelsAvailable')}</p>
+                      <p className="text-[11px] text-secondary">
+                        {i18nService.t('noModelsAvailable')}
+                      </p>
                       <button
                         type="button"
                         onClick={handleAddModel}
@@ -3742,54 +4262,102 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           </div>
         );
 
-      case 'coworkAgent':
-        return (
-          <div className="space-y-6">
-            {/* Agent Settings (IDENTITY.md + SOUL.md) */}
-            <div className="space-y-4 rounded-xl border px-4 py-4 border-border">
-              <div className="text-sm font-medium text-foreground">
-                {i18nService.t('coworkBootstrapAgentSectionTitle')}
+      case 'coworkAgent': {
+        if (bootstrapLoading) {
+          return (
+            <div className="flex flex-col gap-4 animate-pulse">
+              <div className="flex gap-1 p-1 rounded-xl bg-surface-raised w-fit">
+                {[76, 76, 72].map((w, i) => (
+                  <div key={i} className="h-8 rounded-lg bg-background/60" style={{ width: w }} />
+                ))}
               </div>
-              {[
-                { filename: 'IDENTITY.md', titleKey: 'coworkBootstrapIdentityTitle', hintKey: 'coworkBootstrapIdentityHint', value: bootstrapIdentity, setter: setBootstrapIdentity },
-                { filename: 'SOUL.md', titleKey: 'coworkBootstrapSoulTitle', hintKey: 'coworkBootstrapSoulHint', value: bootstrapSoul, setter: setBootstrapSoul },
-              ].map(({ filename, titleKey, hintKey, value, setter }) => (
-                <div key={filename} className="space-y-2">
-                  <div className="text-xs font-medium text-secondary">
-                    {i18nService.t(titleKey)}
-                    <span className="ml-1.5 font-normal opacity-60">
-                      （{i18nService.t('coworkBootstrapStoragePath')}：<span className="font-mono">{joinWorkspacePath(coworkConfig.workingDirectory, filename)}</span>）
-                    </span>
-                  </div>
-                  <textarea
-                    value={value}
-                    onChange={(e) => setter(e.target.value)}
-                    rows={3}
-                    className="w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground resize-y"
-                    placeholder={i18nService.t(hintKey)}
-                  />
-                </div>
+              <div className="h-3 w-2/3 rounded bg-surface-raised" />
+              <div className="h-[320px] rounded-lg bg-surface-raised" />
+            </div>
+          );
+        }
+
+        const agentFileConfig = [
+          {
+            key: 'identity' as const,
+            filename: 'IDENTITY.md',
+            titleKey: 'coworkBootstrapIdentityTitle',
+            hintKey: 'coworkBootstrapIdentityHint',
+            value: bootstrapIdentity,
+            setter: setBootstrapIdentity,
+          },
+          {
+            key: 'soul' as const,
+            filename: 'SOUL.md',
+            titleKey: 'coworkBootstrapSoulTitle',
+            hintKey: 'coworkBootstrapSoulHint',
+            value: bootstrapSoul,
+            setter: setBootstrapSoul,
+          },
+          {
+            key: 'user' as const,
+            filename: 'USER.md',
+            titleKey: 'coworkBootstrapUserTitle',
+            hintKey: 'coworkBootstrapUserHint',
+            value: bootstrapUser,
+            setter: setBootstrapUser,
+          },
+        ];
+
+        const activeFileConfig = agentFileConfig.find(f => f.key === bootstrapActiveFile)!;
+        const activeFilePath = joinWorkspacePath(
+          coworkConfig.workingDirectory,
+          activeFileConfig.filename,
+        );
+
+        return (
+          <div className="flex flex-col gap-4">
+            {/* Segment control */}
+            <div className="flex items-center gap-1 p-1 rounded-xl bg-surface-raised w-fit">
+              {agentFileConfig.map(({ key, titleKey }) => (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setBootstrapActiveFile(key)}
+                  className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-all ${
+                    bootstrapActiveFile === key
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-secondary hover:text-foreground'
+                  }`}
+                >
+                  {i18nService.t(titleKey)}
+                </button>
               ))}
             </div>
 
-            {/* User Profile (USER.md) */}
-            <div className="space-y-3 rounded-xl border px-4 py-4 border-border">
-              <div className="text-sm font-medium text-foreground">
-                {i18nService.t('coworkBootstrapUserTitle')}
-                <span className="ml-1.5 text-xs font-normal opacity-60 text-secondary">
-                  （{i18nService.t('coworkBootstrapStoragePath')}：<span className="font-mono">{joinWorkspacePath(coworkConfig.workingDirectory, 'USER.md')}</span>）
+            {/* Description + file path */}
+            <div className="flex items-start justify-between gap-4">
+              <p className="text-xs text-secondary/70 leading-relaxed">
+                {i18nService.t(activeFileConfig.hintKey)}
+              </p>
+              <button
+                type="button"
+                onClick={() => void window.electron.shell.showItemInFolder(activeFilePath)}
+                title={`${i18nService.t('showInFolder')}\n${activeFilePath}`}
+                className="group flex items-center gap-1 shrink-0 mt-0.5"
+              >
+                <FolderOpenIcon className="h-3 w-3 text-secondary/30 group-hover:text-primary transition-colors" />
+                <span className="text-[10px] font-mono text-secondary/40 group-hover:text-primary/70 transition-colors">
+                  {activeFileConfig.filename}
                 </span>
-              </div>
-              <textarea
-                value={bootstrapUser}
-                onChange={(e) => setBootstrapUser(e.target.value)}
-                rows={3}
-                className="w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground resize-y"
-                placeholder={i18nService.t('coworkBootstrapUserHint')}
-              />
+              </button>
             </div>
+
+            {/* Editor */}
+            <MarkdownEditor
+              value={activeFileConfig.value}
+              onChange={activeFileConfig.setter}
+              placeholder={`# ${activeFileConfig.filename}\n\n`}
+              height={320}
+            />
           </div>
         );
+      }
 
       case 'shortcuts':
         return (
@@ -3801,15 +4369,24 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('newChat')}</span>
-                  <ShortcutRecorder value={shortcuts.newChat} onChange={(v) => handleShortcutChange('newChat', v)} />
+                  <ShortcutRecorder
+                    value={shortcuts.newChat}
+                    onChange={v => handleShortcutChange('newChat', v)}
+                  />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('search')}</span>
-                  <ShortcutRecorder value={shortcuts.search} onChange={(v) => handleShortcutChange('search', v)} />
+                  <ShortcutRecorder
+                    value={shortcuts.search}
+                    onChange={v => handleShortcutChange('search', v)}
+                  />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('openSettings')}</span>
-                  <ShortcutRecorder value={shortcuts.settings} onChange={(v) => handleShortcutChange('settings', v)} />
+                  <ShortcutRecorder
+                    value={shortcuts.settings}
+                    onChange={v => handleShortcutChange('settings', v)}
+                  />
                 </div>
               </div>
             </div>
@@ -3845,34 +4422,36 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center gap-2">
                   <span className="text-sm text-secondary">{appVersion}</span>
                   {!enterpriseConfig?.disableUpdate && (
-                  <button
-                    type="button"
-                    disabled={updateCheckStatus === 'checking'}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void handleCheckUpdate();
-                    }}
-                    className="text-xs px-2 py-0.5 rounded-md border border-border text-secondary hover:text-primary dark:hover:text-primary hover:border-primary dark:hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {updateCheckStatus === 'checking' && i18nService.t('updateChecking')}
-                    {updateCheckStatus === 'upToDate' && i18nService.t('updateUpToDate')}
-                    {updateCheckStatus === 'error' && i18nService.t('updateCheckFailed')}
-                    {updateCheckStatus === 'idle' && i18nService.t('checkForUpdate')}
-                  </button>
+                    <button
+                      type="button"
+                      disabled={updateCheckStatus === 'checking'}
+                      onClick={e => {
+                        e.stopPropagation();
+                        void handleCheckUpdate();
+                      }}
+                      className="text-xs px-2 py-0.5 rounded-md border border-border text-secondary hover:text-primary dark:hover:text-primary hover:border-primary dark:hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {updateCheckStatus === 'checking' && i18nService.t('updateChecking')}
+                      {updateCheckStatus === 'upToDate' && i18nService.t('updateUpToDate')}
+                      {updateCheckStatus === 'error' && i18nService.t('updateCheckFailed')}
+                      {updateCheckStatus === 'idle' && i18nService.t('checkForUpdate')}
+                    </button>
                   )}
                   {enterpriseConfig?.disableUpdate && (
-                  <span className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
-                    {i18nService.t('settings.enterprise.managed')}
-                  </span>
+                    <span className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
+                      {i18nService.t('settings.enterprise.managed')}
+                    </span>
                   )}
                 </div>
               </div>
               <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-                <span className="text-sm text-foreground">{i18nService.t('aboutContactEmail')}</span>
+                <span className="text-sm text-foreground">
+                  {i18nService.t('aboutContactEmail')}
+                </span>
                 <div className="flex items-center gap-2">
                   <button
                     type="button"
-                    onClick={(e) => {
+                    onClick={e => {
                       e.stopPropagation();
                       void handleCopyContactEmail();
                     }}
@@ -3892,7 +4471,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <span className="text-sm text-foreground">{i18nService.t('aboutUserManual')}</span>
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     handleOpenUserManual();
                   }}
@@ -3901,11 +4480,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {ABOUT_USER_MANUAL_URL}
                 </button>
               </div>
-              <div className={`flex items-center justify-between px-4 py-3${testModeUnlocked ? ' border-b border-border' : ''}`}>
-                <span className="text-sm text-foreground">{i18nService.t('aboutUserCommunity')}</span>
+              <div
+                className={`flex items-center justify-between px-4 py-3${testModeUnlocked ? ' border-b border-border' : ''}`}
+              >
+                <span className="text-sm text-foreground">
+                  {i18nService.t('aboutUserCommunity')}
+                </span>
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     handleOpenUserCommunity();
                   }}
@@ -3921,7 +4504,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     type="button"
                     role="switch"
                     aria-checked={testMode}
-                    onClick={() => setTestMode((prev) => !prev)}
+                    onClick={() => setTestMode(prev => !prev)}
                     className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                       testMode ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
                     }`}
@@ -3941,7 +4524,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <div className="flex items-center justify-center text-sm text-secondary">
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     handleOpenServiceTerms();
                   }}
@@ -3952,20 +4535,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <span className="mx-3 text-xs opacity-40">|</span>
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     void handleExportLogs();
                   }}
                   disabled={isExportingLogs}
                   className="bg-transparent border-none appearance-none px-1.5 py-0.5 -mx-1.5 -my-0.5 rounded-md cursor-pointer hover:text-primary dark:hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  {isExportingLogs ? i18nService.t('aboutExportingLogs') : i18nService.t('aboutExportLogs')}
+                  {isExportingLogs
+                    ? i18nService.t('aboutExportingLogs')
+                    : i18nService.t('aboutExportLogs')}
                 </button>
               </div>
 
-              <p className="mt-5 text-xs text-secondary">
-                {i18nService.t('copyrightHolder')}
-              </p>
+              <p className="mt-5 text-xs text-secondary">{i18nService.t('copyrightHolder')}</p>
               <p className="mt-1 text-xs text-secondary">
                 Copyright &copy; {new Date().getFullYear()} NetEase Youdao. All Rights Reserved.
               </p>
@@ -3979,7 +4562,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   };
 
   return (
-    <Modal onClose={onClose} overlayClassName="fixed inset-0 z-50 modal-backdrop flex items-center justify-center">
+    <Modal
+      onClose={onClose}
+      overlayClassName="fixed inset-0 z-50 modal-backdrop flex items-center justify-center"
+    >
       <div
         className="relative flex w-[900px] h-[80vh] rounded-2xl border-border border shadow-modal overflow-hidden modal-content"
         onClick={handleSettingsClick}
@@ -3990,7 +4576,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             <h2 className="text-lg font-semibold text-foreground">{i18nService.t('settings')}</h2>
           </div>
           <nav className="flex flex-col gap-0.5 px-3 pb-4">
-            {sidebarTabs.map((tab) => (
+            {sidebarTabs.map(tab => (
               <button
                 key={tab.key}
                 onClick={() => handleTabChange(tab.key)}
@@ -4022,19 +4608,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
           {noticeMessage && (
             <div className="px-6">
-              <ErrorMessage
-                message={noticeMessage}
-                onClose={() => setNoticeMessage(null)}
-              />
+              <ErrorMessage message={noticeMessage} onClose={() => setNoticeMessage(null)} />
             </div>
           )}
 
           {error && (
             <div className="px-6">
-              <ErrorMessage
-                message={error}
-                onClose={() => setError(null)}
-              />
+              <ErrorMessage message={error} onClose={() => setError(null)} />
             </div>
           )}
 
@@ -4066,7 +4646,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               </button>
             </div>
           </form>
-
         </div>
 
         {isTestResultModalOpen && testResult && (
@@ -4078,7 +4657,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               role="dialog"
               aria-modal="true"
               aria-label={i18nService.t('connectionTestResult')}
-              onClick={(e) => e.stopPropagation()}
+              onClick={e => e.stopPropagation()}
               className="w-full max-w-md rounded-2xl bg-background border-border border shadow-modal p-4"
             >
               <div className="flex items-center justify-between mb-3">
@@ -4097,13 +4676,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <div className="flex items-center gap-2 text-xs text-secondary">
                 <span>{providerMeta[testResult.provider]?.label ?? testResult.provider}</span>
                 <span className="text-[11px]">•</span>
-                <span className={`inline-flex items-center gap-1 ${testResult.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                <span
+                  className={`inline-flex items-center gap-1 ${testResult.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+                >
                   {testResult.success ? (
                     <CheckCircleIcon className="h-4 w-4" />
                   ) : (
                     <XCircleIcon className="h-4 w-4" />
                   )}
-                  {testResult.success ? i18nService.t('connectionSuccess') : i18nService.t('connectionFailed')}
+                  {testResult.success
+                    ? i18nService.t('connectionSuccess')
+                    : i18nService.t('connectionFailed')}
                 </span>
               </div>
 
@@ -4132,7 +4715,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             <div
               role="dialog"
               aria-modal="true"
-              onClick={(e) => e.stopPropagation()}
+              onClick={e => e.stopPropagation()}
               className="w-full max-w-sm rounded-2xl dark:bg-claude-darkSurface bg-claude-bg dark:border-claude-darkBorder border-claude-border border shadow-modal p-4"
             >
               <p className="text-sm dark:text-claude-darkText text-claude-text">
@@ -4163,211 +4746,217 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4 rounded-2xl"
             onClick={handleCancelModelEdit}
           >
-              <div
-                role="dialog"
-                aria-modal="true"
-                aria-label={isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')}
-                onClick={(e) => e.stopPropagation()}
-                onKeyDown={handleModelDialogKeyDown}
-                className="w-full max-w-md rounded-2xl bg-background border-border border shadow-modal p-4"
-              >
-                <div className="flex items-center justify-between mb-3">
-                  <h4 className="text-sm font-semibold text-foreground">
-                    {isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')}
-                  </h4>
-                  <button
-                    type="button"
-                    onClick={handleCancelModelEdit}
-                    className="p-1 text-secondary hover:text-foreground rounded-md hover:bg-surface-raised"
-                  >
-                    <XMarkIcon className="h-4 w-4" />
-                  </button>
-                </div>
-
-                {modelFormError && (
-                  <p className="mb-3 text-xs text-red-600 dark:text-red-400">
-                    {modelFormError}
-                  </p>
-                )}
-
-                <div className="space-y-3">
-                  {activeProvider === 'ollama' ? (
-                    <>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('ollamaModelName')}
-                        </label>
-                        <input
-                          autoFocus
-                          type="text"
-                          value={newModelId}
-                          onChange={(e) => {
-                            setNewModelId(e.target.value);
-                            if (!newModelName || newModelName === newModelId) {
-                              setNewModelName(e.target.value);
-                            }
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder={i18nService.t('ollamaModelNamePlaceholder')}
-                        />
-                        <p className="mt-1 text-[11px] text-muted">
-                          {i18nService.t('ollamaModelNameHint')}
-                        </p>
-                      </div>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('ollamaDisplayName')}
-                        </label>
-                        <input
-                          type="text"
-                          value={newModelName === newModelId ? '' : newModelName}
-                          onChange={(e) => {
-                            setNewModelName(e.target.value || newModelId);
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder={i18nService.t('ollamaDisplayNamePlaceholder')}
-                        />
-                        <p className="mt-1 text-[11px] text-muted">
-                          {i18nService.t('ollamaDisplayNameHint')}
-                        </p>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('modelName')}
-                        </label>
-                        <input
-                          autoFocus
-                          type="text"
-                          value={newModelName}
-                          onChange={(e) => {
-                            setNewModelName(e.target.value);
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder="GPT-4"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('modelId')}
-                        </label>
-                        <input
-                          type="text"
-                          value={newModelId}
-                          onChange={(e) => {
-                            setNewModelId(e.target.value);
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder="gpt-4"
-                        />
-                      </div>
-                    </>
-                  )}
-                  <div className="flex items-center space-x-2">
-                    <input
-                      id={`${activeProvider}-supportsImage`}
-                      type="checkbox"
-                      checked={newModelSupportsImage}
-                      onChange={(e) => setNewModelSupportsImage(e.target.checked)}
-                      className="h-3.5 w-3.5 text-primary focus:ring-primary bg-surface border-border rounded"
-                    />
-                    <label
-                      htmlFor={`${activeProvider}-supportsImage`}
-                      className="text-xs text-secondary"
-                    >
-                      {i18nService.t('supportsImageInput')}
-                    </label>
-                  </div>
-                </div>
-
-                <div className="flex justify-end space-x-2 mt-4">
-                  <button
-                    type="button"
-                    onClick={handleCancelModelEdit}
-                    className="px-3 py-1.5 text-xs text-foreground hover:bg-surface-raised rounded-xl border border-border"
-                  >
-                    {i18nService.t('cancel')}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleSaveNewModel}
-                    className="px-3 py-1.5 text-xs text-white bg-primary hover:bg-primary-hover rounded-xl active:scale-[0.98]"
-                  >
-                    {i18nService.t('save')}
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Memory Modal */}
-          {showMemoryModal && (
             <div
-              className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4 rounded-2xl"
-              onClick={resetCoworkMemoryEditor}
+              role="dialog"
+              aria-modal="true"
+              aria-label={
+                isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')
+              }
+              onClick={e => e.stopPropagation()}
+              onKeyDown={handleModelDialogKeyDown}
+              className="w-full max-w-md rounded-2xl bg-background border-border border shadow-modal p-4"
             >
-              <div
-                className="bg-surface border-border border rounded-2xl shadow-xl w-full max-w-md"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <div className="px-5 pt-5 pb-4 border-b border-border">
-                  <h3 className="text-base font-semibold text-foreground">
-                    {coworkMemoryEditingId ? i18nService.t('coworkMemoryCrudUpdate') : i18nService.t('coworkMemoryCrudCreate')}
-                  </h3>
-                </div>
+              <div className="flex items-center justify-between mb-3">
+                <h4 className="text-sm font-semibold text-foreground">
+                  {isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')}
+                </h4>
+                <button
+                  type="button"
+                  onClick={handleCancelModelEdit}
+                  className="p-1 text-secondary hover:text-foreground rounded-md hover:bg-surface-raised"
+                >
+                  <XMarkIcon className="h-4 w-4" />
+                </button>
+              </div>
 
-                <div className="px-5 py-4 space-y-4">
-                  {coworkMemoryEditingId && (
-                    <div className="rounded-lg border px-2 py-1 text-xs border-border text-secondary">
-                      {i18nService.t('coworkMemoryEditingTag')}
+              {modelFormError && (
+                <p className="mb-3 text-xs text-red-600 dark:text-red-400">{modelFormError}</p>
+              )}
+
+              <div className="space-y-3">
+                {activeProvider === 'ollama' ? (
+                  <>
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('ollamaModelName')}
+                      </label>
+                      <input
+                        autoFocus
+                        type="text"
+                        value={newModelId}
+                        onChange={e => {
+                          setNewModelId(e.target.value);
+                          if (!newModelName || newModelName === newModelId) {
+                            setNewModelName(e.target.value);
+                          }
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder={i18nService.t('ollamaModelNamePlaceholder')}
+                      />
+                      <p className="mt-1 text-[11px] text-muted">
+                        {i18nService.t('ollamaModelNameHint')}
+                      </p>
                     </div>
-                  )}
-                  <textarea
-                    value={coworkMemoryDraftText}
-                    onChange={(event) => setCoworkMemoryDraftText(event.target.value)}
-                    placeholder={i18nService.t('coworkMemoryCrudTextPlaceholder')}
-                    autoFocus
-                    className="min-h-[200px] w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground focus:border-primary focus:ring-1 focus:ring-primary/30"
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('ollamaDisplayName')}
+                      </label>
+                      <input
+                        type="text"
+                        value={newModelName === newModelId ? '' : newModelName}
+                        onChange={e => {
+                          setNewModelName(e.target.value || newModelId);
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder={i18nService.t('ollamaDisplayNamePlaceholder')}
+                      />
+                      <p className="mt-1 text-[11px] text-muted">
+                        {i18nService.t('ollamaDisplayNameHint')}
+                      </p>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('modelName')}
+                      </label>
+                      <input
+                        autoFocus
+                        type="text"
+                        value={newModelName}
+                        onChange={e => {
+                          setNewModelName(e.target.value);
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder="GPT-4"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('modelId')}
+                      </label>
+                      <input
+                        type="text"
+                        value={newModelId}
+                        onChange={e => {
+                          setNewModelId(e.target.value);
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder="gpt-4"
+                      />
+                    </div>
+                  </>
+                )}
+                <div className="flex items-center space-x-2">
+                  <input
+                    id={`${activeProvider}-supportsImage`}
+                    type="checkbox"
+                    checked={newModelSupportsImage}
+                    onChange={e => setNewModelSupportsImage(e.target.checked)}
+                    className="h-3.5 w-3.5 text-primary focus:ring-primary bg-surface border-border rounded"
                   />
-                </div>
-
-                <div className="flex justify-end space-x-2 px-5 pb-5">
-                  <button
-                    type="button"
-                    onClick={resetCoworkMemoryEditor}
-                    className="px-3 py-1.5 text-sm text-foreground hover:bg-surface-raised rounded-xl border border-border transition-colors"
+                  <label
+                    htmlFor={`${activeProvider}-supportsImage`}
+                    className="text-xs text-secondary"
                   >
-                    {i18nService.t('cancel')}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => { void handleSaveCoworkMemoryEntry(); }}
-                    disabled={!coworkMemoryDraftText.trim() || coworkMemoryListLoading}
-                    className="px-3 py-1.5 text-sm text-white bg-primary hover:bg-primary-hover rounded-xl disabled:opacity-60 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
-                  >
-                    {coworkMemoryEditingId ? i18nService.t('save') : i18nService.t('coworkMemoryCrudCreate')}
-                  </button>
+                    {i18nService.t('supportsImageInput')}
+                  </label>
                 </div>
               </div>
+
+              <div className="flex justify-end space-x-2 mt-4">
+                <button
+                  type="button"
+                  onClick={handleCancelModelEdit}
+                  className="px-3 py-1.5 text-xs text-foreground hover:bg-surface-raised rounded-xl border border-border"
+                >
+                  {i18nService.t('cancel')}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSaveNewModel}
+                  className="px-3 py-1.5 text-xs text-white bg-primary hover:bg-primary-hover rounded-xl active:scale-[0.98]"
+                >
+                  {i18nService.t('save')}
+                </button>
+              </div>
             </div>
-          )}
+          </div>
+        )}
+
+        {/* Memory Modal */}
+        {showMemoryModal && (
+          <div
+            className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4 rounded-2xl"
+            onClick={resetCoworkMemoryEditor}
+          >
+            <div
+              className="bg-surface border-border border rounded-2xl shadow-xl w-full max-w-md"
+              onClick={e => e.stopPropagation()}
+            >
+              <div className="px-5 pt-5 pb-4 border-b border-border">
+                <h3 className="text-base font-semibold text-foreground">
+                  {coworkMemoryEditingId
+                    ? i18nService.t('coworkMemoryCrudUpdate')
+                    : i18nService.t('coworkMemoryCrudCreate')}
+                </h3>
+              </div>
+
+              <div className="px-5 py-4 space-y-4">
+                {coworkMemoryEditingId && (
+                  <div className="rounded-lg border px-2 py-1 text-xs border-border text-secondary">
+                    {i18nService.t('coworkMemoryEditingTag')}
+                  </div>
+                )}
+                <textarea
+                  value={coworkMemoryDraftText}
+                  onChange={event => setCoworkMemoryDraftText(event.target.value)}
+                  placeholder={i18nService.t('coworkMemoryCrudTextPlaceholder')}
+                  autoFocus
+                  className="min-h-[200px] w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground focus:border-primary focus:ring-1 focus:ring-primary/30"
+                />
+              </div>
+
+              <div className="flex justify-end space-x-2 px-5 pb-5">
+                <button
+                  type="button"
+                  onClick={resetCoworkMemoryEditor}
+                  className="px-3 py-1.5 text-sm text-foreground hover:bg-surface-raised rounded-xl border border-border transition-colors"
+                >
+                  {i18nService.t('cancel')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    void handleSaveCoworkMemoryEntry();
+                  }}
+                  disabled={!coworkMemoryDraftText.trim() || coworkMemoryListLoading}
+                  className="px-3 py-1.5 text-sm text-white bg-primary hover:bg-primary-hover rounded-xl disabled:opacity-60 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
+                >
+                  {coworkMemoryEditingId
+                    ? i18nService.t('save')
+                    : i18nService.t('coworkMemoryCrudCreate')}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </Modal>
   );
 };
 
-export default Settings; 
+export default Settings;

--- a/src/renderer/components/common/MarkdownEditor.tsx
+++ b/src/renderer/components/common/MarkdownEditor.tsx
@@ -1,0 +1,126 @@
+import '@uiw/react-md-editor/markdown-editor.css';
+
+import MDEditor, { commands } from '@uiw/react-md-editor';
+import React, { useEffect, useRef, useState } from 'react';
+
+interface MarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  height?: number;
+}
+
+const headingIcon = (label: string) => (
+  <span style={{ fontSize: 11, fontWeight: 700, lineHeight: 1, letterSpacing: '-0.02em' }}>
+    {label}
+  </span>
+);
+
+const h1Command = { ...commands.title1, icon: headingIcon('H1') };
+const h2Command = { ...commands.title2, icon: headingIcon('H2') };
+const h3Command = { ...commands.title3, icon: headingIcon('H3') };
+
+/**
+ * Thin wrapper around @uiw/react-md-editor that:
+ * - Keeps the color-mode in sync with the app's dark/light theme
+ * - Strips non-relevant toolbar actions (fullscreen, link, image, etc.)
+ * - Provides sensible defaults for use inside Settings panels
+ */
+const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
+  value,
+  onChange,
+  placeholder,
+  height = 220,
+}) => {
+  const [colorMode, setColorMode] = useState<'light' | 'dark'>('light');
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Mirror the `dark` class on <html> set by ThemeManager
+  useEffect(() => {
+    const update = () => {
+      setColorMode(document.documentElement.classList.contains('dark') ? 'dark' : 'light');
+    };
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  /**
+   * Clicking the empty space below text in the editor content area does not
+   * naturally focus the textarea because the textarea only covers the height
+   * of the actual text, not the full editor height (a known issue with the
+   * textarea-overlay approach used by @uiw/react-md-editor).
+   *
+   * Fix: intercept clicks that land inside the content area but outside the
+   * textarea itself, and programmatically forward focus to the textarea.
+   */
+  const handleContentClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as Element;
+    // Let normal clicks on interactive elements pass through untouched
+    if (
+      target.tagName === 'TEXTAREA' ||
+      target.closest('.w-md-editor-toolbar') ||
+      target.closest('button')
+    ) {
+      return;
+    }
+    // Only act on clicks inside the text editing area
+    if (!target.closest('.w-md-editor-content')) return;
+
+    const textarea =
+      wrapperRef.current?.querySelector<HTMLTextAreaElement>('.w-md-editor-text-input');
+    if (textarea) {
+      textarea.focus();
+      // Place cursor at end so the user can start typing immediately
+      const len = textarea.value.length;
+      textarea.setSelectionRange(len, len);
+    }
+  };
+
+  return (
+    <div
+      ref={wrapperRef}
+      data-color-mode={colorMode}
+      className="md-editor-wrapper rounded-lg overflow-hidden border border-border"
+      onClick={handleContentClick}
+    >
+      <MDEditor
+        value={value}
+        onChange={val => onChange(val ?? '')}
+        height={height}
+        preview="edit"
+        data-color-mode={colorMode}
+        textareaProps={{ placeholder }}
+        commands={[
+          commands.bold,
+          commands.italic,
+          commands.strikethrough,
+          commands.divider,
+          h1Command,
+          h2Command,
+          h3Command,
+          commands.divider,
+          commands.unorderedListCommand,
+          commands.orderedListCommand,
+          commands.divider,
+          commands.quote,
+          commands.code,
+          commands.codeBlock,
+        ]}
+        extraCommands={[
+          commands.codeEdit,
+          commands.codeLive,
+          commands.codePreview,
+          commands.divider,
+          commands.fullscreen,
+        ]}
+      />
+    </div>
+  );
+};
+
+export default MarkdownEditor;

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -42,7 +42,8 @@ table {
   width: 100%;
 }
 
-th, td {
+th,
+td {
   border-color: var(--lobster-border);
   padding: 0.5em;
 }
@@ -69,7 +70,9 @@ blockquote {
 }
 
 :root {
-  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Inter', system-ui, 'Segoe UI', Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Inter', system-ui, 'Segoe UI', Roboto,
+    sans-serif;
   line-height: 1.6;
   font-weight: 400;
 
@@ -81,7 +84,10 @@ blockquote {
 
 /* Theme colors are driven by CSS variables from themes.css.
  * color-scheme is set by the [data-theme] selectors. */
-body, #root, .App, main {
+body,
+#root,
+.App,
+main {
   background-color: var(--lobster-background);
   color: var(--lobster-foreground);
 }
@@ -210,7 +216,7 @@ select::-ms-expand {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.08), transparent);
   animation: shimmer 1.5s infinite;
 }
 
@@ -220,7 +226,7 @@ select::-ms-expand {
   height: 2px;
   overflow: hidden;
   border-radius: 1px;
-  background: rgba(59,130,246,0.1);
+  background: rgba(59, 130, 246, 0.1);
 }
 .streaming-bar::before {
   content: '';
@@ -230,7 +236,12 @@ select::-ms-expand {
   height: 100%;
   width: 40%;
   border-radius: 1px;
-  background: linear-gradient(90deg, rgba(59,130,246,0.3) 0%, rgba(59,130,246,0.8) 50%, rgba(59,130,246,0.3) 100%);
+  background: linear-gradient(
+    90deg,
+    rgba(59, 130, 246, 0.3) 0%,
+    rgba(59, 130, 246, 0.8) 50%,
+    rgba(59, 130, 246, 0.3) 100%
+  );
   animation: streaming-slide 1.5s ease-in-out infinite;
 }
 /* Streaming bar glow uses primary color */
@@ -238,6 +249,114 @@ select::-ms-expand {
   box-shadow: 0 0 6px var(--lobster-primary-muted);
 }
 @keyframes streaming-slide {
-  0% { left: -40%; }
-  100% { left: 100%; }
+  0% {
+    left: -40%;
+  }
+  100% {
+    left: 100%;
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   MarkdownEditor (@uiw/react-md-editor) — theme integration + style overrides
+   Maps GitHub CSS variables to the app's --lobster-* tokens and tightens up
+   the toolbar/button appearance to match the app's design language.
+───────────────────────────────────────────────────────────────────────────── */
+
+/* 1. Bridge GitHub color vars → lobster theme tokens */
+.md-editor-wrapper {
+  --color-fg-default: var(--lobster-foreground);
+  --color-accent-fg: var(--lobster-primary);
+  --color-neutral-muted: var(--lobster-surface-raised);
+  --color-danger-fg: var(--lobster-destructive);
+  --color-canvas-default: var(--lobster-surface);
+  --color-border-default: var(--lobster-border);
+}
+
+/* 2. Editor root: remove GitHub's box-shadow (outer wrapper already has a border) */
+.md-editor-wrapper .w-md-editor {
+  --md-editor-background-color: var(--lobster-surface);
+  --md-editor-box-shadow-color: var(--lobster-border);
+  box-shadow: none !important;
+  border-radius: 0 !important;
+  color: var(--lobster-foreground);
+  font-family: inherit;
+}
+
+/* 3. Toolbar container */
+.md-editor-wrapper .w-md-editor-toolbar {
+  background-color: var(--lobster-surface-raised) !important;
+  border-bottom: 1px solid var(--lobster-border) !important;
+  padding: 4px 6px !important;
+  border-radius: 0 !important;
+  gap: 2px;
+}
+
+/* 4. Toolbar buttons — larger hit area, rounder corners, better icon alignment */
+.md-editor-wrapper .w-md-editor-toolbar li > button {
+  height: 28px !important;
+  min-width: 28px;
+  line-height: 1 !important;
+  border-radius: 6px !important;
+  padding: 0 6px !important;
+  margin: 0 !important;
+  color: var(--lobster-text-secondary) !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease !important;
+}
+
+.md-editor-wrapper .w-md-editor-toolbar li > button:hover,
+.md-editor-wrapper .w-md-editor-toolbar li > button:focus {
+  background-color: var(--lobster-border) !important;
+  color: var(--lobster-foreground) !important;
+}
+
+.md-editor-wrapper .w-md-editor-toolbar li > button:active {
+  background-color: var(--lobster-primary-muted) !important;
+  color: var(--lobster-primary) !important;
+}
+
+.md-editor-wrapper .w-md-editor-toolbar li.active > button {
+  background-color: var(--lobster-primary-muted) !important;
+  color: var(--lobster-primary) !important;
+}
+
+/* 5. SVG icons — normalise size and block rendering */
+.md-editor-wrapper .w-md-editor-toolbar li > button svg {
+  display: block !important;
+  width: 14px !important;
+  height: 14px !important;
+  pointer-events: none;
+}
+
+/* 6. Divider between button groups */
+.md-editor-wrapper .w-md-editor-toolbar-divider {
+  background-color: var(--lobster-border) !important;
+  margin: 0 4px !important;
+  opacity: 0.8;
+}
+
+/* 7. Text/editing area — prevent global pre/code resets from leaking in */
+.md-editor-wrapper .w-md-editor-text-pre,
+.md-editor-wrapper .w-md-editor-text-pre > code {
+  background-color: transparent !important;
+  border-radius: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+/* 8. Make the editable area fill the full editor height so clicking any
+      empty space below the last line still focuses the textarea */
+.md-editor-wrapper .w-md-editor-area {
+  height: 100% !important;
+  cursor: text;
+}
+
+/* 8. Preview pane scrollbar */
+.md-editor-wrapper .w-md-editor-preview {
+  background-color: var(--lobster-surface) !important;
 }


### PR DESCRIPTION
## 摘要

本 PR 为「设置 → Agent 配置」面板中的三个引导文件（`IDENTITY.md`、`SOUL.md`、`USER.md`）引入了富文本 Markdown 编辑器，取代了原先的纯文本 `<textarea>`，同时完善了加载态与多文件切换体验。

---

## 新增特性

### 1. 新建 `MarkdownEditor` 公共组件

**文件：** `src/renderer/components/common/MarkdownEditor.tsx`

- 基于 `@uiw/react-md-editor@^4.1.0` 封装，提供所见即所得的 Markdown 编辑体验。
- **自动深色/浅色模式同步**：通过 `MutationObserver` 监听 `<html>` 元素的 `class` 属性变化，与应用主题系统完全联动，无需手动传入 `colorMode` 属性。
- **精简工具栏**：仅保留与文档撰写相关的命令（加粗、斜体、删除线、H1/H2/H3、有序/无序列表、引用、行内代码、代码块），移除了上传图片、外部链接等无关操作。
- **点击空白区域自动聚焦修复**：编辑区底部的空白空间原本无法触发 `<textarea>` 聚焦（`@uiw/react-md-editor` 的已知问题），通过拦截点击事件并手动将焦点转发至 `<textarea>` 解决。
- 组件接受 `value`、`onChange`、`placeholder`、`height` 四个简洁的 props，可在其他设置面板复用。

### 2. Agent 配置面板升级（`coworkAgent` 标签页）

**文件：** `src/renderer/components/Settings.tsx`

- **分段控制选项卡**：新增分段控制（Segment Control）用于在 `IDENTITY.md`、`SOUL.md`、`USER.md` 三个文件之间切换，无需离开当前设置面板。配合文件路径按钮，单击即可在访达/文件管理器中定位对应文件。
- **加载骨架屏**：新增 `bootstrapLoading` 状态，异步读取三个引导文件期间显示骨架屏占位（Skeleton Placeholder），避免界面空白闪烁。
- **富文本编辑器替代纯文本框**：将三个 bootstrap 文件的编辑区域替换为 `MarkdownEditor` 组件，高度设置为 320 px，提供格式化工具栏与语法高亮预览。
- 新增 `bootstrapActiveFile` 状态（`'identity' | 'soul' | 'user'`）用于跟踪当前激活的文件标签。
- 文件读取完成前将 `bootstrapLoading` 置为 `true`，完成后置为 `false`，保证骨架屏的正确显示与隐藏。

### 3. CSS 主题集成

**文件：** `src/renderer/index.css`

在 `.md-editor-wrapper` 作用域内添加全面的样式覆盖，将 `@uiw/react-md-editor` 使用的 GitHub CSS 变量（`--color-*`）映射到应用的 `--lobster-*` 设计令牌，确保编辑器在深色/浅色两种主题下均能正确呈现：

| 覆盖内容 | 说明 |
|---|---|
| GitHub 颜色变量桥接 | `--color-fg-default`、`--color-canvas-default` 等映射到 `--lobster-*` |
| 编辑器根容器 | 移除 GitHub 自带的 `box-shadow`，使用应用表面色 |
| 工具栏容器 | 背景色、底部边框、圆角对齐应用风格 |
| 工具栏按钮 | 更大点击区域（28 px）、圆角、悬停/激活状态颜色过渡 |
| SVG 图标 | 固定 14 × 14 px，防止尺寸溢出 |
| 分隔线 | 颜色与间距对齐应用设计系统 |
| 编辑文本区 | 防止全局 `pre/code` 重置样式泄入编辑器 |
| 编辑区高度 | 占满编辑器全高，使点击任意空白区域均可聚焦 |
| 预览区 | 背景色与应用表面色对齐 |

### 4. 依赖变更

**文件：** `package.json`

新增依赖：

```json
"@uiw/react-md-editor": "^4.1.0"
```

---

## 测试建议

1. 运行 `npm run electron:dev`，打开「设置 → Agent 配置」标签页。
2. 验证三个文件标签（Identity / Soul / User）可正常切换，切换后编辑区内容对应刷新。
3. 验证首次进入标签页时出现骨架屏，文件加载完成后骨架屏消失。
4. 在编辑器中输入文字，验证工具栏格式化操作（加粗、标题、列表等）正常工作。
5. 切换应用深色/浅色主题，验证编辑器颜色随之切换，工具栏和文字均可辨认。
6. 点击编辑区空白空间（文字末行之后），验证光标自动聚焦到编辑框末尾。
7. 保存设置后重新打开，验证内容持久化正常。

<img width="939" height="794" alt="image" src="https://github.com/user-attachments/assets/6c270e7a-62e6-4d07-a6c2-4f28f8561f37" />
