### PR TITLE
在Agent设置面板保存技能列表后当前会话activeSkillIds未同步，需切换Agent才能生效

### DIFF
--- a/src/renderer/services/agent.ts
+++ b/src/renderer/services/agent.ts
@@ -89,6 +89,16 @@ class AgentService {
             skillIds: agent.skillIds ?? [],
           },
         }));
+        // Sync activeSkillIds for the current agent so changes take effect immediately
+        // without requiring the user to switch away and back
+        const currentAgentId = store.getState().agent.currentAgentId;
+        if (agent.id === currentAgentId) {
+          if (agent.skillIds?.length) {
+            store.dispatch(setActiveSkillIds(agent.skillIds));
+          } else {
+            store.dispatch(clearActiveSkills());
+          }
+        }
         return agent;
       }
       return null;


### PR DESCRIPTION
## 问题描述

在 Agent 设置面板中修改技能列表并保存后，当前对话的 `activeSkillIds` 不会立即更新。用户必须切换 Agent 再切回才能看到新配置。

## 修复方案

在 `src/renderer/services/agent.ts` 的 `updateAgent` 方法中，`dispatch(updateAgentAction(...))` 之后，检查被更新的 agent 是否是当前激活的 agent，若是则同步更新 `activeSkillIds`：

```ts
const currentAgentId = store.getState().agent.currentAgentId;
if (agent.id === currentAgentId) {
  if (agent.skillIds?.length) {
    store.dispatch(setActiveSkillIds(agent.skillIds));
  } else {
    store.dispatch(clearActiveSkills());
  }
}
```

## 影响范围

仅在 `agent.ts` 的 `updateAgent` 方法中添加同步逻辑，不改变其他行为。保存技能配置后立即生效，无需手动切换 Agent。

关联 Issue: #1502