### PR TITLE
fix(log-export): 修复导出日志时提示超时的问题

### DIFF
--- a/src/main/libs/logExport.ts
+++ b/src/main/libs/logExport.ts
@@ -16,7 +16,9 @@ export type ExportLogsZipResult = {
   missingEntries: string[];
 };
 
-const EXPORT_TIMEOUT_MS = 30_000;
+// Increased from 30 s to 2 minutes to accommodate slow disks and network
+// filesystems. The hard limit still exists so the UI never hangs indefinitely.
+const EXPORT_TIMEOUT_MS = 120_000;
 
 export async function exportLogsZip(input: ExportLogsZipInput): Promise<ExportLogsZipResult> {
   const zipFile = new yazl.ZipFile();
@@ -26,7 +28,7 @@ export async function exportLogsZip(input: ExportLogsZipInput): Promise<ExportLo
   // pipeline() can reject immediately instead of hanging until timeout.
   // Cast needed because @types/yazl types outputStream as NodeJS.ReadableStream,
   // but the runtime value is a PassThrough which has destroy().
-  zipFile.on('error', (err) => {
+  zipFile.on('error', err => {
     (zipFile.outputStream as unknown as { destroy(err: Error): void }).destroy(err as Error);
   });
 
@@ -45,7 +47,17 @@ export async function exportLogsZip(input: ExportLogsZipInput): Promise<ExportLo
         const { size } = stat;
         if (size > 0) {
           const readStream = fs.createReadStream(entry.filePath, { start: 0, end: size - 1 });
-          zipFile.addReadStream(readStream, entry.archiveName);
+          // Forward ReadStream errors to the ZipFile so pipeline() rejects
+          // immediately instead of hanging until timeout. yazl's internal
+          // .pipe() chain does not propagate ReadStream errors: if a ReadStream
+          // emits 'error', compressedSizeCounter never fires its 'end' event,
+          // pumpEntries stalls, and outputStream never ends — causing a hang.
+          readStream.on('error', err => zipFile.emit('error', err));
+          // Use stored mode (compress: false) to avoid CPU-intensive DEFLATE
+          // compression. At the default level-6 DEFLATE, compressing many large
+          // log files serially can easily exceed the timeout on slow machines.
+          // Log files are for debugging; export speed matters more than size.
+          zipFile.addReadStream(readStream, entry.archiveName, { compress: false });
         } else {
           zipFile.addBuffer(Buffer.alloc(0), entry.archiveName);
         }
@@ -77,7 +89,11 @@ export async function exportLogsZip(input: ExportLogsZipInput): Promise<ExportLo
     outputStream.destroy();
     pipelinePromise.catch(() => {});
     // Remove the partial zip so users don't find a corrupt file on disk.
-    try { fs.unlinkSync(input.outputPath); } catch { /* ignore cleanup errors */ }
+    try {
+      fs.unlinkSync(input.outputPath);
+    } catch {
+      /* ignore cleanup errors */
+    }
     throw err;
   } finally {
     clearTimeout(timer);


### PR DESCRIPTION
## 问题描述

关联 Issue：#1206

用户在设置页面点击「导出日志」后，等待约 30 秒会看到导出失败并提示超时（`Log export timed out`），无法成功导出日志文件。

---

## 根因分析

问题由两个叠加缺陷导致：

### 1. DEFLATE 压缩耗时过长（必现）

`yazl` 默认使用 zlib DEFLATE 压缩级别 6 对每个文件进行串行压缩。main 进程日志最大 80 MB/天，保留 7 天（含 `.old.log` 最多 14 个文件）。在配置较低的机器上，串行压缩数百 MB 的日志数据轻易超过 30 秒的超时限制。

### 2. ReadStream 错误导致 pipeline 永久挂起（偶现）

`yazl` 内部 `pumpFileDataReadStream` 使用旧式 `.pipe()` 串联流：

```
readStream → crc32Watcher → uncompressedSizeCounter → compressor → compressedSizeCounter
```

`.pipe()` **不会传播 source stream 的 error 事件**。若某个 ReadStream 在读取过程中出错（文件被其他进程删除、I/O 错误等），`compressedSizeCounter` 的 `end` 事件永远不触发，`pumpEntries` 停止推进，`outputStream` 永远不结束，整个 `pipeline()` Promise 挂死，直到 30 秒超时才返回错误。

---

## 修改内容

变更文件：`src/main/libs/logExport.ts`

| 改动 | 说明 |
|------|------|
| `addReadStream(..., { compress: false })` | 切换为存储模式（不压缩），消除 CPU 瓶颈，导出操作变为纯 I/O，速度大幅提升 |
| `readStream.on('error', err => zipFile.emit('error', err))` | 修复 ReadStream 错误不传播的 bug：错误立即转发给 ZipFile → 销毁 outputStream → pipeline 立即 reject，不再挂死等超时 |
| `EXPORT_TIMEOUT_MS`: `30_000` → `120_000` | 将超时兜底时间从 30 秒提升至 2 分钟，为慢速磁盘和网络文件系统预留足够余量 |

> 存储模式的代价是 ZIP 文件不压缩，体积略大。但日志文件用于排查问题，导出速度的可靠性比文件大小更重要。