### PR TITLE
关闭Settings面板时未取消GitHub Copilot OAuth轮询，认证成功后Token静默丢失

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -725,6 +725,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     }
   }, []);
 
+  // Cancel any ongoing GitHub Copilot OAuth polling when Settings is closed,
+  // preventing background polling and ensuring the token is not silently discarded.
+  useEffect(() => {
+    return () => {
+      if (copilotAuthStatus === 'awaiting_user' || copilotAuthStatus === 'polling') {
+        void window.electron.githubCopilot.cancelPolling().catch(() => {/* ignore cleanup errors */});
+      }
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [copilotAuthStatus]);
+
   useEffect(() => {
     let active = true;
     void coworkService.getOpenClawEngineStatus().then((status) => {


### PR DESCRIPTION
## 问题描述

在 GitHub Copilot OAuth 轮询期间关闭 Settings 面板时，`cancelPolling()` 从未被调用，导致后台轮询持续运行；若认证成功，Token 因组件已卸载而静默丢失，用户必须重新认证。

## 修复方案

在 `Settings.tsx` 中新增一个 `useEffect` cleanup，当 `copilotAuthStatus` 为 `'awaiting_user'` 或 `'polling'` 时，在组件卸载时调用 `window.electron.githubCopilot.cancelPolling()`：

```tsx
useEffect(() => {
  return () => {
    if (copilotAuthStatus === 'awaiting_user' || copilotAuthStatus === 'polling') {
      void window.electron.githubCopilot.cancelPolling().catch(() => {});
    }
  };
// eslint-disable-next-line react-hooks/exhaustive-deps
}, [copilotAuthStatus]);
```

这样可以确保：
- Settings 关闭时立即中止后台轮询，释放资源
- 用户下次打开 Settings 时状态干净，可正常重新发起认证

## 影响范围

仅添加一个 cleanup effect，不影响正常认证流程。与微信 QR 扫码的 `isMountedRef` 处理方式保持一致。

关联 Issue: #1516