### PR TITLE
fix(openclaw): prevent skills-changed from triggering spurious gateway restart

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4929,7 +4929,7 @@ if (!gotTheLock) {
     // When skills change (install/enable/disable/delete), re-sync AGENTS.md
     // so OpenClaw's IM channel agents pick up the latest skill list.
     manager.onSkillsChanged(() => {
-      syncOpenClawConfig({ reason: 'skills-changed' }).catch((error) => {
+      syncOpenClawConfig({ reason: 'skills-changed', restartGatewayIfRunning: false }).catch((error) => {
         console.warn('[Main] Failed to sync OpenClaw config after skills change:', error);
       });
     });


### PR DESCRIPTION
fix(openclaw): prevent skills-changed from triggering spurious gateway restart                                                                                  
                                                                                                                                                                  
  When the skills file watcher fires, syncOpenClawConfig is called with                                                                                           
  reason 'skills-changed' to re-sync AGENTS.md. Previously the call did                                                                                           
  not set restartGatewayIfRunning, so the function treated it the same as
  undefined — and the secretEnvVarsChanged override could still force a                                                                                           
  full gateway restart. On Windows this caused ~2-minute outages (the                                                                                             
  gateway import is slow) and could interrupt active cowork sessions.                                                                                             
                                                                                                                                                                  
  Pass `restartGatewayIfRunning: false` for skills-changed syncs, making                                                                                          
  the "sync only, never restart" intent explicit.                                                                                                                 
                                                                                                                                                                  
  Note: the original PR also included a guard for explicit `false` in the                                                                                         
  restart condition, but main has since been refactored — the new
  `needsHardRestart` logic already handles `undefined` correctly, so only                                                                                         
  the call-site change is needed.                                                                                                                                 
                                                                                                                                                                  
  Closes #1217     