### PR TITLE
refactor(providers): consolidate provider metadata into shared registry

### DIFF
--- a/spec/refactor/providers/provider-config-consolidation.md
+++ b/spec/refactor/providers/provider-config-consolidation.md
@@ -1,0 +1,591 @@
+# Provider Config Consolidation Plan
+
+**Goal:** 消除所有与 provider 相关的重复定义，使 `src/shared/providers/constants.ts` 成为 provider 所有信息（技术配置 + 展示元数据）的唯一来源，未来新增 provider 只需修改最少位置。
+
+---
+
+## Current State: Where Duplication Lives
+
+### What's Already Good ✅
+
+- `src/shared/providers/constants.ts` — `ProviderRegistry` 已是技术元数据的单一数据源（defaultBaseUrl、defaultApiFormat、codingPlanSupported、region 等）
+- `buildDefaultProviders()` 已从 ProviderRegistry 生成默认配置
+- `CHINA_PROVIDERS` / `GLOBAL_PROVIDERS` / `getVisibleProviders` 已从 Registry 派生
+- `src/main/libs/openclawConfigSync.ts` 的 `PROVIDER_REGISTRY` 映射已使用 `ProviderName` 常量
+
+### 剩余的重复点（按优先级）
+
+| # | 位置 | 问题 | 影响 |
+|---|------|------|------|
+| 1 | `src/renderer/config.ts` 第 21–248 行 | `AppConfig['providers']` 手动枚举了 15 个具名 key | 每次增删 provider 需同步修改，226 行纯样板代码 |
+| 2 | `src/renderer/components/Settings.tsx` 第 150–185 行 | `providerMeta` 硬编码每个 provider 的 label（可迁移至 shared）和 icon | 加 provider 时需同步维护 |
+| 3 | `src/renderer/components/Settings.tsx` 第 172–186 行 | `providerLinks` 硬编码每个 provider 的官网和 API Key 申请页 URL | 加 provider 时需同步维护 |
+| 4 | `src/renderer/components/Settings.tsx` 第 77–90 行 | `providerKeys` 常量数组手动枚举所有 provider 顺序 | 加 provider 时需同步维护顺序 |
+| 5 | `src/renderer/services/config.ts` 第 4–15 行 | `getFixedProviderApiFormat()` 用字符串硬编码 provider 名判断 API 格式 | 加 provider 时漏改导致格式不一致 |
+| 6 | `src/main/libs/claudeSettings.ts` 第 14–35 行 | 本地 `ProviderConfig` / `AppConfig` 类型各自定义，与 renderer 重复 | 字段变更时两处均需同步 |
+
+---
+
+## 架构分层原则
+
+`providerMeta` 同时包含 `label`（字符串）和 `icon`（React JSX 组件），二者属于不同层：
+
+| 数据 | 能否入 shared | 原因 |
+|------|-------------|------|
+| `label` | ✅ 可以 | 纯字符串，main/renderer 均可使用 |
+| `website` / `apiKeyUrl` | ✅ 可以 | 纯字符串 URL |
+| `icon`（`<OpenAIIcon />`） | ❌ 不行 | React JSX 组件，main process 无 React/JSX 编译上下文 |
+
+**解决方案：两层分离**
+
+```
+shared/providers/constants.ts      ← label + website + apiKeyUrl（字符串，两端可用）
+renderer/providers/uiRegistry.ts   ← icon 映射（仅 renderer，极简 ~30 行）
+```
+
+---
+
+## Proposed Changes
+
+### Change 1: 扩展 `src/shared/providers/constants.ts` — label / website / apiKeyUrl 进入 ProviderDef
+
+**Why:** `label` 和链接 URL 是 provider 的固有属性，与 defaultBaseUrl、region 同级，应统一在 registry 中管理；同时消除 `providerMeta`（label 部分）和 `providerLinks` 两处重复。
+
+#### 1a. 扩展 `ProviderDefInput` 和 `ProviderDef` 接口
+
+```typescript
+// src/shared/providers/constants.ts — 在 ProviderDefInput 和 ProviderDef 中新增字段
+
+interface ProviderDefInput {
+  // ...现有字段保持不变...
+
+  /** Human-readable display name shown in UI, e.g. 'OpenAI', 'GitHub Copilot' */
+  readonly label: string;
+  /** Provider console / product website URL */
+  readonly website?: string;
+  /** API key creation page URL. Omit for providers that don't use API keys (e.g. Ollama). */
+  readonly apiKeyUrl?: string;
+}
+```
+
+#### 1b. 在每条 PROVIDER_DEFINITIONS 记录中补充新字段
+
+```typescript
+const PROVIDER_DEFINITIONS = [
+  // ── China ──
+  {
+    id: ProviderName.DeepSeek,
+    label: 'DeepSeek',
+    website: 'https://platform.deepseek.com',
+    apiKeyUrl: 'https://platform.deepseek.com/api_keys',
+    // ...其余字段不变...
+  },
+  {
+    id: ProviderName.Moonshot,
+    label: 'Moonshot',
+    website: 'https://platform.moonshot.cn',
+    apiKeyUrl: 'https://platform.moonshot.cn/console/api-keys',
+    // ...
+  },
+  {
+    id: ProviderName.Qwen,
+    label: 'Qwen',
+    website: 'https://dashscope.console.aliyun.com',
+    apiKeyUrl: 'https://dashscope.console.aliyun.com/apiKey',
+    // ...
+  },
+  {
+    id: ProviderName.Zhipu,
+    label: 'Zhipu',
+    website: 'https://open.bigmodel.cn',
+    apiKeyUrl: 'https://open.bigmodel.cn/usercenter/apikeys',
+    // ...
+  },
+  {
+    id: ProviderName.Minimax,
+    label: 'MiniMax',
+    website: 'https://platform.minimaxi.com',
+    apiKeyUrl: 'https://platform.minimaxi.com/user-center/basic-information/interface-key',
+    // ...
+  },
+  {
+    id: ProviderName.Volcengine,
+    label: 'Volcengine',
+    website: 'https://console.volcengine.com/ark',
+    apiKeyUrl: 'https://console.volcengine.com/ark',
+    // ...
+  },
+  {
+    id: ProviderName.Youdaozhiyun,
+    label: 'Youdao',
+    website: 'https://ai.youdao.com',
+    apiKeyUrl: 'https://ai.youdao.com/console',
+    // ...
+  },
+  {
+    id: ProviderName.StepFun,
+    label: 'StepFun',
+    website: 'https://platform.stepfun.com',
+    apiKeyUrl: 'https://platform.stepfun.com/interface-key',
+    // ...
+  },
+  {
+    id: ProviderName.Xiaomi,
+    label: 'Xiaomi',
+    website: 'https://dev.mi.com/platform',
+    apiKeyUrl: 'https://dev.mi.com/platform',
+    // ...
+  },
+  {
+    id: ProviderName.Ollama,
+    label: 'Ollama',
+    website: 'https://ollama.com',
+    // apiKeyUrl 省略（Ollama 不需要 API Key）
+    // ...
+  },
+  // ── Global ──
+  {
+    id: ProviderName.Copilot,
+    label: 'GitHub Copilot',
+    // website / apiKeyUrl 省略（Copilot 走 OAuth，无独立 API Key 申请页）
+    // ...
+  },
+  {
+    id: ProviderName.OpenAI,
+    label: 'OpenAI',
+    website: 'https://platform.openai.com',
+    apiKeyUrl: 'https://platform.openai.com/api-keys',
+    // ...
+  },
+  {
+    id: ProviderName.Gemini,
+    label: 'Gemini',
+    website: 'https://aistudio.google.com',
+    apiKeyUrl: 'https://aistudio.google.com/apikey',
+    // ...
+  },
+  {
+    id: ProviderName.Anthropic,
+    label: 'Anthropic',
+    website: 'https://console.anthropic.com',
+    apiKeyUrl: 'https://console.anthropic.com/settings/keys',
+    // ...
+  },
+  {
+    id: ProviderName.OpenRouter,
+    label: 'OpenRouter',
+    website: 'https://openrouter.ai',
+    apiKeyUrl: 'https://openrouter.ai/keys',
+    // ...
+  },
+] as const satisfies readonly ProviderDefInput[];
+```
+
+---
+
+### Change 2: 新建 `src/shared/providers/types.ts` — ProviderConfig 类型设计
+
+**Why:** renderer 和 main 各自定义 `ProviderConfig` 类型，将其移入 shared 作为两端的共同合约。
+
+**设计原则：** 字段是否入接口，看它是否是**可复用的通用概念**，而不是看「现在有几个 provider 在用」：
+
+- `codingPlanEnabled` — Coding Plan 是通用的模式切换概念，未来可扩展 → 直接放进来
+- `authType` — 鉴权方式选择器，和 `apiFormat` 同一量级的通用概念 → 直接放进来
+- `oauthRefreshToken` / `oauthTokenExpiresAt` — 任何走 OAuth 的 provider 都会用到的通用凭证字段 → 直接放进来
+
+结论：**单一 interface，无 extension，无交叉类型。** 用 JSDoc 注明各字段的当前适用范围。
+
+**⚠️ 已移除的字段：** Qwen OAuth 相关字段（`oauthCredentials`、`oauthBaseUrl`、`useOAuth`）不纳入新类型——对应功能已移除，现有代码通过 `as any` 访问，应随 `qwenOAuth.ts` 一并清理。
+
+```typescript
+// src/shared/providers/types.ts  (NEW FILE)
+
+import type { ApiFormat } from './constants';
+
+/**
+ * Runtime configuration for a single provider as stored in AppConfig / SQLite.
+ *
+ * Optional fields that currently apply to a subset of providers are noted
+ * in their JSDoc. They are designed as general capabilities — if a new
+ * provider needs the same feature, it reuses the same field without any
+ * type changes.
+ */
+export interface ProviderConfig {
+  enabled: boolean;
+  apiKey: string;
+  baseUrl: string;
+  /** API protocol. Defaults to ProviderDef.defaultApiFormat when undefined. */
+  apiFormat?: ApiFormat;
+  models?: Array<{
+    id: string;
+    name: string;
+    supportsImage?: boolean;
+  }>;
+  /** User-visible name. Currently only used by custom_N providers. */
+  displayName?: string;
+
+  /**
+   * Coding Plan mode toggle.
+   * Currently applicable: moonshot, zhipu, qwen, volcengine
+   * (ProviderDef.codingPlanSupported === true).
+   */
+  codingPlanEnabled?: boolean;
+
+  /**
+   * Authentication method selector. Defaults to 'apikey'.
+   * Currently applicable: minimax ('apikey' | 'oauth').
+   * General capability — any provider adding OAuth reuses this field.
+   */
+  authType?: 'apikey' | 'oauth';
+
+  /**
+   * Long-lived OAuth refresh token for automatic access token renewal.
+   * Currently applicable: minimax (OAuth mode).
+   */
+  oauthRefreshToken?: string;
+
+  /**
+   * OAuth access token expiry as Unix timestamp (ms).
+   * Currently applicable: minimax (OAuth mode).
+   */
+  oauthTokenExpiresAt?: number;
+}
+```
+
+**向后兼容性：** 纯类型定义，零运行时改动，不影响存储的 JSON 结构。
+
+---
+
+### Change 3: 更新 `src/shared/providers/index.ts` — 导出新类型
+
+```diff
+ export type { ProviderDef } from './constants';
+ export {
+   ProviderName,
+   OpenClawProviderId,
+   OpenClawApi,
+   ApiFormat,
+   AuthType,
+   ProviderRegistry,
+ } from './constants';
+ export { resolveCodingPlanBaseUrl } from './codingPlan';
++export type { ProviderConfig } from './types';
+```
+
+---
+
+### Change 4: 新建 `src/renderer/providers/uiRegistry.ts` — renderer 侧 icon 注册表
+
+**Why:** icon 是 React JSX 组件，无法进入 shared 模块（main process 无 React），但可以从 Settings.tsx 中提取为独立的 renderer 侧薄层，供未来其他组件复用。
+
+```typescript
+// src/renderer/providers/uiRegistry.ts  (NEW FILE)
+
+import React from 'react';
+import { ProviderName } from '@shared/providers';
+import {
+  OpenAIIcon, DeepSeekIcon, GeminiIcon, AnthropicIcon,
+  MoonshotIcon, ZhipuIcon, MiniMaxIcon, YouDaoZhiYunIcon,
+  QwenIcon, XiaomiIcon, StepfunIcon, VolcengineIcon,
+  OpenRouterIcon, OllamaIcon, GitHubCopilotIcon, CustomProviderIcon,
+} from '../components/icons/providers';
+
+/**
+ * Maps provider ID to its React icon element.
+ * Unknown / custom provider IDs fall back to CustomProviderIcon.
+ *
+ * NOTE: icon lives here (renderer-only) rather than in @shared/providers
+ * because React JSX cannot be used in the Electron main process.
+ */
+const PROVIDER_ICON_MAP: Record<string, React.ReactNode> = {
+  [ProviderName.OpenAI]:        <OpenAIIcon />,
+  [ProviderName.DeepSeek]:      <DeepSeekIcon />,
+  [ProviderName.Gemini]:        <GeminiIcon />,
+  [ProviderName.Anthropic]:     <AnthropicIcon />,
+  [ProviderName.Moonshot]:      <MoonshotIcon />,
+  [ProviderName.Zhipu]:         <ZhipuIcon />,
+  [ProviderName.Minimax]:       <MiniMaxIcon />,
+  [ProviderName.Youdaozhiyun]:  <YouDaoZhiYunIcon />,
+  [ProviderName.Qwen]:          <QwenIcon />,
+  [ProviderName.Xiaomi]:        <XiaomiIcon />,
+  [ProviderName.StepFun]:       <StepfunIcon />,
+  [ProviderName.Volcengine]:    <VolcengineIcon />,
+  [ProviderName.OpenRouter]:    <OpenRouterIcon />,
+  [ProviderName.Copilot]:       <GitHubCopilotIcon />,
+  [ProviderName.Ollama]:        <OllamaIcon />,
+};
+
+/** Returns the icon for a provider. Falls back to CustomProviderIcon for unknown IDs. */
+export function getProviderIcon(id: string): React.ReactNode {
+  return PROVIDER_ICON_MAP[id] ?? <CustomProviderIcon />;
+}
+```
+
+---
+
+### Change 5: 简化 `src/renderer/config.ts` 的 `AppConfig['providers']` — 删除 226 行样板
+
+**After：**
+
+```diff
+-import { ProviderRegistry } from '@shared/providers';
++import { ProviderRegistry, type ProviderConfig } from '@shared/providers';
+
+ export interface AppConfig {
+   api: { key: string; baseUrl: string };
+   model: { ... };
+-  providers?: {
+-    openai: { enabled: boolean; apiKey: string; baseUrl: string; ... };
+-    deepseek: { ... };
+-    moonshot: { ...; codingPlanEnabled?: boolean; };
+-    // ... 12 more providers, ~200 lines ...
+-    [key: string]: { enabled: boolean; apiKey: string; ... };
+-  };
++  /**
++   * Per-provider runtime configuration.
++   * Keys: ProviderName values + custom_N dynamic keys.
++   * Shape: ProviderConfig defined in @shared/providers/types.
++   * Default values populated by buildDefaultProviders() via ProviderRegistry.
++   */
++  providers?: Record<string, ProviderConfig>;
+   // ...
+ }
+```
+
+**影响分析：**
+- `buildDefaultProviders()` — 无需改动（已使用 ProviderRegistry）
+- Settings.tsx 中 `type ProvidersConfig = NonNullable<AppConfig['providers']>` → 自动变为 `Record<string, ProviderConfig>` ✅
+- `providers.minimax.authType`、`providers.zhipu.codingPlanEnabled` 等直接属性访问 — 字段在 `ProviderConfig` 上，类型安全 ✅（`strict: true` 不含 `noUncheckedIndexedAccess`）
+---
+
+### Change 6: 修复 `src/renderer/services/config.ts` — 消除硬编码 provider 字符串
+
+**Before（第 4–15 行）：**
+```typescript
+const getFixedProviderApiFormat = (providerKey: string): 'anthropic' | 'openai' | 'gemini' | null => {
+  if (providerKey === 'openai' || providerKey === 'stepfun' || providerKey === 'youdaozhiyun' || providerKey === 'github-copilot') {
+    return 'openai';
+  }
+  if (providerKey === 'anthropic') { return 'anthropic'; }
+  if (providerKey === 'gemini') { return 'gemini'; }
+  return null;
+};
+```
+
+**After：**
+```typescript
+import { ProviderRegistry, ApiFormat } from '@shared/providers';
+
+/**
+ * Returns the fixed API format for providers where the format is non-switchable
+ * (no switchableBaseUrls in ProviderRegistry). Returns null for switchable providers.
+ */
+const getFixedProviderApiFormat = (providerKey: string): ApiFormat | null => {
+  const def = ProviderRegistry.get(providerKey);
+  if (def && !def.switchableBaseUrls) {
+    return def.defaultApiFormat;
+  }
+  return null;
+};
+```
+
+**验证（所有现有 provider 的映射不变）：**
+
+| Provider | switchableBaseUrls? | defaultApiFormat | 结果 |
+|---|---|---|---|
+| openai | ❌ 无 | openai | `'openai'` ✅ |
+| stepfun | ❌ 无 | openai | `'openai'` ✅ |
+| youdaozhiyun | ❌ 无 | openai | `'openai'` ✅ |
+| github-copilot | ❌ 无 | openai | `'openai'` ✅ |
+| anthropic | ❌ 无 | anthropic | `'anthropic'` ✅ |
+| gemini | ❌ 无 | gemini | `'gemini'` ✅ |
+| moonshot | ✅ 有 | openai | `null`（可切换）✅ |
+| deepseek | ✅ 有 | anthropic | `null`（可切换）✅ |
+| qwen / zhipu / ollama… | ✅ 有 | — | `null`（可切换）✅ |
+
+未知/自定义 provider（`def === undefined`）→ 返回 `null`，继续使用用户保存的 `apiFormat`，行为不变。
+
+---
+
+### Change 7: 重构 `src/renderer/components/Settings.tsx` — 三处合并为 Registry 查询
+
+此 Change 合并三个独立改动，统一在 Settings.tsx 中完成。
+
+#### 7a. 替换 `providerKeys` 数组
+
+**Before（第 77–90 行）：**
+```typescript
+const providerKeys = [
+  'openai', 'gemini', 'anthropic', 'deepseek', 'moonshot',
+  'zhipu', 'minimax', 'volcengine', 'qwen', 'youdaozhiyun',
+  'stepfun', 'xiaomi', 'openrouter', 'github-copilot', 'ollama',
+  ...CUSTOM_PROVIDER_KEYS,
+] as const;
+type ProviderType = (typeof providerKeys)[number];
+```
+
+**After：**
+```typescript
+import { ProviderName } from '@shared/providers';
+
+// ProviderName 的值顺序与 PROVIDER_DEFINITIONS 定义顺序一致（China first, then Global）
+const providerKeys = [
+  ...Object.values(ProviderName).filter(id => id !== ProviderName.Custom && id !== ProviderName.LobsteraiServer),
+  ...CUSTOM_PROVIDER_KEYS,
+] as const;
+
+// 保持字面量类型安全：ProviderName 是 as const 对象，派生的联合类型包含所有已知 provider
+type BuiltinProviderType = ProviderName;
+type CustomProviderType = (typeof CUSTOM_PROVIDER_KEYS)[number];
+type ProviderType = BuiltinProviderType | CustomProviderType;
+```
+
+> **注：** `ProviderName.Custom`（`'custom'`）是遗留占位符，实际使用 `custom_0`…`custom_9`，需过滤掉。`LobsteraiServer` 是后端内部 provider，不在 UI 中展示，同样过滤。
+
+#### 7b. 删除 `providerMeta`，改为 Registry 查询 + `getProviderIcon()`
+
+**Before（第 148–170 行）：**
+```typescript
+const providerMeta: Record<ProviderType, { label: string; icon: React.ReactNode }> = {
+  openai:       { label: 'OpenAI',         icon: <OpenAIIcon /> },
+  deepseek:     { label: 'DeepSeek',       icon: <DeepSeekIcon /> },
+  // ... 13 more lines ...
+  ...Object.fromEntries(
+    CUSTOM_PROVIDER_KEYS.map(key => [key, { label: getCustomProviderDefaultName(key), icon: <CustomProviderIcon /> }])
+  ),
+};
+```
+
+**After：**
+```typescript
+import { getProviderIcon } from '../providers/uiRegistry';
+
+// label 从 ProviderRegistry 取（已在 Change 1 中入库）
+// icon  从 uiRegistry 取（renderer 侧，支持 React JSX）
+// providerMeta 整体删除
+
+// 原 providerMeta[id].label 的调用点替换为：
+//   ProviderRegistry.get(id)?.label ?? getCustomProviderDefaultName(id)
+
+// 原 providerMeta[id].icon 的调用点替换为：
+//   getProviderIcon(id)
+```
+
+#### 7c. 删除 `providerLinks`，改为 Registry 查询
+
+**Before（第 172–186 行）：**
+```typescript
+const providerLinks: Partial<Record<ProviderType, { website: string; apiKey?: string }>> = {
+  openai: { website: 'https://platform.openai.com', apiKey: 'https://platform.openai.com/api-keys' },
+  // ... 13 more lines ...
+};
+```
+
+**After：**
+```typescript
+// providerLinks 整体删除
+
+// 原 providerLinks[id]?.website 的调用点替换为：
+//   ProviderRegistry.get(id)?.website
+
+// 原 providerLinks[id]?.apiKey 的调用点替换为：
+//   ProviderRegistry.get(id)?.apiKeyUrl
+```
+
+---
+
+### Change 8: 对齐 `src/main/libs/claudeSettings.ts` 本地类型
+
+**Before（第 14–35 行）：** 本地自定义 `ProviderModel`、`ProviderConfig`、`AppConfig` 三个类型。
+
+**After：**
+```typescript
+import type { ProviderConfig } from '../../shared/providers';
+
+// 使用 shared 的规范类型；本地 ProviderModel / ProviderConfig 定义全部删除。
+
+type AppConfig = {
+  model?: { defaultModel?: string; defaultModelProvider?: string };
+  providers?: Record<string, ProviderConfig>;
+};
+```
+
+**⚠️ 遗留值 `apiFormat: 'native'`：** `claudeSettings.ts` 中存在遗留的 `'native'` 值（不在 `ApiFormat` 常量中）。运行时已通过 `normalizeProviderApiFormat()` 处理，不会有功能问题。若 TypeScript 严格报错，在本地做最小扩展：
+```typescript
+import type { ProviderConfig, ApiFormat } from '../../shared/providers';
+type LocalProviderConfig = Omit<ProviderConfig, 'apiFormat'> & { apiFormat?: ApiFormat | 'native' };
+type AppConfig = {
+  model?: { defaultModel?: string; defaultModelProvider?: string };
+  providers?: Record<string, LocalProviderConfig>;
+};
+```
+
+---
+
+## 不需要改动的地方
+
+| 文件 | 保持不变的原因 |
+|------|--------------|
+| `src/renderer/config.ts` 的 `buildDefaultProviders()` | 已使用 ProviderRegistry ✅ |
+| `src/renderer/config.ts` 的 `CHINA_PROVIDERS` / `GLOBAL_PROVIDERS` | 已使用 ProviderRegistry ✅ |
+| `src/renderer/services/config.ts` 的 `REMOVED_PROVIDER_MODELS` / `ADDED_PROVIDER_MODELS` | 迁移专用数据，不是 provider 定义 |
+| `src/main/libs/openclawConfigSync.ts` 的 `PROVIDER_REGISTRY` | OpenClaw 协议特定映射，已使用 `ProviderName` 常量 |
+| SQLite 存储格式 | 纯 JSON，类型重构零影响 |
+| `src/shared/providers/codingPlan.ts` | 无需改动 |
+| 所有已有测试 | `constants.test.ts`、`codingPlan.test.ts` 不涉及 AppConfig / providerMeta |
+
+## 范围外（本次不处理，单独跟进）
+
+| 内容 | 说明 |
+|------|------|
+| Qwen OAuth 残留代码 | `src/main/libs/qwenOAuth.ts`、`main.ts` 中的 `startQwenOAuth` / `refreshQwenOAuthToken` 调用、`claudeSettings.ts` 中的 `as any` oauthCredentials 访问、Settings.tsx 中相关 UI 和 i18n keys——这些应作为独立任务整体清理，不纳入本次重构 |
+
+---
+
+## 实施顺序
+
+按依赖关系排列，每步独立可编译：
+
+```
+Step 1  src/shared/providers/constants.ts       扩展 ProviderDef：加 label / website / apiKeyUrl
+Step 2  src/shared/providers/types.ts           新建 ProviderConfig 类型
+Step 3  src/shared/providers/index.ts           导出 ProviderConfig
+Step 4  src/renderer/providers/uiRegistry.ts    新建 icon 注册表
+Step 5  src/renderer/config.ts                  AppConfig['providers'] 简化为 Record（删除 226 行）
+Step 6  src/renderer/services/config.ts         getFixedProviderApiFormat() 改为 Registry 派生
+Step 7  src/renderer/components/Settings.tsx    删除 providerKeys / providerMeta / providerLinks，改用 Registry + uiRegistry
+Step 8  src/main/libs/claudeSettings.ts         本地类型改为 import ProviderConfig
+```
+
+Step 5 完成后 `npm run lint` 可能报 Settings.tsx 类型警告，Step 7/8 同步修复。
+
+---
+
+## 历史兼容性保障
+
+1. **SQLite 存储：** AppConfig 以 JSON 保存，类型重构对持久化数据零影响
+2. **运行时行为：** 所有 provider 访问均为动态字符串索引（`providers[key]`），不依赖命名 key 的静态类型
+3. **自定义 provider（custom_0...custom_9）：** `Record<string, ProviderConfig>` 天然支持任意字符串 key；icon 通过 `getProviderIcon()` 的 fallback 机制提供 `<CustomProviderIcon />`
+4. **provider 展示顺序：** `Object.values(ProviderName)` 的枚举顺序与 `PROVIDER_DEFINITIONS` 数组顺序一致（由 `as const` 保证），UI 展示顺序不变
+5. **导入/导出功能：** Settings 中的 provider 导入导出以 JSON 字符串操作，不受类型影响
+
+---
+
+## 未来迭代中新增 provider 的步骤（目标状态）
+
+完成本次重构后，新增一个 provider 的完整操作缩减为 **3 处**：
+
+| 步骤 | 文件 | 操作 |
+|------|------|------|
+| 1 | `src/shared/providers/constants.ts` | 在 `ProviderName` 加常量；在 `PROVIDER_DEFINITIONS` 加一条记录（含 label、website、apiKeyUrl、技术配置） |
+| 2 | `src/main/libs/openclawConfigSync.ts` | 在 `PROVIDER_REGISTRY` 加一条 `ProviderDescriptor`（OpenClaw 协议映射）|
+| 3 | `src/renderer/providers/uiRegistry.ts` | 在 `PROVIDER_ICON_MAP` 加 `[ProviderName.NewProvider]: <NewProviderIcon />` |
+
+若新 provider 有特殊配置字段，根据字段性质决定：
+
+| 情况 | 做法 |
+|------|------|
+| 通用概念（未来其他 provider 可能复用，如新的鉴权方式） | 直接加进 `ProviderConfig`，JSDoc 注明当前适用范围 |
+| 完全专属单一 provider 且字段较多（目前无此情况） | 新建 `XxxExtension` interface，加入 `ProviderConfig` 交叉类型 |
+
+**不再需要修改：** `AppConfig` 类型 / `providerKeys` 数组 / `providerMeta` / `providerLinks` / `getFixedProviderApiFormat()` 硬编码列表。

--- a/src/main/libs/claudeSettings.ts
+++ b/src/main/libs/claudeSettings.ts
@@ -1,37 +1,25 @@
-import { join } from 'path';
 import { app } from 'electron';
+import { join } from 'path';
+
+import { type ApiFormat,type ProviderConfig, ProviderName, resolveCodingPlanBaseUrl } from '../../shared/providers';
 import type { SqliteStore } from '../sqliteStore';
 import type { CoworkApiConfig } from './coworkConfigStore';
+import { type AnthropicApiFormat,normalizeProviderApiFormat } from './coworkFormatTransform';
 import {
   configureCoworkOpenAICompatProxy,
-  type OpenAICompatProxyTarget,
   getCoworkOpenAICompatProxyBaseURL,
   getCoworkOpenAICompatProxyStatus,
+  type OpenAICompatProxyTarget,
 } from './coworkOpenAICompatProxy';
-import { normalizeProviderApiFormat, type AnthropicApiFormat } from './coworkFormatTransform';
-import { ProviderName, resolveCodingPlanBaseUrl } from '../../shared/providers';
 
-type ProviderModel = {
-  id: string;
-  name?: string;
-  supportsImage?: boolean;
-};
-
-type ProviderConfig = {
-  enabled: boolean;
-  apiKey: string;
-  baseUrl: string;
-  apiFormat?: 'anthropic' | 'openai' | 'native';
-  codingPlanEnabled?: boolean;
-  models?: ProviderModel[];
-};
+type LocalProviderConfig = Omit<ProviderConfig, 'apiFormat'> & { apiFormat?: ApiFormat | 'native' };
 
 type AppConfig = {
   model?: {
     defaultModel?: string;
     defaultModelProvider?: string;
   };
-  providers?: Record<string, ProviderConfig>;
+  providers?: Record<string, LocalProviderConfig>;
 };
 
 export type ApiConfigResolution = {
@@ -114,7 +102,7 @@ export function getClaudeCodePath(): string {
 
 type MatchedProvider = {
   providerName: string;
-  providerConfig: ProviderConfig;
+  providerConfig: LocalProviderConfig;
   modelId: string;
   apiFormat: AnthropicApiFormat;
   baseURL: string;
@@ -147,7 +135,7 @@ function tryLobsteraiServerFallback(modelId?: string): MatchedProvider | null {
   console.log('[ClaudeSettings] lobsterai-server fallback activated:', { baseURL, modelId: effectiveModelId, supportsImage: cachedMeta?.supportsImage });
   return {
     providerName: ProviderName.LobsteraiServer,
-    providerConfig: { enabled: true, apiKey: tokens.accessToken, baseUrl: baseURL, apiFormat: 'openai', models: [{ id: effectiveModelId, supportsImage: cachedMeta?.supportsImage }] },
+    providerConfig: { enabled: true, apiKey: tokens.accessToken, baseUrl: baseURL, apiFormat: 'openai', models: [{ id: effectiveModelId, name: effectiveModelId, supportsImage: cachedMeta?.supportsImage }] },
     modelId: effectiveModelId,
     apiFormat: 'openai',
     baseURL,
@@ -160,7 +148,7 @@ function resolveMatchedProvider(appConfig: AppConfig): { matched: MatchedProvide
 
   const resolveFallbackModel = (): {
     providerName: string;
-    providerConfig: ProviderConfig;
+    providerConfig: LocalProviderConfig;
     modelId: string;
   } | null => {
     for (const [providerName, providerConfig] of Object.entries(providers)) {
@@ -192,7 +180,7 @@ function resolveMatchedProvider(appConfig: AppConfig): { matched: MatchedProvide
     modelId = fallback.modelId;
   }
 
-  let providerEntry: [string, ProviderConfig] | undefined;
+  let providerEntry: [string, LocalProviderConfig] | undefined;
   const preferredProviderName = appConfig.model?.defaultModelProvider?.trim();
 
   // Handle lobsterai-server provider: dynamically construct from auth tokens

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -29,26 +29,10 @@ import type {
 import IMSettings from './im/IMSettings';
 import { imService } from '../services/im';
 import EmailSkillConfig from './skills/EmailSkillConfig';
-import { ProviderRegistry, resolveCodingPlanBaseUrl } from '../../shared/providers';
+import { ProviderRegistry, ProviderName, resolveCodingPlanBaseUrl } from '../../shared/providers';
 import { defaultConfig, type AppConfig, getVisibleProviders, isCustomProvider, getCustomProviderDefaultName,getProviderDisplayName } from '../config';
-import {
-  OpenAIIcon,
-  DeepSeekIcon,
-  GeminiIcon,
-  AnthropicIcon,
-  MoonshotIcon,
-  ZhipuIcon,
-  MiniMaxIcon,
-  YouDaoZhiYunIcon,
-  QwenIcon,
-  XiaomiIcon,
-  StepfunIcon,
-  VolcengineIcon,
-  OpenRouterIcon,
-  OllamaIcon,
-  GitHubCopilotIcon,
-  CustomProviderIcon,
-} from './icons/providers';
+import { GitHubCopilotIcon } from './icons/providers';
+import { getProviderIcon } from '../providers/uiRegistry';
 
 type TabType = 'general'| 'coworkAgentEngine' | 'model' | 'coworkMemory' | 'coworkAgent' | 'shortcuts' | 'im' | 'email' | 'about';
 
@@ -75,25 +59,13 @@ const CUSTOM_PROVIDER_KEYS = [
 ] as const;
 
 const providerKeys = [
-  'openai',
-  'gemini',
-  'anthropic',
-  'deepseek',
-  'moonshot',
-  'zhipu',
-  'minimax',
-  'volcengine',
-  'qwen',
-  'youdaozhiyun',
-  'stepfun',
-  'xiaomi',
-  'openrouter',
-  'github-copilot',
-  'ollama',
+  ...Object.values(ProviderName).filter(id => id !== ProviderName.Custom && id !== ProviderName.LobsteraiServer),
   ...CUSTOM_PROVIDER_KEYS,
 ] as const;
 
-type ProviderType = (typeof providerKeys)[number];
+type BuiltinProviderType = ProviderName;
+type CustomProviderType = (typeof CUSTOM_PROVIDER_KEYS)[number];
+type ProviderType = BuiltinProviderType | CustomProviderType;
 type ProvidersConfig = NonNullable<AppConfig['providers']>;
 type ProviderConfig = ProvidersConfig[string];
 type Model = NonNullable<ProviderConfig['models']>[number];
@@ -145,44 +117,6 @@ interface ProvidersImportPayload {
   };
   providers?: Record<string, ProvidersImportEntry>;
 }
-
-const providerMeta: Record<ProviderType, { label: string; icon: React.ReactNode }> = {
-  openai: { label: 'OpenAI', icon: <OpenAIIcon /> },
-  deepseek: { label: 'DeepSeek', icon: <DeepSeekIcon /> },
-  gemini: { label: 'Gemini', icon: <GeminiIcon /> },
-  anthropic: { label: 'Anthropic', icon: <AnthropicIcon /> },
-  moonshot: { label: 'Moonshot', icon: <MoonshotIcon /> },
-  zhipu: { label: 'Zhipu', icon: <ZhipuIcon /> },
-  minimax: { label: 'MiniMax', icon: <MiniMaxIcon /> },
-  youdaozhiyun: { label: 'Youdao', icon: <YouDaoZhiYunIcon /> },
-  qwen: { label: 'Qwen', icon: <QwenIcon /> },
-  xiaomi: { label: 'Xiaomi', icon: <XiaomiIcon /> },
-  stepfun: { label: 'StepFun', icon: <StepfunIcon /> },
-  volcengine: { label: 'Volcengine', icon: <VolcengineIcon /> },
-  openrouter: { label: 'OpenRouter', icon: <OpenRouterIcon /> },
-  'github-copilot': { label: 'GitHub Copilot', icon: <GitHubCopilotIcon /> },
-  ollama: { label: 'Ollama', icon: <OllamaIcon /> },
-  ...Object.fromEntries(
-    CUSTOM_PROVIDER_KEYS.map(key => [key, { label: getCustomProviderDefaultName(key), icon: <CustomProviderIcon /> }])
-  ) as Record<(typeof CUSTOM_PROVIDER_KEYS)[number], { label: string; icon: React.ReactNode }>,
-};
-
-const providerLinks: Partial<Record<ProviderType, { website: string; apiKey?: string }>> = {
-  openai:       { website: 'https://platform.openai.com',              apiKey: 'https://platform.openai.com/api-keys' },
-  gemini:       { website: 'https://aistudio.google.com',              apiKey: 'https://aistudio.google.com/apikey' },
-  anthropic:    { website: 'https://console.anthropic.com',            apiKey: 'https://console.anthropic.com/settings/keys' },
-  deepseek:     { website: 'https://platform.deepseek.com',            apiKey: 'https://platform.deepseek.com/api_keys' },
-  moonshot:     { website: 'https://platform.moonshot.cn',             apiKey: 'https://platform.moonshot.cn/console/api-keys' },
-  zhipu:        { website: 'https://open.bigmodel.cn',                 apiKey: 'https://open.bigmodel.cn/usercenter/apikeys' },
-  minimax:      { website: 'https://platform.minimaxi.com',            apiKey: 'https://platform.minimaxi.com/user-center/basic-information/interface-key' },
-  volcengine:   { website: 'https://console.volcengine.com/ark',       apiKey: 'https://console.volcengine.com/ark' },
-  qwen:         { website: 'https://dashscope.console.aliyun.com',     apiKey: 'https://dashscope.console.aliyun.com/apiKey' },
-  youdaozhiyun: { website: 'https://ai.youdao.com',                    apiKey: 'https://ai.youdao.com/console' },
-  stepfun:      { website: 'https://platform.stepfun.com',             apiKey: 'https://platform.stepfun.com/interface-key' },
-  xiaomi:       { website: 'https://dev.mi.com/platform',              apiKey: 'https://dev.mi.com/platform' },
-  openrouter:   { website: 'https://openrouter.ai',                    apiKey: 'https://openrouter.ai/keys' },
-  ollama:       { website: 'https://ollama.com' },
-};
 
 const providerRequiresApiKey = (provider: ProviderType) => provider !== 'ollama' && provider !== 'github-copilot';
 const normalizeBaseUrl = (baseUrl: string): string => baseUrl.trim().replace(/\/+$/, '').toLowerCase();
@@ -2926,12 +2860,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               {Object.entries(visibleProviders).map(([provider, config]) => {
                 const providerKey = provider as ProviderType;
                 const isCustom = isCustomProvider(provider);
-                const providerInfo = providerMeta[providerKey];
                 const missingApiKey = providerRequiresApiKey(providerKey) && !config.apiKey.trim();
                 const canToggleProvider = config.enabled || !missingApiKey;
                 const displayLabel = isCustom
                   ? ((config as ProviderConfig).displayName || getCustomProviderDefaultName(provider))
-                  : (providerInfo?.label ?? getProviderDisplayName(provider));
+                  : (ProviderRegistry.get(providerKey)?.label ?? getProviderDisplayName(provider));
                 return (
                   <div
                     key={provider}
@@ -2945,7 +2878,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <div className="flex flex-1 items-center min-w-0">
                       <div className="mr-2 flex h-7 w-7 items-center justify-center shrink-0">
                         <span className="text-foreground">
-                          {isCustom ? <CustomProviderIcon /> : providerInfo?.icon}
+                          {getProviderIcon(provider)}
                         </span>
                       </div>
                       <div className="flex flex-col min-w-0">
@@ -3023,13 +2956,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   <h3 className="text-base font-medium text-foreground">
                     {isCustomProvider(activeProvider)
                       ? ((providers[activeProvider] as ProviderConfig)?.displayName || getCustomProviderDefaultName(activeProvider))
-                      : (providerMeta[activeProvider]?.label ?? getProviderDisplayName(activeProvider))
+                      : (ProviderRegistry.get(activeProvider)?.label ?? getProviderDisplayName(activeProvider))
                     } {i18nService.t('providerSettings')}
                   </h3>
-                  {providerLinks[activeProvider]?.website && (
+                  {ProviderRegistry.get(activeProvider)?.website && (
                     <button
                       type="button"
-                      onClick={() => void window.electron.shell.openExternal(providerLinks[activeProvider]!.website)}
+                      onClick={() => void window.electron.shell.openExternal(ProviderRegistry.get(activeProvider)!.website!)}
                       className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                       title={i18nService.t('visitOfficialSite')}
                       aria-label={i18nService.t('visitOfficialSite')}
@@ -3082,10 +3015,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         <label htmlFor="minimax-apiKey" className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
                           {i18nService.t('apiKey')}
                         </label>
-                        {providerLinks.minimax?.apiKey && (
+                        {ProviderRegistry.get('minimax')?.apiKeyUrl && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks.minimax!.apiKey!)}
+                            onClick={() => void window.electron.shell.openExternal(ProviderRegistry.get('minimax')!.apiKeyUrl!)}
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -3284,10 +3217,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         <label htmlFor={`${activeProvider}-apiKey`} className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
                           {i18nService.t('apiKey')}
                         </label>
-                        {providerLinks[activeProvider]?.apiKey && (
+                        {ProviderRegistry.get(activeProvider)?.apiKeyUrl && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks[activeProvider]!.apiKey!)}
+                            onClick={() => void window.electron.shell.openExternal(ProviderRegistry.get(activeProvider)!.apiKeyUrl!)}
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -3334,10 +3267,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         <label htmlFor="qwen-apiKey" className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
                           API Key
                         </label>
-                        {providerLinks.qwen?.apiKey && (
+                        {ProviderRegistry.get('qwen')?.apiKeyUrl && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks.qwen!.apiKey!)}
+                            onClick={() => void window.electron.shell.openExternal(ProviderRegistry.get('qwen')!.apiKeyUrl!)}
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -4190,7 +4123,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               </div>
 
               <div className="flex items-center gap-2 text-xs text-secondary">
-                <span>{providerMeta[testResult.provider]?.label ?? testResult.provider}</span>
+                <span>{ProviderRegistry.get(testResult.provider)?.label ?? testResult.provider}</span>
                 <span className="text-[11px]">•</span>
                 <span className={`inline-flex items-center gap-1 ${testResult.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
                   {testResult.success ? (

--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -1,4 +1,4 @@
-import { ProviderRegistry } from '@shared/providers';
+import { type ProviderConfig,ProviderRegistry } from '@shared/providers';
 
 // 配置类型定义
 export interface AppConfig {
@@ -17,235 +17,7 @@ export interface AppConfig {
     defaultModel: string;
     defaultModelProvider?: string;
   };
-  // 多模型提供商配置
-  providers?: {
-    openai: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      // API 协议格式：anthropic 为 Anthropic 兼容，openai 为 OpenAI 兼容
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    deepseek: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    moonshot: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      /** 是否启用 Moonshot Coding Plan 模式（使用专属 Coding API 端点） */
-      codingPlanEnabled?: boolean;
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    zhipu: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      /** 是否启用 GLM Coding Plan 模式（使用专属 Coding API 端点） */
-      codingPlanEnabled?: boolean;
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    minimax: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      /** OAuth auth type: 'apikey' (default) or 'oauth' (MiniMax Portal OAuth) */
-      authType?: 'apikey' | 'oauth';
-      /** OAuth refresh token for automatic token renewal */
-      oauthRefreshToken?: string;
-      /** OAuth token expiry as Unix timestamp in milliseconds */
-      oauthTokenExpiresAt?: number;
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    youdaozhiyun: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    qwen: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      /** 是否启用 Qwen Coding Plan 模式（使用专属 Coding API 端点） */
-      codingPlanEnabled?: boolean;
-      /** OAuth 凭据 */
-      oauthCredentials?: {
-        access: string;
-        refresh: string;
-        expires: number;
-        resourceUrl?: string;
-      };
-      /** OAuth 专用 Base URL（与 API Key 的 baseUrl 独立） */
-      oauthBaseUrl?: string;
-      /** 是否使用OAuth方式而非API Key */
-      useOAuth?: boolean;
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    openrouter: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    gemini: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    anthropic: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    volcengine: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      /** 是否启用 Volcengine Coding Plan 模式（使用专属 Coding API 端点） */
-      codingPlanEnabled?: boolean;
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    xiaomi: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    stepfun: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    'github-copilot': {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    ollama: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    custom: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-    [key: string]: {
-      enabled: boolean;
-      apiKey: string;
-      baseUrl: string;
-      apiFormat?: 'anthropic' | 'openai' | 'gemini';
-      codingPlanEnabled?: boolean;
-      oauthCredentials?: {
-        access: string;
-        refresh: string;
-        expires: number;
-        resourceUrl?: string;
-      };
-      oauthBaseUrl?: string;
-      useOAuth?: boolean;
-      authType?: 'apikey' | 'oauth';
-      oauthRefreshToken?: string;
-      oauthTokenExpiresAt?: number;
-      displayName?: string;
-      models?: Array<{
-        id: string;
-        name: string;
-        supportsImage?: boolean;
-      }>;
-    };
-  };
+  providers?: Record<string, ProviderConfig>;
   // 主题配置
   theme: 'light' | 'dark' | 'system';
   // 语言配置
@@ -271,14 +43,7 @@ export interface AppConfig {
 }
 
 const buildDefaultProviders = (): AppConfig['providers'] => {
-  const providers: Record<string, {
-    enabled: boolean;
-    apiKey: string;
-    baseUrl: string;
-    apiFormat?: 'anthropic' | 'openai' | 'gemini';
-    codingPlanEnabled?: boolean;
-    models?: Array<{ id: string; name: string; supportsImage?: boolean }>;
-  }> = {};
+  const providers: Record<string, ProviderConfig> = {};
 
   for (const id of ProviderRegistry.providerIds) {
     const def = ProviderRegistry.get(id)!;
@@ -292,7 +57,7 @@ const buildDefaultProviders = (): AppConfig['providers'] => {
     };
   }
 
-  return providers as AppConfig['providers'];
+  return providers;
 };
 
 // 默认配置
@@ -364,7 +129,7 @@ export const getCustomProviderDefaultName = (key: string): string => {
  */
 export const getProviderDisplayName = (
   providerKey: string,
-  providerConfig?: Record<string, unknown>,
+  providerConfig?: { displayName?: string },
 ): string => {
   if (isCustomProvider(providerKey)) {
     const name = providerConfig && typeof providerConfig.displayName === 'string'

--- a/src/renderer/providers/uiRegistry.tsx
+++ b/src/renderer/providers/uiRegistry.tsx
@@ -1,0 +1,43 @@
+import { ProviderName } from '@shared/providers';
+import React from 'react';
+
+import {
+  AnthropicIcon,
+  CustomProviderIcon,
+  DeepSeekIcon,
+  GeminiIcon,
+  GitHubCopilotIcon,
+  MiniMaxIcon,
+  MoonshotIcon,
+  OllamaIcon,
+  OpenAIIcon,
+  OpenRouterIcon,
+  QwenIcon,
+  StepfunIcon,
+  VolcengineIcon,
+  XiaomiIcon,
+  YouDaoZhiYunIcon,
+  ZhipuIcon,
+} from '../components/icons/providers';
+
+const PROVIDER_ICON_MAP: Record<string, React.ReactNode> = {
+  [ProviderName.OpenAI]:       <OpenAIIcon />,
+  [ProviderName.DeepSeek]:     <DeepSeekIcon />,
+  [ProviderName.Gemini]:       <GeminiIcon />,
+  [ProviderName.Anthropic]:    <AnthropicIcon />,
+  [ProviderName.Moonshot]:     <MoonshotIcon />,
+  [ProviderName.Zhipu]:        <ZhipuIcon />,
+  [ProviderName.Minimax]:      <MiniMaxIcon />,
+  [ProviderName.Youdaozhiyun]: <YouDaoZhiYunIcon />,
+  [ProviderName.Qwen]:         <QwenIcon />,
+  [ProviderName.Xiaomi]:       <XiaomiIcon />,
+  [ProviderName.StepFun]:      <StepfunIcon />,
+  [ProviderName.Volcengine]:   <VolcengineIcon />,
+  [ProviderName.OpenRouter]:   <OpenRouterIcon />,
+  [ProviderName.Copilot]:      <GitHubCopilotIcon />,
+  [ProviderName.Ollama]:       <OllamaIcon />,
+};
+
+export function getProviderIcon(id: string): React.ReactNode {
+  return PROVIDER_ICON_MAP[id] ?? <CustomProviderIcon />;
+}

--- a/src/renderer/services/config.ts
+++ b/src/renderer/services/config.ts
@@ -1,15 +1,12 @@
+import { type ApiFormat,ProviderRegistry } from '@shared/providers';
+
 import { AppConfig, CONFIG_KEYS, defaultConfig, isCustomProvider } from '../config';
 import { localStore } from './store';
 
-const getFixedProviderApiFormat = (providerKey: string): 'anthropic' | 'openai' | 'gemini' | null => {
-  if (providerKey === 'openai' || providerKey === 'stepfun' || providerKey === 'youdaozhiyun' || providerKey === 'github-copilot') {
-    return 'openai';
-  }
-  if (providerKey === 'anthropic') {
-    return 'anthropic';
-  }
-  if (providerKey === 'gemini') {
-    return 'gemini';
+const getFixedProviderApiFormat = (providerKey: string): ApiFormat | null => {
+  const def = ProviderRegistry.get(providerKey);
+  if (def && !def.switchableBaseUrls) {
+    return def.defaultApiFormat;
   }
   return null;
 };

--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -97,6 +97,12 @@ export type AuthType = typeof AuthType[keyof typeof AuthType];
 interface ProviderDefInput {
   /** Provider identifier (e.g. 'openai', 'moonshot') */
   readonly id: string;
+  /** Human-readable display name shown in UI, e.g. 'OpenAI', 'GitHub Copilot' */
+  readonly label: string;
+  /** Provider console / product website URL */
+  readonly website?: string;
+  /** API key creation page URL. Omit for providers that don't use API keys (e.g. Ollama). */
+  readonly apiKeyUrl?: string;
   /** Default base URL */
   readonly defaultBaseUrl: string;
   /** Default API format */
@@ -167,6 +173,9 @@ const PROVIDER_DEFINITIONS = [
   // ── China ──
   {
     id: ProviderName.DeepSeek,
+    label: 'DeepSeek',
+    website: 'https://platform.deepseek.com',
+    apiKeyUrl: 'https://platform.deepseek.com/api_keys',
     openClawProviderId: OpenClawProviderId.DeepSeek,
     defaultBaseUrl: 'https://api.deepseek.com/anthropic',
     defaultApiFormat: ApiFormat.Anthropic,
@@ -181,6 +190,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.Moonshot,
+    label: 'Moonshot',
+    website: 'https://platform.moonshot.cn',
+    apiKeyUrl: 'https://platform.moonshot.cn/console/api-keys',
     openClawProviderId: OpenClawProviderId.Moonshot,
     // Moonshot's /anthropic endpoint does not fully implement the Anthropic Messages spec
     // (no tool use, incomplete streaming, etc.). API connectivity tests pass, but actual
@@ -204,6 +216,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.Qwen,
+    label: 'Qwen',
+    website: 'https://dashscope.console.aliyun.com',
+    apiKeyUrl: 'https://dashscope.console.aliyun.com/apiKey',
     openClawProviderId: OpenClawProviderId.Qwen,
     defaultBaseUrl: 'https://dashscope.aliyuncs.com/apps/anthropic',
     defaultApiFormat: ApiFormat.Anthropic,
@@ -226,6 +241,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.Zhipu,
+    label: 'Zhipu',
+    website: 'https://open.bigmodel.cn',
+    apiKeyUrl: 'https://open.bigmodel.cn/usercenter/apikeys',
     openClawProviderId: OpenClawProviderId.Zai,
     defaultBaseUrl: 'https://open.bigmodel.cn/api/anthropic',
     defaultApiFormat: ApiFormat.Anthropic,
@@ -248,6 +266,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.Minimax,
+    label: 'MiniMax',
+    website: 'https://platform.minimaxi.com',
+    apiKeyUrl: 'https://platform.minimaxi.com/user-center/basic-information/interface-key',
     openClawProviderId: OpenClawProviderId.Minimax,
     defaultBaseUrl: 'https://api.minimaxi.com/anthropic',
     defaultApiFormat: ApiFormat.Anthropic,
@@ -265,6 +286,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.Volcengine,
+    label: 'Volcengine',
+    website: 'https://console.volcengine.com/ark',
+    apiKeyUrl: 'https://console.volcengine.com/ark',
     openClawProviderId: OpenClawProviderId.Volcengine,
     defaultBaseUrl: 'https://ark.cn-beijing.volces.com/api/compatible',
     defaultApiFormat: ApiFormat.Anthropic,
@@ -288,6 +312,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.Youdaozhiyun,
+    label: 'Youdao',
+    website: 'https://ai.youdao.com',
+    apiKeyUrl: 'https://ai.youdao.com/console',
     openClawProviderId: OpenClawProviderId.Youdaozhiyun,
     defaultBaseUrl: 'https://openapi.youdao.com/llmgateway/api/v1/chat/completions',
     defaultApiFormat: ApiFormat.OpenAI,
@@ -307,6 +334,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.StepFun,
+    label: 'StepFun',
+    website: 'https://platform.stepfun.com',
+    apiKeyUrl: 'https://platform.stepfun.com/interface-key',
     openClawProviderId: OpenClawProviderId.StepFun,
     defaultBaseUrl: 'https://api.stepfun.com/v1',
     defaultApiFormat: ApiFormat.OpenAI,
@@ -317,6 +347,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.Xiaomi,
+    label: 'Xiaomi',
+    website: 'https://dev.mi.com/platform',
+    apiKeyUrl: 'https://dev.mi.com/platform',
     openClawProviderId: OpenClawProviderId.Xiaomi,
     defaultBaseUrl: 'https://api.xiaomimimo.com/anthropic',
     defaultApiFormat: ApiFormat.Anthropic,
@@ -331,6 +364,8 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.Ollama,
+    label: 'Ollama',
+    website: 'https://ollama.com',
     openClawProviderId: OpenClawProviderId.Ollama,
     defaultBaseUrl: 'http://localhost:11434/v1',
     defaultApiFormat: ApiFormat.OpenAI,
@@ -349,6 +384,7 @@ const PROVIDER_DEFINITIONS = [
   // ── Global ──
   {
     id: ProviderName.Copilot,
+    label: 'GitHub Copilot',
     openClawProviderId: OpenClawProviderId.Copilot,
     defaultBaseUrl: 'https://api.individual.githubcopilot.com',
     defaultApiFormat: ApiFormat.OpenAI,
@@ -364,6 +400,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.OpenAI,
+    label: 'OpenAI',
+    website: 'https://platform.openai.com',
+    apiKeyUrl: 'https://platform.openai.com/api-keys',
     openClawProviderId: OpenClawProviderId.OpenAI,
     defaultBaseUrl: 'https://api.openai.com/v1',
     defaultApiFormat: ApiFormat.OpenAI,
@@ -379,6 +418,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.Gemini,
+    label: 'Gemini',
+    website: 'https://aistudio.google.com',
+    apiKeyUrl: 'https://aistudio.google.com/apikey',
     openClawProviderId: OpenClawProviderId.Google,
     defaultBaseUrl: 'https://generativelanguage.googleapis.com/v1beta',
     defaultApiFormat: ApiFormat.Gemini,
@@ -393,6 +435,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.Anthropic,
+    label: 'Anthropic',
+    website: 'https://console.anthropic.com',
+    apiKeyUrl: 'https://console.anthropic.com/settings/keys',
     openClawProviderId: OpenClawProviderId.Anthropic,
     defaultBaseUrl: 'https://api.anthropic.com',
     defaultApiFormat: ApiFormat.Anthropic,
@@ -407,6 +452,9 @@ const PROVIDER_DEFINITIONS = [
   },
   {
     id: ProviderName.OpenRouter,
+    label: 'OpenRouter',
+    website: 'https://openrouter.ai',
+    apiKeyUrl: 'https://openrouter.ai/keys',
     openClawProviderId: OpenClawProviderId.OpenRouter,
     defaultBaseUrl: 'https://openrouter.ai/api',
     defaultApiFormat: ApiFormat.Anthropic,
@@ -433,6 +481,12 @@ const PROVIDER_DEFINITIONS = [
 export interface ProviderDef {
   /** Provider identifier (e.g. 'openai', 'moonshot') */
   readonly id: string;
+  /** Human-readable display name shown in UI */
+  readonly label: string;
+  /** Provider console / product website URL */
+  readonly website?: string;
+  /** API key creation page URL */
+  readonly apiKeyUrl?: string;
   /** Default base URL */
   readonly defaultBaseUrl: string;
   /** Default API format */

--- a/src/shared/providers/index.ts
+++ b/src/shared/providers/index.ts
@@ -1,10 +1,11 @@
+export { resolveCodingPlanBaseUrl } from './codingPlan';
 export type { ProviderDef } from './constants';
 export {
-  ProviderName,
-  OpenClawProviderId,
-  OpenClawApi,
   ApiFormat,
   AuthType,
+  OpenClawApi,
+  OpenClawProviderId,
+  ProviderName,
   ProviderRegistry,
 } from './constants';
-export { resolveCodingPlanBaseUrl } from './codingPlan';
+export type { ProviderConfig } from './types';

--- a/src/shared/providers/types.ts
+++ b/src/shared/providers/types.ts
@@ -1,0 +1,18 @@
+import type { ApiFormat } from './constants';
+
+export interface ProviderConfig {
+  enabled: boolean;
+  apiKey: string;
+  baseUrl: string;
+  apiFormat?: ApiFormat;
+  models?: Array<{
+    id: string;
+    name: string;
+    supportsImage?: boolean;
+  }>;
+  displayName?: string;
+  codingPlanEnabled?: boolean;
+  authType?: 'apikey' | 'oauth';
+  oauthRefreshToken?: string;
+  oauthTokenExpiresAt?: number;
+}


### PR DESCRIPTION
## 概述
将所有 provider 元数据合并到 `PROVIDER_DEFINITIONS`（现有的单一数据源），使新增 provider 时只需修改 3 处代码，而非原来的 6 处。
**净变化：8 个文件 +100 行，−362 行（新增 2 个文件）**
## 背景
此前每次新增 provider，同一份信息需要在 6 个地方同步维护：
| 位置 | 重复的信息 |
|---|---|
| `config.ts` 中的 `AppConfig['providers']` | 226 行具名 key 类型定义 |
| `Settings.tsx` 中的 `providerKeys[]` | 展示顺序 |
| `Settings.tsx` 中的 `providerMeta{}` | label + icon |
| `Settings.tsx` 中的 `providerLinks{}` | 官网链接 + API Key 申请链接 |
| `services/config.ts` 中的 `getFixedProviderApiFormat()` | 硬编码 provider 名称字符串 |
| `claudeSettings.ts` 中的 `ProviderConfig` 类型 | 重复的运行时配置结构 |
## 变更说明
 `src/shared/providers/constants.ts`
- `ProviderDefInput` / `ProviderDef` 新增 `label`、`website`、`apiKeyUrl` 字段
- 15 条 provider 记录全部补充上述字段
 `src/shared/providers/types.ts` *(新建)*
- 定义单一 `ProviderConfig` interface，替代 renderer 和 main 中的重复定义
- 包含通用字段：`codingPlanEnabled`、`authType`、`oauthRefreshToken`、`oauthTokenExpiresAt`、`displayName`
 `src/shared/providers/index.ts`
- 导出新建的 `types.ts` 中的 `ProviderConfig`
 `src/renderer/providers/uiRegistry.tsx` *(新建)*
- 仅用于 React JSX 的 icon 注册表（不能放入 `shared`，main process 无 React）
- 导出 `getProviderIcon(id: string)`，未知 ID 统一 fallback 为 `<CustomProviderIcon />`
 `src/renderer/config.ts`
- 将 226 行具名 key 的 `providers` 类型替换为 `providers?: Record<string, ProviderConfig>`
- `buildDefaultProviders()` 同步简化，直接使用 shared 类型
 `src/renderer/services/config.ts`
- 重写 `getFixedProviderApiFormat()`：改为通过 `ProviderRegistry.get(key)?.switchableBaseUrls` 派生，消除硬编码字符串比较
- 已验证所有现有 provider 的映射结果与重写前完全一致
 `src/renderer/components/Settings.tsx`
- 删除 `providerMeta`（label + icon）、`providerLinks`（website + apiKeyUrl）以及硬编码 `providerKeys[]`
- 替换为 `ProviderRegistry.get(id)` 查询和 `getProviderIcon(id)`
- `providerKeys` 改为由 `Object.values(ProviderName)` 派生，展示顺序与 `PROVIDER_DEFINITIONS` 数组顺序保持一致
 `src/main/libs/claudeSettings.ts`
- 删除本地 `ProviderModel` / `ProviderConfig` 定义
- 改为从 `@shared/providers` 导入 `ProviderConfig`
- 保留 `LocalProviderConfig` 别名，用于兼容部分存量配置中仍存在的 `'native'` apiFormat 值
 兼容性说明
- **SQLite 存储**：`AppConfig` 以 JSON 持久化，`Record<string, ProviderConfig>` 与现有存储格式完全兼容，无需迁移
- **运行时行为**：`getFixedProviderApiFormat()` 重写后，所有 provider 映射结果经表格逐一验证，与重写前完全一致
- **自定义 provider（custom_0…9）**：`Record<string, T>` 原生支持动态 key，icon 通过 `getProviderIcon()` fallback 到 `<CustomProviderIcon />`
- **展示顺序**：`Object.values(ProviderName)` 顺序与 `PROVIDER_DEFINITIONS` 数组顺序一致（由 `as const satisfies` 强制保证），UI 顺序不变
- **遗留 `'native'` apiFormat**：通过 `claudeSettings.ts` 中的 `LocalProviderConfig` 兼容处理，运行时 `normalizeProviderApiFormat()` 已覆盖该值
 不在本次范围内
Qwen OAuth 残留代码（`qwenOAuth.ts`、相关 `main.ts` 调用点、`claudeSettings.ts` 中的 `as any` 访问、Settings UI、i18n key）—— 单独跟进。
## 本次 PR 后新增 provider 的步骤
| 步骤 | 文件 | 操作 |
|---|---|---|
| 1 | `src/shared/providers/constants.ts` | 在 `ProviderName` 中添加新值；在 `PROVIDER_DEFINITIONS` 中添加一条记录（label、website、apiKeyUrl 及技术配置） |
| 2 | `src/main/libs/openclawConfigSync.ts` | 在 `PROVIDER_REGISTRY` 中添加一条 `ProviderDescriptor` |
| 3 | `src/renderer/providers/uiRegistry.tsx` | 在 `PROVIDER_ICON_MAP` 中添加 `[ProviderName.New]: <NewIcon />` |

无需再改：`AppConfig` 类型、`providerKeys[]`、`providerMeta` / `providerLinks`、`getFixedProviderApiFormat()` 字符串列表。

## 测试清单
- [x] Settings 中 15 个内置 provider 的 icon、label、官网链接、"获取 API Key" 链接均正确显示
- [x] enable/disable 开关状态在应用重启后正常恢复
- [x] 不可切换格式的 provider（OpenAI、Anthropic、Gemini、StepFun、有道智云、GitHub Copilot、Qwen 默认 OpenAI、Moonshot 默认 OpenAI）发起 Cowork 会话，请求走正确协议
- [ ] 可切换格式的 provider（DeepSeek）在 Settings 中切换 anthropic ↔ openai 后，baseUrl 自动跟随更新
- [ ] Coding Plan 开关（Moonshot、Zhipu、Qwen、Volcengine）开启后请求使用专属端点
- [ ] MiniMax OAuth：完整授权流程、token 持久化及刷新均正常
- [ ] 自定义 provider（custom_0…9）：新建 / 编辑 / 删除，displayName 及 icon fallback 正常
- [ ] provider 配置导出后清空，再导入，所有 provider 数据完整恢复