### PR TITLE
feat(settings): 测试连接失败时提供更详细的错误信息

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -6,11 +6,30 @@ import { checkForAppUpdate } from '../services/appUpdate';
 import type { AppUpdateInfo } from '../services/appUpdate';
 import { themeService } from '../services/theme';
 import { i18nService, LanguageType } from '../services/i18n';
-import { decryptSecret, encryptWithPassword, decryptWithPassword, EncryptedPayload, PasswordEncryptedPayload } from '../services/encryption';
+import {
+  decryptSecret,
+  encryptWithPassword,
+  decryptWithPassword,
+  EncryptedPayload,
+  PasswordEncryptedPayload,
+} from '../services/encryption';
 import { coworkService } from '../services/cowork';
 import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
 import ErrorMessage from './ErrorMessage';
-import { XMarkIcon, Cog6ToothIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, EnvelopeIcon, CpuChipIcon, InformationCircleIcon, UserCircleIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import {
+  XMarkIcon,
+  Cog6ToothIcon,
+  SignalIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+  CubeIcon,
+  ChatBubbleLeftIcon,
+  EnvelopeIcon,
+  CpuChipIcon,
+  InformationCircleIcon,
+  UserCircleIcon,
+  ArrowTopRightOnSquareIcon,
+} from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
 import PlusCircleIcon from './icons/PlusCircleIcon';
 import TrashIcon from './icons/TrashIcon';
@@ -30,7 +49,14 @@ import IMSettings from './im/IMSettings';
 import { imService } from '../services/im';
 import EmailSkillConfig from './skills/EmailSkillConfig';
 import { ProviderRegistry, resolveCodingPlanBaseUrl } from '../../shared/providers';
-import { defaultConfig, type AppConfig, getVisibleProviders, isCustomProvider, getCustomProviderDefaultName,getProviderDisplayName } from '../config';
+import {
+  defaultConfig,
+  type AppConfig,
+  getVisibleProviders,
+  isCustomProvider,
+  getCustomProviderDefaultName,
+  getProviderDisplayName,
+} from '../config';
 import {
   OpenAIIcon,
   DeepSeekIcon,
@@ -50,7 +76,16 @@ import {
   CustomProviderIcon,
 } from './icons/providers';
 
-type TabType = 'general'| 'coworkAgentEngine' | 'model' | 'coworkMemory' | 'coworkAgent' | 'shortcuts' | 'im' | 'email' | 'about';
+type TabType =
+  | 'general'
+  | 'coworkAgentEngine'
+  | 'model'
+  | 'coworkMemory'
+  | 'coworkAgent'
+  | 'shortcuts'
+  | 'im'
+  | 'email'
+  | 'about';
 
 export type SettingsOpenOptions = {
   initialTab?: TabType;
@@ -68,10 +103,17 @@ interface SettingsProps extends SettingsOpenOptions {
   } | null;
 }
 
-
 const CUSTOM_PROVIDER_KEYS = [
-  'custom_0', 'custom_1', 'custom_2', 'custom_3', 'custom_4',
-  'custom_5', 'custom_6', 'custom_7', 'custom_8', 'custom_9',
+  'custom_0',
+  'custom_1',
+  'custom_2',
+  'custom_3',
+  'custom_4',
+  'custom_5',
+  'custom_6',
+  'custom_7',
+  'custom_8',
+  'custom_9',
 ] as const;
 
 const providerKeys = [
@@ -162,37 +204,69 @@ const providerMeta: Record<ProviderType, { label: string; icon: React.ReactNode 
   openrouter: { label: 'OpenRouter', icon: <OpenRouterIcon /> },
   'github-copilot': { label: 'GitHub Copilot', icon: <GitHubCopilotIcon /> },
   ollama: { label: 'Ollama', icon: <OllamaIcon /> },
-  ...Object.fromEntries(
-    CUSTOM_PROVIDER_KEYS.map(key => [key, { label: getCustomProviderDefaultName(key), icon: <CustomProviderIcon /> }])
-  ) as Record<(typeof CUSTOM_PROVIDER_KEYS)[number], { label: string; icon: React.ReactNode }>,
+  ...(Object.fromEntries(
+    CUSTOM_PROVIDER_KEYS.map(key => [
+      key,
+      { label: getCustomProviderDefaultName(key), icon: <CustomProviderIcon /> },
+    ]),
+  ) as Record<(typeof CUSTOM_PROVIDER_KEYS)[number], { label: string; icon: React.ReactNode }>),
 };
 
 const providerLinks: Partial<Record<ProviderType, { website: string; apiKey?: string }>> = {
-  openai:       { website: 'https://platform.openai.com',              apiKey: 'https://platform.openai.com/api-keys' },
-  gemini:       { website: 'https://aistudio.google.com',              apiKey: 'https://aistudio.google.com/apikey' },
-  anthropic:    { website: 'https://console.anthropic.com',            apiKey: 'https://console.anthropic.com/settings/keys' },
-  deepseek:     { website: 'https://platform.deepseek.com',            apiKey: 'https://platform.deepseek.com/api_keys' },
-  moonshot:     { website: 'https://platform.moonshot.cn',             apiKey: 'https://platform.moonshot.cn/console/api-keys' },
-  zhipu:        { website: 'https://open.bigmodel.cn',                 apiKey: 'https://open.bigmodel.cn/usercenter/apikeys' },
-  minimax:      { website: 'https://platform.minimaxi.com',            apiKey: 'https://platform.minimaxi.com/user-center/basic-information/interface-key' },
-  volcengine:   { website: 'https://console.volcengine.com/ark',       apiKey: 'https://console.volcengine.com/ark' },
-  qwen:         { website: 'https://dashscope.console.aliyun.com',     apiKey: 'https://dashscope.console.aliyun.com/apiKey' },
-  youdaozhiyun: { website: 'https://ai.youdao.com',                    apiKey: 'https://ai.youdao.com/console' },
-  stepfun:      { website: 'https://platform.stepfun.com',             apiKey: 'https://platform.stepfun.com/interface-key' },
-  xiaomi:       { website: 'https://dev.mi.com/platform',              apiKey: 'https://dev.mi.com/platform' },
-  openrouter:   { website: 'https://openrouter.ai',                    apiKey: 'https://openrouter.ai/keys' },
-  ollama:       { website: 'https://ollama.com' },
+  openai: {
+    website: 'https://platform.openai.com',
+    apiKey: 'https://platform.openai.com/api-keys',
+  },
+  gemini: { website: 'https://aistudio.google.com', apiKey: 'https://aistudio.google.com/apikey' },
+  anthropic: {
+    website: 'https://console.anthropic.com',
+    apiKey: 'https://console.anthropic.com/settings/keys',
+  },
+  deepseek: {
+    website: 'https://platform.deepseek.com',
+    apiKey: 'https://platform.deepseek.com/api_keys',
+  },
+  moonshot: {
+    website: 'https://platform.moonshot.cn',
+    apiKey: 'https://platform.moonshot.cn/console/api-keys',
+  },
+  zhipu: {
+    website: 'https://open.bigmodel.cn',
+    apiKey: 'https://open.bigmodel.cn/usercenter/apikeys',
+  },
+  minimax: {
+    website: 'https://platform.minimaxi.com',
+    apiKey: 'https://platform.minimaxi.com/user-center/basic-information/interface-key',
+  },
+  volcengine: {
+    website: 'https://console.volcengine.com/ark',
+    apiKey: 'https://console.volcengine.com/ark',
+  },
+  qwen: {
+    website: 'https://dashscope.console.aliyun.com',
+    apiKey: 'https://dashscope.console.aliyun.com/apiKey',
+  },
+  youdaozhiyun: { website: 'https://ai.youdao.com', apiKey: 'https://ai.youdao.com/console' },
+  stepfun: {
+    website: 'https://platform.stepfun.com',
+    apiKey: 'https://platform.stepfun.com/interface-key',
+  },
+  xiaomi: { website: 'https://dev.mi.com/platform', apiKey: 'https://dev.mi.com/platform' },
+  openrouter: { website: 'https://openrouter.ai', apiKey: 'https://openrouter.ai/keys' },
+  ollama: { website: 'https://ollama.com' },
 };
 
-const providerRequiresApiKey = (provider: ProviderType) => provider !== 'ollama' && provider !== 'github-copilot';
-const normalizeBaseUrl = (baseUrl: string): string => baseUrl.trim().replace(/\/+$/, '').toLowerCase();
-const normalizeApiFormat = (value: unknown): 'anthropic' | 'openai' => (
-  value === 'openai' ? 'openai' : 'anthropic'
-);
+const providerRequiresApiKey = (provider: ProviderType) =>
+  provider !== 'ollama' && provider !== 'github-copilot';
+const normalizeBaseUrl = (baseUrl: string): string =>
+  baseUrl.trim().replace(/\/+$/, '').toLowerCase();
+const normalizeApiFormat = (value: unknown): 'anthropic' | 'openai' =>
+  value === 'openai' ? 'openai' : 'anthropic';
 const ABOUT_CONTACT_EMAIL = 'lobsterai.project@rd.netease.com';
 const ABOUT_USER_MANUAL_URL = 'https://lobsterai.youdao.com/#/docs/lobsterai_user_manual';
 const ABOUT_USER_COMMUNITY_URL = 'https://lobsterai.youdao.com/#/about';
-const ABOUT_SERVICE_TERMS_URL = 'https://c.youdao.com/dict/hardware/lobsterai/lobsterai_service.html';
+const ABOUT_SERVICE_TERMS_URL =
+  'https://c.youdao.com/dict/hardware/lobsterai/lobsterai_service.html';
 
 // MiniMax Portal OAuth constants
 const MINIMAX_OAUTH_CLIENT_ID = '78257093-7e40-4613-99e0-527b14b39113';
@@ -213,19 +287,29 @@ type MiniMaxOAuthPhase =
   | { kind: 'success' }
   | { kind: 'error'; message: string };
 
-async function generateMiniMaxPkce(): Promise<{ verifier: string; challenge: string; state: string }> {
+async function generateMiniMaxPkce(): Promise<{
+  verifier: string;
+  challenge: string;
+  state: string;
+}> {
   const verifierArray = new Uint8Array(32);
   crypto.getRandomValues(verifierArray);
   const verifier = btoa(String.fromCharCode(...verifierArray))
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
   const encoded = new TextEncoder().encode(verifier);
   const digest = await crypto.subtle.digest('SHA-256', encoded);
   const challenge = btoa(String.fromCharCode(...new Uint8Array(digest)))
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
   const stateArray = new Uint8Array(16);
   crypto.getRandomValues(stateArray);
   const state = btoa(String.fromCharCode(...stateArray))
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
   return { verifier, challenge, state };
 }
 
@@ -263,7 +347,9 @@ const copyTextToClipboard = async (text: string): Promise<boolean> => {
   }
 };
 
-const getFixedApiFormatForProvider = (provider: string): 'anthropic' | 'openai' | 'gemini' | null => {
+const getFixedApiFormatForProvider = (
+  provider: string,
+): 'anthropic' | 'openai' | 'gemini' | null => {
   if (provider === 'openai' || provider === 'stepfun') {
     return 'openai';
   }
@@ -284,15 +370,16 @@ const getFixedApiFormatForProvider = (provider: string): 'anthropic' | 'openai' 
   }
   return null;
 };
-const getEffectiveApiFormat = (provider: string, value: unknown): 'anthropic' | 'openai' | 'gemini' => (
-  getFixedApiFormatForProvider(provider) ?? normalizeApiFormat(value)
-);
-const shouldShowApiFormatSelector = (provider: string): boolean => (
-  getFixedApiFormatForProvider(provider) === null
-);
+const getEffectiveApiFormat = (
+  provider: string,
+  value: unknown,
+): 'anthropic' | 'openai' | 'gemini' =>
+  getFixedApiFormatForProvider(provider) ?? normalizeApiFormat(value);
+const shouldShowApiFormatSelector = (provider: string): boolean =>
+  getFixedApiFormatForProvider(provider) === null;
 const getProviderDefaultBaseUrl = (
   provider: ProviderType,
-  apiFormat: 'anthropic' | 'openai' | 'gemini'
+  apiFormat: 'anthropic' | 'openai' | 'gemini',
 ): string | null => {
   if (apiFormat === 'gemini') return null;
   return ProviderRegistry.getSwitchableBaseUrl(provider, apiFormat) ?? null;
@@ -300,20 +387,28 @@ const getProviderDefaultBaseUrl = (
 const resolveBaseUrl = (
   provider: ProviderType,
   baseUrl: string,
-  apiFormat: 'anthropic' | 'openai' | 'gemini'
+  apiFormat: 'anthropic' | 'openai' | 'gemini',
 ): string => {
   if (baseUrl.trim()) {
-    if (shouldAutoSwitchProviderBaseUrl(provider, baseUrl) && (apiFormat === 'anthropic' || apiFormat === 'openai')) {
+    if (
+      shouldAutoSwitchProviderBaseUrl(provider, baseUrl) &&
+      (apiFormat === 'anthropic' || apiFormat === 'openai')
+    ) {
       const switchedUrl = ProviderRegistry.getSwitchableBaseUrl(provider, apiFormat);
       if (switchedUrl) return switchedUrl;
     }
     return baseUrl;
   }
-  return getProviderDefaultBaseUrl(provider, apiFormat)
-    || defaultConfig.providers?.[provider]?.baseUrl
-    || '';
+  return (
+    getProviderDefaultBaseUrl(provider, apiFormat) ||
+    defaultConfig.providers?.[provider]?.baseUrl ||
+    ''
+  );
 };
-const shouldAutoSwitchProviderBaseUrl = (provider: ProviderType, currentBaseUrl: string): boolean => {
+const shouldAutoSwitchProviderBaseUrl = (
+  provider: ProviderType,
+  currentBaseUrl: string,
+): boolean => {
   const anthropicUrl = ProviderRegistry.getSwitchableBaseUrl(provider, 'anthropic');
   const openaiUrl = ProviderRegistry.getSwitchableBaseUrl(provider, 'openai');
   if (!anthropicUrl && !openaiUrl) {
@@ -322,8 +417,8 @@ const shouldAutoSwitchProviderBaseUrl = (provider: ProviderType, currentBaseUrl:
 
   const normalizedCurrent = normalizeBaseUrl(currentBaseUrl);
   return (
-    (anthropicUrl ? normalizedCurrent === normalizeBaseUrl(anthropicUrl) : false)
-    || (openaiUrl ? normalizedCurrent === normalizeBaseUrl(openaiUrl) : false)
+    (anthropicUrl ? normalizedCurrent === normalizeBaseUrl(anthropicUrl) : false) ||
+    (openaiUrl ? normalizedCurrent === normalizeBaseUrl(openaiUrl) : false)
   );
 };
 const buildOpenAICompatibleChatCompletionsUrl = (baseUrl: string, provider: string): string => {
@@ -335,15 +430,14 @@ const buildOpenAICompatibleChatCompletionsUrl = (baseUrl: string, provider: stri
     return normalized;
   }
 
-  const isGeminiLike = provider === 'gemini' || normalized.includes('generativelanguage.googleapis.com');
+  const isGeminiLike =
+    provider === 'gemini' || normalized.includes('generativelanguage.googleapis.com');
   if (isGeminiLike) {
     if (normalized.endsWith('/v1beta/openai') || normalized.endsWith('/v1/openai')) {
       return `${normalized}/chat/completions`;
     }
     if (normalized.endsWith('/v1beta') || normalized.endsWith('/v1')) {
-      const betaBase = normalized.endsWith('/v1')
-        ? `${normalized.slice(0, -3)}v1beta`
-        : normalized;
+      const betaBase = normalized.endsWith('/v1') ? `${normalized.slice(0, -3)}v1beta` : normalized;
       return `${betaBase}/openai/chat/completions`;
     }
     return `${normalized}/v1beta/openai/chat/completions`;
@@ -372,9 +466,7 @@ const buildOpenAIResponsesUrl = (baseUrl: string): string => {
   }
   return `${normalized}/v1/responses`;
 };
-const shouldUseOpenAIResponsesForProvider = (provider: string): boolean => (
-  provider === 'openai'
-);
+const shouldUseOpenAIResponsesForProvider = (provider: string): boolean => provider === 'openai';
 const shouldUseMaxCompletionTokensForOpenAI = (provider: string, modelId?: string): boolean => {
   if (provider !== 'openai') {
     return false;
@@ -383,12 +475,73 @@ const shouldUseMaxCompletionTokensForOpenAI = (provider: string, modelId?: strin
   const resolvedModel = normalizedModel.includes('/')
     ? normalizedModel.slice(normalizedModel.lastIndexOf('/') + 1)
     : normalizedModel;
-  return resolvedModel.startsWith('gpt-5')
-    || resolvedModel.startsWith('o1')
-    || resolvedModel.startsWith('o3')
-    || resolvedModel.startsWith('o4');
+  return (
+    resolvedModel.startsWith('gpt-5') ||
+    resolvedModel.startsWith('o1') ||
+    resolvedModel.startsWith('o3') ||
+    resolvedModel.startsWith('o4')
+  );
 };
 const CONNECTIVITY_TEST_TOKEN_BUDGET = 64;
+
+const getConnectionStatusHint = (status: number): string => {
+  const map: Record<number, string> = {
+    400: i18nService.t('connectionStatus400'),
+    401: i18nService.t('connectionStatus401'),
+    403: i18nService.t('connectionStatus403'),
+    404: i18nService.t('connectionStatus404'),
+    429: i18nService.t('connectionStatus429'),
+    500: i18nService.t('connectionStatus500'),
+    502: i18nService.t('connectionStatus502'),
+    503: i18nService.t('connectionStatus503'),
+  };
+  return map[status] ?? '';
+};
+
+const buildConnectionErrorMessage = (
+  response: { status: number; statusText: string; data: unknown; error?: string },
+  testUrl: string,
+): string => {
+  const parts: string[] = [];
+
+  if (response.status === 0) {
+    // Network-level failure — no HTTP response received
+    parts.push(i18nService.t('connectionFailedNetwork'));
+    const networkError = response.error || response.statusText;
+    if (networkError) {
+      parts.push(networkError);
+    }
+    parts.push('');
+    parts.push(`${i18nService.t('connectionTestUrl')}: ${testUrl}`);
+    parts.push(i18nService.t('connectionFailedNetworkHint'));
+  } else {
+    const statusHint = getConnectionStatusHint(response.status);
+    parts.push(`HTTP ${response.status}${statusHint ? ` — ${statusHint}` : ''}`);
+
+    // Extract the server's own error message when present
+    const data = response.data;
+    let apiError: string | undefined;
+    if (data !== null && typeof data === 'object') {
+      const obj = data as Record<string, unknown>;
+      const errMsg = (obj.error as Record<string, unknown> | undefined)?.message;
+      apiError =
+        (typeof errMsg === 'string' ? errMsg : undefined) ||
+        (typeof obj.message === 'string' ? obj.message : undefined);
+    }
+    if (apiError) {
+      parts.push('');
+      parts.push(apiError);
+    }
+
+    // Show test URL when the endpoint itself might be misconfigured
+    if (response.status === 404 || !statusHint) {
+      parts.push('');
+      parts.push(`${i18nService.t('connectionTestUrl')}: ${testUrl}`);
+    }
+  }
+
+  return parts.join('\n');
+};
 
 const getDefaultProviders = (): ProvidersConfig => {
   const providers = (defaultConfig.providers ?? {}) as ProvidersConfig;
@@ -405,7 +558,7 @@ const getDefaultProviders = (): ProvidersConfig => {
           supportsImage: model.supportsImage ?? false,
         })),
       },
-    ])
+    ]),
   ) as ProvidersConfig;
 };
 
@@ -448,16 +601,26 @@ const formatShortcutFromEvent = (e: React.KeyboardEvent): string | null => {
   if (e.shiftKey) parts.push('Shift');
 
   const keyMap: Record<string, string> = {
-    ArrowUp: 'Up', ArrowDown: 'Down', ArrowLeft: 'Left', ArrowRight: 'Right',
-    ' ': 'Space', Escape: 'Esc', Enter: 'Enter', Backspace: 'Backspace',
-    Delete: 'Delete', Tab: 'Tab',
+    ArrowUp: 'Up',
+    ArrowDown: 'Down',
+    ArrowLeft: 'Left',
+    ArrowRight: 'Right',
+    ' ': 'Space',
+    Escape: 'Esc',
+    Enter: 'Enter',
+    Backspace: 'Backspace',
+    Delete: 'Delete',
+    Tab: 'Tab',
   };
   const key = keyMap[e.key] ?? (e.key.length === 1 ? e.key.toUpperCase() : e.key);
   parts.push(key);
   return parts.join('+');
 };
 
-const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void }> = ({ value, onChange }) => {
+const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void }> = ({
+  value,
+  onChange,
+}) => {
   const [recording, setRecording] = useState(false);
   const divRef = useRef<HTMLDivElement>(null);
 
@@ -465,10 +628,20 @@ const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void 
     if (!recording) return;
     e.preventDefault();
     e.stopPropagation();
-    if (e.key === 'Escape') { setRecording(false); return; }
-    if (e.key === 'Delete' || e.key === 'Backspace') { onChange(''); setRecording(false); return; }
+    if (e.key === 'Escape') {
+      setRecording(false);
+      return;
+    }
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      onChange('');
+      setRecording(false);
+      return;
+    }
     const shortcut = formatShortcutFromEvent(e);
-    if (shortcut) { onChange(shortcut); setRecording(false); }
+    if (shortcut) {
+      onChange(shortcut);
+      setRecording(false);
+    }
   };
 
   useEffect(() => {
@@ -490,9 +663,10 @@ const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void 
       onBlur={() => setRecording(false)}
       className={`w-36 rounded-xl border px-3 py-1.5 text-sm cursor-pointer select-none text-center outline-none transition-colors
         dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset dark:text-claude-darkText text-claude-text
-        ${recording
-          ? 'border-claude-accent ring-1 ring-claude-accent/30 dark:text-claude-darkTextSecondary text-claude-textSecondary'
-          : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
+        ${
+          recording
+            ? 'border-claude-accent ring-1 ring-claude-accent/30 dark:text-claude-darkTextSecondary text-claude-textSecondary'
+            : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
         }`}
     >
       {value || i18nService.t('shortcutNotSet')}
@@ -500,7 +674,15 @@ const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void 
   );
 };
 
-const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, noticeI18nKey, noticeExtra, onUpdateFound, enterpriseConfig }) => {
+const Settings: React.FC<SettingsProps> = ({
+  onClose,
+  initialTab,
+  notice,
+  noticeI18nKey,
+  noticeExtra,
+  onUpdateFound,
+  enterpriseConfig,
+}) => {
   const dispatch = useDispatch();
   // 状态
   const [activeTab, setActiveTab] = useState<TabType>(initialTab ?? 'general');
@@ -546,17 +728,21 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   // Add state for providers configuration
   const [providers, setProviders] = useState<ProvidersConfig>(() => getDefaultProviders());
 
-
   // authType defaults to undefined on first open, which should behave as OAuth mode
   const minimaxIsOAuthMode = providers.minimax.authType !== 'apikey';
-  const isBaseUrlLocked = (activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled) || (activeProvider === 'qwen' && providers.qwen.codingPlanEnabled) || (activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled) || (activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled) || (activeProvider === 'minimax' && minimaxIsOAuthMode);
-  
+  const isBaseUrlLocked =
+    (activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled) ||
+    (activeProvider === 'qwen' && providers.qwen.codingPlanEnabled) ||
+    (activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled) ||
+    (activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled) ||
+    (activeProvider === 'minimax' && minimaxIsOAuthMode);
+
   // 创建引用来确保内容区域的滚动
   const contentRef = useRef<HTMLDivElement>(null);
   const importInputRef = useRef<HTMLInputElement>(null);
   const emailCopiedTimerRef = useRef<number | null>(null);
   const updateCheckTimerRef = useRef<number | null>(null);
-  
+
   // 快捷键设置
   const [shortcuts, setShortcuts] = useState({
     newChat: 'Ctrl+N',
@@ -565,7 +751,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   });
 
   // GitHub Copilot device code auth state
-  const [copilotAuthStatus, setCopilotAuthStatus] = useState<'idle' | 'requesting' | 'awaiting_user' | 'polling' | 'authenticated' | 'error'>('idle');
+  const [copilotAuthStatus, setCopilotAuthStatus] = useState<
+    'idle' | 'requesting' | 'awaiting_user' | 'polling' | 'authenticated' | 'error'
+  >('idle');
   const [copilotUserCode, setCopilotUserCode] = useState('');
   const [copilotVerificationUri, setCopilotVerificationUri] = useState('');
   const [copilotGithubUser, setCopilotGithubUser] = useState('');
@@ -587,7 +775,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [testMode, setTestMode] = useState(false);
   const [logoClickCount, setLogoClickCount] = useState(0);
   const [testModeUnlocked, setTestModeUnlocked] = useState(false);
-  const [updateCheckStatus, setUpdateCheckStatus] = useState<'idle' | 'checking' | 'upToDate' | 'error'>('idle');
+  const [updateCheckStatus, setUpdateCheckStatus] = useState<
+    'idle' | 'checking' | 'upToDate' | 'error'
+  >('idle');
 
   useEffect(() => {
     window.electron.appInfo.getVersion().then(setAppVersion);
@@ -682,7 +872,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         setNoticeMessage(i18nService.t('aboutExportLogsSuccess'));
       }
     } catch (exportError) {
-      setError(exportError instanceof Error ? exportError.message : i18nService.t('aboutExportLogsFailed'));
+      setError(
+        exportError instanceof Error ? exportError.message : i18nService.t('aboutExportLogsFailed'),
+      );
     } finally {
       setIsExportingLogs(false);
     }
@@ -690,9 +882,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   const coworkConfig = useSelector((state: RootState) => state.cowork.config);
 
-  const [coworkAgentEngine, setCoworkAgentEngine] = useState<CoworkAgentEngine>(coworkConfig.agentEngine || 'openclaw');
-  const [coworkMemoryEnabled, setCoworkMemoryEnabled] = useState<boolean>(coworkConfig.memoryEnabled ?? true);
-  const [coworkMemoryLlmJudgeEnabled, setCoworkMemoryLlmJudgeEnabled] = useState<boolean>(coworkConfig.memoryLlmJudgeEnabled ?? false);
+  const [coworkAgentEngine, setCoworkAgentEngine] = useState<CoworkAgentEngine>(
+    coworkConfig.agentEngine || 'openclaw',
+  );
+  const [coworkMemoryEnabled, setCoworkMemoryEnabled] = useState<boolean>(
+    coworkConfig.memoryEnabled ?? true,
+  );
+  const [coworkMemoryLlmJudgeEnabled, setCoworkMemoryLlmJudgeEnabled] = useState<boolean>(
+    coworkConfig.memoryLlmJudgeEnabled ?? false,
+  );
   const [coworkMemoryEntries, setCoworkMemoryEntries] = useState<CoworkUserMemoryEntry[]>([]);
   const [coworkMemoryStats, setCoworkMemoryStats] = useState<CoworkMemoryStats | null>(null);
   const [coworkMemoryListLoading, setCoworkMemoryListLoading] = useState<boolean>(false);
@@ -704,34 +902,35 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [bootstrapUser, setBootstrapUser] = useState<string>('');
   const [bootstrapSoul, setBootstrapSoul] = useState<string>('');
   const [bootstrapLoaded, setBootstrapLoaded] = useState<boolean>(false);
-  const [openClawEngineStatus, setOpenClawEngineStatus] = useState<OpenClawEngineStatus | null>(null);
+  const [openClawEngineStatus, setOpenClawEngineStatus] = useState<OpenClawEngineStatus | null>(
+    null,
+  );
 
   useEffect(() => {
     setCoworkAgentEngine(coworkConfig.agentEngine || 'openclaw');
     setCoworkMemoryEnabled(coworkConfig.memoryEnabled ?? true);
     setCoworkMemoryLlmJudgeEnabled(coworkConfig.memoryLlmJudgeEnabled ?? false);
-  }, [
-    coworkConfig.agentEngine,
-    coworkConfig.memoryEnabled,
-    coworkConfig.memoryLlmJudgeEnabled,
-  ]);
+  }, [coworkConfig.agentEngine, coworkConfig.memoryEnabled, coworkConfig.memoryLlmJudgeEnabled]);
 
-  useEffect(() => () => {
-    if (emailCopiedTimerRef.current != null) {
-      window.clearTimeout(emailCopiedTimerRef.current);
-    }
-    if (updateCheckTimerRef.current != null) {
-      window.clearTimeout(updateCheckTimerRef.current);
-    }
-  }, []);
+  useEffect(
+    () => () => {
+      if (emailCopiedTimerRef.current != null) {
+        window.clearTimeout(emailCopiedTimerRef.current);
+      }
+      if (updateCheckTimerRef.current != null) {
+        window.clearTimeout(updateCheckTimerRef.current);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     let active = true;
-    void coworkService.getOpenClawEngineStatus().then((status) => {
+    void coworkService.getOpenClawEngineStatus().then(status => {
       if (!active || !status) return;
       setOpenClawEngineStatus(status);
     });
-    const unsubscribe = coworkService.onOpenClawEngineStatus((status) => {
+    const unsubscribe = coworkService.onOpenClawEngineStatus(status => {
       if (!active) return;
       setOpenClawEngineStatus(status);
     });
@@ -744,7 +943,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   useEffect(() => {
     try {
       const config = configService.getConfig();
-      
+
       // Set general settings
       initialThemeRef.current = config.theme;
       initialLanguageRef.current = config.language;
@@ -756,18 +955,24 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       if (savedTestMode) setTestModeUnlocked(true);
 
       // Load auto-launch setting
-      window.electron.autoLaunch.get().then(({ enabled }) => {
-        setAutoLaunchState(enabled);
-      }).catch(err => {
-        console.error('Failed to load auto-launch setting:', err);
-      });
+      window.electron.autoLaunch
+        .get()
+        .then(({ enabled }) => {
+          setAutoLaunchState(enabled);
+        })
+        .catch(err => {
+          console.error('Failed to load auto-launch setting:', err);
+        });
 
       // Load prevent-sleep setting
-      window.electron.preventSleep.get().then(({ enabled }) => {
-        setPreventSleepState(enabled);
-      }).catch(err => {
-        console.error('Failed to load prevent-sleep setting:', err);
-      });
+      window.electron.preventSleep
+        .get()
+        .then(({ enabled }) => {
+          setPreventSleepState(enabled);
+        })
+        .catch(err => {
+          console.error('Failed to load prevent-sleep setting:', err);
+        });
 
       // Set up providers based on saved config
       if (config.api) {
@@ -782,8 +987,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.openai,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('deepseek')) {
           setActiveProvider('deepseek');
@@ -793,10 +998,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.deepseek,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
-        } else if (normalizedApiBaseUrl.includes('moonshot.ai') || normalizedApiBaseUrl.includes('moonshot.cn')) {
+        } else if (
+          normalizedApiBaseUrl.includes('moonshot.ai') ||
+          normalizedApiBaseUrl.includes('moonshot.cn')
+        ) {
           setActiveProvider('moonshot');
           setProviders(prev => ({
             ...prev,
@@ -804,8 +1012,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.moonshot,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('bigmodel.cn')) {
           setActiveProvider('zhipu');
@@ -815,8 +1023,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.zhipu,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('minimax')) {
           setActiveProvider('minimax');
@@ -826,8 +1034,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.minimax,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('openapi.youdao.com')) {
           setActiveProvider('youdaozhiyun');
@@ -837,8 +1045,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.youdaozhiyun,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('dashscope')) {
           setActiveProvider('qwen');
@@ -848,8 +1056,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.qwen,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('stepfun')) {
           setActiveProvider('stepfun');
@@ -859,8 +1067,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.stepfun,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('openrouter.ai')) {
           setActiveProvider('openrouter');
@@ -870,8 +1078,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.openrouter,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('googleapis')) {
           setActiveProvider('gemini');
@@ -881,8 +1089,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.gemini,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('anthropic')) {
           setActiveProvider('anthropic');
@@ -892,10 +1100,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.anthropic,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
-        } else if (normalizedApiBaseUrl.includes('ollama') || normalizedApiBaseUrl.includes('11434')) {
+        } else if (
+          normalizedApiBaseUrl.includes('ollama') ||
+          normalizedApiBaseUrl.includes('11434')
+        ) {
           setActiveProvider('ollama');
           setProviders(prev => ({
             ...prev,
@@ -903,24 +1114,26 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.ollama,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         }
       }
-      
+
       // Load provider-specific configurations if available
       // 合并已保存的配置和默认配置，确保新添加的 provider 能被显示
       if (config.providers) {
         setProviders(prev => {
           const merged = {
-            ...prev,  // 保留默认的 providers（包括新添加的 anthropic）
-            ...config.providers,  // 覆盖已保存的配置
+            ...prev, // 保留默认的 providers（包括新添加的 anthropic）
+            ...config.providers, // 覆盖已保存的配置
           };
 
           // After merging, find the first enabled provider to set as activeProvider
           // This ensures we don't use stale activeProvider from old config.api.baseUrl
-          const firstEnabledProvider = providerKeys.find(providerKey => merged[providerKey]?.enabled);
+          const firstEnabledProvider = providerKeys.find(
+            providerKey => merged[providerKey]?.enabled,
+          );
           if (firstEnabledProvider) {
             setActiveProvider(firstEnabledProvider);
           }
@@ -932,7 +1145,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 // Fix corrupted model IDs from previous OAuth mutation bug
                 if (providerKey === 'qwen' && (id === 'vision-model' || id === 'coder-model')) {
                   const defaultModel = defaultConfig.providers?.qwen?.models?.[idx];
-                  id = defaultModel?.id || (model.supportsImage ? 'qwen3.5-plus' : 'qwen3-coder-plus');
+                  id =
+                    defaultModel?.id || (model.supportsImage ? 'qwen3.5-plus' : 'qwen3-coder-plus');
                 }
                 return {
                   ...model,
@@ -944,15 +1158,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 providerKey,
                 {
                   ...providerConfig,
-                  apiFormat: getEffectiveApiFormat(providerKey, (providerConfig as ProviderConfig).apiFormat),
+                  apiFormat: getEffectiveApiFormat(
+                    providerKey,
+                    (providerConfig as ProviderConfig).apiFormat,
+                  ),
                   models,
                 },
               ];
-            })
+            }),
           ) as ProvidersConfig;
         });
       }
-      
+
       // 加载快捷键设置
       if (config.shortcuts) {
         setShortcuts(prev => ({
@@ -1132,9 +1349,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         const def = ProviderRegistry.get(provider);
         if (def?.codingPlanSupported) {
           const enabled = value === 'true';
-          const nextModels = enabled && def.codingPlanModels
-            ? def.codingPlanModels.map(m => ({ ...m }))
-            : def.defaultModels.map(m => ({ ...m }));
+          const nextModels =
+            enabled && def.codingPlanModels
+              ? def.codingPlanModels.map(m => ({ ...m }))
+              : def.defaultModels.map(m => ({ ...m }));
           return {
             ...prev,
             [provider]: {
@@ -1161,7 +1379,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     setMinimaxOAuthPhase({ kind: 'requesting_code' });
 
     const codeEndpoint = region === 'cn' ? MINIMAX_CODE_ENDPOINT_CN : MINIMAX_CODE_ENDPOINT_GLOBAL;
-    const tokenEndpoint = region === 'cn' ? MINIMAX_TOKEN_ENDPOINT_CN : MINIMAX_TOKEN_ENDPOINT_GLOBAL;
+    const tokenEndpoint =
+      region === 'cn' ? MINIMAX_TOKEN_ENDPOINT_CN : MINIMAX_TOKEN_ENDPOINT_GLOBAL;
     const defaultBaseUrl = region === 'cn' ? MINIMAX_BASE_URL_CN : MINIMAX_BASE_URL_GLOBAL;
 
     try {
@@ -1181,7 +1400,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
-          'Accept': 'application/json',
+          Accept: 'application/json',
         },
         body: codeBody,
       });
@@ -1200,7 +1419,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       };
 
       if (!codePayload.user_code || !codePayload.verification_uri) {
-        throw new Error(codePayload.error ?? 'MiniMax OAuth returned incomplete authorization payload');
+        throw new Error(
+          codePayload.error ?? 'MiniMax OAuth returned incomplete authorization payload',
+        );
       }
 
       if (codePayload.state !== state) {
@@ -1209,7 +1430,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       try {
         await window.electron.shell.openExternal(codePayload.verification_uri);
-      } catch { /* ignore: user can open manually */ }
+      } catch {
+        /* ignore: user can open manually */
+      }
 
       setMinimaxOAuthPhase({
         kind: 'pending',
@@ -1218,7 +1441,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       });
 
       let pollIntervalMs = codePayload.interval ?? 2000;
-      const expireTimeMs = codePayload.expired_in ?? (Date.now() + 5 * 60 * 1000);
+      const expireTimeMs = codePayload.expired_in ?? Date.now() + 5 * 60 * 1000;
 
       while (Date.now() < expireTimeMs) {
         if (minimaxOAuthCancelRef.current) {
@@ -1245,7 +1468,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           method: 'POST',
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
-            'Accept': 'application/json',
+            Accept: 'application/json',
           },
           body: tokenBody,
         });
@@ -1326,13 +1549,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     setMinimaxOAuthPhase({ kind: 'idle' });
   };
 
-  const hasCoworkConfigChanges = coworkAgentEngine !== coworkConfig.agentEngine
-    || coworkMemoryEnabled !== coworkConfig.memoryEnabled
-    || coworkMemoryLlmJudgeEnabled !== coworkConfig.memoryLlmJudgeEnabled;
+  const hasCoworkConfigChanges =
+    coworkAgentEngine !== coworkConfig.agentEngine ||
+    coworkMemoryEnabled !== coworkConfig.memoryEnabled ||
+    coworkMemoryLlmJudgeEnabled !== coworkConfig.memoryLlmJudgeEnabled;
   const isOpenClawAgentEngine = coworkAgentEngine === 'openclaw';
 
   const openClawProgressPercent = useMemo(() => {
-    if (typeof openClawEngineStatus?.progressPercent !== 'number' || !Number.isFinite(openClawEngineStatus.progressPercent)) {
+    if (
+      typeof openClawEngineStatus?.progressPercent !== 'number' ||
+      !Number.isFinite(openClawEngineStatus.progressPercent)
+    ) {
       return null;
     }
     return Math.max(0, Math.min(100, Math.round(openClawEngineStatus.progressPercent)));
@@ -1380,9 +1607,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     } finally {
       setCoworkMemoryListLoading(false);
     }
-  }, [
-    coworkMemoryQuery,
-  ]);
+  }, [coworkMemoryQuery]);
 
   useEffect(() => {
     if (activeTab !== 'coworkMemory') return;
@@ -1398,9 +1623,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     const TEMPLATE_MARKERS = [
       'Fill this in during your first conversation',
       "You're not a chatbot. You're becoming someone",
-      'Learn about the person you\'re helping',
+      "Learn about the person you're helping",
     ];
-    if (TEMPLATE_MARKERS.some((m) => content.includes(m))) return '';
+    if (TEMPLATE_MARKERS.some(m => content.includes(m))) return '';
     return content;
   };
 
@@ -1446,7 +1671,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       resetCoworkMemoryEditor();
       await loadCoworkMemoryData();
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : i18nService.t('coworkMemoryCrudSaveFailed'));
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : i18nService.t('coworkMemoryCrudSaveFailed'),
+      );
     } finally {
       setCoworkMemoryListLoading(false);
     }
@@ -1467,7 +1696,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       }
       await loadCoworkMemoryData();
     } catch (deleteError) {
-      setError(deleteError instanceof Error ? deleteError.message : i18nService.t('coworkMemoryCrudDeleteFailed'));
+      setError(
+        deleteError instanceof Error
+          ? deleteError.message
+          : i18nService.t('coworkMemoryCrudDeleteFailed'),
+      );
     } finally {
       setCoworkMemoryListLoading(false);
     }
@@ -1499,8 +1732,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       ...prev,
       [provider]: {
         ...prev[provider],
-        enabled: !prev[provider].enabled
-      }
+        enabled: !prev[provider].enabled,
+      },
     }));
   };
 
@@ -1539,7 +1772,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       // Step 2: Poll for token
       setCopilotAuthStatus('polling');
-      const result = await window.electron.githubCopilot.pollForToken(deviceCode, interval, expiresIn);
+      const result = await window.electron.githubCopilot.pollForToken(
+        deviceCode,
+        interval,
+        expiresIn,
+      );
 
       if (result.success && result.token) {
         setCopilotGithubUser(result.githubUser || '');
@@ -1606,15 +1843,19 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             {
               ...providerConfig,
               apiFormat,
-              baseUrl: resolveBaseUrl(providerKey as ProviderType, providerConfig.baseUrl, apiFormat),
+              baseUrl: resolveBaseUrl(
+                providerKey as ProviderType,
+                providerConfig.baseUrl,
+                apiFormat,
+              ),
             },
           ];
-        })
+        }),
       ) as ProvidersConfig;
 
       // Find the first enabled provider to use as the primary API
       const firstEnabledProvider = Object.entries(normalizedProviders).find(
-        ([_, config]) => config.enabled
+        ([_, config]) => config.enabled,
       );
 
       const primaryProvider = firstEnabledProvider
@@ -1663,7 +1904,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       });
 
       // 更新 Redux store 中的可用模型列表
-      const allModels: { id: string; name: string; provider?: string; providerKey?: string; supportsImage?: boolean }[] = [];
+      const allModels: {
+        id: string;
+        name: string;
+        provider?: string;
+        providerKey?: string;
+        supportsImage?: boolean;
+      }[] = [];
       Object.entries(normalizedProviders).forEach(([providerName, config]) => {
         if (config.enabled && config.models) {
           config.models.forEach(model => {
@@ -1734,7 +1981,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const handleShortcutChange = (key: keyof typeof shortcuts, value: string) => {
     setShortcuts(prev => ({
       ...prev,
-      [key]: value
+      [key]: value,
     }));
   };
 
@@ -1766,17 +2013,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   const handleDeleteModel = (modelId: string) => {
     if (!providers[activeProvider].models) return;
-    
-    const updatedModels = providers[activeProvider].models.filter(
-      model => model.id !== modelId
-    );
-    
+
+    const updatedModels = providers[activeProvider].models.filter(model => model.id !== modelId);
+
     setProviders(prev => ({
       ...prev,
       [activeProvider]: {
         ...prev[activeProvider],
-        models: updatedModels
-      }
+        models: updatedModels,
+      },
     }));
   };
 
@@ -1798,13 +2043,16 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     }
 
     // For Ollama, auto-fill display name from modelId if not provided
-    const modelName = activeProvider === 'ollama'
-      ? (newModelName.trim() && newModelName.trim() !== modelId ? newModelName.trim() : modelId)
-      : newModelName.trim();
+    const modelName =
+      activeProvider === 'ollama'
+        ? newModelName.trim() && newModelName.trim() !== modelId
+          ? newModelName.trim()
+          : modelId
+        : newModelName.trim();
 
     const currentModels = providers[activeProvider].models ?? [];
     const duplicateModel = currentModels.find(
-      model => model.id === modelId && (!isEditingModel || model.id !== editingModelId)
+      model => model.id === modelId && (!isEditingModel || model.id !== editingModelId),
     );
     if (duplicateModel) {
       setModelFormError(i18nService.t('modelIdExists'));
@@ -1816,16 +2064,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       name: modelName,
       supportsImage: newModelSupportsImage,
     };
-    const updatedModels = isEditingModel && editingModelId
-      ? currentModels.map(model => (model.id === editingModelId ? nextModel : model))
-      : [...currentModels, nextModel];
+    const updatedModels =
+      isEditingModel && editingModelId
+        ? currentModels.map(model => (model.id === editingModelId ? nextModel : model))
+        : [...currentModels, nextModel];
 
     setProviders(prev => ({
       ...prev,
       [activeProvider]: {
         ...prev[activeProvider],
-        models: updatedModels
-      }
+        models: updatedModels,
+      },
     }));
 
     setIsAddingModel(false);
@@ -1861,7 +2110,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   const showTestResultModal = (
     result: Omit<ProviderConnectionTestResult, 'provider'>,
-    provider: ProviderType
+    provider: ProviderType,
   ) => {
     setTestResult({
       ...result,
@@ -1879,11 +2128,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     setTestResult(null);
 
     // Check if provider has valid authentication (API Key or OAuth for Qwen)
-    const hasValidAuth = providerConfig.apiKey || 
+    const hasValidAuth =
+      providerConfig.apiKey ||
       (testingProvider === 'qwen' && (providerConfig as any).oauthCredentials);
-    
+
     if (providerRequiresApiKey(testingProvider) && !hasValidAuth) {
-      showTestResultModal({ success: false, message: i18nService.t('apiKeyRequired') }, testingProvider);
+      showTestResultModal(
+        { success: false, message: i18nService.t('apiKeyRequired') },
+        testingProvider,
+      );
       setIsTesting(false);
       return;
     }
@@ -1891,7 +2144,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     // 获取第一个可用模型 - use a shallow copy to avoid mutating state
     const originalModel = providerConfig.models?.[0];
     if (!originalModel) {
-      showTestResultModal({ success: false, message: i18nService.t('noModelsConfigured') }, testingProvider);
+      showTestResultModal(
+        { success: false, message: i18nService.t('noModelsConfigured') },
+        testingProvider,
+      );
       setIsTesting(false);
       return;
     }
@@ -1900,17 +2156,30 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
     try {
       let response: Awaited<ReturnType<typeof window.electron.api.fetch>>;
+      let testRequestUrl = '';
       // Apply Coding Plan endpoint switch
-      let effectiveBaseUrl = resolveBaseUrl(testingProvider, providerConfig.baseUrl, getEffectiveApiFormat(testingProvider, providerConfig.apiFormat));
+      let effectiveBaseUrl = resolveBaseUrl(
+        testingProvider,
+        providerConfig.baseUrl,
+        getEffectiveApiFormat(testingProvider, providerConfig.apiFormat),
+      );
       let effectiveApiFormat = getEffectiveApiFormat(testingProvider, providerConfig.apiFormat);
-      
+
       // Handle Coding Plan endpoint switch for supported providers
-      if ((providerConfig as { codingPlanEnabled?: boolean }).codingPlanEnabled && (effectiveApiFormat === 'anthropic' || effectiveApiFormat === 'openai')) {
-        const resolved = resolveCodingPlanBaseUrl(testingProvider, true, effectiveApiFormat, effectiveBaseUrl);
+      if (
+        (providerConfig as { codingPlanEnabled?: boolean }).codingPlanEnabled &&
+        (effectiveApiFormat === 'anthropic' || effectiveApiFormat === 'openai')
+      ) {
+        const resolved = resolveCodingPlanBaseUrl(
+          testingProvider,
+          true,
+          effectiveApiFormat,
+          effectiveBaseUrl,
+        );
         effectiveBaseUrl = resolved.baseUrl;
         effectiveApiFormat = resolved.effectiveFormat;
       }
-      
+
       let normalizedBaseUrl = effectiveBaseUrl.replace(/\/+$/, '');
 
       // Determine effective API key
@@ -1939,6 +2208,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         const anthropicUrl = normalizedBaseUrl.endsWith('/v1')
           ? `${normalizedBaseUrl}/messages`
           : `${normalizedBaseUrl}/v1/messages`;
+        testRequestUrl = anthropicUrl;
         response = await window.electron.api.fetch({
           url: anthropicUrl,
           method: 'POST',
@@ -1958,6 +2228,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         const openaiUrl = useResponsesApi
           ? buildOpenAIResponsesUrl(normalizedBaseUrl)
           : buildOpenAICompatibleChatCompletionsUrl(normalizedBaseUrl, testingProvider);
+        testRequestUrl = openaiUrl;
         const headers: Record<string, string> = {
           'Content-Type': 'application/json',
         };
@@ -1965,11 +2236,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           headers.Authorization = `Bearer ${effectiveApiKey}`;
         }
         if (testingProvider === 'github-copilot') {
-                  headers['Copilot-Integration-Id'] = 'vscode-chat';
-                  headers['Editor-Version'] = 'vscode/1.96.2';
-                  headers['Editor-Plugin-Version'] = 'copilot-chat/0.26.7';
-                  headers['User-Agent'] = 'GitHubCopilotChat/0.26.7';
-                  headers['Openai-Intent'] = 'conversation-panel';
+          headers['Copilot-Integration-Id'] = 'vscode-chat';
+          headers['Editor-Version'] = 'vscode/1.96.2';
+          headers['Editor-Plugin-Version'] = 'copilot-chat/0.26.7';
+          headers['User-Agent'] = 'GitHubCopilotChat/0.26.7';
+          headers['Openai-Intent'] = 'conversation-panel';
         }
         const openAIRequestBody: Record<string, unknown> = useResponsesApi
           ? {
@@ -1981,7 +2252,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               model: firstModel.id,
               messages: [{ role: 'user', content: 'Hi' }],
             };
-        if (!useResponsesApi && shouldUseMaxCompletionTokensForOpenAI(testingProvider, firstModel.id)) {
+        if (
+          !useResponsesApi &&
+          shouldUseMaxCompletionTokensForOpenAI(testingProvider, firstModel.id)
+        ) {
           openAIRequestBody.max_completion_tokens = CONNECTIVITY_TEST_TOKEN_BUDGET;
         } else {
           if (!useResponsesApi) {
@@ -1998,23 +2272,42 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       if (response.ok) {
         enableProvider(testingProvider);
-        showTestResultModal({ success: true, message: i18nService.t('connectionSuccess') }, testingProvider);
+        showTestResultModal(
+          { success: true, message: i18nService.t('connectionSuccess') },
+          testingProvider,
+        );
       } else {
-        const data = response.data || {};
-        // 提取错误信息
-        const errorMessage = data.error?.message || data.message || `${i18nService.t('connectionFailed')}: ${response.status}`;
-        if (typeof errorMessage === 'string' && errorMessage.toLowerCase().includes('model output limit was reached')) {
+        const data = response.data;
+        // Check for the special case where hitting model output limit = successful connection
+        const rawApiMsg =
+          data !== null && typeof data === 'object'
+            ? ((data as Record<string, unknown>).error as Record<string, unknown> | undefined)
+                ?.message || (data as Record<string, unknown>).message
+            : typeof data === 'string'
+              ? data
+              : '';
+        if (
+          typeof rawApiMsg === 'string' &&
+          rawApiMsg.toLowerCase().includes('model output limit was reached')
+        ) {
           enableProvider(testingProvider);
-          showTestResultModal({ success: true, message: i18nService.t('connectionSuccess') }, testingProvider);
+          showTestResultModal(
+            { success: true, message: i18nService.t('connectionSuccess') },
+            testingProvider,
+          );
           return;
         }
+        const errorMessage = buildConnectionErrorMessage(response, testRequestUrl);
         showTestResultModal({ success: false, message: errorMessage }, testingProvider);
       }
     } catch (err) {
-      showTestResultModal({
-        success: false,
-        message: err instanceof Error ? err.message : i18nService.t('connectionFailed'),
-      }, testingProvider);
+      showTestResultModal(
+        {
+          success: false,
+          message: err instanceof Error ? err.message : i18nService.t('connectionFailed'),
+        },
+        testingProvider,
+      );
     } finally {
       setIsTesting(false);
     }
@@ -2036,7 +2329,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             models: providerConfig.models,
           },
         ] as const;
-      })
+      }),
     );
 
     return {
@@ -2153,9 +2446,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             hadDecryptFailure = true;
             console.warn(`Failed to decrypt provider key for ${providerKey}`, error);
           }
-        } else if (typeof providerData.apiKeyEncrypted === 'string' && typeof providerData.apiKeyIv === 'string') {
+        } else if (
+          typeof providerData.apiKeyEncrypted === 'string' &&
+          typeof providerData.apiKeyIv === 'string'
+        ) {
           try {
-            apiKey = await decryptSecret({ encrypted: providerData.apiKeyEncrypted, iv: providerData.apiKeyIv });
+            apiKey = await decryptSecret({
+              encrypted: providerData.apiKeyEncrypted,
+              iv: providerData.apiKeyIv,
+            });
           } catch (error) {
             hadDecryptFailure = true;
             console.warn(`Failed to decrypt provider key for ${providerKey}`, error);
@@ -2165,11 +2464,23 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         const models = normalizeModels(providerData.models);
 
         providerUpdates[providerKey] = {
-          enabled: typeof providerData.enabled === 'boolean' ? providerData.enabled : providers[providerKey].enabled,
+          enabled:
+            typeof providerData.enabled === 'boolean'
+              ? providerData.enabled
+              : providers[providerKey].enabled,
           apiKey: apiKey ?? providers[providerKey].apiKey,
-          baseUrl: typeof providerData.baseUrl === 'string' ? providerData.baseUrl : providers[providerKey].baseUrl,
-          apiFormat: getEffectiveApiFormat(providerKey, providerData.apiFormat ?? providers[providerKey].apiFormat),
-          codingPlanEnabled: typeof providerData.codingPlanEnabled === 'boolean' ? providerData.codingPlanEnabled : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
+          baseUrl:
+            typeof providerData.baseUrl === 'string'
+              ? providerData.baseUrl
+              : providers[providerKey].baseUrl,
+          apiFormat: getEffectiveApiFormat(
+            providerKey,
+            providerData.apiFormat ?? providers[providerKey].apiFormat,
+          ),
+          codingPlanEnabled:
+            typeof providerData.codingPlanEnabled === 'boolean'
+              ? providerData.codingPlanEnabled
+              : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
           models: models ?? providers[providerKey].models,
         };
       }
@@ -2196,8 +2507,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       }
     } catch (err) {
       console.error('Failed to import providers:', err);
-      const isDecryptError = err instanceof Error
-        && (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
+      const isDecryptError =
+        err instanceof Error &&
+        (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
       const message = isDecryptError
         ? i18nService.t('decryptProvidersFailed')
         : i18nService.t('importProvidersFailed');
@@ -2243,11 +2555,23 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         const models = normalizeModels(providerData.models);
 
         providerUpdates[providerKey] = {
-          enabled: typeof providerData.enabled === 'boolean' ? providerData.enabled : providers[providerKey].enabled,
+          enabled:
+            typeof providerData.enabled === 'boolean'
+              ? providerData.enabled
+              : providers[providerKey].enabled,
           apiKey: apiKey ?? providers[providerKey].apiKey,
-          baseUrl: typeof providerData.baseUrl === 'string' ? providerData.baseUrl : providers[providerKey].baseUrl,
-          apiFormat: getEffectiveApiFormat(providerKey, providerData.apiFormat ?? providers[providerKey].apiFormat),
-          codingPlanEnabled: typeof providerData.codingPlanEnabled === 'boolean' ? providerData.codingPlanEnabled : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
+          baseUrl:
+            typeof providerData.baseUrl === 'string'
+              ? providerData.baseUrl
+              : providers[providerKey].baseUrl,
+          apiFormat: getEffectiveApiFormat(
+            providerKey,
+            providerData.apiFormat ?? providers[providerKey].apiFormat,
+          ),
+          codingPlanEnabled:
+            typeof providerData.codingPlanEnabled === 'boolean'
+              ? providerData.codingPlanEnabled
+              : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
           models: models ?? providers[providerKey].models,
         };
       }
@@ -2259,7 +2583,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       // Check if any key was successfully decrypted
       const anyKeyDecrypted = Object.entries(providerUpdates).some(
-        ([key, update]) => update?.apiKey && update.apiKey !== providers[key]?.apiKey
+        ([key, update]) => update?.apiKey && update.apiKey !== providers[key]?.apiKey,
       );
 
       if (!anyKeyDecrypted && hadDecryptFailure) {
@@ -2285,8 +2609,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       }
     } catch (err) {
       console.error('Failed to import providers:', err);
-      const isDecryptError = err instanceof Error
-        && (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
+      const isDecryptError =
+        err instanceof Error &&
+        (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
       const message = isDecryptError
         ? i18nService.t('decryptProvidersFailed')
         : i18nService.t('importProvidersFailed');
@@ -2299,15 +2624,69 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   // 渲染标签页
   const sidebarTabs: { key: TabType; label: string; icon: React.ReactNode }[] = useMemo(() => {
     const allTabs = [
-      { key: 'general' as TabType,        label: i18nService.t('general'),        icon: <Cog6ToothIcon className="h-5 w-5" /> },
-      { key: 'coworkAgentEngine' as TabType, label: i18nService.t('coworkAgentEngine'), icon: <CpuChipIcon className="h-5 w-5" /> },
-      { key: 'model' as TabType,          label: i18nService.t('model'),          icon: <CubeIcon className="h-5 w-5" /> },
-      { key: 'im' as TabType,             label: i18nService.t('imBot'),          icon: <ChatBubbleLeftIcon className="h-5 w-5" /> },
-      { key: 'email' as TabType,          label: i18nService.t('emailTab'),       icon: <EnvelopeIcon className="h-5 w-5" /> },
-      { key: 'coworkMemory' as TabType,   label: i18nService.t('coworkMemoryTitle'), icon: <BrainIcon className="h-5 w-5" /> },
-      { key: 'coworkAgent' as TabType,    label: i18nService.t('coworkAgentTab'),    icon: <UserCircleIcon className="h-5 w-5" /> },
-      { key: 'shortcuts' as TabType,      label: i18nService.t('shortcuts'),      icon: <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-5 w-5"><rect x="2" y="4" width="20" height="14" rx="2" /><line x1="6" y1="8" x2="8" y2="8" /><line x1="10" y1="8" x2="12" y2="8" /><line x1="14" y1="8" x2="16" y2="8" /><line x1="6" y1="12" x2="8" y2="12" /><line x1="10" y1="12" x2="14" y2="12" /><line x1="16" y1="12" x2="18" y2="12" /><line x1="8" y1="15.5" x2="16" y2="15.5" /></svg> },
-      { key: 'about' as TabType,          label: i18nService.t('about'),          icon: <InformationCircleIcon className="h-5 w-5" /> },
+      {
+        key: 'general' as TabType,
+        label: i18nService.t('general'),
+        icon: <Cog6ToothIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'coworkAgentEngine' as TabType,
+        label: i18nService.t('coworkAgentEngine'),
+        icon: <CpuChipIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'model' as TabType,
+        label: i18nService.t('model'),
+        icon: <CubeIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'im' as TabType,
+        label: i18nService.t('imBot'),
+        icon: <ChatBubbleLeftIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'email' as TabType,
+        label: i18nService.t('emailTab'),
+        icon: <EnvelopeIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'coworkMemory' as TabType,
+        label: i18nService.t('coworkMemoryTitle'),
+        icon: <BrainIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'coworkAgent' as TabType,
+        label: i18nService.t('coworkAgentTab'),
+        icon: <UserCircleIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'shortcuts' as TabType,
+        label: i18nService.t('shortcuts'),
+        icon: (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="h-5 w-5"
+          >
+            <rect x="2" y="4" width="20" height="14" rx="2" />
+            <line x1="6" y1="8" x2="8" y2="8" />
+            <line x1="10" y1="8" x2="12" y2="8" />
+            <line x1="14" y1="8" x2="16" y2="8" />
+            <line x1="6" y1="12" x2="8" y2="12" />
+            <line x1="10" y1="12" x2="14" y2="12" />
+            <line x1="16" y1="12" x2="18" y2="12" />
+            <line x1="8" y1="15.5" x2="16" y2="15.5" />
+          </svg>
+        ),
+      },
+      {
+        key: 'about' as TabType,
+        label: i18nService.t('about'),
+        icon: <InformationCircleIcon className="h-5 w-5" />,
+      },
     ];
     // Filter out tabs hidden by enterprise config
     // Filter out tabs with 'hide' action in enterprise config
@@ -2324,27 +2703,25 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   }, [activeTab, sidebarTabs]);
 
   const renderTabContent = () => {
-    switch(activeTab) {
+    switch (activeTab) {
       case 'general':
         return (
           <div className="space-y-8">
             {/* Language Section */}
             <div className="flex items-center justify-between">
-              <h4 className="text-sm font-medium text-foreground">
-                {i18nService.t('language')}
-              </h4>
+              <h4 className="text-sm font-medium text-foreground">{i18nService.t('language')}</h4>
               <div className="w-[140px] shrink-0">
                 <ThemedSelect
                   id="language"
                   value={language}
-                  onChange={(value) => {
+                  onChange={value => {
                     const nextLanguage = value as LanguageType;
                     setLanguage(nextLanguage);
                     i18nService.setLanguage(nextLanguage, { persist: false });
                   }}
                   options={[
                     { value: 'zh', label: i18nService.t('chinese') },
-                    { value: 'en', label: i18nService.t('english') }
+                    { value: 'en', label: i18nService.t('english') },
                   ]}
                 />
               </div>
@@ -2384,11 +2761,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   disabled={isUpdatingAutoLaunch}
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                     isUpdatingAutoLaunch ? 'opacity-50 cursor-not-allowed' : ''
-                  } ${
-                    autoLaunch
-                      ? 'bg-primary'
-                      : 'bg-gray-300 dark:bg-gray-600'
-                  }`}
+                  } ${autoLaunch ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'}`}
                 >
                   <span
                     className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
@@ -2433,11 +2806,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   disabled={isUpdatingPreventSleep}
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                     isUpdatingPreventSleep ? 'opacity-50 cursor-not-allowed' : ''
-                  } ${
-                    preventSleep
-                      ? 'bg-primary'
-                      : 'bg-gray-300 dark:bg-gray-600'
-                  }`}
+                  } ${preventSleep ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'}`}
                 >
                   <span
                     className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
@@ -2462,12 +2831,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   role="switch"
                   aria-checked={useSystemProxy}
                   onClick={() => {
-                    setUseSystemProxy((prev) => !prev);
+                    setUseSystemProxy(prev => !prev);
                   }}
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
-                    useSystemProxy
-                      ? 'bg-primary'
-                      : 'bg-gray-300 dark:bg-gray-600'
+                    useSystemProxy ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
                   }`}
                 >
                   <span
@@ -2481,13 +2848,16 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
             {/* Appearance Section — mode selector + theme gallery */}
             <div>
-              <h4 className="text-sm font-medium mb-3" style={{ color: 'var(--lobster-text-primary)' }}>
+              <h4
+                className="text-sm font-medium mb-3"
+                style={{ color: 'var(--lobster-text-primary)' }}
+              >
                 {i18nService.t('appearance')}
               </h4>
 
               {/* Level 1: Mode selector */}
               <div className="grid grid-cols-3 gap-3 mb-4">
-                {(['light', 'dark', 'system'] as const).map((mode) => {
+                {(['light', 'dark', 'system'] as const).map(mode => {
                   const isSelected = theme === mode;
                   return (
                     <button
@@ -2500,11 +2870,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       }}
                       className="flex flex-col items-center rounded-xl border-2 p-3 transition-colors cursor-pointer"
                       style={{
-                        borderColor: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-border)',
+                        borderColor: isSelected
+                          ? 'var(--lobster-primary)'
+                          : 'var(--lobster-border)',
                         backgroundColor: isSelected ? 'var(--lobster-primary-muted)' : undefined,
                       }}
                     >
-                      <svg viewBox="0 0 120 80" className="w-full h-auto rounded-md mb-2 overflow-hidden" xmlns="http://www.w3.org/2000/svg">
+                      <svg
+                        viewBox="0 0 120 80"
+                        className="w-full h-auto rounded-md mb-2 overflow-hidden"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
                         {mode === 'light' && (
                           <>
                             <rect width="120" height="80" fill="#F8F9FB" />
@@ -2585,7 +2961,14 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           </>
                         )}
                       </svg>
-                      <span className="text-xs font-medium" style={{ color: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-text-primary)' }}>
+                      <span
+                        className="text-xs font-medium"
+                        style={{
+                          color: isSelected
+                            ? 'var(--lobster-primary)'
+                            : 'var(--lobster-text-primary)',
+                        }}
+                      >
                         {i18nService.t(mode)}
                       </span>
                     </button>
@@ -2594,13 +2977,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               </div>
 
               {/* Theme color gallery — all themes */}
-              <h4 className="text-sm font-medium mb-3 mt-5" style={{ color: 'var(--lobster-text-primary)' }}>
+              <h4
+                className="text-sm font-medium mb-3 mt-5"
+                style={{ color: 'var(--lobster-text-primary)' }}
+              >
                 {i18nService.t('themeColor')}
               </h4>
               {(() => {
                 const allThemes = themeService.getAllThemes();
-                const classicThemes = allThemes.filter(t => t.meta.id === 'classic-light' || t.meta.id === 'classic-dark');
-                const otherThemes = allThemes.filter(t => t.meta.id !== 'classic-light' && t.meta.id !== 'classic-dark');
+                const classicThemes = allThemes.filter(
+                  t => t.meta.id === 'classic-light' || t.meta.id === 'classic-dark',
+                );
+                const otherThemes = allThemes.filter(
+                  t => t.meta.id !== 'classic-light' && t.meta.id !== 'classic-dark',
+                );
                 const renderTile = (t: import('../theme').ThemeDefinition) => {
                   const isSelected = themeId === t.meta.id;
                   const [bg, c1, c2, c3] = t.meta.preview;
@@ -2615,18 +3005,31 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       }}
                       className="flex flex-col items-center rounded-xl border-2 p-2 transition-colors cursor-pointer"
                       style={{
-                        borderColor: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-border)',
+                        borderColor: isSelected
+                          ? 'var(--lobster-primary)'
+                          : 'var(--lobster-border)',
                         backgroundColor: isSelected ? 'var(--lobster-primary-muted)' : undefined,
                       }}
                     >
-                      <svg viewBox="0 0 80 48" className="w-full h-auto rounded-md mb-1.5 overflow-hidden" xmlns="http://www.w3.org/2000/svg">
+                      <svg
+                        viewBox="0 0 80 48"
+                        className="w-full h-auto rounded-md mb-1.5 overflow-hidden"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
                         <rect width="80" height="48" fill={bg} />
                         <rect x="4" y="6" width="20" height="36" rx="3" fill={c1} opacity="0.7" />
                         <rect x="28" y="6" width="48" height="36" rx="3" fill={c2} opacity="0.5" />
                         <circle cx="52" cy="24" r="8" fill={c3} opacity="0.8" />
                         <rect x="32" y="34" width="40" height="4" rx="2" fill={c1} opacity="0.6" />
                       </svg>
-                      <span className="text-[10px] font-medium truncate w-full text-center" style={{ color: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-text-primary)' }}>
+                      <span
+                        className="text-[10px] font-medium truncate w-full text-center"
+                        style={{
+                          color: isSelected
+                            ? 'var(--lobster-primary)'
+                            : 'var(--lobster-text-primary)',
+                        }}
+                      >
                         {t.meta.name}
                       </span>
                     </button>
@@ -2637,9 +3040,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <div className="grid grid-cols-2 gap-3 mb-3">
                       {classicThemes.map(renderTile)}
                     </div>
-                    <div className="grid grid-cols-4 gap-3">
-                      {otherThemes.map(renderTile)}
-                    </div>
+                    <div className="grid grid-cols-4 gap-3">{otherThemes.map(renderTile)}</div>
                   </>
                 );
               })()}
@@ -2655,12 +3056,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           <div className="space-y-6">
             <div className="space-y-3">
               <div className="flex items-start gap-3 rounded-xl border px-3 py-2 text-sm border-border">
-                <input
-                  type="radio"
-                  checked={true}
-                  readOnly
-                  className="mt-1"
-                />
+                <input type="radio" checked={true} readOnly className="mt-1" />
                 <span>
                   <span className="block font-medium text-foreground">
                     {i18nService.t('coworkAgentEngineOpenClaw')}
@@ -2676,9 +3072,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="text-xs text-secondary">
                   {i18nService.t('coworkOpenClawInstallHint')}
                 </div>
-                <div className={`rounded-xl border px-4 py-3 text-sm ${openClawEngineStatus?.phase === 'error'
-                  ? 'border-red-300 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300'
-                  : 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-300'}`}
+                <div
+                  className={`rounded-xl border px-4 py-3 text-sm ${
+                    openClawEngineStatus?.phase === 'error'
+                      ? 'border-red-300 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300'
+                      : 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-300'
+                  }`}
                 >
                   <div className="flex items-center justify-between gap-3">
                     <div>
@@ -2748,24 +3147,25 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <input
                 type="text"
                 value={coworkMemoryQuery}
-                onChange={(event) => setCoworkMemoryQuery(event.target.value)}
+                onChange={event => setCoworkMemoryQuery(event.target.value)}
                 placeholder={i18nService.t('coworkMemorySearchPlaceholder')}
                 className="w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface"
               />
 
               <div className="rounded-lg border border-border">
                 {coworkMemoryListLoading ? (
-                  <div className="px-3 py-3 text-xs text-secondary">
-                    {i18nService.t('loading')}
-                  </div>
+                  <div className="px-3 py-3 text-xs text-secondary">{i18nService.t('loading')}</div>
                 ) : coworkMemoryEntries.length === 0 ? (
                   <div className="px-3 py-3 text-xs text-secondary">
                     {i18nService.t('coworkMemoryEmpty')}
                   </div>
                 ) : (
                   <div className="divide-y divide-border">
-                    {coworkMemoryEntries.map((entry) => (
-                      <div key={entry.id} className="px-3 py-3 text-xs hover:bg-surface-raised transition-colors">
+                    {coworkMemoryEntries.map(entry => (
+                      <div
+                        key={entry.id}
+                        className="px-3 py-3 text-xs hover:bg-surface-raised transition-colors"
+                      >
                         <div className="flex items-start justify-between gap-3">
                           <div className="flex-1 min-w-0">
                             <div className="font-medium text-foreground break-words">
@@ -2782,7 +3182,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                             </button>
                             <button
                               type="button"
-                              onClick={() => { void handleDeleteCoworkMemoryEntry(entry); }}
+                              onClick={() => {
+                                void handleDeleteCoworkMemoryEntry(entry);
+                              }}
                               className="rounded border px-2 py-1 text-red-500 border-border hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-60 transition-colors"
                               disabled={coworkMemoryListLoading}
                             >
@@ -2796,7 +3198,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 )}
               </div>
             </div>
-
           </div>
         );
 
@@ -2842,7 +3243,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 const missingApiKey = providerRequiresApiKey(providerKey) && !config.apiKey.trim();
                 const canToggleProvider = config.enabled || !missingApiKey;
                 const displayLabel = isCustom
-                  ? ((config as ProviderConfig).displayName || getCustomProviderDefaultName(provider))
+                  ? (config as ProviderConfig).displayName || getCustomProviderDefaultName(provider)
                   : (providerInfo?.label ?? getProviderDisplayName(provider));
                 return (
                   <div
@@ -2861,11 +3262,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         </span>
                       </div>
                       <div className="flex flex-col min-w-0">
-                        <span className={`text-sm font-medium truncate ${
-                          activeProvider === provider
-                            ? 'text-primary'
-                            : 'text-foreground'
-                        }`}>
+                        <span
+                          className={`text-sm font-medium truncate ${
+                            activeProvider === provider ? 'text-primary' : 'text-foreground'
+                          }`}
+                        >
                           {displayLabel}
                         </span>
                         {isCustom && (
@@ -2880,13 +3281,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         <button
                           type="button"
                           className="opacity-0 group-hover:opacity-100 transition-opacity text-claude-secondaryText hover:text-red-500 dark:text-claude-darkSecondaryText dark:hover:text-red-400 p-0.5"
-                          onClick={(e) => {
+                          onClick={e => {
                             e.stopPropagation();
                             handleDeleteCustomProvider(providerKey);
                           }}
                           title={i18nService.t('deleteCustomProvider')}
                         >
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                            className="w-3.5 h-3.5"
+                          >
                             <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
                           </svg>
                         </button>
@@ -2898,7 +3304,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         } ${
                           canToggleProvider ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'
                         }`}
-                        onClick={(e) => {
+                        onClick={e => {
                           e.stopPropagation();
                           if (!canToggleProvider) {
                             return;
@@ -2918,13 +3324,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               })}
               {/* Add Custom Provider Button */}
               {CUSTOM_PROVIDER_KEYS.some(k => !providers[k]) && (
-              <button
-                type="button"
-                onClick={handleAddCustomProvider}
-                className="w-full flex items-center justify-center p-2 rounded-xl border border-dashed border-claude-border dark:border-claude-darkBorder text-claude-secondaryText dark:text-claude-darkSecondaryText hover:border-claude-accent hover:text-claude-accent transition-colors text-sm"
-              >
-                {i18nService.t('addCustomProvider')}
-              </button>
+                <button
+                  type="button"
+                  onClick={handleAddCustomProvider}
+                  className="w-full flex items-center justify-center p-2 rounded-xl border border-dashed border-claude-border dark:border-claude-darkBorder text-claude-secondaryText dark:text-claude-darkSecondaryText hover:border-claude-accent hover:text-claude-accent transition-colors text-sm"
+                >
+                  {i18nService.t('addCustomProvider')}
+                </button>
               )}
             </div>
 
@@ -2934,14 +3340,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center gap-1.5">
                   <h3 className="text-base font-medium text-foreground">
                     {isCustomProvider(activeProvider)
-                      ? ((providers[activeProvider] as ProviderConfig)?.displayName || getCustomProviderDefaultName(activeProvider))
-                      : (providerMeta[activeProvider]?.label ?? getProviderDisplayName(activeProvider))
-                    } {i18nService.t('providerSettings')}
+                      ? (providers[activeProvider] as ProviderConfig)?.displayName ||
+                        getCustomProviderDefaultName(activeProvider)
+                      : (providerMeta[activeProvider]?.label ??
+                        getProviderDisplayName(activeProvider))}{' '}
+                    {i18nService.t('providerSettings')}
                   </h3>
                   {providerLinks[activeProvider]?.website && (
                     <button
                       type="button"
-                      onClick={() => void window.electron.shell.openExternal(providerLinks[activeProvider]!.website)}
+                      onClick={() =>
+                        void window.electron.shell.openExternal(
+                          providerLinks[activeProvider]!.website,
+                        )
+                      }
                       className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                       title={i18nService.t('visitOfficialSite')}
                       aria-label={i18nService.t('visitOfficialSite')}
@@ -2957,7 +3369,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       : 'bg-red-500/20 text-red-600 dark:text-red-400'
                   }`}
                 >
-                  {providers[activeProvider].enabled ? i18nService.t('providerStatusOn') : i18nService.t('providerStatusOff')}
+                  {providers[activeProvider].enabled
+                    ? i18nService.t('providerStatusOn')
+                    : i18nService.t('providerStatusOff')}
                 </div>
               </div>
 
@@ -2969,7 +3383,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <div className="flex rounded-xl overflow-hidden border border-border mb-3">
                       <button
                         type="button"
-                        onClick={() => setProviders(prev => ({ ...prev, minimax: { ...prev.minimax, authType: 'oauth' } }))}
+                        onClick={() =>
+                          setProviders(prev => ({
+                            ...prev,
+                            minimax: { ...prev.minimax, authType: 'oauth' },
+                          }))
+                        }
                         className={`flex-1 py-1.5 text-xs font-medium transition-colors ${minimaxIsOAuthMode ? 'bg-primary text-white' : 'text-secondary hover:bg-surface-raised'}`}
                       >
                         {i18nService.t('minimaxOAuthTabOAuth')}
@@ -2977,7 +3396,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       <button
                         type="button"
                         onClick={() => {
-                          setProviders(prev => ({ ...prev, minimax: { ...prev.minimax, authType: 'apikey' } }));
+                          setProviders(prev => ({
+                            ...prev,
+                            minimax: { ...prev.minimax, authType: 'apikey' },
+                          }));
                           setMinimaxOAuthPhase({ kind: 'idle' });
                         }}
                         className={`flex-1 py-1.5 text-xs font-medium transition-colors ${!minimaxIsOAuthMode ? 'bg-primary text-white' : 'text-secondary hover:bg-surface-raised'}`}
@@ -2991,13 +3413,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {!minimaxIsOAuthMode && (
                     <div className="min-h-[68px]">
                       <div className="flex items-center justify-between mb-1">
-                        <label htmlFor="minimax-apiKey" className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
+                        <label
+                          htmlFor="minimax-apiKey"
+                          className="block text-xs font-medium dark:text-claude-darkText text-claude-text"
+                        >
                           {i18nService.t('apiKey')}
                         </label>
                         {providerLinks.minimax?.apiKey && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks.minimax!.apiKey!)}
+                            onClick={() =>
+                              void window.electron.shell.openExternal(
+                                providerLinks.minimax!.apiKey!,
+                              )
+                            }
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -3005,34 +3434,44 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         )}
                       </div>
                       <div className="relative">
-                      <input
-                        type={showApiKey ? 'text' : 'password'}
-                        id="minimax-apiKey"
-                        value={providers.minimax.apiKey}
-                        onChange={(e) => handleProviderConfigChange('minimax', 'apiKey', e.target.value)}
-                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-xs"
-                        placeholder={i18nService.t('apiKeyPlaceholder')}
-                      />
-                      <div className="absolute right-2 inset-y-0 flex items-center gap-1">
-                        {providers.minimax.apiKey && (
+                        <input
+                          type={showApiKey ? 'text' : 'password'}
+                          id="minimax-apiKey"
+                          value={providers.minimax.apiKey}
+                          onChange={e =>
+                            handleProviderConfigChange('minimax', 'apiKey', e.target.value)
+                          }
+                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-xs"
+                          placeholder={i18nService.t('apiKeyPlaceholder')}
+                        />
+                        <div className="absolute right-2 inset-y-0 flex items-center gap-1">
+                          {providers.minimax.apiKey && (
+                            <button
+                              type="button"
+                              onClick={() => handleProviderConfigChange('minimax', 'apiKey', '')}
+                              className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
+                              title={i18nService.t('clear') || 'Clear'}
+                            >
+                              <XCircleIconSolid className="h-4 w-4" />
+                            </button>
+                          )}
                           <button
                             type="button"
-                            onClick={() => handleProviderConfigChange('minimax', 'apiKey', '')}
+                            onClick={() => setShowApiKey(!showApiKey)}
                             className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                            title={i18nService.t('clear') || 'Clear'}
+                            title={
+                              showApiKey
+                                ? i18nService.t('hide') || 'Hide'
+                                : i18nService.t('show') || 'Show'
+                            }
                           >
-                            <XCircleIconSolid className="h-4 w-4" />
+                            {showApiKey ? (
+                              <EyeIcon className="h-4 w-4" />
+                            ) : (
+                              <EyeSlashIcon className="h-4 w-4" />
+                            )}
                           </button>
-                        )}
-                        <button
-                          type="button"
-                          onClick={() => setShowApiKey(!showApiKey)}
-                          className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                          title={showApiKey ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
-                        >
-                          {showApiKey ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
-                        </button>
-                      </div>
+                        </div>
                       </div>
                     </div>
                   )}
@@ -3127,7 +3566,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           </div>
                           <a
                             href={minimaxOAuthPhase.verificationUri}
-                            onClick={(e) => { e.preventDefault(); void window.electron.shell.openExternal(minimaxOAuthPhase.verificationUri); }}
+                            onClick={e => {
+                              e.preventDefault();
+                              void window.electron.shell.openExternal(
+                                minimaxOAuthPhase.verificationUri,
+                              );
+                            }}
                             className="block text-[11px] text-primary underline truncate"
                           >
                             {minimaxOAuthPhase.verificationUri}
@@ -3193,13 +3637,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {activeProvider !== 'qwen' && (
                     <div>
                       <div className="flex items-center justify-between mb-1">
-                        <label htmlFor={`${activeProvider}-apiKey`} className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
+                        <label
+                          htmlFor={`${activeProvider}-apiKey`}
+                          className="block text-xs font-medium dark:text-claude-darkText text-claude-text"
+                        >
                           {i18nService.t('apiKey')}
                         </label>
                         {providerLinks[activeProvider]?.apiKey && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks[activeProvider]!.apiKey!)}
+                            onClick={() =>
+                              void window.electron.shell.openExternal(
+                                providerLinks[activeProvider]!.apiKey!,
+                              )
+                            }
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -3211,7 +3662,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           type={showApiKey ? 'text' : 'password'}
                           id={`${activeProvider}-apiKey`}
                           value={providers[activeProvider].apiKey}
-                          onChange={(e) => handleProviderConfigChange(activeProvider, 'apiKey', e.target.value)}
+                          onChange={e =>
+                            handleProviderConfigChange(activeProvider, 'apiKey', e.target.value)
+                          }
                           className="block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-16 text-xs"
                           placeholder={i18nService.t('apiKeyPlaceholder')}
                         />
@@ -3219,7 +3672,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           {providers[activeProvider].apiKey && (
                             <button
                               type="button"
-                              onClick={() => handleProviderConfigChange(activeProvider, 'apiKey', '')}
+                              onClick={() =>
+                                handleProviderConfigChange(activeProvider, 'apiKey', '')
+                              }
                               className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
                               title={i18nService.t('clear') || 'Clear'}
                             >
@@ -3230,9 +3685,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                             type="button"
                             onClick={() => setShowApiKey(!showApiKey)}
                             className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                            title={showApiKey ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                            title={
+                              showApiKey
+                                ? i18nService.t('hide') || 'Hide'
+                                : i18nService.t('show') || 'Show'
+                            }
                           >
-                            {showApiKey ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                            {showApiKey ? (
+                              <EyeIcon className="h-4 w-4" />
+                            ) : (
+                              <EyeSlashIcon className="h-4 w-4" />
+                            )}
                           </button>
                         </div>
                       </div>
@@ -3243,13 +3706,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {activeProvider === 'qwen' && (
                     <div>
                       <div className="flex items-center justify-between mb-1">
-                        <label htmlFor="qwen-apiKey" className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
+                        <label
+                          htmlFor="qwen-apiKey"
+                          className="block text-xs font-medium dark:text-claude-darkText text-claude-text"
+                        >
                           API Key
                         </label>
                         {providerLinks.qwen?.apiKey && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks.qwen!.apiKey!)}
+                            onClick={() =>
+                              void window.electron.shell.openExternal(providerLinks.qwen!.apiKey!)
+                            }
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -3261,7 +3729,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           type={showApiKey ? 'text' : 'password'}
                           id="qwen-apiKey"
                           value={providers.qwen.apiKey}
-                          onChange={(e) => handleProviderConfigChange('qwen', 'apiKey', e.target.value)}
+                          onChange={e =>
+                            handleProviderConfigChange('qwen', 'apiKey', e.target.value)
+                          }
                           className="block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-16 text-xs"
                           placeholder={i18nService.t('apiKeyPlaceholder')}
                         />
@@ -3280,9 +3750,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                             type="button"
                             onClick={() => setShowApiKey(!showApiKey)}
                             className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                            title={showApiKey ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                            title={
+                              showApiKey
+                                ? i18nService.t('hide') || 'Hide'
+                                : i18nService.t('show') || 'Show'
+                            }
                           >
-                            {showApiKey ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                            {showApiKey ? (
+                              <EyeIcon className="h-4 w-4" />
+                            ) : (
+                              <EyeSlashIcon className="h-4 w-4" />
+                            )}
                           </button>
                         </div>
                       </div>
@@ -3297,27 +3775,39 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     {i18nService.t('githubCopilotAuth')}
                   </label>
 
-                  {(copilotAuthStatus === 'idle' || copilotAuthStatus === 'error') && !providers['github-copilot'].apiKey && (
-                    <div className="space-y-2">
-                      <button
-                        type="button"
-                        onClick={handleCopilotSignIn}
-                        className="flex items-center gap-2 px-4 py-2 rounded-xl bg-claude-accent text-white text-xs font-medium hover:bg-claude-accent/90 transition-colors"
-                      >
-                        <GitHubCopilotIcon className="w-4 h-4" />
-                        {i18nService.t('githubCopilotSignIn')}
-                      </button>
-                      {copilotError && (
-                        <p className="text-xs text-red-500 dark:text-red-400">{copilotError}</p>
-                      )}
-                    </div>
-                  )}
+                  {(copilotAuthStatus === 'idle' || copilotAuthStatus === 'error') &&
+                    !providers['github-copilot'].apiKey && (
+                      <div className="space-y-2">
+                        <button
+                          type="button"
+                          onClick={handleCopilotSignIn}
+                          className="flex items-center gap-2 px-4 py-2 rounded-xl bg-claude-accent text-white text-xs font-medium hover:bg-claude-accent/90 transition-colors"
+                        >
+                          <GitHubCopilotIcon className="w-4 h-4" />
+                          {i18nService.t('githubCopilotSignIn')}
+                        </button>
+                        {copilotError && (
+                          <p className="text-xs text-red-500 dark:text-red-400">{copilotError}</p>
+                        )}
+                      </div>
+                    )}
 
                   {copilotAuthStatus === 'requesting' && (
                     <div className="flex items-center gap-2 text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
                       <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                        />
                       </svg>
                       {i18nService.t('githubCopilotRequesting')}
                     </div>
@@ -3354,8 +3844,19 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       <div className="flex items-center gap-3">
                         <div className="flex items-center gap-2 text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
                           <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
-                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                            <circle
+                              className="opacity-25"
+                              cx="12"
+                              cy="12"
+                              r="10"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                            />
+                            <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                            />
                           </svg>
                           {i18nService.t('githubCopilotWaiting')}
                         </div>
@@ -3370,38 +3871,46 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     </div>
                   )}
 
-                  {(copilotAuthStatus === 'authenticated' || providers['github-copilot'].apiKey) && copilotAuthStatus !== 'requesting' && copilotAuthStatus !== 'awaiting_user' && copilotAuthStatus !== 'polling' && (
-                    <div className="flex items-center justify-between p-3 rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset border border-claude-border dark:border-claude-darkBorder">
-                      <div className="flex items-center gap-2">
-                        <div className="w-2 h-2 rounded-full bg-green-500" />
-                        <span className="text-xs dark:text-claude-darkText text-claude-text">
-                          {copilotGithubUser
-                            ? `${i18nService.t('githubCopilotConnected')} @${copilotGithubUser}`
-                            : i18nService.t('githubCopilotConnected')}
-                        </span>
+                  {(copilotAuthStatus === 'authenticated' || providers['github-copilot'].apiKey) &&
+                    copilotAuthStatus !== 'requesting' &&
+                    copilotAuthStatus !== 'awaiting_user' &&
+                    copilotAuthStatus !== 'polling' && (
+                      <div className="flex items-center justify-between p-3 rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset border border-claude-border dark:border-claude-darkBorder">
+                        <div className="flex items-center gap-2">
+                          <div className="w-2 h-2 rounded-full bg-green-500" />
+                          <span className="text-xs dark:text-claude-darkText text-claude-text">
+                            {copilotGithubUser
+                              ? `${i18nService.t('githubCopilotConnected')} @${copilotGithubUser}`
+                              : i18nService.t('githubCopilotConnected')}
+                          </span>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={handleCopilotSignOut}
+                          className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-red-500 transition-colors"
+                        >
+                          {i18nService.t('githubCopilotSignOut')}
+                        </button>
                       </div>
-                      <button
-                        type="button"
-                        onClick={handleCopilotSignOut}
-                        className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-red-500 transition-colors"
-                      >
-                        {i18nService.t('githubCopilotSignOut')}
-                      </button>
-                    </div>
-                  )}
+                    )}
                 </div>
               )}
 
               {isCustomProvider(activeProvider) && (
                 <div>
-                  <label htmlFor={`${activeProvider}-displayName`} className="block text-xs font-medium dark:text-claude-darkText text-claude-text mb-1">
+                  <label
+                    htmlFor={`${activeProvider}-displayName`}
+                    className="block text-xs font-medium dark:text-claude-darkText text-claude-text mb-1"
+                  >
                     {i18nService.t('customDisplayName')}
                   </label>
                   <input
                     type="text"
                     id={`${activeProvider}-displayName`}
                     value={(providers[activeProvider] as ProviderConfig)?.displayName ?? ''}
-                    onChange={(e) => handleProviderConfigChange(activeProvider, 'displayName', e.target.value)}
+                    onChange={e =>
+                      handleProviderConfigChange(activeProvider, 'displayName', e.target.value)
+                    }
                     className="block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-xs"
                     placeholder={i18nService.t('customDisplayNamePlaceholder')}
                   />
@@ -3409,146 +3918,184 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               )}
 
               {!(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
-              <div>
-                <label htmlFor={`${activeProvider}-baseUrl`} className="block text-xs font-medium text-foreground mb-1">
-                  {i18nService.t('baseUrl')}
-                </label>
-                <div className="relative">
-                  <input
-                    type="text"
-                    id={`${activeProvider}-baseUrl`}
-                    value={
-                      (() => {
+                <div>
+                  <label
+                    htmlFor={`${activeProvider}-baseUrl`}
+                    className="block text-xs font-medium text-foreground mb-1"
+                  >
+                    {i18nService.t('baseUrl')}
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      id={`${activeProvider}-baseUrl`}
+                      value={(() => {
                         // Coding plan override: delegate to ProviderRegistry (50e20b76)
-                        const fmt = getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat);
+                        const fmt = getEffectiveApiFormat(
+                          activeProvider,
+                          providers[activeProvider].apiFormat,
+                        );
                         if (fmt !== 'gemini') {
-                          const cpUrl = (providers[activeProvider] as { codingPlanEnabled?: boolean }).codingPlanEnabled
+                          const cpUrl = (
+                            providers[activeProvider] as { codingPlanEnabled?: boolean }
+                          ).codingPlanEnabled
                             ? ProviderRegistry.getCodingPlanUrl(activeProvider, fmt)
                             : undefined;
                           if (cpUrl) return cpUrl;
                         }
                         return providers[activeProvider].baseUrl;
-                      })()
-                    }
-                    onChange={(e) => handleProviderConfigChange(activeProvider, 'baseUrl', e.target.value)}
-                    disabled={isBaseUrlLocked}
-                    className={`block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-8 text-xs ${isBaseUrlLocked ? 'opacity-50 cursor-not-allowed' : ''}`}
-                    placeholder={
-                      activeProvider === 'qwen'
-                        ? 'https://dashscope.aliyuncs.com/apps/anthropic'
-                        : getProviderDefaultBaseUrl(activeProvider, getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat)) || defaultConfig.providers?.[activeProvider]?.baseUrl || i18nService.t('baseUrlPlaceholder')
-                    }
-                  />
-                  {providers[activeProvider].baseUrl && !isBaseUrlLocked && (
-                    <div className="absolute right-2 inset-y-0 flex items-center">
-                      <button
-                        type="button"
-                        onClick={() => handleProviderConfigChange(activeProvider, 'baseUrl', '')}
-                        className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                        title={i18nService.t('clear') || 'Clear'}
-                      >
-                        <XCircleIconSolid className="h-4 w-4" />
-                      </button>
+                      })()}
+                      onChange={e =>
+                        handleProviderConfigChange(activeProvider, 'baseUrl', e.target.value)
+                      }
+                      disabled={isBaseUrlLocked}
+                      className={`block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-8 text-xs ${isBaseUrlLocked ? 'opacity-50 cursor-not-allowed' : ''}`}
+                      placeholder={
+                        activeProvider === 'qwen'
+                          ? 'https://dashscope.aliyuncs.com/apps/anthropic'
+                          : getProviderDefaultBaseUrl(
+                              activeProvider,
+                              getEffectiveApiFormat(
+                                activeProvider,
+                                providers[activeProvider].apiFormat,
+                              ),
+                            ) ||
+                            defaultConfig.providers?.[activeProvider]?.baseUrl ||
+                            i18nService.t('baseUrlPlaceholder')
+                      }
+                    />
+                    {providers[activeProvider].baseUrl && !isBaseUrlLocked && (
+                      <div className="absolute right-2 inset-y-0 flex items-center">
+                        <button
+                          type="button"
+                          onClick={() => handleProviderConfigChange(activeProvider, 'baseUrl', '')}
+                          className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
+                          title={i18nService.t('clear') || 'Clear'}
+                        >
+                          <XCircleIconSolid className="h-4 w-4" />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  {isCustomProvider(activeProvider) && (
+                    <div className="mt-1.5 space-y-0.5 text-[11px] text-secondary">
+                      <p>
+                        <span className="text-sm text-muted mr-1">•</span>
+                        {i18nService.t('baseUrlHint1')}
+                        <code className="ml-1 text-primary break-all">
+                          {i18nService.t('baseUrlHintExample1')}
+                        </code>
+                      </p>
+                      <p>
+                        <span className="text-sm text-muted mr-1">•</span>
+                        {i18nService.t('baseUrlHint2')}
+                        <code className="ml-1 text-primary break-all">
+                          {i18nService.t('baseUrlHintExample2')}
+                        </code>
+                      </p>
+                    </div>
+                  )}
+                  {/* GLM Coding Plan 提示 */}
+                  {activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">GLM Coding Plan:</span>{' '}
+                        {i18nService.t('zhipuCodingPlanEndpointHint')}
+                      </p>
+                    </div>
+                  )}
+                  {/* Qwen Coding Plan 提示 */}
+                  {activeProvider === 'qwen' && providers.qwen.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">Coding Plan:</span>{' '}
+                        {i18nService.t('qwenCodingPlanEndpointHint')}
+                      </p>
+                    </div>
+                  )}
+                  {/* Volcengine Coding Plan 提示 */}
+                  {activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">Coding Plan:</span>{' '}
+                        {i18nService.t('volcengineCodingPlanEndpointHint')}
+                      </p>
+                    </div>
+                  )}
+                  {/* Moonshot Coding Plan 提示 */}
+                  {activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">Coding Plan:</span>{' '}
+                        {i18nService.t('moonshotCodingPlanEndpointHint')}
+                      </p>
                     </div>
                   )}
                 </div>
-                {isCustomProvider(activeProvider) && (
-                <div className="mt-1.5 space-y-0.5 text-[11px] text-secondary">
-                  <p>
-                    <span className="text-sm text-muted mr-1">•</span>
-                    {i18nService.t('baseUrlHint1')}
-                    <code className="ml-1 text-primary break-all">{i18nService.t('baseUrlHintExample1')}</code>
-                  </p>
-                  <p>
-                    <span className="text-sm text-muted mr-1">•</span>
-                    {i18nService.t('baseUrlHint2')}
-                    <code className="ml-1 text-primary break-all">{i18nService.t('baseUrlHintExample2')}</code>
-                  </p>
-                </div>
-                )}
-                {/* GLM Coding Plan 提示 */}
-                {activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">GLM Coding Plan:</span> {i18nService.t('zhipuCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-                {/* Qwen Coding Plan 提示 */}
-                {activeProvider === 'qwen' && providers.qwen.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">Coding Plan:</span> {i18nService.t('qwenCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-                {/* Volcengine Coding Plan 提示 */}
-                {activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">Coding Plan:</span> {i18nService.t('volcengineCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-                {/* Moonshot Coding Plan 提示 */}
-                {activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">Coding Plan:</span> {i18nService.t('moonshotCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-              </div>
               )}
 
               {/* API 格式选择器 */}
-              {shouldShowApiFormatSelector(activeProvider) && !(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
-                <div>
-                  <label htmlFor={`${activeProvider}-apiFormat`} className="block text-xs font-medium text-foreground mb-1">
-                    {i18nService.t('apiFormat')}
-                  </label>
-                  <div className="flex items-center space-x-4">
-                    <label className="flex items-center">
-                      <input
-                        type="radio"
-                        name={`${activeProvider}-apiFormat`}
-                        value="anthropic"
-                        checked={getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat) !== 'openai'}
-                        onChange={() => handleProviderConfigChange(activeProvider, 'apiFormat', 'anthropic')}
-                        className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
-                      />
-                      <span className="ml-2 text-xs text-foreground">
-                        {i18nService.t('apiFormatNative')}
-                      </span>
+              {shouldShowApiFormatSelector(activeProvider) &&
+                !(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
+                  <div>
+                    <label
+                      htmlFor={`${activeProvider}-apiFormat`}
+                      className="block text-xs font-medium text-foreground mb-1"
+                    >
+                      {i18nService.t('apiFormat')}
                     </label>
-                    <label className="flex items-center">
-                      <input
-                        type="radio"
-                        name={`${activeProvider}-apiFormat`}
-                        value="openai"
-                        checked={getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat) === 'openai'}
-                        onChange={() => handleProviderConfigChange(activeProvider, 'apiFormat', 'openai')}
-                        className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
-                      />
-                      <span className="ml-2 text-xs text-foreground">
-                        {i18nService.t('apiFormatOpenAI')}
-                      </span>
-                    </label>
+                    <div className="flex items-center space-x-4">
+                      <label className="flex items-center">
+                        <input
+                          type="radio"
+                          name={`${activeProvider}-apiFormat`}
+                          value="anthropic"
+                          checked={
+                            getEffectiveApiFormat(
+                              activeProvider,
+                              providers[activeProvider].apiFormat,
+                            ) !== 'openai'
+                          }
+                          onChange={() =>
+                            handleProviderConfigChange(activeProvider, 'apiFormat', 'anthropic')
+                          }
+                          className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
+                        />
+                        <span className="ml-2 text-xs text-foreground">
+                          {i18nService.t('apiFormatNative')}
+                        </span>
+                      </label>
+                      <label className="flex items-center">
+                        <input
+                          type="radio"
+                          name={`${activeProvider}-apiFormat`}
+                          value="openai"
+                          checked={
+                            getEffectiveApiFormat(
+                              activeProvider,
+                              providers[activeProvider].apiFormat,
+                            ) === 'openai'
+                          }
+                          onChange={() =>
+                            handleProviderConfigChange(activeProvider, 'apiFormat', 'openai')
+                          }
+                          className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
+                        />
+                        <span className="ml-2 text-xs text-foreground">
+                          {i18nService.t('apiFormatOpenAI')}
+                        </span>
+                      </label>
+                    </div>
+                    <p className="mt-1 text-xs text-secondary">{i18nService.t('apiFormatHint')}</p>
                   </div>
-                  <p className="mt-1 text-xs text-secondary">
-                    {i18nService.t('apiFormatHint')}
-                  </p>
-                </div>
-              )}
+                )}
 
               {/* GLM Coding Plan 开关 (仅 Zhipu) */}
               {activeProvider === 'zhipu' && (
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        GLM Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">GLM Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         Beta
                       </span>
@@ -3561,7 +4108,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.zhipu.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('zhipu', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'zhipu',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3574,9 +4127,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         {i18nService.t('codingPlanSubscriptionBadge')}
                       </span>
@@ -3589,7 +4140,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.qwen.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('qwen', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'qwen',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3602,9 +4159,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         Beta
                       </span>
@@ -3617,7 +4172,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.volcengine.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('volcengine', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'volcengine',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3630,9 +4191,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         Beta
                       </span>
@@ -3645,7 +4204,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.moonshot.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('moonshot', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'moonshot',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3655,17 +4220,22 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
               {/* 测试连接按钮 */}
               {!(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
-              <div className="flex items-center space-x-3">
-                <button
-                  type="button"
-                  onClick={handleTestConnection}
-                  disabled={isTesting || (providerRequiresApiKey(activeProvider) && !providers[activeProvider].apiKey && !(activeProvider === 'qwen' && (providers.qwen as any).oauthCredentials))}
-                  className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-xl border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
-                >
-                  <SignalIcon className="h-3.5 w-3.5 mr-1.5" />
-                  {isTesting ? i18nService.t('testing') : i18nService.t('testConnection')}
-                </button>
-              </div>
+                <div className="flex items-center space-x-3">
+                  <button
+                    type="button"
+                    onClick={handleTestConnection}
+                    disabled={
+                      isTesting ||
+                      (providerRequiresApiKey(activeProvider) &&
+                        !providers[activeProvider].apiKey &&
+                        !(activeProvider === 'qwen' && (providers.qwen as any).oauthCredentials))
+                    }
+                    className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-xl border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
+                  >
+                    <SignalIcon className="h-3.5 w-3.5 mr-1.5" />
+                    {isTesting ? i18nService.t('testing') : i18nService.t('testConnection')}
+                  </button>
+                </div>
               )}
 
               <div>
@@ -3694,7 +4264,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         <div className="flex items-center gap-1.5 min-w-0 flex-1">
                           <div className="w-1.5 h-1.5 shrink-0 rounded-full bg-green-400"></div>
                           <div className="min-w-0">
-                            <div className="text-foreground font-medium text-[11px] truncate">{model.name}</div>
+                            <div className="text-foreground font-medium text-[11px] truncate">
+                              {model.name}
+                            </div>
                             <div className="text-[10px] text-secondary truncate">{model.id}</div>
                           </div>
                         </div>
@@ -3706,7 +4278,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           )}
                           <button
                             type="button"
-                            onClick={() => handleEditModel(model.id, model.name, model.supportsImage)}
+                            onClick={() =>
+                              handleEditModel(model.id, model.name, model.supportsImage)
+                            }
                             className="p-0.5 text-secondary hover:text-primary opacity-0 group-hover:opacity-100 transition-opacity"
                           >
                             <PencilIcon className="h-3.5 w-3.5" />
@@ -3723,9 +4297,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     </div>
                   ))}
 
-                  {(!providers[activeProvider].models || providers[activeProvider].models.length === 0) && (
+                  {(!providers[activeProvider].models ||
+                    providers[activeProvider].models.length === 0) && (
                     <div className="bg-surface p-2.5 rounded-xl border border-border-subtle text-center">
-                      <p className="text-[11px] text-secondary">{i18nService.t('noModelsAvailable')}</p>
+                      <p className="text-[11px] text-secondary">
+                        {i18nService.t('noModelsAvailable')}
+                      </p>
                       <button
                         type="button"
                         onClick={handleAddModel}
@@ -3751,19 +4328,35 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 {i18nService.t('coworkBootstrapAgentSectionTitle')}
               </div>
               {[
-                { filename: 'IDENTITY.md', titleKey: 'coworkBootstrapIdentityTitle', hintKey: 'coworkBootstrapIdentityHint', value: bootstrapIdentity, setter: setBootstrapIdentity },
-                { filename: 'SOUL.md', titleKey: 'coworkBootstrapSoulTitle', hintKey: 'coworkBootstrapSoulHint', value: bootstrapSoul, setter: setBootstrapSoul },
+                {
+                  filename: 'IDENTITY.md',
+                  titleKey: 'coworkBootstrapIdentityTitle',
+                  hintKey: 'coworkBootstrapIdentityHint',
+                  value: bootstrapIdentity,
+                  setter: setBootstrapIdentity,
+                },
+                {
+                  filename: 'SOUL.md',
+                  titleKey: 'coworkBootstrapSoulTitle',
+                  hintKey: 'coworkBootstrapSoulHint',
+                  value: bootstrapSoul,
+                  setter: setBootstrapSoul,
+                },
               ].map(({ filename, titleKey, hintKey, value, setter }) => (
                 <div key={filename} className="space-y-2">
                   <div className="text-xs font-medium text-secondary">
                     {i18nService.t(titleKey)}
                     <span className="ml-1.5 font-normal opacity-60">
-                      （{i18nService.t('coworkBootstrapStoragePath')}：<span className="font-mono">{joinWorkspacePath(coworkConfig.workingDirectory, filename)}</span>）
+                      （{i18nService.t('coworkBootstrapStoragePath')}：
+                      <span className="font-mono">
+                        {joinWorkspacePath(coworkConfig.workingDirectory, filename)}
+                      </span>
+                      ）
                     </span>
                   </div>
                   <textarea
                     value={value}
-                    onChange={(e) => setter(e.target.value)}
+                    onChange={e => setter(e.target.value)}
                     rows={3}
                     className="w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground resize-y"
                     placeholder={i18nService.t(hintKey)}
@@ -3777,12 +4370,16 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <div className="text-sm font-medium text-foreground">
                 {i18nService.t('coworkBootstrapUserTitle')}
                 <span className="ml-1.5 text-xs font-normal opacity-60 text-secondary">
-                  （{i18nService.t('coworkBootstrapStoragePath')}：<span className="font-mono">{joinWorkspacePath(coworkConfig.workingDirectory, 'USER.md')}</span>）
+                  （{i18nService.t('coworkBootstrapStoragePath')}：
+                  <span className="font-mono">
+                    {joinWorkspacePath(coworkConfig.workingDirectory, 'USER.md')}
+                  </span>
+                  ）
                 </span>
               </div>
               <textarea
                 value={bootstrapUser}
-                onChange={(e) => setBootstrapUser(e.target.value)}
+                onChange={e => setBootstrapUser(e.target.value)}
                 rows={3}
                 className="w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground resize-y"
                 placeholder={i18nService.t('coworkBootstrapUserHint')}
@@ -3801,15 +4398,24 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('newChat')}</span>
-                  <ShortcutRecorder value={shortcuts.newChat} onChange={(v) => handleShortcutChange('newChat', v)} />
+                  <ShortcutRecorder
+                    value={shortcuts.newChat}
+                    onChange={v => handleShortcutChange('newChat', v)}
+                  />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('search')}</span>
-                  <ShortcutRecorder value={shortcuts.search} onChange={(v) => handleShortcutChange('search', v)} />
+                  <ShortcutRecorder
+                    value={shortcuts.search}
+                    onChange={v => handleShortcutChange('search', v)}
+                  />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('openSettings')}</span>
-                  <ShortcutRecorder value={shortcuts.settings} onChange={(v) => handleShortcutChange('settings', v)} />
+                  <ShortcutRecorder
+                    value={shortcuts.settings}
+                    onChange={v => handleShortcutChange('settings', v)}
+                  />
                 </div>
               </div>
             </div>
@@ -3845,34 +4451,36 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center gap-2">
                   <span className="text-sm text-secondary">{appVersion}</span>
                   {!enterpriseConfig?.disableUpdate && (
-                  <button
-                    type="button"
-                    disabled={updateCheckStatus === 'checking'}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void handleCheckUpdate();
-                    }}
-                    className="text-xs px-2 py-0.5 rounded-md border border-border text-secondary hover:text-primary dark:hover:text-primary hover:border-primary dark:hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {updateCheckStatus === 'checking' && i18nService.t('updateChecking')}
-                    {updateCheckStatus === 'upToDate' && i18nService.t('updateUpToDate')}
-                    {updateCheckStatus === 'error' && i18nService.t('updateCheckFailed')}
-                    {updateCheckStatus === 'idle' && i18nService.t('checkForUpdate')}
-                  </button>
+                    <button
+                      type="button"
+                      disabled={updateCheckStatus === 'checking'}
+                      onClick={e => {
+                        e.stopPropagation();
+                        void handleCheckUpdate();
+                      }}
+                      className="text-xs px-2 py-0.5 rounded-md border border-border text-secondary hover:text-primary dark:hover:text-primary hover:border-primary dark:hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {updateCheckStatus === 'checking' && i18nService.t('updateChecking')}
+                      {updateCheckStatus === 'upToDate' && i18nService.t('updateUpToDate')}
+                      {updateCheckStatus === 'error' && i18nService.t('updateCheckFailed')}
+                      {updateCheckStatus === 'idle' && i18nService.t('checkForUpdate')}
+                    </button>
                   )}
                   {enterpriseConfig?.disableUpdate && (
-                  <span className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
-                    {i18nService.t('settings.enterprise.managed')}
-                  </span>
+                    <span className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
+                      {i18nService.t('settings.enterprise.managed')}
+                    </span>
                   )}
                 </div>
               </div>
               <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-                <span className="text-sm text-foreground">{i18nService.t('aboutContactEmail')}</span>
+                <span className="text-sm text-foreground">
+                  {i18nService.t('aboutContactEmail')}
+                </span>
                 <div className="flex items-center gap-2">
                   <button
                     type="button"
-                    onClick={(e) => {
+                    onClick={e => {
                       e.stopPropagation();
                       void handleCopyContactEmail();
                     }}
@@ -3892,7 +4500,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <span className="text-sm text-foreground">{i18nService.t('aboutUserManual')}</span>
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     handleOpenUserManual();
                   }}
@@ -3901,11 +4509,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {ABOUT_USER_MANUAL_URL}
                 </button>
               </div>
-              <div className={`flex items-center justify-between px-4 py-3${testModeUnlocked ? ' border-b border-border' : ''}`}>
-                <span className="text-sm text-foreground">{i18nService.t('aboutUserCommunity')}</span>
+              <div
+                className={`flex items-center justify-between px-4 py-3${testModeUnlocked ? ' border-b border-border' : ''}`}
+              >
+                <span className="text-sm text-foreground">
+                  {i18nService.t('aboutUserCommunity')}
+                </span>
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     handleOpenUserCommunity();
                   }}
@@ -3921,7 +4533,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     type="button"
                     role="switch"
                     aria-checked={testMode}
-                    onClick={() => setTestMode((prev) => !prev)}
+                    onClick={() => setTestMode(prev => !prev)}
                     className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                       testMode ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
                     }`}
@@ -3941,7 +4553,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <div className="flex items-center justify-center text-sm text-secondary">
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     handleOpenServiceTerms();
                   }}
@@ -3952,20 +4564,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <span className="mx-3 text-xs opacity-40">|</span>
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     void handleExportLogs();
                   }}
                   disabled={isExportingLogs}
                   className="bg-transparent border-none appearance-none px-1.5 py-0.5 -mx-1.5 -my-0.5 rounded-md cursor-pointer hover:text-primary dark:hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  {isExportingLogs ? i18nService.t('aboutExportingLogs') : i18nService.t('aboutExportLogs')}
+                  {isExportingLogs
+                    ? i18nService.t('aboutExportingLogs')
+                    : i18nService.t('aboutExportLogs')}
                 </button>
               </div>
 
-              <p className="mt-5 text-xs text-secondary">
-                {i18nService.t('copyrightHolder')}
-              </p>
+              <p className="mt-5 text-xs text-secondary">{i18nService.t('copyrightHolder')}</p>
               <p className="mt-1 text-xs text-secondary">
                 Copyright &copy; {new Date().getFullYear()} NetEase Youdao. All Rights Reserved.
               </p>
@@ -3979,7 +4591,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   };
 
   return (
-    <Modal onClose={onClose} overlayClassName="fixed inset-0 z-50 modal-backdrop flex items-center justify-center">
+    <Modal
+      onClose={onClose}
+      overlayClassName="fixed inset-0 z-50 modal-backdrop flex items-center justify-center"
+    >
       <div
         className="relative flex w-[900px] h-[80vh] rounded-2xl border-border border shadow-modal overflow-hidden modal-content"
         onClick={handleSettingsClick}
@@ -3990,7 +4605,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             <h2 className="text-lg font-semibold text-foreground">{i18nService.t('settings')}</h2>
           </div>
           <nav className="flex flex-col gap-0.5 px-3 pb-4">
-            {sidebarTabs.map((tab) => (
+            {sidebarTabs.map(tab => (
               <button
                 key={tab.key}
                 onClick={() => handleTabChange(tab.key)}
@@ -4022,19 +4637,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
           {noticeMessage && (
             <div className="px-6">
-              <ErrorMessage
-                message={noticeMessage}
-                onClose={() => setNoticeMessage(null)}
-              />
+              <ErrorMessage message={noticeMessage} onClose={() => setNoticeMessage(null)} />
             </div>
           )}
 
           {error && (
             <div className="px-6">
-              <ErrorMessage
-                message={error}
-                onClose={() => setError(null)}
-              />
+              <ErrorMessage message={error} onClose={() => setError(null)} />
             </div>
           )}
 
@@ -4066,7 +4675,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               </button>
             </div>
           </form>
-
         </div>
 
         {isTestResultModalOpen && testResult && (
@@ -4078,7 +4686,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               role="dialog"
               aria-modal="true"
               aria-label={i18nService.t('connectionTestResult')}
-              onClick={(e) => e.stopPropagation()}
+              onClick={e => e.stopPropagation()}
               className="w-full max-w-md rounded-2xl bg-background border-border border shadow-modal p-4"
             >
               <div className="flex items-center justify-between mb-3">
@@ -4097,13 +4705,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <div className="flex items-center gap-2 text-xs text-secondary">
                 <span>{providerMeta[testResult.provider]?.label ?? testResult.provider}</span>
                 <span className="text-[11px]">•</span>
-                <span className={`inline-flex items-center gap-1 ${testResult.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                <span
+                  className={`inline-flex items-center gap-1 ${testResult.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+                >
                   {testResult.success ? (
                     <CheckCircleIcon className="h-4 w-4" />
                   ) : (
                     <XCircleIcon className="h-4 w-4" />
                   )}
-                  {testResult.success ? i18nService.t('connectionSuccess') : i18nService.t('connectionFailed')}
+                  {testResult.success
+                    ? i18nService.t('connectionSuccess')
+                    : i18nService.t('connectionFailed')}
                 </span>
               </div>
 
@@ -4132,7 +4744,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             <div
               role="dialog"
               aria-modal="true"
-              onClick={(e) => e.stopPropagation()}
+              onClick={e => e.stopPropagation()}
               className="w-full max-w-sm rounded-2xl dark:bg-claude-darkSurface bg-claude-bg dark:border-claude-darkBorder border-claude-border border shadow-modal p-4"
             >
               <p className="text-sm dark:text-claude-darkText text-claude-text">
@@ -4163,211 +4775,217 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4 rounded-2xl"
             onClick={handleCancelModelEdit}
           >
-              <div
-                role="dialog"
-                aria-modal="true"
-                aria-label={isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')}
-                onClick={(e) => e.stopPropagation()}
-                onKeyDown={handleModelDialogKeyDown}
-                className="w-full max-w-md rounded-2xl bg-background border-border border shadow-modal p-4"
-              >
-                <div className="flex items-center justify-between mb-3">
-                  <h4 className="text-sm font-semibold text-foreground">
-                    {isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')}
-                  </h4>
-                  <button
-                    type="button"
-                    onClick={handleCancelModelEdit}
-                    className="p-1 text-secondary hover:text-foreground rounded-md hover:bg-surface-raised"
-                  >
-                    <XMarkIcon className="h-4 w-4" />
-                  </button>
-                </div>
-
-                {modelFormError && (
-                  <p className="mb-3 text-xs text-red-600 dark:text-red-400">
-                    {modelFormError}
-                  </p>
-                )}
-
-                <div className="space-y-3">
-                  {activeProvider === 'ollama' ? (
-                    <>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('ollamaModelName')}
-                        </label>
-                        <input
-                          autoFocus
-                          type="text"
-                          value={newModelId}
-                          onChange={(e) => {
-                            setNewModelId(e.target.value);
-                            if (!newModelName || newModelName === newModelId) {
-                              setNewModelName(e.target.value);
-                            }
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder={i18nService.t('ollamaModelNamePlaceholder')}
-                        />
-                        <p className="mt-1 text-[11px] text-muted">
-                          {i18nService.t('ollamaModelNameHint')}
-                        </p>
-                      </div>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('ollamaDisplayName')}
-                        </label>
-                        <input
-                          type="text"
-                          value={newModelName === newModelId ? '' : newModelName}
-                          onChange={(e) => {
-                            setNewModelName(e.target.value || newModelId);
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder={i18nService.t('ollamaDisplayNamePlaceholder')}
-                        />
-                        <p className="mt-1 text-[11px] text-muted">
-                          {i18nService.t('ollamaDisplayNameHint')}
-                        </p>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('modelName')}
-                        </label>
-                        <input
-                          autoFocus
-                          type="text"
-                          value={newModelName}
-                          onChange={(e) => {
-                            setNewModelName(e.target.value);
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder="GPT-4"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('modelId')}
-                        </label>
-                        <input
-                          type="text"
-                          value={newModelId}
-                          onChange={(e) => {
-                            setNewModelId(e.target.value);
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder="gpt-4"
-                        />
-                      </div>
-                    </>
-                  )}
-                  <div className="flex items-center space-x-2">
-                    <input
-                      id={`${activeProvider}-supportsImage`}
-                      type="checkbox"
-                      checked={newModelSupportsImage}
-                      onChange={(e) => setNewModelSupportsImage(e.target.checked)}
-                      className="h-3.5 w-3.5 text-primary focus:ring-primary bg-surface border-border rounded"
-                    />
-                    <label
-                      htmlFor={`${activeProvider}-supportsImage`}
-                      className="text-xs text-secondary"
-                    >
-                      {i18nService.t('supportsImageInput')}
-                    </label>
-                  </div>
-                </div>
-
-                <div className="flex justify-end space-x-2 mt-4">
-                  <button
-                    type="button"
-                    onClick={handleCancelModelEdit}
-                    className="px-3 py-1.5 text-xs text-foreground hover:bg-surface-raised rounded-xl border border-border"
-                  >
-                    {i18nService.t('cancel')}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleSaveNewModel}
-                    className="px-3 py-1.5 text-xs text-white bg-primary hover:bg-primary-hover rounded-xl active:scale-[0.98]"
-                  >
-                    {i18nService.t('save')}
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Memory Modal */}
-          {showMemoryModal && (
             <div
-              className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4 rounded-2xl"
-              onClick={resetCoworkMemoryEditor}
+              role="dialog"
+              aria-modal="true"
+              aria-label={
+                isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')
+              }
+              onClick={e => e.stopPropagation()}
+              onKeyDown={handleModelDialogKeyDown}
+              className="w-full max-w-md rounded-2xl bg-background border-border border shadow-modal p-4"
             >
-              <div
-                className="bg-surface border-border border rounded-2xl shadow-xl w-full max-w-md"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <div className="px-5 pt-5 pb-4 border-b border-border">
-                  <h3 className="text-base font-semibold text-foreground">
-                    {coworkMemoryEditingId ? i18nService.t('coworkMemoryCrudUpdate') : i18nService.t('coworkMemoryCrudCreate')}
-                  </h3>
-                </div>
+              <div className="flex items-center justify-between mb-3">
+                <h4 className="text-sm font-semibold text-foreground">
+                  {isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')}
+                </h4>
+                <button
+                  type="button"
+                  onClick={handleCancelModelEdit}
+                  className="p-1 text-secondary hover:text-foreground rounded-md hover:bg-surface-raised"
+                >
+                  <XMarkIcon className="h-4 w-4" />
+                </button>
+              </div>
 
-                <div className="px-5 py-4 space-y-4">
-                  {coworkMemoryEditingId && (
-                    <div className="rounded-lg border px-2 py-1 text-xs border-border text-secondary">
-                      {i18nService.t('coworkMemoryEditingTag')}
+              {modelFormError && (
+                <p className="mb-3 text-xs text-red-600 dark:text-red-400">{modelFormError}</p>
+              )}
+
+              <div className="space-y-3">
+                {activeProvider === 'ollama' ? (
+                  <>
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('ollamaModelName')}
+                      </label>
+                      <input
+                        autoFocus
+                        type="text"
+                        value={newModelId}
+                        onChange={e => {
+                          setNewModelId(e.target.value);
+                          if (!newModelName || newModelName === newModelId) {
+                            setNewModelName(e.target.value);
+                          }
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder={i18nService.t('ollamaModelNamePlaceholder')}
+                      />
+                      <p className="mt-1 text-[11px] text-muted">
+                        {i18nService.t('ollamaModelNameHint')}
+                      </p>
                     </div>
-                  )}
-                  <textarea
-                    value={coworkMemoryDraftText}
-                    onChange={(event) => setCoworkMemoryDraftText(event.target.value)}
-                    placeholder={i18nService.t('coworkMemoryCrudTextPlaceholder')}
-                    autoFocus
-                    className="min-h-[200px] w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground focus:border-primary focus:ring-1 focus:ring-primary/30"
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('ollamaDisplayName')}
+                      </label>
+                      <input
+                        type="text"
+                        value={newModelName === newModelId ? '' : newModelName}
+                        onChange={e => {
+                          setNewModelName(e.target.value || newModelId);
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder={i18nService.t('ollamaDisplayNamePlaceholder')}
+                      />
+                      <p className="mt-1 text-[11px] text-muted">
+                        {i18nService.t('ollamaDisplayNameHint')}
+                      </p>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('modelName')}
+                      </label>
+                      <input
+                        autoFocus
+                        type="text"
+                        value={newModelName}
+                        onChange={e => {
+                          setNewModelName(e.target.value);
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder="GPT-4"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('modelId')}
+                      </label>
+                      <input
+                        type="text"
+                        value={newModelId}
+                        onChange={e => {
+                          setNewModelId(e.target.value);
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder="gpt-4"
+                      />
+                    </div>
+                  </>
+                )}
+                <div className="flex items-center space-x-2">
+                  <input
+                    id={`${activeProvider}-supportsImage`}
+                    type="checkbox"
+                    checked={newModelSupportsImage}
+                    onChange={e => setNewModelSupportsImage(e.target.checked)}
+                    className="h-3.5 w-3.5 text-primary focus:ring-primary bg-surface border-border rounded"
                   />
-                </div>
-
-                <div className="flex justify-end space-x-2 px-5 pb-5">
-                  <button
-                    type="button"
-                    onClick={resetCoworkMemoryEditor}
-                    className="px-3 py-1.5 text-sm text-foreground hover:bg-surface-raised rounded-xl border border-border transition-colors"
+                  <label
+                    htmlFor={`${activeProvider}-supportsImage`}
+                    className="text-xs text-secondary"
                   >
-                    {i18nService.t('cancel')}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => { void handleSaveCoworkMemoryEntry(); }}
-                    disabled={!coworkMemoryDraftText.trim() || coworkMemoryListLoading}
-                    className="px-3 py-1.5 text-sm text-white bg-primary hover:bg-primary-hover rounded-xl disabled:opacity-60 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
-                  >
-                    {coworkMemoryEditingId ? i18nService.t('save') : i18nService.t('coworkMemoryCrudCreate')}
-                  </button>
+                    {i18nService.t('supportsImageInput')}
+                  </label>
                 </div>
               </div>
+
+              <div className="flex justify-end space-x-2 mt-4">
+                <button
+                  type="button"
+                  onClick={handleCancelModelEdit}
+                  className="px-3 py-1.5 text-xs text-foreground hover:bg-surface-raised rounded-xl border border-border"
+                >
+                  {i18nService.t('cancel')}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSaveNewModel}
+                  className="px-3 py-1.5 text-xs text-white bg-primary hover:bg-primary-hover rounded-xl active:scale-[0.98]"
+                >
+                  {i18nService.t('save')}
+                </button>
+              </div>
             </div>
-          )}
+          </div>
+        )}
+
+        {/* Memory Modal */}
+        {showMemoryModal && (
+          <div
+            className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4 rounded-2xl"
+            onClick={resetCoworkMemoryEditor}
+          >
+            <div
+              className="bg-surface border-border border rounded-2xl shadow-xl w-full max-w-md"
+              onClick={e => e.stopPropagation()}
+            >
+              <div className="px-5 pt-5 pb-4 border-b border-border">
+                <h3 className="text-base font-semibold text-foreground">
+                  {coworkMemoryEditingId
+                    ? i18nService.t('coworkMemoryCrudUpdate')
+                    : i18nService.t('coworkMemoryCrudCreate')}
+                </h3>
+              </div>
+
+              <div className="px-5 py-4 space-y-4">
+                {coworkMemoryEditingId && (
+                  <div className="rounded-lg border px-2 py-1 text-xs border-border text-secondary">
+                    {i18nService.t('coworkMemoryEditingTag')}
+                  </div>
+                )}
+                <textarea
+                  value={coworkMemoryDraftText}
+                  onChange={event => setCoworkMemoryDraftText(event.target.value)}
+                  placeholder={i18nService.t('coworkMemoryCrudTextPlaceholder')}
+                  autoFocus
+                  className="min-h-[200px] w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground focus:border-primary focus:ring-1 focus:ring-primary/30"
+                />
+              </div>
+
+              <div className="flex justify-end space-x-2 px-5 pb-5">
+                <button
+                  type="button"
+                  onClick={resetCoworkMemoryEditor}
+                  className="px-3 py-1.5 text-sm text-foreground hover:bg-surface-raised rounded-xl border border-border transition-colors"
+                >
+                  {i18nService.t('cancel')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    void handleSaveCoworkMemoryEntry();
+                  }}
+                  disabled={!coworkMemoryDraftText.trim() || coworkMemoryListLoading}
+                  className="px-3 py-1.5 text-sm text-white bg-primary hover:bg-primary-hover rounded-xl disabled:opacity-60 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
+                >
+                  {coworkMemoryEditingId
+                    ? i18nService.t('save')
+                    : i18nService.t('coworkMemoryCrudCreate')}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </Modal>
   );
 };
 
-export default Settings; 
+export default Settings;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -18,7 +18,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: '用户',
     login: '登录',
     inDevelopment: '正在开发中',
-    
+
     // 设置
     settings: '设置',
     general: '通用',
@@ -45,7 +45,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: '主题色',
     chinese: '中文',
     english: 'English',
-    
+
     // API设置
     apiKey: 'API Key',
     apiKeyPlaceholder: '输入你的 API Key',
@@ -60,7 +60,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: '当前模型',
     availableModels: '可用模型列表',
     modelSwitchHint: '在聊天界面可以切换使用的模型',
-    
+
     // 模型提供商设置
     enabled: '已启用',
     disabled: '已禁用',
@@ -87,7 +87,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelSuffixSecure: '（安全）',
     codingPlanSubscriptionBadge: '订阅套餐',
     inputFileLabel: '输入文件',
-    imageVisionHint: '当前模型未启用图片输入，图片将以文件路径形式发送。若该模型本身支持图片理解，可在模型配置中开启图片输入选项。',
+    imageVisionHint:
+      '当前模型未启用图片输入，图片将以文件路径形式发送。若该模型本身支持图片理解，可在模型配置中开启图片输入选项。',
     copied: '已复制',
     copyrightHolder: '网易有道 版权所有',
     noModelsAvailable: '暂无可用模型',
@@ -97,6 +98,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     testing: '测试中...',
     connectionSuccess: '连接成功',
     connectionFailed: '连接失败',
+    connectionFailedNetwork: '无法连接到服务器',
+    connectionFailedNetworkHint: '请检查网络连接及 Base URL 配置',
+    connectionTestUrl: '测试地址',
+    connectionStatus400: '请求格式错误',
+    connectionStatus401: 'API Key 无效或已过期，请检查密钥配置',
+    connectionStatus403: '访问被拒绝，请检查 API Key 权限或账户状态',
+    connectionStatus404: 'API 端点不存在，请检查 Base URL 配置',
+    connectionStatus429: '请求过于频繁，已触发速率限制，请稍后再试',
+    connectionStatus500: '服务器内部错误，请稍后再试',
+    connectionStatus502: '网关错误，服务暂时不可用',
+    connectionStatus503: '服务暂时不可用，请稍后再试',
     noModelsConfigured: '请先添加模型',
     apiFormat: 'API 格式',
     apiFormatNative: 'Anthropic 兼容',
@@ -168,7 +180,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: '两次输入的密码不一致',
     passwordTooShort: '密码长度至少为4位',
     wrongPassword: '密码错误，请检查后重试',
-    
+
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
     shortcutNotSet: '未设置',
@@ -190,7 +202,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     authLogout: '退出登录',
     authLoginRequired: '请先登录后再开始对话。',
     authLoginRequiredBtn: '登录',
-    authQuotaExhausted: '今日免费额度已用完。您可以登录 LobsterAI Portal 购买套餐或积分包继续使用，或在设置中配置自己的 API Key。',
+    authQuotaExhausted:
+      '今日免费额度已用完。您可以登录 LobsterAI Portal 购买套餐或积分包继续使用，或在设置中配置自己的 API Key。',
     authTopUpLink: '充值',
     authSettingsLink: '设置',
     authLoginToChat: '登录后即可开始聊天',
@@ -205,14 +218,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     planStandard: '标准',
     planAdvanced: '进阶',
     planPro: '专业',
-    
+
     // 错误信息
     failedToLoadSettings: '加载设置失败',
     failedToSaveSettings: '保存设置失败',
-    
+
     // 加载状态
     loading: '加载中...',
-    
+
     // 侧边栏
     conversations: '对话',
     noConversations: '暂无对话',
@@ -251,7 +264,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: '工作',
     folderIconCode: '代码',
     folderIconIdea: '灵感',
-    
+
     // 聊天窗口
     sendMessage: '发送消息',
     typeMessage: '询问任何问题...',
@@ -281,17 +294,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: '最多上传 10 张图片',
     imageReadError: '读取图片失败',
     imageInputNotSupported: '当前模型不支持图像输入',
-    
+
     // 模型选择
     selectModel: '选择模型',
-    
+
     // 错误提示
     errorOccurred: '发生错误',
     tryAgain: '请重试',
     networkError: '网络错误',
     apiKeyRequired: '需要设置API密钥',
     configureApiKey: '请在设置中配置您的API密钥',
-    
+
     // 初始化
     initializationError: '初始化应用程序失败。请检查您的配置。',
     apiKeyNotConfigured: 'API密钥未配置。请在设置中设置您的API密钥。',
@@ -320,7 +333,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelGroupUser: '自定义模型',
     modelSelectorNoModels: '请先在设置中配置模型',
     coworkApiConfigTitle: 'API 配置',
-    coworkApiConfigHint: '支持 Anthropic 兼容与 OpenAI 兼容协议（OpenAI 兼容通过本地转换服务接入）。',
+    coworkApiConfigHint:
+      '支持 Anthropic 兼容与 OpenAI 兼容协议（OpenAI 兼容通过本地转换服务接入）。',
     coworkAgentEngine: 'Agent 引擎',
     coworkAgentEngineOpenClaw: 'OpenClaw（默认）',
     coworkAgentEngineOpenClawHint: '个人 AI 助理',
@@ -333,7 +347,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkOpenClawInstallHint: 'OpenClaw 运行时已内置。切换到该引擎或启动任务时会自动拉起网关。',
     coworkOpenClawGoToSettingsInstall: '查看引擎设置',
     coworkOpenClawRestartGateway: '重新启动网关',
-    coworkOpenClawNotInstalledNotice: '未检测到内置 OpenClaw runtime（cfmind），请先执行打包前构建脚本。',
+    coworkOpenClawNotInstalledNotice:
+      '未检测到内置 OpenClaw runtime（cfmind），请先执行打包前构建脚本。',
     coworkOpenClawReadyNotice: 'OpenClaw runtime 已就绪。开始任务时会自动启动网关。',
     coworkOpenClawStarting: 'AI 引擎正在启动网关...',
     coworkOpenClawRunning: 'AI 引擎已就绪。',
@@ -353,7 +368,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryEnabledHint: 'OpenClaw 会自动索引 MEMORY.md 文件，为 Agent 提供长期记忆检索。',
     coworkMemoryFilePath: '记忆文件路径',
     coworkMemoryLlmJudgeEnabled: '启用 LLM 二级判定',
-    coworkMemoryLlmJudgeEnabledHint: '仅对规则边界样本调用模型复核，提升准确率（会增加少量 API 调用）。',
+    coworkMemoryLlmJudgeEnabledHint:
+      '仅对规则边界样本调用模型复核，提升准确率（会增加少量 API 调用）。',
     coworkMemoryLegacyNotice: '当前为 OpenClaw 引擎模式。本页功能仅对 Cowork 生效。',
     coworkMemoryAutoWrite: '自动写入记忆',
     coworkMemoryCaptureEachTurn: '启用隐式更新',
@@ -394,14 +410,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryEmbeddingEnabled: '启用本地 embedding 重排',
     coworkMemoryEmbeddingEnabledHint: '在词法检索基础上用本地向量相似度重排结果，提升召回质量',
     coworkMemoryEmbeddingModel: 'Embedding 模型',
-    coworkMemoryEmbeddingModelHint: '推荐 BAAI/bge-m3；可改为你已下载的其他 sentence-transformers 模型',
+    coworkMemoryEmbeddingModelHint:
+      '推荐 BAAI/bge-m3；可改为你已下载的其他 sentence-transformers 模型',
     coworkMemoryEmbeddingLocalModelPath: '本地模型目录（可选）',
     coworkMemoryEmbeddingLocalModelPathHint: '填写后优先加载本地目录；留空时按模型名加载',
     coworkMemoryEmbeddingAutoDownload: '允许自动下载模型',
     coworkMemoryEmbeddingAutoDownloadHint: '关闭后必须提供本地模型目录',
     coworkMemoryEmbeddingDownload: '下载 / 校验模型',
     coworkMemoryEmbeddingDownloading: '下载中...',
-    coworkMemoryEmbeddingDownloadHint: '手动触发模型下载（或校验本地模型目录），下载过程可能较慢，请等待进度完成',
+    coworkMemoryEmbeddingDownloadHint:
+      '手动触发模型下载（或校验本地模型目录），下载过程可能较慢，请等待进度完成',
     coworkMemoryEmbeddingDownloadSuccess: 'Embedding 模型已就绪',
     coworkMemoryEmbeddingDownloadFailed: 'Embedding 模型下载失败',
     coworkMemoryEmbeddingProgressPreparing: '准备下载任务',
@@ -480,10 +498,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     customCreate: '自定义创建',
     choosePreset: '选择预设',
     agentSettings: 'Agent 设置',
-     agentName: '名称',
-     agentNamePlaceholder: 'Agent 名称',
-     emojiPickerTitle: '选择图标',
-     emojiCustomInput: '或者直接输入 Emoji',
+    agentName: '名称',
+    agentNamePlaceholder: 'Agent 名称',
+    emojiPickerTitle: '选择图标',
+    emojiCustomInput: '或者直接输入 Emoji',
     agentDescription: '描述',
     agentDescriptionPlaceholder: '简短描述',
     agentIdentity: '身份',
@@ -569,7 +587,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noFolderSelected: '未选择文件夹',
     coworkSelectFolderFirst: '请选择任务目录后再提交',
     noRecentFolders: '暂无最近文件夹',
-    folderDriveRootNotAllowed: '不支持使用磁盘根目录作为工作目录，请选择一个子文件夹（例如 D:\\Projects）。',
+    folderDriveRootNotAllowed:
+      '不支持使用磁盘根目录作为工作目录，请选择一个子文件夹（例如 D:\\Projects）。',
     coworkOpenFolder: '打开文件夹',
 
     // Cowork 错误消息
@@ -602,21 +621,24 @@ const translations: Record<LanguageType, Record<string, string>> = {
     remoteImport: '远程导入',
     remoteImportTitle: '远程导入',
     createSkillByChat: '通过对话创建',
-    skillCreatorPrompt: '使用你的skill-creator技能，来创建一个技能。首先，请询问我这个技能需要干什么。',
+    skillCreatorPrompt:
+      '使用你的skill-creator技能，来创建一个技能。首先，请询问我这个技能需要干什么。',
     skillCreatorNotInstalled: '请先安装 skill-creator 技能',
     skillCreatorNotEnabled: '请先启用 skill-creator 技能',
     githubTabLabel: 'GitHub',
     githubImportDescription: '支持仓库链接与子目录链接；若仓库内有多个技能，将自动全部导入。',
     githubImportUrlLabel: 'URL',
     githubSkillPlaceholder: '例如：owner/repo 或 GitHub tree/blob 链接',
-    githubImportExamples: '示例：owner/repo；https://github.com/owner/repo/tree/main/SKILLs/my-skill',
+    githubImportExamples:
+      '示例：owner/repo；https://github.com/owner/repo/tree/main/SKILLs/my-skill',
     clawhubTabLabel: 'ClawHub',
     clawhubImportDescription: '粘贴 clawhub.ai 的技能页面链接，将自动安装对应技能。',
     clawhubImportUrlLabel: 'ClawHub URL',
     clawhubSkillPlaceholder: '例如：https://clawhub.ai/skills/owner/skill-name',
     clawhubImportExamples: '示例：https://clawhub.ai/skills/owner/skill-name',
     importSourceMismatchClawhub: '请输入 clawhub.ai 的链接，或切换到 GitHub 标签页导入。',
-    importSourceMismatchGithub: '请输入 GitHub 链接或 owner/repo 格式，或切换到 ClawHub 标签页导入。',
+    importSourceMismatchGithub:
+      '请输入 GitHub 链接或 owner/repo 格式，或切换到 ClawHub 标签页导入。',
     importSkill: '导入',
     importingSkill: '导入中...',
     official: '官方',
@@ -775,7 +797,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpInstallFromUrl: '通过 URL 安装',
     mcpInstallFromUrlTitle: '通过 URL 安装 MCP',
     mcpInstallFromUrlPlaceholder: '输入 npm 包名或 URL',
-    mcpInstallFromUrlHint: '支持 npm 包名（如 @modelcontextprotocol/server-filesystem）、npx 命令或 HTTP/HTTPS URL',
+    mcpInstallFromUrlHint:
+      '支持 npm 包名（如 @modelcontextprotocol/server-filesystem）、npx 命令或 HTTP/HTTPS URL',
     mcpRequiredConfig: '必填配置',
     mcpOptionalConfig: '可选配置',
     mcpViewOnGithub: '在 GitHub 上查看',
@@ -886,15 +909,20 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imConnectivityCheckTitle_nim_p2p_only_hint: '云信私聊模式',
     imConnectivityCheckSuggestion_missing_credentials: '补全必填配置项后重试。',
     imConnectivityCheckSuggestion_auth_check: '核对平台凭证、应用权限和发布状态。',
-    imConnectivityCheckSuggestion_gateway_running: '若显示未启用，请点击对应 IM 渠道胶囊按钮启用；启用后确认网络可访问平台服务。',
+    imConnectivityCheckSuggestion_gateway_running:
+      '若显示未启用，请点击对应 IM 渠道胶囊按钮启用；启用后确认网络可访问平台服务。',
     imConnectivityCheckSuggestion_inbound_activity: '向机器人发一条测试消息；群聊场景请 @机器人。',
-    imConnectivityCheckSuggestion_outbound_activity: '检查机器人发消息权限、可见范围和会话回包权限。',
+    imConnectivityCheckSuggestion_outbound_activity:
+      '检查机器人发消息权限、可见范围和会话回包权限。',
     imConnectivityCheckSuggestion_platform_last_error: '根据错误提示修复后再重测。',
     imConnectivityCheckSuggestion_feishu_group_requires_mention: '在群聊中使用 @机器人 + 内容。',
-    imConnectivityCheckSuggestion_feishu_event_subscription_required: '在飞书后台开启 im.message.receive_v1 并发布版本。',
+    imConnectivityCheckSuggestion_feishu_event_subscription_required:
+      '在飞书后台开启 im.message.receive_v1 并发布版本。',
     imConnectivityCheckSuggestion_discord_group_requires_mention: '在频道中使用 @机器人 + 内容。',
-    imConnectivityCheckSuggestion_telegram_privacy_mode_hint: '在 @BotFather 调整 Privacy Mode 设置。',
-    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint: '确认机器人已加入目标会话并允许收发消息。',
+    imConnectivityCheckSuggestion_telegram_privacy_mode_hint:
+      '在 @BotFather 调整 Privacy Mode 设置。',
+    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint:
+      '确认机器人已加入目标会话并允许收发消息。',
     imConnectivityCheckSuggestion_nim_p2p_only_hint: '通过私聊方式向机器人账号发送消息。',
     nimAccountPlaceholder: '机器人账号ID',
     nimAccountHint: '在云信控制台"账号管理"中创建的 IM 账号 ID',
@@ -906,7 +934,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimAppKeyHint: '从云信控制台应用信息中获取',
     nimTokenHint: '为该账号生成的访问凭证（建议设置为长期有效）',
     nimAccountWhitelist: '白名单账号',
-    nimAccountWhitelistHint: '填写允许与机器人对话的云信账号，多个账号用逗号分隔。留空则不限制，响应所有账号的消息。',
+    nimAccountWhitelistHint:
+      '填写允许与机器人对话的云信账号，多个账号用逗号分隔。留空则不限制，响应所有账号的消息。',
     nimTeamPolicy: '群消息策略',
     nimTeamPolicyDisabled: '禁用 - 不响应群消息',
     nimTeamPolicyOpen: '开放 - 响应所有群的@消息',
@@ -918,7 +947,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimQChatEnabledHint: '订阅圈组消息，仅响应@机器人的消息',
     nimQChatServerIds: '圈组服务器 ID',
     nimQChatServerIdsPlaceholder: '留空自动发现所有已加入的服务器',
-    nimQChatServerIdsHint: '指定要订阅的服务器 ID，多个用逗号分隔。留空则自动订阅所有已加入的服务器。',
+    nimQChatServerIdsHint:
+      '指定要订阅的服务器 ID，多个用逗号分隔。留空则自动订阅所有已加入的服务器。',
     neteaseBeeChanClientIdPlaceholder: '小蜜蜂助理Client ID',
 
     // IM 设置页面国际化
@@ -1001,7 +1031,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     feishuBotCreateWizardOrManual: '或 手动填写、修改已有机器人信息',
     feishuBotCreateWizardOptionNew: '新建机器人',
     feishuBotCreateWizardOptionExisting: '关联已有机器人',
-    feishuBotCreateWizardQrcodeDesc: '使用飞书客户端扫描二维码，选择「一键创建飞书机器人」完成配置。',
+    feishuBotCreateWizardQrcodeDesc:
+      '使用飞书客户端扫描二维码，选择「一键创建飞书机器人」完成配置。',
     feishuBotCreateWizardQrcodeExpired: '二维码已过期，请点击刷新',
     feishuBotCreateWizardQrcodeRefresh: '刷新二维码',
     feishuBotCreateWizardVerify: '验证',
@@ -1159,7 +1190,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormValidationDatetimeFuture: '执行时间必须在未来',
     scheduledTasksFormValidationIntervalPositive: '间隔时间必须大于 0',
     scheduledTasksFormValidationCronRequired: '请输入 Cron 表达式',
-    scheduledTasksFormValidationPayloadMismatch: '主会话只能使用系统事件，隔离会话只能使用 Agent 对话',
+    scheduledTasksFormValidationPayloadMismatch:
+      '主会话只能使用系统事件，隔离会话只能使用 Agent 对话',
     scheduledTasksFormValidationWebhookRequired: '请输入 Webhook URL',
     scheduledTasksFormValidationTimeout: '超时秒数必须是大于等于 0 的整数',
     scheduledTasksFormSubmitError: '保存失败：',
@@ -1264,7 +1296,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormNotifyConversationNone: '无可用会话',
     scheduledTasksToggleWarningAtPast: '该任务的执行时间已过，启用后将不会运行',
     scheduledTasksToggleWarningExpired: '该任务已过期，启用后将不会运行',
-    scheduledTasksDataAnomalyWarning: '定时任务「{name}」存在异常数据，已自动修正显示，建议重新编辑该任务',
+    scheduledTasksDataAnomalyWarning:
+      '定时任务「{name}」存在异常数据，已自动修正显示，建议重新编辑该任务',
 
     // 隐私协议弹窗
     privacyDialogTitle: '网易有道LobsterAI服务协议',
@@ -1297,7 +1330,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: 'User',
     login: 'Login',
     inDevelopment: 'In development',
-    
+
     // Settings
     settings: 'Settings',
     general: 'General',
@@ -1324,7 +1357,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: 'Color Themes',
     chinese: 'Chinese',
     english: 'English',
-    
+
     // API Settings
     apiKey: 'API Key',
     apiKeyPlaceholder: 'Enter your API Key',
@@ -1339,7 +1372,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: 'Current Model',
     availableModels: 'Available Models',
     modelSwitchHint: 'You can switch models in the chat interface',
-    
+
     // Model Provider Settings
     enabled: 'Enabled',
     disabled: 'Disabled',
@@ -1355,10 +1388,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelNameAndIdRequired: 'Model name and model ID are required',
     modelIdExists: 'Model ID already exists. Use a different one',
     ollamaModelName: 'Model Name',
-    ollamaModelNameHint: 'Enter the name of a model installed in Ollama, e.g. qwen3:8b, lfm2:latest',
+    ollamaModelNameHint:
+      'Enter the name of a model installed in Ollama, e.g. qwen3:8b, lfm2:latest',
     ollamaModelNamePlaceholder: 'qwen3:8b',
     ollamaDisplayName: 'Display Name (optional)',
-    ollamaDisplayNameHint: 'Custom name shown in the model list. Leave empty to use the model name.',
+    ollamaDisplayNameHint:
+      'Custom name shown in the model list. Leave empty to use the model name.',
     ollamaDisplayNamePlaceholder: 'My Qwen3 Model',
     ollamaModelNameRequired: 'Model name is required',
     supportsImageInput: 'Supports image input',
@@ -1366,7 +1401,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelSuffixSecure: '(Secure)',
     codingPlanSubscriptionBadge: 'Subscription',
     inputFileLabel: 'Input Files',
-    imageVisionHint: 'Image input is not enabled for the current model. Images will be sent as file paths. If the model supports vision, you can enable image input in the model configuration.',
+    imageVisionHint:
+      'Image input is not enabled for the current model. Images will be sent as file paths. If the model supports vision, you can enable image input in the model configuration.',
     copied: 'Copied',
     copyrightHolder: 'NetEase Youdao. All rights reserved.',
     noModelsAvailable: 'No models available',
@@ -1376,15 +1412,29 @@ const translations: Record<LanguageType, Record<string, string>> = {
     testing: 'Testing...',
     connectionSuccess: 'Connection successful',
     connectionFailed: 'Connection failed',
+    connectionFailedNetwork: 'Unable to connect to server',
+    connectionFailedNetworkHint: 'Please check your network connection and Base URL configuration',
+    connectionTestUrl: 'Test URL',
+    connectionStatus400: 'Bad request',
+    connectionStatus401: 'API Key is invalid or expired, please check your key configuration',
+    connectionStatus403: 'Access denied, please check your API Key permissions or account status',
+    connectionStatus404: 'API endpoint not found, please check your Base URL configuration',
+    connectionStatus429: 'Too many requests, rate limit triggered, please try again later',
+    connectionStatus500: 'Internal server error, please try again later',
+    connectionStatus502: 'Gateway error, service temporarily unavailable',
+    connectionStatus503: 'Service temporarily unavailable, please try again later',
     noModelsConfigured: 'Please add a model first',
     apiFormat: 'API Format',
     apiFormatNative: 'Anthropic Compatible',
     apiFormatOpenAI: 'OpenAI Compatible',
     apiFormatHint: 'Select protocol compatibility: Anthropic Compatible or OpenAI Compatible',
     zhipuCodingPlanHint: 'When enabled, uses the GLM Coding Plan dedicated API endpoint',
-    zhipuCodingPlanEndpointHint: 'When using GLM Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
-    qwenCodingPlanHint: 'When enabled, uses the Alibaba Cloud Bailian Coding Plan dedicated API endpoint',
-    qwenCodingPlanEndpointHint: 'When using Coding Plan, you need a dedicated API Key (format: sk-sp-xxxxx)',
+    zhipuCodingPlanEndpointHint:
+      'When using GLM Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
+    qwenCodingPlanHint:
+      'When enabled, uses the Alibaba Cloud Bailian Coding Plan dedicated API endpoint',
+    qwenCodingPlanEndpointHint:
+      'When using Coding Plan, you need a dedicated API Key (format: sk-sp-xxxxx)',
     qwenOAuthTab: 'OAuth Login',
     qwenOAuthLogin: 'OAuth Login',
     qwenOAuthLoginFree: 'OAuth Login',
@@ -1397,12 +1447,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     qwenAuthMethod: 'Authentication Method',
     qwenApiKeyOptional: 'API Key (Optional)',
     qwenApiKeyPriority: 'sk-xxxxx (Traditional method, higher priority than OAuth)',
-    qwenAuthPriorityHint: '💡 Authentication Priority: API Key > OAuth. If both are configured, API Key will be used first.',
+    qwenAuthPriorityHint:
+      '💡 Authentication Priority: API Key > OAuth. If both are configured, API Key will be used first.',
     qwenOrUseApiKey: 'Or use API Key',
-    volcengineCodingPlanHint: 'When enabled, uses the Volcengine Coding Plan dedicated API endpoint',
-    volcengineCodingPlanEndpointHint: 'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
+    volcengineCodingPlanHint:
+      'When enabled, uses the Volcengine Coding Plan dedicated API endpoint',
+    volcengineCodingPlanEndpointHint:
+      'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
     moonshotCodingPlanHint: 'When enabled, uses the Moonshot Coding Plan dedicated API endpoint',
-    moonshotCodingPlanEndpointHint: 'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
+    moonshotCodingPlanEndpointHint:
+      'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
     minimaxOAuthTabApiKey: 'API Key',
     minimaxOAuthTabOAuth: 'OAuth',
     minimaxOAuthRegionLabel: 'Region',
@@ -1415,7 +1469,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     minimaxOAuthStatusSuccess: 'OAuth login successful',
     minimaxOAuthStatusError: 'OAuth login failed',
     minimaxOAuthUserCode: 'Authorization code',
-    minimaxOAuthOpenBrowserHint: 'Browser opened, please enter the authorization code and complete login',
+    minimaxOAuthOpenBrowserHint:
+      'Browser opened, please enter the authorization code and complete login',
     minimaxOAuthLoggedIn: 'Logged in via MiniMax OAuth',
     minimaxOAuthRelogin: 'Re-login',
     minimaxOAuthLogout: 'Log out',
@@ -1431,8 +1486,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     importProvidersFailed: 'Failed to import providers',
     exportProvidersFailed: 'Failed to export providers',
     invalidProvidersFile: 'Invalid providers file',
-    decryptProvidersFailed: 'Failed to decrypt API key. Make sure the file was exported on this device.',
-    decryptProvidersPartial: 'Some keys could not be decrypted. Existing keys were kept or left blank.',
+    decryptProvidersFailed:
+      'Failed to decrypt API key. Make sure the file was exported on this device.',
+    decryptProvidersPartial:
+      'Some keys could not be decrypted. Existing keys were kept or left blank.',
 
     // Password related
     password: 'Password',
@@ -1441,13 +1498,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     enterPasswordAgain: 'Enter password again',
     exportPasswordTitle: 'Set Export Password',
     importPasswordTitle: 'Enter Import Password',
-    exportPasswordHint: 'This password encrypts your API keys. Use the same password when importing.',
+    exportPasswordHint:
+      'This password encrypts your API keys. Use the same password when importing.',
     importPasswordHint: 'Enter the password you set when exporting',
     passwordRequired: 'Password is required',
     passwordMismatch: 'Passwords do not match',
     passwordTooShort: 'Password must be at least 4 characters',
     wrongPassword: 'Wrong password, please try again',
-    
+
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
     shortcutNotSet: 'Not set',
@@ -1469,7 +1527,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     authLogout: 'Log Out',
     authLoginRequired: 'Please log in to start a conversation.',
     authLoginRequiredBtn: 'Log In',
-    authQuotaExhausted: 'Daily free quota exhausted. Visit LobsterAI Portal to purchase a plan or credits, or configure your own API Key in Settings.',
+    authQuotaExhausted:
+      'Daily free quota exhausted. Visit LobsterAI Portal to purchase a plan or credits, or configure your own API Key in Settings.',
     authTopUpLink: 'Top Up',
     authSettingsLink: 'Settings',
     authLoginToChat: 'Log in to start chatting',
@@ -1483,14 +1542,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     planFree: 'Free',
     planAdvanced: 'Advanced',
     planPro: 'Pro',
-    
+
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',
-    
+
     // Loading State
     loading: 'Loading...',
-    
+
     // Sidebar
     conversations: 'Conversations',
     noConversations: 'No conversations',
@@ -1504,7 +1563,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noProjects: 'No projects',
     delete: 'Delete',
     confirmDelete: 'Confirm Delete',
-    confirmDeleteMessage: 'Are you sure you want to delete this conversation? This action cannot be undone.',
+    confirmDeleteMessage:
+      'Are you sure you want to delete this conversation? This action cannot be undone.',
     searchChats: 'Search Chats',
     searchConversations: 'Search tasks...',
     searchNoResults: 'No matching tasks',
@@ -1521,7 +1581,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     projectSettings: 'Project settings',
     projectNameLabel: 'Project name',
     deleteProject: 'Delete project',
-    confirmDeleteProject: 'Are you sure you want to delete this project? Chats in this project will be moved to your chat list. This action cannot be undone.',
+    confirmDeleteProject:
+      'Are you sure you want to delete this project? Chats in this project will be moved to your chat list. This action cannot be undone.',
     folderIconDefault: 'Default',
     folderIconHealth: 'Health',
     folderIconStudy: 'Study',
@@ -1529,7 +1590,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: 'Work',
     folderIconCode: 'Code',
     folderIconIdea: 'Ideas',
-    
+
     // Chat Window
     sendMessage: 'Send Message',
     typeMessage: 'Type a message...',
@@ -1539,7 +1600,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkReEdit: 'Re-edit',
     messageCopied: 'Message copied',
     clearConversation: 'Clear Conversation',
-    confirmClearConversation: 'Are you sure you want to clear the current conversation? This action cannot be undone.',
+    confirmClearConversation:
+      'Are you sure you want to clear the current conversation? This action cannot be undone.',
     today: 'Today',
     yesterday: 'Yesterday',
     daysAgo: 'days ago',
@@ -1559,17 +1621,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: 'Up to 10 images',
     imageReadError: 'Failed to read image',
     imageInputNotSupported: 'Current model does not support images',
-    
+
     // Model Selection
     selectModel: 'Select Model',
-    
+
     // Error Messages
     errorOccurred: 'An error occurred',
     tryAgain: 'Please try again',
     networkError: 'Network error',
     apiKeyRequired: 'API Key Required',
     configureApiKey: 'Please configure your API key in settings',
-    
+
     // Initialization
     initializationError: 'Failed to initialize application. Please check your configuration.',
     apiKeyNotConfigured: 'API key not configured. Please set up your API key in settings.',
@@ -1589,30 +1651,36 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkWorkingDirectoryHint: 'LobsterAI will execute commands in this directory',
     coworkSystemPrompt: 'System Prompt',
     coworkSystemPromptPlaceholder: 'Set custom instructions for LobsterAI...',
-    coworkSystemPromptHint: 'Optional system prompt to customize LobsterAI\'s behavior',
+    coworkSystemPromptHint: "Optional system prompt to customize LobsterAI's behavior",
     coworkModelSettingsRequired: 'Please configure models and API keys in Model Settings first.',
     coworkModelSettingsTitle: 'Model Settings',
-    coworkModelSettingsHint: 'LobsterAI uses the current model and provider configuration from Model Settings.',
+    coworkModelSettingsHint:
+      'LobsterAI uses the current model and provider configuration from Model Settings.',
     coworkModelSettingsAction: 'Go to Model Settings',
     modelGroupServer: 'Plan Models',
     modelGroupUser: 'Custom Models',
     modelSelectorNoModels: 'Please configure models in settings first',
     coworkApiConfigTitle: 'API Configuration',
-    coworkApiConfigHint: 'Supports Anthropic-compatible and OpenAI-compatible APIs (OpenAI compatibility is bridged by a local adapter).',
+    coworkApiConfigHint:
+      'Supports Anthropic-compatible and OpenAI-compatible APIs (OpenAI compatibility is bridged by a local adapter).',
     coworkAgentEngine: 'Agent Engine',
     coworkAgentEngineOpenClaw: 'OpenClaw (Default)',
     coworkAgentEngineOpenClawHint: 'Personal AI assistant',
     coworkAgentEngineClaudeLegacy: 'Cowork',
-    coworkAgentEngineClaudeLegacyHint: 'Built-in engine, ready out of the box, recommended for daily tasks.',
+    coworkAgentEngineClaudeLegacyHint:
+      'Built-in engine, ready out of the box, recommended for daily tasks.',
     coworkOpenClawInstall: 'Start OpenClaw',
     coworkOpenClawRetryInstall: 'Retry OpenClaw Startup',
     coworkOpenClawStart: 'Start OpenClaw',
     coworkOpenClawInstalling: 'Starting OpenClaw...',
-    coworkOpenClawInstallHint: 'OpenClaw runtime is bundled. Switching to this engine or starting a task will auto-start the gateway.',
+    coworkOpenClawInstallHint:
+      'OpenClaw runtime is bundled. Switching to this engine or starting a task will auto-start the gateway.',
     coworkOpenClawGoToSettingsInstall: 'View Engine Settings',
     coworkOpenClawRestartGateway: 'Restart Gateway',
-    coworkOpenClawNotInstalledNotice: 'Bundled OpenClaw runtime (cfmind) was not found. Build the runtime before packaging.',
-    coworkOpenClawReadyNotice: 'OpenClaw runtime is ready. The gateway will auto-start when you run a task.',
+    coworkOpenClawNotInstalledNotice:
+      'Bundled OpenClaw runtime (cfmind) was not found. Build the runtime before packaging.',
+    coworkOpenClawReadyNotice:
+      'OpenClaw runtime is ready. The gateway will auto-start when you run a task.',
     coworkOpenClawStarting: 'AI engine is starting the gateway...',
     coworkOpenClawRunning: 'AI engine is ready.',
     coworkOpenClawError: 'OpenClaw gateway failed to become healthy in time.',
@@ -1622,16 +1690,20 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkBootstrapIdentityTitle: 'Agent Identity',
     coworkBootstrapIdentityHint: 'Agent metadata (name, emoji, avatar, etc.)',
     coworkBootstrapUserTitle: 'User Profile',
-    coworkBootstrapUserHint: 'Information about yourself (name, preferences, etc.) that the Agent will remember.',
+    coworkBootstrapUserHint:
+      'Information about yourself (name, preferences, etc.) that the Agent will remember.',
     coworkBootstrapSoulTitle: 'Agent Persona',
-    coworkBootstrapSoulHint: 'Agent personality, tone, and behavior guidelines. The Agent will be instructed to follow this.',
+    coworkBootstrapSoulHint:
+      'Agent personality, tone, and behavior guidelines. The Agent will be instructed to follow this.',
     coworkBootstrapStoragePath: 'Storage path',
     coworkBootstrapSaveFailed: 'Failed to save agent settings',
     coworkMemoryEnabled: 'Enable user memories',
-    coworkMemoryEnabledHint: 'OpenClaw automatically indexes MEMORY.md for long-term memory retrieval by the Agent.',
+    coworkMemoryEnabledHint:
+      'OpenClaw automatically indexes MEMORY.md for long-term memory retrieval by the Agent.',
     coworkMemoryFilePath: 'Memory file path',
     coworkMemoryLlmJudgeEnabled: 'Enable LLM secondary judge',
-    coworkMemoryLlmJudgeEnabledHint: 'Only borderline rule cases are reviewed by the model for better accuracy (adds a small number of API calls).',
+    coworkMemoryLlmJudgeEnabledHint:
+      'Only borderline rule cases are reviewed by the model for better accuracy (adds a small number of API calls).',
     coworkMemoryLegacyNotice: 'OpenClaw engine mode is active. This page only applies to Cowork.',
     coworkMemoryAutoWrite: 'Auto-write memory',
     coworkMemoryCaptureEachTurn: 'Enable implicit updates',
@@ -1670,16 +1742,20 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryAdvancedShow: 'Show advanced settings',
     coworkMemoryAdvancedHide: 'Hide advanced settings',
     coworkMemoryEmbeddingEnabled: 'Enable local embedding rerank',
-    coworkMemoryEmbeddingEnabledHint: 'Rerank lexical hits with local vector similarity for better recall quality',
+    coworkMemoryEmbeddingEnabledHint:
+      'Rerank lexical hits with local vector similarity for better recall quality',
     coworkMemoryEmbeddingModel: 'Embedding model',
-    coworkMemoryEmbeddingModelHint: 'Recommended: BAAI/bge-m3. You can switch to any downloaded sentence-transformers model',
+    coworkMemoryEmbeddingModelHint:
+      'Recommended: BAAI/bge-m3. You can switch to any downloaded sentence-transformers model',
     coworkMemoryEmbeddingLocalModelPath: 'Local model path (optional)',
-    coworkMemoryEmbeddingLocalModelPathHint: 'If set, load model from this directory first; if empty, load by model id',
+    coworkMemoryEmbeddingLocalModelPathHint:
+      'If set, load model from this directory first; if empty, load by model id',
     coworkMemoryEmbeddingAutoDownload: 'Allow auto model download',
     coworkMemoryEmbeddingAutoDownloadHint: 'When disabled, you must provide a local model path',
     coworkMemoryEmbeddingDownload: 'Download / Validate model',
     coworkMemoryEmbeddingDownloading: 'Downloading...',
-    coworkMemoryEmbeddingDownloadHint: 'Manually trigger model download (or validate local path). This can take a while, wait for progress to finish',
+    coworkMemoryEmbeddingDownloadHint:
+      'Manually trigger model download (or validate local path). This can take a while, wait for progress to finish',
     coworkMemoryEmbeddingDownloadSuccess: 'Embedding model is ready',
     coworkMemoryEmbeddingDownloadFailed: 'Failed to download embedding model',
     coworkMemoryEmbeddingProgressPreparing: 'Preparing download task',
@@ -1690,11 +1766,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryEmbeddingProgressDone: 'Completed',
     coworkMemoryEmbeddingProgressError: 'Failed',
     coworkMemoryEmbeddingWeight: 'Semantic rerank weight',
-    coworkMemoryEmbeddingWeightHint: 'Range 0-1. Higher means more embedding influence. Recommended: 0.62',
+    coworkMemoryEmbeddingWeightHint:
+      'Range 0-1. Higher means more embedding influence. Recommended: 0.62',
     coworkConfigSaveFailed: 'Failed to save LobsterAI settings. Please try again.',
     coworkApiProviderModel: 'Select from provider models',
     coworkApiProviderModelCustom: 'Custom',
-    coworkApiProviderModelHint: 'Only shows enabled providers with configured API key and base URL.',
+    coworkApiProviderModelHint:
+      'Only shows enabled providers with configured API key and base URL.',
     coworkApiBaseUrl: 'API Base URL',
     coworkApiKey: 'API Key',
     coworkApiModel: 'Model Name',
@@ -1724,9 +1802,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkTodoPending: 'pending',
     coworkTodoUntitled: 'Untitled todo',
     coworkTodoUnknownStatus: 'Unknown status',
-    coworkDangerousOperation: 'Warning: This operation may modify files or execute system commands. Please review carefully.',
-    coworkDestructiveOperation: 'Destructive operation: This command may cause irreversible data loss. Please confirm carefully.',
-    coworkCautionOperation: 'Caution: This command may modify files or system state. Please review carefully.',
+    coworkDangerousOperation:
+      'Warning: This operation may modify files or execute system commands. Please review carefully.',
+    coworkDestructiveOperation:
+      'Destructive operation: This command may cause irreversible data loss. Please confirm carefully.',
+    coworkCautionOperation:
+      'Caution: This command may modify files or system state. Please review carefully.',
     dangerReasonRecursiveDelete: 'Recursive file deletion',
     dangerReasonGitForcePush: 'Git force push',
     dangerReasonGitResetHard: 'Git hard reset',
@@ -1758,16 +1839,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     customCreate: 'Custom Create',
     choosePreset: 'Choose Preset',
     agentSettings: 'Agent Settings',
-     agentName: 'Name',
-     agentNamePlaceholder: 'Agent name',
-     emojiPickerTitle: 'Choose icon',
-     emojiCustomInput: 'Or type an emoji',
+    agentName: 'Name',
+    agentNamePlaceholder: 'Agent name',
+    emojiPickerTitle: 'Choose icon',
+    emojiCustomInput: 'Or type an emoji',
     agentDescription: 'Description',
     agentDescriptionPlaceholder: 'Brief description',
     agentIdentity: 'Identity',
     agentIdentityPlaceholder: 'Identity description (IDENTITY.md)...',
     agentSkills: 'Skills',
-    agentSkillsHint: 'Select skills available to this Agent. Leave empty to use all enabled skills.',
+    agentSkillsHint:
+      'Select skills available to this Agent. Leave empty to use all enabled skills.',
     agentSkillsSearch: 'Search skills...',
     agentSkillsNone: 'Click to select skills',
     agentsSubtitle: 'Custom personas and skill sets for your AI agents',
@@ -1790,11 +1872,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     coworkNewSession: 'New Session',
     coworkContinuePlaceholder: 'Continue the conversation...',
-    coworkRemoteManagedPlaceholder: 'This session was created via IM. Please use the corresponding IM platform.',
+    coworkRemoteManagedPlaceholder:
+      'This session was created via IM. Please use the corresponding IM platform.',
     aiGeneratedDisclaimer: 'Content generated by AI, for reference only.',
     updateAvailablePill: 'New update',
     updateAvailableTitle: 'New version available',
-    updateAvailableMessage: 'A new version is available. Please download it from the official website and install over the current version.',
+    updateAvailableMessage:
+      'A new version is available. Please download it from the official website and install over the current version.',
     updateAvailableConfirm: 'Update Now',
     updateAvailableCancel: 'Cancel',
     updateOpenFailed: 'Failed to open download page',
@@ -1833,13 +1917,15 @@ const translations: Record<LanguageType, Record<string, string>> = {
     deleteSession: 'Delete Task',
     turnIndex: 'Turn index',
     deleteTaskConfirmTitle: 'Confirm Deletion',
-    deleteTaskConfirmMessage: 'This action cannot be undone. All messages in this task will be permanently deleted.',
+    deleteTaskConfirmMessage:
+      'This action cannot be undone. All messages in this task will be permanently deleted.',
     batchOperations: 'Batch Operations',
     batchSelectAll: 'Select All',
     batchDelete: 'Delete',
     batchCancel: 'Cancel',
     batchDeleteConfirmTitle: 'Confirm Batch Deletion',
-    batchDeleteConfirmMessage: 'Are you sure you want to delete {count} selected tasks? This action cannot be undone.',
+    batchDeleteConfirmMessage:
+      'Are you sure you want to delete {count} selected tasks? This action cannot be undone.',
     back: 'Back',
     browse: 'Browse',
     addFolder: 'Add Folder',
@@ -1847,26 +1933,35 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noFolderSelected: 'No folder selected',
     coworkSelectFolderFirst: 'Please select a task folder before submitting',
     noRecentFolders: 'No recent folders',
-    folderDriveRootNotAllowed: 'Drive root directories are not supported as working directories. Please select a subfolder (e.g. D:\\Projects).',
+    folderDriveRootNotAllowed:
+      'Drive root directories are not supported as working directories. Please select a subfolder (e.g. D:\\Projects).',
     coworkOpenFolder: 'Open folder',
 
     // Cowork error messages
-    coworkErrorAuthInvalid: 'Invalid or expired API key. Please check and update your API key in settings.',
+    coworkErrorAuthInvalid:
+      'Invalid or expired API key. Please check and update your API key in settings.',
     coworkErrorInsufficientBalance: 'Insufficient API balance. Please top up and try again.',
-    coworkErrorInputTooLong: 'Input too long, exceeding model context limit. Please shorten the conversation and try again.',
-    coworkErrorCouldNotProcessPdf: 'Unable to process the PDF file. Please try converting the PDF to text format and resend.',
-    coworkErrorModelNotFound: 'The requested model does not exist or is unavailable. Please check the model configuration in settings.',
-    coworkErrorGatewayDisconnected: 'AI engine connection lost. Please retry. If the issue persists, try restarting the app.',
+    coworkErrorInputTooLong:
+      'Input too long, exceeding model context limit. Please shorten the conversation and try again.',
+    coworkErrorCouldNotProcessPdf:
+      'Unable to process the PDF file. Please try converting the PDF to text format and resend.',
+    coworkErrorModelNotFound:
+      'The requested model does not exist or is unavailable. Please check the model configuration in settings.',
+    coworkErrorGatewayDisconnected:
+      'AI engine connection lost. Please retry. If the issue persists, try restarting the app.',
     coworkErrorServiceRestart: 'AI engine is restarting. Please try again later.',
     coworkErrorGatewayDraining: 'AI engine is restarting. Please wait a moment and try again.',
-    coworkErrorNetworkError: 'Network connection failed. Please check your network settings and try again.',
+    coworkErrorNetworkError:
+      'Network connection failed. Please check your network settings and try again.',
     coworkErrorRateLimit: 'Too many requests. Please try again later.',
-    coworkErrorContentFiltered: 'Content did not pass the safety review. Please modify and try again.',
+    coworkErrorContentFiltered:
+      'Content did not pass the safety review. Please modify and try again.',
     coworkErrorServerError: 'Server error occurred. Please try again later.',
     coworkErrorSessionStartFailed: 'Failed to start session: {error}',
     coworkErrorSessionContinueFailed: 'Failed to send message: {error}',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
-    coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
+    coworkErrorUnknown:
+      'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
 
     // Skills
     skills: 'Skills',
@@ -1880,21 +1975,26 @@ const translations: Record<LanguageType, Record<string, string>> = {
     remoteImport: 'Remote Import',
     remoteImportTitle: 'Remote Import',
     createSkillByChat: 'Create via Conversation',
-    skillCreatorPrompt: 'Use your skill-creator skill to create a new skill. First, please ask me what this skill should do.',
+    skillCreatorPrompt:
+      'Use your skill-creator skill to create a new skill. First, please ask me what this skill should do.',
     skillCreatorNotInstalled: 'Please install the skill-creator skill first',
     skillCreatorNotEnabled: 'Please enable the skill-creator skill first',
     githubTabLabel: 'GitHub',
-    githubImportDescription: 'Supports both repository and subdirectory links. If a repo contains multiple skills, all will be imported.',
+    githubImportDescription:
+      'Supports both repository and subdirectory links. If a repo contains multiple skills, all will be imported.',
     githubImportUrlLabel: 'URL',
     githubSkillPlaceholder: 'e.g. owner/repo or a GitHub tree/blob URL',
-    githubImportExamples: 'Examples: owner/repo; https://github.com/owner/repo/tree/main/SKILLs/my-skill',
+    githubImportExamples:
+      'Examples: owner/repo; https://github.com/owner/repo/tree/main/SKILLs/my-skill',
     clawhubTabLabel: 'ClawHub',
-    clawhubImportDescription: 'Paste a clawhub.ai skill page URL to automatically install the skill.',
+    clawhubImportDescription:
+      'Paste a clawhub.ai skill page URL to automatically install the skill.',
     clawhubImportUrlLabel: 'ClawHub URL',
     clawhubSkillPlaceholder: 'e.g. https://clawhub.ai/skills/owner/skill-name',
     clawhubImportExamples: 'Example: https://clawhub.ai/skills/owner/skill-name',
     importSourceMismatchClawhub: 'Please enter a clawhub.ai URL, or switch to the GitHub tab.',
-    importSourceMismatchGithub: 'Please enter a GitHub URL or owner/repo, or switch to the ClawHub tab.',
+    importSourceMismatchGithub:
+      'Please enter a GitHub URL or owner/repo, or switch to the ClawHub tab.',
     importSkill: 'Import',
     importingSkill: 'Importing...',
     official: 'Official',
@@ -2006,7 +2106,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // MCP Servers
     mcpServers: 'MCP',
-    mcpDescription: 'Configure and manage MCP (Model Context Protocol) servers to extend your agent\'s tool capabilities',
+    mcpDescription:
+      "Configure and manage MCP (Model Context Protocol) servers to extend your agent's tool capabilities",
     searchMcpServers: 'Search MCP servers',
     addMcpServer: 'Custom',
     editMcpServer: 'Edit MCP Server',
@@ -2053,7 +2154,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpInstallFromUrl: 'Install from URL',
     mcpInstallFromUrlTitle: 'Install MCP from URL',
     mcpInstallFromUrlPlaceholder: 'Enter npm package name or URL',
-    mcpInstallFromUrlHint: 'Supports npm package names (e.g. @modelcontextprotocol/server-filesystem), npx commands, or HTTP/HTTPS URLs',
+    mcpInstallFromUrlHint:
+      'Supports npm package names (e.g. @modelcontextprotocol/server-filesystem), npx commands, or HTTP/HTTPS URLs',
     mcpRequiredConfig: 'Required Configuration',
     mcpOptionalConfig: 'Optional Configuration',
     mcpViewOnGithub: 'View on GitHub',
@@ -2069,7 +2171,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpDesc_github: 'GitHub platform integration: repos, issues, PRs, Actions management',
     mcpDesc_gitlab: 'GitLab API integration: project management, merge requests, pipelines',
     mcpDesc_context7: 'Up-to-date library documentation and code examples for AI coding',
-    mcpDesc_google_drive: 'Google Drive file access and search with auto-export for Workspace files',
+    mcpDesc_google_drive:
+      'Google Drive file access and search with auto-export for Workspace files',
     mcpDesc_gmail: 'Gmail management: read, send, search emails with auto authentication',
     mcpDesc_google_calendar: 'Google Calendar management: create, query, update calendar events',
     mcpDesc_notion: 'Notion API: search, create/update pages, manage databases',
@@ -2077,7 +2180,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpDesc_todoist: 'Task management: create, update, complete and organize to-do items',
     mcpDesc_playwright: 'Advanced browser automation supporting Chromium/Firefox/WebKit',
     mcpDesc_canva: 'Canva design platform: create and manage designs, template operations',
-    mcpDesc_firecrawl: 'Web scraping and data extraction: batch processing, structured extraction and content analysis',
+    mcpDesc_firecrawl:
+      'Web scraping and data extraction: batch processing, structured extraction and content analysis',
     mcpDesc_fetch: 'Web content fetching and HTML-to-markdown conversion for LLM consumption',
 
     // Email Skill Config
@@ -2091,13 +2195,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     emailPasswordPlaceholder: 'Password or app-specific password',
     emailAdvancedSettings: 'Advanced Settings',
     emailAllowInsecureCert: 'Allow insecure certificates',
-    emailAllowInsecureCertHint: 'Skip TLS certificate verification, useful when proxy/VPN causes self-signed certificate errors',
+    emailAllowInsecureCertHint:
+      'Skip TLS certificate verification, useful when proxy/VPN causes self-signed certificate errors',
     emailMailbox: 'Default Mailbox',
     emailConfigSaved: 'Email configuration saved',
     emailConfigError: 'Failed to save configuration',
     emailHintGmail: 'If 2FA is enabled, use an App Password instead of your account password',
-    emailHint163: 'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
-    emailHintQQ: 'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
+    emailHint163:
+      'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
+    emailHintQQ:
+      'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
 
     // File operations
     openFile: 'Open File',
@@ -2118,12 +2225,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nim: 'NetEase IM',
     'netease-bee': 'Netease Bee',
     weixin: 'WeChat',
-    wecom: 'WeCom',    popo: 'POPO',
+    wecom: 'WeCom',
+    popo: 'POPO',
     connected: 'Connected',
     disconnected: 'Disconnected',
     imAgentBinding: 'Responding Agent',
     imAgentBindingDefault: 'Default (main)',
-    imAgentBindingHint: 'Select the Agent that responds to messages on this platform. Different Agents have different personas and skill configurations.',
+    imAgentBindingHint:
+      'Select the Agent that responds to messages on this platform. Different Agents have different personas and skill configurations.',
     kickedByOtherClient: 'Account logged in elsewhere',
     starting: 'Starting',
     start: 'Start',
@@ -2156,23 +2265,35 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imConnectivityCheckTitle_outbound_activity: 'Outbound Message Activity',
     imConnectivityCheckTitle_platform_last_error: 'Recent Platform Error',
     imConnectivityCheckTitle_feishu_group_requires_mention: 'Feishu Group Trigger Rule',
-    imConnectivityCheckTitle_feishu_event_subscription_required: 'Feishu Event Subscription Requirement',
+    imConnectivityCheckTitle_feishu_event_subscription_required:
+      'Feishu Event Subscription Requirement',
     imConnectivityCheckTitle_discord_group_requires_mention: 'Discord Group Trigger Rule',
     imConnectivityCheckTitle_telegram_privacy_mode_hint: 'Telegram Privacy Mode',
     imConnectivityCheckTitle_dingtalk_bot_membership_hint: 'DingTalk Conversation Permission',
     imConnectivityCheckTitle_nim_p2p_only_hint: 'NetEase IM P2P Mode',
     imConnectivityCheckSuggestion_missing_credentials: 'Fill required credentials and test again.',
-    imConnectivityCheckSuggestion_auth_check: 'Verify credentials, permissions, and app release status.',
-    imConnectivityCheckSuggestion_gateway_running: 'If disabled, click the IM channel pill to enable it, then verify platform endpoints are reachable.',
-    imConnectivityCheckSuggestion_inbound_activity: 'Send a test message to the bot; mention it in group chats.',
-    imConnectivityCheckSuggestion_outbound_activity: 'Check bot send permissions and conversation reply scope.',
-    imConnectivityCheckSuggestion_platform_last_error: 'Fix the reported error and run diagnostics again.',
-    imConnectivityCheckSuggestion_feishu_group_requires_mention: 'Use @bot plus your message in group chats.',
-    imConnectivityCheckSuggestion_feishu_event_subscription_required: 'Enable im.message.receive_v1 and publish app version.',
-    imConnectivityCheckSuggestion_discord_group_requires_mention: 'Use @bot plus your message in channels.',
-    imConnectivityCheckSuggestion_telegram_privacy_mode_hint: 'Review Privacy Mode in @BotFather settings.',
-    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint: 'Ensure the bot is in the target conversation with send/receive rights.',
-    imConnectivityCheckSuggestion_nim_p2p_only_hint: 'Send messages via direct chat to the bot account.',
+    imConnectivityCheckSuggestion_auth_check:
+      'Verify credentials, permissions, and app release status.',
+    imConnectivityCheckSuggestion_gateway_running:
+      'If disabled, click the IM channel pill to enable it, then verify platform endpoints are reachable.',
+    imConnectivityCheckSuggestion_inbound_activity:
+      'Send a test message to the bot; mention it in group chats.',
+    imConnectivityCheckSuggestion_outbound_activity:
+      'Check bot send permissions and conversation reply scope.',
+    imConnectivityCheckSuggestion_platform_last_error:
+      'Fix the reported error and run diagnostics again.',
+    imConnectivityCheckSuggestion_feishu_group_requires_mention:
+      'Use @bot plus your message in group chats.',
+    imConnectivityCheckSuggestion_feishu_event_subscription_required:
+      'Enable im.message.receive_v1 and publish app version.',
+    imConnectivityCheckSuggestion_discord_group_requires_mention:
+      'Use @bot plus your message in channels.',
+    imConnectivityCheckSuggestion_telegram_privacy_mode_hint:
+      'Review Privacy Mode in @BotFather settings.',
+    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint:
+      'Ensure the bot is in the target conversation with send/receive rights.',
+    imConnectivityCheckSuggestion_nim_p2p_only_hint:
+      'Send messages via direct chat to the bot account.',
     nimAccountPlaceholder: 'Bot account ID',
     nimAccountHint: 'IM account ID (accid) created in NetEase IM console account management',
     nimCredentialsGuide: 'How to obtain NetEase IM credentials:',
@@ -2183,7 +2304,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimAppKeyHint: 'Obtain from app information in NetEase IM console',
     nimTokenHint: 'Access credential generated for this account (long-term validity recommended)',
     nimAccountWhitelist: 'Account Whitelist',
-    nimAccountWhitelistHint: 'Enter NIM accounts allowed to chat with the bot, separated by commas. Leave empty to allow all accounts.',
+    nimAccountWhitelistHint:
+      'Enter NIM accounts allowed to chat with the bot, separated by commas. Leave empty to allow all accounts.',
     nimTeamPolicy: 'Team Message Policy',
     nimTeamPolicyDisabled: 'Disabled - Do not respond to team messages',
     nimTeamPolicyOpen: 'Open - Respond to @mentions in all teams',
@@ -2195,7 +2317,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimQChatEnabledHint: 'Subscribe to QChat messages, only responds to @mentions',
     nimQChatServerIds: 'QChat Server IDs',
     nimQChatServerIdsPlaceholder: 'Leave empty to auto-discover all joined servers',
-    nimQChatServerIdsHint: 'Specify server IDs to subscribe, separated by commas. Leave empty to auto-subscribe all joined servers.',
+    nimQChatServerIdsHint:
+      'Specify server IDs to subscribe, separated by commas. Leave empty to auto-subscribe all joined servers.',
     neteaseBeeChanClientIdPlaceholder: 'Netease Bee IM Client ID',
 
     // IM settings page i18n
@@ -2208,12 +2331,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imDebugMode: 'Debug Mode',
     imSessionTimeout: 'Session Timeout (min, deprecated)',
     imSeparateSessionByConversation: 'Separate Session by Conversation',
-    imSeparateSessionByConversationDesc: 'Maintain independent sessions for DMs, groups, and different groups',
+    imSeparateSessionByConversationDesc:
+      'Maintain independent sessions for DMs, groups, and different groups',
     imGroupSessionScope: 'Group Session Scope',
     imGroupSessionScopeGroup: 'Shared in group',
     imGroupSessionScopeGroupSender: 'Per user in group',
     imSharedMemoryAcrossConversations: 'Share Memory Across Conversations',
-    imSharedMemoryAcrossConversationsDesc: 'Share memory across different conversations (isolated by default)',
+    imSharedMemoryAcrossConversationsDesc:
+      'Share memory across different conversations (isolated by default)',
     imGatewayBaseUrl: 'Custom Gateway URL',
     imGatewayBaseUrlPlaceholder: 'e.g. https://proxy.example.com',
     imSendThinkingMessage: 'Send "thinking" message',
@@ -2266,19 +2391,25 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imWecomQuickSetupSuccess: 'Bot created successfully, credentials auto-filled',
     imWecomQuickSetupError: 'Creation failed',
     imViewGuide: 'Setup Manual',
-    imDingtalkGuideStep1: 'Go to DingTalk Open Platform, create or pick an enterprise app under "App Development > Bot"',
-    imDingtalkGuideStep2: 'Copy the Client ID (AppKey) and Client Secret (AppSecret) from the credentials page',
-    imDingtalkGuideStep3: 'Turn on the "Bot" capability and enter Client ID and Client Secret below',
+    imDingtalkGuideStep1:
+      'Go to DingTalk Open Platform, create or pick an enterprise app under "App Development > Bot"',
+    imDingtalkGuideStep2:
+      'Copy the Client ID (AppKey) and Client Secret (AppSecret) from the credentials page',
+    imDingtalkGuideStep3:
+      'Turn on the "Bot" capability and enter Client ID and Client Secret below',
     imDingtalkGuideStep4: 'Once saved, the bot will auto-connect via Stream mode',
     imFeishuGuideStep1: 'Enter the Feishu bot App ID and App Secret below to complete setup',
-    imFeishuGuideStep2: 'App credentials are available on the Feishu Open Platform. See the setup manual for details.',
+    imFeishuGuideStep2:
+      'App credentials are available on the Feishu Open Platform. See the setup manual for details.',
     feishuBotCreateWizardTitle: 'Create Bot',
     feishuBotCreateWizardScanBtn: 'Scan QR Code to Create Bot',
-    feishuBotCreateWizardScanHint: 'Scan the QR code with your Feishu app to create and configure a bot in one step',
+    feishuBotCreateWizardScanHint:
+      'Scan the QR code with your Feishu app to create and configure a bot in one step',
     feishuBotCreateWizardOrManual: 'or manually enter / edit bot credentials',
     feishuBotCreateWizardOptionNew: 'Create a new bot',
     feishuBotCreateWizardOptionExisting: 'Use an existing bot',
-    feishuBotCreateWizardQrcodeDesc: 'Scan the QR code with your Feishu app and select "One-click create Feishu bot" to complete setup.',
+    feishuBotCreateWizardQrcodeDesc:
+      'Scan the QR code with your Feishu app and select "One-click create Feishu bot" to complete setup.',
     feishuBotCreateWizardQrcodeExpired: 'QR code expired, please refresh',
     feishuBotCreateWizardQrcodeRefresh: 'Refresh QR Code',
     feishuBotCreateWizardVerify: 'Verify',
@@ -2320,8 +2451,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imTelegramGuideStep4: 'Paste the token into the field below',
     imDiscordGuideStep1: 'Open Discord Developer Portal and create a new application',
     imDiscordGuideStep2: 'Under the Bot section, add a bot and copy its token',
-    imDiscordGuideStep3: 'Under Bot – Privileged Gateway Intents, enable Message Content and Server Members intents',
-    imDiscordGuideStep4: 'In the OAuth2 URL Generator, select "bot" and "applications.commands" with messaging permissions',
+    imDiscordGuideStep3:
+      'Under Bot – Privileged Gateway Intents, enable Message Content and Server Members intents',
+    imDiscordGuideStep4:
+      'In the OAuth2 URL Generator, select "bot" and "applications.commands" with messaging permissions',
     imDiscordGuideStep5: 'Invite the bot to your server using the generated URL',
     imDiscordGuideStep6: 'Paste the bot token into the field below',
 
@@ -2329,7 +2462,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     autoLaunch: 'Launch at Login',
     autoLaunchDescription: 'Automatically start the app when you log in',
     useSystemProxy: 'Use System Proxy',
-    useSystemProxyDescription: 'When enabled, network requests follow system proxy settings (applies after Save)',
+    useSystemProxyDescription:
+      'When enabled, network requests follow system proxy settings (applies after Save)',
     preventSleep: 'Prevent Sleep',
     preventSleepDescription: 'Prevent the system from sleeping while the app is running',
 
@@ -2436,13 +2570,15 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormValidationDatetimeFuture: 'Execution time must be in the future',
     scheduledTasksFormValidationIntervalPositive: 'Interval must be greater than 0',
     scheduledTasksFormValidationCronRequired: 'Cron expression is required',
-    scheduledTasksFormValidationPayloadMismatch: 'Main sessions require system events, isolated sessions require agent turns',
+    scheduledTasksFormValidationPayloadMismatch:
+      'Main sessions require system events, isolated sessions require agent turns',
     scheduledTasksFormValidationWebhookRequired: 'Webhook URL is required',
     scheduledTasksFormValidationTimeout: 'Timeout must be an integer greater than or equal to 0',
     scheduledTasksFormSubmitError: 'Save failed: ',
     scheduledTasksEdit: 'Edit',
     scheduledTasksDelete: 'Delete',
-    scheduledTasksDeleteConfirm: 'Are you sure you want to delete task "{name}"? This cannot be undone.',
+    scheduledTasksDeleteConfirm:
+      'Are you sure you want to delete task "{name}"? This cannot be undone.',
     scheduledTasksRun: 'Run Now',
     scheduledTasksStop: 'Stop',
     scheduledTasksEnabled: 'Enabled',
@@ -2539,13 +2675,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormNotifyConversationPlaceholder: 'Select target conversation',
     scheduledTasksFormNotifyConversationLoading: 'Loading conversations...',
     scheduledTasksFormNotifyConversationNone: 'No conversations available',
-    scheduledTasksToggleWarningAtPast: 'The execution time of this task has passed. It will not run after enabling',
+    scheduledTasksToggleWarningAtPast:
+      'The execution time of this task has passed. It will not run after enabling',
     scheduledTasksToggleWarningExpired: 'This task has expired. It will not run after enabling',
-    scheduledTasksDataAnomalyWarning: 'Scheduled task "{name}" has abnormal data. Display has been auto-corrected. Consider re-editing this task',
+    scheduledTasksDataAnomalyWarning:
+      'Scheduled task "{name}" has abnormal data. Display has been auto-corrected. Consider re-editing this task',
 
     // Privacy dialog
     privacyDialogTitle: 'NetEase Youdao LobsterAI Terms of Service',
-    privacyDialogDesc: 'Before using NetEase Youdao LobsterAI, please carefully read the {link} and confirm.',
+    privacyDialogDesc:
+      'Before using NetEase Youdao LobsterAI, please carefully read the {link} and confirm.',
     privacyDialogLinkText: 'NetEase Youdao LobsterAI Terms of Service',
     privacyDialogAccept: 'I have read and agree',
     privacyDialogReject: 'Decline',
@@ -2553,25 +2692,26 @@ const translations: Record<LanguageType, Record<string, string>> = {
     githubCopilotSignIn: 'Sign in with GitHub',
     githubCopilotSignOut: 'Sign Out',
     githubCopilotRequesting: 'Requesting device code...',
-    githubCopilotEnterCode: 'Open the link below in your browser and enter the device code to authorize:',
+    githubCopilotEnterCode:
+      'Open the link below in your browser and enter the device code to authorize:',
     githubCopilotWaiting: 'Waiting for authorization...',
     githubCopilotConnected: 'Connected',
     githubCopilotNoSubscription: 'You do not have an active GitHub Copilot subscription',
     copy: 'Copy',
 
     'settings.enterprise.managed': 'Managed by enterprise',
-  }
+  },
 };
 
 class I18nService {
   private currentLanguage: LanguageType = 'zh';
   private listeners = new Set<() => void>();
-  
+
   constructor() {
     // 默认使用中文
     this.currentLanguage = 'zh';
   }
-  
+
   // 初始化语言设置
   async initialize(): Promise<void> {
     try {
@@ -2591,7 +2731,7 @@ class I18nService {
           this.currentLanguage = config.language;
           configService.updateConfig({
             ...config,
-            language_initialized: true
+            language_initialized: true,
           });
         } else {
           // 新用户或使用默认中文的旧用户:检测系统语言
@@ -2599,7 +2739,9 @@ class I18nService {
             const systemLocale = await window.electron.appInfo.getSystemLocale();
             const defaultLanguage = this.inferLanguageFromLocale(systemLocale);
 
-            console.log(`[i18n] First run detected. System locale: ${systemLocale}, default language: ${defaultLanguage}`);
+            console.log(
+              `[i18n] First run detected. System locale: ${systemLocale}, default language: ${defaultLanguage}`,
+            );
 
             this.currentLanguage = defaultLanguage;
 
@@ -2607,7 +2749,7 @@ class I18nService {
             configService.updateConfig({
               ...config,
               language: defaultLanguage,
-              language_initialized: true
+              language_initialized: true,
             });
           } catch (error) {
             console.error('Failed to get system locale:', error);
@@ -2616,7 +2758,7 @@ class I18nService {
             configService.updateConfig({
               ...config,
               language: 'en',
-              language_initialized: true
+              language_initialized: true,
             });
           }
         }
@@ -2629,7 +2771,7 @@ class I18nService {
           this.currentLanguage = 'en';
           configService.updateConfig({
             ...config,
-            language: 'en'
+            language: 'en',
           });
         }
       }
@@ -2648,7 +2790,7 @@ class I18nService {
     }
     return 'en'; // 默认英文 (包括 zh-TW, zh-HK, en-*, 以及其他所有语言)
   }
-  
+
   // 设置语言
   setLanguage(language: LanguageType, options: { persist?: boolean } = {}): void {
     const { persist = true } = options;
@@ -2656,7 +2798,7 @@ class I18nService {
     this.currentLanguage = language;
 
     if (hasChanged) {
-      this.listeners.forEach((listener) => listener());
+      this.listeners.forEach(listener => listener());
     }
 
     if (!persist) {
@@ -2668,18 +2810,18 @@ class I18nService {
       const config = configService.getConfig();
       configService.updateConfig({
         ...config,
-        language
+        language,
       });
     } catch (error) {
       console.error('Failed to save language setting:', error);
     }
   }
-  
+
   // 获取当前语言
   getLanguage(): LanguageType {
     return this.currentLanguage;
   }
-  
+
   // 获取翻译文本
   t(key: string): string {
     const translation = translations[this.currentLanguage][key];
@@ -2700,4 +2842,4 @@ class I18nService {
   }
 }
 
-export const i18nService = new I18nService(); 
+export const i18nService = new I18nService();


### PR DESCRIPTION
## 背景

当用户在模型配置页面点击「测试连接」时，若连接失败，之前只会显示一句简单的「连接失败」或「连接失败: 0」，缺少可帮助用户定位问题的上下文信息。

## 改动内容

### `src/renderer/services/i18n.ts`

新增 13 个 i18n Key（中英文双语），覆盖以下场景：

| Key | 中文 | 英文 |
|-----|------|------|
| `connectionFailedNetwork` | 无法连接到服务器 | Unable to connect to server |
| `connectionFailedNetworkHint` | 请检查网络连接及 Base URL 配置 | Please check your network connection and Base URL configuration |
| `connectionTestUrl` | 测试地址 | Test URL |
| `connectionStatus400` | 请求格式错误 | Bad request |
| `connectionStatus401` | API Key 无效或已过期，请检查密钥配置 | API Key is invalid or expired, please check your key configuration |
| `connectionStatus403` | 访问被拒绝，请检查 API Key 权限或账户状态 | Access denied, please check your API Key permissions or account status |
| `connectionStatus404` | API 端点不存在，请检查 Base URL 配置 | API endpoint not found, please check your Base URL configuration |
| `connectionStatus429` | 请求过于频繁，已触发速率限制，请稍后再试 | Too many requests, rate limit triggered, please try again later |
| `connectionStatus500` | 服务器内部错误，请稍后再试 | Internal server error, please try again later |
| `connectionStatus502` | 网关错误，服务暂时不可用 | Gateway error, service temporarily unavailable |
| `connectionStatus503` | 服务暂时不可用，请稍后再试 | Service temporarily unavailable, please try again later |

### `src/renderer/components/Settings.tsx`

**新增两个模块级工具函数：**

- `getConnectionStatusHint(status: number)` — 将 HTTP 状态码映射为人类可读的说明文字
- `buildConnectionErrorMessage(response, testUrl)` — 根据响应内容组装结构化的多行错误信息

**更新 `handleTestConnection` 错误处理逻辑：**

- 在 Anthropic 和 OpenAI 两条分支中均记录实际请求 URL（`testRequestUrl`），用于在错误信息中展示
- 将原来简单的 `data.error?.message || data.message || "连接失败: {status}"` 替换为调用 `buildConnectionErrorMessage`，按场景组装结构化的多行提示

## 各场景错误信息对比

| 场景 | 改动前 | 改动后 |
|------|--------|--------|
| 网络不通 (status 0) | `连接失败: 0` | `无法连接到服务器` + 原始网络错误 + 测试地址 + 配置检查提示 |
| API Key 错误 (401) | 仅服务器原文（或无内容） | `HTTP 401 — API Key 无效或已过期，请检查密钥配置` + 服务器原文（如有） |
| 端点不存在 (404) | `连接失败: 404` | `HTTP 404 — API 端点不存在，请检查 Base URL 配置` + 测试地址 |
| 速率限制 (429) | `连接失败: 429` | `HTTP 429 — 请求过于频繁，已触发速率限制，请稍后再试` |
| 服务器错误 (5xx) | `连接失败: 500` | `HTTP 500 — 服务器内部错误，请稍后再试` |
| 其他 HTTP 错误 | 仅服务器原文或裸状态码 | HTTP 状态 + 说明 + 服务器原文 + 测试地址（无法识别时） |

## 兼容性说明

- 「model output limit was reached」的特殊成功判断逻辑保持不变
- 结果弹窗已有 `whitespace-pre-wrap` 和 `max-h-56 overflow-y-auto` 样式，多行内容可正常展示与滚动
- 无 Breaking Change，纯展示层增强，不涉及任何 IPC / 存储 / 数据结构变动