### PR TITLE
fix(security): 避免 api 代理日志泄露凭证与完整响应体

### DIFF
--- a/src/main/libs/apiProxyLog.test.ts
+++ b/src/main/libs/apiProxyLog.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from 'vitest';
+import {
+  sanitizeUrlForApiProxyLog,
+  responsePayloadByteLength,
+} from './apiProxyLog';
+
+test('sanitizeUrlForApiProxyLog strips query and hash', () => {
+  expect(
+    sanitizeUrlForApiProxyLog('https://api.example.com/v1/chat?key=secret#frag'),
+  ).toBe('https://api.example.com/v1/chat');
+});
+
+test('sanitizeUrlForApiProxyLog returns placeholder for invalid input', () => {
+  expect(sanitizeUrlForApiProxyLog('not-a-url')).toBe('(invalid-url)');
+});
+
+test('responsePayloadByteLength measures string utf8 bytes', () => {
+  expect(responsePayloadByteLength('a')).toBe(1);
+  expect(responsePayloadByteLength('é')).toBe(2);
+});
+
+test('responsePayloadByteLength measures json object', () => {
+  expect(responsePayloadByteLength({ a: 1 })).toBeGreaterThan(0);
+});

--- a/src/main/libs/apiProxyLog.ts
+++ b/src/main/libs/apiProxyLog.ts
@@ -1,0 +1,51 @@
+/**
+ * Safe logging for api:fetch / api:stream — avoids writing credentials or response
+ * bodies to electron-log at info level.
+ */
+
+export function sanitizeUrlForApiProxyLog(urlString: string): string {
+  try {
+    const u = new URL(urlString);
+    return `${u.protocol}//${u.host}${u.pathname}`;
+  } catch {
+    return '(invalid-url)';
+  }
+}
+
+export function responsePayloadByteLength(data: string | object): number {
+  if (typeof data === 'string') {
+    return Buffer.byteLength(data, 'utf8');
+  }
+  try {
+    return Buffer.byteLength(JSON.stringify(data), 'utf8');
+  } catch {
+    return 0;
+  }
+}
+
+export function logApiProxyRequestDebug(
+  method: string,
+  urlString: string,
+  headers: Record<string, string>,
+  body: string | undefined,
+): void {
+  const safeUrl = sanitizeUrlForApiProxyLog(urlString);
+  const bodyBytes = body != null ? Buffer.byteLength(body, 'utf8') : 0;
+  console.debug(
+    `[ApiProxy] Starting ${method} request to ${safeUrl} with ${Object.keys(headers).length} request headers and a ${bodyBytes}-byte body`,
+  );
+}
+
+export function logApiProxyResponseDebug(
+  method: string,
+  urlString: string,
+  status: number,
+  statusText: string,
+  data: string | object,
+): void {
+  const safeUrl = sanitizeUrlForApiProxyLog(urlString);
+  const bytes = responsePayloadByteLength(data);
+  console.debug(
+    `[ApiProxy] Received ${method} response from ${safeUrl}: HTTP ${status} ${statusText}, ${bytes} bytes in body`,
+  );
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -76,6 +76,11 @@ import type { McpBridgeConfig } from './libs/openclawConfigSync';
 import { downloadUpdate, installUpdate, cancelActiveDownload } from './libs/appUpdateInstaller';
 import { resolveEnterpriseConfigPath, syncEnterpriseConfig, mergeEnterpriseOpenclawConfig } from './libs/enterpriseConfigSync';
 import { initLogger, getLogFilePath, getRecentMainLogEntries } from './logger';
+import {
+  logApiProxyRequestDebug,
+  logApiProxyResponseDebug,
+  sanitizeUrlForApiProxyLog,
+} from './libs/apiProxyLog';
 import { getCoworkLogPath } from './libs/coworkLogger';
 import { exportLogsZip } from './libs/logExport';
 import { ensurePythonRuntimeReady } from './libs/pythonRuntime';
@@ -4085,7 +4090,7 @@ if (!gotTheLock) {
     headers: Record<string, string>;
     body?: string;
   }) => {
-    console.log(`[api:fetch] ${options.method} ${options.url}, headers: ${JSON.stringify(options.headers)}, body: ${options.body}`);
+    logApiProxyRequestDebug(options.method, options.url, options.headers, options.body);
 
     const doFetch = async (headers: Record<string, string>) => {
       const response = await session.defaultSession.fetch(options.url, {
@@ -4116,21 +4121,42 @@ if (!gotTheLock) {
 
     try {
       let result = await doFetch(options.headers);
-      console.log(`[api:fetch] ${options.method} ${options.url} -> ${result.status} ${result.statusText}`, typeof result.data === 'object' ? JSON.stringify(result.data) : result.data);
+      logApiProxyResponseDebug(
+        options.method,
+        options.url,
+        result.status,
+        result.statusText,
+        result.data,
+      );
+      console.log(
+        `[ApiProxy] Finished ${options.method} request to ${sanitizeUrlForApiProxyLog(options.url)} with HTTP status ${result.status}`,
+      );
 
       // Auto-retry once for Copilot 401/403
       if (!result.ok && (result.status === 401 || result.status === 403) && isCopilotUrl(options.url)) {
-        console.log('[api:fetch] Copilot auth error, attempting token refresh and retry');
+        console.log('[ApiProxy] Copilot rejected credentials; refreshing token and retrying');
         const { headers: refreshedHeaders, retried } = await retryCopilotWithRefreshedToken(options);
         if (retried) {
           result = await doFetch(refreshedHeaders);
-          console.log(`[api:fetch] retry -> ${result.status} ${result.statusText}`);
+          logApiProxyResponseDebug(
+            options.method,
+            options.url,
+            result.status,
+            result.statusText,
+            result.data,
+          );
+          console.log(
+            `[ApiProxy] After token refresh, finished ${options.method} request to ${sanitizeUrlForApiProxyLog(options.url)} with HTTP status ${result.status}`,
+          );
         }
       }
 
       return result;
     } catch (error) {
-      console.error(`[api:fetch] ${options.method} ${options.url} -> ERROR:`, error instanceof Error ? error.message : error);
+      console.error(
+        `[ApiProxy] Outbound request failed for ${sanitizeUrlForApiProxyLog(options.url)}:`,
+        error,
+      );
       return {
         ok: false,
         status: 0,
@@ -4165,7 +4191,7 @@ if (!gotTheLock) {
 
       // Auto-retry once for Copilot 401/403
       if (!response.ok && (response.status === 401 || response.status === 403) && isCopilotUrl(options.url)) {
-        console.log('[api:stream] Copilot auth error, attempting token refresh and retry');
+        console.log('[ApiProxy] Copilot rejected streaming credentials; refreshing token and retrying');
         const { headers: refreshedHeaders, retried } = await retryCopilotWithRefreshedToken(options);
         if (retried) {
           response = await session.defaultSession.fetch(options.url, {
@@ -4174,7 +4200,9 @@ if (!gotTheLock) {
             body: options.body,
             signal: controller.signal,
           });
-          console.log(`[api:stream] retry -> ${response.status} ${response.statusText}`);
+          console.log(
+            `[ApiProxy] After token refresh, streaming ${options.method} request to ${sanitizeUrlForApiProxyLog(options.url)} returned HTTP ${response.status}`,
+          );
         }
       }
 


### PR DESCRIPTION
## 问题

`api:fetch` 处理函数曾在 **info** 级别打印完整请求 URL（含 query）、全部请求头、原始 body 以及完整响应数据。这会把 API Key、Bearer Token、对话内容等写入 electron-log 日志文件。

## 改动

- 新增 `src/main/libs/apiProxyLog.ts`：日志中的 URL 仅保留 **协议 + 主机 + 路径**（去掉 query/hash）；请求与响应的细节仅在 `console.debug` 中记录 **header 数量、body 字节数、响应体字节数**，不记录具体内容。
- `src/main/main.ts` 中 `api:fetch`：用一条可读的 info 级别句子汇总每次请求（method、脱敏 URL、HTTP 状态码）；错误日志附带脱敏 URL 与 Error 对象。
- `api:stream` 中 Copilot 重试相关日志统一为 `[ApiProxy]` 标签，并对 URL 做相同脱敏（不新增 body 日志）。
- `src/main/libs/apiProxyLog.test.ts`：为 URL 脱敏与响应体字节统计补充 Vitest 单测。

## 测试

- `npm test -- apiProxyLog`