### PR TITLE
fix(security): 为渲染进程 kv store IPC 增加键白名单

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -85,6 +85,7 @@ import {
   restoreOriginalProxyEnv,
   setSystemProxyEnabled,
 } from './libs/systemProxy';
+import { isAllowedRendererKvStoreKey, RendererKvStoreKey } from '../shared/rendererKvStoreKeys';
 
 // 设置应用程序名称
 app.name = APP_NAME;
@@ -1728,12 +1729,20 @@ if (!gotTheLock) {
 
   // IPC 处理程序
   ipcMain.handle('store:get', (_event, key) => {
+    if (!isAllowedRendererKvStoreKey(key)) {
+      console.warn('[KvStore] Rejected store:get from the renderer because the key is not on the allowlist');
+      throw new Error('KvStore: key is not exposed to the renderer process');
+    }
     return getStore().get(key);
   });
 
   ipcMain.handle('store:set', async (_event, key, value) => {
+    if (!isAllowedRendererKvStoreKey(key)) {
+      console.warn('[KvStore] Rejected store:set from the renderer because the key is not on the allowlist');
+      throw new Error('KvStore: key is not exposed to the renderer process');
+    }
     getStore().set(key, value);
-    if (key === 'app_config') {
+    if (key === RendererKvStoreKey.AppConfig) {
       refreshEndpointsTestMode(getStore());
       const syncResult = await syncOpenClawConfig({
         reason: 'app-config-change',
@@ -1746,6 +1755,10 @@ if (!gotTheLock) {
   });
 
   ipcMain.handle('store:remove', (_event, key) => {
+    if (!isAllowedRendererKvStoreKey(key)) {
+      console.warn('[KvStore] Rejected store:remove from the renderer because the key is not on the allowlist');
+      throw new Error('KvStore: key is not exposed to the renderer process');
+    }
     getStore().delete(key);
   });
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -20,7 +20,7 @@ import { coworkService } from './services/cowork';
 import { authService } from './services/auth';
 import { scheduledTaskService } from './services/scheduledTask';
 import { checkForAppUpdate, type AppUpdateInfo, type AppUpdateDownloadProgress, UPDATE_POLL_INTERVAL_MS, UPDATE_HEARTBEAT_INTERVAL_MS } from './services/appUpdate';
-import { defaultConfig, getProviderDisplayName } from './config';
+import { CONFIG_KEYS, defaultConfig, getProviderDisplayName } from './config';
 import { setAvailableModels, setSelectedModel } from './store/slices/modelSlice';
 import { clearSelection } from './store/slices/quickActionSlice';
 import { setDraftPrompt } from './store/slices/coworkSlice';
@@ -161,7 +161,7 @@ const App: React.FC = () => {
         }
 
         // 检查隐私协议是否已同意（必须在 setIsInitialized 之前）
-        const agreed = await window.electron.store.get('privacy_agreed');
+        const agreed = await window.electron.store.get(CONFIG_KEYS.PRIVACY_AGREED);
         setPrivacyAgreed(agreed === true);
 
         setIsInitialized(true);
@@ -423,7 +423,7 @@ const App: React.FC = () => {
   }, []);
 
   const handlePrivacyAccept = useCallback(async () => {
-    await window.electron.store.set('privacy_agreed', true);
+    await window.electron.store.set(CONFIG_KEYS.PRIVACY_AGREED, true);
     setPrivacyAgreed(true);
   }, []);
 

--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -1,4 +1,5 @@
 import { ProviderRegistry } from '@shared/providers';
+import { RendererKvStoreKey } from '@shared/rendererKvStoreKeys';
 
 // 配置类型定义
 export interface AppConfig {
@@ -323,12 +324,13 @@ export const defaultConfig: AppConfig = {
   }
 };
 
-// 配置存储键
+// 配置存储键（与主进程 store IPC 白名单一致，见 RendererKvStoreKey）
 export const CONFIG_KEYS = {
-  APP_CONFIG: 'app_config',
+  APP_CONFIG: RendererKvStoreKey.AppConfig,
   AUTH: 'auth_state',
   CONVERSATIONS: 'conversations',
-  PROVIDERS_EXPORT_KEY: 'providers_export_key',
+  PROVIDERS_EXPORT_KEY: RendererKvStoreKey.ProvidersExportKey,
+  PRIVACY_AGREED: RendererKvStoreKey.PrivacyAgreed,
   SKILLS: 'skills',
 };
 

--- a/src/shared/rendererKvStoreKeys.test.ts
+++ b/src/shared/rendererKvStoreKeys.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from 'vitest';
+import {
+  RendererKvStoreKey,
+  isAllowedRendererKvStoreKey,
+} from './rendererKvStoreKeys';
+
+test('isAllowedRendererKvStoreKey accepts renderer keys only', () => {
+  expect(isAllowedRendererKvStoreKey(RendererKvStoreKey.AppConfig)).toBe(true);
+  expect(isAllowedRendererKvStoreKey(RendererKvStoreKey.ProvidersExportKey)).toBe(
+    true,
+  );
+  expect(isAllowedRendererKvStoreKey(RendererKvStoreKey.PrivacyAgreed)).toBe(true);
+});
+
+test('isAllowedRendererKvStoreKey rejects sensitive and unknown keys', () => {
+  expect(isAllowedRendererKvStoreKey('auth_tokens')).toBe(false);
+  expect(isAllowedRendererKvStoreKey('enterprise_config')).toBe(false);
+  expect(isAllowedRendererKvStoreKey('skills_state')).toBe(false);
+  expect(isAllowedRendererKvStoreKey('')).toBe(false);
+  expect(isAllowedRendererKvStoreKey(null)).toBe(false);
+});

--- a/src/shared/rendererKvStoreKeys.ts
+++ b/src/shared/rendererKvStoreKeys.ts
@@ -1,0 +1,18 @@
+/**
+ * KV keys the renderer may read/write via store:get / store:set / store:remove.
+ * All other keys (e.g. auth_tokens, enterprise_config) are main-process only.
+ */
+export const RendererKvStoreKey = {
+  AppConfig: 'app_config',
+  ProvidersExportKey: 'providers_export_key',
+  PrivacyAgreed: 'privacy_agreed',
+} as const;
+
+export type RendererKvStoreKey =
+  (typeof RendererKvStoreKey)[keyof typeof RendererKvStoreKey];
+
+const ALLOWED = new Set<string>(Object.values(RendererKvStoreKey));
+
+export function isAllowedRendererKvStoreKey(key: unknown): key is string {
+  return typeof key === 'string' && ALLOWED.has(key);
+}


### PR DESCRIPTION
## 问题

`store:get` / `store:set` / `store:remove` 此前对 **任意** `kv` 键开放，渲染进程可读写 `auth_tokens`、`enterprise_config`、`github_copilot_github_token`、`skills_state` 等仅应由主进程管理的敏感数据，削弱纵深防御（例如在渲染层被突破时）。

## 改动

- 新增 `src/shared/rendererKvStoreKeys.ts`：定义渲染进程允许的键 `RendererKvStoreKey`（当前为 `app_config`、`providers_export_key`、`privacy_agreed`）及 `isAllowedRendererKvStoreKey()`。
- `src/main/main.ts`：上述三个 IPC 在处理前校验键；不允许时 `console.warn`（英文）并 `throw`，避免静默失败或误写。
- `app_config` 变更后的 OpenClaw 同步条件改为与 `RendererKvStoreKey.AppConfig` 比较，避免裸字符串。
- `src/renderer/config.ts`：`CONFIG_KEYS` 中与应用设置相关的键引用共享常量，并新增 `PRIVACY_AGREED`。
- `src/renderer/App.tsx`：隐私协议同意状态改用 `CONFIG_KEYS.PRIVACY_AGREED`。
- `src/shared/rendererKvStoreKeys.test.ts`：Vitest 覆盖允许/拒绝逻辑。

## 说明

- 企业配置等仍通过既有 `enterprise:getConfig` 等专用 IPC；认证令牌仍仅由主进程 `auth_*` 流程读写。
- 若将来渲染进程需要新的 kv 键，须同时扩展 `RendererKvStoreKey` 并审计敏感性。

## 测试

- `npm test -- rendererKvStoreKeys`
- `npx tsc --noEmit`
