### PR TITLE
feat(cowork): Cowork 会话完成/失败时发送系统通知

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -69,6 +69,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorUnknown: '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
     imErrorPrefix: '处理消息时出错',
 
+    // Session completion notifications (used by renderer i18n, kept here for reference)
+
     // Exec approval continuation
     execApprovalApproved: '用户已确认执行该命令，请检查执行结果并继续。',
     execApprovalDenied: '用户已拒绝执行该命令。',
@@ -243,6 +245,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
     coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
     imErrorPrefix: 'Error processing message',
+
+    // Session completion notifications (used by renderer i18n, kept here for reference)
 
     // Exec approval continuation
     execApprovalApproved: 'The user approved the command execution. Please check the result and continue.',

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,83 +1,78 @@
-import { app, BrowserWindow, ipcMain, session, nativeTheme, dialog, shell, nativeImage, systemPreferences, Menu, protocol, net, powerMonitor, powerSaveBlocker } from 'electron';
+import type { PermissionResult } from '@anthropic-ai/claude-agent-sdk';
 import type { WebContents } from 'electron';
-import path from 'path';
+import { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, nativeTheme, net, Notification,powerMonitor, powerSaveBlocker, protocol, session, shell, systemPreferences } from 'electron';
 import fs from 'fs';
 import os from 'os';
-import { SqliteStore } from './sqliteStore';
-import { CoworkStore } from './coworkStore';
-import { AgentManager } from './agentManager';
-import { CoworkRunner } from './libs/coworkRunner';
-import {
-  ClaudeRuntimeAdapter,
-  CoworkEngineRouter,
-  OpenClawRuntimeAdapter,
-  type CoworkAgentEngine,
-} from './libs/agentEngine';
-import { SkillManager } from './skillManager';
-import type { PermissionResult } from '@anthropic-ai/claude-agent-sdk';
-import { getCurrentApiConfig, resolveCurrentApiConfig, setStoreGetter, setAuthTokensGetter, setServerBaseUrlGetter, updateServerModelMetadata, clearServerModelMetadata } from './libs/claudeSettings';
-import { saveCoworkApiConfig } from './libs/coworkConfigStore';
-import { generateSessionTitle, probeCoworkModelReadiness } from './libs/coworkUtil';
-import { startCoworkOpenAICompatProxy, stopCoworkOpenAICompatProxy, registerProxyTokenRefresher } from './libs/coworkOpenAICompatProxy';
-import { startOpenClawTokenProxy, stopOpenClawTokenProxy } from './libs/openclawTokenProxy';
-import { OpenClawEngineManager, type OpenClawEngineStatus } from './libs/openclawEngineManager';
-import {
-  listPairingRequests,
-  approvePairingCode,
-  rejectPairingRequest,
-  readAllowFromStore,
-} from './im/imPairingStore';
-import { OpenClawConfigSync } from './libs/openclawConfigSync';
-import {
-  initCopilotTokenManager,
-  setCopilotTokenState,
-  clearCopilotTokenState,
-  refreshCopilotTokenNow,
-} from './libs/copilotTokenManager';
-import {
-  resolveMemoryFilePath,
-  readMemoryEntries,
-  addMemoryEntry,
-  updateMemoryEntry,
-  deleteMemoryEntry,
-  searchMemoryEntries,
-  migrateSqliteToMemoryMd,
-  syncMemoryFileOnWorkspaceChange,
-  readBootstrapFile,
-  writeBootstrapFile,
-  ensureDefaultIdentity,
-} from './libs/openclawMemoryFile';
-import {
-  OpenClawChannelSessionSync,
-  buildManagedSessionKey,
-  DEFAULT_MANAGED_AGENT_ID,
-} from './libs/openclawChannelSessionSync';
-import { IMGatewayManager, IMGatewayConfig } from './im';
-import type { Platform } from './im/types';
-import { APP_NAME } from './appConstants';
-import { getSkillServiceManager } from './skillServices';
-import { createTray, destroyTray, updateTrayMenu } from './trayManager';
-import { setLanguage, t } from './i18n';
-import { isAutoLaunched, getAutoLaunchEnabled, setAutoLaunchEnabled } from './autoLaunchManager';
-import { McpStore } from './mcpStore';
-import { migrateScheduledTasksToOpenclaw, migrateScheduledTaskRunsToOpenclaw } from '../scheduledTask/migrate';
+import path from 'path';
+
 import { buildScheduledTaskEnginePrompt } from '../scheduledTask/enginePrompt';
+import { migrateScheduledTaskRunsToOpenclaw,migrateScheduledTasksToOpenclaw } from '../scheduledTask/migrate';
 import { PlatformRegistry } from '../shared/platform';
+import { AgentManager } from './agentManager';
+import { APP_NAME } from './appConstants';
+import { getAutoLaunchEnabled, isAutoLaunched, setAutoLaunchEnabled } from './autoLaunchManager';
+import { CoworkStore } from './coworkStore';
+import { setLanguage, t } from './i18n';
+import { IMGatewayConfig,IMGatewayManager } from './im';
+import {
+  approvePairingCode,
+  listPairingRequests,
+  readAllowFromStore,
+  rejectPairingRequest,
+} from './im/imPairingStore';
+import type { Platform } from './im/types';
 import {
   getCronJobService,
   initCronJobServiceManager,
-  registerScheduledTaskHandlers,
   initScheduledTaskHelpers,
+  registerScheduledTaskHandlers,
 } from './ipcHandlers/scheduledTask';
-import { McpServerManager } from './libs/mcpServerManager';
-import { getServerApiBaseUrl, refreshEndpointsTestMode } from './libs/endpoints';
-import { McpBridgeServer } from './libs/mcpBridgeServer';
-import type { McpBridgeConfig } from './libs/openclawConfigSync';
-import { downloadUpdate, installUpdate, cancelActiveDownload } from './libs/appUpdateInstaller';
-import { resolveEnterpriseConfigPath, syncEnterpriseConfig, mergeEnterpriseOpenclawConfig } from './libs/enterpriseConfigSync';
-import { initLogger, getLogFilePath, getRecentMainLogEntries } from './logger';
+import {
+  ClaudeRuntimeAdapter,
+  type CoworkAgentEngine,
+  CoworkEngineRouter,
+  OpenClawRuntimeAdapter,
+} from './libs/agentEngine';
+import { cancelActiveDownload,downloadUpdate, installUpdate } from './libs/appUpdateInstaller';
+import { clearServerModelMetadata,getCurrentApiConfig, resolveCurrentApiConfig, setAuthTokensGetter, setServerBaseUrlGetter, setStoreGetter, updateServerModelMetadata } from './libs/claudeSettings';
+import {
+  clearCopilotTokenState,
+  initCopilotTokenManager,
+  refreshCopilotTokenNow,
+  setCopilotTokenState,
+} from './libs/copilotTokenManager';
+import { saveCoworkApiConfig } from './libs/coworkConfigStore';
 import { getCoworkLogPath } from './libs/coworkLogger';
+import { registerProxyTokenRefresher,startCoworkOpenAICompatProxy, stopCoworkOpenAICompatProxy } from './libs/coworkOpenAICompatProxy';
+import { CoworkRunner } from './libs/coworkRunner';
+import { generateSessionTitle, probeCoworkModelReadiness } from './libs/coworkUtil';
+import { getServerApiBaseUrl, refreshEndpointsTestMode } from './libs/endpoints';
+import { mergeEnterpriseOpenclawConfig,resolveEnterpriseConfigPath, syncEnterpriseConfig } from './libs/enterpriseConfigSync';
 import { exportLogsZip } from './libs/logExport';
+import { McpBridgeServer } from './libs/mcpBridgeServer';
+import { McpServerManager } from './libs/mcpServerManager';
+import {
+  buildManagedSessionKey,
+  DEFAULT_MANAGED_AGENT_ID,
+  OpenClawChannelSessionSync,
+} from './libs/openclawChannelSessionSync';
+import type { McpBridgeConfig } from './libs/openclawConfigSync';
+import { OpenClawConfigSync } from './libs/openclawConfigSync';
+import { OpenClawEngineManager, type OpenClawEngineStatus } from './libs/openclawEngineManager';
+import {
+  addMemoryEntry,
+  deleteMemoryEntry,
+  ensureDefaultIdentity,
+  migrateSqliteToMemoryMd,
+  readBootstrapFile,
+  readMemoryEntries,
+  resolveMemoryFilePath,
+  searchMemoryEntries,
+  syncMemoryFileOnWorkspaceChange,
+  updateMemoryEntry,
+  writeBootstrapFile,
+} from './libs/openclawMemoryFile';
+import { startOpenClawTokenProxy, stopOpenClawTokenProxy } from './libs/openclawTokenProxy';
 import { ensurePythonRuntimeReady } from './libs/pythonRuntime';
 import {
   applySystemProxyEnv,
@@ -85,10 +80,20 @@ import {
   restoreOriginalProxyEnv,
   setSystemProxyEnabled,
 } from './libs/systemProxy';
+import { getLogFilePath, getRecentMainLogEntries,initLogger } from './logger';
+import { McpStore } from './mcpStore';
+import { SkillManager } from './skillManager';
+import { getSkillServiceManager } from './skillServices';
+import { SqliteStore } from './sqliteStore';
+import { createTray, destroyTray, updateTrayMenu } from './trayManager';
 
 // 设置应用程序名称
 app.name = APP_NAME;
 app.setName(APP_NAME);
+// Required on Windows for system notifications to work
+if (process.platform === 'win32') {
+  app.setAppUserModelId(`🦞 ${APP_NAME}`);
+}
 
 const INVALID_FILE_NAME_PATTERN = /[<>:"/\\|?*\u0000-\u001F]/g;
 const MIN_MEMORY_USER_MEMORIES_MAX_ITEMS = 1;
@@ -3271,6 +3276,29 @@ if (!gotTheLock) {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to set config',
       };
+    }
+  });
+
+  // ==================== Session Notification IPC Handler ====================
+
+  ipcMain.handle('notification:send', (_event, params: { title: string; body: string; sessionId: string }) => {
+    try {
+      if (!Notification.isSupported()) return;
+      const notification = new Notification({
+        title: params.title,
+        body: params.body,
+        silent: false,
+      });
+      notification.on('click', () => {
+        if (mainWindow) {
+          if (mainWindow.isMinimized()) mainWindow.restore();
+          mainWindow.focus();
+          mainWindow.webContents.send('notification:clicked', params.sessionId);
+        }
+      });
+      notification.show();
+    } catch (error) {
+      console.debug('[Notification] failed to send notification:', error);
     }
   });
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+
 import { IpcChannel as ScheduledTaskIpc } from '../scheduledTask/constants';
 import type { Platform } from '../shared/platform';
 
@@ -126,6 +127,15 @@ contextBridge.exposeInMainWorld('electron', {
       const handler = (_event: any, state: { isMaximized: boolean; isFullscreen: boolean; isFocused: boolean }) => callback(state);
       ipcRenderer.on('window:state-changed', handler);
       return () => ipcRenderer.removeListener('window:state-changed', handler);
+    },
+  },
+  notification: {
+    send: (title: string, body: string, sessionId: string) =>
+      ipcRenderer.invoke('notification:send', { title, body, sessionId }),
+    onClicked: (callback: (sessionId: string) => void) => {
+      const handler = (_event: any, sessionId: string) => callback(sessionId);
+      ipcRenderer.on('notification:clicked', handler);
+      return () => ipcRenderer.removeListener('notification:clicked', handler);
     },
   },
   getApiConfig: () => ipcRenderer.invoke('get-api-config'),

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -1,22 +1,23 @@
-import React, { useEffect, useState, useCallback } from 'react';
-import Modal from './common/Modal';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import React, { useCallback,useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { RootState } from '../store';
+
 import { agentService } from '../services/agent';
 import { coworkService } from '../services/cowork';
 import { i18nService } from '../services/i18n';
-import CoworkSessionList from './cowork/CoworkSessionList';
+import { RootState } from '../store';
+import Modal from './common/Modal';
 import CoworkSearchModal from './cowork/CoworkSearchModal';
-import LoginButton from './LoginButton';
+import CoworkSessionList from './cowork/CoworkSessionList';
+import ClockIcon from './icons/ClockIcon';
 import ComposeIcon from './icons/ComposeIcon';
 import ConnectorIcon from './icons/ConnectorIcon';
-import SearchIcon from './icons/SearchIcon';
-import ClockIcon from './icons/ClockIcon';
 import PuzzleIcon from './icons/PuzzleIcon';
+import SearchIcon from './icons/SearchIcon';
 import SidebarToggleIcon from './icons/SidebarToggleIcon';
 import TrashIcon from './icons/TrashIcon';
-import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import UserGroupIcon from './icons/UserGroupIcon';
+import LoginButton from './LoginButton';
 
 interface SidebarProps {
   onShowSettings: () => void;
@@ -67,6 +68,19 @@ const Sidebar: React.FC<SidebarProps> = ({
     window.addEventListener('cowork:shortcut:search', handleSearch);
     return () => {
       window.removeEventListener('cowork:shortcut:search', handleSearch);
+    };
+  }, [onShowCowork]);
+
+  useEffect(() => {
+    const handleNotificationClick = (e: Event) => {
+      const sessionId = (e as CustomEvent<{ sessionId: string }>).detail?.sessionId;
+      if (!sessionId) return;
+      onShowCowork();
+      void coworkService.loadSession(sessionId);
+    };
+    window.addEventListener('cowork:notification:clicked', handleNotificationClick);
+    return () => {
+      window.removeEventListener('cowork:notification:clicked', handleNotificationClick);
     };
   }, [onShowCowork]);
 

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -1,36 +1,36 @@
+import { classifyErrorKey } from '../../common/coworkErrorClassify';
 import { store } from '../store';
 import {
-  setSessions,
-  setCurrentSession,
+  addMessage,
   addSession,
-  updateSessionStatus,
+  clearCurrentSession,
+  clearPendingPermissions,
   deleteSession as deleteSessionAction,
   deleteSessions as deleteSessionsAction,
-  addMessage,
-  updateMessageContent,
-  setStreaming,
-  setRemoteManaged,
-  updateSessionPinned,
-  updateSessionTitle,
-  enqueuePendingPermission,
   dequeuePendingPermission,
-  clearPendingPermissions,
+  enqueuePendingPermission,
   setConfig,
-  clearCurrentSession,
+  setCurrentSession,
+  setRemoteManaged,
+  setSessions,
+  setStreaming,
+  updateMessageContent,
+  updateSessionPinned,
+  updateSessionStatus,
+  updateSessionTitle,
 } from '../store/slices/coworkSlice';
 import type {
-  CoworkSession,
-  CoworkConfigUpdate,
   CoworkApiConfig,
-  CoworkUserMemoryEntry,
+  CoworkConfigUpdate,
+  CoworkContinueOptions,
   CoworkMemoryStats,
   CoworkPermissionResult,
-  OpenClawEngineStatus,
+  CoworkSession,
   CoworkStartOptions,
-  CoworkContinueOptions,
+  CoworkUserMemoryEntry,
+  OpenClawEngineStatus,
 } from '../types/cowork';
 import { i18nService } from './i18n';
-import { classifyErrorKey } from '../../common/coworkErrorClassify';
 
 const classifyError = (error: string): string => {
   const key = classifyErrorKey(error);
@@ -139,12 +139,46 @@ class CoworkService {
     // Complete listener
     const completeCleanup = cowork.onStreamComplete(({ sessionId }) => {
       store.dispatch(updateSessionStatus({ sessionId, status: 'completed' }));
+      // Send notification when window is hidden OR user is not viewing this session
+      const isWindowHidden = document.visibilityState === 'hidden';
+      const isViewingThisSession = store.getState().cowork.currentSessionId === sessionId;
+      if (isWindowHidden || !isViewingThisSession) {
+        try {
+          const state = store.getState().cowork;
+          const session = state.sessions.find(s => s.id === sessionId) ?? state.currentSession;
+          const title = session?.title?.trim() || i18nService.t('coworkNewSession');
+          void window.electron.notification.send(
+            i18nService.t('notificationTaskTitle').replace('{title}', title),
+            i18nService.t('notificationTaskCompleteBody'),
+            sessionId,
+          );
+        } catch {
+          // Silently ignore notification errors
+        }
+      }
     });
     this.streamListenerCleanups.push(completeCleanup);
 
     // Error listener
     const errorCleanup = cowork.onStreamError(({ sessionId, error }) => {
       store.dispatch(updateSessionStatus({ sessionId, status: 'error' }));
+      // Send error notification when window is hidden OR user is not viewing this session
+      const isWindowHidden = document.visibilityState === 'hidden';
+      const isViewingThisSession = store.getState().cowork.currentSessionId === sessionId;
+      if (isWindowHidden || !isViewingThisSession) {
+        try {
+          const state = store.getState().cowork;
+          const session = state.sessions.find(s => s.id === sessionId) ?? state.currentSession;
+          const title = session?.title?.trim() || i18nService.t('coworkNewSession');
+          void window.electron.notification.send(
+            i18nService.t('notificationTaskTitle').replace('{title}', title),
+            i18nService.t('notificationTaskErrorBody'),
+            sessionId,
+          );
+        } catch {
+          // Silently ignore notification errors
+        }
+      }
       // Surface the error as a visible message so the user knows what happened.
       if (error) {
         store.dispatch(addMessage({
@@ -159,6 +193,12 @@ class CoworkService {
       }
     });
     this.streamListenerCleanups.push(errorCleanup);
+
+    // Notification click listener - navigate to the session when user clicks a system notification
+    const notificationClickedCleanup = window.electron.notification.onClicked((sessionId: string) => {
+      window.dispatchEvent(new CustomEvent('cowork:notification:clicked', { detail: { sessionId } }));
+    });
+    this.streamListenerCleanups.push(notificationClickedCleanup);
 
     // Sessions changed listener (new channel sessions discovered by polling)
     const sessionsChangedCleanup = cowork.onSessionsChanged(() => {

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -18,7 +18,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: '用户',
     login: '登录',
     inDevelopment: '正在开发中',
-    
+
     // 设置
     settings: '设置',
     general: '通用',
@@ -45,7 +45,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: '主题色',
     chinese: '中文',
     english: 'English',
-    
+
     // API设置
     apiKey: 'API Key',
     apiKeyPlaceholder: '输入你的 API Key',
@@ -60,7 +60,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: '当前模型',
     availableModels: '可用模型列表',
     modelSwitchHint: '在聊天界面可以切换使用的模型',
-    
+
     // 模型提供商设置
     enabled: '已启用',
     disabled: '已禁用',
@@ -168,7 +168,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: '两次输入的密码不一致',
     passwordTooShort: '密码长度至少为4位',
     wrongPassword: '密码错误，请检查后重试',
-    
+
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
     shortcutNotSet: '未设置',
@@ -205,14 +205,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     planStandard: '标准',
     planAdvanced: '进阶',
     planPro: '专业',
-    
+
     // 错误信息
     failedToLoadSettings: '加载设置失败',
     failedToSaveSettings: '保存设置失败',
-    
+
     // 加载状态
     loading: '加载中...',
-    
+
     // 侧边栏
     conversations: '对话',
     noConversations: '暂无对话',
@@ -251,7 +251,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: '工作',
     folderIconCode: '代码',
     folderIconIdea: '灵感',
-    
+
     // 聊天窗口
     sendMessage: '发送消息',
     typeMessage: '询问任何问题...',
@@ -281,17 +281,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: '最多上传 10 张图片',
     imageReadError: '读取图片失败',
     imageInputNotSupported: '当前模型不支持图像输入',
-    
+
     // 模型选择
     selectModel: '选择模型',
-    
+
     // 错误提示
     errorOccurred: '发生错误',
     tryAgain: '请重试',
     networkError: '网络错误',
     apiKeyRequired: '需要设置API密钥',
     configureApiKey: '请在设置中配置您的API密钥',
-    
+
     // 初始化
     initializationError: '初始化应用程序失败。请检查您的配置。',
     apiKeyNotConfigured: 'API密钥未配置。请在设置中设置您的API密钥。',
@@ -511,6 +511,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     creating: '创建中...',
 
     coworkNewSession: '新会话',
+    notificationTaskTitle: '{title}',
+    notificationTaskCompleteBody: '已完成',
+    notificationTaskErrorBody: '执行出错',
     coworkContinuePlaceholder: '继续对话...',
     coworkRemoteManagedPlaceholder: '该会话由 IM 通道创建，请在对应的 IM 平台操作',
     aiGeneratedDisclaimer: '内容由 AI 生成，仅供参考',
@@ -1297,7 +1300,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: 'User',
     login: 'Login',
     inDevelopment: 'In development',
-    
+
     // Settings
     settings: 'Settings',
     general: 'General',
@@ -1324,7 +1327,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: 'Color Themes',
     chinese: 'Chinese',
     english: 'English',
-    
+
     // API Settings
     apiKey: 'API Key',
     apiKeyPlaceholder: 'Enter your API Key',
@@ -1339,7 +1342,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: 'Current Model',
     availableModels: 'Available Models',
     modelSwitchHint: 'You can switch models in the chat interface',
-    
+
     // Model Provider Settings
     enabled: 'Enabled',
     disabled: 'Disabled',
@@ -1447,7 +1450,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: 'Passwords do not match',
     passwordTooShort: 'Password must be at least 4 characters',
     wrongPassword: 'Wrong password, please try again',
-    
+
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
     shortcutNotSet: 'Not set',
@@ -1483,14 +1486,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     planFree: 'Free',
     planAdvanced: 'Advanced',
     planPro: 'Pro',
-    
+
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',
-    
+
     // Loading State
     loading: 'Loading...',
-    
+
     // Sidebar
     conversations: 'Conversations',
     noConversations: 'No conversations',
@@ -1529,7 +1532,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: 'Work',
     folderIconCode: 'Code',
     folderIconIdea: 'Ideas',
-    
+
     // Chat Window
     sendMessage: 'Send Message',
     typeMessage: 'Type a message...',
@@ -1559,17 +1562,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: 'Up to 10 images',
     imageReadError: 'Failed to read image',
     imageInputNotSupported: 'Current model does not support images',
-    
+
     // Model Selection
     selectModel: 'Select Model',
-    
+
     // Error Messages
     errorOccurred: 'An error occurred',
     tryAgain: 'Please try again',
     networkError: 'Network error',
     apiKeyRequired: 'API Key Required',
     configureApiKey: 'Please configure your API key in settings',
-    
+
     // Initialization
     initializationError: 'Failed to initialize application. Please check your configuration.',
     apiKeyNotConfigured: 'API key not configured. Please set up your API key in settings.',
@@ -1789,6 +1792,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     creating: 'Creating...',
 
     coworkNewSession: 'New Session',
+    notificationTaskTitle: '{title}',
+    notificationTaskCompleteBody: 'Completed',
+    notificationTaskErrorBody: 'Failed',
     coworkContinuePlaceholder: 'Continue the conversation...',
     coworkRemoteManagedPlaceholder: 'This session was created via IM. Please use the corresponding IM platform.',
     aiGeneratedDisclaimer: 'Content generated by AI, for reference only.',
@@ -2566,12 +2572,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
 class I18nService {
   private currentLanguage: LanguageType = 'zh';
   private listeners = new Set<() => void>();
-  
+
   constructor() {
     // 默认使用中文
     this.currentLanguage = 'zh';
   }
-  
+
   // 初始化语言设置
   async initialize(): Promise<void> {
     try {
@@ -2648,7 +2654,7 @@ class I18nService {
     }
     return 'en'; // 默认英文 (包括 zh-TW, zh-HK, en-*, 以及其他所有语言)
   }
-  
+
   // 设置语言
   setLanguage(language: LanguageType, options: { persist?: boolean } = {}): void {
     const { persist = true } = options;
@@ -2674,12 +2680,12 @@ class I18nService {
       console.error('Failed to save language setting:', error);
     }
   }
-  
+
   // 获取当前语言
   getLanguage(): LanguageType {
     return this.currentLanguage;
   }
-  
+
   // 获取翻译文本
   t(key: string): string {
     const translation = translations[this.currentLanguage][key];
@@ -2700,4 +2706,4 @@ class I18nService {
   }
 }
 
-export const i18nService = new I18nService(); 
+export const i18nService = new I18nService();

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -223,8 +223,9 @@ interface McpMarketplaceData {
   servers: McpMarketplaceServer[];
 }
 
-import type { Agent, PresetAgent } from './agent';
 import type { Platform } from '@shared/platform';
+
+import type { Agent, PresetAgent } from './agent';
 
 interface CreditItem {
   type: 'subscription' | 'boost' | 'free';
@@ -332,6 +333,10 @@ interface IElectronAPI {
     isMaximized: () => Promise<boolean>;
     showSystemMenu: (position: { x: number; y: number }) => void;
     onStateChanged: (callback: (state: WindowState) => void) => () => void;
+  };
+  notification: {
+    send: (title: string, body: string, sessionId: string) => Promise<void>;
+    onClicked: (callback: (sessionId: string) => void) => () => void;
   };
   cowork: {
     startSession: (options: { prompt: string; cwd?: string; systemPrompt?: string; title?: string; activeSkillIds?: string[]; agentId?: string; imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }> }) => Promise<{ success: boolean; session?: CoworkSession; error?: string; code?: string; engineStatus?: OpenClawEngineStatus }>;
@@ -981,4 +986,4 @@ declare global {
   }
 }
 
-export {}; 
+export {};


### PR DESCRIPTION
## Summary

Cowork 会话执行完成或失败时，通过操作系统原生通知提醒用户，解决用户切换到其他窗口后无法感知任务完成的问题。

## Changes Made

- **主进程** (`main.ts`)：注册 `notification:send` IPC handler，使用 Electron `Notification` API 发送系统通知；点击通知自动聚焦窗口并跳转到对应会话
- **预加载脚本** (`preload.ts`)：暴露 `window.electron.notification.send()` 和 `onClicked()` 方法
- **渲染进程** (`cowork.ts`)：在 `complete` / `error` 事件中触发通知；仅在窗口不可见或用户不在当前会话页面时通知
- **Sidebar.tsx**：监听通知点击事件，跳转到对应会话
- **i18n**：新增中英文通知文本
- **Windows 兼容**：设置 `AppUserModelId` 确保 Windows 下通知正常显示

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## 通知触发条件

| 场景 | 是否通知 |
|------|--------|
| 切到其他应用（窗口不可见） | ✅ |
| 切到其他 Agent | ✅ |
| 新建了另一个会话 | ✅ |
| 正在当前会话页面上看着它完成 | ❌ |

## 跨平台支持

- **Windows**：通过 `AppUserModelId` + Electron Notification API ✅
- **macOS**：Electron 原生支持 ✅
- **Linux**：通过 `libnotify` 支持 ✅（不可用时静默降级）

## 截图展示
<img width="582" height="198" alt="0407-06" src="https://github.com/user-attachments/assets/4040fa30-9455-44a2-80f7-fef4b36b3db6" />



## Testing

- [x] Tested locally
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [x] Changes to preload script (src/main/preload.ts)
- [x] Changes to IPC communication