### PR TITLE
fix(web-search): 修复 Bridge Server CORS 配置漏洞及 URL scheme 未校验问题

### DIFF
--- a/SKILLs/web-search/SKILL.md
+++ b/SKILLs/web-search/SKILL.md
@@ -2,7 +2,7 @@
 name: web-search
 description: Real-time web search using Playwright-controlled browser. Use this skill when you need current information, latest documentation, recent news, or any data beyond your knowledge cutoff (January 2025).
 official: true
-version: 1.0.1
+version: 1.0.2
 ---
 
 # Web Search Skill

--- a/SKILLs/web-search/package.json
+++ b/SKILLs/web-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobsterai/skill-web-search",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Web search skill using Playwright-controlled browser for real-time information retrieval",
   "main": "dist/server/index.js",
   "scripts": {

--- a/SKILLs/web-search/server/index.ts
+++ b/SKILLs/web-search/server/index.ts
@@ -16,6 +16,20 @@ import { SearchResponse } from './search/types';
 type SearchEngine = 'google' | 'bing';
 type SearchEnginePreference = SearchEngine | 'auto';
 
+const ALLOWED_URL_SCHEMES = ['http:', 'https:'];
+
+function validateNavigationUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+  if (!ALLOWED_URL_SCHEMES.includes(parsed.protocol)) {
+    throw new Error(`Blocked URL scheme "${parsed.protocol}" — only http/https allowed`);
+  }
+}
+
 function decodeJsonRequestBody(raw: Buffer): string {
   if (raw.length === 0) {
     return '';
@@ -118,9 +132,22 @@ export class BridgeServer {
 
     // CORS for localhost only
     this.app.use((req, res, next) => {
-      res.header('Access-Control-Allow-Origin', 'http://127.0.0.1:*');
-      res.header('Access-Control-Allow-Methods', 'GET, POST, DELETE');
+      const origin = req.headers.origin;
+      const isLocalhost = origin && /^http:\/\/(127\.0\.0\.1|localhost)(:\d+)?$/.test(origin);
+
+      if (isLocalhost) {
+        res.header('Access-Control-Allow-Origin', origin);
+      }
+
+      res.header('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
       res.header('Access-Control-Allow-Headers', 'Content-Type');
+      res.header('Vary', 'Origin');
+
+      if (req.method === 'OPTIONS') {
+        res.sendStatus(200);
+        return;
+      }
+
       next();
     });
 
@@ -440,6 +467,8 @@ export class BridgeServer {
         return;
       }
 
+      validateNavigationUrl(url);
+
       const content = await this.bingSearch.getResultContent(connectionId, url);
 
       res.json({
@@ -466,6 +495,8 @@ export class BridgeServer {
         });
         return;
       }
+
+      validateNavigationUrl(url);
 
       const page = await this.playwrightManager.getPage(connectionId);
       await navigate(page, { url, waitUntil, timeout });

--- a/SKILLs/web-search/server/search/bing.ts
+++ b/SKILLs/web-search/server/search/bing.ts
@@ -6,6 +6,20 @@ import { Page } from 'playwright-core';
 import { PlaywrightManager } from '../playwright/manager';
 import { SearchResult, SearchResponse } from './types';
 
+const ALLOWED_URL_SCHEMES = ['http:', 'https:'];
+
+function validateNavigationUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+  if (!ALLOWED_URL_SCHEMES.includes(parsed.protocol)) {
+    throw new Error(`Blocked URL scheme "${parsed.protocol}" — only http/https allowed`);
+  }
+}
+
 export interface BingSearchOptions {
   /** Maximum number of results to return */
   maxResults?: number;
@@ -122,6 +136,8 @@ export class BingSearch {
    */
   async getResultContent(connectionId: string, url: string): Promise<string> {
     console.log(`[Bing] Fetching content from: ${url}`);
+
+    validateNavigationUrl(url);
 
     const page = await this.playwrightManager.getPage(connectionId);
 

--- a/SKILLs/web-search/server/search/google.ts
+++ b/SKILLs/web-search/server/search/google.ts
@@ -6,6 +6,20 @@ import { Page } from 'playwright-core';
 import { PlaywrightManager } from '../playwright/manager';
 import { SearchResponse, SearchResult } from './types';
 
+const ALLOWED_URL_SCHEMES = ['http:', 'https:'];
+
+function validateNavigationUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+  if (!ALLOWED_URL_SCHEMES.includes(parsed.protocol)) {
+    throw new Error(`Blocked URL scheme "${parsed.protocol}" — only http/https allowed`);
+  }
+}
+
 export interface GoogleSearchOptions {
   /** Maximum number of results to return */
   maxResults?: number;
@@ -193,6 +207,8 @@ export class GoogleSearch {
    */
   async getResultContent(connectionId: string, url: string): Promise<string> {
     console.log(`[Google] Fetching content from: ${url}`);
+
+    validateNavigationUrl(url);
 
     const page = await this.playwrightManager.getPage(connectionId);
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "preview": "vite preview",
     "compile:electron": "tsc --project electron-tsconfig.json",
     "precompile:electron": "electron-builder install-app-deps",
-    "build:skill:web-search": "npm install --prefix SKILLs/web-search && npx tsc -p SKILLs/web-search/tsconfig.json",
+    "build:skill:web-search": "npm install --prefix SKILLs/web-search && npx tsc -p SKILLs/web-search/tsconfig.json && rm -f SKILLs/web-search/.connection SKILLs/web-search/.server.log SKILLs/web-search/.server.pid",
     "build:skill:tech-news": "node scripts/build-skill-tech-news.js",
     "build:skill:email": "cd SKILLs/imap-smtp-email && npm install --production",
     "build:skills": "npm run build:skill:web-search && npm run build:skill:tech-news && npm run build:skill:email",


### PR DESCRIPTION
- 将无效的静态 CORS header 替换为动态 Origin 校验，仅允许 localhost 来源
- 新增 URL scheme 白名单，拦截 file:/data:/javascript: 等非 http(s) 协议
- 添加 OPTIONS 预检处理和 Vary: Origin header
- 打包时清理 web-search 运行时临时文件（.connection/.server.log/.server.pid）