### PR TITLE
fix(i18n): hardcoded Chinese strings in approval dialogs break English mode

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -73,6 +73,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     execApprovalApproved: '用户已确认执行该命令，请检查执行结果并继续。',
     execApprovalDenied: '用户已拒绝执行该命令。',
 
+    // Safety approval options (shown in permission dialog)
+    safetyApprovalAllow: '允许本次操作',
+    safetyApprovalDeny: '拒绝本次操作',
+
     // Skill manager errors
     skillErrNoSkillMd: '来源中未找到 SKILL.md',
     skillErrInvalidSource: '无效的技能来源。支持 owner/repo、仓库链接、npm 包名、ClawHub 链接或 GitHub tree/blob 链接。',
@@ -247,6 +251,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Exec approval continuation
     execApprovalApproved: 'The user approved the command execution. Please check the result and continue.',
     execApprovalDenied: 'The user denied the command execution.',
+
+    // Safety approval options (shown in permission dialog)
+    safetyApprovalAllow: 'Allow this operation',
+    safetyApprovalDeny: 'Deny this operation',
 
     // Skill manager errors
     skillErrNoSkillMd: 'No SKILL.md found in source',

--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -47,7 +47,6 @@ const PERMISSION_CONFIRM_TIMEOUT_MS = 60_000;
 const ACCUMULATOR_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const IM_ALLOW_RESPONSE_RE = /^(允许|同意|yes|y)$/i;
 const IM_DENY_RESPONSE_RE = /^(拒绝|不同意|no|n)$/i;
-const IM_ALLOW_OPTION_LABEL = '允许本次操作';
 
 export interface IMCoworkHandlerOptions {
   coworkRuntime: CoworkRuntime;
@@ -717,12 +716,12 @@ export class IMCoworkHandler extends EventEmitter {
         : [];
       const preferredOption = options.find((option) => {
         const label = typeof option?.label === 'string' ? option.label : '';
-        return label.includes(IM_ALLOW_OPTION_LABEL);
+        return label.includes(t('safetyApprovalAllow'));
       });
       const fallbackOption = options[0];
       const selectedLabel = typeof preferredOption?.label === 'string'
         ? preferredOption.label
-        : (typeof fallbackOption?.label === 'string' ? fallbackOption.label : IM_ALLOW_OPTION_LABEL);
+        : (typeof fallbackOption?.label === 'string' ? fallbackOption.label : t('safetyApprovalAllow'));
       answers[questionTitle] = selectedLabel;
     });
 

--- a/src/main/libs/coworkRunner.ts
+++ b/src/main/libs/coworkRunner.ts
@@ -16,6 +16,7 @@ import { isQuestionLikeMemoryText, type CoworkMemoryGuardLevel } from './coworkM
 import { setCoworkProxySessionId } from './coworkOpenAICompatProxy';
 import { SCHEDULED_TASK_SWITCH_MESSAGE } from '../../scheduledTask/enginePrompt';
 import { z } from 'zod';
+import { t } from '../i18n';
 
 const ATTACHMENT_LINE_RE = /^\s*(?:[-*]\s*)?(输入文件|input\s*file)\s*[:：]\s*(.+?)\s*$/i;
 const INFERRED_FILE_REFERENCE_RE = /([^\s"'`，。！？：:；;（）()\[\]{}<>《》【】]+?\.[A-Za-z][A-Za-z0-9]{0,7})/g;
@@ -55,8 +56,6 @@ const TOOL_INPUT_PREVIEW_MAX_ITEMS = 30;
 const TASK_WORKSPACE_CONTAINER_DIR = '.lobsterai-tasks';
 const PERMISSION_RESPONSE_TIMEOUT_MS = 60_000;
 const DELETE_TOOL_NAMES = new Set(['delete', 'remove', 'unlink', 'rmdir']);
-const SAFETY_APPROVAL_ALLOW_OPTION = '允许本次操作';
-const SAFETY_APPROVAL_DENY_OPTION = '拒绝本次操作';
 const PYTHON_BASH_COMMAND_RE = /(?:^|[^\w.-])(?:python(?:3)?|py(?:\.exe)?|pip(?:3)?)(?:\s+-3)?(?:\s|$)|\.py(?:\s|$)/i;
 const PYTHON_PIP_BASH_COMMAND_RE = /(?:^|[^\w.-])(?:pip(?:3)?|python(?:3)?\s+-m\s+pip|py(?:\.exe)?\s+-m\s+pip)(?:\s|$)/i;
 const MEMORY_REQUEST_TAIL_SPLIT_RE = /[,，。]\s*(?:请|麻烦)?你(?:帮我|帮忙|给我|为我|看下|看一下|查下|查一下)|[,，。]\s*帮我|[,，。]\s*请帮我|[,，。]\s*(?:能|可以)不能?\s*帮我|[,，。]\s*你看|[,，。]\s*请你/i;
@@ -1262,11 +1261,11 @@ export class CoworkRunner extends EventEmitter {
           question,
           options: [
             {
-              label: SAFETY_APPROVAL_ALLOW_OPTION,
-              description: '仅允许当前这一次操作继续执行。',
-            },
-            {
-              label: SAFETY_APPROVAL_DENY_OPTION,
+          label: t('safetyApprovalAllow'),
+            description: '仅允许当前这一次操作继续执行。',
+          },
+          {
+            label: t('safetyApprovalDeny'),
               description: '拒绝当前操作，保持文件安全边界。',
             },
           ],
@@ -1304,7 +1303,7 @@ export class CoworkRunner extends EventEmitter {
       .split('|||')
       .map((value) => value.trim())
       .filter(Boolean)
-      .includes(SAFETY_APPROVAL_ALLOW_OPTION);
+      .includes(t('safetyApprovalAllow'));
   }
 
   private async requestSafetyApproval(

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -14,6 +14,7 @@ import type { McpToolManifestEntry } from './mcpServerManager';
 import { hasBundledOpenClawExtension } from './openclawLocalExtensions';
 import { buildScheduledTaskEnginePrompt } from '../../scheduledTask/enginePrompt';
 import { getOpenClawTokenProxyPort } from './openclawTokenProxy';
+import { getLanguage } from '../i18n';
 
 export type McpBridgeConfig = {
   callbackUrl: string;
@@ -1690,6 +1691,14 @@ export class OpenClawConfigSync {
 
       // Build the managed section
       const sections: string[] = [];
+
+      // Inject UI language directive for tool-generated confirmation dialogs.
+      // This only covers AskUserQuestion options and confirmations shown in the App UI,
+      // not general conversation language (IM channels respond in their user's language).
+      const uiLanguage = getLanguage();
+      if (uiLanguage === 'en') {
+        sections.push('## UI Language\n\nThe LobsterAI desktop app UI language is English. When you call the AskUserQuestion tool to ask the user for confirmation (e.g. before deleting files), write the question text and all option labels in English.');
+      }
 
       // Add system prompt if configured — strip MARKER to prevent content corruption
       const systemPrompt = (coworkConfig.systemPrompt || '').trim().replaceAll(MARKER, '');


### PR DESCRIPTION
[问题]
切换 App 语言为英文后，Cowork 会话中触发危险操作（如删除文件）时弹出的
审批对话框，问题文本与按钮选项仍然显示中文，与 UI 语言不一致。

[根因]
1. coworkRunner.ts 和 imCoworkHandler.ts 中将审批选项 label 硬编码为中文 常量（'允许本次操作' / '拒绝本次操作'），未经过 i18n 体系，语言切换后 不会跟随变化。

2. OpenClaw 引擎在生成 AskUserQuestion 工具调用时（用于弹出确认弹窗）， 未收到任何语言指令，导致始终以中文生成问题文本和按钮选项。

[修复]
- 在 src/main/i18n.ts 新增 safetyApprovalAllow / safetyApprovalDeny 键， 提供中英文翻译。
- coworkRunner.ts：删除硬编码常量，改为在构建选项和字符串比较处均调用 t('safetyApprovalAllow')，保证两处始终取同一语言的值。
- imCoworkHandler.ts：同上，删除 IM_ALLOW_OPTION_LABEL 硬编码常量。
- openclawConfigSync.ts：App 语言为英文时，在同步写入工作目录 AGENTS.md 的 managed section 里注入语言指令，要求 OpenClaw 在调用 AskUserQuestion 时使用英文，指令范围限定为确认弹窗，不影响 IM 渠道的对话语言。

[复现路径]
1. Settings -> 通用 -> 语言切换为 English
2. 新建 Cowork 会话，向 AI 发送 Delete the file test.txt
3. 弹出审批弹窗，观察问题文本和按钮是否为中文（修复前）/ 英文（修复后）
