### PR TITLE
fix(agent): sync activeSkillIds immediately when updating current agent's skills

### DIFF
--- a/src/renderer/services/agent.ts
+++ b/src/renderer/services/agent.ts
@@ -17,16 +17,20 @@ class AgentService {
     try {
       const agents = await window.electron?.agents?.list();
       if (agents) {
-        store.dispatch(setAgents(agents.map((a) => ({
-          id: a.id,
-          name: a.name,
-          description: a.description,
-          icon: a.icon,
-          enabled: a.enabled,
-          isDefault: a.isDefault,
-          source: a.source,
-          skillIds: a.skillIds ?? [],
-        }))));
+        store.dispatch(
+          setAgents(
+            agents.map(a => ({
+              id: a.id,
+              name: a.name,
+              description: a.description,
+              icon: a.icon,
+              enabled: a.enabled,
+              isDefault: a.isDefault,
+              source: a.source,
+              skillIds: a.skillIds ?? [],
+            })),
+          ),
+        );
       }
     } catch (error) {
       console.error('Failed to load agents:', error);
@@ -47,16 +51,18 @@ class AgentService {
     try {
       const agent = await window.electron?.agents?.create(request);
       if (agent) {
-        store.dispatch(addAgent({
-          id: agent.id,
-          name: agent.name,
-          description: agent.description,
-          icon: agent.icon,
-          enabled: agent.enabled,
-          isDefault: agent.isDefault,
-          source: agent.source,
-          skillIds: agent.skillIds ?? [],
-        }));
+        store.dispatch(
+          addAgent({
+            id: agent.id,
+            name: agent.name,
+            description: agent.description,
+            icon: agent.icon,
+            enabled: agent.enabled,
+            isDefault: agent.isDefault,
+            source: agent.source,
+            skillIds: agent.skillIds ?? [],
+          }),
+        );
         return agent;
       }
       return null;
@@ -66,29 +72,43 @@ class AgentService {
     }
   }
 
-  async updateAgent(id: string, updates: {
-    name?: string;
-    description?: string;
-    systemPrompt?: string;
-    identity?: string;
-    model?: string;
-    icon?: string;
-    skillIds?: string[];
-    enabled?: boolean;
-  }): Promise<Agent | null> {
+  async updateAgent(
+    id: string,
+    updates: {
+      name?: string;
+      description?: string;
+      systemPrompt?: string;
+      identity?: string;
+      model?: string;
+      icon?: string;
+      skillIds?: string[];
+      enabled?: boolean;
+    },
+  ): Promise<Agent | null> {
     try {
       const agent = await window.electron?.agents?.update(id, updates);
       if (agent) {
-        store.dispatch(updateAgentAction({
-          id: agent.id,
-          updates: {
-            name: agent.name,
-            description: agent.description,
-            icon: agent.icon,
-            enabled: agent.enabled,
-            skillIds: agent.skillIds ?? [],
-          },
-        }));
+        store.dispatch(
+          updateAgentAction({
+            id: agent.id,
+            updates: {
+              name: agent.name,
+              description: agent.description,
+              icon: agent.icon,
+              enabled: agent.enabled,
+              skillIds: agent.skillIds ?? [],
+            },
+          }),
+        );
+        // If the updated agent is currently active, sync activeSkillIds immediately
+        const currentAgentId = store.getState().agent.currentAgentId;
+        if (currentAgentId === agent.id) {
+          if (agent.skillIds?.length) {
+            store.dispatch(setActiveSkillIds(agent.skillIds));
+          } else {
+            store.dispatch(clearActiveSkills());
+          }
+        }
         return agent;
       }
       return null;
@@ -129,16 +149,18 @@ class AgentService {
     try {
       const agent = await window.electron?.agents?.addPreset(presetId);
       if (agent) {
-        store.dispatch(addAgent({
-          id: agent.id,
-          name: agent.name,
-          description: agent.description,
-          icon: agent.icon,
-          enabled: agent.enabled,
-          isDefault: agent.isDefault,
-          source: agent.source,
-          skillIds: agent.skillIds ?? [],
-        }));
+        store.dispatch(
+          addAgent({
+            id: agent.id,
+            name: agent.name,
+            description: agent.description,
+            icon: agent.icon,
+            enabled: agent.enabled,
+            isDefault: agent.isDefault,
+            source: agent.source,
+            skillIds: agent.skillIds ?? [],
+          }),
+        );
         return agent;
       }
       return null;
@@ -151,7 +173,7 @@ class AgentService {
   switchAgent(agentId: string): void {
     store.dispatch(setCurrentAgentId(agentId));
     store.dispatch(clearCurrentSession());
-    const agent = store.getState().agent.agents.find((a) => a.id === agentId);
+    const agent = store.getState().agent.agents.find(a => a.id === agentId);
     if (agent?.skillIds?.length) {
       store.dispatch(setActiveSkillIds(agent.skillIds));
     } else {


### PR DESCRIPTION
## 问题

在 Agent 设置面板中修改技能列表并保存后，当前对话的技能徽章（Active Skill Badges）不会立即更新。用户必须手动切换到其他 Agent 再切换回来才能看到新的技能配置生效。

Fixes #1502

## 根本原因

`agentService.updateAgent()` 调用 `store.dispatch(updateAgentAction(...))` 更新了 Redux 中 agent 的 `skillIds`，但没有同步更新 `state.skill.activeSkillIds`。

而 `activeSkillIds` 只在 `switchAgent()` 时会从 `agent.skillIds` 重新赋值，因此保存设置后不切换 Agent 就不会生效。

## 修复方案

在 `updateAgent()` 成功后，检查被更新的 agent 是否是当前激活的 agent。若是，则立即 dispatch `setActiveSkillIds`（或 `clearActiveSkills`），使技能列表变更即时反映到 UI。

## 改动文件

- `src/renderer/services/agent.ts` — 在 `updateAgent` 成功回调中补充对 `activeSkillIds` 的同步更新