### PR TITLE
feat(engine-overlay): 引擎启动超时后显示取消启动和查看日志按钮

### DIFF
--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -557,6 +557,27 @@ export class OpenClawEngineManager extends EventEmitter {
     });
   }
 
+  /**
+   * Cancel an in-progress startup. Sets shutdownRequested so the health-check
+   * polling loop aborts, then kills the gateway process and transitions to
+   * the 'ready' state so the user can retry later.
+   */
+  async cancelStartup(): Promise<OpenClawEngineStatus> {
+    if (this.status.phase !== 'starting') {
+      console.log('[OpenClaw] cancelStartup: not in starting phase, ignoring');
+      return this.getStatus();
+    }
+    console.log('[OpenClaw] cancelStartup: user requested startup cancellation');
+    await this.stopGateway();
+    // stopGateway sets shutdownRequested=true; reset it so future starts work.
+    this.shutdownRequested = false;
+    return this.getStatus();
+  }
+
+  getGatewayLogPath(): string {
+    return this.gatewayLogPath;
+  }
+
   async restartGateway(): Promise<OpenClawEngineStatus> {
     console.log('[OpenClaw] restartGateway: stopping existing gateway...');
     await this.stopGateway();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2309,6 +2309,31 @@ if (!gotTheLock) {
     }
   });
 
+  ipcMain.handle('openclaw:engine:cancelStartup', async () => {
+    try {
+      const manager = getOpenClawEngineManager();
+      const status = await manager.cancelStartup();
+      return { success: true, status };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to cancel startup',
+      };
+    }
+  });
+
+  ipcMain.handle('openclaw:engine:getGatewayLogPath', () => {
+    try {
+      const manager = getOpenClawEngineManager();
+      return { success: true, path: manager.getGatewayLogPath() };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to get log path',
+      };
+    }
+  });
+
   let restartGatewayPromise: Promise<OpenClawEngineStatus> | null = null;
   ipcMain.handle('openclaw:engine:restartGateway', async () => {
     if (restartGatewayPromise) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -142,6 +142,8 @@ contextBridge.exposeInMainWorld('electron', {
       install: () => ipcRenderer.invoke('openclaw:engine:install'),
       retryInstall: () => ipcRenderer.invoke('openclaw:engine:retryInstall'),
       restartGateway: () => ipcRenderer.invoke('openclaw:engine:restartGateway'),
+      cancelStartup: () => ipcRenderer.invoke('openclaw:engine:cancelStartup'),
+      getGatewayLogPath: () => ipcRenderer.invoke('openclaw:engine:getGatewayLogPath'),
       onProgress: (callback: (status: any) => void) => {
         const handler = (_event: any, status: any) => callback(status);
         ipcRenderer.on('openclaw:engine:onProgress', handler);

--- a/src/renderer/components/cowork/EngineStartupOverlay.tsx
+++ b/src/renderer/components/cowork/EngineStartupOverlay.tsx
@@ -1,10 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
 import type { OpenClawEngineStatus } from '../../types/cowork';
+
+/** Delay (ms) before showing cancel/view-logs buttons during startup. */
+const SHOW_ACTIONS_DELAY_MS = 30_000;
 
 const resolveEngineStatusText = (status: OpenClawEngineStatus): string => {
   switch (status.phase) {
@@ -27,11 +30,18 @@ const resolveEngineStatusText = (status: OpenClawEngineStatus): string => {
 /**
  * Global overlay shown when the OpenClaw gateway is starting up.
  * Renders on top of all views (cowork, skills, scheduled tasks, mcp).
+ *
+ * After {@link SHOW_ACTIONS_DELAY_MS} in the `starting` phase, "Cancel Startup"
+ * and "View Logs" buttons appear so the user has an escape hatch if the
+ * gateway is taking unusually long.
  */
 const EngineStartupOverlay: React.FC = () => {
   const config = useSelector((state: RootState) => state.cowork.config);
   const isOpenClawEngine = config.agentEngine !== 'yd_cowork';
   const [status, setStatus] = useState<OpenClawEngineStatus | null>(null);
+  const [showActions, setShowActions] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!isOpenClawEngine) return;
@@ -47,6 +57,28 @@ const EngineStartupOverlay: React.FC = () => {
     return unsubscribe;
   }, [isOpenClawEngine]);
 
+  // Start / reset the delayed-actions timer whenever the phase changes.
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setShowActions(false);
+
+    if (status?.phase === 'starting') {
+      timerRef.current = setTimeout(() => {
+        setShowActions(true);
+      }, SHOW_ACTIONS_DELAY_MS);
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [status?.phase]);
+
   if (!isOpenClawEngine || !status || status.phase !== 'starting') {
     return null;
   }
@@ -54,6 +86,22 @@ const EngineStartupOverlay: React.FC = () => {
   const progressPercent = typeof status.progressPercent === 'number'
     ? Math.max(0, Math.min(100, Math.round(status.progressPercent)))
     : null;
+
+  const handleCancelStartup = async () => {
+    setIsCancelling(true);
+    try {
+      await coworkService.cancelOpenClawStartup();
+    } finally {
+      setIsCancelling(false);
+    }
+  };
+
+  const handleViewLogs = async () => {
+    const logPath = await coworkService.getOpenClawGatewayLogPath();
+    if (logPath) {
+      window.electron?.shell?.showItemInFolder?.(logPath);
+    }
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/90 backdrop-blur-sm">
@@ -76,6 +124,25 @@ const EngineStartupOverlay: React.FC = () => {
               <div className="text-xs text-secondary">
                 {progressPercent}%
               </div>
+            </div>
+          )}
+          {showActions && (
+            <div className="flex items-center gap-3 mt-2">
+              <button
+                type="button"
+                disabled={isCancelling}
+                onClick={handleCancelStartup}
+                className="px-4 py-1.5 text-sm rounded-lg border border-border text-secondary hover:bg-surface-raised transition-colors disabled:opacity-50"
+              >
+                {i18nService.t('coworkOpenClawCancelStartup')}
+              </button>
+              <button
+                type="button"
+                onClick={handleViewLogs}
+                className="px-4 py-1.5 text-sm rounded-lg border border-border text-secondary hover:bg-surface-raised transition-colors"
+              >
+                {i18nService.t('coworkOpenClawViewLogs')}
+              </button>
             </div>
           )}
         </div>

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -661,6 +661,28 @@ class CoworkService {
     return this.openClawStatus;
   }
 
+  async cancelOpenClawStartup(): Promise<OpenClawEngineStatus | null> {
+    const engineApi = window.electron?.openclaw?.engine;
+    if (!engineApi?.cancelStartup) {
+      return null;
+    }
+    const result = await engineApi.cancelStartup();
+    if (result?.status) {
+      this.notifyOpenClawStatus(result.status);
+      return result.status;
+    }
+    return this.openClawStatus;
+  }
+
+  async getOpenClawGatewayLogPath(): Promise<string | null> {
+    const engineApi = window.electron?.openclaw?.engine;
+    if (!engineApi?.getGatewayLogPath) {
+      return null;
+    }
+    const result = await engineApi.getGatewayLogPath();
+    return result?.success ? result.path : null;
+  }
+
   async generateSessionTitle(prompt: string | null): Promise<string | null> {
     if (!window.electron?.generateSessionTitle) {
       return null;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -18,7 +18,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: '用户',
     login: '登录',
     inDevelopment: '正在开发中',
-    
+
     // 设置
     settings: '设置',
     general: '通用',
@@ -45,7 +45,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: '主题色',
     chinese: '中文',
     english: 'English',
-    
+
     // API设置
     apiKey: 'API Key',
     apiKeyPlaceholder: '输入你的 API Key',
@@ -60,7 +60,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: '当前模型',
     availableModels: '可用模型列表',
     modelSwitchHint: '在聊天界面可以切换使用的模型',
-    
+
     // 模型提供商设置
     enabled: '已启用',
     disabled: '已禁用',
@@ -168,7 +168,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: '两次输入的密码不一致',
     passwordTooShort: '密码长度至少为4位',
     wrongPassword: '密码错误，请检查后重试',
-    
+
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
     shortcutNotSet: '未设置',
@@ -205,14 +205,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     planStandard: '标准',
     planAdvanced: '进阶',
     planPro: '专业',
-    
+
     // 错误信息
     failedToLoadSettings: '加载设置失败',
     failedToSaveSettings: '保存设置失败',
-    
+
     // 加载状态
     loading: '加载中...',
-    
+
     // 侧边栏
     conversations: '对话',
     noConversations: '暂无对话',
@@ -251,7 +251,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: '工作',
     folderIconCode: '代码',
     folderIconIdea: '灵感',
-    
+
     // 聊天窗口
     sendMessage: '发送消息',
     typeMessage: '询问任何问题...',
@@ -281,17 +281,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: '最多上传 10 张图片',
     imageReadError: '读取图片失败',
     imageInputNotSupported: '当前模型不支持图像输入',
-    
+
     // 模型选择
     selectModel: '选择模型',
-    
+
     // 错误提示
     errorOccurred: '发生错误',
     tryAgain: '请重试',
     networkError: '网络错误',
     apiKeyRequired: '需要设置API密钥',
     configureApiKey: '请在设置中配置您的API密钥',
-    
+
     // 初始化
     initializationError: '初始化应用程序失败。请检查您的配置。',
     apiKeyNotConfigured: 'API密钥未配置。请在设置中设置您的API密钥。',
@@ -336,6 +336,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkOpenClawNotInstalledNotice: '未检测到内置 OpenClaw runtime（cfmind），请先执行打包前构建脚本。',
     coworkOpenClawReadyNotice: 'OpenClaw runtime 已就绪。开始任务时会自动启动网关。',
     coworkOpenClawStarting: 'AI 引擎正在启动网关...',
+    coworkOpenClawCancelStartup: '取消启动',
+    coworkOpenClawViewLogs: '查看日志',
     coworkOpenClawRunning: 'AI 引擎已就绪。',
     coworkOpenClawError: 'OpenClaw 网关未能在规定时间内启动成功。',
     coworkMemoryTitle: '记忆',
@@ -1297,7 +1299,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: 'User',
     login: 'Login',
     inDevelopment: 'In development',
-    
+
     // Settings
     settings: 'Settings',
     general: 'General',
@@ -1324,7 +1326,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: 'Color Themes',
     chinese: 'Chinese',
     english: 'English',
-    
+
     // API Settings
     apiKey: 'API Key',
     apiKeyPlaceholder: 'Enter your API Key',
@@ -1339,7 +1341,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: 'Current Model',
     availableModels: 'Available Models',
     modelSwitchHint: 'You can switch models in the chat interface',
-    
+
     // Model Provider Settings
     enabled: 'Enabled',
     disabled: 'Disabled',
@@ -1447,7 +1449,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: 'Passwords do not match',
     passwordTooShort: 'Password must be at least 4 characters',
     wrongPassword: 'Wrong password, please try again',
-    
+
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
     shortcutNotSet: 'Not set',
@@ -1483,14 +1485,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     planFree: 'Free',
     planAdvanced: 'Advanced',
     planPro: 'Pro',
-    
+
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',
-    
+
     // Loading State
     loading: 'Loading...',
-    
+
     // Sidebar
     conversations: 'Conversations',
     noConversations: 'No conversations',
@@ -1529,7 +1531,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: 'Work',
     folderIconCode: 'Code',
     folderIconIdea: 'Ideas',
-    
+
     // Chat Window
     sendMessage: 'Send Message',
     typeMessage: 'Type a message...',
@@ -1559,17 +1561,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: 'Up to 10 images',
     imageReadError: 'Failed to read image',
     imageInputNotSupported: 'Current model does not support images',
-    
+
     // Model Selection
     selectModel: 'Select Model',
-    
+
     // Error Messages
     errorOccurred: 'An error occurred',
     tryAgain: 'Please try again',
     networkError: 'Network error',
     apiKeyRequired: 'API Key Required',
     configureApiKey: 'Please configure your API key in settings',
-    
+
     // Initialization
     initializationError: 'Failed to initialize application. Please check your configuration.',
     apiKeyNotConfigured: 'API key not configured. Please set up your API key in settings.',
@@ -1614,6 +1616,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkOpenClawNotInstalledNotice: 'Bundled OpenClaw runtime (cfmind) was not found. Build the runtime before packaging.',
     coworkOpenClawReadyNotice: 'OpenClaw runtime is ready. The gateway will auto-start when you run a task.',
     coworkOpenClawStarting: 'AI engine is starting the gateway...',
+    coworkOpenClawCancelStartup: 'Cancel Startup',
+    coworkOpenClawViewLogs: 'View Logs',
     coworkOpenClawRunning: 'AI engine is ready.',
     coworkOpenClawError: 'OpenClaw gateway failed to become healthy in time.',
     coworkMemoryTitle: 'Memory',
@@ -2566,12 +2570,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
 class I18nService {
   private currentLanguage: LanguageType = 'zh';
   private listeners = new Set<() => void>();
-  
+
   constructor() {
     // 默认使用中文
     this.currentLanguage = 'zh';
   }
-  
+
   // 初始化语言设置
   async initialize(): Promise<void> {
     try {
@@ -2648,7 +2652,7 @@ class I18nService {
     }
     return 'en'; // 默认英文 (包括 zh-TW, zh-HK, en-*, 以及其他所有语言)
   }
-  
+
   // 设置语言
   setLanguage(language: LanguageType, options: { persist?: boolean } = {}): void {
     const { persist = true } = options;
@@ -2674,12 +2678,12 @@ class I18nService {
       console.error('Failed to save language setting:', error);
     }
   }
-  
+
   // 获取当前语言
   getLanguage(): LanguageType {
     return this.currentLanguage;
   }
-  
+
   // 获取翻译文本
   t(key: string): string {
     const translation = translations[this.currentLanguage][key];
@@ -2700,4 +2704,4 @@ class I18nService {
   }
 }
 
-export const i18nService = new I18nService(); 
+export const i18nService = new I18nService();


### PR DESCRIPTION
## 概述

OpenClaw 引擎启动时会显示全屏遮罩（EngineStartupOverlay），但之前没有任何交互按钮。如果启动卡住（如网络问题、编译缓存失效），用户只能等待 5 分钟硬超时，期间无法操作任何功能。

本 PR 在启动超过 **30 秒**后自动显示两个操作按钮，提供逃逸出口：

- **取消启动**：中止网关进程，回到 ready 状态，用户可以稍后重试
- **查看日志**：在系统文件管理器中打开网关日志文件，方便排查启动失败原因

## 改动内容

| 文件 | 说明 |
|------|------|
| `src/main/libs/openclawEngineManager.ts` | 新增 `cancelStartup()` 和 `getGatewayLogPath()` 方法 |
| `src/main/main.ts` | 注册 `openclaw:engine:cancelStartup` 和 `openclaw:engine:getGatewayLogPath` IPC 通道 |
| `src/main/preload.ts` | 通过 contextBridge 暴露新 API |
| `src/renderer/services/cowork.ts` | 添加 `cancelOpenClawStartup()` 和 `getOpenClawGatewayLogPath()` 服务方法 |
| `src/renderer/components/cowork/EngineStartupOverlay.tsx` | 30 秒计时器 + 取消/日志按钮 UI |
| `src/renderer/services/i18n.ts` | 新增中英文 i18n 键 |

## 设计决策

- **30 秒延迟**：正常启动通常在 30 秒内完成，延迟显示避免干扰正常流程
- **取消后状态**：调用 `stopGateway()` 后重置 `shutdownRequested`，确保后续启动不受影响
- **查看日志**：使用 `showItemInFolder` 而非 `openPath`，在文件管理器中定位日志文件，用户可以选择用自己偏好的编辑器打开

## 测试验证

1. 正常启动（<30s）：overlay 正常显示进度条，无操作按钮
2. 慢速启动（>30s）：30 秒后按钮渐现，点击取消可立即退出启动状态
3. 查看日志：正确打开系统文件管理器并定位到 gateway.log
4. 取消后重试：取消启动后可正常重新启动引擎