### PR TITLE
fix(scheduledTask): 修复定时任务通知渠道选择后无法改回"不通知"的问题

### DIFF
--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -3,6 +3,7 @@ import { OpenClawProviderId,ProviderRegistry } from '@shared/providers/constants
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { DeliveryMode } from '../../../scheduledTask/constants';
 import type {
   ScheduledTask,
   ScheduledTaskChannelOption,
@@ -95,7 +96,7 @@ function createFormState(task?: ScheduledTask): FormState {
     weekdays: planInfo.weekdays,
     monthDay: planInfo.monthDay,
     payloadText: task.payload.kind === 'systemEvent' ? task.payload.text : task.payload.message,
-    notifyChannel: task.delivery.channel || 'none',
+    notifyChannel: task.delivery.mode === DeliveryMode.None ? 'none' : (task.delivery.channel || 'none'),
     notifyTo: task.delivery.to || '',
     notifyAccountId: task.delivery.accountId,
     modelId: task.payload.kind === 'agentTurn' ? (task.payload.model ?? '') : '',


### PR DESCRIPTION
### 问题描述
定时任务编辑页面中，当用户将通知渠道从某个 IM 渠道（如飞书）改为"不通知"并保存后，
再次编辑该任务时，通知渠道下拉框仍然显示之前的 IM 渠道，而非"不通知"。

### 根因分析
问题由两处代码的设计不一致导致（均来自 commit `61cfe60`，属于历史 bug）：

### 修复方案
在表单初始化时优先检查 `delivery.mode`，若为 `'none'` 则直接设为"不通知"：

### 影响范围
- 仅修改 `src/renderer/components/scheduledTasks/TaskForm.tsx`（+2 行 / -1 行）
- 不涉及后端逻辑或数据结构变更
- 风险极低，仅影响编辑表单的初始化逻辑