### PR TITLE
feat(cowork): 为流式活动栏和工具调用组添加耗时计时器

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -703,6 +703,22 @@ const ToolCallGroup: React.FC<{
     ? truncatePreview(toolResultDisplay.replace(/\s+/g, ' '))
     : null;
 
+  // Elapsed timer for running tools
+  const [toolElapsed, setToolElapsed] = useState(0);
+  const isToolRunning = !toolResult;
+  useEffect(() => {
+    if (!isToolRunning) {
+      setToolElapsed(0);
+      return;
+    }
+    const startTs = toolUse.timestamp;
+    if (!startTs) return;
+    const compute = () => Math.max(0, Math.floor((Date.now() - startTs) / 1000));
+    setToolElapsed(compute());
+    const timer = setInterval(() => setToolElapsed(compute()), 1000);
+    return () => clearInterval(timer);
+  }, [isToolRunning, toolUse.timestamp]);
+
   // Check if this is a Bash-like tool that should show terminal style
   const isBashTool = isBashLikeToolName(rawToolName);
 
@@ -755,8 +771,11 @@ const ToolCallGroup: React.FC<{
             </div>
           )}
           {!toolResult && (
-            <div className="text-xs text-muted mt-0.5">
-              {i18nService.t('coworkToolRunning')}
+            <div className="text-xs text-muted mt-0.5 flex items-center gap-1.5">
+              <span>{i18nService.t('coworkToolRunning')}</span>
+              {toolElapsed > 0 && (
+                <span className="tabular-nums text-muted/60">{formatElapsedTime(toolElapsed)}</span>
+              )}
             </div>
           )}
         </div>
@@ -793,8 +812,11 @@ const ToolCallGroup: React.FC<{
                   </div>
                 )}
                 {!toolResult && (
-                  <div className="text-muted mt-1.5 italic">
-                    {i18nService.t('coworkToolRunning')}
+                  <div className="text-muted mt-1.5 italic flex items-center gap-1.5">
+                    <span>{i18nService.t('coworkToolRunning')}</span>
+                    {toolElapsed > 0 && (
+                      <span className="tabular-nums not-italic text-muted/60">{formatElapsedTime(toolElapsed)}</span>
+                    )}
                   </div>
                 )}
               </div>
@@ -1117,42 +1139,76 @@ const AssistantMessageItem: React.FC<{
 };
 
 // Streaming activity bar shown between messages and input
+const formatElapsedTime = (seconds: number): string => {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m ${remainingSeconds}s`;
+};
+
 const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ messages }) => {
-  // Walk messages backwards to find the latest tool_use without a paired tool_result
-  const getStatusText = (): string => {
-    const toolUseIds = new Set<string>();
+  const [elapsed, setElapsed] = useState(0);
+
+  // Find the latest user message timestamp as the total execution start time
+  const executionStartTimestamp = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].type === 'user') {
+        return messages[i].timestamp;
+      }
+    }
+    return 0;
+  }, [messages]);
+
+  // Find the latest unresolved tool_use for status text
+  const latestToolName = useMemo(() => {
     const toolResultIds = new Set<string>();
     for (const msg of messages) {
       const id = msg.metadata?.toolUseId;
-      if (typeof id === 'string') {
-        if (msg.type === 'tool_result') toolResultIds.add(id);
-        if (msg.type === 'tool_use') toolUseIds.add(id);
+      if (typeof id === 'string' && msg.type === 'tool_result') {
+        toolResultIds.add(id);
       }
     }
-    // Walk backwards to find latest unresolved tool_use
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i];
       if (msg.type === 'tool_use') {
         const id = msg.metadata?.toolUseId;
         if (typeof id === 'string' && !toolResultIds.has(id)) {
-          const toolName = typeof msg.metadata?.toolName === 'string' ? msg.metadata.toolName : null;
-          if (toolName) {
-            return `${i18nService.t('coworkToolRunning')} ${toolName}...`;
-          }
+          return typeof msg.metadata?.toolName === 'string' ? msg.metadata.toolName : null;
         }
       }
     }
-    return `${i18nService.t('coworkToolRunning')}`;
-  };
+    return null;
+  }, [messages]);
+
+  // Tick the elapsed timer every second from user message timestamp
+  useEffect(() => {
+    if (!executionStartTimestamp) {
+      setElapsed(0);
+      return;
+    }
+    const computeElapsed = () => Math.max(0, Math.floor((Date.now() - executionStartTimestamp) / 1000));
+    setElapsed(computeElapsed());
+    const timer = setInterval(() => setElapsed(computeElapsed()), 1000);
+    return () => clearInterval(timer);
+  }, [executionStartTimestamp]);
+
+  const statusText = latestToolName
+    ? `${i18nService.t('coworkToolRunning')} ${latestToolName}...`
+    : `${i18nService.t('coworkToolRunning')}`;
 
   return (
     <div className="shrink-0 animate-fade-in px-4">
       <div className="max-w-3xl mx-auto">
         <div className="streaming-bar" />
-        <div className="py-1">
+        <div className="py-1 flex items-center gap-2">
           <span className="text-xs text-secondary">
-            {getStatusText()}
+            {statusText}
           </span>
+          {elapsed > 0 && (
+            <span className="text-xs text-secondary/60 tabular-nums">
+              {formatElapsedTime(elapsed)}
+            </span>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概述
为 Cowork 流式处理界面添加可见的耗时计时器，让用户能够直观地看到当前执行已运行了多长时间。

## 改动内容

### 流式活动栏（Streaming Activity Bar）
- 显示从最近一条用户消息开始计算的总耗时（如 `12s`、`1m 30s`）。
- 将 `getStatusText()` 重构为 memoized 值（`latestToolName`、`executionStartTimestamp`），避免每次渲染时重复遍历消息列表。

### 工具调用组（Tool Call Groups）
- 在工具仍在运行（尚未返回结果）时，显示单个工具的耗时计时器。
- 工具结果返回后，计时器重置为 0。

### 通用
- 新增 `formatElapsedTime(seconds)` 工具函数，将秒数格式化为可读字符串（`45s`、`2m 15s`）。
- 使用 `tabular-nums` CSS 类确保计时数字宽度稳定，避免跳动。

## 图片展示
### 变更前
<img width="1426" height="597" alt="0407-11" src="https://github.com/user-attachments/assets/1f26d6f2-bcf7-4b07-9db2-cfac0e746434" />

### 变更后
<img width="1421" height="1117" alt="0407-12" src="https://github.com/user-attachments/assets/c2922f5a-59c5-4353-85a4-ccd2a31988fb" />

## 测试
- 通过 `npm run electron:dev` 验证：启动 Cowork 会话，观察活动栏和各工具调用上的耗时计时器。
- 计时器每秒更新一次，完成后正确重置。