### PR TITLE
fix(scheduledTask): 投递模式为"不通知"时，去除发送给网关的 channel/to 字段

### DIFF
--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -250,14 +250,13 @@ function toGatewayDelivery(delivery?: ScheduledTaskDelivery): GatewayDelivery | 
     return undefined;
   }
   if (delivery.mode === DeliveryMode.None) {
-    // Preserve channel/to even with mode='none' so IM notification target round-trips
-    // through the gateway for the edit form to display.
-    const result: GatewayDelivery = {
-      mode: DeliveryMode.None,
-      ...(delivery.channel ? { channel: delivery.channel } : {}),
-      ...(delivery.to ? { to: delivery.to } : {}),
-    } as GatewayDelivery;
-    console.log('[CronJobService][toGatewayDelivery] mode=none with preserved channel/to:', JSON.stringify(result));
+    // Do NOT forward channel/to to the gateway when mode='none'.
+    // Sending channel with mode=none triggers a multi-channel validation error on
+    // the gateway side ("Channel is required when multiple channels are configured")
+    // even though no delivery is intended.  The edit form should rely on locally
+    // stored delivery config rather than round-tripping through the gateway.
+    const result: GatewayDelivery = { mode: DeliveryMode.None } as GatewayDelivery;
+    console.log('[CronJobService][toGatewayDelivery] mode=none, omitting channel/to to avoid gateway validation error');
     return result;
   }
 


### PR DESCRIPTION
## 问题
通过会话/IM 创建的定时任务，投递模式设为"不通知"（mode=none）后，
任务在**触发运行时**网关报出校验错误：

> "Channel is required when multiple channels are configured"

而通过 UI 表单手动创建的定时任务，同样选择"不通知"，触发运行时完全正常。
该问题仅在会话创建的定时任务被**实际触发执行**时才会出现。

## 根因
两种创建路径构建 delivery 对象的方式不同：
- **手动创建**（`TaskForm.tsx`）：mode=none 时生成干净的 `{ mode: 'none' }`，
  不带 channel/to 字段。
- **会话创建**（`main.ts`）：即使 mode=none，仍会将 conversationId 作为 to 
  字段附加上去，生成 `{ mode: 'none', to: '...' }`。

任务运行时，`toGatewayDelivery()` 会将这些多余字段原样转发给网关。
网关只要收到 channel 或 to 字段就会触发渠道校验，不管 mode 是什么值，
因此导致报错。

## 修复方案
在 `toGatewayDelivery()` 中，当 mode=none 时，强制只返回 `{ mode: 'none' }`，
在发送给网关前剥离所有 channel/to 字段。编辑表单的回显应依赖本地存储的配置数据，
而非网关返回值。

## 问题截图
<img width="771" height="56" alt="image" src="https://github.com/user-attachments/assets/41a429c3-8a62-4105-9349-882fabdc634e" />