### PR TITLE
fix(main): use prevent-app-suspension instead of prevent-display-sleep

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1967,7 +1967,7 @@ if (!gotTheLock) {
     try {
       if (enabled) {
         if (preventSleepBlockerId === null || !powerSaveBlocker.isStarted(preventSleepBlockerId)) {
-          preventSleepBlockerId = powerSaveBlocker.start('prevent-display-sleep');
+          preventSleepBlockerId = powerSaveBlocker.start('prevent-app-suspension');
         }
       } else {
         if (preventSleepBlockerId !== null && powerSaveBlocker.isStarted(preventSleepBlockerId)) {


### PR DESCRIPTION
## Summary

Switch powerSaveBlocker mode to prevent-app-suspension to block the OS
from suspending the application process, not just the display. This
ensures background tasks (e.g. agent sessions) continue running even
when the display sleeps.

## Changes Made

use prevent-app-suspension instead of prevent-display-sleep
