### PR TITLE
fix: 修复Agent编辑后点击原Agent无法切换回聊天界面的问题

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -382,9 +382,9 @@ const SidebarAgentList: React.FC<{
   const enabledAgents = agents.filter((a) => a.enabled);
 
   const handleSwitch = async (agentId: string) => {
+    onShowCowork();
     if (agentId === currentAgentId) return;
     agentService.switchAgent(agentId);
-    onShowCowork();
     onSessionsLoadingChange(true);
     try {
       await coworkService.loadSessions(agentId);


### PR DESCRIPTION
## 问题描述
在"我的Agent"界面编辑某个 Agent 后，点击之前已选中的 Agent A，界面不会切换回 Agent A 的聊天界面，而是仍然停留在"我的Agent"界面。只有点击其他 Agent（非 Agent A）才能正常切换。

## 问题原因
在 SidebarAgentList 组件的 handleSwitch 函数中，当 agentId === currentAgentId 时会直接返回，不会调用 onShowCowork()。这导致当用户从"我的Agent"界面返回时，即使点击的是当前已选中的 Agent，也无法切换回聊天界面。

## 修复方案
将 onShowCowork() 调用提前到 if (agentId === currentAgentId) return; 检查之前，确保即使用户点击的是当前已选中的 Agent，也会先切换到聊天界面，然后再决定是否需要进行 Agent 切换操作。
