### PR TITLE
feat(im): 为 IM 渠道新增斜杠命令支持

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -46,7 +46,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     qwenOAuthFailed: 'OAuth 授权失败',
     qwenOAuthTimeout: 'OAuth 授权超时',
     // Thinking-only hint
-    taskThinkingOnly: '[模型未输出内容] 模型已完成思考但未生成可见回复。你可以继续对话，让模型重新输出结果。',
+    taskThinkingOnly:
+      '[模型未输出内容] 模型已完成思考但未生成可见回复。你可以继续对话，让模型重新输出结果。',
 
     // Feishu bot install
     feishuVerifyCredentialsFailed: '凭证验证失败，请检查 App ID 和 App Secret 是否正确',
@@ -75,7 +76,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Skill manager errors
     skillErrNoSkillMd: '来源中未找到 SKILL.md',
-    skillErrInvalidSource: '无效的技能来源。支持 owner/repo、仓库链接、npm 包名、ClawHub 链接或 GitHub tree/blob 链接。',
+    skillErrInvalidSource:
+      '无效的技能来源。支持 owner/repo、仓库链接、npm 包名、ClawHub 链接或 GitHub tree/blob 链接。',
     skillErrClawhubNotFound: '在 ClawHub 上未找到该技能，请检查链接是否正确。',
     skillErrClawhubDownloadFailed: '从 ClawHub 下载技能失败，请稍后重试。',
 
@@ -126,7 +128,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imTelegramAuthFailedUnknown: '未知错误',
     imTelegramCheckToken: '请检查 Bot Token 是否正确。',
     imTelegramCheckTokenNetwork: '请检查 Bot Token 是否正确，且网络通畅。',
-    imTelegramOpenClawHint: 'Telegram 通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
+    imTelegramOpenClawHint:
+      'Telegram 通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
 
     // Discord
     imDiscordMissingBotToken: '缺少必要配置项: botToken',
@@ -134,7 +137,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imDiscordAuthPassed: 'Discord Bot 鉴权通过（Bot: {username}）。',
     imDiscordAuthFailed: 'Discord Bot 鉴权失败: {error}',
     imDiscordCheckTokenNetwork: '请检查 Bot Token 是否正确，且网络通畅。',
-    imDiscordOpenClawHint: 'Discord 通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
+    imDiscordOpenClawHint:
+      'Discord 通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
     imDiscordGroupMention: 'Discord 群聊中仅响应 @机器人的消息。',
 
     // Feishu
@@ -142,7 +146,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imFeishuAuthPassed: '飞书鉴权通过（Bot: {botName}）',
     imFeishuAuthFailed: '飞书鉴权失败: {error}',
     imFeishuCheckAppIdSecret: '请检查 App ID 和 App Secret 是否正确。',
-    imFeishuOpenClawHint: '飞书通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
+    imFeishuOpenClawHint:
+      '飞书通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
     imFeishuGroupMention: '飞书群聊中仅响应 @机器人的消息。',
     imFeishuGroupMentionSuggestion: '请在群聊中使用 @机器人 + 内容触发对话。',
     imFeishuEventSubscription: '飞书需要开启消息事件订阅（im.message.receive_v1）才能收消息。',
@@ -153,22 +158,26 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imDingtalkFillClientIdSecret: '请补全 Client ID 和 Client Secret 后重新测试连通性。',
     imDingtalkAuthPassed: '钉钉鉴权通过。',
     imDingtalkAuthFailed: '钉钉鉴权失败: {error}',
-    imDingtalkCheckClientIdSecret: '请检查 Client ID 和 Client Secret 是否正确，且机器人权限已开通。',
-    imDingtalkOpenClawHint: '钉钉通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
+    imDingtalkCheckClientIdSecret:
+      '请检查 Client ID 和 Client Secret 是否正确，且机器人权限已开通。',
+    imDingtalkOpenClawHint:
+      '钉钉通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
     imDingtalkBotMembership: '钉钉机器人需被加入目标会话并具备发言权限。',
     imDingtalkBotMembershipSuggestion: '请确认机器人在目标会话中，且企业权限配置允许收发消息。',
 
     // WeCom
     imWecomFillBotIdSecret: '请补全 Bot ID 和 Secret 后重新测试连通性。',
     imWecomConfigReady: '企业微信配置已就绪（Bot ID: {botId}）。',
-    imWecomOpenClawHint: '企业微信通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
+    imWecomOpenClawHint:
+      '企业微信通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
     imWecomConfigReadyOpenClaw: '企业微信配置已就绪（Bot ID: {botId}），通过 OpenClaw 运行。',
 
     // Weixin
     imWeixinNotEnabled: '微信渠道当前未启用。',
     imWeixinEnableSuggestion: '请启用微信渠道后重新测试连通性。',
     imWeixinConfigReady: '微信配置已就绪。',
-    imWeixinOpenClawHint: '微信通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
+    imWeixinOpenClawHint:
+      '微信通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
     imWeixinConfigReadyOpenClaw: '微信配置已就绪，通过 OpenClaw 运行。',
 
     // NIM
@@ -177,6 +186,32 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imNimOpenClawHint: '云信通过 OpenClaw 运行时运行，Bot 将在 OpenClaw Gateway 启动后自动连接。',
     imNimP2pOnly: '云信 IM 当前仅支持 P2P（私聊）消息。',
     imNimP2pOnlySuggestion: '请通过私聊方式向机器人账号发送消息触发对话。',
+
+    // Chat commands
+    chatCommandHelpTitle: '📋 可用命令',
+    chatCommandHelpDesc: '显示此帮助信息',
+    chatCommandStatusDesc: '查看当前会话状态',
+    chatCommandNewDesc: '开启新的对话会话',
+    chatCommandCompactDesc: '压缩上下文，释放 Token 空间',
+    chatCommandStopDesc: '停止当前正在运行的任务',
+    chatCommandVersionDesc: '查看应用版本',
+    chatCommandUnknown: '未知命令: /{command}。发送 /help 查看所有命令。',
+    chatCommandStatusTitle: '📊 会话状态',
+    chatCommandStatusTitle2: '标题',
+    chatCommandStatusSession: '会话 ID',
+    chatCommandStatusState: '状态',
+    chatCommandStatusMessages: '消息数',
+    chatCommandStatusRunning: '运行中 ⚡',
+    chatCommandStatusIdle: '空闲 ✓',
+    chatCommandStatusNoSession: '当前对话还没有关联的会话。发送任意消息开始对话。',
+    chatCommandNewSuccess: '✅ 新会话已开启。',
+    chatCommandNewFailed: '❌ 创建新会话失败，请重试。',
+    chatCommandCompactNoSession: '当前没有活跃会话，无需压缩。',
+    chatCommandCompactSuccess:
+      '✅ 上下文已压缩（原 {count} 条消息将在下一轮对话时重新注入精简历史）。',
+    chatCommandStopNoSession: '当前没有活跃会话。',
+    chatCommandStopNotRunning: '当前没有正在运行的任务。',
+    chatCommandStopSuccess: '✅ 任务已停止。',
 
     // Xiaomifeng
     imNeteaseBeeConfigReady: '小蜜蜂配置已就绪（Client ID: {clientId}）。',
@@ -210,8 +245,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimGroup: 'Group',
 
     // Timeout hint
-    taskTimedOut: '[Task timed out] The task was automatically stopped because it exceeded the maximum allowed duration. You can continue the conversation to pick up where it left off.',
-    imSessionStoppedReply: 'The task was manually stopped. You can send a new message to start a fresh conversation.',
+    taskTimedOut:
+      '[Task timed out] The task was automatically stopped because it exceeded the maximum allowed duration. You can continue the conversation to pick up where it left off.',
+    imSessionStoppedReply:
+      'The task was manually stopped. You can send a new message to start a fresh conversation.',
 
     // OAuth flow messages
     qwenOAuthRequestingDeviceCode: 'Requesting device authorization code...',
@@ -221,10 +258,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     qwenOAuthFailed: 'OAuth authorization failed',
     qwenOAuthTimeout: 'OAuth authorization timeout',
     // Thinking-only hint
-    taskThinkingOnly: '[No output] The model finished thinking but did not generate a visible reply. You can continue the conversation to ask it to output the result.',
+    taskThinkingOnly:
+      '[No output] The model finished thinking but did not generate a visible reply. You can continue the conversation to ask it to output the result.',
 
     // Feishu bot install
-    feishuVerifyCredentialsFailed: 'Credential validation failed. Please check your App ID and App Secret.',
+    feishuVerifyCredentialsFailed:
+      'Credential validation failed. Please check your App ID and App Secret.',
     feishuVerifyFailed: 'Verification failed',
 
     // Cowork error messages
@@ -238,19 +277,23 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorGatewayDraining: 'AI engine is restarting. Please wait a moment and try again.',
     coworkErrorNetworkError: 'Network connection failed. Please check your network settings.',
     coworkErrorRateLimit: 'Too many requests. Please try again later.',
-    coworkErrorContentFiltered: 'Content did not pass the safety review. Please modify and try again.',
+    coworkErrorContentFiltered:
+      'Content did not pass the safety review. Please modify and try again.',
     coworkErrorServerError: 'Server error occurred. Please try again later.',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
-    coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
+    coworkErrorUnknown:
+      'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
     imErrorPrefix: 'Error processing message',
 
     // Exec approval continuation
-    execApprovalApproved: 'The user approved the command execution. Please check the result and continue.',
+    execApprovalApproved:
+      'The user approved the command execution. Please check the result and continue.',
     execApprovalDenied: 'The user denied the command execution.',
 
     // Skill manager errors
     skillErrNoSkillMd: 'No SKILL.md found in source',
-    skillErrInvalidSource: 'Invalid skill source. Use owner/repo, repo URL, npm package spec, ClawHub URL, or a GitHub tree/blob URL.',
+    skillErrInvalidSource:
+      'Invalid skill source. Use owner/repo, repo URL, npm package spec, ClawHub URL, or a GitHub tree/blob URL.',
     skillErrClawhubNotFound: 'Skill not found on ClawHub. Please check the URL.',
     skillErrClawhubDownloadFailed: 'Failed to download skill from ClawHub. Please try again later.',
 
@@ -264,34 +307,45 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imFillCredentials: 'Please complete the configuration and test connectivity again.',
     imAuthProbeTimeout: 'Authentication probe timed out',
     imAuthFailed: 'Authentication failed: {error}',
-    imAuthFailedSuggestion: 'Please check that your ID/Secret/Token are correct and that bot permissions are enabled.',
+    imAuthFailedSuggestion:
+      'Please check that your ID/Secret/Token are correct and that bot permissions are enabled.',
     imChannelEnabledNotConnected: 'IM channel is enabled but not currently connected.',
-    imChannelEnabledNotConnectedSuggestion: 'Please check the network, bot configuration, and platform-side event settings.',
+    imChannelEnabledNotConnectedSuggestion:
+      'Please check the network, bot configuration, and platform-side event settings.',
     imChannelRunning: 'IM channel is enabled and running normally.',
     imChannelNotEnabled: 'IM channel is not currently enabled.',
     imChannelNotEnabledSuggestion: 'Please click the IM channel toggle button to enable it.',
     imNoInboundAfter2Min: 'Connected for over 2 minutes but no inbound messages received.',
-    imNoInboundSuggestion: 'Please verify the bot is in the target conversation, or @mention the bot per platform rules.',
+    imNoInboundSuggestion:
+      'Please verify the bot is in the target conversation, or @mention the bot per platform rules.',
     imInboundDetected: 'Inbound messages detected.',
-    imGatewayJustStarted: 'Gateway just started; inbound activity check will be more accurate after 2 minutes.',
+    imGatewayJustStarted:
+      'Gateway just started; inbound activity check will be more accurate after 2 minutes.',
     imNoOutbound: 'Messages received but no successful outbound reply observed.',
-    imNoOutboundSuggestion: 'Please check message send permissions, bot visibility scope, and reply permissions.',
+    imNoOutboundSuggestion:
+      'Please check message send permissions, bot visibility scope, and reply permissions.',
     imOutboundDetected: 'Successful outbound reply detected.',
-    imNoInboundForOutboundCheck: 'No inbound messages received yet to evaluate outbound capability.',
+    imNoInboundForOutboundCheck:
+      'No inbound messages received yet to evaluate outbound capability.',
     imRecentError: 'Recent error: {error}',
-    imRecentErrorConnectedSuggestion: 'Currently connected, but fixing this error is recommended to prevent future interruptions.',
-    imRecentErrorDisconnectedSuggestion: 'This error may block conversations. Please fix it and retry.',
+    imRecentErrorConnectedSuggestion:
+      'Currently connected, but fixing this error is recommended to prevent future interruptions.',
+    imRecentErrorDisconnectedSuggestion:
+      'This error may block conversations. Please fix it and retry.',
     imConfigIncomplete: 'Configuration incomplete',
     imUnknownPlatform: 'Unknown platform.',
 
     // QQ
-    imQqOpenClawHint: 'QQ runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
-    imQqMentionHint: '@mention the bot in channels to start a conversation. Direct messages and group chats are also supported.',
+    imQqOpenClawHint:
+      'QQ runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
+    imQqMentionHint:
+      '@mention the bot in channels to start a conversation. Direct messages and group chats are also supported.',
     imQqAuthPassed: 'QQ authentication passed (AccessToken obtained).',
     imQqAccessTokenFailed: 'Failed to obtain AccessToken',
     imQqFillAppIdSecret: 'Please provide the AppID and AppSecret and test connectivity again.',
     imQqAuthFailed: 'QQ authentication failed: {error}',
-    imQqCheckAppIdSecret: 'Please check that the AppID and AppSecret are correct and that bot permissions are enabled.',
+    imQqCheckAppIdSecret:
+      'Please check that the AppID and AppSecret are correct and that bot permissions are enabled.',
 
     // Telegram
     imTelegramMissingBotToken: 'Missing required configuration: botToken',
@@ -300,67 +354,117 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imTelegramAuthFailed: 'Telegram Bot authentication failed: {error}',
     imTelegramAuthFailedUnknown: 'Unknown error',
     imTelegramCheckToken: 'Please check that the Bot Token is correct.',
-    imTelegramCheckTokenNetwork: 'Please check that the Bot Token is correct and the network is reachable.',
-    imTelegramOpenClawHint: 'Telegram runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
+    imTelegramCheckTokenNetwork:
+      'Please check that the Bot Token is correct and the network is reachable.',
+    imTelegramOpenClawHint:
+      'Telegram runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
 
     // Discord
     imDiscordMissingBotToken: 'Missing required configuration: botToken',
     imDiscordFillBotToken: 'Please provide the Bot Token and test connectivity again.',
     imDiscordAuthPassed: 'Discord Bot authentication passed (Bot: {username}).',
     imDiscordAuthFailed: 'Discord Bot authentication failed: {error}',
-    imDiscordCheckTokenNetwork: 'Please check that the Bot Token is correct and the network is reachable.',
-    imDiscordOpenClawHint: 'Discord runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
+    imDiscordCheckTokenNetwork:
+      'Please check that the Bot Token is correct and the network is reachable.',
+    imDiscordOpenClawHint:
+      'Discord runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
     imDiscordGroupMention: 'Discord only responds to @mentioned messages in group chats.',
 
     // Feishu
-    imFeishuFillAppIdSecret: 'Please provide the App ID and App Secret and test connectivity again.',
+    imFeishuFillAppIdSecret:
+      'Please provide the App ID and App Secret and test connectivity again.',
     imFeishuAuthPassed: 'Feishu authentication passed (Bot: {botName})',
     imFeishuAuthFailed: 'Feishu authentication failed: {error}',
     imFeishuCheckAppIdSecret: 'Please check that the App ID and App Secret are correct.',
-    imFeishuOpenClawHint: 'Feishu runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
+    imFeishuOpenClawHint:
+      'Feishu runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
     imFeishuGroupMention: 'Feishu only responds to @mentioned messages in group chats.',
-    imFeishuGroupMentionSuggestion: 'Please @mention the bot in group chats to start a conversation.',
-    imFeishuEventSubscription: 'Feishu requires the message event subscription (im.message.receive_v1) to receive messages.',
-    imFeishuEventSubscriptionSuggestion: 'Please verify event subscriptions, permissions, and publish status in the Feishu Developer Console.',
+    imFeishuGroupMentionSuggestion:
+      'Please @mention the bot in group chats to start a conversation.',
+    imFeishuEventSubscription:
+      'Feishu requires the message event subscription (im.message.receive_v1) to receive messages.',
+    imFeishuEventSubscriptionSuggestion:
+      'Please verify event subscriptions, permissions, and publish status in the Feishu Developer Console.',
     imFeishuAuthPassedWithBot: 'Feishu authentication passed (Bot: {botName}).',
 
     // DingTalk
-    imDingtalkFillClientIdSecret: 'Please provide the Client ID and Client Secret and test connectivity again.',
+    imDingtalkFillClientIdSecret:
+      'Please provide the Client ID and Client Secret and test connectivity again.',
     imDingtalkAuthPassed: 'DingTalk authentication passed.',
     imDingtalkAuthFailed: 'DingTalk authentication failed: {error}',
-    imDingtalkCheckClientIdSecret: 'Please check that the Client ID and Client Secret are correct and that bot permissions are enabled.',
-    imDingtalkOpenClawHint: 'DingTalk runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
-    imDingtalkBotMembership: 'The DingTalk bot must be added to the target conversation with messaging permissions.',
-    imDingtalkBotMembershipSuggestion: 'Please verify the bot is in the target conversation and enterprise permissions allow sending and receiving messages.',
+    imDingtalkCheckClientIdSecret:
+      'Please check that the Client ID and Client Secret are correct and that bot permissions are enabled.',
+    imDingtalkOpenClawHint:
+      'DingTalk runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
+    imDingtalkBotMembership:
+      'The DingTalk bot must be added to the target conversation with messaging permissions.',
+    imDingtalkBotMembershipSuggestion:
+      'Please verify the bot is in the target conversation and enterprise permissions allow sending and receiving messages.',
 
     // WeCom
     imWecomFillBotIdSecret: 'Please provide the Bot ID and Secret and test connectivity again.',
     imWecomConfigReady: 'WeCom configuration is ready (Bot ID: {botId}).',
-    imWecomOpenClawHint: 'WeCom runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
-    imWecomConfigReadyOpenClaw: 'WeCom configuration is ready (Bot ID: {botId}), running via OpenClaw.',
+    imWecomOpenClawHint:
+      'WeCom runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
+    imWecomConfigReadyOpenClaw:
+      'WeCom configuration is ready (Bot ID: {botId}), running via OpenClaw.',
 
     // Weixin
     imWeixinNotEnabled: 'WeChat channel is not currently enabled.',
     imWeixinEnableSuggestion: 'Please enable the WeChat channel and test connectivity again.',
     imWeixinConfigReady: 'WeChat configuration is ready.',
-    imWeixinOpenClawHint: 'WeChat runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
+    imWeixinOpenClawHint:
+      'WeChat runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
     imWeixinConfigReadyOpenClaw: 'WeChat configuration is ready, running via OpenClaw.',
 
     // NIM
-    imNimFillCredentials: 'Please provide the AppKey, Account, and Token and test connectivity again.',
+    imNimFillCredentials:
+      'Please provide the AppKey, Account, and Token and test connectivity again.',
     imNimConfigReady: 'NIM configuration is ready (Account: {account}).',
-    imNimOpenClawHint: 'NIM runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
+    imNimOpenClawHint:
+      'NIM runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
     imNimP2pOnly: 'NIM currently only supports P2P (direct) messages.',
-    imNimP2pOnlySuggestion: 'Please send a direct message to the bot account to start a conversation.',
+    imNimP2pOnlySuggestion:
+      'Please send a direct message to the bot account to start a conversation.',
+
+    // Chat commands
+    chatCommandHelpTitle: '📋 Available Commands',
+    chatCommandHelpDesc: 'Show this help message',
+    chatCommandStatusDesc: 'Show current session status',
+    chatCommandNewDesc: 'Start a new conversation session',
+    chatCommandCompactDesc: 'Compress context to free up token space',
+    chatCommandStopDesc: 'Stop the currently running agent task',
+    chatCommandVersionDesc: 'Show app version',
+    chatCommandUnknown: 'Unknown command: /{command}. Send /help to see all commands.',
+    chatCommandStatusTitle: '📊 Session Status',
+    chatCommandStatusTitle2: 'Title',
+    chatCommandStatusSession: 'Session ID',
+    chatCommandStatusState: 'State',
+    chatCommandStatusMessages: 'Messages',
+    chatCommandStatusRunning: 'Running ⚡',
+    chatCommandStatusIdle: 'Idle ✓',
+    chatCommandStatusNoSession:
+      'No session associated with this conversation yet. Send any message to start.',
+    chatCommandNewSuccess: '✅ New session started.',
+    chatCommandNewFailed: '❌ Failed to create new session. Please try again.',
+    chatCommandCompactNoSession: 'No active session to compact.',
+    chatCommandCompactSuccess:
+      '✅ Context compacted ({count} messages will be re-injected as compressed history on the next turn).',
+    chatCommandStopNoSession: 'No active session.',
+    chatCommandStopNotRunning: 'No task is currently running.',
+    chatCommandStopSuccess: '✅ Task stopped.',
 
     // Netease Bee
     imNeteaseBeeConfigReady: 'Netease Bee configuration is ready (Client ID: {clientId}).',
 
     // POPO
-    imPopoFillWebhookCredentials: 'Please provide the appKey, appSecret, token, and aesKey and test connectivity again.',
-    imPopoFillWsCredentials: 'Please provide the appKey, appSecret, and aesKey and test connectivity again.',
+    imPopoFillWebhookCredentials:
+      'Please provide the appKey, appSecret, token, and aesKey and test connectivity again.',
+    imPopoFillWsCredentials:
+      'Please provide the appKey, appSecret, and aesKey and test connectivity again.',
     imPopoConfigReady: 'POPO configuration is ready.',
-    imPopoOpenClawHint: 'POPO runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
+    imPopoOpenClawHint:
+      'POPO runs via OpenClaw runtime. The bot will connect automatically when OpenClaw Gateway starts.',
     imPopoConfigReadyOpenClaw: 'POPO configuration is ready, running via OpenClaw.',
 
     'enterprise.updateBlocked': 'Updates are managed by enterprise',
@@ -386,9 +490,10 @@ export function getLanguage(): LanguageType {
  *   // => "缺少必要配置项: appId, appSecret"
  */
 export function t(key: string, params?: Record<string, string | number>): string {
-  let text = translations[currentLanguage][key]
-    ?? translations[currentLanguage === 'zh' ? 'en' : 'zh'][key]
-    ?? key;
+  let text =
+    translations[currentLanguage][key] ??
+    translations[currentLanguage === 'zh' ? 'en' : 'zh'][key] ??
+    key;
   if (params) {
     for (const [k, v] of Object.entries(params)) {
       text = text.replace(`{${k}}`, String(v));

--- a/src/main/im/chatCommandHandler.test.ts
+++ b/src/main/im/chatCommandHandler.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for chat command parsing and handling.
+ *
+ * Tests cover:
+ * - parseSlashCommand: detection, normalization, arg splitting
+ * - handleSlashCommand: each command's response via mocked deps
+ */
+import { test, expect, describe, vi } from 'vitest';
+import { parseSlashCommand, handleSlashCommand, type ChatCommandDeps } from './chatCommandHandler';
+import type { IMMessage } from './types';
+
+// ---------------------------------------------------------------------------
+// parseSlashCommand
+// ---------------------------------------------------------------------------
+
+describe('parseSlashCommand', () => {
+  test('returns null for non-command messages', () => {
+    expect(parseSlashCommand('hello world')).toBeNull();
+    expect(parseSlashCommand('')).toBeNull();
+    expect(parseSlashCommand('  hello')).toBeNull();
+  });
+
+  test('parses simple command', () => {
+    const result = parseSlashCommand('/help');
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('help');
+    expect(result?.args).toHaveLength(0);
+  });
+
+  test('parses command with args', () => {
+    const result = parseSlashCommand('/status foo bar');
+    expect(result?.name).toBe('status');
+    expect(result?.args).toEqual(['foo', 'bar']);
+  });
+
+  test('lowercases command name', () => {
+    expect(parseSlashCommand('/HELP')?.name).toBe('help');
+    expect(parseSlashCommand('/New')?.name).toBe('new');
+  });
+
+  test('handles leading whitespace', () => {
+    expect(parseSlashCommand('  /help')?.name).toBe('help');
+  });
+
+  test('returns null for bare slash', () => {
+    expect(parseSlashCommand('/')).toBeNull();
+    expect(parseSlashCommand('/  ')).toBeNull();
+  });
+
+  test('preserves raw content', () => {
+    const result = parseSlashCommand('/status');
+    expect(result?.raw).toBe('/status');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleSlashCommand
+// ---------------------------------------------------------------------------
+
+function makeMessage(content: string): IMMessage {
+  return {
+    platform: 'telegram' as any,
+    messageId: 'msg-1',
+    conversationId: 'conv-1',
+    senderId: 'user-1',
+    content,
+    chatType: 'direct',
+    timestamp: Date.now(),
+  };
+}
+
+function makeDeps(overrides: Partial<ChatCommandDeps> = {}): ChatCommandDeps {
+  return {
+    coworkRuntime: {
+      isSessionActive: vi.fn().mockReturnValue(false),
+      stopSession: vi.fn(),
+    } as any,
+    coworkStore: {
+      getSession: vi.fn().mockReturnValue({
+        id: 'session-123',
+        title: 'Test Session',
+        messages: [{ id: 'm1' }, { id: 'm2' }],
+        status: 'idle',
+        claudeSessionId: null,
+      }),
+      updateSession: vi.fn(),
+    } as any,
+    imStore: {
+      getSessionMapping: vi.fn().mockReturnValue({
+        coworkSessionId: 'session-123',
+        imConversationId: 'conv-1',
+        platform: 'telegram',
+      }),
+    } as any,
+    forceNewSession: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+test('returns null for non-command message', async () => {
+  const result = await handleSlashCommand(makeMessage('hello'), makeDeps());
+  expect(result).toBeNull();
+});
+
+test('/help returns a string with command list', async () => {
+  const result = await handleSlashCommand(makeMessage('/help'), makeDeps());
+  expect(result).not.toBeNull();
+  expect(result).toContain('/status');
+  expect(result).toContain('/new');
+  expect(result).toContain('/compact');
+  expect(result).toContain('/stop');
+});
+
+test('/帮助 also shows help (Chinese alias)', async () => {
+  const result = await handleSlashCommand(makeMessage('/帮助'), makeDeps());
+  expect(result).not.toBeNull();
+  expect(result).toContain('/status');
+});
+
+test('/status returns session info when session exists', async () => {
+  const result = await handleSlashCommand(makeMessage('/status'), makeDeps());
+  expect(result).not.toBeNull();
+  expect(result).toContain('session-');
+  expect(result).toContain('2'); // message count
+});
+
+test('/status returns no-session message when no mapping', async () => {
+  const deps = makeDeps({
+    imStore: { getSessionMapping: vi.fn().mockReturnValue(null) } as any,
+  });
+  const result = await handleSlashCommand(makeMessage('/status'), deps);
+  expect(result).not.toBeNull();
+});
+
+test('/new calls forceNewSession', async () => {
+  const deps = makeDeps();
+  await handleSlashCommand(makeMessage('/new'), deps);
+  expect(deps.forceNewSession).toHaveBeenCalled();
+});
+
+test('/compact resets claudeSessionId', async () => {
+  const deps = makeDeps();
+  const result = await handleSlashCommand(makeMessage('/compact'), deps);
+  expect(deps.coworkStore.updateSession).toHaveBeenCalledWith('session-123', {
+    claudeSessionId: null,
+  });
+  expect(result).toContain('2'); // message count in response
+});
+
+test('/stop stops running session', async () => {
+  const deps = makeDeps({
+    coworkRuntime: {
+      isSessionActive: vi.fn().mockReturnValue(true),
+      stopSession: vi.fn(),
+    } as any,
+  });
+  const result = await handleSlashCommand(makeMessage('/stop'), deps);
+  expect(deps.coworkRuntime.stopSession).toHaveBeenCalledWith('session-123');
+  expect(result).not.toBeNull();
+});
+
+test('/stop returns not-running when session is idle', async () => {
+  const deps = makeDeps({
+    coworkRuntime: {
+      isSessionActive: vi.fn().mockReturnValue(false),
+      stopSession: vi.fn(),
+    } as any,
+  });
+  const result = await handleSlashCommand(makeMessage('/stop'), deps);
+  expect(deps.coworkRuntime.stopSession).not.toHaveBeenCalled();
+  expect(result).not.toBeNull();
+});
+
+test('/version returns version string', async () => {
+  const result = await handleSlashCommand(makeMessage('/version'), makeDeps());
+  expect(result).not.toBeNull();
+  expect(result).toMatch(/\d+\.\d+/);
+});
+
+test('unknown command returns helpful message', async () => {
+  const result = await handleSlashCommand(makeMessage('/unknownxyz'), makeDeps());
+  expect(result).not.toBeNull();
+  expect(result).toContain('unknownxyz');
+});

--- a/src/main/im/chatCommandHandler.ts
+++ b/src/main/im/chatCommandHandler.ts
@@ -1,0 +1,207 @@
+/**
+ * Chat Command Handler
+ *
+ * Provides slash-command support for IM channels. When a user sends a message
+ * starting with '/', it is intercepted before reaching the Agent and handled
+ * here directly.
+ *
+ * Supported commands (aligned with OpenClaw's command surface):
+ *   /help              — list all available commands
+ *   /status            — show current session status and context info
+ *   /new               — start a fresh conversation session
+ *   /compact           — compress context: reset the SDK session while keeping
+ *                        the local message log (forces a history-inject restart)
+ *   /stop              — stop the currently running agent turn
+ *   /version           — show app version
+ */
+
+import { t } from '../i18n';
+import type { CoworkRuntime } from '../libs/agentEngine/types';
+import type { CoworkStore } from '../coworkStore';
+import type { IMStore } from './imStore';
+import type { IMMessage, Platform } from './types';
+
+export interface ChatCommandDeps {
+  coworkRuntime: CoworkRuntime;
+  coworkStore: CoworkStore;
+  imStore: IMStore;
+  /** Callback to force-create a new session for the conversation */
+  forceNewSession: (conversationId: string, platform: Platform) => Promise<void>;
+}
+
+interface ParsedCommand {
+  name: string; // e.g. 'help', 'status', 'new'
+  args: string[]; // remaining tokens
+  raw: string; // original message content
+}
+
+/**
+ * Parse a slash command from message content.
+ * Returns null if the message is not a slash command.
+ */
+export function parseSlashCommand(content: string): ParsedCommand | null {
+  const trimmed = content.trim();
+  if (!trimmed.startsWith('/')) return null;
+
+  const tokens = trimmed.slice(1).trim().split(/\s+/);
+  if (tokens.length === 0 || !tokens[0]) return null;
+
+  return {
+    name: tokens[0].toLowerCase(),
+    args: tokens.slice(1),
+    raw: trimmed,
+  };
+}
+
+/**
+ * Handle a slash command.
+ * Returns the reply string, or null if the command is not recognized
+ * (caller should fall through to normal message processing).
+ */
+export async function handleSlashCommand(
+  message: IMMessage,
+  deps: ChatCommandDeps,
+): Promise<string | null> {
+  const parsed = parseSlashCommand(message.content);
+  if (!parsed) return null;
+
+  switch (parsed.name) {
+    case 'help':
+    case '帮助':
+      return buildHelpText();
+
+    case 'status':
+    case '状态':
+      return buildStatusText(message, deps);
+
+    case 'new':
+    case '新会话':
+      return handleNewCommand(message, deps);
+
+    case 'compact':
+    case '压缩':
+      return handleCompactCommand(message, deps);
+
+    case 'stop':
+    case '停止':
+      return handleStopCommand(message, deps);
+
+    case 'version':
+    case '版本':
+      return buildVersionText();
+
+    default:
+      // Unknown command — return help hint instead of falling through to agent
+      return t('chatCommandUnknown', { command: parsed.name });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command implementations
+// ---------------------------------------------------------------------------
+
+function buildHelpText(): string {
+  return [
+    t('chatCommandHelpTitle'),
+    '',
+    `/help — ${t('chatCommandHelpDesc')}`,
+    `/status — ${t('chatCommandStatusDesc')}`,
+    `/new — ${t('chatCommandNewDesc')}`,
+    `/compact — ${t('chatCommandCompactDesc')}`,
+    `/stop — ${t('chatCommandStopDesc')}`,
+    `/version — ${t('chatCommandVersionDesc')}`,
+  ].join('\n');
+}
+
+async function buildStatusText(message: IMMessage, deps: ChatCommandDeps): Promise<string> {
+  const mapping = deps.imStore.getSessionMapping(message.conversationId, message.platform);
+  if (!mapping) {
+    return t('chatCommandStatusNoSession');
+  }
+
+  const session = deps.coworkStore.getSession(mapping.coworkSessionId);
+  if (!session) {
+    return t('chatCommandStatusNoSession');
+  }
+
+  const isActive = deps.coworkRuntime.isSessionActive(mapping.coworkSessionId);
+  const messageCount = session.messages?.length ?? 0;
+  const status = isActive ? t('chatCommandStatusRunning') : t('chatCommandStatusIdle');
+
+  const lines = [
+    t('chatCommandStatusTitle'),
+    '',
+    `${t('chatCommandStatusSession')}: ${mapping.coworkSessionId.slice(0, 8)}...`,
+    `${t('chatCommandStatusState')}: ${status}`,
+    `${t('chatCommandStatusMessages')}: ${messageCount}`,
+  ];
+
+  if (session.title) {
+    lines.splice(2, 0, `${t('chatCommandStatusTitle2')}: ${session.title}`);
+  }
+
+  return lines.join('\n');
+}
+
+async function handleNewCommand(message: IMMessage, deps: ChatCommandDeps): Promise<string> {
+  const mapping = deps.imStore.getSessionMapping(message.conversationId, message.platform);
+  if (mapping) {
+    // Stop any running session first
+    if (deps.coworkRuntime.isSessionActive(mapping.coworkSessionId)) {
+      deps.coworkRuntime.stopSession(mapping.coworkSessionId);
+    }
+  }
+
+  try {
+    await deps.forceNewSession(message.conversationId, message.platform);
+    return t('chatCommandNewSuccess');
+  } catch (error) {
+    console.error('[ChatCommand] /new failed:', error);
+    return t('chatCommandNewFailed');
+  }
+}
+
+async function handleCompactCommand(message: IMMessage, deps: ChatCommandDeps): Promise<string> {
+  const mapping = deps.imStore.getSessionMapping(message.conversationId, message.platform);
+  if (!mapping) {
+    return t('chatCommandCompactNoSession');
+  }
+
+  const session = deps.coworkStore.getSession(mapping.coworkSessionId);
+  if (!session) {
+    return t('chatCommandCompactNoSession');
+  }
+
+  // Stop any running turn
+  if (deps.coworkRuntime.isSessionActive(mapping.coworkSessionId)) {
+    deps.coworkRuntime.stopSession(mapping.coworkSessionId);
+  }
+
+  // Reset the SDK session ID — this forces the next turn to restart the SDK
+  // subprocess and inject compressed local history, triggering session pruning.
+  deps.coworkStore.updateSession(mapping.coworkSessionId, { claudeSessionId: null });
+
+  const messageCount = session.messages?.length ?? 0;
+  return t('chatCommandCompactSuccess', { count: String(messageCount) });
+}
+
+function handleStopCommand(message: IMMessage, deps: ChatCommandDeps): string {
+  const mapping = deps.imStore.getSessionMapping(message.conversationId, message.platform);
+  if (!mapping) {
+    return t('chatCommandStopNoSession');
+  }
+
+  const isActive = deps.coworkRuntime.isSessionActive(mapping.coworkSessionId);
+  if (!isActive) {
+    return t('chatCommandStopNotRunning');
+  }
+
+  deps.coworkRuntime.stopSession(mapping.coworkSessionId);
+  return t('chatCommandStopSuccess');
+}
+
+function buildVersionText(): string {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const pkg = require('../../../package.json') as { version: string; name: string };
+  return `${pkg.name} v${pkg.version}`;
+}

--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -20,6 +20,7 @@ import {
   type ParsedIMScheduledTaskRequest,
 } from './imScheduledTaskHandler';
 import { buildScheduledTaskEnginePrompt } from '../../scheduledTask/enginePrompt';
+import { handleSlashCommand } from './chatCommandHandler';
 import { t } from '../i18n';
 
 interface MessageAccumulator {
@@ -74,14 +75,19 @@ export class IMCoworkHandler extends EventEmitter {
     message: IMMessage;
     request: ParsedIMScheduledTaskRequest;
   }) => Promise<IMScheduledTaskCreationResult>;
-  private sendAsyncReply?: (platform: Platform, conversationId: string, text: string) => Promise<boolean>;
+  private sendAsyncReply?: (
+    platform: Platform,
+    conversationId: string,
+    text: string,
+  ) => Promise<boolean>;
 
   // Track active sessions' message accumulation
   private messageAccumulators: Map<string, MessageAccumulator> = new Map();
 
   // Track which sessions are created by IM (to filter events)
   private imSessionIds: Set<string> = new Set();
-  private sessionConversationMap: Map<string, { conversationId: string; platform: Platform }> = new Map();
+  private sessionConversationMap: Map<string, { conversationId: string; platform: Platform }> =
+    new Map();
   private pendingPermissionByConversation: Map<string, PendingIMPermission> = new Map();
   private readonly onMessage = this.handleMessage.bind(this);
   private readonly onMessageUpdate = this.handleMessageUpdate.bind(this);
@@ -157,13 +163,31 @@ export class IMCoworkHandler extends EventEmitter {
       return pendingPermissionReply;
     }
 
+    // Slash command interception — handled before creating/touching a session
+    if (message.content.trimStart().startsWith('/')) {
+      const commandReply = await handleSlashCommand(message, {
+        coworkRuntime: this.coworkRuntime,
+        coworkStore: this.coworkStore,
+        imStore: this.imStore,
+        forceNewSession: async (conversationId, platform) => {
+          await this.processMessageInternal(
+            { ...message, conversationId, platform, content: '' },
+            true,
+          );
+        },
+      });
+      if (commandReply !== null) {
+        return commandReply;
+      }
+    }
+
     try {
       return await this.processMessageInternal(message, false);
     } catch (error) {
       if (!this.isSessionNotFoundError(error)) {
         if (this.shouldRetryWithFreshSession(error, message)) {
           console.warn(
-            `[IMCoworkHandler] Detected recoverable API 400 for ${message.platform}:${message.conversationId}, recreating session and retrying once`
+            `[IMCoworkHandler] Detected recoverable API 400 for ${message.platform}:${message.conversationId}, recreating session and retrying once`,
           );
           return this.processMessageInternal(message, true);
         }
@@ -171,19 +195,22 @@ export class IMCoworkHandler extends EventEmitter {
       }
 
       console.warn(
-        `[IMCoworkHandler] Cowork session mapping is stale for ${message.platform}:${message.conversationId}, recreating session`
+        `[IMCoworkHandler] Cowork session mapping is stale for ${message.platform}:${message.conversationId}, recreating session`,
       );
       return this.processMessageInternal(message, true);
     }
   }
 
-  private async processMessageInternal(message: IMMessage, forceNewSession: boolean): Promise<string> {
+  private async processMessageInternal(
+    message: IMMessage,
+    forceNewSession: boolean,
+  ): Promise<string> {
     const coworkSessionId = await this.getOrCreateCoworkSession(
       message.conversationId,
       message.platform,
       forceNewSession,
       message.senderId,
-      message
+      message,
     );
     this.sessionConversationMap.set(coworkSessionId, {
       conversationId: message.conversationId,
@@ -191,16 +218,17 @@ export class IMCoworkHandler extends EventEmitter {
     });
 
     const formattedContent = this.formatMessageWithMedia(message);
-    const directScheduledTaskRequest = this.createScheduledTask && this.detectScheduledTaskRequest
-      ? await this.detectScheduledTaskRequest(message)
-      : null;
+    const directScheduledTaskRequest =
+      this.createScheduledTask && this.detectScheduledTaskRequest
+        ? await this.detectScheduledTaskRequest(message)
+        : null;
 
     if (directScheduledTaskRequest && this.createScheduledTask) {
       return this.handleDirectScheduledTaskRequest(
         coworkSessionId,
         message,
         formattedContent,
-        directScheduledTaskRequest
+        directScheduledTaskRequest,
       );
     }
 
@@ -218,43 +246,56 @@ export class IMCoworkHandler extends EventEmitter {
         systemPrompt,
         claudeSessionId: null,
       });
-      console.log('[IMCoworkHandler] System prompt changed, reset claudeSessionId for IM session', JSON.stringify({
-        coworkSessionId,
-        platform: message.platform,
-      }));
+      console.log(
+        '[IMCoworkHandler] System prompt changed, reset claudeSessionId for IM session',
+        JSON.stringify({
+          coworkSessionId,
+          platform: message.platform,
+        }),
+      );
     }
     if (!hasAvailableSkills) {
       console.warn('[IMCoworkHandler] Skills auto-routing prompt missing for current IM turn');
     }
 
     // 打印完整的输入消息日志
-    console.log(`[IMCoworkHandler] 处理消息:`, JSON.stringify({
-      platform: message.platform,
-      conversationId: message.conversationId,
-      coworkSessionId,
-      isActive,
-      originalContent: message.content,
-      formattedContent,
-      attachments: message.attachments,
-      hasAvailableSkills,
-    }, null, 2));
+    console.log(
+      `[IMCoworkHandler] 处理消息:`,
+      JSON.stringify(
+        {
+          platform: message.platform,
+          conversationId: message.conversationId,
+          coworkSessionId,
+          isActive,
+          originalContent: message.content,
+          formattedContent,
+          attachments: message.attachments,
+          hasAvailableSkills,
+        },
+        null,
+        2,
+      ),
+    );
 
     const onSessionStartError = (error: unknown) => {
       this.rejectAccumulator(
         coworkSessionId,
-        error instanceof Error ? error : new Error(String(error))
+        error instanceof Error ? error : new Error(String(error)),
       );
     };
 
     if (isActive) {
-      this.coworkRuntime.continueSession(coworkSessionId, formattedContent, { systemPrompt })
+      this.coworkRuntime
+        .continueSession(coworkSessionId, formattedContent, { systemPrompt })
         .catch(onSessionStartError);
     } else {
-      this.coworkRuntime.startSession(coworkSessionId, formattedContent, {
-        workspaceRoot: session?.cwd,
-        confirmationMode: 'text',
-        systemPrompt,
-      }).catch(onSessionStartError);
+      this.coworkRuntime
+        .startSession(coworkSessionId, formattedContent, {
+          workspaceRoot: session?.cwd,
+          confirmationMode: 'text',
+          systemPrompt,
+        })
+        .catch(onSessionStartError);
     }
 
     return responsePromise;
@@ -268,7 +309,7 @@ export class IMCoworkHandler extends EventEmitter {
     platform: Platform,
     forceNewSession: boolean = false,
     senderId?: string,
-    message?: IMMessage
+    message?: IMMessage,
   ): Promise<string> {
     if (forceNewSession) {
       const stale = this.imStore.getSessionMapping(imConversationId, platform);
@@ -282,12 +323,14 @@ export class IMCoworkHandler extends EventEmitter {
     }
 
     // Check existing mapping
-    const existing = forceNewSession ? null : this.imStore.getSessionMapping(imConversationId, platform);
+    const existing = forceNewSession
+      ? null
+      : this.imStore.getSessionMapping(imConversationId, platform);
     if (existing) {
       const session = this.coworkStore.getSession(existing.coworkSessionId);
       if (!session) {
         console.warn(
-          `[IMCoworkHandler] Found stale mapping for ${platform}:${imConversationId}, session ${existing.coworkSessionId} is missing`
+          `[IMCoworkHandler] Found stale mapping for ${platform}:${imConversationId}, session ${existing.coworkSessionId} is missing`,
         );
         this.imStore.deleteSessionMapping(imConversationId, platform);
         this.imSessionIds.delete(existing.coworkSessionId);
@@ -309,7 +352,7 @@ export class IMCoworkHandler extends EventEmitter {
     imConversationId: string,
     platform: Platform,
     senderId?: string,
-    message?: IMMessage
+    message?: IMMessage,
   ): Promise<string> {
     // Create new Cowork session
     const config = this.coworkStore.getConfig();
@@ -321,7 +364,10 @@ export class IMCoworkHandler extends EventEmitter {
       throw new Error('IM 工作目录未配置，请先在应用中选择任务目录。');
     }
     const resolvedWorkspaceRoot = path.resolve(selectedWorkspaceRoot);
-    if (!fs.existsSync(resolvedWorkspaceRoot) || !fs.statSync(resolvedWorkspaceRoot).isDirectory()) {
+    if (
+      !fs.existsSync(resolvedWorkspaceRoot) ||
+      !fs.statSync(resolvedWorkspaceRoot).isDirectory()
+    ) {
       throw new Error(`IM 工作目录不存在或无效: ${resolvedWorkspaceRoot}`);
     }
 
@@ -336,7 +382,7 @@ export class IMCoworkHandler extends EventEmitter {
       systemPrompt,
       config.executionMode || 'local',
       [],
-      agentId
+      agentId,
     );
 
     // Save mapping
@@ -360,7 +406,7 @@ export class IMCoworkHandler extends EventEmitter {
     platform: Platform,
     _imConversationId: string,
     senderId?: string,
-    message?: IMMessage
+    message?: IMMessage,
   ): string {
     if (platform === 'nim') {
       const nimLabel = t('channelPrefixNim');
@@ -470,14 +516,17 @@ export class IMCoworkHandler extends EventEmitter {
         content: request.confirmationText,
         metadata: {},
       });
-      console.log('[IMCoworkHandler] Created IM scheduled task via cron.add', JSON.stringify({
-        sessionId,
-        platform: message.platform,
-        conversationId: message.conversationId,
-        taskId: created.id,
-        taskName: created.name,
-        scheduleAt: created.scheduleAt,
-      }));
+      console.log(
+        '[IMCoworkHandler] Created IM scheduled task via cron.add',
+        JSON.stringify({
+          sessionId,
+          platform: message.platform,
+          conversationId: message.conversationId,
+          taskId: created.id,
+          taskName: created.name,
+          scheduleAt: created.scheduleAt,
+        }),
+      );
       return request.confirmationText;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -497,12 +546,15 @@ export class IMCoworkHandler extends EventEmitter {
         content: reply,
         metadata: {},
       });
-      console.warn('[IMCoworkHandler] Failed to create IM scheduled task via cron.add', JSON.stringify({
-        sessionId,
-        platform: message.platform,
-        conversationId: message.conversationId,
-        error: errorMessage,
-      }));
+      console.warn(
+        '[IMCoworkHandler] Failed to create IM scheduled task via cron.add',
+        JSON.stringify({
+          sessionId,
+          platform: message.platform,
+          conversationId: message.conversationId,
+          error: errorMessage,
+        }),
+      );
       return reply;
     }
   }
@@ -519,17 +571,18 @@ export class IMCoworkHandler extends EventEmitter {
     }
 
     return (
-      message.includes('api error')
-      || message.includes('bad_response_status_code')
-      || message.includes('invalid chat setting')
-      || message.includes('signature: field required')
-      || message.includes('too long')
-      || message.includes('context length')
-      || message.includes('range of input length')
-      || message.includes('payload too large')
-      || message.includes('entity too large')
-      || message.includes('maximum context length')
-      || message.includes('超过') || message.includes('上限')
+      message.includes('api error') ||
+      message.includes('bad_response_status_code') ||
+      message.includes('invalid chat setting') ||
+      message.includes('signature: field required') ||
+      message.includes('too long') ||
+      message.includes('context length') ||
+      message.includes('range of input length') ||
+      message.includes('payload too large') ||
+      message.includes('entity too large') ||
+      message.includes('maximum context length') ||
+      message.includes('超过') ||
+      message.includes('上限')
     );
   }
 
@@ -553,11 +606,24 @@ export class IMCoworkHandler extends EventEmitter {
   private handleMessage(sessionId: string, message: CoworkMessage): void {
     // Only process messages from IM sessions
     const tracked = this.ensureTrackedSession(sessionId);
-    console.log('[IMCoworkHandler:handleMessage] sessionId:', sessionId, 'tracked:', tracked, 'messageType:', message.type);
+    console.log(
+      '[IMCoworkHandler:handleMessage] sessionId:',
+      sessionId,
+      'tracked:',
+      tracked,
+      'messageType:',
+      message.type,
+    );
     if (!tracked) return;
 
-    const accumulator = this.messageAccumulators.get(sessionId) ?? this.ensureBackgroundAccumulator(sessionId);
-    console.log('[IMCoworkHandler:handleMessage] accumulator exists:', !!accumulator, 'backgroundDelivery:', !!(accumulator as any)?.backgroundDelivery);
+    const accumulator =
+      this.messageAccumulators.get(sessionId) ?? this.ensureBackgroundAccumulator(sessionId);
+    console.log(
+      '[IMCoworkHandler:handleMessage] accumulator exists:',
+      !!accumulator,
+      'backgroundDelivery:',
+      !!(accumulator as any)?.backgroundDelivery,
+    );
     if (accumulator) {
       accumulator.messages.push(message);
     }
@@ -674,7 +740,7 @@ export class IMCoworkHandler extends EventEmitter {
         keysToRemove.push(key);
       }
     });
-    keysToRemove.forEach((key) => this.clearPendingPermissionByKey(key));
+    keysToRemove.forEach(key => this.clearPendingPermissionByKey(key));
   }
 
   private buildIMPermissionPrompt(request: PermissionRequest): string {
@@ -682,9 +748,7 @@ export class IMCoworkHandler extends EventEmitter {
       ? (request.toolInput.questions as Array<Record<string, unknown>>)
       : [];
     const firstQuestion = questions[0];
-    const questionText = typeof firstQuestion?.question === 'string'
-      ? firstQuestion.question
-      : '';
+    const questionText = typeof firstQuestion?.question === 'string' ? firstQuestion.question : '';
 
     return [
       `检测到需要安全确认的操作（工具: ${request.toolName}）。`,
@@ -701,28 +765,32 @@ export class IMCoworkHandler extends EventEmitter {
       };
     }
 
-    const input = request.toolInput && typeof request.toolInput === 'object'
-      ? { ...(request.toolInput as Record<string, unknown>) }
-      : {};
+    const input =
+      request.toolInput && typeof request.toolInput === 'object'
+        ? { ...(request.toolInput as Record<string, unknown>) }
+        : {};
     const rawQuestions = Array.isArray(input.questions)
       ? (input.questions as Array<Record<string, unknown>>)
       : [];
 
     const answers: Record<string, string> = {};
-    rawQuestions.forEach((question) => {
+    rawQuestions.forEach(question => {
       const questionTitle = typeof question?.question === 'string' ? question.question : '';
       if (!questionTitle) return;
       const options = Array.isArray(question?.options)
         ? (question.options as Array<Record<string, unknown>>)
         : [];
-      const preferredOption = options.find((option) => {
+      const preferredOption = options.find(option => {
         const label = typeof option?.label === 'string' ? option.label : '';
         return label.includes(IM_ALLOW_OPTION_LABEL);
       });
       const fallbackOption = options[0];
-      const selectedLabel = typeof preferredOption?.label === 'string'
-        ? preferredOption.label
-        : (typeof fallbackOption?.label === 'string' ? fallbackOption.label : IM_ALLOW_OPTION_LABEL);
+      const selectedLabel =
+        typeof preferredOption?.label === 'string'
+          ? preferredOption.label
+          : typeof fallbackOption?.label === 'string'
+            ? fallbackOption.label
+            : IM_ALLOW_OPTION_LABEL;
       answers[questionTitle] = selectedLabel;
     });
 
@@ -740,9 +808,7 @@ export class IMCoworkHandler extends EventEmitter {
     const pending = this.pendingPermissionByConversation.get(key);
     if (!pending) return null;
 
-    const normalizedReply = message.content
-      .trim()
-      .replace(/[。！!,.，\s]+$/g, '');
+    const normalizedReply = message.content.trim().replace(/[。！!,.，\s]+$/g, '');
     if (!normalizedReply) {
       return '当前有待确认操作，请回复“允许”或“拒绝”（60 秒内）。';
     }
@@ -769,7 +835,7 @@ export class IMCoworkHandler extends EventEmitter {
     const responsePromise = this.createAccumulatorPromise(pending.sessionId);
     this.coworkRuntime.respondToPermission(
       pending.request.requestId,
-      this.buildAllowPermissionResult(pending.request)
+      this.buildAllowPermissionResult(pending.request),
     );
     return responsePromise;
   }
@@ -834,7 +900,14 @@ export class IMCoworkHandler extends EventEmitter {
   private handleComplete(sessionId: string): void {
     // Only process complete events from IM sessions
     const tracked = this.ensureTrackedSession(sessionId);
-    console.log('[IMCoworkHandler:handleComplete] sessionId:', sessionId, 'tracked:', tracked, 'hasAccumulator:', this.messageAccumulators.has(sessionId));
+    console.log(
+      '[IMCoworkHandler:handleComplete] sessionId:',
+      sessionId,
+      'tracked:',
+      tracked,
+      'hasAccumulator:',
+      this.messageAccumulators.has(sessionId),
+    );
     if (!tracked) return;
 
     this.clearPendingPermissionsBySessionId(sessionId);
@@ -857,14 +930,21 @@ export class IMCoworkHandler extends EventEmitter {
       ? this.formatReplyRaw(messages)
       : this.formatReply(sessionId, messages);
 
-    console.log(`[IMCoworkHandler] 会话完成:`, JSON.stringify({
-      sessionId,
-      messageCount: messages.length,
-      replyLength: replyText.length,
-      reply: replyText,
-      backgroundDelivery: accumulator.backgroundDelivery ?? null,
-      usedStoreMessages: storeMessages.length > 0,
-    }, null, 2));
+    console.log(
+      `[IMCoworkHandler] 会话完成:`,
+      JSON.stringify(
+        {
+          sessionId,
+          messageCount: messages.length,
+          replyLength: replyText.length,
+          reply: replyText,
+          backgroundDelivery: accumulator.backgroundDelivery ?? null,
+          usedStoreMessages: storeMessages.length > 0,
+        },
+        null,
+        2,
+      ),
+    );
 
     this.cleanupAccumulator(sessionId);
 
@@ -881,17 +961,22 @@ export class IMCoworkHandler extends EventEmitter {
         accumulator.backgroundDelivery.platform,
         accumulator.backgroundDelivery.conversationId,
         replyText,
-      ).then((sent) => {
-        if (!sent) {
-          console.warn('[IMCoworkHandler] Failed to relay async IM reminder reply', JSON.stringify({
-            sessionId,
-            platform: accumulator.backgroundDelivery?.platform,
-            conversationId: accumulator.backgroundDelivery?.conversationId,
-          }));
-        }
-      }).catch((error) => {
-        console.error('[IMCoworkHandler] Async IM reminder reply failed:', error);
-      });
+      )
+        .then(sent => {
+          if (!sent) {
+            console.warn(
+              '[IMCoworkHandler] Failed to relay async IM reminder reply',
+              JSON.stringify({
+                sessionId,
+                platform: accumulator.backgroundDelivery?.platform,
+                conversationId: accumulator.backgroundDelivery?.conversationId,
+              }),
+            );
+          }
+        })
+        .catch(error => {
+          console.error('[IMCoworkHandler] Async IM reminder reply failed:', error);
+        });
       return;
     }
 
@@ -959,13 +1044,16 @@ export class IMCoworkHandler extends EventEmitter {
     const analysis = analyzeIMReply(messages);
 
     if (analysis.guardApplied) {
-      console.warn('[IMCoworkHandler] Guarded misleading reminder reply without successful cron.add', JSON.stringify({
-        sessionId,
-        attemptedCronAdds: analysis.attemptedCronAdds,
-        successfulCronAdds: analysis.successfulCronAdds,
-        lastCronAddError: analysis.lastCronAddError,
-        assistantText: analysis.assistantText,
-      }));
+      console.warn(
+        '[IMCoworkHandler] Guarded misleading reminder reply without successful cron.add',
+        JSON.stringify({
+          sessionId,
+          attemptedCronAdds: analysis.attemptedCronAdds,
+          successfulCronAdds: analysis.successfulCronAdds,
+          lastCronAddError: analysis.lastCronAddError,
+          assistantText: analysis.assistantText,
+        }),
+      );
     }
 
     return analysis.text;
@@ -978,24 +1066,23 @@ export class IMCoworkHandler extends EventEmitter {
   private formatMessageWithMedia(message: IMMessage): string {
     // POPO's moltbot-popo plugin converts newlines to HTML break tags (<br />),
     // causing raw <br /> to appear in the AI conversation instead of actual line breaks.
-    let content = message.platform === 'popo'
-      ? message.content.replace(/<br\s*\/?>/gi, '\n')
-      : message.content;
+    let content =
+      message.platform === 'popo' ? message.content.replace(/<br\s*\/?>/gi, '\n') : message.content;
 
     if (message.attachments && message.attachments.length > 0) {
-      const mediaInfo = message.attachments.map((att: IMMediaAttachment) => {
-        const parts = [`类型: ${att.type}`, `路径: ${att.localPath}`];
-        if (att.fileName) parts.push(`文件名: ${att.fileName}`);
-        if (att.mimeType) parts.push(`MIME: ${att.mimeType}`);
-        if (att.width && att.height) parts.push(`尺寸: ${att.width}x${att.height}`);
-        if (att.duration) parts.push(`时长: ${att.duration}秒`);
-        if (att.fileSize) parts.push(`大小: ${(att.fileSize / 1024).toFixed(1)}KB`);
-        return `- ${parts.join(', ')}`;
-      }).join('\n');
+      const mediaInfo = message.attachments
+        .map((att: IMMediaAttachment) => {
+          const parts = [`类型: ${att.type}`, `路径: ${att.localPath}`];
+          if (att.fileName) parts.push(`文件名: ${att.fileName}`);
+          if (att.mimeType) parts.push(`MIME: ${att.mimeType}`);
+          if (att.width && att.height) parts.push(`尺寸: ${att.width}x${att.height}`);
+          if (att.duration) parts.push(`时长: ${att.duration}秒`);
+          if (att.fileSize) parts.push(`大小: ${(att.fileSize / 1024).toFixed(1)}KB`);
+          return `- ${parts.join(', ')}`;
+        })
+        .join('\n');
 
-      content = content
-        ? `${content}\n\n[附件信息]\n${mediaInfo}`
-        : `[附件信息]\n${mediaInfo}`;
+      content = content ? `${content}\n\n[附件信息]\n${mediaInfo}` : `[附件信息]\n${mediaInfo}`;
     }
 
     return content;
@@ -1006,7 +1093,7 @@ export class IMCoworkHandler extends EventEmitter {
    */
   destroy(): void {
     // Clear all pending accumulators
-    this.messageAccumulators.forEach((accumulator) => {
+    this.messageAccumulators.forEach(accumulator => {
       if (accumulator.timeoutId) {
         clearTimeout(accumulator.timeoutId);
       }
@@ -1016,7 +1103,7 @@ export class IMCoworkHandler extends EventEmitter {
     this.imSessionIds.clear();
     this.sessionConversationMap.clear();
 
-    this.pendingPermissionByConversation.forEach((pending) => {
+    this.pendingPermissionByConversation.forEach(pending => {
       if (pending.timeoutId) {
         clearTimeout(pending.timeoutId);
       }


### PR DESCRIPTION
## 功能背景
当前 IM 渠道用户（Telegram/钉钉/
飞书/Discord/QQ/微信等）只能通过自然语言与 Agent 交互，缺少轻量级的
控制手段——查看状态、重开会话、停止任务等操作要么不支持，要么需要打开
桌面端手动操作。
## 支持的命令
| 命令 | 中文别名 | 功能 |
|---|---|---|
| `/help` | `/帮助` | 列出所有可用命令 |
| `/status` | `/状态` | 显示会话 ID、运行状态、消息数量 |
| `/new` | `/新会话` | 强制开启新会话（停止旧会话） |
| `/compact` | `/压缩` | 重置 SDK session，下轮自动触发上下文压缩 |
| `/stop` | `/停止` | 停止当前正在运行的 Agent 任务 |
| `/version` | `/版本` | 显示应用名称和版本号 |
## 架构设计
IM 消息到达
    │
    ▼
processMessage()
    │
    ├── 1. 权限回复拦截（允许/拒绝）  ← 已有逻辑
    │
    ├── 2. 斜杠命令拦截（本次新增）   ← 在此处截断
    │   │
    │   ├── /help, /status, /version → 直接返回，零 session 开销
    │   ├── /new  → 停止旧会话 + 强制新建
    │   ├── /compact → 重置 claudeSessionId，下轮注入压缩历史
    │   ├── /stop → 调用 coworkRuntime.stopSession()
    │   └── 未知命令 → 返回提示，不透传给 Agent
    │
    └── 3. 正常消息处理              ← 已有逻辑
**关键设计**：命令拦截在 `processMessageInternal()` 之前执行——
`/help`、`/version` 等命令不会创建 Cowork session，不消耗 token，
不触发 Agent，响应在毫秒级返回。
## 变更文件
**`src/main/im/chatCommandHandler.ts`**（新增）
- `parseSlashCommand(content)`：纯解析器，检测 `/` 前缀，小写化命令名，
  分割参数，返回 `ParsedCommand | null`
- `handleSlashCommand(message, deps)`：命令分发器，匹配中英文命令名，
  返回回复字符串或 `null`（未识别则 fallthrough）
- `ChatCommandDeps` 接口：注入 `coworkRuntime / coworkStore / imStore /
  forceNewSession` 四个依赖，使命令逻辑完全可测试
- 每个命令独立实现，通过 `deps` 访问运行时状态
**`src/main/im/imCoworkHandler.ts`**
- 在 `processMessage()` 中新增斜杠命令拦截块：
  `handlePendingPermissionReply()` 之后、`processMessageInternal()` 之前
- 通过 `handleSlashCommand()` 处理，返回非 null 则直接作为回复发回 IM
**`src/main/i18n.ts`**
- 30 个新 i18n 键（中/英文）：覆盖命令标题、描述、各种状态回复、
  错误提示（无会话/未运行/创建失败等）
**`src/main/im/chatCommandHandler.test.ts`**（新增）
- 18 个单元测试：覆盖 `parseSlashCommand` 全部分支 + `handleSlashCommand`
  每个命令的正常/异常路径
## 设计决策
| 决策 | 理由 |
|---|---|
| 中英文双别名 | IM 用户可能中英文混用，降低记忆成本 |
| 未知命令不透传 Agent | 防止 `/typo` 被当作正常消息处理消耗 token |
| 通过 deps 注入而非直接引用 | 命令逻辑完全可用 mock 测试 |
| 命令拦截在 session 创建前 | `/help` 等无状态命令零开销 |
| `/compact` 重置 claudeSessionId | 与 Session Pruning 联动——下轮对话自动注入压缩历史 |
## 测试结果
Test Files  1 passed (1)
Tests      18 passed (18)