### PR TITLE
fix(api): 修复 SSE 流监听器被旧请求的异步 abort 回调错误清理的竞态条件

### DIFF
--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -27,7 +27,13 @@ const generateRequestId = () => `req_${Date.now()}_${Math.random().toString(36).
 class ApiService {
   private config: ApiConfig | null = null;
   private currentRequestId: string | null = null;
-  private cleanupFunctions: (() => void)[] = [];
+  /**
+   * Cleanup callback for the currently active stream request.
+   * Each request captures its own listeners in a closure so that an
+   * async abort callback from a *previous* request can never accidentally
+   * remove listeners belonging to the *current* request.
+   */
+  private activeCleanup: (() => void) | null = null;
 
   setConfig(config: ApiConfig) {
     this.config = config;
@@ -35,16 +41,18 @@ class ApiService {
 
   cancelOngoingRequest() {
     if (this.currentRequestId) {
-      window.electron.api.cancelStream(this.currentRequestId);
+      const requestId = this.currentRequestId;
+      // Detach old listeners *before* sending the cancel signal so the async
+      // abort callback that follows cannot interfere with a new request.
+      if (this.activeCleanup) {
+        this.activeCleanup();
+        this.activeCleanup = null;
+      }
+      this.currentRequestId = null;
+      window.electron.api.cancelStream(requestId);
       return true;
     }
     return false;
-  }
-
-  private cleanup() {
-    this.cleanupFunctions.forEach(fn => fn());
-    this.cleanupFunctions = [];
-    this.currentRequestId = null;
   }
 
   private normalizeApiFormat(apiFormat: unknown): 'anthropic' | 'openai' | 'gemini' {
@@ -299,7 +307,7 @@ class ApiService {
           baseUrl = resolved.baseUrl;
           apiFormat = resolved.effectiveFormat;
         }
-        
+
         return {
           apiKey: providerConfig.apiKey,
           baseUrl,
@@ -454,6 +462,23 @@ class ApiService {
 
       return new Promise((resolve, reject) => {
         let aborted = false;
+        let cleaned = false;
+
+        // Per-request cleanup captured via closure. Safe from cross-request
+        // interference because each invocation owns its own `cleaned` flag
+        // and remove* references.
+        const localCleanup = () => {
+          if (cleaned) return;
+          cleaned = true;
+          removeDataListener();
+          removeDoneListener();
+          removeErrorListener();
+          removeAbortListener();
+          if (this.currentRequestId === requestId) {
+            this.currentRequestId = null;
+            this.activeCleanup = null;
+          }
+        };
 
         // 设置流式监听器
         const removeDataListener = window.electron.api.onStreamData(requestId, (chunk) => {
@@ -486,7 +511,7 @@ class ApiService {
         });
 
         const removeDoneListener = window.electron.api.onStreamDone(requestId, () => {
-          this.cleanup();
+          localCleanup();
           if (!fullContent) {
             reject(new ApiError('No content received from the API. Please try again.'));
           } else {
@@ -495,17 +520,17 @@ class ApiService {
         });
 
         const removeErrorListener = window.electron.api.onStreamError(requestId, (error) => {
-          this.cleanup();
+          localCleanup();
           reject(new ApiError(error));
         });
 
         const removeAbortListener = window.electron.api.onStreamAbort(requestId, () => {
           aborted = true;
-          this.cleanup();
+          localCleanup();
           resolve({ content: fullContent || 'Response was stopped.', reasoning: fullReasoning || undefined });
         });
 
-        this.cleanupFunctions = [removeDataListener, removeDoneListener, removeErrorListener, removeAbortListener];
+        this.activeCleanup = localCleanup;
 
         // 发起流式请求
         console.log(`[api-chat] Anthropic request: baseUrl=${config.baseUrl}, finalUrl=${config.baseUrl}/v1/messages, model=${modelId}, apiFormat=${config.apiFormat}`);
@@ -521,7 +546,7 @@ class ApiService {
           requestId,
         }).then((response) => {
           if (!response.ok && !aborted) {
-            this.cleanup();
+            localCleanup();
             let errorMessage = 'API request failed';
             if (response.error) {
               try {
@@ -537,13 +562,17 @@ class ApiService {
           }
         }).catch((error) => {
           if (!aborted) {
-            this.cleanup();
+            localCleanup();
             reject(new ApiError(error.message || 'Network error'));
           }
         });
       });
     } catch (error) {
-      this.cleanup();
+      if (this.activeCleanup) {
+        this.activeCleanup();
+        this.activeCleanup = null;
+      }
+      this.currentRequestId = null;
       if (error instanceof ApiError) {
         throw error;
       }
@@ -622,6 +651,20 @@ class ApiService {
 
       return new Promise((resolve, reject) => {
         let aborted = false;
+        let cleaned = false;
+
+        const localCleanup = () => {
+          if (cleaned) return;
+          cleaned = true;
+          removeDataListener();
+          removeDoneListener();
+          removeErrorListener();
+          removeAbortListener();
+          if (this.currentRequestId === requestId) {
+            this.currentRequestId = null;
+            this.activeCleanup = null;
+          }
+        };
 
         const removeDataListener = window.electron.api.onStreamData(requestId, (chunk) => {
           const lines = chunk.split('\n');
@@ -652,7 +695,7 @@ class ApiService {
         });
 
         const removeDoneListener = window.electron.api.onStreamDone(requestId, () => {
-          this.cleanup();
+          localCleanup();
           if (!fullContent) {
             reject(new ApiError('No content received from the API. Please try again.'));
           } else {
@@ -661,17 +704,17 @@ class ApiService {
         });
 
         const removeErrorListener = window.electron.api.onStreamError(requestId, (error) => {
-          this.cleanup();
+          localCleanup();
           reject(new ApiError(error));
         });
 
         const removeAbortListener = window.electron.api.onStreamAbort(requestId, () => {
           aborted = true;
-          this.cleanup();
+          localCleanup();
           resolve({ content: fullContent || 'Response was stopped.', reasoning: fullReasoning || undefined });
         });
 
-        this.cleanupFunctions = [removeDataListener, removeDoneListener, removeErrorListener, removeAbortListener];
+        this.activeCleanup = localCleanup;
 
         console.log(`[api-chat] Gemini request: baseUrl=${config.baseUrl}, finalUrl=${requestUrl}, model=${modelId}`);
         window.electron.api.stream({
@@ -685,7 +728,7 @@ class ApiService {
           requestId,
         }).then((response) => {
           if (!response.ok && !aborted) {
-            this.cleanup();
+            localCleanup();
             let errorMessage = 'API request failed';
             if (response.error) {
               try {
@@ -701,13 +744,17 @@ class ApiService {
           }
         }).catch((error) => {
           if (!aborted) {
-            this.cleanup();
+            localCleanup();
             reject(new ApiError(error.message || 'Network error'));
           }
         });
       });
     } catch (error) {
-      this.cleanup();
+      if (this.activeCleanup) {
+        this.activeCleanup();
+        this.activeCleanup = null;
+      }
+      this.currentRequestId = null;
       if (error instanceof ApiError) {
         throw error;
       }
@@ -759,8 +806,22 @@ class ApiService {
 
       return new Promise((resolve, reject) => {
         let aborted = false;
+        let cleaned = false;
         let sseBuffer = '';
         let currentEvent = '';
+
+        const localCleanup = () => {
+          if (cleaned) return;
+          cleaned = true;
+          removeDataListener();
+          removeDoneListener();
+          removeErrorListener();
+          removeAbortListener();
+          if (this.currentRequestId === requestId) {
+            this.currentRequestId = null;
+            this.activeCleanup = null;
+          }
+        };
 
         // 设置流式监听器
         const removeDataListener = window.electron.api.onStreamData(requestId, (chunk) => {
@@ -850,7 +911,7 @@ class ApiService {
         });
 
         const removeDoneListener = window.electron.api.onStreamDone(requestId, () => {
-          this.cleanup();
+          localCleanup();
           if (!fullContent) {
             reject(new ApiError('No content received from the API. Please try again.'));
           } else {
@@ -859,17 +920,17 @@ class ApiService {
         });
 
         const removeErrorListener = window.electron.api.onStreamError(requestId, (error) => {
-          this.cleanup();
+          localCleanup();
           reject(new ApiError(error));
         });
 
         const removeAbortListener = window.electron.api.onStreamAbort(requestId, () => {
           aborted = true;
-          this.cleanup();
+          localCleanup();
           resolve({ content: fullContent || 'Response was stopped.', reasoning: fullReasoning || undefined });
         });
 
-        this.cleanupFunctions = [removeDataListener, removeDoneListener, removeErrorListener, removeAbortListener];
+        this.activeCleanup = localCleanup;
 
         const headers: Record<string, string> = {
           'Content-Type': 'application/json',
@@ -916,7 +977,7 @@ class ApiService {
           requestId,
         }).then((response) => {
           if (!response.ok && !aborted) {
-            this.cleanup();
+            localCleanup();
             let errorMessage = 'API request failed';
             if (response.error) {
               try {
@@ -932,13 +993,17 @@ class ApiService {
           }
         }).catch((error) => {
           if (!aborted) {
-            this.cleanup();
+            localCleanup();
             reject(new ApiError(error.message || 'Network error'));
           }
         });
       });
     } catch (error) {
-      this.cleanup();
+      if (this.activeCleanup) {
+        this.activeCleanup();
+        this.activeCleanup = null;
+      }
+      this.currentRequestId = null;
       if (error instanceof ApiError) {
         throw error;
       }


### PR DESCRIPTION
## 问题描述

当用户快速点击停止后立即发送新消息时，旧请求的异步 abort 回调可能在新请求注册完监听器之后才触发。由于所有请求共享 `ApiService` 实例上同一个 `cleanupFunctions` 数组，旧请求的 abort 回调会错误地移除**新请求**的所有 SSE 流监听器，导致新请求的流式数据**静默丢失**。

## 根因分析

```text
时序：
1. chatWithAnthropic() 调用 cancelOngoingRequest()
   → 仅发送 IPC 取消信号，未清理旧 listeners
2. 生成新 requestId，注册新 listeners
3. this.cleanupFunctions = [新 listeners]  // 覆盖旧引用
4. 旧请求的 abort IPC 回调异步返回
   → 调用 this.cleanup()
   → 遍历 this.cleanupFunctions（此时已是新 listeners）
   → 新请求的监听器被错误移除
   → 新请求的流式数据静默丢失
```

## 修复方案

采用**闭包隔离**方案（方案 B），从架构上消除共享可变状态：

### 1. 每个请求独立持有 cleanup 闭包

```typescript
// 每个请求创建自己的 localCleanup，通过闭包捕获自己的 remove* 函数
const localCleanup = () => {
  if (cleaned) return;  // 幂等保护
  cleaned = true;
  removeDataListener();
  removeDoneListener();
  removeErrorListener();
  removeAbortListener();
  if (this.currentRequestId === requestId) {
    this.currentRequestId = null;
    this.activeCleanup = null;
  }
};
```

### 2. cancelOngoingRequest() 先清理旧 listeners

```typescript
cancelOngoingRequest() {
  if (this.currentRequestId) {
    const requestId = this.currentRequestId;
    // 先清理旧 listeners，再发取消信号
    if (this.activeCleanup) {
      this.activeCleanup();
      this.activeCleanup = null;
    }
    this.currentRequestId = null;
    window.electron.api.cancelStream(requestId);
    return true;
  }
  return false;
}
```

### 关键改进

| 改动前 | 改动后 |
|--------|--------|
| 所有请求共享 `cleanupFunctions` 数组 | 每个请求通过闭包持有独立的 `localCleanup` |
| `cancelOngoingRequest()` 不清理旧 listeners | 先清理旧 listeners 再发取消信号 |
| `cleanup()` 无幂等保护 | `cleaned` 标志保证只执行一次 |
| 仅修改 1 个方法 | 统一修复 3 个 chat 方法（Anthropic/Gemini/OpenAI） |

## 影响范围

- `src/renderer/services/api.ts` — `ApiService` 类的流式请求生命周期管理
- 影响所有 API 格式：Anthropic、Gemini、OpenAI 兼容
- 无新增依赖，无 IPC 变更

## 测试验证

1. 正常对话流程：发送消息 → 流式接收 → 完成（无回归）
2. 停止并重发：点击停止 → 立即发送新消息 → 新消息正常流式接收
3. 快速连续发送：连续点击发送 → 只有最后一条请求的流式数据被保留
4. 网络错误恢复：请求失败后重发 → 新请求正常工作