### PR TITLE
feat(permission-modal): 权限审批弹窗增加 Bash 命令语法高亮

### DIFF
--- a/src/renderer/components/cowork/CoworkPermissionModal.tsx
+++ b/src/renderer/components/cowork/CoworkPermissionModal.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import type { CoworkPermissionRequest, CoworkPermissionResult } from '../../types/cowork';
 import { ExclamationTriangleIcon, XMarkIcon } from '@heroicons/react/24/outline';
+// @ts-ignore
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+// @ts-ignore
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+// @ts-ignore
+import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { i18nService } from '../../services/i18n';
 
 type DangerLevel = 'safe' | 'caution' | 'destructive';
@@ -41,6 +47,23 @@ const DANGER_REASON_I18N_MAP: Record<string, string> = {
   'git-push': 'dangerReasonGitPush',
   'process-kill': 'dangerReasonProcessKill',
   'permission-change': 'dangerReasonPermissionChange',
+};
+
+const CODE_HIGHLIGHT_STYLE = { margin: 0, borderRadius: 0, padding: '0.5rem 0.75rem' };
+
+/** Syntax-highlighted code block used inside the permission modal. */
+const CodeHighlight: React.FC<{ code: string; language: string }> = ({ code, language }) => {
+  const isDark = document.documentElement.classList.contains('dark');
+  return (
+    <SyntaxHighlighter
+      language={language}
+      style={isDark ? oneDark : oneLight}
+      customStyle={CODE_HIGHLIGHT_STYLE}
+      wrapLongLines
+    >
+      {code}
+    </SyntaxHighlighter>
+  );
 };
 
 /** Fallback detection when dangerLevel is not provided by the adapter */
@@ -382,10 +405,8 @@ const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({
                   <label className="block text-xs font-medium text-secondary uppercase tracking-wider mb-1">
                     {i18nService.t('coworkToolInput')}
                   </label>
-                  <div className="px-3 py-2 rounded-lg bg-surface max-h-40 overflow-y-auto">
-                    <pre className="text-xs text-foreground whitespace-pre-wrap break-words font-mono">
-                      {requestedCommand}
-                    </pre>
+                  <div className="rounded-lg bg-surface max-h-40 overflow-y-auto text-xs">
+                    <CodeHighlight code={requestedCommand} language="bash" />
                   </div>
                 </div>
               )}
@@ -414,10 +435,8 @@ const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({
                         <label className="block text-xs font-medium text-secondary uppercase tracking-wider mb-1">
                           {i18nService.t('coworkToolInput')}
                         </label>
-                        <div className="px-3 py-2 rounded-lg bg-background max-h-40 overflow-y-auto">
-                          <pre className="text-xs text-foreground whitespace-pre-wrap break-words font-mono">
-                            {requestedCommand}
-                          </pre>
+                        <div className="rounded-lg bg-background max-h-40 overflow-y-auto text-xs">
+                          <CodeHighlight code={requestedCommand} language="bash" />
                         </div>
                       </div>
                     )}
@@ -467,10 +486,18 @@ const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({
                 <label className="block text-xs font-medium text-secondary uppercase tracking-wider mb-1">
                   {i18nService.t('coworkToolInput')}
                 </label>
-                <div className="px-3 py-2 rounded-lg bg-background">
-                  <pre className="text-xs text-foreground whitespace-pre-wrap break-words font-mono">
-                    {formatToolInput(permission.toolInput)}
-                  </pre>
+                <div className="rounded-lg bg-background overflow-hidden text-xs">
+                  {permission.toolName === 'Bash' && typeof (permission.toolInput as Record<string, unknown>)?.command === 'string' ? (
+                    <CodeHighlight
+                      code={(permission.toolInput as Record<string, unknown>).command as string}
+                      language="bash"
+                    />
+                  ) : (
+                    <CodeHighlight
+                      code={formatToolInput(permission.toolInput)}
+                      language="json"
+                    />
+                  )}
                 </div>
               </div>
             </>


### PR DESCRIPTION
## 概述

权限审批弹窗（CoworkPermissionModal）中的 Bash 命令和工具输入原先使用纯文本 `<pre>` 渲染，用户在审批危险操作时需要逐字阅读才能识别风险。本 PR 为命令内容添加语法高亮，帮助用户更快识别 `rm -rf`、`--force`、管道符等关键片段。

## 改动内容

### 改动前

所有命令和工具输入以纯白色等宽字体展示，无颜色区分：

```html
<pre class='font-mono'>{requestedCommand}</pre>
```

### 改动后

- **Bash 命令**：使用 `bash` 语法高亮（关键字、参数、管道符、字符串着色）
- **其他工具输入**：使用 `json` 语法高亮（键值对、括号着色）
- **暗色/亮色主题**：自动适配当前主题（`oneDark` / `oneLight`）

### 涉及的 3 处渲染位置

| 位置 | 场景 | 高亮语言 |
|------|------|----------|
| Confirm 模式 | `requestedCommand` 展示 | `bash` |
| Question 模式 | `requestedCommand` 展示 | `bash` |
| 通用 Tool Input | Bash 工具 → `bash`，其他工具 → `json` | 自动判断 |

### 技术方案

- 复用项目已有的 `react-syntax-highlighter`（Prism），**零新增依赖**
- 提取 `CodeHighlight` 内联组件，统一 3 处渲染
- 通过 `document.documentElement.classList.contains('dark')` 自动切换主题

## 影响范围

- 仅修改 `src/renderer/components/cowork/CoworkPermissionModal.tsx`（+39 行 / -12 行）
- 纯 UI 展示层改动，**不影响权限审批逻辑**
- 无新增依赖

## 安全价值

颜色区分让用户在审批工具调用时能更快识别危险命令片段（如 `rm -rf`、`--force`、`dd if=`），降低误批风险。