### PR TITLE
feat(prompt-input): 输入框图片附件展示缩略图预览

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -607,7 +607,31 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     <div className="relative">
       {attachments.length > 0 && (
         <div className="mb-2 flex flex-wrap gap-2">
-          {attachments.map((attachment) => (
+          {attachments.map((attachment) =>
+            attachment.isImage && attachment.dataUrl ? (
+              /* Image attachment — thumbnail card */
+              <div
+                key={attachment.path}
+                className="group relative h-16 w-16 flex-shrink-0 rounded-lg border border-border bg-surface overflow-hidden"
+                title={attachment.path}
+              >
+                <img
+                  src={attachment.dataUrl}
+                  alt={attachment.name}
+                  className="h-full w-full object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() => handleRemoveAttachment(attachment.path)}
+                  className="absolute -right-1.5 -top-1.5 hidden group-hover:flex h-5 w-5 items-center justify-center rounded-full bg-foreground/80 text-background shadow-sm"
+                  aria-label={i18nService.t('coworkAttachmentRemove')}
+                  title={i18nService.t('coworkAttachmentRemove')}
+                >
+                  <XMarkIcon className="h-3 w-3" />
+                </button>
+              </div>
+            ) : (
+              /* Non-image or image without dataUrl — pill badge */
               <div
                 key={attachment.path}
                 className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-2.5 py-1 text-xs text-foreground max-w-full"
@@ -629,7 +653,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                   <XMarkIcon className="h-3 w-3" />
                 </button>
               </div>
-          ))}
+            ),
+          )}
         </div>
       )}
       {imageVisionHint && (


### PR DESCRIPTION
## 概述

对话输入框上传图片附件时，原先仅显示一个蓝色图片图标（PhotoIcon）加文件名的 pill 样式。用户无法直观确认上传的图片内容是否正确，需要靠文件名来辨别。

本 PR 将图片附件改为 **64×64 缩略图卡片**展示，直接渲染已有的 `dataUrl` 数据，让用户一眼确认上传内容。

## 改动前后对比

| 改动前 | 改动后 |
|--------|--------|
| 蓝色 PhotoIcon + 文件名文字 | 64×64 图片缩略图（`object-cover` 填充） |
| 删除按钮始终显示在 pill 内 | 删除按钮 hover 时出现在右上角 |
| 图片和文件样式完全相同 | 图片用缩略图卡片，文件保持 pill 样式 |

## 技术实现

```tsx
{attachment.isImage && attachment.dataUrl ? (
  // 图片附件 — 缩略图卡片
  <div className='group relative h-16 w-16 rounded-lg ...'>
    <img src={attachment.dataUrl} className='h-full w-full object-cover' />
    <button className='absolute -right-1.5 -top-1.5 hidden group-hover:flex ...' />
  </div>
) : (
  // 非图片 / 无 dataUrl — 保持原有 pill 样式
  <div className='inline-flex rounded-full ...'> ... </div>
)}
```

### 关键设计

- **条件判断**：`attachment.isImage && attachment.dataUrl` 双重检查，确保有图片数据时才渲染缩略图
- **降级兼容**：图片无 `dataUrl` 时（如模型不支持 vision 的 fallback 路径）仍显示 PhotoIcon pill
- **hover 交互**：删除按钮使用 `group-hover:flex` + 绝对定位，不遮挡缩略图主体
- **零新增依赖**：`dataUrl` 在上传时已通过 `readFileAsDataUrl` / `FileReader` 存入 Redux store

## 影响范围

- 仅修改 `src/renderer/components/cowork/CoworkPromptInput.tsx`（+27 行 / -2 行）
- 纯 UI 展示层改动，不影响附件上传逻辑和数据结构
- 文件类型附件（非图片）保持原有样式，无回归风险