### PR TITLE
fix(setup-python): 检测并覆盖旧版本的pip文件，解决pip无法使用问题

### DIFF
--- a/scripts/setup-python-runtime.js
+++ b/scripts/setup-python-runtime.js
@@ -45,6 +45,27 @@ const PIP_RUNTIME_ARCHIVE_REL_PATH = path.join('tools', 'pip.pyz');
 const PIP_MODULE_MAIN_REL_PATH = path.join('Lib', 'site-packages', 'pip', '__main__.py');
 const PIP_MODULE_INIT_REL_PATH = path.join('Lib', 'site-packages', 'pip', '__init__.py');
 
+const EXPECTED_PIP_MAIN_CONTENT = [
+  'import pathlib',
+  'import runpy',
+  'import sys',
+  '',
+  'root = pathlib.Path(__file__).resolve().parents[3]',
+  "pip_pyz = root / 'tools' / 'pip.pyz'",
+  'if not pip_pyz.exists():',
+  "    raise SystemExit(f'pip runtime archive missing: {pip_pyz}')",
+  '',
+  '# Ensure pip imports resolve to the zipapp payload, not this shim package.',
+  'sys.path.insert(0, str(pip_pyz))',
+  'for name in list(sys.modules):',
+  "    if name == 'pip' or name.startswith('pip.'):",
+  '        del sys.modules[name]',
+  '',
+  "sys.argv[0] = 'pip'",
+  "runpy.run_module('pip', run_name='__main__', alter_sys=True)",
+  '',
+].join('\n');
+
 function hasPipCommand(rootDir) {
   return PIP_EXECUTABLE_CANDIDATES.some((relPath) => fs.existsSync(path.join(rootDir, relPath)));
 }
@@ -52,6 +73,15 @@ function hasPipCommand(rootDir) {
 function hasPipModule(rootDir) {
   return fs.existsSync(path.join(rootDir, PIP_MODULE_MAIN_REL_PATH))
     || fs.existsSync(path.join(rootDir, PIP_MODULE_INIT_REL_PATH));
+}
+
+function isPipShimCurrent(rootDir) {
+  const pipMainPath = path.join(rootDir, PIP_MODULE_MAIN_REL_PATH);
+  try {
+    return fs.readFileSync(pipMainPath, 'utf8') === EXPECTED_PIP_MAIN_CONTENT;
+  } catch {
+    return false;
+  }
 }
 
 function parseArgs(argv) {
@@ -109,6 +139,9 @@ function checkRuntimeHealth(rootDir, options = {}) {
     }
     if (!hasPipModule(rootDir)) {
       missing.push(PIP_MODULE_MAIN_REL_PATH.replace(/\\/g, '/'));
+    }
+    if (!isPipShimCurrent(rootDir)) {
+      missing.push('pip shim (__main__.py) outdated');
     }
   }
 
@@ -274,29 +307,8 @@ async function ensurePipPayload(rootDir, options = {}) {
   const pipModuleDir = path.join(rootDir, 'Lib', 'site-packages', 'pip');
   const pipInitPath = path.join(pipModuleDir, '__init__.py');
   const pipMainPath = path.join(pipModuleDir, '__main__.py');
-  const pipMain = [
-    'import pathlib',
-    'import runpy',
-    'import sys',
-    '',
-    'root = pathlib.Path(__file__).resolve().parents[3]',
-    "pip_pyz = root / 'tools' / 'pip.pyz'",
-    'if not pip_pyz.exists():',
-    "    raise SystemExit(f'pip runtime archive missing: {pip_pyz}')",
-    '',
-    '# Ensure pip imports resolve to the zipapp payload, not this shim package.',
-    'sys.path.insert(0, str(pip_pyz))',
-    'for name in list(sys.modules):',
-    "    if name == 'pip' or name.startswith('pip.'):",
-    '        del sys.modules[name]',
-    '',
-    "sys.argv[0] = 'pip'",
-    "runpy.run_module('pip', run_name='__main__', alter_sys=True)",
-    '',
-  ].join('\n');
-
   writeFileIfChanged(pipInitPath, '');
-  writeFileIfChanged(pipMainPath, pipMain);
+  writeFileIfChanged(pipMainPath, EXPECTED_PIP_MAIN_CONTENT);
   createPipWrappers(rootDir);
 
   const finalHealth = checkRuntimeHealth(rootDir, { requirePip: true });


### PR DESCRIPTION
## 问题
- 在 #475 问题解决之前安装过旧版本的LobsterAI，本机上仍残留旧版本的__main__.py文件，新版本的__main__.py文件没有覆盖旧版本的__main__.py文件，导致在调用pip安装三方库时依然报递归调用错误
- setup-python-runtime.js 中的 ensurePipPayload() 函数在判断 pip 是否已安装时，checkRuntimeHealth 仅检查 __main__.py 文件是否存在，不检查其内容。
- 当脚本升级导致 pipMain（即 __main__.py 的期望内容）发生变化时，由于旧文件仍然存在，健康检查直接通过并 early return，新版本的 __main__.py中 内容永远不会被写入。
<img width="779" height="275" alt="image" src="https://github.com/user-attachments/assets/f3931216-f0a5-42cc-9cf8-e85148ff65dd" />

## 复现场景
1. 旧版本脚本安装了 Python 运行时，Lib/site-packages/pip/__main__.py 已存在
2. 脚本更新，pipMain 内容发生变化
3. 重新运行脚本 → hasPipModule() 返回 true → checkRuntimeHealth 通过 → ensurePipPayload 直接 return
4. writeFileIfChanged(pipMainPath, pipMain) 永远不会被执行
## 修复方案
在 checkRuntimeHealth 的 requirePip 分支中新增 shim 内容校验，当磁盘上的 __main__.py 内容与期望不一致时，视为健康检查失败，触发重新写入流程。
## 具体改动
文件：scripts/setup-python-runtime.js
1. 新增模块级常量 EXPECTED_PIP_MAIN_CONTENT：将原先 ensurePipPayload 内部的 pipMain 局部变量提升为模块顶层常量，作为内容比对和写入的唯一来源
2. 新增 isPipShimCurrent(rootDir) 函数：读取磁盘上的 __main__.py，与 EXPECTED_PIP_MAIN_CONTENT 比对，返回是否一致
3. checkRuntimeHealth 扩展：在 requirePip 分支内新增 isPipShimCurrent 检查，不一致时将 'pip shim (__main__.py) outdated' 加入 missing 列表
4. ensurePipPayload 内部：删除局部 pipMain 变量定义，writeFileIfChanged 改为引用 EXPECTED_PIP_MAIN_CONTENT
## 设计考量
- isPipShimCurrent 放在 requirePip 分支内而非独立参数控制，因为所有"安装后验证"场景中 shim 必定是最新的（刚写入），额外的文件读取（几百字节同步读）开销可忽略
- 无需新增 API 参数，现有调用方无需任何修改
## 测试验证
在 Windows 本机手动验证：
1. 正常运行脚本安装 Python 运行时 → __main__.py 内容正确
2. 手动篡改 __main__.py 为任意旧内容，模拟旧版本
3. 再次运行脚本 → 检测到 shim 过期 → 触发重新安装流程 → __main__.py 恢复为正确内容
## 关联issue
#475 
   