### PR TITLE
fix(settings): prevent Enter key in inputs from closing Settings page

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -6,11 +6,30 @@ import { checkForAppUpdate } from '../services/appUpdate';
 import type { AppUpdateInfo } from '../services/appUpdate';
 import { themeService } from '../services/theme';
 import { i18nService, LanguageType } from '../services/i18n';
-import { decryptSecret, encryptWithPassword, decryptWithPassword, EncryptedPayload, PasswordEncryptedPayload } from '../services/encryption';
+import {
+  decryptSecret,
+  encryptWithPassword,
+  decryptWithPassword,
+  EncryptedPayload,
+  PasswordEncryptedPayload,
+} from '../services/encryption';
 import { coworkService } from '../services/cowork';
 import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
 import ErrorMessage from './ErrorMessage';
-import { XMarkIcon, Cog6ToothIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, EnvelopeIcon, CpuChipIcon, InformationCircleIcon, UserCircleIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import {
+  XMarkIcon,
+  Cog6ToothIcon,
+  SignalIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+  CubeIcon,
+  ChatBubbleLeftIcon,
+  EnvelopeIcon,
+  CpuChipIcon,
+  InformationCircleIcon,
+  UserCircleIcon,
+  ArrowTopRightOnSquareIcon,
+} from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
 import PlusCircleIcon from './icons/PlusCircleIcon';
 import TrashIcon from './icons/TrashIcon';
@@ -30,7 +49,14 @@ import IMSettings from './im/IMSettings';
 import { imService } from '../services/im';
 import EmailSkillConfig from './skills/EmailSkillConfig';
 import { ProviderRegistry, resolveCodingPlanBaseUrl } from '../../shared/providers';
-import { defaultConfig, type AppConfig, getVisibleProviders, isCustomProvider, getCustomProviderDefaultName,getProviderDisplayName } from '../config';
+import {
+  defaultConfig,
+  type AppConfig,
+  getVisibleProviders,
+  isCustomProvider,
+  getCustomProviderDefaultName,
+  getProviderDisplayName,
+} from '../config';
 import {
   OpenAIIcon,
   DeepSeekIcon,
@@ -50,7 +76,16 @@ import {
   CustomProviderIcon,
 } from './icons/providers';
 
-type TabType = 'general'| 'coworkAgentEngine' | 'model' | 'coworkMemory' | 'coworkAgent' | 'shortcuts' | 'im' | 'email' | 'about';
+type TabType =
+  | 'general'
+  | 'coworkAgentEngine'
+  | 'model'
+  | 'coworkMemory'
+  | 'coworkAgent'
+  | 'shortcuts'
+  | 'im'
+  | 'email'
+  | 'about';
 
 export type SettingsOpenOptions = {
   initialTab?: TabType;
@@ -68,10 +103,17 @@ interface SettingsProps extends SettingsOpenOptions {
   } | null;
 }
 
-
 const CUSTOM_PROVIDER_KEYS = [
-  'custom_0', 'custom_1', 'custom_2', 'custom_3', 'custom_4',
-  'custom_5', 'custom_6', 'custom_7', 'custom_8', 'custom_9',
+  'custom_0',
+  'custom_1',
+  'custom_2',
+  'custom_3',
+  'custom_4',
+  'custom_5',
+  'custom_6',
+  'custom_7',
+  'custom_8',
+  'custom_9',
 ] as const;
 
 const providerKeys = [
@@ -162,37 +204,69 @@ const providerMeta: Record<ProviderType, { label: string; icon: React.ReactNode 
   openrouter: { label: 'OpenRouter', icon: <OpenRouterIcon /> },
   'github-copilot': { label: 'GitHub Copilot', icon: <GitHubCopilotIcon /> },
   ollama: { label: 'Ollama', icon: <OllamaIcon /> },
-  ...Object.fromEntries(
-    CUSTOM_PROVIDER_KEYS.map(key => [key, { label: getCustomProviderDefaultName(key), icon: <CustomProviderIcon /> }])
-  ) as Record<(typeof CUSTOM_PROVIDER_KEYS)[number], { label: string; icon: React.ReactNode }>,
+  ...(Object.fromEntries(
+    CUSTOM_PROVIDER_KEYS.map(key => [
+      key,
+      { label: getCustomProviderDefaultName(key), icon: <CustomProviderIcon /> },
+    ]),
+  ) as Record<(typeof CUSTOM_PROVIDER_KEYS)[number], { label: string; icon: React.ReactNode }>),
 };
 
 const providerLinks: Partial<Record<ProviderType, { website: string; apiKey?: string }>> = {
-  openai:       { website: 'https://platform.openai.com',              apiKey: 'https://platform.openai.com/api-keys' },
-  gemini:       { website: 'https://aistudio.google.com',              apiKey: 'https://aistudio.google.com/apikey' },
-  anthropic:    { website: 'https://console.anthropic.com',            apiKey: 'https://console.anthropic.com/settings/keys' },
-  deepseek:     { website: 'https://platform.deepseek.com',            apiKey: 'https://platform.deepseek.com/api_keys' },
-  moonshot:     { website: 'https://platform.moonshot.cn',             apiKey: 'https://platform.moonshot.cn/console/api-keys' },
-  zhipu:        { website: 'https://open.bigmodel.cn',                 apiKey: 'https://open.bigmodel.cn/usercenter/apikeys' },
-  minimax:      { website: 'https://platform.minimaxi.com',            apiKey: 'https://platform.minimaxi.com/user-center/basic-information/interface-key' },
-  volcengine:   { website: 'https://console.volcengine.com/ark',       apiKey: 'https://console.volcengine.com/ark' },
-  qwen:         { website: 'https://dashscope.console.aliyun.com',     apiKey: 'https://dashscope.console.aliyun.com/apiKey' },
-  youdaozhiyun: { website: 'https://ai.youdao.com',                    apiKey: 'https://ai.youdao.com/console' },
-  stepfun:      { website: 'https://platform.stepfun.com',             apiKey: 'https://platform.stepfun.com/interface-key' },
-  xiaomi:       { website: 'https://dev.mi.com/platform',              apiKey: 'https://dev.mi.com/platform' },
-  openrouter:   { website: 'https://openrouter.ai',                    apiKey: 'https://openrouter.ai/keys' },
-  ollama:       { website: 'https://ollama.com' },
+  openai: {
+    website: 'https://platform.openai.com',
+    apiKey: 'https://platform.openai.com/api-keys',
+  },
+  gemini: { website: 'https://aistudio.google.com', apiKey: 'https://aistudio.google.com/apikey' },
+  anthropic: {
+    website: 'https://console.anthropic.com',
+    apiKey: 'https://console.anthropic.com/settings/keys',
+  },
+  deepseek: {
+    website: 'https://platform.deepseek.com',
+    apiKey: 'https://platform.deepseek.com/api_keys',
+  },
+  moonshot: {
+    website: 'https://platform.moonshot.cn',
+    apiKey: 'https://platform.moonshot.cn/console/api-keys',
+  },
+  zhipu: {
+    website: 'https://open.bigmodel.cn',
+    apiKey: 'https://open.bigmodel.cn/usercenter/apikeys',
+  },
+  minimax: {
+    website: 'https://platform.minimaxi.com',
+    apiKey: 'https://platform.minimaxi.com/user-center/basic-information/interface-key',
+  },
+  volcengine: {
+    website: 'https://console.volcengine.com/ark',
+    apiKey: 'https://console.volcengine.com/ark',
+  },
+  qwen: {
+    website: 'https://dashscope.console.aliyun.com',
+    apiKey: 'https://dashscope.console.aliyun.com/apiKey',
+  },
+  youdaozhiyun: { website: 'https://ai.youdao.com', apiKey: 'https://ai.youdao.com/console' },
+  stepfun: {
+    website: 'https://platform.stepfun.com',
+    apiKey: 'https://platform.stepfun.com/interface-key',
+  },
+  xiaomi: { website: 'https://dev.mi.com/platform', apiKey: 'https://dev.mi.com/platform' },
+  openrouter: { website: 'https://openrouter.ai', apiKey: 'https://openrouter.ai/keys' },
+  ollama: { website: 'https://ollama.com' },
 };
 
-const providerRequiresApiKey = (provider: ProviderType) => provider !== 'ollama' && provider !== 'github-copilot';
-const normalizeBaseUrl = (baseUrl: string): string => baseUrl.trim().replace(/\/+$/, '').toLowerCase();
-const normalizeApiFormat = (value: unknown): 'anthropic' | 'openai' => (
-  value === 'openai' ? 'openai' : 'anthropic'
-);
+const providerRequiresApiKey = (provider: ProviderType) =>
+  provider !== 'ollama' && provider !== 'github-copilot';
+const normalizeBaseUrl = (baseUrl: string): string =>
+  baseUrl.trim().replace(/\/+$/, '').toLowerCase();
+const normalizeApiFormat = (value: unknown): 'anthropic' | 'openai' =>
+  value === 'openai' ? 'openai' : 'anthropic';
 const ABOUT_CONTACT_EMAIL = 'lobsterai.project@rd.netease.com';
 const ABOUT_USER_MANUAL_URL = 'https://lobsterai.youdao.com/#/docs/lobsterai_user_manual';
 const ABOUT_USER_COMMUNITY_URL = 'https://lobsterai.youdao.com/#/about';
-const ABOUT_SERVICE_TERMS_URL = 'https://c.youdao.com/dict/hardware/lobsterai/lobsterai_service.html';
+const ABOUT_SERVICE_TERMS_URL =
+  'https://c.youdao.com/dict/hardware/lobsterai/lobsterai_service.html';
 
 // MiniMax Portal OAuth constants
 const MINIMAX_OAUTH_CLIENT_ID = '78257093-7e40-4613-99e0-527b14b39113';
@@ -213,19 +287,29 @@ type MiniMaxOAuthPhase =
   | { kind: 'success' }
   | { kind: 'error'; message: string };
 
-async function generateMiniMaxPkce(): Promise<{ verifier: string; challenge: string; state: string }> {
+async function generateMiniMaxPkce(): Promise<{
+  verifier: string;
+  challenge: string;
+  state: string;
+}> {
   const verifierArray = new Uint8Array(32);
   crypto.getRandomValues(verifierArray);
   const verifier = btoa(String.fromCharCode(...verifierArray))
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
   const encoded = new TextEncoder().encode(verifier);
   const digest = await crypto.subtle.digest('SHA-256', encoded);
   const challenge = btoa(String.fromCharCode(...new Uint8Array(digest)))
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
   const stateArray = new Uint8Array(16);
   crypto.getRandomValues(stateArray);
   const state = btoa(String.fromCharCode(...stateArray))
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
   return { verifier, challenge, state };
 }
 
@@ -263,7 +347,9 @@ const copyTextToClipboard = async (text: string): Promise<boolean> => {
   }
 };
 
-const getFixedApiFormatForProvider = (provider: string): 'anthropic' | 'openai' | 'gemini' | null => {
+const getFixedApiFormatForProvider = (
+  provider: string,
+): 'anthropic' | 'openai' | 'gemini' | null => {
   if (provider === 'openai' || provider === 'stepfun') {
     return 'openai';
   }
@@ -284,15 +370,16 @@ const getFixedApiFormatForProvider = (provider: string): 'anthropic' | 'openai' 
   }
   return null;
 };
-const getEffectiveApiFormat = (provider: string, value: unknown): 'anthropic' | 'openai' | 'gemini' => (
-  getFixedApiFormatForProvider(provider) ?? normalizeApiFormat(value)
-);
-const shouldShowApiFormatSelector = (provider: string): boolean => (
-  getFixedApiFormatForProvider(provider) === null
-);
+const getEffectiveApiFormat = (
+  provider: string,
+  value: unknown,
+): 'anthropic' | 'openai' | 'gemini' =>
+  getFixedApiFormatForProvider(provider) ?? normalizeApiFormat(value);
+const shouldShowApiFormatSelector = (provider: string): boolean =>
+  getFixedApiFormatForProvider(provider) === null;
 const getProviderDefaultBaseUrl = (
   provider: ProviderType,
-  apiFormat: 'anthropic' | 'openai' | 'gemini'
+  apiFormat: 'anthropic' | 'openai' | 'gemini',
 ): string | null => {
   if (apiFormat === 'gemini') return null;
   return ProviderRegistry.getSwitchableBaseUrl(provider, apiFormat) ?? null;
@@ -300,20 +387,28 @@ const getProviderDefaultBaseUrl = (
 const resolveBaseUrl = (
   provider: ProviderType,
   baseUrl: string,
-  apiFormat: 'anthropic' | 'openai' | 'gemini'
+  apiFormat: 'anthropic' | 'openai' | 'gemini',
 ): string => {
   if (baseUrl.trim()) {
-    if (shouldAutoSwitchProviderBaseUrl(provider, baseUrl) && (apiFormat === 'anthropic' || apiFormat === 'openai')) {
+    if (
+      shouldAutoSwitchProviderBaseUrl(provider, baseUrl) &&
+      (apiFormat === 'anthropic' || apiFormat === 'openai')
+    ) {
       const switchedUrl = ProviderRegistry.getSwitchableBaseUrl(provider, apiFormat);
       if (switchedUrl) return switchedUrl;
     }
     return baseUrl;
   }
-  return getProviderDefaultBaseUrl(provider, apiFormat)
-    || defaultConfig.providers?.[provider]?.baseUrl
-    || '';
+  return (
+    getProviderDefaultBaseUrl(provider, apiFormat) ||
+    defaultConfig.providers?.[provider]?.baseUrl ||
+    ''
+  );
 };
-const shouldAutoSwitchProviderBaseUrl = (provider: ProviderType, currentBaseUrl: string): boolean => {
+const shouldAutoSwitchProviderBaseUrl = (
+  provider: ProviderType,
+  currentBaseUrl: string,
+): boolean => {
   const anthropicUrl = ProviderRegistry.getSwitchableBaseUrl(provider, 'anthropic');
   const openaiUrl = ProviderRegistry.getSwitchableBaseUrl(provider, 'openai');
   if (!anthropicUrl && !openaiUrl) {
@@ -322,8 +417,8 @@ const shouldAutoSwitchProviderBaseUrl = (provider: ProviderType, currentBaseUrl:
 
   const normalizedCurrent = normalizeBaseUrl(currentBaseUrl);
   return (
-    (anthropicUrl ? normalizedCurrent === normalizeBaseUrl(anthropicUrl) : false)
-    || (openaiUrl ? normalizedCurrent === normalizeBaseUrl(openaiUrl) : false)
+    (anthropicUrl ? normalizedCurrent === normalizeBaseUrl(anthropicUrl) : false) ||
+    (openaiUrl ? normalizedCurrent === normalizeBaseUrl(openaiUrl) : false)
   );
 };
 const buildOpenAICompatibleChatCompletionsUrl = (baseUrl: string, provider: string): string => {
@@ -335,15 +430,14 @@ const buildOpenAICompatibleChatCompletionsUrl = (baseUrl: string, provider: stri
     return normalized;
   }
 
-  const isGeminiLike = provider === 'gemini' || normalized.includes('generativelanguage.googleapis.com');
+  const isGeminiLike =
+    provider === 'gemini' || normalized.includes('generativelanguage.googleapis.com');
   if (isGeminiLike) {
     if (normalized.endsWith('/v1beta/openai') || normalized.endsWith('/v1/openai')) {
       return `${normalized}/chat/completions`;
     }
     if (normalized.endsWith('/v1beta') || normalized.endsWith('/v1')) {
-      const betaBase = normalized.endsWith('/v1')
-        ? `${normalized.slice(0, -3)}v1beta`
-        : normalized;
+      const betaBase = normalized.endsWith('/v1') ? `${normalized.slice(0, -3)}v1beta` : normalized;
       return `${betaBase}/openai/chat/completions`;
     }
     return `${normalized}/v1beta/openai/chat/completions`;
@@ -372,9 +466,7 @@ const buildOpenAIResponsesUrl = (baseUrl: string): string => {
   }
   return `${normalized}/v1/responses`;
 };
-const shouldUseOpenAIResponsesForProvider = (provider: string): boolean => (
-  provider === 'openai'
-);
+const shouldUseOpenAIResponsesForProvider = (provider: string): boolean => provider === 'openai';
 const shouldUseMaxCompletionTokensForOpenAI = (provider: string, modelId?: string): boolean => {
   if (provider !== 'openai') {
     return false;
@@ -383,10 +475,12 @@ const shouldUseMaxCompletionTokensForOpenAI = (provider: string, modelId?: strin
   const resolvedModel = normalizedModel.includes('/')
     ? normalizedModel.slice(normalizedModel.lastIndexOf('/') + 1)
     : normalizedModel;
-  return resolvedModel.startsWith('gpt-5')
-    || resolvedModel.startsWith('o1')
-    || resolvedModel.startsWith('o3')
-    || resolvedModel.startsWith('o4');
+  return (
+    resolvedModel.startsWith('gpt-5') ||
+    resolvedModel.startsWith('o1') ||
+    resolvedModel.startsWith('o3') ||
+    resolvedModel.startsWith('o4')
+  );
 };
 const CONNECTIVITY_TEST_TOKEN_BUDGET = 64;
 
@@ -405,7 +499,7 @@ const getDefaultProviders = (): ProvidersConfig => {
           supportsImage: model.supportsImage ?? false,
         })),
       },
-    ])
+    ]),
   ) as ProvidersConfig;
 };
 
@@ -448,9 +542,16 @@ const formatShortcutFromEvent = (e: React.KeyboardEvent): string | null => {
   if (e.shiftKey) parts.push('Shift');
 
   const keyMap: Record<string, string> = {
-    ArrowUp: 'Up', ArrowDown: 'Down', ArrowLeft: 'Left', ArrowRight: 'Right',
-    ' ': 'Space', Escape: 'Esc', Enter: 'Enter', Backspace: 'Backspace',
-    Delete: 'Delete', Tab: 'Tab',
+    ArrowUp: 'Up',
+    ArrowDown: 'Down',
+    ArrowLeft: 'Left',
+    ArrowRight: 'Right',
+    ' ': 'Space',
+    Escape: 'Esc',
+    Enter: 'Enter',
+    Backspace: 'Backspace',
+    Delete: 'Delete',
+    Tab: 'Tab',
   };
   const key = keyMap[e.key] ?? (e.key.length === 1 ? e.key.toUpperCase() : e.key);
   parts.push(key);
@@ -466,7 +567,10 @@ const SEND_SHORTCUT_OPTIONS = [
 
 const isMacPlatform = navigator.platform.includes('Mac');
 
-const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void }> = ({ value, onChange }) => {
+const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void }> = ({
+  value,
+  onChange,
+}) => {
   const [recording, setRecording] = useState(false);
   const divRef = useRef<HTMLDivElement>(null);
 
@@ -474,10 +578,20 @@ const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void 
     if (!recording) return;
     e.preventDefault();
     e.stopPropagation();
-    if (e.key === 'Escape') { setRecording(false); return; }
-    if (e.key === 'Delete' || e.key === 'Backspace') { onChange(''); setRecording(false); return; }
+    if (e.key === 'Escape') {
+      setRecording(false);
+      return;
+    }
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      onChange('');
+      setRecording(false);
+      return;
+    }
     const shortcut = formatShortcutFromEvent(e);
-    if (shortcut) { onChange(shortcut); setRecording(false); }
+    if (shortcut) {
+      onChange(shortcut);
+      setRecording(false);
+    }
   };
 
   useEffect(() => {
@@ -499,9 +613,10 @@ const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void 
       onBlur={() => setRecording(false)}
       className={`w-36 rounded-xl border px-3 py-1.5 text-sm cursor-pointer select-none text-center outline-none transition-colors
         dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset dark:text-claude-darkText text-claude-text
-        ${recording
-          ? 'border-claude-accent ring-1 ring-claude-accent/30 dark:text-claude-darkTextSecondary text-claude-textSecondary'
-          : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
+        ${
+          recording
+            ? 'border-claude-accent ring-1 ring-claude-accent/30 dark:text-claude-darkTextSecondary text-claude-textSecondary'
+            : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
         }`}
     >
       {value || i18nService.t('shortcutNotSet')}
@@ -509,7 +624,10 @@ const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void 
   );
 };
 
-const SendShortcutSelect: React.FC<{ value: string; onChange: (v: string) => void }> = ({ value, onChange }) => {
+const SendShortcutSelect: React.FC<{ value: string; onChange: (v: string) => void }> = ({
+  value,
+  onChange,
+}) => {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -534,27 +652,32 @@ const SendShortcutSelect: React.FC<{ value: string; onChange: (v: string) => voi
         onClick={() => setOpen(!open)}
         className={`w-36 rounded-xl border px-3 py-1.5 text-sm cursor-pointer select-none text-center outline-none transition-colors
           dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset dark:text-claude-darkText text-claude-text
-          ${open
-            ? 'border-claude-accent ring-1 ring-claude-accent/30'
-            : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
+          ${
+            open
+              ? 'border-claude-accent ring-1 ring-claude-accent/30'
+              : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
           }`}
       >
         {currentLabel}
       </div>
       {open && (
         <div className="absolute right-0 mt-1 z-50 min-w-[160px] rounded-xl border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset shadow-elevated py-1">
-          {SEND_SHORTCUT_OPTIONS.map((option) => {
+          {SEND_SHORTCUT_OPTIONS.map(option => {
             const label = isMacPlatform ? option.labelMac : option.label;
             const isActive = value === option.value;
             return (
               <button
                 key={option.value}
                 type="button"
-                onClick={() => { onChange(option.value); setOpen(false); }}
+                onClick={() => {
+                  onChange(option.value);
+                  setOpen(false);
+                }}
                 className={`flex items-center justify-between w-full px-3 py-1.5 text-sm transition-colors
-                  ${isActive
-                    ? 'dark:text-claude-accent text-claude-accent font-medium'
-                    : 'dark:text-claude-darkText text-claude-text'
+                  ${
+                    isActive
+                      ? 'dark:text-claude-accent text-claude-accent font-medium'
+                      : 'dark:text-claude-darkText text-claude-text'
                   } hover:bg-claude-accent/10`}
               >
                 <span>{label}</span>
@@ -568,7 +691,15 @@ const SendShortcutSelect: React.FC<{ value: string; onChange: (v: string) => voi
   );
 };
 
-const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, noticeI18nKey, noticeExtra, onUpdateFound, enterpriseConfig }) => {
+const Settings: React.FC<SettingsProps> = ({
+  onClose,
+  initialTab,
+  notice,
+  noticeI18nKey,
+  noticeExtra,
+  onUpdateFound,
+  enterpriseConfig,
+}) => {
   const dispatch = useDispatch();
   // 状态
   const [activeTab, setActiveTab] = useState<TabType>(initialTab ?? 'general');
@@ -614,17 +745,21 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   // Add state for providers configuration
   const [providers, setProviders] = useState<ProvidersConfig>(() => getDefaultProviders());
 
-
   // authType defaults to undefined on first open, which should behave as OAuth mode
   const minimaxIsOAuthMode = providers.minimax.authType !== 'apikey';
-  const isBaseUrlLocked = (activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled) || (activeProvider === 'qwen' && providers.qwen.codingPlanEnabled) || (activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled) || (activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled) || (activeProvider === 'minimax' && minimaxIsOAuthMode);
-  
+  const isBaseUrlLocked =
+    (activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled) ||
+    (activeProvider === 'qwen' && providers.qwen.codingPlanEnabled) ||
+    (activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled) ||
+    (activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled) ||
+    (activeProvider === 'minimax' && minimaxIsOAuthMode);
+
   // 创建引用来确保内容区域的滚动
   const contentRef = useRef<HTMLDivElement>(null);
   const importInputRef = useRef<HTMLInputElement>(null);
   const emailCopiedTimerRef = useRef<number | null>(null);
   const updateCheckTimerRef = useRef<number | null>(null);
-  
+
   // 快捷键设置
   const [shortcuts, setShortcuts] = useState({
     newChat: 'Ctrl+N',
@@ -634,7 +769,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   });
 
   // GitHub Copilot device code auth state
-  const [copilotAuthStatus, setCopilotAuthStatus] = useState<'idle' | 'requesting' | 'awaiting_user' | 'polling' | 'authenticated' | 'error'>('idle');
+  const [copilotAuthStatus, setCopilotAuthStatus] = useState<
+    'idle' | 'requesting' | 'awaiting_user' | 'polling' | 'authenticated' | 'error'
+  >('idle');
   const [copilotUserCode, setCopilotUserCode] = useState('');
   const [copilotVerificationUri, setCopilotVerificationUri] = useState('');
   const [copilotGithubUser, setCopilotGithubUser] = useState('');
@@ -656,7 +793,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [testMode, setTestMode] = useState(false);
   const [logoClickCount, setLogoClickCount] = useState(0);
   const [testModeUnlocked, setTestModeUnlocked] = useState(false);
-  const [updateCheckStatus, setUpdateCheckStatus] = useState<'idle' | 'checking' | 'upToDate' | 'error'>('idle');
+  const [updateCheckStatus, setUpdateCheckStatus] = useState<
+    'idle' | 'checking' | 'upToDate' | 'error'
+  >('idle');
 
   useEffect(() => {
     window.electron.appInfo.getVersion().then(setAppVersion);
@@ -751,7 +890,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         setNoticeMessage(i18nService.t('aboutExportLogsSuccess'));
       }
     } catch (exportError) {
-      setError(exportError instanceof Error ? exportError.message : i18nService.t('aboutExportLogsFailed'));
+      setError(
+        exportError instanceof Error ? exportError.message : i18nService.t('aboutExportLogsFailed'),
+      );
     } finally {
       setIsExportingLogs(false);
     }
@@ -759,10 +900,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   const coworkConfig = useSelector(selectCoworkConfig);
 
-  const [coworkAgentEngine, setCoworkAgentEngine] = useState<CoworkAgentEngine>(coworkConfig.agentEngine || 'openclaw');
-  const [coworkMemoryEnabled, setCoworkMemoryEnabled] = useState<boolean>(coworkConfig.memoryEnabled ?? true);
-  const [coworkMemoryLlmJudgeEnabled, setCoworkMemoryLlmJudgeEnabled] = useState<boolean>(coworkConfig.memoryLlmJudgeEnabled ?? false);
-  const [skipMissedJobs, setSkipMissedJobs] = useState<boolean>(coworkConfig.skipMissedJobs ?? false);
+  const [coworkAgentEngine, setCoworkAgentEngine] = useState<CoworkAgentEngine>(
+    coworkConfig.agentEngine || 'openclaw',
+  );
+  const [coworkMemoryEnabled, setCoworkMemoryEnabled] = useState<boolean>(
+    coworkConfig.memoryEnabled ?? true,
+  );
+  const [coworkMemoryLlmJudgeEnabled, setCoworkMemoryLlmJudgeEnabled] = useState<boolean>(
+    coworkConfig.memoryLlmJudgeEnabled ?? false,
+  );
+  const [skipMissedJobs, setSkipMissedJobs] = useState<boolean>(
+    coworkConfig.skipMissedJobs ?? false,
+  );
   const [coworkMemoryEntries, setCoworkMemoryEntries] = useState<CoworkUserMemoryEntry[]>([]);
   const [coworkMemoryStats, setCoworkMemoryStats] = useState<CoworkMemoryStats | null>(null);
   const [coworkMemoryListLoading, setCoworkMemoryListLoading] = useState<boolean>(false);
@@ -774,7 +923,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [bootstrapUser, setBootstrapUser] = useState<string>('');
   const [bootstrapSoul, setBootstrapSoul] = useState<string>('');
   const [bootstrapLoaded, setBootstrapLoaded] = useState<boolean>(false);
-  const [openClawEngineStatus, setOpenClawEngineStatus] = useState<OpenClawEngineStatus | null>(null);
+  const [openClawEngineStatus, setOpenClawEngineStatus] = useState<OpenClawEngineStatus | null>(
+    null,
+  );
 
   useEffect(() => {
     setCoworkAgentEngine(coworkConfig.agentEngine || 'openclaw');
@@ -788,22 +939,25 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     coworkConfig.skipMissedJobs,
   ]);
 
-  useEffect(() => () => {
-    if (emailCopiedTimerRef.current != null) {
-      window.clearTimeout(emailCopiedTimerRef.current);
-    }
-    if (updateCheckTimerRef.current != null) {
-      window.clearTimeout(updateCheckTimerRef.current);
-    }
-  }, []);
+  useEffect(
+    () => () => {
+      if (emailCopiedTimerRef.current != null) {
+        window.clearTimeout(emailCopiedTimerRef.current);
+      }
+      if (updateCheckTimerRef.current != null) {
+        window.clearTimeout(updateCheckTimerRef.current);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     let active = true;
-    void coworkService.getOpenClawEngineStatus().then((status) => {
+    void coworkService.getOpenClawEngineStatus().then(status => {
       if (!active || !status) return;
       setOpenClawEngineStatus(status);
     });
-    const unsubscribe = coworkService.onOpenClawEngineStatus((status) => {
+    const unsubscribe = coworkService.onOpenClawEngineStatus(status => {
       if (!active) return;
       setOpenClawEngineStatus(status);
     });
@@ -816,7 +970,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   useEffect(() => {
     try {
       const config = configService.getConfig();
-      
+
       // Set general settings
       initialThemeRef.current = config.theme;
       initialLanguageRef.current = config.language;
@@ -828,18 +982,24 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       if (savedTestMode) setTestModeUnlocked(true);
 
       // Load auto-launch setting
-      window.electron.autoLaunch.get().then(({ enabled }) => {
-        setAutoLaunchState(enabled);
-      }).catch(err => {
-        console.error('Failed to load auto-launch setting:', err);
-      });
+      window.electron.autoLaunch
+        .get()
+        .then(({ enabled }) => {
+          setAutoLaunchState(enabled);
+        })
+        .catch(err => {
+          console.error('Failed to load auto-launch setting:', err);
+        });
 
       // Load prevent-sleep setting
-      window.electron.preventSleep.get().then(({ enabled }) => {
-        setPreventSleepState(enabled);
-      }).catch(err => {
-        console.error('Failed to load prevent-sleep setting:', err);
-      });
+      window.electron.preventSleep
+        .get()
+        .then(({ enabled }) => {
+          setPreventSleepState(enabled);
+        })
+        .catch(err => {
+          console.error('Failed to load prevent-sleep setting:', err);
+        });
 
       // Set up providers based on saved config
       if (config.api) {
@@ -854,8 +1014,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.openai,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('deepseek')) {
           setActiveProvider('deepseek');
@@ -865,10 +1025,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.deepseek,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
-        } else if (normalizedApiBaseUrl.includes('moonshot.ai') || normalizedApiBaseUrl.includes('moonshot.cn')) {
+        } else if (
+          normalizedApiBaseUrl.includes('moonshot.ai') ||
+          normalizedApiBaseUrl.includes('moonshot.cn')
+        ) {
           setActiveProvider('moonshot');
           setProviders(prev => ({
             ...prev,
@@ -876,8 +1039,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.moonshot,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('bigmodel.cn')) {
           setActiveProvider('zhipu');
@@ -887,8 +1050,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.zhipu,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('minimax')) {
           setActiveProvider('minimax');
@@ -898,8 +1061,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.minimax,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('openapi.youdao.com')) {
           setActiveProvider('youdaozhiyun');
@@ -909,8 +1072,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.youdaozhiyun,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('dashscope')) {
           setActiveProvider('qwen');
@@ -920,8 +1083,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.qwen,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('stepfun')) {
           setActiveProvider('stepfun');
@@ -931,8 +1094,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.stepfun,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('openrouter.ai')) {
           setActiveProvider('openrouter');
@@ -942,8 +1105,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.openrouter,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('googleapis')) {
           setActiveProvider('gemini');
@@ -953,8 +1116,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.gemini,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         } else if (normalizedApiBaseUrl.includes('anthropic')) {
           setActiveProvider('anthropic');
@@ -964,10 +1127,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.anthropic,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
-        } else if (normalizedApiBaseUrl.includes('ollama') || normalizedApiBaseUrl.includes('11434')) {
+        } else if (
+          normalizedApiBaseUrl.includes('ollama') ||
+          normalizedApiBaseUrl.includes('11434')
+        ) {
           setActiveProvider('ollama');
           setProviders(prev => ({
             ...prev,
@@ -975,24 +1141,26 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               ...prev.ollama,
               enabled: true,
               apiKey: config.api.key,
-              baseUrl: config.api.baseUrl
-            }
+              baseUrl: config.api.baseUrl,
+            },
           }));
         }
       }
-      
+
       // Load provider-specific configurations if available
       // 合并已保存的配置和默认配置，确保新添加的 provider 能被显示
       if (config.providers) {
         setProviders(prev => {
           const merged = {
-            ...prev,  // 保留默认的 providers（包括新添加的 anthropic）
-            ...config.providers,  // 覆盖已保存的配置
+            ...prev, // 保留默认的 providers（包括新添加的 anthropic）
+            ...config.providers, // 覆盖已保存的配置
           };
 
           // After merging, find the first enabled provider to set as activeProvider
           // This ensures we don't use stale activeProvider from old config.api.baseUrl
-          const firstEnabledProvider = providerKeys.find(providerKey => merged[providerKey]?.enabled);
+          const firstEnabledProvider = providerKeys.find(
+            providerKey => merged[providerKey]?.enabled,
+          );
           if (firstEnabledProvider) {
             setActiveProvider(firstEnabledProvider);
           }
@@ -1004,7 +1172,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 // Fix corrupted model IDs from previous OAuth mutation bug
                 if (providerKey === 'qwen' && (id === 'vision-model' || id === 'coder-model')) {
                   const defaultModel = defaultConfig.providers?.qwen?.models?.[idx];
-                  id = defaultModel?.id || (model.supportsImage ? 'qwen3.5-plus' : 'qwen3-coder-plus');
+                  id =
+                    defaultModel?.id || (model.supportsImage ? 'qwen3.5-plus' : 'qwen3-coder-plus');
                 }
                 return {
                   ...model,
@@ -1016,15 +1185,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 providerKey,
                 {
                   ...providerConfig,
-                  apiFormat: getEffectiveApiFormat(providerKey, (providerConfig as ProviderConfig).apiFormat),
+                  apiFormat: getEffectiveApiFormat(
+                    providerKey,
+                    (providerConfig as ProviderConfig).apiFormat,
+                  ),
                   models,
                 },
               ];
-            })
+            }),
           ) as ProvidersConfig;
         });
       }
-      
+
       // 加载快捷键设置
       if (config.shortcuts) {
         setShortcuts(prev => ({
@@ -1204,9 +1376,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         const def = ProviderRegistry.get(provider);
         if (def?.codingPlanSupported) {
           const enabled = value === 'true';
-          const nextModels = enabled && def.codingPlanModels
-            ? def.codingPlanModels.map(m => ({ ...m }))
-            : def.defaultModels.map(m => ({ ...m }));
+          const nextModels =
+            enabled && def.codingPlanModels
+              ? def.codingPlanModels.map(m => ({ ...m }))
+              : def.defaultModels.map(m => ({ ...m }));
           return {
             ...prev,
             [provider]: {
@@ -1233,7 +1406,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     setMinimaxOAuthPhase({ kind: 'requesting_code' });
 
     const codeEndpoint = region === 'cn' ? MINIMAX_CODE_ENDPOINT_CN : MINIMAX_CODE_ENDPOINT_GLOBAL;
-    const tokenEndpoint = region === 'cn' ? MINIMAX_TOKEN_ENDPOINT_CN : MINIMAX_TOKEN_ENDPOINT_GLOBAL;
+    const tokenEndpoint =
+      region === 'cn' ? MINIMAX_TOKEN_ENDPOINT_CN : MINIMAX_TOKEN_ENDPOINT_GLOBAL;
     const defaultBaseUrl = region === 'cn' ? MINIMAX_BASE_URL_CN : MINIMAX_BASE_URL_GLOBAL;
 
     try {
@@ -1253,7 +1427,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
-          'Accept': 'application/json',
+          Accept: 'application/json',
         },
         body: codeBody,
       });
@@ -1272,7 +1446,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       };
 
       if (!codePayload.user_code || !codePayload.verification_uri) {
-        throw new Error(codePayload.error ?? 'MiniMax OAuth returned incomplete authorization payload');
+        throw new Error(
+          codePayload.error ?? 'MiniMax OAuth returned incomplete authorization payload',
+        );
       }
 
       if (codePayload.state !== state) {
@@ -1281,7 +1457,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       try {
         await window.electron.shell.openExternal(codePayload.verification_uri);
-      } catch { /* ignore: user can open manually */ }
+      } catch {
+        /* ignore: user can open manually */
+      }
 
       setMinimaxOAuthPhase({
         kind: 'pending',
@@ -1290,7 +1468,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       });
 
       let pollIntervalMs = codePayload.interval ?? 2000;
-      const expireTimeMs = codePayload.expired_in ?? (Date.now() + 5 * 60 * 1000);
+      const expireTimeMs = codePayload.expired_in ?? Date.now() + 5 * 60 * 1000;
 
       while (Date.now() < expireTimeMs) {
         if (minimaxOAuthCancelRef.current) {
@@ -1317,7 +1495,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           method: 'POST',
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
-            'Accept': 'application/json',
+            Accept: 'application/json',
           },
           body: tokenBody,
         });
@@ -1398,14 +1576,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     setMinimaxOAuthPhase({ kind: 'idle' });
   };
 
-  const hasCoworkConfigChanges = coworkAgentEngine !== coworkConfig.agentEngine
-    || coworkMemoryEnabled !== coworkConfig.memoryEnabled
-    || coworkMemoryLlmJudgeEnabled !== coworkConfig.memoryLlmJudgeEnabled
-    || skipMissedJobs !== (coworkConfig.skipMissedJobs ?? false);
+  const hasCoworkConfigChanges =
+    coworkAgentEngine !== coworkConfig.agentEngine ||
+    coworkMemoryEnabled !== coworkConfig.memoryEnabled ||
+    coworkMemoryLlmJudgeEnabled !== coworkConfig.memoryLlmJudgeEnabled ||
+    skipMissedJobs !== (coworkConfig.skipMissedJobs ?? false);
   const isOpenClawAgentEngine = coworkAgentEngine === 'openclaw';
 
   const openClawProgressPercent = useMemo(() => {
-    if (typeof openClawEngineStatus?.progressPercent !== 'number' || !Number.isFinite(openClawEngineStatus.progressPercent)) {
+    if (
+      typeof openClawEngineStatus?.progressPercent !== 'number' ||
+      !Number.isFinite(openClawEngineStatus.progressPercent)
+    ) {
       return null;
     }
     return Math.max(0, Math.min(100, Math.round(openClawEngineStatus.progressPercent)));
@@ -1453,9 +1635,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     } finally {
       setCoworkMemoryListLoading(false);
     }
-  }, [
-    coworkMemoryQuery,
-  ]);
+  }, [coworkMemoryQuery]);
 
   useEffect(() => {
     if (activeTab !== 'coworkMemory') return;
@@ -1471,9 +1651,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     const TEMPLATE_MARKERS = [
       'Fill this in during your first conversation',
       "You're not a chatbot. You're becoming someone",
-      'Learn about the person you\'re helping',
+      "Learn about the person you're helping",
     ];
-    if (TEMPLATE_MARKERS.some((m) => content.includes(m))) return '';
+    if (TEMPLATE_MARKERS.some(m => content.includes(m))) return '';
     return content;
   };
 
@@ -1519,7 +1699,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       resetCoworkMemoryEditor();
       await loadCoworkMemoryData();
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : i18nService.t('coworkMemoryCrudSaveFailed'));
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : i18nService.t('coworkMemoryCrudSaveFailed'),
+      );
     } finally {
       setCoworkMemoryListLoading(false);
     }
@@ -1540,7 +1724,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       }
       await loadCoworkMemoryData();
     } catch (deleteError) {
-      setError(deleteError instanceof Error ? deleteError.message : i18nService.t('coworkMemoryCrudDeleteFailed'));
+      setError(
+        deleteError instanceof Error
+          ? deleteError.message
+          : i18nService.t('coworkMemoryCrudDeleteFailed'),
+      );
     } finally {
       setCoworkMemoryListLoading(false);
     }
@@ -1572,8 +1760,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       ...prev,
       [provider]: {
         ...prev[provider],
-        enabled: !prev[provider].enabled
-      }
+        enabled: !prev[provider].enabled,
+      },
     }));
   };
 
@@ -1612,7 +1800,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       // Step 2: Poll for token
       setCopilotAuthStatus('polling');
-      const result = await window.electron.githubCopilot.pollForToken(deviceCode, interval, expiresIn);
+      const result = await window.electron.githubCopilot.pollForToken(
+        deviceCode,
+        interval,
+        expiresIn,
+      );
 
       if (result.success && result.token) {
         setCopilotGithubUser(result.githubUser || '');
@@ -1679,15 +1871,19 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             {
               ...providerConfig,
               apiFormat,
-              baseUrl: resolveBaseUrl(providerKey as ProviderType, providerConfig.baseUrl, apiFormat),
+              baseUrl: resolveBaseUrl(
+                providerKey as ProviderType,
+                providerConfig.baseUrl,
+                apiFormat,
+              ),
             },
           ];
-        })
+        }),
       ) as ProvidersConfig;
 
       // Find the first enabled provider to use as the primary API
       const firstEnabledProvider = Object.entries(normalizedProviders).find(
-        ([_, config]) => config.enabled
+        ([_, config]) => config.enabled,
       );
 
       const primaryProvider = firstEnabledProvider
@@ -1736,7 +1932,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       });
 
       // 更新 Redux store 中的可用模型列表
-      const allModels: { id: string; name: string; provider?: string; providerKey?: string; supportsImage?: boolean }[] = [];
+      const allModels: {
+        id: string;
+        name: string;
+        provider?: string;
+        providerKey?: string;
+        supportsImage?: boolean;
+      }[] = [];
       Object.entries(normalizedProviders).forEach(([providerName, config]) => {
         if (config.enabled && config.models) {
           config.models.forEach(model => {
@@ -1816,18 +2018,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const handleShortcutChange = (key: keyof typeof shortcuts, value: string) => {
     // Check for conflicts with other shortcuts
     const conflictKey = Object.keys(shortcuts).find(
-      k => k !== key && shortcuts[k as keyof typeof shortcuts] === value
+      k => k !== key && shortcuts[k as keyof typeof shortcuts] === value,
     );
     if (conflictKey) {
       const conflictLabel = i18nService.t(shortcutLabelMap[conflictKey] ?? conflictKey);
       setNoticeMessage(
-        i18nService.t('shortcutConflict').replace('{0}', value).replace('{1}', conflictLabel)
+        i18nService.t('shortcutConflict').replace('{0}', value).replace('{1}', conflictLabel),
       );
       return;
     }
     setShortcuts(prev => ({
       ...prev,
-      [key]: value
+      [key]: value,
     }));
   };
 
@@ -1859,17 +2061,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   const handleDeleteModel = (modelId: string) => {
     if (!providers[activeProvider].models) return;
-    
-    const updatedModels = providers[activeProvider].models.filter(
-      model => model.id !== modelId
-    );
-    
+
+    const updatedModels = providers[activeProvider].models.filter(model => model.id !== modelId);
+
     setProviders(prev => ({
       ...prev,
       [activeProvider]: {
         ...prev[activeProvider],
-        models: updatedModels
-      }
+        models: updatedModels,
+      },
     }));
   };
 
@@ -1891,13 +2091,16 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     }
 
     // For Ollama, auto-fill display name from modelId if not provided
-    const modelName = activeProvider === 'ollama'
-      ? (newModelName.trim() && newModelName.trim() !== modelId ? newModelName.trim() : modelId)
-      : newModelName.trim();
+    const modelName =
+      activeProvider === 'ollama'
+        ? newModelName.trim() && newModelName.trim() !== modelId
+          ? newModelName.trim()
+          : modelId
+        : newModelName.trim();
 
     const currentModels = providers[activeProvider].models ?? [];
     const duplicateModel = currentModels.find(
-      model => model.id === modelId && (!isEditingModel || model.id !== editingModelId)
+      model => model.id === modelId && (!isEditingModel || model.id !== editingModelId),
     );
     if (duplicateModel) {
       setModelFormError(i18nService.t('modelIdExists'));
@@ -1909,16 +2112,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       name: modelName,
       supportsImage: newModelSupportsImage,
     };
-    const updatedModels = isEditingModel && editingModelId
-      ? currentModels.map(model => (model.id === editingModelId ? nextModel : model))
-      : [...currentModels, nextModel];
+    const updatedModels =
+      isEditingModel && editingModelId
+        ? currentModels.map(model => (model.id === editingModelId ? nextModel : model))
+        : [...currentModels, nextModel];
 
     setProviders(prev => ({
       ...prev,
       [activeProvider]: {
         ...prev[activeProvider],
-        models: updatedModels
-      }
+        models: updatedModels,
+      },
     }));
 
     setIsAddingModel(false);
@@ -1946,7 +2150,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       handleCancelModelEdit();
       return;
     }
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSaveNewModel();
     }
@@ -1954,7 +2158,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   const showTestResultModal = (
     result: Omit<ProviderConnectionTestResult, 'provider'>,
-    provider: ProviderType
+    provider: ProviderType,
   ) => {
     setTestResult({
       ...result,
@@ -1972,11 +2176,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     setTestResult(null);
 
     // Check if provider has valid authentication (API Key or OAuth for Qwen)
-    const hasValidAuth = providerConfig.apiKey || 
+    const hasValidAuth =
+      providerConfig.apiKey ||
       (testingProvider === 'qwen' && (providerConfig as any).oauthCredentials);
-    
+
     if (providerRequiresApiKey(testingProvider) && !hasValidAuth) {
-      showTestResultModal({ success: false, message: i18nService.t('apiKeyRequired') }, testingProvider);
+      showTestResultModal(
+        { success: false, message: i18nService.t('apiKeyRequired') },
+        testingProvider,
+      );
       setIsTesting(false);
       return;
     }
@@ -1984,7 +2192,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     // 获取第一个可用模型 - use a shallow copy to avoid mutating state
     const originalModel = providerConfig.models?.[0];
     if (!originalModel) {
-      showTestResultModal({ success: false, message: i18nService.t('noModelsConfigured') }, testingProvider);
+      showTestResultModal(
+        { success: false, message: i18nService.t('noModelsConfigured') },
+        testingProvider,
+      );
       setIsTesting(false);
       return;
     }
@@ -1994,16 +2205,28 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     try {
       let response: Awaited<ReturnType<typeof window.electron.api.fetch>>;
       // Apply Coding Plan endpoint switch
-      let effectiveBaseUrl = resolveBaseUrl(testingProvider, providerConfig.baseUrl, getEffectiveApiFormat(testingProvider, providerConfig.apiFormat));
+      let effectiveBaseUrl = resolveBaseUrl(
+        testingProvider,
+        providerConfig.baseUrl,
+        getEffectiveApiFormat(testingProvider, providerConfig.apiFormat),
+      );
       let effectiveApiFormat = getEffectiveApiFormat(testingProvider, providerConfig.apiFormat);
-      
+
       // Handle Coding Plan endpoint switch for supported providers
-      if ((providerConfig as { codingPlanEnabled?: boolean }).codingPlanEnabled && (effectiveApiFormat === 'anthropic' || effectiveApiFormat === 'openai')) {
-        const resolved = resolveCodingPlanBaseUrl(testingProvider, true, effectiveApiFormat, effectiveBaseUrl);
+      if (
+        (providerConfig as { codingPlanEnabled?: boolean }).codingPlanEnabled &&
+        (effectiveApiFormat === 'anthropic' || effectiveApiFormat === 'openai')
+      ) {
+        const resolved = resolveCodingPlanBaseUrl(
+          testingProvider,
+          true,
+          effectiveApiFormat,
+          effectiveBaseUrl,
+        );
         effectiveBaseUrl = resolved.baseUrl;
         effectiveApiFormat = resolved.effectiveFormat;
       }
-      
+
       let normalizedBaseUrl = effectiveBaseUrl.replace(/\/+$/, '');
 
       // Determine effective API key
@@ -2058,11 +2281,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           headers.Authorization = `Bearer ${effectiveApiKey}`;
         }
         if (testingProvider === 'github-copilot') {
-                  headers['Copilot-Integration-Id'] = 'vscode-chat';
-                  headers['Editor-Version'] = 'vscode/1.96.2';
-                  headers['Editor-Plugin-Version'] = 'copilot-chat/0.26.7';
-                  headers['User-Agent'] = 'GitHubCopilotChat/0.26.7';
-                  headers['Openai-Intent'] = 'conversation-panel';
+          headers['Copilot-Integration-Id'] = 'vscode-chat';
+          headers['Editor-Version'] = 'vscode/1.96.2';
+          headers['Editor-Plugin-Version'] = 'copilot-chat/0.26.7';
+          headers['User-Agent'] = 'GitHubCopilotChat/0.26.7';
+          headers['Openai-Intent'] = 'conversation-panel';
         }
         const openAIRequestBody: Record<string, unknown> = useResponsesApi
           ? {
@@ -2074,7 +2297,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               model: firstModel.id,
               messages: [{ role: 'user', content: 'Hi' }],
             };
-        if (!useResponsesApi && shouldUseMaxCompletionTokensForOpenAI(testingProvider, firstModel.id)) {
+        if (
+          !useResponsesApi &&
+          shouldUseMaxCompletionTokensForOpenAI(testingProvider, firstModel.id)
+        ) {
           openAIRequestBody.max_completion_tokens = CONNECTIVITY_TEST_TOKEN_BUDGET;
         } else {
           if (!useResponsesApi) {
@@ -2091,23 +2317,38 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       if (response.ok) {
         enableProvider(testingProvider);
-        showTestResultModal({ success: true, message: i18nService.t('connectionSuccess') }, testingProvider);
+        showTestResultModal(
+          { success: true, message: i18nService.t('connectionSuccess') },
+          testingProvider,
+        );
       } else {
         const data = response.data || {};
         // 提取错误信息
-        const errorMessage = data.error?.message || data.message || `${i18nService.t('connectionFailed')}: ${response.status}`;
-        if (typeof errorMessage === 'string' && errorMessage.toLowerCase().includes('model output limit was reached')) {
+        const errorMessage =
+          data.error?.message ||
+          data.message ||
+          `${i18nService.t('connectionFailed')}: ${response.status}`;
+        if (
+          typeof errorMessage === 'string' &&
+          errorMessage.toLowerCase().includes('model output limit was reached')
+        ) {
           enableProvider(testingProvider);
-          showTestResultModal({ success: true, message: i18nService.t('connectionSuccess') }, testingProvider);
+          showTestResultModal(
+            { success: true, message: i18nService.t('connectionSuccess') },
+            testingProvider,
+          );
           return;
         }
         showTestResultModal({ success: false, message: errorMessage }, testingProvider);
       }
     } catch (err) {
-      showTestResultModal({
-        success: false,
-        message: err instanceof Error ? err.message : i18nService.t('connectionFailed'),
-      }, testingProvider);
+      showTestResultModal(
+        {
+          success: false,
+          message: err instanceof Error ? err.message : i18nService.t('connectionFailed'),
+        },
+        testingProvider,
+      );
     } finally {
       setIsTesting(false);
     }
@@ -2129,7 +2370,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             models: providerConfig.models,
           },
         ] as const;
-      })
+      }),
     );
 
     return {
@@ -2246,9 +2487,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             hadDecryptFailure = true;
             console.warn(`Failed to decrypt provider key for ${providerKey}`, error);
           }
-        } else if (typeof providerData.apiKeyEncrypted === 'string' && typeof providerData.apiKeyIv === 'string') {
+        } else if (
+          typeof providerData.apiKeyEncrypted === 'string' &&
+          typeof providerData.apiKeyIv === 'string'
+        ) {
           try {
-            apiKey = await decryptSecret({ encrypted: providerData.apiKeyEncrypted, iv: providerData.apiKeyIv });
+            apiKey = await decryptSecret({
+              encrypted: providerData.apiKeyEncrypted,
+              iv: providerData.apiKeyIv,
+            });
           } catch (error) {
             hadDecryptFailure = true;
             console.warn(`Failed to decrypt provider key for ${providerKey}`, error);
@@ -2258,11 +2505,23 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         const models = normalizeModels(providerData.models);
 
         providerUpdates[providerKey] = {
-          enabled: typeof providerData.enabled === 'boolean' ? providerData.enabled : providers[providerKey].enabled,
+          enabled:
+            typeof providerData.enabled === 'boolean'
+              ? providerData.enabled
+              : providers[providerKey].enabled,
           apiKey: apiKey ?? providers[providerKey].apiKey,
-          baseUrl: typeof providerData.baseUrl === 'string' ? providerData.baseUrl : providers[providerKey].baseUrl,
-          apiFormat: getEffectiveApiFormat(providerKey, providerData.apiFormat ?? providers[providerKey].apiFormat),
-          codingPlanEnabled: typeof providerData.codingPlanEnabled === 'boolean' ? providerData.codingPlanEnabled : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
+          baseUrl:
+            typeof providerData.baseUrl === 'string'
+              ? providerData.baseUrl
+              : providers[providerKey].baseUrl,
+          apiFormat: getEffectiveApiFormat(
+            providerKey,
+            providerData.apiFormat ?? providers[providerKey].apiFormat,
+          ),
+          codingPlanEnabled:
+            typeof providerData.codingPlanEnabled === 'boolean'
+              ? providerData.codingPlanEnabled
+              : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
           models: models ?? providers[providerKey].models,
         };
       }
@@ -2289,8 +2548,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       }
     } catch (err) {
       console.error('Failed to import providers:', err);
-      const isDecryptError = err instanceof Error
-        && (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
+      const isDecryptError =
+        err instanceof Error &&
+        (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
       const message = isDecryptError
         ? i18nService.t('decryptProvidersFailed')
         : i18nService.t('importProvidersFailed');
@@ -2336,11 +2596,23 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         const models = normalizeModels(providerData.models);
 
         providerUpdates[providerKey] = {
-          enabled: typeof providerData.enabled === 'boolean' ? providerData.enabled : providers[providerKey].enabled,
+          enabled:
+            typeof providerData.enabled === 'boolean'
+              ? providerData.enabled
+              : providers[providerKey].enabled,
           apiKey: apiKey ?? providers[providerKey].apiKey,
-          baseUrl: typeof providerData.baseUrl === 'string' ? providerData.baseUrl : providers[providerKey].baseUrl,
-          apiFormat: getEffectiveApiFormat(providerKey, providerData.apiFormat ?? providers[providerKey].apiFormat),
-          codingPlanEnabled: typeof providerData.codingPlanEnabled === 'boolean' ? providerData.codingPlanEnabled : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
+          baseUrl:
+            typeof providerData.baseUrl === 'string'
+              ? providerData.baseUrl
+              : providers[providerKey].baseUrl,
+          apiFormat: getEffectiveApiFormat(
+            providerKey,
+            providerData.apiFormat ?? providers[providerKey].apiFormat,
+          ),
+          codingPlanEnabled:
+            typeof providerData.codingPlanEnabled === 'boolean'
+              ? providerData.codingPlanEnabled
+              : (providers[providerKey] as ProviderConfig).codingPlanEnabled,
           models: models ?? providers[providerKey].models,
         };
       }
@@ -2352,7 +2624,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       // Check if any key was successfully decrypted
       const anyKeyDecrypted = Object.entries(providerUpdates).some(
-        ([key, update]) => update?.apiKey && update.apiKey !== providers[key]?.apiKey
+        ([key, update]) => update?.apiKey && update.apiKey !== providers[key]?.apiKey,
       );
 
       if (!anyKeyDecrypted && hadDecryptFailure) {
@@ -2378,8 +2650,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       }
     } catch (err) {
       console.error('Failed to import providers:', err);
-      const isDecryptError = err instanceof Error
-        && (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
+      const isDecryptError =
+        err instanceof Error &&
+        (err.message === 'Invalid encrypted payload' || err.name === 'OperationError');
       const message = isDecryptError
         ? i18nService.t('decryptProvidersFailed')
         : i18nService.t('importProvidersFailed');
@@ -2392,15 +2665,69 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   // 渲染标签页
   const sidebarTabs: { key: TabType; label: string; icon: React.ReactNode }[] = useMemo(() => {
     const allTabs = [
-      { key: 'general' as TabType,        label: i18nService.t('general'),        icon: <Cog6ToothIcon className="h-5 w-5" /> },
-      { key: 'coworkAgentEngine' as TabType, label: i18nService.t('coworkAgentEngine'), icon: <CpuChipIcon className="h-5 w-5" /> },
-      { key: 'model' as TabType,          label: i18nService.t('model'),          icon: <CubeIcon className="h-5 w-5" /> },
-      { key: 'im' as TabType,             label: i18nService.t('imBot'),          icon: <ChatBubbleLeftIcon className="h-5 w-5" /> },
-      { key: 'email' as TabType,          label: i18nService.t('emailTab'),       icon: <EnvelopeIcon className="h-5 w-5" /> },
-      { key: 'coworkMemory' as TabType,   label: i18nService.t('coworkMemoryTitle'), icon: <BrainIcon className="h-5 w-5" /> },
-      { key: 'coworkAgent' as TabType,    label: i18nService.t('coworkAgentTab'),    icon: <UserCircleIcon className="h-5 w-5" /> },
-      { key: 'shortcuts' as TabType,      label: i18nService.t('shortcuts'),      icon: <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-5 w-5"><rect x="2" y="4" width="20" height="14" rx="2" /><line x1="6" y1="8" x2="8" y2="8" /><line x1="10" y1="8" x2="12" y2="8" /><line x1="14" y1="8" x2="16" y2="8" /><line x1="6" y1="12" x2="8" y2="12" /><line x1="10" y1="12" x2="14" y2="12" /><line x1="16" y1="12" x2="18" y2="12" /><line x1="8" y1="15.5" x2="16" y2="15.5" /></svg> },
-      { key: 'about' as TabType,          label: i18nService.t('about'),          icon: <InformationCircleIcon className="h-5 w-5" /> },
+      {
+        key: 'general' as TabType,
+        label: i18nService.t('general'),
+        icon: <Cog6ToothIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'coworkAgentEngine' as TabType,
+        label: i18nService.t('coworkAgentEngine'),
+        icon: <CpuChipIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'model' as TabType,
+        label: i18nService.t('model'),
+        icon: <CubeIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'im' as TabType,
+        label: i18nService.t('imBot'),
+        icon: <ChatBubbleLeftIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'email' as TabType,
+        label: i18nService.t('emailTab'),
+        icon: <EnvelopeIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'coworkMemory' as TabType,
+        label: i18nService.t('coworkMemoryTitle'),
+        icon: <BrainIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'coworkAgent' as TabType,
+        label: i18nService.t('coworkAgentTab'),
+        icon: <UserCircleIcon className="h-5 w-5" />,
+      },
+      {
+        key: 'shortcuts' as TabType,
+        label: i18nService.t('shortcuts'),
+        icon: (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="h-5 w-5"
+          >
+            <rect x="2" y="4" width="20" height="14" rx="2" />
+            <line x1="6" y1="8" x2="8" y2="8" />
+            <line x1="10" y1="8" x2="12" y2="8" />
+            <line x1="14" y1="8" x2="16" y2="8" />
+            <line x1="6" y1="12" x2="8" y2="12" />
+            <line x1="10" y1="12" x2="14" y2="12" />
+            <line x1="16" y1="12" x2="18" y2="12" />
+            <line x1="8" y1="15.5" x2="16" y2="15.5" />
+          </svg>
+        ),
+      },
+      {
+        key: 'about' as TabType,
+        label: i18nService.t('about'),
+        icon: <InformationCircleIcon className="h-5 w-5" />,
+      },
     ];
     // Filter out tabs hidden by enterprise config
     // Filter out tabs with 'hide' action in enterprise config
@@ -2417,27 +2744,25 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   }, [activeTab, sidebarTabs]);
 
   const renderTabContent = () => {
-    switch(activeTab) {
+    switch (activeTab) {
       case 'general':
         return (
           <div className="space-y-8">
             {/* Language Section */}
             <div className="flex items-center justify-between">
-              <h4 className="text-sm font-medium text-foreground">
-                {i18nService.t('language')}
-              </h4>
+              <h4 className="text-sm font-medium text-foreground">{i18nService.t('language')}</h4>
               <div className="w-[140px] shrink-0">
                 <ThemedSelect
                   id="language"
                   value={language}
-                  onChange={(value) => {
+                  onChange={value => {
                     const nextLanguage = value as LanguageType;
                     setLanguage(nextLanguage);
                     i18nService.setLanguage(nextLanguage, { persist: false });
                   }}
                   options={[
                     { value: 'zh', label: i18nService.t('chinese') },
-                    { value: 'en', label: i18nService.t('english') }
+                    { value: 'en', label: i18nService.t('english') },
                   ]}
                 />
               </div>
@@ -2477,11 +2802,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   disabled={isUpdatingAutoLaunch}
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                     isUpdatingAutoLaunch ? 'opacity-50 cursor-not-allowed' : ''
-                  } ${
-                    autoLaunch
-                      ? 'bg-primary'
-                      : 'bg-gray-300 dark:bg-gray-600'
-                  }`}
+                  } ${autoLaunch ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'}`}
                 >
                   <span
                     className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
@@ -2526,11 +2847,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   disabled={isUpdatingPreventSleep}
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                     isUpdatingPreventSleep ? 'opacity-50 cursor-not-allowed' : ''
-                  } ${
-                    preventSleep
-                      ? 'bg-primary'
-                      : 'bg-gray-300 dark:bg-gray-600'
-                  }`}
+                  } ${preventSleep ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'}`}
                 >
                   <span
                     className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
@@ -2555,12 +2872,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   role="switch"
                   aria-checked={useSystemProxy}
                   onClick={() => {
-                    setUseSystemProxy((prev) => !prev);
+                    setUseSystemProxy(prev => !prev);
                   }}
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
-                    useSystemProxy
-                      ? 'bg-primary'
-                      : 'bg-gray-300 dark:bg-gray-600'
+                    useSystemProxy ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
                   }`}
                 >
                   <span
@@ -2586,12 +2901,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   role="switch"
                   aria-checked={skipMissedJobs}
                   onClick={() => {
-                    setSkipMissedJobs((prev) => !prev);
+                    setSkipMissedJobs(prev => !prev);
                   }}
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
-                    skipMissedJobs
-                      ? 'bg-primary'
-                      : 'bg-gray-300 dark:bg-gray-600'
+                    skipMissedJobs ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
                   }`}
                 >
                   <span
@@ -2605,13 +2918,16 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
             {/* Appearance Section — mode selector + theme gallery */}
             <div>
-              <h4 className="text-sm font-medium mb-3" style={{ color: 'var(--lobster-text-primary)' }}>
+              <h4
+                className="text-sm font-medium mb-3"
+                style={{ color: 'var(--lobster-text-primary)' }}
+              >
                 {i18nService.t('appearance')}
               </h4>
 
               {/* Level 1: Mode selector */}
               <div className="grid grid-cols-3 gap-3 mb-4">
-                {(['light', 'dark', 'system'] as const).map((mode) => {
+                {(['light', 'dark', 'system'] as const).map(mode => {
                   const isSelected = theme === mode;
                   return (
                     <button
@@ -2624,11 +2940,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       }}
                       className="flex flex-col items-center rounded-xl border-2 p-3 transition-colors cursor-pointer"
                       style={{
-                        borderColor: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-border)',
+                        borderColor: isSelected
+                          ? 'var(--lobster-primary)'
+                          : 'var(--lobster-border)',
                         backgroundColor: isSelected ? 'var(--lobster-primary-muted)' : undefined,
                       }}
                     >
-                      <svg viewBox="0 0 120 80" className="w-full h-auto rounded-md mb-2 overflow-hidden" xmlns="http://www.w3.org/2000/svg">
+                      <svg
+                        viewBox="0 0 120 80"
+                        className="w-full h-auto rounded-md mb-2 overflow-hidden"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
                         {mode === 'light' && (
                           <>
                             <rect width="120" height="80" fill="#F8F9FB" />
@@ -2709,7 +3031,14 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           </>
                         )}
                       </svg>
-                      <span className="text-xs font-medium" style={{ color: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-text-primary)' }}>
+                      <span
+                        className="text-xs font-medium"
+                        style={{
+                          color: isSelected
+                            ? 'var(--lobster-primary)'
+                            : 'var(--lobster-text-primary)',
+                        }}
+                      >
                         {i18nService.t(mode)}
                       </span>
                     </button>
@@ -2718,13 +3047,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               </div>
 
               {/* Theme color gallery — all themes */}
-              <h4 className="text-sm font-medium mb-3 mt-5" style={{ color: 'var(--lobster-text-primary)' }}>
+              <h4
+                className="text-sm font-medium mb-3 mt-5"
+                style={{ color: 'var(--lobster-text-primary)' }}
+              >
                 {i18nService.t('themeColor')}
               </h4>
               {(() => {
                 const allThemes = themeService.getAllThemes();
-                const classicThemes = allThemes.filter(t => t.meta.id === 'classic-light' || t.meta.id === 'classic-dark');
-                const otherThemes = allThemes.filter(t => t.meta.id !== 'classic-light' && t.meta.id !== 'classic-dark');
+                const classicThemes = allThemes.filter(
+                  t => t.meta.id === 'classic-light' || t.meta.id === 'classic-dark',
+                );
+                const otherThemes = allThemes.filter(
+                  t => t.meta.id !== 'classic-light' && t.meta.id !== 'classic-dark',
+                );
                 const renderTile = (t: import('../theme').ThemeDefinition) => {
                   const isSelected = themeId === t.meta.id;
                   const [bg, c1, c2, c3] = t.meta.preview;
@@ -2739,18 +3075,31 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       }}
                       className="flex flex-col items-center rounded-xl border-2 p-2 transition-colors cursor-pointer"
                       style={{
-                        borderColor: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-border)',
+                        borderColor: isSelected
+                          ? 'var(--lobster-primary)'
+                          : 'var(--lobster-border)',
                         backgroundColor: isSelected ? 'var(--lobster-primary-muted)' : undefined,
                       }}
                     >
-                      <svg viewBox="0 0 80 48" className="w-full h-auto rounded-md mb-1.5 overflow-hidden" xmlns="http://www.w3.org/2000/svg">
+                      <svg
+                        viewBox="0 0 80 48"
+                        className="w-full h-auto rounded-md mb-1.5 overflow-hidden"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
                         <rect width="80" height="48" fill={bg} />
                         <rect x="4" y="6" width="20" height="36" rx="3" fill={c1} opacity="0.7" />
                         <rect x="28" y="6" width="48" height="36" rx="3" fill={c2} opacity="0.5" />
                         <circle cx="52" cy="24" r="8" fill={c3} opacity="0.8" />
                         <rect x="32" y="34" width="40" height="4" rx="2" fill={c1} opacity="0.6" />
                       </svg>
-                      <span className="text-[10px] font-medium truncate w-full text-center" style={{ color: isSelected ? 'var(--lobster-primary)' : 'var(--lobster-text-primary)' }}>
+                      <span
+                        className="text-[10px] font-medium truncate w-full text-center"
+                        style={{
+                          color: isSelected
+                            ? 'var(--lobster-primary)'
+                            : 'var(--lobster-text-primary)',
+                        }}
+                      >
                         {t.meta.name}
                       </span>
                     </button>
@@ -2761,9 +3110,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <div className="grid grid-cols-2 gap-3 mb-3">
                       {classicThemes.map(renderTile)}
                     </div>
-                    <div className="grid grid-cols-4 gap-3">
-                      {otherThemes.map(renderTile)}
-                    </div>
+                    <div className="grid grid-cols-4 gap-3">{otherThemes.map(renderTile)}</div>
                   </>
                 );
               })()}
@@ -2779,12 +3126,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           <div className="space-y-6">
             <div className="space-y-3">
               <div className="flex items-start gap-3 rounded-xl border px-3 py-2 text-sm border-border">
-                <input
-                  type="radio"
-                  checked={true}
-                  readOnly
-                  className="mt-1"
-                />
+                <input type="radio" checked={true} readOnly className="mt-1" />
                 <span>
                   <span className="block font-medium text-foreground">
                     {i18nService.t('coworkAgentEngineOpenClaw')}
@@ -2800,9 +3142,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="text-xs text-secondary">
                   {i18nService.t('coworkOpenClawInstallHint')}
                 </div>
-                <div className={`rounded-xl border px-4 py-3 text-sm ${openClawEngineStatus?.phase === 'error'
-                  ? 'border-red-300 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300'
-                  : 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-300'}`}
+                <div
+                  className={`rounded-xl border px-4 py-3 text-sm ${
+                    openClawEngineStatus?.phase === 'error'
+                      ? 'border-red-300 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300'
+                      : 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-300'
+                  }`}
                 >
                   <div className="flex items-center justify-between gap-3">
                     <div>
@@ -2872,24 +3217,25 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <input
                 type="text"
                 value={coworkMemoryQuery}
-                onChange={(event) => setCoworkMemoryQuery(event.target.value)}
+                onChange={event => setCoworkMemoryQuery(event.target.value)}
                 placeholder={i18nService.t('coworkMemorySearchPlaceholder')}
                 className="w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface"
               />
 
               <div className="rounded-lg border border-border">
                 {coworkMemoryListLoading ? (
-                  <div className="px-3 py-3 text-xs text-secondary">
-                    {i18nService.t('loading')}
-                  </div>
+                  <div className="px-3 py-3 text-xs text-secondary">{i18nService.t('loading')}</div>
                 ) : coworkMemoryEntries.length === 0 ? (
                   <div className="px-3 py-3 text-xs text-secondary">
                     {i18nService.t('coworkMemoryEmpty')}
                   </div>
                 ) : (
                   <div className="divide-y divide-border">
-                    {coworkMemoryEntries.map((entry) => (
-                      <div key={entry.id} className="px-3 py-3 text-xs hover:bg-surface-raised transition-colors">
+                    {coworkMemoryEntries.map(entry => (
+                      <div
+                        key={entry.id}
+                        className="px-3 py-3 text-xs hover:bg-surface-raised transition-colors"
+                      >
                         <div className="flex items-start justify-between gap-3">
                           <div className="flex-1 min-w-0">
                             <div className="font-medium text-foreground break-words">
@@ -2906,7 +3252,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                             </button>
                             <button
                               type="button"
-                              onClick={() => { void handleDeleteCoworkMemoryEntry(entry); }}
+                              onClick={() => {
+                                void handleDeleteCoworkMemoryEntry(entry);
+                              }}
                               className="rounded border px-2 py-1 text-red-500 border-border hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-60 transition-colors"
                               disabled={coworkMemoryListLoading}
                             >
@@ -2920,7 +3268,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 )}
               </div>
             </div>
-
           </div>
         );
 
@@ -2966,7 +3313,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 const missingApiKey = providerRequiresApiKey(providerKey) && !config.apiKey.trim();
                 const canToggleProvider = config.enabled || !missingApiKey;
                 const displayLabel = isCustom
-                  ? ((config as ProviderConfig).displayName || getCustomProviderDefaultName(provider))
+                  ? (config as ProviderConfig).displayName || getCustomProviderDefaultName(provider)
                   : (providerInfo?.label ?? getProviderDisplayName(provider));
                 return (
                   <div
@@ -2985,11 +3332,11 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         </span>
                       </div>
                       <div className="flex flex-col min-w-0">
-                        <span className={`text-sm font-medium truncate ${
-                          activeProvider === provider
-                            ? 'text-primary'
-                            : 'text-foreground'
-                        }`}>
+                        <span
+                          className={`text-sm font-medium truncate ${
+                            activeProvider === provider ? 'text-primary' : 'text-foreground'
+                          }`}
+                        >
                           {displayLabel}
                         </span>
                         {isCustom && (
@@ -3004,13 +3351,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         <button
                           type="button"
                           className="opacity-0 group-hover:opacity-100 transition-opacity text-claude-secondaryText hover:text-red-500 dark:text-claude-darkSecondaryText dark:hover:text-red-400 p-0.5"
-                          onClick={(e) => {
+                          onClick={e => {
                             e.stopPropagation();
                             handleDeleteCustomProvider(providerKey);
                           }}
                           title={i18nService.t('deleteCustomProvider')}
                         >
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                            className="w-3.5 h-3.5"
+                          >
                             <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
                           </svg>
                         </button>
@@ -3022,7 +3374,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         } ${
                           canToggleProvider ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'
                         }`}
-                        onClick={(e) => {
+                        onClick={e => {
                           e.stopPropagation();
                           if (!canToggleProvider) {
                             return;
@@ -3042,13 +3394,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               })}
               {/* Add Custom Provider Button */}
               {CUSTOM_PROVIDER_KEYS.some(k => !providers[k]) && (
-              <button
-                type="button"
-                onClick={handleAddCustomProvider}
-                className="w-full flex items-center justify-center p-2 rounded-xl border border-dashed border-claude-border dark:border-claude-darkBorder text-claude-secondaryText dark:text-claude-darkSecondaryText hover:border-claude-accent hover:text-claude-accent transition-colors text-sm"
-              >
-                {i18nService.t('addCustomProvider')}
-              </button>
+                <button
+                  type="button"
+                  onClick={handleAddCustomProvider}
+                  className="w-full flex items-center justify-center p-2 rounded-xl border border-dashed border-claude-border dark:border-claude-darkBorder text-claude-secondaryText dark:text-claude-darkSecondaryText hover:border-claude-accent hover:text-claude-accent transition-colors text-sm"
+                >
+                  {i18nService.t('addCustomProvider')}
+                </button>
               )}
             </div>
 
@@ -3058,14 +3410,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center gap-1.5">
                   <h3 className="text-base font-medium text-foreground">
                     {isCustomProvider(activeProvider)
-                      ? ((providers[activeProvider] as ProviderConfig)?.displayName || getCustomProviderDefaultName(activeProvider))
-                      : (providerMeta[activeProvider]?.label ?? getProviderDisplayName(activeProvider))
-                    } {i18nService.t('providerSettings')}
+                      ? (providers[activeProvider] as ProviderConfig)?.displayName ||
+                        getCustomProviderDefaultName(activeProvider)
+                      : (providerMeta[activeProvider]?.label ??
+                        getProviderDisplayName(activeProvider))}{' '}
+                    {i18nService.t('providerSettings')}
                   </h3>
                   {providerLinks[activeProvider]?.website && (
                     <button
                       type="button"
-                      onClick={() => void window.electron.shell.openExternal(providerLinks[activeProvider]!.website)}
+                      onClick={() =>
+                        void window.electron.shell.openExternal(
+                          providerLinks[activeProvider]!.website,
+                        )
+                      }
                       className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                       title={i18nService.t('visitOfficialSite')}
                       aria-label={i18nService.t('visitOfficialSite')}
@@ -3081,7 +3439,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       : 'bg-red-500/20 text-red-600 dark:text-red-400'
                   }`}
                 >
-                  {providers[activeProvider].enabled ? i18nService.t('providerStatusOn') : i18nService.t('providerStatusOff')}
+                  {providers[activeProvider].enabled
+                    ? i18nService.t('providerStatusOn')
+                    : i18nService.t('providerStatusOff')}
                 </div>
               </div>
 
@@ -3093,7 +3453,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <div className="flex rounded-xl overflow-hidden border border-border mb-3">
                       <button
                         type="button"
-                        onClick={() => setProviders(prev => ({ ...prev, minimax: { ...prev.minimax, authType: 'oauth' } }))}
+                        onClick={() =>
+                          setProviders(prev => ({
+                            ...prev,
+                            minimax: { ...prev.minimax, authType: 'oauth' },
+                          }))
+                        }
                         className={`flex-1 py-1.5 text-xs font-medium transition-colors ${minimaxIsOAuthMode ? 'bg-primary text-white' : 'text-secondary hover:bg-surface-raised'}`}
                       >
                         {i18nService.t('minimaxOAuthTabOAuth')}
@@ -3101,7 +3466,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       <button
                         type="button"
                         onClick={() => {
-                          setProviders(prev => ({ ...prev, minimax: { ...prev.minimax, authType: 'apikey' } }));
+                          setProviders(prev => ({
+                            ...prev,
+                            minimax: { ...prev.minimax, authType: 'apikey' },
+                          }));
                           setMinimaxOAuthPhase({ kind: 'idle' });
                         }}
                         className={`flex-1 py-1.5 text-xs font-medium transition-colors ${!minimaxIsOAuthMode ? 'bg-primary text-white' : 'text-secondary hover:bg-surface-raised'}`}
@@ -3115,13 +3483,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {!minimaxIsOAuthMode && (
                     <div className="min-h-[68px]">
                       <div className="flex items-center justify-between mb-1">
-                        <label htmlFor="minimax-apiKey" className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
+                        <label
+                          htmlFor="minimax-apiKey"
+                          className="block text-xs font-medium dark:text-claude-darkText text-claude-text"
+                        >
                           {i18nService.t('apiKey')}
                         </label>
                         {providerLinks.minimax?.apiKey && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks.minimax!.apiKey!)}
+                            onClick={() =>
+                              void window.electron.shell.openExternal(
+                                providerLinks.minimax!.apiKey!,
+                              )
+                            }
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -3129,34 +3504,44 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         )}
                       </div>
                       <div className="relative">
-                      <input
-                        type={showApiKey ? 'text' : 'password'}
-                        id="minimax-apiKey"
-                        value={providers.minimax.apiKey}
-                        onChange={(e) => handleProviderConfigChange('minimax', 'apiKey', e.target.value)}
-                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-xs"
-                        placeholder={i18nService.t('apiKeyPlaceholder')}
-                      />
-                      <div className="absolute right-2 inset-y-0 flex items-center gap-1">
-                        {providers.minimax.apiKey && (
+                        <input
+                          type={showApiKey ? 'text' : 'password'}
+                          id="minimax-apiKey"
+                          value={providers.minimax.apiKey}
+                          onChange={e =>
+                            handleProviderConfigChange('minimax', 'apiKey', e.target.value)
+                          }
+                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-xs"
+                          placeholder={i18nService.t('apiKeyPlaceholder')}
+                        />
+                        <div className="absolute right-2 inset-y-0 flex items-center gap-1">
+                          {providers.minimax.apiKey && (
+                            <button
+                              type="button"
+                              onClick={() => handleProviderConfigChange('minimax', 'apiKey', '')}
+                              className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
+                              title={i18nService.t('clear') || 'Clear'}
+                            >
+                              <XCircleIconSolid className="h-4 w-4" />
+                            </button>
+                          )}
                           <button
                             type="button"
-                            onClick={() => handleProviderConfigChange('minimax', 'apiKey', '')}
+                            onClick={() => setShowApiKey(!showApiKey)}
                             className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                            title={i18nService.t('clear') || 'Clear'}
+                            title={
+                              showApiKey
+                                ? i18nService.t('hide') || 'Hide'
+                                : i18nService.t('show') || 'Show'
+                            }
                           >
-                            <XCircleIconSolid className="h-4 w-4" />
+                            {showApiKey ? (
+                              <EyeIcon className="h-4 w-4" />
+                            ) : (
+                              <EyeSlashIcon className="h-4 w-4" />
+                            )}
                           </button>
-                        )}
-                        <button
-                          type="button"
-                          onClick={() => setShowApiKey(!showApiKey)}
-                          className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                          title={showApiKey ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
-                        >
-                          {showApiKey ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
-                        </button>
-                      </div>
+                        </div>
                       </div>
                     </div>
                   )}
@@ -3251,7 +3636,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           </div>
                           <a
                             href={minimaxOAuthPhase.verificationUri}
-                            onClick={(e) => { e.preventDefault(); void window.electron.shell.openExternal(minimaxOAuthPhase.verificationUri); }}
+                            onClick={e => {
+                              e.preventDefault();
+                              void window.electron.shell.openExternal(
+                                minimaxOAuthPhase.verificationUri,
+                              );
+                            }}
                             className="block text-[11px] text-primary underline truncate"
                           >
                             {minimaxOAuthPhase.verificationUri}
@@ -3317,13 +3707,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {activeProvider !== 'qwen' && (
                     <div>
                       <div className="flex items-center justify-between mb-1">
-                        <label htmlFor={`${activeProvider}-apiKey`} className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
+                        <label
+                          htmlFor={`${activeProvider}-apiKey`}
+                          className="block text-xs font-medium dark:text-claude-darkText text-claude-text"
+                        >
                           {i18nService.t('apiKey')}
                         </label>
                         {providerLinks[activeProvider]?.apiKey && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks[activeProvider]!.apiKey!)}
+                            onClick={() =>
+                              void window.electron.shell.openExternal(
+                                providerLinks[activeProvider]!.apiKey!,
+                              )
+                            }
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -3335,7 +3732,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           type={showApiKey ? 'text' : 'password'}
                           id={`${activeProvider}-apiKey`}
                           value={providers[activeProvider].apiKey}
-                          onChange={(e) => handleProviderConfigChange(activeProvider, 'apiKey', e.target.value)}
+                          onChange={e =>
+                            handleProviderConfigChange(activeProvider, 'apiKey', e.target.value)
+                          }
                           className="block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-16 text-xs"
                           placeholder={i18nService.t('apiKeyPlaceholder')}
                         />
@@ -3343,7 +3742,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           {providers[activeProvider].apiKey && (
                             <button
                               type="button"
-                              onClick={() => handleProviderConfigChange(activeProvider, 'apiKey', '')}
+                              onClick={() =>
+                                handleProviderConfigChange(activeProvider, 'apiKey', '')
+                              }
                               className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
                               title={i18nService.t('clear') || 'Clear'}
                             >
@@ -3354,9 +3755,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                             type="button"
                             onClick={() => setShowApiKey(!showApiKey)}
                             className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                            title={showApiKey ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                            title={
+                              showApiKey
+                                ? i18nService.t('hide') || 'Hide'
+                                : i18nService.t('show') || 'Show'
+                            }
                           >
-                            {showApiKey ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                            {showApiKey ? (
+                              <EyeIcon className="h-4 w-4" />
+                            ) : (
+                              <EyeSlashIcon className="h-4 w-4" />
+                            )}
                           </button>
                         </div>
                       </div>
@@ -3367,13 +3776,18 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {activeProvider === 'qwen' && (
                     <div>
                       <div className="flex items-center justify-between mb-1">
-                        <label htmlFor="qwen-apiKey" className="block text-xs font-medium dark:text-claude-darkText text-claude-text">
+                        <label
+                          htmlFor="qwen-apiKey"
+                          className="block text-xs font-medium dark:text-claude-darkText text-claude-text"
+                        >
                           API Key
                         </label>
                         {providerLinks.qwen?.apiKey && (
                           <button
                             type="button"
-                            onClick={() => void window.electron.shell.openExternal(providerLinks.qwen!.apiKey!)}
+                            onClick={() =>
+                              void window.electron.shell.openExternal(providerLinks.qwen!.apiKey!)
+                            }
                             className="text-[11px] text-claude-accent hover:underline transition-colors"
                           >
                             {i18nService.t('getApiKey')} →
@@ -3385,7 +3799,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           type={showApiKey ? 'text' : 'password'}
                           id="qwen-apiKey"
                           value={providers.qwen.apiKey}
-                          onChange={(e) => handleProviderConfigChange('qwen', 'apiKey', e.target.value)}
+                          onChange={e =>
+                            handleProviderConfigChange('qwen', 'apiKey', e.target.value)
+                          }
                           className="block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-16 text-xs"
                           placeholder={i18nService.t('apiKeyPlaceholder')}
                         />
@@ -3404,9 +3820,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                             type="button"
                             onClick={() => setShowApiKey(!showApiKey)}
                             className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                            title={showApiKey ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                            title={
+                              showApiKey
+                                ? i18nService.t('hide') || 'Hide'
+                                : i18nService.t('show') || 'Show'
+                            }
                           >
-                            {showApiKey ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                            {showApiKey ? (
+                              <EyeIcon className="h-4 w-4" />
+                            ) : (
+                              <EyeSlashIcon className="h-4 w-4" />
+                            )}
                           </button>
                         </div>
                       </div>
@@ -3421,27 +3845,39 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     {i18nService.t('githubCopilotAuth')}
                   </label>
 
-                  {(copilotAuthStatus === 'idle' || copilotAuthStatus === 'error') && !providers['github-copilot'].apiKey && (
-                    <div className="space-y-2">
-                      <button
-                        type="button"
-                        onClick={handleCopilotSignIn}
-                        className="flex items-center gap-2 px-4 py-2 rounded-xl bg-claude-accent text-white text-xs font-medium hover:bg-claude-accent/90 transition-colors"
-                      >
-                        <GitHubCopilotIcon className="w-4 h-4" />
-                        {i18nService.t('githubCopilotSignIn')}
-                      </button>
-                      {copilotError && (
-                        <p className="text-xs text-red-500 dark:text-red-400">{copilotError}</p>
-                      )}
-                    </div>
-                  )}
+                  {(copilotAuthStatus === 'idle' || copilotAuthStatus === 'error') &&
+                    !providers['github-copilot'].apiKey && (
+                      <div className="space-y-2">
+                        <button
+                          type="button"
+                          onClick={handleCopilotSignIn}
+                          className="flex items-center gap-2 px-4 py-2 rounded-xl bg-claude-accent text-white text-xs font-medium hover:bg-claude-accent/90 transition-colors"
+                        >
+                          <GitHubCopilotIcon className="w-4 h-4" />
+                          {i18nService.t('githubCopilotSignIn')}
+                        </button>
+                        {copilotError && (
+                          <p className="text-xs text-red-500 dark:text-red-400">{copilotError}</p>
+                        )}
+                      </div>
+                    )}
 
                   {copilotAuthStatus === 'requesting' && (
                     <div className="flex items-center gap-2 text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
                       <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                        />
                       </svg>
                       {i18nService.t('githubCopilotRequesting')}
                     </div>
@@ -3478,8 +3914,19 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       <div className="flex items-center gap-3">
                         <div className="flex items-center gap-2 text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
                           <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
-                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                            <circle
+                              className="opacity-25"
+                              cx="12"
+                              cy="12"
+                              r="10"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                            />
+                            <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                            />
                           </svg>
                           {i18nService.t('githubCopilotWaiting')}
                         </div>
@@ -3494,38 +3941,46 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     </div>
                   )}
 
-                  {(copilotAuthStatus === 'authenticated' || providers['github-copilot'].apiKey) && copilotAuthStatus !== 'requesting' && copilotAuthStatus !== 'awaiting_user' && copilotAuthStatus !== 'polling' && (
-                    <div className="flex items-center justify-between p-3 rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset border border-claude-border dark:border-claude-darkBorder">
-                      <div className="flex items-center gap-2">
-                        <div className="w-2 h-2 rounded-full bg-green-500" />
-                        <span className="text-xs dark:text-claude-darkText text-claude-text">
-                          {copilotGithubUser
-                            ? `${i18nService.t('githubCopilotConnected')} @${copilotGithubUser}`
-                            : i18nService.t('githubCopilotConnected')}
-                        </span>
+                  {(copilotAuthStatus === 'authenticated' || providers['github-copilot'].apiKey) &&
+                    copilotAuthStatus !== 'requesting' &&
+                    copilotAuthStatus !== 'awaiting_user' &&
+                    copilotAuthStatus !== 'polling' && (
+                      <div className="flex items-center justify-between p-3 rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset border border-claude-border dark:border-claude-darkBorder">
+                        <div className="flex items-center gap-2">
+                          <div className="w-2 h-2 rounded-full bg-green-500" />
+                          <span className="text-xs dark:text-claude-darkText text-claude-text">
+                            {copilotGithubUser
+                              ? `${i18nService.t('githubCopilotConnected')} @${copilotGithubUser}`
+                              : i18nService.t('githubCopilotConnected')}
+                          </span>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={handleCopilotSignOut}
+                          className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-red-500 transition-colors"
+                        >
+                          {i18nService.t('githubCopilotSignOut')}
+                        </button>
                       </div>
-                      <button
-                        type="button"
-                        onClick={handleCopilotSignOut}
-                        className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-red-500 transition-colors"
-                      >
-                        {i18nService.t('githubCopilotSignOut')}
-                      </button>
-                    </div>
-                  )}
+                    )}
                 </div>
               )}
 
               {isCustomProvider(activeProvider) && (
                 <div>
-                  <label htmlFor={`${activeProvider}-displayName`} className="block text-xs font-medium dark:text-claude-darkText text-claude-text mb-1">
+                  <label
+                    htmlFor={`${activeProvider}-displayName`}
+                    className="block text-xs font-medium dark:text-claude-darkText text-claude-text mb-1"
+                  >
                     {i18nService.t('customDisplayName')}
                   </label>
                   <input
                     type="text"
                     id={`${activeProvider}-displayName`}
                     value={(providers[activeProvider] as ProviderConfig)?.displayName ?? ''}
-                    onChange={(e) => handleProviderConfigChange(activeProvider, 'displayName', e.target.value)}
+                    onChange={e =>
+                      handleProviderConfigChange(activeProvider, 'displayName', e.target.value)
+                    }
                     className="block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 text-xs"
                     placeholder={i18nService.t('customDisplayNamePlaceholder')}
                   />
@@ -3533,146 +3988,184 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               )}
 
               {!(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
-              <div>
-                <label htmlFor={`${activeProvider}-baseUrl`} className="block text-xs font-medium text-foreground mb-1">
-                  {i18nService.t('baseUrl')}
-                </label>
-                <div className="relative">
-                  <input
-                    type="text"
-                    id={`${activeProvider}-baseUrl`}
-                    value={
-                      (() => {
+                <div>
+                  <label
+                    htmlFor={`${activeProvider}-baseUrl`}
+                    className="block text-xs font-medium text-foreground mb-1"
+                  >
+                    {i18nService.t('baseUrl')}
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      id={`${activeProvider}-baseUrl`}
+                      value={(() => {
                         // Coding plan override: delegate to ProviderRegistry (50e20b76)
-                        const fmt = getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat);
+                        const fmt = getEffectiveApiFormat(
+                          activeProvider,
+                          providers[activeProvider].apiFormat,
+                        );
                         if (fmt !== 'gemini') {
-                          const cpUrl = (providers[activeProvider] as { codingPlanEnabled?: boolean }).codingPlanEnabled
+                          const cpUrl = (
+                            providers[activeProvider] as { codingPlanEnabled?: boolean }
+                          ).codingPlanEnabled
                             ? ProviderRegistry.getCodingPlanUrl(activeProvider, fmt)
                             : undefined;
                           if (cpUrl) return cpUrl;
                         }
                         return providers[activeProvider].baseUrl;
-                      })()
-                    }
-                    onChange={(e) => handleProviderConfigChange(activeProvider, 'baseUrl', e.target.value)}
-                    disabled={isBaseUrlLocked}
-                    className={`block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-8 text-xs ${isBaseUrlLocked ? 'opacity-50 cursor-not-allowed' : ''}`}
-                    placeholder={
-                      activeProvider === 'qwen'
-                        ? 'https://dashscope.aliyuncs.com/apps/anthropic'
-                        : getProviderDefaultBaseUrl(activeProvider, getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat)) || defaultConfig.providers?.[activeProvider]?.baseUrl || i18nService.t('baseUrlPlaceholder')
-                    }
-                  />
-                  {providers[activeProvider].baseUrl && !isBaseUrlLocked && (
-                    <div className="absolute right-2 inset-y-0 flex items-center">
-                      <button
-                        type="button"
-                        onClick={() => handleProviderConfigChange(activeProvider, 'baseUrl', '')}
-                        className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
-                        title={i18nService.t('clear') || 'Clear'}
-                      >
-                        <XCircleIconSolid className="h-4 w-4" />
-                      </button>
+                      })()}
+                      onChange={e =>
+                        handleProviderConfigChange(activeProvider, 'baseUrl', e.target.value)
+                      }
+                      disabled={isBaseUrlLocked}
+                      className={`block w-full rounded-xl bg-claude-surfaceInset dark:bg-claude-darkSurfaceInset dark:border-claude-darkBorder border-claude-border border focus:border-claude-accent focus:ring-1 focus:ring-claude-accent/30 dark:text-claude-darkText text-claude-text px-3 py-2 pr-8 text-xs ${isBaseUrlLocked ? 'opacity-50 cursor-not-allowed' : ''}`}
+                      placeholder={
+                        activeProvider === 'qwen'
+                          ? 'https://dashscope.aliyuncs.com/apps/anthropic'
+                          : getProviderDefaultBaseUrl(
+                              activeProvider,
+                              getEffectiveApiFormat(
+                                activeProvider,
+                                providers[activeProvider].apiFormat,
+                              ),
+                            ) ||
+                            defaultConfig.providers?.[activeProvider]?.baseUrl ||
+                            i18nService.t('baseUrlPlaceholder')
+                      }
+                    />
+                    {providers[activeProvider].baseUrl && !isBaseUrlLocked && (
+                      <div className="absolute right-2 inset-y-0 flex items-center">
+                        <button
+                          type="button"
+                          onClick={() => handleProviderConfigChange(activeProvider, 'baseUrl', '')}
+                          className="p-0.5 rounded text-claude-textSecondary dark:text-claude-darkTextSecondary hover:text-claude-accent transition-colors"
+                          title={i18nService.t('clear') || 'Clear'}
+                        >
+                          <XCircleIconSolid className="h-4 w-4" />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  {isCustomProvider(activeProvider) && (
+                    <div className="mt-1.5 space-y-0.5 text-[11px] text-secondary">
+                      <p>
+                        <span className="text-sm text-muted mr-1">•</span>
+                        {i18nService.t('baseUrlHint1')}
+                        <code className="ml-1 text-primary break-all">
+                          {i18nService.t('baseUrlHintExample1')}
+                        </code>
+                      </p>
+                      <p>
+                        <span className="text-sm text-muted mr-1">•</span>
+                        {i18nService.t('baseUrlHint2')}
+                        <code className="ml-1 text-primary break-all">
+                          {i18nService.t('baseUrlHintExample2')}
+                        </code>
+                      </p>
+                    </div>
+                  )}
+                  {/* GLM Coding Plan 提示 */}
+                  {activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">GLM Coding Plan:</span>{' '}
+                        {i18nService.t('zhipuCodingPlanEndpointHint')}
+                      </p>
+                    </div>
+                  )}
+                  {/* Qwen Coding Plan 提示 */}
+                  {activeProvider === 'qwen' && providers.qwen.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">Coding Plan:</span>{' '}
+                        {i18nService.t('qwenCodingPlanEndpointHint')}
+                      </p>
+                    </div>
+                  )}
+                  {/* Volcengine Coding Plan 提示 */}
+                  {activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">Coding Plan:</span>{' '}
+                        {i18nService.t('volcengineCodingPlanEndpointHint')}
+                      </p>
+                    </div>
+                  )}
+                  {/* Moonshot Coding Plan 提示 */}
+                  {activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled && (
+                    <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
+                      <p className="text-[11px] text-primary dark:text-primary">
+                        <span className="font-medium">Coding Plan:</span>{' '}
+                        {i18nService.t('moonshotCodingPlanEndpointHint')}
+                      </p>
                     </div>
                   )}
                 </div>
-                {isCustomProvider(activeProvider) && (
-                <div className="mt-1.5 space-y-0.5 text-[11px] text-secondary">
-                  <p>
-                    <span className="text-sm text-muted mr-1">•</span>
-                    {i18nService.t('baseUrlHint1')}
-                    <code className="ml-1 text-primary break-all">{i18nService.t('baseUrlHintExample1')}</code>
-                  </p>
-                  <p>
-                    <span className="text-sm text-muted mr-1">•</span>
-                    {i18nService.t('baseUrlHint2')}
-                    <code className="ml-1 text-primary break-all">{i18nService.t('baseUrlHintExample2')}</code>
-                  </p>
-                </div>
-                )}
-                {/* GLM Coding Plan 提示 */}
-                {activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">GLM Coding Plan:</span> {i18nService.t('zhipuCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-                {/* Qwen Coding Plan 提示 */}
-                {activeProvider === 'qwen' && providers.qwen.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">Coding Plan:</span> {i18nService.t('qwenCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-                {/* Volcengine Coding Plan 提示 */}
-                {activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">Coding Plan:</span> {i18nService.t('volcengineCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-                {/* Moonshot Coding Plan 提示 */}
-                {activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled && (
-                  <div className="mt-1.5 p-2 rounded-lg bg-primary-muted border border-primary-muted">
-                    <p className="text-[11px] text-primary dark:text-primary">
-                      <span className="font-medium">Coding Plan:</span> {i18nService.t('moonshotCodingPlanEndpointHint')}
-                    </p>
-                  </div>
-                )}
-              </div>
               )}
 
               {/* API 格式选择器 */}
-              {shouldShowApiFormatSelector(activeProvider) && !(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
-                <div>
-                  <label htmlFor={`${activeProvider}-apiFormat`} className="block text-xs font-medium text-foreground mb-1">
-                    {i18nService.t('apiFormat')}
-                  </label>
-                  <div className="flex items-center space-x-4">
-                    <label className="flex items-center">
-                      <input
-                        type="radio"
-                        name={`${activeProvider}-apiFormat`}
-                        value="anthropic"
-                        checked={getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat) !== 'openai'}
-                        onChange={() => handleProviderConfigChange(activeProvider, 'apiFormat', 'anthropic')}
-                        className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
-                      />
-                      <span className="ml-2 text-xs text-foreground">
-                        {i18nService.t('apiFormatNative')}
-                      </span>
+              {shouldShowApiFormatSelector(activeProvider) &&
+                !(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
+                  <div>
+                    <label
+                      htmlFor={`${activeProvider}-apiFormat`}
+                      className="block text-xs font-medium text-foreground mb-1"
+                    >
+                      {i18nService.t('apiFormat')}
                     </label>
-                    <label className="flex items-center">
-                      <input
-                        type="radio"
-                        name={`${activeProvider}-apiFormat`}
-                        value="openai"
-                        checked={getEffectiveApiFormat(activeProvider, providers[activeProvider].apiFormat) === 'openai'}
-                        onChange={() => handleProviderConfigChange(activeProvider, 'apiFormat', 'openai')}
-                        className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
-                      />
-                      <span className="ml-2 text-xs text-foreground">
-                        {i18nService.t('apiFormatOpenAI')}
-                      </span>
-                    </label>
+                    <div className="flex items-center space-x-4">
+                      <label className="flex items-center">
+                        <input
+                          type="radio"
+                          name={`${activeProvider}-apiFormat`}
+                          value="anthropic"
+                          checked={
+                            getEffectiveApiFormat(
+                              activeProvider,
+                              providers[activeProvider].apiFormat,
+                            ) !== 'openai'
+                          }
+                          onChange={() =>
+                            handleProviderConfigChange(activeProvider, 'apiFormat', 'anthropic')
+                          }
+                          className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
+                        />
+                        <span className="ml-2 text-xs text-foreground">
+                          {i18nService.t('apiFormatNative')}
+                        </span>
+                      </label>
+                      <label className="flex items-center">
+                        <input
+                          type="radio"
+                          name={`${activeProvider}-apiFormat`}
+                          value="openai"
+                          checked={
+                            getEffectiveApiFormat(
+                              activeProvider,
+                              providers[activeProvider].apiFormat,
+                            ) === 'openai'
+                          }
+                          onChange={() =>
+                            handleProviderConfigChange(activeProvider, 'apiFormat', 'openai')
+                          }
+                          className="h-3.5 w-3.5 text-claude-accent focus:ring-claude-accent dark:bg-claude-darkSurface bg-claude-surface disabled:opacity-50"
+                        />
+                        <span className="ml-2 text-xs text-foreground">
+                          {i18nService.t('apiFormatOpenAI')}
+                        </span>
+                      </label>
+                    </div>
+                    <p className="mt-1 text-xs text-secondary">{i18nService.t('apiFormatHint')}</p>
                   </div>
-                  <p className="mt-1 text-xs text-secondary">
-                    {i18nService.t('apiFormatHint')}
-                  </p>
-                </div>
-              )}
+                )}
 
               {/* GLM Coding Plan 开关 (仅 Zhipu) */}
               {activeProvider === 'zhipu' && (
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        GLM Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">GLM Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         Beta
                       </span>
@@ -3685,7 +4178,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.zhipu.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('zhipu', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'zhipu',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3698,9 +4197,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         {i18nService.t('codingPlanSubscriptionBadge')}
                       </span>
@@ -3713,7 +4210,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.qwen.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('qwen', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'qwen',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3726,9 +4229,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         Beta
                       </span>
@@ -3741,7 +4242,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.volcengine.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('volcengine', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'volcengine',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3754,9 +4261,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-border">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2">
-                      <span className="text-xs font-medium text-foreground">
-                        Coding Plan
-                      </span>
+                      <span className="text-xs font-medium text-foreground">Coding Plan</span>
                       <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-primary-muted text-primary">
                         Beta
                       </span>
@@ -3769,7 +4274,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     <input
                       type="checkbox"
                       checked={providers.moonshot.codingPlanEnabled ?? false}
-                      onChange={(e) => handleProviderConfigChange('moonshot', 'codingPlanEnabled', e.target.checked ? 'true' : 'false')}
+                      onChange={e =>
+                        handleProviderConfigChange(
+                          'moonshot',
+                          'codingPlanEnabled',
+                          e.target.checked ? 'true' : 'false',
+                        )
+                      }
                       className="sr-only peer"
                     />
                     <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
@@ -3779,17 +4290,22 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
               {/* 测试连接按钮 */}
               {!(activeProvider === 'minimax' && minimaxIsOAuthMode) && (
-              <div className="flex items-center space-x-3">
-                <button
-                  type="button"
-                  onClick={handleTestConnection}
-                  disabled={isTesting || (providerRequiresApiKey(activeProvider) && !providers[activeProvider].apiKey && !(activeProvider === 'qwen' && (providers.qwen as any).oauthCredentials))}
-                  className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-xl border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
-                >
-                  <SignalIcon className="h-3.5 w-3.5 mr-1.5" />
-                  {isTesting ? i18nService.t('testing') : i18nService.t('testConnection')}
-                </button>
-              </div>
+                <div className="flex items-center space-x-3">
+                  <button
+                    type="button"
+                    onClick={handleTestConnection}
+                    disabled={
+                      isTesting ||
+                      (providerRequiresApiKey(activeProvider) &&
+                        !providers[activeProvider].apiKey &&
+                        !(activeProvider === 'qwen' && (providers.qwen as any).oauthCredentials))
+                    }
+                    className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-xl border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
+                  >
+                    <SignalIcon className="h-3.5 w-3.5 mr-1.5" />
+                    {isTesting ? i18nService.t('testing') : i18nService.t('testConnection')}
+                  </button>
+                </div>
               )}
 
               <div>
@@ -3818,7 +4334,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                         <div className="flex items-center gap-1.5 min-w-0 flex-1">
                           <div className="w-1.5 h-1.5 shrink-0 rounded-full bg-green-400"></div>
                           <div className="min-w-0">
-                            <div className="text-foreground font-medium text-[11px] truncate">{model.name}</div>
+                            <div className="text-foreground font-medium text-[11px] truncate">
+                              {model.name}
+                            </div>
                             <div className="text-[10px] text-secondary truncate">{model.id}</div>
                           </div>
                         </div>
@@ -3830,7 +4348,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                           )}
                           <button
                             type="button"
-                            onClick={() => handleEditModel(model.id, model.name, model.supportsImage)}
+                            onClick={() =>
+                              handleEditModel(model.id, model.name, model.supportsImage)
+                            }
                             className="p-0.5 text-secondary hover:text-primary opacity-0 group-hover:opacity-100 transition-opacity"
                           >
                             <PencilIcon className="h-3.5 w-3.5" />
@@ -3847,9 +4367,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     </div>
                   ))}
 
-                  {(!providers[activeProvider].models || providers[activeProvider].models.length === 0) && (
+                  {(!providers[activeProvider].models ||
+                    providers[activeProvider].models.length === 0) && (
                     <div className="bg-surface p-2.5 rounded-xl border border-border-subtle text-center">
-                      <p className="text-[11px] text-secondary">{i18nService.t('noModelsAvailable')}</p>
+                      <p className="text-[11px] text-secondary">
+                        {i18nService.t('noModelsAvailable')}
+                      </p>
                       <button
                         type="button"
                         onClick={handleAddModel}
@@ -3875,19 +4398,35 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 {i18nService.t('coworkBootstrapAgentSectionTitle')}
               </div>
               {[
-                { filename: 'IDENTITY.md', titleKey: 'coworkBootstrapIdentityTitle', hintKey: 'coworkBootstrapIdentityHint', value: bootstrapIdentity, setter: setBootstrapIdentity },
-                { filename: 'SOUL.md', titleKey: 'coworkBootstrapSoulTitle', hintKey: 'coworkBootstrapSoulHint', value: bootstrapSoul, setter: setBootstrapSoul },
+                {
+                  filename: 'IDENTITY.md',
+                  titleKey: 'coworkBootstrapIdentityTitle',
+                  hintKey: 'coworkBootstrapIdentityHint',
+                  value: bootstrapIdentity,
+                  setter: setBootstrapIdentity,
+                },
+                {
+                  filename: 'SOUL.md',
+                  titleKey: 'coworkBootstrapSoulTitle',
+                  hintKey: 'coworkBootstrapSoulHint',
+                  value: bootstrapSoul,
+                  setter: setBootstrapSoul,
+                },
               ].map(({ filename, titleKey, hintKey, value, setter }) => (
                 <div key={filename} className="space-y-2">
                   <div className="text-xs font-medium text-secondary">
                     {i18nService.t(titleKey)}
                     <span className="ml-1.5 font-normal opacity-60">
-                      （{i18nService.t('coworkBootstrapStoragePath')}：<span className="font-mono">{joinWorkspacePath(coworkConfig.workingDirectory, filename)}</span>）
+                      （{i18nService.t('coworkBootstrapStoragePath')}：
+                      <span className="font-mono">
+                        {joinWorkspacePath(coworkConfig.workingDirectory, filename)}
+                      </span>
+                      ）
                     </span>
                   </div>
                   <textarea
                     value={value}
-                    onChange={(e) => setter(e.target.value)}
+                    onChange={e => setter(e.target.value)}
                     rows={3}
                     className="w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground resize-y"
                     placeholder={i18nService.t(hintKey)}
@@ -3901,12 +4440,16 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <div className="text-sm font-medium text-foreground">
                 {i18nService.t('coworkBootstrapUserTitle')}
                 <span className="ml-1.5 text-xs font-normal opacity-60 text-secondary">
-                  （{i18nService.t('coworkBootstrapStoragePath')}：<span className="font-mono">{joinWorkspacePath(coworkConfig.workingDirectory, 'USER.md')}</span>）
+                  （{i18nService.t('coworkBootstrapStoragePath')}：
+                  <span className="font-mono">
+                    {joinWorkspacePath(coworkConfig.workingDirectory, 'USER.md')}
+                  </span>
+                  ）
                 </span>
               </div>
               <textarea
                 value={bootstrapUser}
-                onChange={(e) => setBootstrapUser(e.target.value)}
+                onChange={e => setBootstrapUser(e.target.value)}
                 rows={3}
                 className="w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground resize-y"
                 placeholder={i18nService.t('coworkBootstrapUserHint')}
@@ -3925,21 +4468,32 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('newChat')}</span>
-                  <ShortcutRecorder value={shortcuts.newChat} onChange={(v) => handleShortcutChange('newChat', v)} />
+                  <ShortcutRecorder
+                    value={shortcuts.newChat}
+                    onChange={v => handleShortcutChange('newChat', v)}
+                  />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('search')}</span>
-                  <ShortcutRecorder value={shortcuts.search} onChange={(v) => handleShortcutChange('search', v)} />
+                  <ShortcutRecorder
+                    value={shortcuts.search}
+                    onChange={v => handleShortcutChange('search', v)}
+                  />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">{i18nService.t('openSettings')}</span>
-                  <ShortcutRecorder value={shortcuts.settings} onChange={(v) => handleShortcutChange('settings', v)} />
+                  <ShortcutRecorder
+                    value={shortcuts.settings}
+                    onChange={v => handleShortcutChange('settings', v)}
+                  />
                 </div>
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-foreground">{i18nService.t('sendMessageShortcut')}</span>
+                  <span className="text-sm text-foreground">
+                    {i18nService.t('sendMessageShortcut')}
+                  </span>
                   <SendShortcutSelect
                     value={shortcuts.sendMessage}
-                    onChange={(v) => handleShortcutChange('sendMessage', v)}
+                    onChange={v => handleShortcutChange('sendMessage', v)}
                   />
                 </div>
               </div>
@@ -3976,34 +4530,36 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <div className="flex items-center gap-2">
                   <span className="text-sm text-secondary">{appVersion}</span>
                   {!enterpriseConfig?.disableUpdate && (
-                  <button
-                    type="button"
-                    disabled={updateCheckStatus === 'checking'}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void handleCheckUpdate();
-                    }}
-                    className="text-xs px-2 py-0.5 rounded-md border border-border text-secondary hover:text-primary dark:hover:text-primary hover:border-primary dark:hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {updateCheckStatus === 'checking' && i18nService.t('updateChecking')}
-                    {updateCheckStatus === 'upToDate' && i18nService.t('updateUpToDate')}
-                    {updateCheckStatus === 'error' && i18nService.t('updateCheckFailed')}
-                    {updateCheckStatus === 'idle' && i18nService.t('checkForUpdate')}
-                  </button>
+                    <button
+                      type="button"
+                      disabled={updateCheckStatus === 'checking'}
+                      onClick={e => {
+                        e.stopPropagation();
+                        void handleCheckUpdate();
+                      }}
+                      className="text-xs px-2 py-0.5 rounded-md border border-border text-secondary hover:text-primary dark:hover:text-primary hover:border-primary dark:hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {updateCheckStatus === 'checking' && i18nService.t('updateChecking')}
+                      {updateCheckStatus === 'upToDate' && i18nService.t('updateUpToDate')}
+                      {updateCheckStatus === 'error' && i18nService.t('updateCheckFailed')}
+                      {updateCheckStatus === 'idle' && i18nService.t('checkForUpdate')}
+                    </button>
                   )}
                   {enterpriseConfig?.disableUpdate && (
-                  <span className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
-                    {i18nService.t('settings.enterprise.managed')}
-                  </span>
+                    <span className="text-xs text-claude-textSecondary dark:text-claude-darkTextSecondary">
+                      {i18nService.t('settings.enterprise.managed')}
+                    </span>
                   )}
                 </div>
               </div>
               <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-                <span className="text-sm text-foreground">{i18nService.t('aboutContactEmail')}</span>
+                <span className="text-sm text-foreground">
+                  {i18nService.t('aboutContactEmail')}
+                </span>
                 <div className="flex items-center gap-2">
                   <button
                     type="button"
-                    onClick={(e) => {
+                    onClick={e => {
                       e.stopPropagation();
                       void handleCopyContactEmail();
                     }}
@@ -4023,7 +4579,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <span className="text-sm text-foreground">{i18nService.t('aboutUserManual')}</span>
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     handleOpenUserManual();
                   }}
@@ -4032,11 +4588,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {ABOUT_USER_MANUAL_URL}
                 </button>
               </div>
-              <div className={`flex items-center justify-between px-4 py-3${testModeUnlocked ? ' border-b border-border' : ''}`}>
-                <span className="text-sm text-foreground">{i18nService.t('aboutUserCommunity')}</span>
+              <div
+                className={`flex items-center justify-between px-4 py-3${testModeUnlocked ? ' border-b border-border' : ''}`}
+              >
+                <span className="text-sm text-foreground">
+                  {i18nService.t('aboutUserCommunity')}
+                </span>
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     handleOpenUserCommunity();
                   }}
@@ -4052,7 +4612,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                     type="button"
                     role="switch"
                     aria-checked={testMode}
-                    onClick={() => setTestMode((prev) => !prev)}
+                    onClick={() => setTestMode(prev => !prev)}
                     className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                       testMode ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
                     }`}
@@ -4072,7 +4632,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <div className="flex items-center justify-center text-sm text-secondary">
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     handleOpenServiceTerms();
                   }}
@@ -4083,20 +4643,20 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <span className="mx-3 text-xs opacity-40">|</span>
                 <button
                   type="button"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     void handleExportLogs();
                   }}
                   disabled={isExportingLogs}
                   className="bg-transparent border-none appearance-none px-1.5 py-0.5 -mx-1.5 -my-0.5 rounded-md cursor-pointer hover:text-primary dark:hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  {isExportingLogs ? i18nService.t('aboutExportingLogs') : i18nService.t('aboutExportLogs')}
+                  {isExportingLogs
+                    ? i18nService.t('aboutExportingLogs')
+                    : i18nService.t('aboutExportLogs')}
                 </button>
               </div>
 
-              <p className="mt-5 text-xs text-secondary">
-                {i18nService.t('copyrightHolder')}
-              </p>
+              <p className="mt-5 text-xs text-secondary">{i18nService.t('copyrightHolder')}</p>
               <p className="mt-1 text-xs text-secondary">
                 Copyright &copy; {new Date().getFullYear()} NetEase Youdao. All Rights Reserved.
               </p>
@@ -4110,7 +4670,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   };
 
   return (
-    <Modal onClose={onClose} overlayClassName="fixed inset-0 z-50 modal-backdrop flex items-center justify-center">
+    <Modal
+      onClose={onClose}
+      overlayClassName="fixed inset-0 z-50 modal-backdrop flex items-center justify-center"
+    >
       <div
         className="relative flex w-[900px] h-[80vh] rounded-2xl border-border border shadow-modal overflow-hidden modal-content"
         onClick={handleSettingsClick}
@@ -4121,7 +4684,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             <h2 className="text-lg font-semibold text-foreground">{i18nService.t('settings')}</h2>
           </div>
           <nav className="flex flex-col gap-0.5 px-3 pb-4">
-            {sidebarTabs.map((tab) => (
+            {sidebarTabs.map(tab => (
               <button
                 key={tab.key}
                 onClick={() => handleTabChange(tab.key)}
@@ -4153,23 +4716,33 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
           {noticeMessage && (
             <div className="px-6">
-              <ErrorMessage
-                message={noticeMessage}
-                onClose={() => setNoticeMessage(null)}
-              />
+              <ErrorMessage message={noticeMessage} onClose={() => setNoticeMessage(null)} />
             </div>
           )}
 
           {error && (
             <div className="px-6">
-              <ErrorMessage
-                message={error}
-                onClose={() => setError(null)}
-              />
+              <ErrorMessage message={error} onClose={() => setError(null)} />
             </div>
           )}
 
-          <form onSubmit={handleSubmit} className="flex flex-col flex-1 overflow-hidden">
+          <form
+            onSubmit={handleSubmit}
+            onKeyDown={e => {
+              // Prevent Enter key inside inputs from triggering form submission.
+              // This avoids accidental save+close when pressing Enter in text fields
+              // or confirming an IME composition candidate.
+              if (
+                e.key === 'Enter' &&
+                e.target instanceof HTMLElement &&
+                e.target.tagName !== 'BUTTON' &&
+                !(e.target.tagName === 'TEXTAREA')
+              ) {
+                e.preventDefault();
+              }
+            }}
+            className="flex flex-col flex-1 overflow-hidden"
+          >
             {/* Tab content */}
             <div
               ref={contentRef}
@@ -4197,7 +4770,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               </button>
             </div>
           </form>
-
         </div>
 
         {isTestResultModalOpen && testResult && (
@@ -4209,7 +4781,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               role="dialog"
               aria-modal="true"
               aria-label={i18nService.t('connectionTestResult')}
-              onClick={(e) => e.stopPropagation()}
+              onClick={e => e.stopPropagation()}
               className="w-full max-w-md rounded-2xl bg-background border-border border shadow-modal p-4"
             >
               <div className="flex items-center justify-between mb-3">
@@ -4228,13 +4800,17 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               <div className="flex items-center gap-2 text-xs text-secondary">
                 <span>{providerMeta[testResult.provider]?.label ?? testResult.provider}</span>
                 <span className="text-[11px]">•</span>
-                <span className={`inline-flex items-center gap-1 ${testResult.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                <span
+                  className={`inline-flex items-center gap-1 ${testResult.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+                >
                   {testResult.success ? (
                     <CheckCircleIcon className="h-4 w-4" />
                   ) : (
                     <XCircleIcon className="h-4 w-4" />
                   )}
-                  {testResult.success ? i18nService.t('connectionSuccess') : i18nService.t('connectionFailed')}
+                  {testResult.success
+                    ? i18nService.t('connectionSuccess')
+                    : i18nService.t('connectionFailed')}
                 </span>
               </div>
 
@@ -4263,7 +4839,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             <div
               role="dialog"
               aria-modal="true"
-              onClick={(e) => e.stopPropagation()}
+              onClick={e => e.stopPropagation()}
               className="w-full max-w-sm rounded-2xl dark:bg-claude-darkSurface bg-claude-bg dark:border-claude-darkBorder border-claude-border border shadow-modal p-4"
             >
               <p className="text-sm dark:text-claude-darkText text-claude-text">
@@ -4294,211 +4870,217 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4 rounded-2xl"
             onClick={handleCancelModelEdit}
           >
-              <div
-                role="dialog"
-                aria-modal="true"
-                aria-label={isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')}
-                onClick={(e) => e.stopPropagation()}
-                onKeyDown={handleModelDialogKeyDown}
-                className="w-full max-w-md rounded-2xl bg-background border-border border shadow-modal p-4"
-              >
-                <div className="flex items-center justify-between mb-3">
-                  <h4 className="text-sm font-semibold text-foreground">
-                    {isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')}
-                  </h4>
-                  <button
-                    type="button"
-                    onClick={handleCancelModelEdit}
-                    className="p-1 text-secondary hover:text-foreground rounded-md hover:bg-surface-raised"
-                  >
-                    <XMarkIcon className="h-4 w-4" />
-                  </button>
-                </div>
-
-                {modelFormError && (
-                  <p className="mb-3 text-xs text-red-600 dark:text-red-400">
-                    {modelFormError}
-                  </p>
-                )}
-
-                <div className="space-y-3">
-                  {activeProvider === 'ollama' ? (
-                    <>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('ollamaModelName')}
-                        </label>
-                        <input
-                          autoFocus
-                          type="text"
-                          value={newModelId}
-                          onChange={(e) => {
-                            setNewModelId(e.target.value);
-                            if (!newModelName || newModelName === newModelId) {
-                              setNewModelName(e.target.value);
-                            }
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder={i18nService.t('ollamaModelNamePlaceholder')}
-                        />
-                        <p className="mt-1 text-[11px] text-muted">
-                          {i18nService.t('ollamaModelNameHint')}
-                        </p>
-                      </div>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('ollamaDisplayName')}
-                        </label>
-                        <input
-                          type="text"
-                          value={newModelName === newModelId ? '' : newModelName}
-                          onChange={(e) => {
-                            setNewModelName(e.target.value || newModelId);
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder={i18nService.t('ollamaDisplayNamePlaceholder')}
-                        />
-                        <p className="mt-1 text-[11px] text-muted">
-                          {i18nService.t('ollamaDisplayNameHint')}
-                        </p>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('modelName')}
-                        </label>
-                        <input
-                          autoFocus
-                          type="text"
-                          value={newModelName}
-                          onChange={(e) => {
-                            setNewModelName(e.target.value);
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder="GPT-4"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs font-medium text-secondary mb-1">
-                          {i18nService.t('modelId')}
-                        </label>
-                        <input
-                          type="text"
-                          value={newModelId}
-                          onChange={(e) => {
-                            setNewModelId(e.target.value);
-                            if (modelFormError) {
-                              setModelFormError(null);
-                            }
-                          }}
-                          className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
-                          placeholder="gpt-4"
-                        />
-                      </div>
-                    </>
-                  )}
-                  <div className="flex items-center space-x-2">
-                    <input
-                      id={`${activeProvider}-supportsImage`}
-                      type="checkbox"
-                      checked={newModelSupportsImage}
-                      onChange={(e) => setNewModelSupportsImage(e.target.checked)}
-                      className="h-3.5 w-3.5 text-primary focus:ring-primary bg-surface border-border rounded"
-                    />
-                    <label
-                      htmlFor={`${activeProvider}-supportsImage`}
-                      className="text-xs text-secondary"
-                    >
-                      {i18nService.t('supportsImageInput')}
-                    </label>
-                  </div>
-                </div>
-
-                <div className="flex justify-end space-x-2 mt-4">
-                  <button
-                    type="button"
-                    onClick={handleCancelModelEdit}
-                    className="px-3 py-1.5 text-xs text-foreground hover:bg-surface-raised rounded-xl border border-border"
-                  >
-                    {i18nService.t('cancel')}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleSaveNewModel}
-                    className="px-3 py-1.5 text-xs text-white bg-primary hover:bg-primary-hover rounded-xl active:scale-[0.98]"
-                  >
-                    {i18nService.t('save')}
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Memory Modal */}
-          {showMemoryModal && (
             <div
-              className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4 rounded-2xl"
-              onClick={resetCoworkMemoryEditor}
+              role="dialog"
+              aria-modal="true"
+              aria-label={
+                isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')
+              }
+              onClick={e => e.stopPropagation()}
+              onKeyDown={handleModelDialogKeyDown}
+              className="w-full max-w-md rounded-2xl bg-background border-border border shadow-modal p-4"
             >
-              <div
-                className="bg-surface border-border border rounded-2xl shadow-xl w-full max-w-md"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <div className="px-5 pt-5 pb-4 border-b border-border">
-                  <h3 className="text-base font-semibold text-foreground">
-                    {coworkMemoryEditingId ? i18nService.t('coworkMemoryCrudUpdate') : i18nService.t('coworkMemoryCrudCreate')}
-                  </h3>
-                </div>
+              <div className="flex items-center justify-between mb-3">
+                <h4 className="text-sm font-semibold text-foreground">
+                  {isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')}
+                </h4>
+                <button
+                  type="button"
+                  onClick={handleCancelModelEdit}
+                  className="p-1 text-secondary hover:text-foreground rounded-md hover:bg-surface-raised"
+                >
+                  <XMarkIcon className="h-4 w-4" />
+                </button>
+              </div>
 
-                <div className="px-5 py-4 space-y-4">
-                  {coworkMemoryEditingId && (
-                    <div className="rounded-lg border px-2 py-1 text-xs border-border text-secondary">
-                      {i18nService.t('coworkMemoryEditingTag')}
+              {modelFormError && (
+                <p className="mb-3 text-xs text-red-600 dark:text-red-400">{modelFormError}</p>
+              )}
+
+              <div className="space-y-3">
+                {activeProvider === 'ollama' ? (
+                  <>
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('ollamaModelName')}
+                      </label>
+                      <input
+                        autoFocus
+                        type="text"
+                        value={newModelId}
+                        onChange={e => {
+                          setNewModelId(e.target.value);
+                          if (!newModelName || newModelName === newModelId) {
+                            setNewModelName(e.target.value);
+                          }
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder={i18nService.t('ollamaModelNamePlaceholder')}
+                      />
+                      <p className="mt-1 text-[11px] text-muted">
+                        {i18nService.t('ollamaModelNameHint')}
+                      </p>
                     </div>
-                  )}
-                  <textarea
-                    value={coworkMemoryDraftText}
-                    onChange={(event) => setCoworkMemoryDraftText(event.target.value)}
-                    placeholder={i18nService.t('coworkMemoryCrudTextPlaceholder')}
-                    autoFocus
-                    className="min-h-[200px] w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground focus:border-primary focus:ring-1 focus:ring-primary/30"
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('ollamaDisplayName')}
+                      </label>
+                      <input
+                        type="text"
+                        value={newModelName === newModelId ? '' : newModelName}
+                        onChange={e => {
+                          setNewModelName(e.target.value || newModelId);
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder={i18nService.t('ollamaDisplayNamePlaceholder')}
+                      />
+                      <p className="mt-1 text-[11px] text-muted">
+                        {i18nService.t('ollamaDisplayNameHint')}
+                      </p>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('modelName')}
+                      </label>
+                      <input
+                        autoFocus
+                        type="text"
+                        value={newModelName}
+                        onChange={e => {
+                          setNewModelName(e.target.value);
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder="GPT-4"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-secondary mb-1">
+                        {i18nService.t('modelId')}
+                      </label>
+                      <input
+                        type="text"
+                        value={newModelId}
+                        onChange={e => {
+                          setNewModelId(e.target.value);
+                          if (modelFormError) {
+                            setModelFormError(null);
+                          }
+                        }}
+                        className="block w-full rounded-xl bg-surface-inset border-border border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-xs"
+                        placeholder="gpt-4"
+                      />
+                    </div>
+                  </>
+                )}
+                <div className="flex items-center space-x-2">
+                  <input
+                    id={`${activeProvider}-supportsImage`}
+                    type="checkbox"
+                    checked={newModelSupportsImage}
+                    onChange={e => setNewModelSupportsImage(e.target.checked)}
+                    className="h-3.5 w-3.5 text-primary focus:ring-primary bg-surface border-border rounded"
                   />
-                </div>
-
-                <div className="flex justify-end space-x-2 px-5 pb-5">
-                  <button
-                    type="button"
-                    onClick={resetCoworkMemoryEditor}
-                    className="px-3 py-1.5 text-sm text-foreground hover:bg-surface-raised rounded-xl border border-border transition-colors"
+                  <label
+                    htmlFor={`${activeProvider}-supportsImage`}
+                    className="text-xs text-secondary"
                   >
-                    {i18nService.t('cancel')}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => { void handleSaveCoworkMemoryEntry(); }}
-                    disabled={!coworkMemoryDraftText.trim() || coworkMemoryListLoading}
-                    className="px-3 py-1.5 text-sm text-white bg-primary hover:bg-primary-hover rounded-xl disabled:opacity-60 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
-                  >
-                    {coworkMemoryEditingId ? i18nService.t('save') : i18nService.t('coworkMemoryCrudCreate')}
-                  </button>
+                    {i18nService.t('supportsImageInput')}
+                  </label>
                 </div>
               </div>
+
+              <div className="flex justify-end space-x-2 mt-4">
+                <button
+                  type="button"
+                  onClick={handleCancelModelEdit}
+                  className="px-3 py-1.5 text-xs text-foreground hover:bg-surface-raised rounded-xl border border-border"
+                >
+                  {i18nService.t('cancel')}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSaveNewModel}
+                  className="px-3 py-1.5 text-xs text-white bg-primary hover:bg-primary-hover rounded-xl active:scale-[0.98]"
+                >
+                  {i18nService.t('save')}
+                </button>
+              </div>
             </div>
-          )}
+          </div>
+        )}
+
+        {/* Memory Modal */}
+        {showMemoryModal && (
+          <div
+            className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4 rounded-2xl"
+            onClick={resetCoworkMemoryEditor}
+          >
+            <div
+              className="bg-surface border-border border rounded-2xl shadow-xl w-full max-w-md"
+              onClick={e => e.stopPropagation()}
+            >
+              <div className="px-5 pt-5 pb-4 border-b border-border">
+                <h3 className="text-base font-semibold text-foreground">
+                  {coworkMemoryEditingId
+                    ? i18nService.t('coworkMemoryCrudUpdate')
+                    : i18nService.t('coworkMemoryCrudCreate')}
+                </h3>
+              </div>
+
+              <div className="px-5 py-4 space-y-4">
+                {coworkMemoryEditingId && (
+                  <div className="rounded-lg border px-2 py-1 text-xs border-border text-secondary">
+                    {i18nService.t('coworkMemoryEditingTag')}
+                  </div>
+                )}
+                <textarea
+                  value={coworkMemoryDraftText}
+                  onChange={event => setCoworkMemoryDraftText(event.target.value)}
+                  placeholder={i18nService.t('coworkMemoryCrudTextPlaceholder')}
+                  autoFocus
+                  className="min-h-[200px] w-full rounded-lg border px-3 py-2 text-sm border-border bg-surface text-foreground focus:border-primary focus:ring-1 focus:ring-primary/30"
+                />
+              </div>
+
+              <div className="flex justify-end space-x-2 px-5 pb-5">
+                <button
+                  type="button"
+                  onClick={resetCoworkMemoryEditor}
+                  className="px-3 py-1.5 text-sm text-foreground hover:bg-surface-raised rounded-xl border border-border transition-colors"
+                >
+                  {i18nService.t('cancel')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    void handleSaveCoworkMemoryEntry();
+                  }}
+                  disabled={!coworkMemoryDraftText.trim() || coworkMemoryListLoading}
+                  className="px-3 py-1.5 text-sm text-white bg-primary hover:bg-primary-hover rounded-xl disabled:opacity-60 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
+                >
+                  {coworkMemoryEditingId
+                    ? i18nService.t('save')
+                    : i18nService.t('coworkMemoryCrudCreate')}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </Modal>
   );
 };
 
-export default Settings; 
+export default Settings;

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -21,7 +21,11 @@ import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { RootState } from '../../store';
 import { setActiveSkillIds } from '../../store/slices/skillSlice';
-import type { CoworkMessage, CoworkMessageMetadata, CoworkImageAttachment } from '../../types/cowork';
+import type {
+  CoworkMessage,
+  CoworkMessageMetadata,
+  CoworkImageAttachment,
+} from '../../types/cowork';
 import type { Skill } from '../../types/skill';
 import { getCompactFolderName } from '../../utils/path';
 import Modal from '../common/Modal';
@@ -41,7 +45,11 @@ import LazyRenderTurn, { clearHeightCache } from './LazyRenderTurn';
 
 interface CoworkSessionDetailProps {
   onManageSkills?: () => void;
-  onContinue: (prompt: string, skillPrompt?: string, imageAttachments?: CoworkImageAttachment[]) => boolean | void | Promise<boolean | void>;
+  onContinue: (
+    prompt: string,
+    skillPrompt?: string,
+    imageAttachments?: CoworkImageAttachment[],
+  ) => boolean | void | Promise<boolean | void>;
   onStop: () => void;
   onDeleteSession?: (sessionId: string) => Promise<void>;
   onNavigateHome?: () => void;
@@ -72,7 +80,7 @@ const MAX_EXPORT_CANVAS_HEIGHT = 32760;
 const MAX_EXPORT_SEGMENTS = 240;
 
 const waitForNextFrame = (): Promise<void> =>
-  new Promise((resolve) => {
+  new Promise(resolve => {
     window.requestAnimationFrame(() => resolve());
   });
 
@@ -100,7 +108,11 @@ const formatExportDate = (ts: number): string => {
 /** Draw a rounded-rectangle path (for card clipping / filling). */
 const roundRectPath = (
   ctx: CanvasRenderingContext2D,
-  x: number, y: number, w: number, h: number, r: number,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
 ) => {
   ctx.beginPath();
   ctx.moveTo(x + r, y);
@@ -126,19 +138,20 @@ const composeExportCanvas = async (
 ): Promise<HTMLCanvasElement> => {
   const isDark = document.documentElement.classList.contains('dark');
   const dpr = window.devicePixelRatio || 1;
-  const fontStack = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif';
+  const fontStack =
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif';
 
-  const contentW = contentCanvas.width;   // CSS px
-  const contentH = contentCanvas.height;  // CSS px
+  const contentW = contentCanvas.width; // CSS px
+  const contentH = contentCanvas.height; // CSS px
 
   // ── Layout constants (CSS px) ──
-  const outerPadX = 24;          // horizontal breathing room around card
-  const outerPadTop = 28;        // top breathing room
-  const outerPadBottom = 28;     // bottom breathing room
-  const cardRadius = 16;         // card corner radius
-  const cardInnerPadX = 28;      // text indent inside card
-  const headerHeight = 80;       // header area inside card
-  const footerHeight = 80;       // footer area inside card
+  const outerPadX = 24; // horizontal breathing room around card
+  const outerPadTop = 28; // top breathing room
+  const outerPadBottom = 28; // bottom breathing room
+  const cardRadius = 16; // card corner radius
+  const cardInnerPadX = 28; // text indent inside card
+  const headerHeight = 80; // header area inside card
+  const footerHeight = 80; // footer area inside card
   const dividerThick = 1;
   const logoCssSize = 34;
 
@@ -186,8 +199,8 @@ const composeExportCanvas = async (
   ctx.clip();
 
   // card-local origin helpers
-  const cx = outerPadX;           // card left
-  const cy = outerPadTop;         // card top
+  const cx = outerPadX; // card left
+  const cy = outerPadTop; // card top
 
   // ── Header ──
   const titleFontSize = 17;
@@ -211,7 +224,11 @@ const composeExportCanvas = async (
   // Date
   ctx.fillStyle = dateColor;
   ctx.font = `400 ${dateFontSize}px ${fontStack}`;
-  ctx.fillText(formatExportDate(createdAt), cx + cardInnerPadX, headerCenterY + titleFontSize / 2 + 3);
+  ctx.fillText(
+    formatExportDate(createdAt),
+    cx + cardInnerPadX,
+    headerCenterY + titleFontSize / 2 + 3,
+  );
 
   // ── Top divider ──
   ctx.fillStyle = dividerColor;
@@ -264,7 +281,11 @@ const composeExportCanvas = async (
 
   ctx.fillStyle = subtitleColor;
   ctx.font = `400 ${taglineFontSize}px ${fontStack}`;
-  ctx.fillText('7×24 小时帮你干活的全场景个人助理，由网易有道开发', textX, footerCenterY + brandFontSize / 2 + 3);
+  ctx.fillText(
+    '7×24 小时帮你干活的全场景个人助理，由网易有道开发',
+    textX,
+    footerCenterY + brandFontSize / 2 + 3,
+  );
 
   ctx.restore(); // card clip
 
@@ -306,7 +327,7 @@ const formatUnknown = (value: unknown): string => {
 
 const getStringArray = (value: unknown): string | null => {
   if (!Array.isArray(value)) return null;
-  const lines = value.filter((item) => typeof item === 'string') as string[];
+  const lines = value.filter(item => typeof item === 'string') as string[];
   return lines.length > 0 ? lines.join('\n') : null;
 };
 
@@ -357,10 +378,7 @@ const isBashLikeToolName = (toolName: string | undefined): boolean => {
   return normalized === 'bash' || normalized === 'exec' || normalized === 'shell';
 };
 
-const getToolInputString = (
-  input: Record<string, unknown>,
-  keys: string[],
-): string | null => {
+const getToolInputString = (input: Record<string, unknown>, keys: string[]): string | null => {
   for (const key of keys) {
     const value = input[key];
     if (typeof value === 'string' && value.trim()) {
@@ -393,14 +411,11 @@ const getCronToolSummary = (input: Record<string, unknown>): string | null => {
   const action = getToolInputString(input, ['action']);
   if (!action) return null;
 
-  const job = input.job && typeof input.job === 'object'
-    ? input.job as Record<string, unknown>
-    : null;
-  const jobName = job
-    ? getToolInputString(job, ['name', 'id'])
-    : null;
-  const jobId = getToolInputString(input, ['jobId', 'id'])
-    ?? (job ? getToolInputString(job, ['id']) : null);
+  const job =
+    input.job && typeof input.job === 'object' ? (input.job as Record<string, unknown>) : null;
+  const jobName = job ? getToolInputString(job, ['name', 'id']) : null;
+  const jobId =
+    getToolInputString(input, ['jobId', 'id']) ?? (job ? getToolInputString(job, ['id']) : null);
   const wakeText = getToolInputString(input, ['text']);
 
   switch (action) {
@@ -431,14 +446,11 @@ const formatStructuredText = (value: string): string => {
   }
 };
 
-const toTrimmedString = (value: unknown): string | null => (
-  typeof value === 'string' && value.trim() ? value.trim() : null
-);
+const toTrimmedString = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim() ? value.trim() : null;
 
 const normalizeTodoStatus = (value: unknown): TodoStatus => {
-  const normalized = typeof value === 'string'
-    ? value.trim().toLowerCase().replace(/-/g, '_')
-    : '';
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase().replace(/-/g, '_') : '';
 
   if (normalized === 'completed') return 'completed';
   if (normalized === 'in_progress' || normalized === 'running') return 'in_progress';
@@ -452,7 +464,7 @@ const parseTodoWriteItems = (input: unknown): ParsedTodoItem[] | null => {
   if (!Array.isArray(record.todos)) return null;
 
   const parsedItems = record.todos
-    .map((rawTodo) => {
+    .map(rawTodo => {
       if (!rawTodo || typeof rawTodo !== 'object') {
         return null;
       }
@@ -475,8 +487,8 @@ const parseTodoWriteItems = (input: unknown): ParsedTodoItem[] | null => {
 };
 
 const getTodoWriteSummary = (items: ParsedTodoItem[]): string => {
-  const completedCount = items.filter((item) => item.status === 'completed').length;
-  const inProgressCount = items.filter((item) => item.status === 'in_progress').length;
+  const completedCount = items.filter(item => item.status === 'completed').length;
+  const inProgressCount = items.filter(item => item.status === 'in_progress').length;
   const pendingCount = items.length - completedCount - inProgressCount;
 
   const summary = [
@@ -486,7 +498,7 @@ const getTodoWriteSummary = (items: ParsedTodoItem[]): string => {
     `${pendingCount} ${i18nService.t('coworkTodoPending')}`,
   ];
 
-  const activeItem = items.find((item) => item.status === 'in_progress');
+  const activeItem = items.find(item => item.status === 'in_progress');
   if (activeItem) {
     summary.push(activeItem.primaryText);
   }
@@ -496,7 +508,7 @@ const getTodoWriteSummary = (items: ParsedTodoItem[]): string => {
 
 const getToolInputSummary = (
   toolName: string | undefined,
-  toolInput?: Record<string, unknown>
+  toolInput?: Record<string, unknown>,
 ): string | null => {
   if (!toolName || !toolInput) return null;
   const input = toolInput as Record<string, unknown>;
@@ -513,8 +525,9 @@ const getToolInputSummary = (
     case 'bash':
     case 'exec':
     case 'shell':
-      return getToolInputString(input, ['command', 'cmd', 'script'])
-        ?? getStringArray(input.commands);
+      return (
+        getToolInputString(input, ['command', 'cmd', 'script']) ?? getStringArray(input.commands)
+      );
     case 'read':
     case 'readfile':
     case 'write':
@@ -522,12 +535,12 @@ const getToolInputSummary = (
     case 'edit':
     case 'editfile':
     case 'multiedit':
-      return getToolInputString(input, ['file_path', 'path', 'filePath', 'target_file', 'targetFile'])
-        ?? (
-          typeof input.content === 'string' && input.content.trim()
-            ? truncatePreview(input.content.split('\n')[0].trim())
-            : null
-        );
+      return (
+        getToolInputString(input, ['file_path', 'path', 'filePath', 'target_file', 'targetFile']) ??
+        (typeof input.content === 'string' && input.content.trim()
+          ? truncatePreview(input.content.split('\n')[0].trim())
+          : null)
+      );
     case 'glob':
     case 'grep':
       return getToolInputString(input, ['pattern', 'query']);
@@ -548,7 +561,7 @@ const getToolInputSummary = (
 
 const formatToolInput = (
   toolName: string | undefined,
-  toolInput?: Record<string, unknown>
+  toolInput?: Record<string, unknown>,
 ): string | null => {
   if (!toolInput) return null;
   const summary = getToolInputSummary(toolName, toolInput);
@@ -594,9 +607,8 @@ const stripFileProtocol = (value: string): string => {
 
 const hasScheme = (value: string): boolean => /^[a-z][a-z0-9+.-]*:/i.test(value);
 
-const isAbsolutePath = (value: string): boolean => (
-  value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)
-);
+const isAbsolutePath = (value: string): boolean =>
+  value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value);
 
 const isRelativePath = (value: string): boolean => !isAbsolutePath(value) && !hasScheme(value);
 
@@ -622,7 +634,7 @@ const parseRootRelativePath = (value: string): string | null => {
 };
 
 const normalizeLocalPath = (
-  value: string
+  value: string,
 ): { path: string; isRelative: boolean; isAbsolute: boolean } | null => {
   const trimmed = value.trim();
   if (!trimmed) return null;
@@ -658,9 +670,7 @@ export type ToolGroupItem = {
   toolResult?: CoworkMessage | null;
 };
 
-export type DisplayItem =
-  | { type: 'message'; message: CoworkMessage }
-  | ToolGroupItem;
+export type DisplayItem = { type: 'message'; message: CoworkMessage } | ToolGroupItem;
 
 export type AssistantTurnItem =
   | { type: 'assistant'; message: CoworkMessage }
@@ -807,9 +817,8 @@ const isVisibleAssistantTurnItem = (item: AssistantTurnItem): boolean => {
 const getVisibleAssistantItems = (assistantItems: AssistantTurnItem[]): AssistantTurnItem[] =>
   assistantItems.filter(isVisibleAssistantTurnItem);
 
-export const hasRenderableAssistantContent = (turn: ConversationTurn): boolean => (
-  getVisibleAssistantItems(turn.assistantItems).length > 0
-);
+export const hasRenderableAssistantContent = (turn: ConversationTurn): boolean =>
+  getVisibleAssistantItems(turn.assistantItems).length > 0;
 
 const getToolResultLineCount = (result: string): number => {
   if (!result) return 0;
@@ -833,19 +842,18 @@ const TodoWriteInputView: React.FC<{ items: ParsedTodoItem[] }> = ({ items }) =>
   return (
     <div className="space-y-2">
       {items.map((item, index) => (
-        <div
-          key={`todo-item-${index}`}
-          className="flex items-start gap-2"
-        >
-          <span className={`mt-0.5 h-4 w-4 rounded-[4px] border flex-shrink-0 inline-flex items-center justify-center ${getStatusCheckboxClass(item.status)}`}>
+        <div key={`todo-item-${index}`} className="flex items-start gap-2">
+          <span
+            className={`mt-0.5 h-4 w-4 rounded-[4px] border flex-shrink-0 inline-flex items-center justify-center ${getStatusCheckboxClass(item.status)}`}
+          >
             {item.status === 'completed' && <CheckIcon className="h-3 w-3 stroke-[2.5]" />}
           </span>
           <div className="min-w-0 flex-1">
-            <div className={`text-xs whitespace-pre-wrap break-words leading-5 ${
-              item.status === 'completed'
-                ? 'text-muted'
-                : 'text-foreground'
-            }`}>
+            <div
+              className={`text-xs whitespace-pre-wrap break-words leading-5 ${
+                item.status === 'completed' ? 'text-muted' : 'text-foreground'
+              }`}
+            >
               {item.primaryText}
             </div>
           </div>
@@ -859,13 +867,10 @@ const ToolCallGroup: React.FC<{
   group: ToolGroupItem;
   isLastInSequence?: boolean;
   mapDisplayText?: (value: string) => string;
-}> = ({
-  group,
-  isLastInSequence = true,
-  mapDisplayText,
-}) => {
+}> = ({ group, isLastInSequence = true, mapDisplayText }) => {
   const { toolUse, toolResult } = group;
-  const rawToolName = typeof toolUse.metadata?.toolName === 'string' ? toolUse.metadata.toolName : 'Tool';
+  const rawToolName =
+    typeof toolUse.metadata?.toolName === 'string' ? toolUse.metadata.toolName : 'Tool';
   const toolName = getToolDisplayName(rawToolName);
   const toolInput = toolUse.metadata?.toolInput;
   const isCronTool = isCronToolName(rawToolName);
@@ -885,9 +890,10 @@ const ToolCallGroup: React.FC<{
   const displayToolResult = hasToolResultText ? toolResultDisplay : toolResultFallback;
   const [isExpanded, setIsExpanded] = useState(false);
   const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0;
-  const toolResultSummary = isCronTool && hasToolResultText
-    ? truncatePreview(toolResultDisplay.replace(/\s+/g, ' '))
-    : null;
+  const toolResultSummary =
+    isCronTool && hasToolResultText
+      ? truncatePreview(toolResultDisplay.replace(/\s+/g, ' '))
+      : null;
 
   // Check if this is a Bash-like tool that should show terminal style
   const isBashTool = isBashLikeToolName(rawToolName);
@@ -909,18 +915,14 @@ const ToolCallGroup: React.FC<{
         onClick={() => setIsExpanded(!isExpanded)}
         className="w-full flex items-start gap-2 text-left group relative z-10"
       >
-        <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
-          !toolResult
-            ? 'bg-blue-500 animate-pulse'
-            : isToolError
-              ? 'bg-red-500'
-              : 'bg-green-500'
-        }`} />
+        <span
+          className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
+            !toolResult ? 'bg-blue-500 animate-pulse' : isToolError ? 'bg-red-500' : 'bg-green-500'
+          }`}
+        />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-sm font-medium text-secondary">
-              {toolName}
-            </span>
+            <span className="text-sm font-medium text-secondary">{toolName}</span>
             {toolInputSummary && (
               <code className="text-xs text-muted font-mono truncate max-w-[400px]">
                 {toolInputSummary}
@@ -928,22 +930,23 @@ const ToolCallGroup: React.FC<{
             )}
           </div>
           {toolResult && !isTodoWriteTool && (hasToolResultText || showNoDetailError) && (
-            <div className={`text-xs mt-0.5 ${
-              hasToolResultText
-                ? 'text-muted'
-                : showNoDetailError
-                  ? 'text-red-500/80'
-                  : 'text-muted'
-            }`}>
+            <div
+              className={`text-xs mt-0.5 ${
+                hasToolResultText
+                  ? 'text-muted'
+                  : showNoDetailError
+                    ? 'text-red-500/80'
+                    : 'text-muted'
+              }`}
+            >
               {hasToolResultText
-                ? (toolResultSummary ?? `${resultLineCount} ${resultLineCount === 1 ? 'line' : 'lines'} of output`)
+                ? (toolResultSummary ??
+                  `${resultLineCount} ${resultLineCount === 1 ? 'line' : 'lines'} of output`)
                 : toolResultFallback}
             </div>
           )}
           {!toolResult && (
-            <div className="text-xs text-muted mt-0.5">
-              {i18nService.t('coworkToolRunning')}
-            </div>
+            <div className="text-xs text-muted mt-0.5">{i18nService.t('coworkToolRunning')}</div>
           )}
         </div>
       </button>
@@ -968,13 +971,15 @@ const ToolCallGroup: React.FC<{
                   </div>
                 )}
                 {toolResult && (hasToolResultText || showNoDetailError) && (
-                  <div className={`mt-1.5 whitespace-pre-wrap break-words ${
-                    isToolError
-                      ? 'text-red-400'
-                      : hasToolResultText
-                        ? 'text-secondary'
-                        : 'text-muted italic'
-                  }`}>
+                  <div
+                    className={`mt-1.5 whitespace-pre-wrap break-words ${
+                      isToolError
+                        ? 'text-red-400'
+                        : hasToolResultText
+                          ? 'text-secondary'
+                          : 'text-muted italic'
+                    }`}
+                  >
                     {displayToolResult}
                   </div>
                 )}
@@ -1004,13 +1009,15 @@ const ToolCallGroup: React.FC<{
                     {i18nService.t('coworkToolResult')}
                   </div>
                   <div className="max-h-32 overflow-y-auto">
-                    <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${
-                      isToolError
-                        ? 'text-red-500'
-                        : hasToolResultText
-                          ? 'dark:text-claude-darkText text-claude-text'
-                          : 'dark:text-claude-darkTextSecondary text-claude-textSecondary italic'
-                    }`}>
+                    <pre
+                      className={`text-xs whitespace-pre-wrap break-words font-mono ${
+                        isToolError
+                          ? 'text-red-500'
+                          : hasToolResultText
+                            ? 'dark:text-claude-darkText text-claude-text'
+                            : 'dark:text-claude-darkTextSecondary text-claude-textSecondary italic'
+                      }`}
+                    >
                       {displayToolResult}
                     </pre>
                   </div>
@@ -1038,13 +1045,15 @@ const ToolCallGroup: React.FC<{
                     {i18nService.t('coworkToolResult')}
                   </div>
                   <div className="max-h-64 overflow-y-auto">
-                    <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${
-                      isToolError
-                        ? 'text-red-500'
-                        : hasToolResultText
-                          ? 'text-foreground'
-                          : 'text-secondary italic'
-                    }`}>
+                    <pre
+                      className={`text-xs whitespace-pre-wrap break-words font-mono ${
+                        isToolError
+                          ? 'text-red-500'
+                          : hasToolResultText
+                            ? 'text-foreground'
+                            : 'text-secondary italic'
+                      }`}
+                    >
                       {displayToolResult}
                     </pre>
                   </div>
@@ -1129,7 +1138,7 @@ const ReEditButton: React.FC<{
 }> = ({ visible, onClick }) => {
   return (
     <button
-      onClick={(e) => {
+      onClick={e => {
         e.stopPropagation();
         onClick();
       }}
@@ -1173,7 +1182,8 @@ export const UserMessageItem: React.FC<{
     .filter((s): s is NonNullable<typeof s> => s !== undefined);
 
   // Get image attachments from metadata
-  const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ?? []) as CoworkImageAttachment[];
+  const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ??
+    []) as CoworkImageAttachment[];
 
   return (
     <div
@@ -1201,7 +1211,9 @@ export const UserMessageItem: React.FC<{
                           alt={img.name}
                           className="max-h-48 max-w-[16rem] rounded-lg object-contain cursor-pointer border border-border hover:border-primary transition-colors"
                           title={img.name}
-                          onClick={() => setExpandedImage(`data:${img.mimeType};base64,${img.base64Data}`)}
+                          onClick={() =>
+                            setExpandedImage(`data:${img.mimeType};base64,${img.base64Data}`)
+                          }
                         />
                         <div className="absolute bottom-1 left-1 right-1 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/50 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity truncate pointer-events-none">
                           <PhotoIcon className="h-3 w-3 flex-shrink-0" />
@@ -1213,16 +1225,8 @@ export const UserMessageItem: React.FC<{
                 )}
               </div>
               <div className="flex items-center justify-end gap-1.5 mt-1">
-                {onReEdit && (
-                  <ReEditButton
-                    visible={isHovered}
-                    onClick={() => onReEdit(message)}
-                  />
-                )}
-                <CopyButton
-                  content={message.content}
-                  visible={isHovered}
-                />
+                {onReEdit && <ReEditButton visible={isHovered} onClick={() => onReEdit(message)} />}
+                <CopyButton content={message.content} visible={isHovered} />
                 {messageSkills.length > 0 && (
                   <div className="flex items-center gap-1.5 mr-1.5">
                     {messageSkills.map(skill => (
@@ -1254,7 +1258,7 @@ export const UserMessageItem: React.FC<{
             src={expandedImage}
             alt="Preview"
             className="max-h-[90vh] max-w-[90vw] object-contain rounded-lg shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
+            onClick={e => e.stopPropagation()}
           />
         </div>
       )}
@@ -1267,12 +1271,7 @@ const AssistantMessageItem: React.FC<{
   resolveLocalFilePath?: (href: string, text: string) => string | null;
   mapDisplayText?: (value: string) => string;
   showCopyButton?: boolean;
-}> = ({
-  message,
-  resolveLocalFilePath,
-  mapDisplayText,
-  showCopyButton = false,
-}) => {
+}> = ({ message, resolveLocalFilePath, mapDisplayText, showCopyButton = false }) => {
   const [isHovered, setIsHovered] = useState(false);
   const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content;
 
@@ -1292,10 +1291,7 @@ const AssistantMessageItem: React.FC<{
       </div>
       {showCopyButton && (
         <div className="flex items-center gap-1.5 mt-1">
-          <CopyButton
-            content={displayContent}
-            visible={isHovered}
-          />
+          <CopyButton content={displayContent} visible={isHovered} />
         </div>
       )}
     </div>
@@ -1321,7 +1317,8 @@ const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ message
       if (msg.type === 'tool_use') {
         const id = msg.metadata?.toolUseId;
         if (typeof id === 'string' && !toolResultIds.has(id)) {
-          const toolName = typeof msg.metadata?.toolName === 'string' ? msg.metadata.toolName : null;
+          const toolName =
+            typeof msg.metadata?.toolName === 'string' ? msg.metadata.toolName : null;
           if (toolName) {
             return `${i18nService.t('coworkToolRunning')} ${toolName}...`;
           }
@@ -1336,9 +1333,7 @@ const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ message
       <div className="max-w-3xl mx-auto">
         <div className="streaming-bar" />
         <div className="py-1">
-          <span className="text-xs text-secondary">
-            {getStatusText()}
-          </span>
+          <span className="text-xs text-secondary">{getStatusText()}</span>
         </div>
       </div>
     </div>
@@ -1347,9 +1342,18 @@ const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ message
 
 const TypingDots: React.FC = () => (
   <div className="flex items-center space-x-1.5 py-1">
-    <div className="w-2 h-2 rounded-full bg-primary animate-bounce" style={{ animationDelay: '0ms' }} />
-    <div className="w-2 h-2 rounded-full bg-primary animate-bounce" style={{ animationDelay: '150ms' }} />
-    <div className="w-2 h-2 rounded-full bg-primary animate-bounce" style={{ animationDelay: '300ms' }} />
+    <div
+      className="w-2 h-2 rounded-full bg-primary animate-bounce"
+      style={{ animationDelay: '0ms' }}
+    />
+    <div
+      className="w-2 h-2 rounded-full bg-primary animate-bounce"
+      style={{ animationDelay: '150ms' }}
+    />
+    <div
+      className="w-2 h-2 rounded-full bg-primary animate-bounce"
+      style={{ animationDelay: '300ms' }}
+    />
   </div>
 );
 
@@ -1381,9 +1385,7 @@ const ThinkingBlock: React.FC<{
             isExpanded ? 'rotate-90' : ''
           }`}
         />
-        <span className="text-xs font-medium text-secondary">
-          {i18nService.t('reasoning')}
-        </span>
+        <span className="text-xs font-medium text-secondary">{i18nService.t('reasoning')}</span>
         {isCurrentlyStreaming && (
           <span className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
         )}
@@ -1418,7 +1420,9 @@ export const AssistantTurnBlock: React.FC<{
     const isError = !hasText(message.content) && typeof message.metadata?.error === 'string';
     const rawContent = hasText(message.content)
       ? message.content
-      : (typeof message.metadata?.error === 'string' ? message.metadata.error : '');
+      : typeof message.metadata?.error === 'string'
+        ? message.metadata.error
+        : '';
     const normalizedContent = getScheduledReminderDisplayText(rawContent) ?? rawContent;
     const content = mapDisplayText ? mapDisplayText(normalizedContent) : normalizedContent;
     if (!content.trim()) return null;
@@ -1426,13 +1430,12 @@ export const AssistantTurnBlock: React.FC<{
     return (
       <div className="rounded-lg border border-border bg-background px-3 py-2">
         <div className="flex items-center gap-2">
-          {isError
-            ? <ExclamationTriangleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
-            : <InformationCircleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
-          }
-          <div className="text-xs whitespace-pre-wrap text-secondary">
-            {content}
-          </div>
+          {isError ? (
+            <ExclamationTriangleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
+          ) : (
+            <InformationCircleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
+          )}
+          <div className="text-xs whitespace-pre-wrap text-secondary">{content}</div>
         </div>
       </div>
     );
@@ -1440,7 +1443,9 @@ export const AssistantTurnBlock: React.FC<{
 
   const renderOrphanToolResult = (message: CoworkMessage) => {
     const toolResultDisplayRaw = getToolResultDisplay(message);
-    const toolResultDisplay = mapDisplayText ? mapDisplayText(toolResultDisplayRaw) : toolResultDisplayRaw;
+    const toolResultDisplay = mapDisplayText
+      ? mapDisplayText(toolResultDisplayRaw)
+      : toolResultDisplayRaw;
     const isToolError = Boolean(message.metadata?.isError || message.metadata?.error);
     const hasToolResultText = hasText(toolResultDisplay);
     const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0;
@@ -1450,9 +1455,11 @@ export const AssistantTurnBlock: React.FC<{
     return (
       <div className="py-1">
         <div className="flex items-start gap-2">
-          <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
-            isToolError ? 'bg-red-500' : 'bg-surface-raised'
-          }`} />
+          <span
+            className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
+              isToolError ? 'bg-red-500' : 'bg-surface-raised'
+            }`}
+          />
           <div className="flex-1 min-w-0">
             <div className="text-sm font-medium text-secondary">
               {i18nService.t('coworkToolResult')}
@@ -1463,23 +1470,21 @@ export const AssistantTurnBlock: React.FC<{
               </div>
             )}
             {resultLineCount === 0 && showNoDetailError && (
-              <div className={`text-xs mt-0.5 ${
-                isToolError
-                  ? 'text-red-500/80'
-                  : 'text-muted'
-              }`}>
+              <div className={`text-xs mt-0.5 ${isToolError ? 'text-red-500/80' : 'text-muted'}`}>
                 {fallbackText}
               </div>
             )}
             {(hasToolResultText || showNoDetailError) && (
               <div className="mt-2 px-3 py-2 rounded-lg bg-surface-raised max-h-64 overflow-y-auto">
-                <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${
-                  isToolError
-                    ? 'text-red-500'
-                    : hasToolResultText
-                      ? 'text-foreground'
-                      : 'text-secondary italic'
-                }`}>
+                <pre
+                  className={`text-xs whitespace-pre-wrap break-words font-mono ${
+                    isToolError
+                      ? 'text-red-500'
+                      : hasToolResultText
+                        ? 'text-foreground'
+                        : 'text-secondary italic'
+                  }`}
+                >
                   {displayText}
                 </pre>
               </div>
@@ -1540,18 +1545,10 @@ export const AssistantTurnBlock: React.FC<{
                 if (!systemMessage) {
                   return null;
                 }
-                return (
-                  <div key={item.message.id}>
-                    {systemMessage}
-                  </div>
-                );
+                return <div key={item.message.id}>{systemMessage}</div>;
               }
 
-              return (
-                <div key={item.message.id}>
-                  {renderOrphanToolResult(item.message)}
-                </div>
-              );
+              return <div key={item.message.id}>{renderOrphanToolResult(item.message)}</div>;
             })}
             {showTypingIndicator && <TypingDots />}
           </div>
@@ -1604,7 +1601,12 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const [isScrollable, setIsScrollable] = useState(false);
   const [hoveredRailIndex, setHoveredRailIndex] = useState<number | null>(null);
   const [isRailHovered, setIsRailHovered] = useState(false);
-  const [railTooltip, setRailTooltip] = useState<{ label: string; top: number; right: number; isUser: boolean } | null>(null);
+  const [railTooltip, setRailTooltip] = useState<{
+    label: string;
+    top: number;
+    right: number;
+    isUser: boolean;
+  } | null>(null);
 
   // Menu and action states
   const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
@@ -1700,7 +1702,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     const padding = 8;
     const x = Math.min(
       Math.max(padding, rect.right - menuWidth),
-      window.innerWidth - menuWidth - padding
+      window.innerWidth - menuWidth - padding,
     );
     const y = Math.min(rect.bottom + 8, window.innerHeight - height - padding);
     return { x, y };
@@ -1795,7 +1797,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     const lines: string[] = [];
     lines.push(`# ${currentSession.title}`);
     lines.push('');
-    lines.push(`> ${i18nService.t('coworkExportCreatedAt')}: ${new Date(currentSession.createdAt).toLocaleString()}`);
+    lines.push(
+      `> ${i18nService.t('coworkExportCreatedAt')}: ${new Date(currentSession.createdAt).toLocaleString()}`,
+    );
     lines.push('');
     lines.push('---');
     lines.push('');
@@ -1823,7 +1827,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         lines.push('#### Tool Result');
         lines.push('');
         lines.push('```');
-        lines.push(msg.content.slice(0, 2000) + (msg.content.length > 2000 ? '\n... (truncated)' : ''));
+        lines.push(
+          msg.content.slice(0, 2000) + (msg.content.length > 2000 ? '\n... (truncated)' : ''),
+        );
         lines.push('```');
         lines.push('');
       }
@@ -1833,47 +1839,58 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
   const sessionToJSON = useCallback((): string => {
     if (!currentSession) return '{}';
-    return JSON.stringify({
-      title: currentSession.title,
-      createdAt: new Date(currentSession.createdAt).toISOString(),
-      updatedAt: new Date(currentSession.updatedAt).toISOString(),
-      status: currentSession.status,
-      messages: currentSession.messages.map(msg => ({
-        type: msg.type,
-        content: msg.content,
-        timestamp: new Date(msg.timestamp).toISOString(),
-        ...(msg.metadata?.toolName ? { toolName: msg.metadata.toolName } : {}),
-        ...(msg.metadata?.toolInput ? { toolInput: msg.metadata.toolInput } : {}),
-      })),
-    }, null, 2);
+    return JSON.stringify(
+      {
+        title: currentSession.title,
+        createdAt: new Date(currentSession.createdAt).toISOString(),
+        updatedAt: new Date(currentSession.updatedAt).toISOString(),
+        status: currentSession.status,
+        messages: currentSession.messages.map(msg => ({
+          type: msg.type,
+          content: msg.content,
+          timestamp: new Date(msg.timestamp).toISOString(),
+          ...(msg.metadata?.toolName ? { toolName: msg.metadata.toolName } : {}),
+          ...(msg.metadata?.toolInput ? { toolInput: msg.metadata.toolInput } : {}),
+        })),
+      },
+      null,
+      2,
+    );
   }, [currentSession]);
 
-  const handleExportText = useCallback(async (format: 'md' | 'json') => {
-    if (!currentSession) return;
-    closeMenu();
-    const content = format === 'md' ? sessionToMarkdown() : sessionToJSON();
-    const timestamp = new Date().toISOString().slice(0, 10);
-    const fileName = sanitizeExportFileName(`${currentSession.title}-${timestamp}.${format}`);
-    try {
-      const result = await window.electron.cowork.exportSessionText({
-        content,
-        defaultFileName: fileName,
-        fileExtension: format,
-      });
-      if (result.success && !result.canceled) {
-        window.dispatchEvent(new CustomEvent('app:showToast', {
-          detail: i18nService.t('coworkExportTextSuccess'),
-        }));
-      } else if (!result.success) {
-        throw new Error(result.error || 'Export failed');
+  const handleExportText = useCallback(
+    async (format: 'md' | 'json') => {
+      if (!currentSession) return;
+      closeMenu();
+      const content = format === 'md' ? sessionToMarkdown() : sessionToJSON();
+      const timestamp = new Date().toISOString().slice(0, 10);
+      const fileName = sanitizeExportFileName(`${currentSession.title}-${timestamp}.${format}`);
+      try {
+        const result = await window.electron.cowork.exportSessionText({
+          content,
+          defaultFileName: fileName,
+          fileExtension: format,
+        });
+        if (result.success && !result.canceled) {
+          window.dispatchEvent(
+            new CustomEvent('app:showToast', {
+              detail: i18nService.t('coworkExportTextSuccess'),
+            }),
+          );
+        } else if (!result.success) {
+          throw new Error(result.error || 'Export failed');
+        }
+      } catch (error) {
+        console.error('Failed to export session text:', error);
+        window.dispatchEvent(
+          new CustomEvent('app:showToast', {
+            detail: i18nService.t('coworkExportTextFailed'),
+          }),
+        );
       }
-    } catch (error) {
-      console.error('Failed to export session text:', error);
-      window.dispatchEvent(new CustomEvent('app:showToast', {
-        detail: i18nService.t('coworkExportTextFailed'),
-      }));
-    }
-  }, [currentSession, closeMenu, sessionToMarkdown, sessionToJSON]);
+    },
+    [currentSession, closeMenu, sessionToMarkdown, sessionToJSON],
+  );
 
   const handleShareClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1895,7 +1912,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               throw new Error('Invalid capture area');
             }
 
-            const scrollContentHeight = Math.max(scrollContainer.scrollHeight, scrollContainer.clientHeight);
+            const scrollContentHeight = Math.max(
+              scrollContainer.scrollHeight,
+              scrollContainer.clientHeight,
+            );
             if (scrollContentHeight <= 0) {
               throw new Error('Invalid content height');
             }
@@ -1905,8 +1925,12 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               return Math.max(0, Math.min(scrollContentHeight, y));
             };
 
-            const userAnchors = scrollContainer.querySelectorAll<HTMLElement>('[data-export-role="user-message"]');
-            const assistantAnchors = scrollContainer.querySelectorAll<HTMLElement>('[data-export-role="assistant-block"]');
+            const userAnchors = scrollContainer.querySelectorAll<HTMLElement>(
+              '[data-export-role="user-message"]',
+            );
+            const assistantAnchors = scrollContainer.querySelectorAll<HTMLElement>(
+              '[data-export-role="assistant-block"]',
+            );
 
             let contentStart = 0;
             let contentEnd = scrollContentHeight;
@@ -1927,7 +1951,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
             const maxStart = Math.max(0, scrollContentHeight - 1);
             contentStart = Math.max(0, Math.min(maxStart, Math.round(contentStart)));
-            contentEnd = Math.max(contentStart + 1, Math.min(scrollContentHeight, Math.round(contentEnd)));
+            contentEnd = Math.max(
+              contentStart + 1,
+              Math.min(scrollContentHeight, Math.round(contentEnd)),
+            );
 
             const outputHeight = contentEnd - contentStart;
 
@@ -1956,11 +1983,17 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               return loadImageFromBase64(chunk.pngBase64);
             };
 
-            scrollContainer.scrollTop = Math.min(contentStart, Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight));
+            scrollContainer.scrollTop = Math.min(
+              contentStart,
+              Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight),
+            );
             await waitForNextFrame();
             await waitForNextFrame();
 
-            const maxScrollTop = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
+            const maxScrollTop = Math.max(
+              0,
+              scrollContainer.scrollHeight - scrollContainer.clientHeight,
+            );
             let contentOffset = contentStart;
             while (contentOffset < contentEnd) {
               const targetScrollTop = Math.min(contentOffset, maxScrollTop);
@@ -1970,16 +2003,22 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
               const chunkImage = await captureAndLoad(scrollRect);
               const sourceYOffset = Math.max(0, contentOffset - targetScrollTop);
-              const drawableHeight = Math.min(scrollRect.height - sourceYOffset, contentEnd - contentOffset);
+              const drawableHeight = Math.min(
+                scrollRect.height - sourceYOffset,
+                contentEnd - contentOffset,
+              );
               if (drawableHeight <= 0) {
                 throw new Error('Failed to stitch export image');
               }
               const scaleY = chunkImage.naturalHeight / scrollRect.height;
               const sourceYInImage = Math.max(0, Math.round(sourceYOffset * scaleY));
-              const sourceHeightInImage = Math.max(1, Math.min(
-                chunkImage.naturalHeight - sourceYInImage,
-                Math.round(drawableHeight * scaleY),
-              ));
+              const sourceHeightInImage = Math.max(
+                1,
+                Math.min(
+                  chunkImage.naturalHeight - sourceYInImage,
+                  Math.round(drawableHeight * scaleY),
+                ),
+              );
 
               context.drawImage(
                 chunkImage,
@@ -2015,9 +2054,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               defaultFileName: sanitizeExportFileName(`${currentSession.title}-${timestamp}.png`),
             });
             if (saveResult.success && !saveResult.canceled) {
-              window.dispatchEvent(new CustomEvent('app:showToast', {
-                detail: i18nService.t('coworkExportImageSuccess'),
-              }));
+              window.dispatchEvent(
+                new CustomEvent('app:showToast', {
+                  detail: i18nService.t('coworkExportImageSuccess'),
+                }),
+              );
               return;
             }
             if (!saveResult.success) {
@@ -2028,9 +2069,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
           }
         } catch (error) {
           console.error('Failed to export session image:', error);
-          window.dispatchEvent(new CustomEvent('app:showToast', {
-            detail: i18nService.t('coworkExportImageFailed'),
-          }));
+          window.dispatchEvent(
+            new CustomEvent('app:showToast', {
+              detail: i18nService.t('coworkExportImageFailed'),
+            }),
+          );
         } finally {
           setIsExportingImage(false);
         }
@@ -2061,11 +2104,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     if (!container) return;
     const distanceToBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
     const isNearBottom = distanceToBottom <= AUTO_SCROLL_THRESHOLD;
-    setShouldAutoScroll((prev) => (prev === isNearBottom ? prev : isNearBottom));
+    setShouldAutoScroll(prev => (prev === isNearBottom ? prev : isNearBottom));
 
     // Check if content overflows the container (use functional updater to avoid redundant re-renders)
     const scrollable = container.scrollHeight > container.clientHeight;
-    setIsScrollable((prev) => (prev === scrollable ? prev : scrollable));
+    setIsScrollable(prev => (prev === scrollable ? prev : scrollable));
     if (!scrollable) return;
 
     // Skip index recalculation during programmatic navigation
@@ -2104,9 +2147,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     let railIdx = range.first;
     if (range.first !== range.last) {
       const turnEl = turnEls[currentTurn];
-      const nextTurnTop = currentTurn + 1 < turnEls.length
-        ? turnEls[currentTurn + 1].offsetTop
-        : container.scrollHeight;
+      const nextTurnTop =
+        currentTurn + 1 < turnEls.length
+          ? turnEls[currentTurn + 1].offsetTop
+          : container.scrollHeight;
       const turnMid = turnEl.offsetTop + (nextTurnTop - turnEl.offsetTop) / 2;
       if (scrollTop + 80 >= turnMid) {
         railIdx = range.last;
@@ -2134,7 +2178,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
     isNavigatingRef.current = true;
     if (navigatingTimerRef.current) clearTimeout(navigatingTimerRef.current);
-    navigatingTimerRef.current = setTimeout(() => { isNavigatingRef.current = false; }, NAV_SCROLL_LOCK_DURATION);
+    navigatingTimerRef.current = setTimeout(() => {
+      isNavigatingRef.current = false;
+    }, NAV_SCROLL_LOCK_DURATION);
 
     // Try to scroll to the exact data-rail-index element if it's in the DOM
     const container = scrollContainerRef.current;
@@ -2159,77 +2205,87 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   // selectors (selectLastMessageContent / selectCurrentMessagesLength)
   // so there is no need to derive them from currentSession here.
 
-  const resolveLocalFilePath = useCallback((href: string, text: string) => {
-    const hrefValue = typeof href === 'string' ? href.trim() : '';
-    const textValue = typeof text === 'string' ? text.trim() : '';
-    if (!hrefValue && !textValue) return null;
+  const resolveLocalFilePath = useCallback(
+    (href: string, text: string) => {
+      const hrefValue = typeof href === 'string' ? href.trim() : '';
+      const textValue = typeof text === 'string' ? text.trim() : '';
+      if (!hrefValue && !textValue) return null;
 
-    const hrefRootRelative = hrefValue ? parseRootRelativePath(hrefValue) : null;
-    if (hrefRootRelative) {
-      return hrefRootRelative;
-    }
-
-    const hrefPath = hrefValue ? normalizeLocalPath(hrefValue) : null;
-    if (hrefPath) {
-      if (hrefPath.isRelative && currentSession?.cwd) {
-        return toAbsolutePathFromCwd(hrefPath.path, currentSession.cwd);
+      const hrefRootRelative = hrefValue ? parseRootRelativePath(hrefValue) : null;
+      if (hrefRootRelative) {
+        return hrefRootRelative;
       }
-      if (hrefPath.isAbsolute) {
-        return hrefPath.path;
-      }
-    }
 
-    const textRootRelative = textValue ? parseRootRelativePath(textValue) : null;
-    if (textRootRelative) {
-      return textRootRelative;
-    }
-
-    const textPath = textValue ? normalizeLocalPath(textValue) : null;
-    if (textPath) {
-      if (textPath.isRelative && currentSession?.cwd) {
-        return toAbsolutePathFromCwd(textPath.path, currentSession.cwd);
+      const hrefPath = hrefValue ? normalizeLocalPath(hrefValue) : null;
+      if (hrefPath) {
+        if (hrefPath.isRelative && currentSession?.cwd) {
+          return toAbsolutePathFromCwd(hrefPath.path, currentSession.cwd);
+        }
+        if (hrefPath.isAbsolute) {
+          return hrefPath.path;
+        }
       }
-      if (textPath.isAbsolute) {
-        return textPath.path;
-      }
-    }
 
-    return null;
-  }, [currentSession?.cwd]);
+      const textRootRelative = textValue ? parseRootRelativePath(textValue) : null;
+      if (textRootRelative) {
+        return textRootRelative;
+      }
+
+      const textPath = textValue ? normalizeLocalPath(textValue) : null;
+      if (textPath) {
+        if (textPath.isRelative && currentSession?.cwd) {
+          return toAbsolutePathFromCwd(textPath.path, currentSession.cwd);
+        }
+        if (textPath.isAbsolute) {
+          return textPath.path;
+        }
+      }
+
+      return null;
+    },
+    [currentSession?.cwd],
+  );
 
   const mapDisplayText = useCallback((value: string): string => {
     return value;
   }, []);
 
-  const handleReEdit = useCallback((message: CoworkMessage) => {
-    const ref = promptInputRef.current;
-    if (!ref) return;
-    // Set text content
-    if (message.content?.trim()) {
-      ref.setValue(message.content);
-    }
-    // Restore image attachments (always call to clear previous attachments)
-    const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ?? []) as CoworkImageAttachment[];
-    ref.setImageAttachments(imageAttachments);
-    // Restore active skills
-    const skillIds = (message.metadata as CoworkMessageMetadata)?.skillIds;
-    if (skillIds && skillIds.length > 0) {
-      dispatch(setActiveSkillIds(skillIds));
-    }
-    // Focus the input
-    ref.focus();
-  }, [dispatch]);
+  const handleReEdit = useCallback(
+    (message: CoworkMessage) => {
+      const ref = promptInputRef.current;
+      if (!ref) return;
+      // Set text content
+      if (message.content?.trim()) {
+        ref.setValue(message.content);
+      }
+      // Restore image attachments (always call to clear previous attachments)
+      const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ??
+        []) as CoworkImageAttachment[];
+      ref.setImageAttachments(imageAttachments);
+      // Restore active skills
+      const skillIds = (message.metadata as CoworkMessageMetadata)?.skillIds;
+      if (skillIds && skillIds.length > 0) {
+        dispatch(setActiveSkillIds(skillIds));
+      }
+      // Focus the input
+      ref.focus();
+    },
+    [dispatch],
+  );
 
   const messages = currentSession?.messages;
-  const displayItems = useMemo(() => messages ? buildDisplayItems(messages) : [], [messages]);
+  const displayItems = useMemo(() => (messages ? buildDisplayItems(messages) : []), [messages]);
   const turns = useMemo(() => buildConversationTurns(displayItems), [displayItems]);
 
   // Cache turn-level DOM elements (data-turn-index, always in DOM even for lazy turns)
   useEffect(() => {
     const container = scrollContainerRef.current;
-    if (!container) { turnElsCacheRef.current = []; return; }
+    if (!container) {
+      turnElsCacheRef.current = [];
+      return;
+    }
     turnElsCacheRef.current = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-turn-index]')
+      container.querySelectorAll<HTMLElement>('[data-turn-index]'),
     );
   }, [turns]);
 
@@ -2286,7 +2342,6 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     }
   }, [messagesLength, lastMessageContent, isStreaming, shouldAutoScroll, turns.length]);
 
-
   if (!currentSession) {
     return null;
   }
@@ -2329,14 +2384,29 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       const asstRailIdx = asstContent ? railCounter++ : -1;
 
       return (
-        <LazyRenderTurn key={turn.id} turnId={turn.id} alwaysRender={alwaysRender} data-turn-index={index}>
+        <LazyRenderTurn
+          key={turn.id}
+          turnId={turn.id}
+          alwaysRender={alwaysRender}
+          data-turn-index={index}
+        >
           {turn.userMessage && (
-            <div data-export-role="user-message" {...(userRailIdx >= 0 ? { 'data-rail-index': userRailIdx } : undefined)}>
-              <UserMessageItem message={turn.userMessage} skills={skills} onReEdit={remoteManaged ? undefined : handleReEdit} />
+            <div
+              data-export-role="user-message"
+              {...(userRailIdx >= 0 ? { 'data-rail-index': userRailIdx } : undefined)}
+            >
+              <UserMessageItem
+                message={turn.userMessage}
+                skills={skills}
+                onReEdit={remoteManaged ? undefined : handleReEdit}
+              />
             </div>
           )}
           {showAssistantBlock && (
-            <div data-export-role="assistant-block" {...(asstRailIdx >= 0 ? { 'data-rail-index': asstRailIdx } : undefined)}>
+            <div
+              data-export-role="assistant-block"
+              {...(asstRailIdx >= 0 ? { 'data-rail-index': asstRailIdx } : undefined)}
+            >
               <AssistantTurnBlock
                 turn={turn}
                 resolveLocalFilePath={resolveLocalFilePath}
@@ -2380,10 +2450,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             <input
               ref={renameInputRef}
               value={renameValue}
-              onChange={(e) => setRenameValue(e.target.value)}
-              onClick={(e) => e.stopPropagation()}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
+              onChange={e => setRenameValue(e.target.value)}
+              onClick={e => e.stopPropagation()}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                   handleRenameSave(e);
                 }
                 if (e.key === 'Escape') {
@@ -2454,11 +2524,17 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               slashed={currentSession.pinned}
               className={`h-[18px] w-[18px] text-secondary ${currentSession.pinned ? 'opacity-60' : ''}`}
             />
-            {currentSession.pinned ? i18nService.t('coworkUnpinSession') : i18nService.t('coworkPinSession')}
+            {currentSession.pinned
+              ? i18nService.t('coworkUnpinSession')
+              : i18nService.t('coworkPinSession')}
           </button>
           <button
             type="button"
-            onClick={(e) => { e.stopPropagation(); closeMenu(); setShowExportOptions(true); }}
+            onClick={e => {
+              e.stopPropagation();
+              closeMenu();
+              setShowExportOptions(true);
+            }}
             disabled={isExportingImage}
             className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm dark:text-claude-darkText text-claude-text hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors"
           >
@@ -2484,7 +2560,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         >
           <div
             className="w-full max-w-xs mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal overflow-hidden modal-content"
-            onClick={(e) => e.stopPropagation()}
+            onClick={e => e.stopPropagation()}
           >
             <div className="px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">
               <h3 className="text-base font-semibold dark:text-claude-darkText text-claude-text">
@@ -2494,36 +2570,51 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             <div className="py-1">
               <button
                 type="button"
-                onClick={(e) => { setShowExportOptions(false); handleShareClick(e); }}
+                onClick={e => {
+                  setShowExportOptions(false);
+                  handleShareClick(e);
+                }}
                 disabled={isExportingImage}
                 className="w-full flex items-center gap-3 px-5 py-3 text-left text-sm dark:text-claude-darkText text-claude-text hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors disabled:opacity-50"
               >
                 <PhotoIcon className="h-5 w-5 dark:text-claude-darkTextSecondary text-claude-textSecondary" />
                 <div>
                   <div className="font-medium">{i18nService.t('coworkExportImage')}</div>
-                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">{i18nService.t('coworkExportImageDesc')}</div>
+                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                    {i18nService.t('coworkExportImageDesc')}
+                  </div>
                 </div>
               </button>
               <button
                 type="button"
-                onClick={() => { setShowExportOptions(false); handleExportText('md'); }}
+                onClick={() => {
+                  setShowExportOptions(false);
+                  handleExportText('md');
+                }}
                 className="w-full flex items-center gap-3 px-5 py-3 text-left text-sm dark:text-claude-darkText text-claude-text hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors"
               >
                 <DocumentArrowDownIcon className="h-5 w-5 dark:text-claude-darkTextSecondary text-claude-textSecondary" />
                 <div>
                   <div className="font-medium">Markdown</div>
-                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">{i18nService.t('coworkExportMarkdownDesc')}</div>
+                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                    {i18nService.t('coworkExportMarkdownDesc')}
+                  </div>
                 </div>
               </button>
               <button
                 type="button"
-                onClick={() => { setShowExportOptions(false); handleExportText('json'); }}
+                onClick={() => {
+                  setShowExportOptions(false);
+                  handleExportText('json');
+                }}
                 className="w-full flex items-center gap-3 px-5 py-3 text-left text-sm dark:text-claude-darkText text-claude-text hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors"
               >
                 <DocumentArrowDownIcon className="h-5 w-5 dark:text-claude-darkTextSecondary text-claude-textSecondary" />
                 <div>
                   <div className="font-medium">JSON</div>
-                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">{i18nService.t('coworkExportJSONDesc')}</div>
+                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                    {i18nService.t('coworkExportJSONDesc')}
+                  </div>
                 </div>
               </button>
             </div>
@@ -2533,39 +2624,41 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
       {/* Delete Confirmation Modal */}
       {showConfirmDelete && (
-        <Modal onClose={handleCancelDelete} overlayClassName="fixed inset-0 z-50 flex items-center justify-center modal-backdrop" className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden modal-content">
-            {/* Header */}
-            <div className="flex items-center gap-3 px-5 py-4">
-              <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
-                <ExclamationTriangleIcon className="h-5 w-5 text-red-600 dark:text-red-500" />
-              </div>
-              <h2 className="text-base font-semibold text-foreground">
-                {i18nService.t('deleteTaskConfirmTitle')}
-              </h2>
+        <Modal
+          onClose={handleCancelDelete}
+          overlayClassName="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
+          className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden modal-content"
+        >
+          {/* Header */}
+          <div className="flex items-center gap-3 px-5 py-4">
+            <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
+              <ExclamationTriangleIcon className="h-5 w-5 text-red-600 dark:text-red-500" />
             </div>
+            <h2 className="text-base font-semibold text-foreground">
+              {i18nService.t('deleteTaskConfirmTitle')}
+            </h2>
+          </div>
 
-            {/* Content */}
-            <div className="px-5 pb-4">
-              <p className="text-sm text-secondary">
-                {i18nService.t('deleteTaskConfirmMessage')}
-              </p>
-            </div>
+          {/* Content */}
+          <div className="px-5 pb-4">
+            <p className="text-sm text-secondary">{i18nService.t('deleteTaskConfirmMessage')}</p>
+          </div>
 
-            {/* Footer */}
-            <div className="flex items-center justify-end gap-3 px-5 py-4 border-t border-border">
-              <button
-                onClick={handleCancelDelete}
-                className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                {i18nService.t('cancel')}
-              </button>
-              <button
-                onClick={handleConfirmDelete}
-                className="px-4 py-2 text-sm font-medium rounded-lg bg-red-500 hover:bg-red-600 text-white transition-colors"
-              >
-                {i18nService.t('deleteSession')}
-              </button>
-            </div>
+          {/* Footer */}
+          <div className="flex items-center justify-end gap-3 px-5 py-4 border-t border-border">
+            <button
+              onClick={handleCancelDelete}
+              className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
+            >
+              {i18nService.t('cancel')}
+            </button>
+            <button
+              onClick={handleConfirmDelete}
+              className="px-4 py-2 text-sm font-medium rounded-lg bg-red-500 hover:bg-red-600 text-white transition-colors"
+            >
+              {i18nService.t('deleteSession')}
+            </button>
+          </div>
         </Modal>
       )}
       <div className="relative flex-1 min-h-0">
@@ -2594,19 +2687,31 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             <button
               type="button"
               onClick={() => {
-                const resolvedRail = currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex;
+                const resolvedRail =
+                  currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex;
                 if (resolvedRail <= 0) return;
                 navigateToRailItem(resolvedRail - 1);
               }}
-              onMouseEnter={() => { setHoveredRailIndex(null); }}
+              onMouseEnter={() => {
+                setHoveredRailIndex(null);
+              }}
               className={`shrink-0 flex items-center justify-center w-5 h-5 mb-2 -mr-[5px] rounded-full transition-all text-neutral-600 dark:text-neutral-400
-                ${!isRailHovered
-                  ? 'opacity-0 pointer-events-none'
-                  : (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) <= 0
-                    ? 'opacity-30 cursor-default'
-                    : 'cursor-pointer hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60'}`}
+                ${
+                  !isRailHovered
+                    ? 'opacity-0 pointer-events-none'
+                    : (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) <= 0
+                      ? 'opacity-30 cursor-default'
+                      : 'cursor-pointer hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60'
+                }`}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-3.5 h-3.5">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2.5}
+                stroke="currentColor"
+                className="w-3.5 h-3.5"
+              >
                 <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
               </svg>
             </button>
@@ -2617,112 +2722,123 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               className="overflow-y-auto min-h-0 flex-1"
               style={{ scrollbarWidth: 'none' }}
             >
-            {(() => {
-              // Build flat list of messages with their content length and turn index
-              const MIN_W = 6;  // px
-              const MAX_W = 16; // px
-              // Strip common markdown syntax for tooltip display
-              const stripMd = (s: string) => s
-                .replace(/^#+\s+/gm, '')
-                .replace(/```[\s\S]*?```/g, ' ')
-                .replace(/`[^`]*`/g, ' ')
-                .replace(/[*_~>]/g, '')
-                .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-                .replace(/\s+/g, ' ')
-                .trim();
-              // Get first meaningful text snippet from content
-              const getLabel = (content: string, fallback: string) => {
-                const stripped = stripMd(content);
-                return stripped.slice(0, 50) || fallback;
-              };
-              type RailItem = { key: string; turnIndex: number; label: string; contentLen: number; isUser: boolean };
-              const items: RailItem[] = [];
-              for (let i = 0; i < turns.length; i++) {
-                const turn = turns[i];
-                if (turn.userMessage) {
-                  const content = turn.userMessage.content ?? '';
-                  items.push({
-                    key: `${turn.id}-user`,
-                    turnIndex: i,
-                    label: getLabel(content, `Turn ${i + 1}`),
-                    contentLen: content.length,
-                    isUser: true,
-                  });
-                }
-                // Aggregate all assistant content into one line per turn
-                let asstContent = '';
-                for (const item of turn.assistantItems) {
-                  if (item.type === 'assistant' && item.message?.content) {
-                    asstContent += item.message.content;
+              {(() => {
+                // Build flat list of messages with their content length and turn index
+                const MIN_W = 6; // px
+                const MAX_W = 16; // px
+                // Strip common markdown syntax for tooltip display
+                const stripMd = (s: string) =>
+                  s
+                    .replace(/^#+\s+/gm, '')
+                    .replace(/```[\s\S]*?```/g, ' ')
+                    .replace(/`[^`]*`/g, ' ')
+                    .replace(/[*_~>]/g, '')
+                    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+                    .replace(/\s+/g, ' ')
+                    .trim();
+                // Get first meaningful text snippet from content
+                const getLabel = (content: string, fallback: string) => {
+                  const stripped = stripMd(content);
+                  return stripped.slice(0, 50) || fallback;
+                };
+                type RailItem = {
+                  key: string;
+                  turnIndex: number;
+                  label: string;
+                  contentLen: number;
+                  isUser: boolean;
+                };
+                const items: RailItem[] = [];
+                for (let i = 0; i < turns.length; i++) {
+                  const turn = turns[i];
+                  if (turn.userMessage) {
+                    const content = turn.userMessage.content ?? '';
+                    items.push({
+                      key: `${turn.id}-user`,
+                      turnIndex: i,
+                      label: getLabel(content, `Turn ${i + 1}`),
+                      contentLen: content.length,
+                      isUser: true,
+                    });
+                  }
+                  // Aggregate all assistant content into one line per turn
+                  let asstContent = '';
+                  for (const item of turn.assistantItems) {
+                    if (item.type === 'assistant' && item.message?.content) {
+                      asstContent += item.message.content;
+                    }
+                  }
+                  if (asstContent) {
+                    items.push({
+                      key: `${turn.id}-asst`,
+                      turnIndex: i,
+                      label: getLabel(asstContent, 'LobsterAI'),
+                      contentLen: asstContent.length,
+                      isUser: false,
+                    });
                   }
                 }
-                if (asstContent) {
-                  items.push({
-                    key: `${turn.id}-asst`,
-                    turnIndex: i,
-                    label: getLabel(asstContent, 'LobsterAI'),
-                    contentLen: asstContent.length,
-                    isUser: false,
-                  });
+                const maxLen = items.reduce((acc, m) => Math.max(acc, m.contentLen), 1);
+                // Sync rail item count and turn-to-rail mapping
+                railItemCountRef.current = items.length;
+                const rangeMap: { first: number; last: number }[] = [];
+                for (let ri = 0; ri < items.length; ri++) {
+                  const ti = items[ri].turnIndex;
+                  if (!rangeMap[ti]) {
+                    rangeMap[ti] = { first: ri, last: ri };
+                  } else {
+                    rangeMap[ti].last = ri;
+                  }
                 }
-              }
-              const maxLen = items.reduce((acc, m) => Math.max(acc, m.contentLen), 1);
-              // Sync rail item count and turn-to-rail mapping
-              railItemCountRef.current = items.length;
-              const rangeMap: { first: number; last: number }[] = [];
-              for (let ri = 0; ri < items.length; ri++) {
-                const ti = items[ri].turnIndex;
-                if (!rangeMap[ti]) {
-                  rangeMap[ti] = { first: ri, last: ri };
-                } else {
-                  rangeMap[ti].last = ri;
-                }
-              }
-              turnToRailRangeRef.current = rangeMap;
+                turnToRailRangeRef.current = rangeMap;
 
-              // Clamp rail index to valid range
-              const resolvedRailIndex = currentRailIndex < 0 || currentRailIndex >= items.length
-                ? items.length - 1
-                : currentRailIndex;
+                // Clamp rail index to valid range
+                const resolvedRailIndex =
+                  currentRailIndex < 0 || currentRailIndex >= items.length
+                    ? items.length - 1
+                    : currentRailIndex;
 
-              return items.map((msg, idx) => {
-                const isActive = idx === resolvedRailIndex;
-                const isHovered = idx === hoveredRailIndex;
-                const ratio = msg.contentLen / maxLen;
-                const lineW = Math.round(MIN_W + ratio * (MAX_W - MIN_W));
-                return (
-                  <button
-                    key={msg.key}
-                    type="button"
-                    onClick={() => {
-                      navigateToRailItem(idx);
-                    }}
-                    onMouseEnter={(e) => {
-                      setHoveredRailIndex(idx);
-                      const rect = e.currentTarget.getBoundingClientRect();
-                      const top = Math.max(8, Math.min(rect.top + rect.height / 2, window.innerHeight - 8));
-                      setRailTooltip({
-                        label: msg.label,
-                        top,
-                        right: window.innerWidth - rect.left + 8,
-                        isUser: msg.isUser,
-                      });
-                    }}
-                    onMouseLeave={() => setRailTooltip(null)}
-                    className="flex items-center justify-end cursor-pointer w-5 py-[5px]"
-                  >
-                    <div
-                      className={`h-[2px] rounded-full transition-all ${
-                        isActive || isHovered
-                          ? 'bg-neutral-800 dark:bg-neutral-200'
-                          : 'bg-neutral-300 dark:bg-neutral-600'
-                      }`}
-                      style={{ width: isActive || isHovered ? MAX_W : lineW }}
-                    />
-                  </button>
-                );
-              });
-            })()}
+                return items.map((msg, idx) => {
+                  const isActive = idx === resolvedRailIndex;
+                  const isHovered = idx === hoveredRailIndex;
+                  const ratio = msg.contentLen / maxLen;
+                  const lineW = Math.round(MIN_W + ratio * (MAX_W - MIN_W));
+                  return (
+                    <button
+                      key={msg.key}
+                      type="button"
+                      onClick={() => {
+                        navigateToRailItem(idx);
+                      }}
+                      onMouseEnter={e => {
+                        setHoveredRailIndex(idx);
+                        const rect = e.currentTarget.getBoundingClientRect();
+                        const top = Math.max(
+                          8,
+                          Math.min(rect.top + rect.height / 2, window.innerHeight - 8),
+                        );
+                        setRailTooltip({
+                          label: msg.label,
+                          top,
+                          right: window.innerWidth - rect.left + 8,
+                          isUser: msg.isUser,
+                        });
+                      }}
+                      onMouseLeave={() => setRailTooltip(null)}
+                      className="flex items-center justify-end cursor-pointer w-5 py-[5px]"
+                    >
+                      <div
+                        className={`h-[2px] rounded-full transition-all ${
+                          isActive || isHovered
+                            ? 'bg-neutral-800 dark:bg-neutral-200'
+                            : 'bg-neutral-300 dark:bg-neutral-600'
+                        }`}
+                        style={{ width: isActive || isHovered ? MAX_W : lineW }}
+                      />
+                    </button>
+                  );
+                });
+              })()}
             </div>
 
             {/* Down Arrow */}
@@ -2734,56 +2850,74 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 if (resolvedRail >= maxRail) return;
                 navigateToRailItem(resolvedRail + 1);
               }}
-              onMouseEnter={() => { setHoveredRailIndex(null); }}
+              onMouseEnter={() => {
+                setHoveredRailIndex(null);
+              }}
               className={`shrink-0 flex items-center justify-center w-5 h-5 mt-2 -mr-[5px] rounded-full transition-all text-neutral-600 dark:text-neutral-400
-                ${!isRailHovered
-                  ? 'opacity-0 pointer-events-none'
-                  : (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) >= railItemCountRef.current - 1
-                    ? 'opacity-30 cursor-default'
-                    : 'cursor-pointer hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60'}`}
+                ${
+                  !isRailHovered
+                    ? 'opacity-0 pointer-events-none'
+                    : (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) >=
+                        railItemCountRef.current - 1
+                      ? 'opacity-30 cursor-default'
+                      : 'cursor-pointer hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60'
+                }`}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-3.5 h-3.5">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2.5}
+                stroke="currentColor"
+                className="w-3.5 h-3.5"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+                />
               </svg>
             </button>
           </div>
         )}
 
-        {railTooltip && createPortal(
-          <div
-            className={`fixed z-[100] px-3.5 py-2 text-[13px] leading-snug pointer-events-none overflow-hidden
+        {railTooltip &&
+          createPortal(
+            <div
+              className={`fixed z-[100] px-3.5 py-2 text-[13px] leading-snug pointer-events-none overflow-hidden
               max-w-[240px] shadow-[0_2px_12px_rgba(0,0,0,0.12)]
               border dark:shadow-[0_2px_12px_rgba(0,0,0,0.4)]
-              ${railTooltip.isUser
-                ? 'rounded-[12px_12px_4px_12px] bg-white border-neutral-200/80 dark:bg-neutral-800 dark:border-neutral-700'
-                : 'rounded-xl bg-neutral-50 border-neutral-200/80 dark:bg-neutral-800 dark:border-neutral-700'
+              ${
+                railTooltip.isUser
+                  ? 'rounded-[12px_12px_4px_12px] bg-white border-neutral-200/80 dark:bg-neutral-800 dark:border-neutral-700'
+                  : 'rounded-xl bg-neutral-50 border-neutral-200/80 dark:bg-neutral-800 dark:border-neutral-700'
               }`}
-            style={{
-              top: railTooltip.top,
-              right: railTooltip.right,
-              transform: 'translateY(-50%)',
-            }}
-          >
-            {!railTooltip.isUser && (
-              <div className="text-[12px] font-medium mb-0.5 text-neutral-800 dark:text-neutral-200">
-                LobsterAI:
-              </div>
-            )}
-            <div
-              className="text-neutral-600 dark:text-neutral-300"
               style={{
-                display: '-webkit-box',
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: 'vertical',
-                overflow: 'hidden',
-                wordBreak: 'break-all',
+                top: railTooltip.top,
+                right: railTooltip.right,
+                transform: 'translateY(-50%)',
               }}
             >
-              {railTooltip.label}
-            </div>
-          </div>,
-          document.body
-        )}
+              {!railTooltip.isUser && (
+                <div className="text-[12px] font-medium mb-0.5 text-neutral-800 dark:text-neutral-200">
+                  LobsterAI:
+                </div>
+              )}
+              <div
+                className="text-neutral-600 dark:text-neutral-300"
+                style={{
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  wordBreak: 'break-all',
+                }}
+              >
+                {railTooltip.label}
+              </div>
+            </div>,
+            document.body,
+          )}
       </div>
 
       {/* Streaming Activity Bar */}
@@ -2797,7 +2931,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             onSubmit={onContinue}
             onStop={onStop}
             isStreaming={isStreaming}
-            placeholder={i18nService.t(remoteManaged ? 'coworkRemoteManagedPlaceholder' : 'coworkContinuePlaceholder')}
+            placeholder={i18nService.t(
+              remoteManaged ? 'coworkRemoteManagedPlaceholder' : 'coworkContinuePlaceholder',
+            )}
             disabled={remoteManaged}
             size="large"
             remoteManaged={remoteManaged}

--- a/src/renderer/components/im/DingTalkInstanceSettings.tsx
+++ b/src/renderer/components/im/DingTalkInstanceSettings.tsx
@@ -7,7 +7,12 @@ import React, { useState } from 'react';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
 import { SignalIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import TrashIcon from '../icons/TrashIcon';
-import type { DingTalkInstanceConfig, DingTalkInstanceStatus, DingTalkOpenClawConfig, IMConnectivityTestResult } from '../../types/im';
+import type {
+  DingTalkInstanceConfig,
+  DingTalkInstanceStatus,
+  DingTalkOpenClawConfig,
+  IMConnectivityTestResult,
+} from '../../types/im';
 import { i18nService } from '../../services/i18n';
 import { PlatformRegistry } from '@shared/platform';
 
@@ -57,16 +62,25 @@ const PairingSection: React.FC<{
   platform: string;
 }> = ({ platform }) => {
   const [pairingCodeInput, setPairingCodeInput] = useState('');
-  const [pairingStatus, setPairingStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [pairingStatus, setPairingStatus] = useState<{
+    type: 'success' | 'error';
+    message: string;
+  } | null>(null);
 
   const handleApprovePairing = async (code: string) => {
     setPairingStatus(null);
     try {
       const result = await window.electron.im.approvePairingCode(platform, code);
       if (result.success) {
-        setPairingStatus({ type: 'success', message: i18nService.t('imPairingCodeApproved').replace('{code}', code) });
+        setPairingStatus({
+          type: 'success',
+          message: i18nService.t('imPairingCodeApproved').replace('{code}', code),
+        });
       } else {
-        setPairingStatus({ type: 'error', message: result.error || i18nService.t('imPairingCodeInvalid') });
+        setPairingStatus({
+          type: 'error',
+          message: result.error || i18nService.t('imPairingCodeInvalid'),
+        });
       }
     } catch {
       setPairingStatus({ type: 'error', message: i18nService.t('imPairingCodeInvalid') });
@@ -82,12 +96,12 @@ const PairingSection: React.FC<{
         <input
           type="text"
           value={pairingCodeInput}
-          onChange={(e) => {
+          onChange={e => {
             setPairingCodeInput(e.target.value.toUpperCase());
             if (pairingStatus) setPairingStatus(null);
           }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
+          onKeyDown={e => {
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
               e.preventDefault();
               const code = pairingCodeInput.trim();
               if (code) {
@@ -117,7 +131,9 @@ const PairingSection: React.FC<{
         </button>
       </div>
       {pairingStatus && (
-        <p className={`text-xs ${pairingStatus.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+        <p
+          className={`text-xs ${pairingStatus.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+        >
           {pairingStatus.type === 'success' ? '\u2713' : '\u2717'} {pairingStatus.message}
         </p>
       )}
@@ -175,11 +191,14 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             <input
               type="text"
               value={nameValue}
-              onChange={(e) => setNameValue(e.target.value)}
+              onChange={e => setNameValue(e.target.value)}
               onBlur={handleNameBlur}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleNameBlur();
-                if (e.key === 'Escape') { setNameValue(instance.instanceName); setEditingName(false); }
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) handleNameBlur();
+                if (e.key === 'Escape') {
+                  setNameValue(instance.instanceName);
+                  setEditingName(false);
+                }
               }}
               autoFocus
               className="text-sm font-medium text-foreground bg-transparent border-b border-primary focus:outline-none px-0 py-0"
@@ -196,14 +215,14 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
         </div>
 
         {/* Status badge */}
-        <div className={`px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${
-          instanceStatus?.connected
-            ? 'bg-green-500/15 text-green-600 dark:text-green-400'
-            : 'bg-gray-500/15 text-gray-500 dark:text-gray-400'
-        }`}>
-          {instanceStatus?.connected
-            ? i18nService.t('connected')
-            : i18nService.t('disconnected')}
+        <div
+          className={`px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${
+            instanceStatus?.connected
+              ? 'bg-green-500/15 text-green-600 dark:text-green-400'
+              : 'bg-gray-500/15 text-gray-500 dark:text-gray-400'
+          }`}
+        >
+          {instanceStatus?.connected ? i18nService.t('connected') : i18nService.t('disconnected')}
         </div>
 
         {/* Enable toggle */}
@@ -213,18 +232,28 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
           disabled={!instance.enabled && !(instance.clientId && instance.clientSecret)}
           className={`relative inline-flex h-5 w-9 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out ${
             instance.enabled
-              ? (instanceStatus?.connected ? 'bg-green-500' : 'bg-yellow-500')
+              ? instanceStatus?.connected
+                ? 'bg-green-500'
+                : 'bg-yellow-500'
               : 'bg-gray-400 dark:bg-gray-600'
           } ${!instance.enabled && !(instance.clientId && instance.clientSecret) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-          title={instance.enabled
-            ? (language === 'zh' ? '禁用此实例' : 'Disable this instance')
-            : (!(instance.clientId && instance.clientSecret)
-              ? i18nService.t('imInstanceFillCredentials')
-              : (language === 'zh' ? '启用此实例' : 'Enable this instance'))}
+          title={
+            instance.enabled
+              ? language === 'zh'
+                ? '禁用此实例'
+                : 'Disable this instance'
+              : !(instance.clientId && instance.clientSecret)
+                ? i18nService.t('imInstanceFillCredentials')
+                : language === 'zh'
+                  ? '启用此实例'
+                  : 'Enable this instance'
+          }
         >
-          <span className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-            instance.enabled ? 'translate-x-4' : 'translate-x-0'
-          }`} />
+          <span
+            className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+              instance.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
         </button>
 
         {/* Delete button */}
@@ -252,14 +281,12 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
 
       {/* Client ID (AppKey) */}
       <div className="space-y-1.5">
-        <label className="block text-xs font-medium text-secondary">
-          Client ID (AppKey)
-        </label>
+        <label className="block text-xs font-medium text-secondary">Client ID (AppKey)</label>
         <div className="relative">
           <input
             type="text"
             value={instance.clientId}
-            onChange={(e) => onConfigChange({ clientId: e.target.value })}
+            onChange={e => onConfigChange({ clientId: e.target.value })}
             onBlur={() => void onSave()}
             className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-8 text-sm transition-colors"
             placeholder="dingxxxxxx"
@@ -268,7 +295,10 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             <div className="absolute right-2 inset-y-0 flex items-center">
               <button
                 type="button"
-                onClick={() => { onConfigChange({ clientId: '' }); void onSave({ clientId: '' }); }}
+                onClick={() => {
+                  onConfigChange({ clientId: '' });
+                  void onSave({ clientId: '' });
+                }}
                 className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                 title={i18nService.t('clear') || 'Clear'}
               >
@@ -288,7 +318,7 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
           <input
             type={showSecrets['clientSecret'] ? 'text' : 'password'}
             value={instance.clientSecret}
-            onChange={(e) => onConfigChange({ clientSecret: e.target.value })}
+            onChange={e => onConfigChange({ clientSecret: e.target.value })}
             onBlur={() => void onSave()}
             className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-sm transition-colors"
             placeholder="••••••••••••"
@@ -297,7 +327,10 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             {instance.clientSecret && (
               <button
                 type="button"
-                onClick={() => { onConfigChange({ clientSecret: '' }); void onSave({ clientSecret: '' }); }}
+                onClick={() => {
+                  onConfigChange({ clientSecret: '' });
+                  void onSave({ clientSecret: '' });
+                }}
                 className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                 title={i18nService.t('clear') || 'Clear'}
               >
@@ -306,11 +339,21 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             )}
             <button
               type="button"
-              onClick={() => setShowSecrets(prev => ({ ...prev, 'clientSecret': !prev['clientSecret'] }))}
+              onClick={() =>
+                setShowSecrets(prev => ({ ...prev, clientSecret: !prev['clientSecret'] }))
+              }
               className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-              title={showSecrets['clientSecret'] ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+              title={
+                showSecrets['clientSecret']
+                  ? i18nService.t('hide') || 'Hide'
+                  : i18nService.t('show') || 'Show'
+              }
             >
-              {showSecrets['clientSecret'] ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+              {showSecrets['clientSecret'] ? (
+                <EyeIcon className="h-4 w-4" />
+              ) : (
+                <EyeSlashIcon className="h-4 w-4" />
+              )}
             </button>
           </div>
         </div>
@@ -324,12 +367,10 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
         <div className="mt-2 space-y-3 pl-2 border-l-2 border-border-subtle">
           {/* DM Policy */}
           <div className="space-y-1.5">
-            <label className="block text-xs font-medium text-secondary">
-              DM Policy
-            </label>
+            <label className="block text-xs font-medium text-secondary">DM Policy</label>
             <select
               value={instance.dmPolicy}
-              onChange={(e) => {
+              onChange={e => {
                 const update = { dmPolicy: e.target.value as DingTalkOpenClawConfig['dmPolicy'] };
                 onConfigChange(update);
                 void onSave(update);
@@ -343,9 +384,7 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
           </div>
 
           {/* Pairing Requests (shown when dmPolicy is 'pairing') */}
-          {instance.dmPolicy === 'pairing' && (
-            <PairingSection platform="dingtalk" />
-          )}
+          {instance.dmPolicy === 'pairing' && <PairingSection platform="dingtalk" />}
 
           {/* Allow From (User IDs) */}
           <div className="space-y-1.5">
@@ -356,9 +395,9 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
               <input
                 type="text"
                 value={allowedUserIdInput}
-                onChange={(e) => setAllowedUserIdInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
+                onChange={e => setAllowedUserIdInput(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                     e.preventDefault();
                     const id = allowedUserIdInput.trim();
                     if (id && !instance.allowFrom.includes(id)) {
@@ -390,7 +429,7 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             </div>
             {instance.allowFrom.length > 0 && (
               <div className="flex flex-wrap gap-1.5 mt-1.5">
-                {instance.allowFrom.map((id) => (
+                {instance.allowFrom.map(id => (
                   <span
                     key={id}
                     className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
@@ -399,7 +438,7 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
                     <button
                       type="button"
                       onClick={() => {
-                        const newIds = instance.allowFrom.filter((uid) => uid !== id);
+                        const newIds = instance.allowFrom.filter(uid => uid !== id);
                         onConfigChange({ allowFrom: newIds });
                         void onSave({ allowFrom: newIds });
                       }}
@@ -415,13 +454,13 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
 
           {/* Group Policy */}
           <div className="space-y-1.5">
-            <label className="block text-xs font-medium text-secondary">
-              Group Policy
-            </label>
+            <label className="block text-xs font-medium text-secondary">Group Policy</label>
             <select
               value={instance.groupPolicy}
-              onChange={(e) => {
-                const update = { groupPolicy: e.target.value as DingTalkOpenClawConfig['groupPolicy'] };
+              onChange={e => {
+                const update = {
+                  groupPolicy: e.target.value as DingTalkOpenClawConfig['groupPolicy'],
+                };
                 onConfigChange(update);
                 void onSave(update);
               }}
@@ -440,7 +479,7 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             <input
               type="number"
               value={Math.round(instance.sessionTimeout / 60000)}
-              onChange={(e) => {
+              onChange={e => {
                 const minutes = parseInt(e.target.value, 10);
                 if (!isNaN(minutes) && minutes > 0) {
                   onConfigChange({ sessionTimeout: minutes * 60000 });
@@ -458,7 +497,7 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             <input
               type="checkbox"
               checked={instance.separateSessionByConversation}
-              onChange={(e) => {
+              onChange={e => {
                 const update = { separateSessionByConversation: e.target.checked };
                 onConfigChange(update);
                 void onSave(update);
@@ -467,7 +506,9 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             />
             <span>
               {i18nService.t('imSeparateSessionByConversation')}
-              <span className="ml-1 opacity-60">— {i18nService.t('imSeparateSessionByConversationDesc')}</span>
+              <span className="ml-1 opacity-60">
+                — {i18nService.t('imSeparateSessionByConversationDesc')}
+              </span>
             </span>
           </label>
 
@@ -479,7 +520,7 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
               </label>
               <select
                 value={instance.groupSessionScope}
-                onChange={(e) => {
+                onChange={e => {
                   const update = { groupSessionScope: e.target.value as 'group' | 'group_sender' };
                   onConfigChange(update);
                   void onSave(update);
@@ -487,7 +528,9 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
                 className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
               >
                 <option value="group">{i18nService.t('imGroupSessionScopeGroup')}</option>
-                <option value="group_sender">{i18nService.t('imGroupSessionScopeGroupSender')}</option>
+                <option value="group_sender">
+                  {i18nService.t('imGroupSessionScopeGroupSender')}
+                </option>
               </select>
             </div>
           )}
@@ -497,7 +540,7 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             <input
               type="checkbox"
               checked={instance.sharedMemoryAcrossConversations}
-              onChange={(e) => {
+              onChange={e => {
                 const update = { sharedMemoryAcrossConversations: e.target.checked };
                 onConfigChange(update);
                 void onSave(update);
@@ -506,7 +549,9 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             />
             <span>
               {i18nService.t('imSharedMemoryAcrossConversations')}
-              <span className="ml-1 opacity-60">— {i18nService.t('imSharedMemoryAcrossConversationsDesc')}</span>
+              <span className="ml-1 opacity-60">
+                — {i18nService.t('imSharedMemoryAcrossConversationsDesc')}
+              </span>
             </span>
           </label>
 
@@ -518,7 +563,7 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             <input
               type="text"
               value={instance.gatewayBaseUrl}
-              onChange={(e) => {
+              onChange={e => {
                 onConfigChange({ gatewayBaseUrl: e.target.value });
               }}
               onBlur={() => void onSave()}
@@ -532,7 +577,7 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
             <input
               type="checkbox"
               checked={instance.debug}
-              onChange={(e) => {
+              onChange={e => {
                 const update = { debug: e.target.checked };
                 onConfigChange(update);
                 void onSave(update);

--- a/src/renderer/components/im/FeishuInstanceSettings.tsx
+++ b/src/renderer/components/im/FeishuInstanceSettings.tsx
@@ -5,10 +5,21 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
-import { ArrowPathIcon, CheckCircleIcon, SignalIcon, XCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowPathIcon,
+  CheckCircleIcon,
+  SignalIcon,
+  XCircleIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
 import TrashIcon from '../icons/TrashIcon';
 import { QRCodeSVG } from 'qrcode.react';
-import type { FeishuInstanceConfig, FeishuInstanceStatus, FeishuOpenClawConfig, IMConnectivityTestResult } from '../../types/im';
+import type {
+  FeishuInstanceConfig,
+  FeishuInstanceStatus,
+  FeishuOpenClawConfig,
+  IMConnectivityTestResult,
+} from '../../types/im';
 import { i18nService } from '../../services/i18n';
 import { PlatformRegistry } from '@shared/platform';
 
@@ -58,16 +69,25 @@ const PairingSection: React.FC<{
   platform: string;
 }> = ({ platform }) => {
   const [pairingCodeInput, setPairingCodeInput] = useState('');
-  const [pairingStatus, setPairingStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [pairingStatus, setPairingStatus] = useState<{
+    type: 'success' | 'error';
+    message: string;
+  } | null>(null);
 
   const handleApprovePairing = async (code: string) => {
     setPairingStatus(null);
     try {
       const result = await window.electron.im.approvePairingCode(platform, code);
       if (result.success) {
-        setPairingStatus({ type: 'success', message: i18nService.t('imPairingCodeApproved').replace('{code}', code) });
+        setPairingStatus({
+          type: 'success',
+          message: i18nService.t('imPairingCodeApproved').replace('{code}', code),
+        });
       } else {
-        setPairingStatus({ type: 'error', message: result.error || i18nService.t('imPairingCodeInvalid') });
+        setPairingStatus({
+          type: 'error',
+          message: result.error || i18nService.t('imPairingCodeInvalid'),
+        });
       }
     } catch {
       setPairingStatus({ type: 'error', message: i18nService.t('imPairingCodeInvalid') });
@@ -83,12 +103,12 @@ const PairingSection: React.FC<{
         <input
           type="text"
           value={pairingCodeInput}
-          onChange={(e) => {
+          onChange={e => {
             setPairingCodeInput(e.target.value.toUpperCase());
             if (pairingStatus) setPairingStatus(null);
           }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
+          onKeyDown={e => {
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
               e.preventDefault();
               const code = pairingCodeInput.trim();
               if (code) {
@@ -118,7 +138,9 @@ const PairingSection: React.FC<{
         </button>
       </div>
       {pairingStatus && (
-        <p className={`text-xs ${pairingStatus.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+        <p
+          className={`text-xs ${pairingStatus.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+        >
           {pairingStatus.type === 'success' ? '\u2713' : '\u2717'} {pairingStatus.message}
         </p>
       )}
@@ -146,7 +168,9 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
   const [nameValue, setNameValue] = useState(instance.instanceName);
 
   // QR code scanning state
-  const [qrStatus, setQrStatus] = useState<'idle' | 'loading' | 'showing' | 'success' | 'error'>('idle');
+  const [qrStatus, setQrStatus] = useState<'idle' | 'loading' | 'showing' | 'success' | 'error'>(
+    'idle',
+  );
   const [qrUrl, setQrUrl] = useState('');
   const [qrTimeLeft, setQrTimeLeft] = useState(0);
   const [qrError, setQrError] = useState('');
@@ -179,11 +203,14 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
       setQrStatus('showing');
 
       qrCountdownTimerRef.current = setInterval(() => {
-        setQrTimeLeft((prev) => {
+        setQrTimeLeft(prev => {
           if (prev <= 1) {
             clearInterval(qrCountdownTimerRef.current!);
             qrCountdownTimerRef.current = null;
-            if (qrPollTimerRef.current) { clearInterval(qrPollTimerRef.current); qrPollTimerRef.current = null; }
+            if (qrPollTimerRef.current) {
+              clearInterval(qrPollTimerRef.current);
+              qrPollTimerRef.current = null;
+            }
             setQrStatus('error');
             setQrError(i18nService.t('feishuBotCreateWizardQrcodeExpired'));
             return 0;
@@ -198,18 +225,36 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
           const pollResult = await window.electron.feishu.install.poll(qrDeviceCodeRef.current);
           if (!isMountedRef.current) return;
           if (pollResult.done && pollResult.appId && pollResult.appSecret) {
-            clearInterval(qrPollTimerRef.current!); qrPollTimerRef.current = null;
-            clearInterval(qrCountdownTimerRef.current!); qrCountdownTimerRef.current = null;
-            onConfigChange({ appId: pollResult.appId, appSecret: pollResult.appSecret, enabled: true });
-            await onSave({ appId: pollResult.appId, appSecret: pollResult.appSecret, enabled: true });
+            clearInterval(qrPollTimerRef.current!);
+            qrPollTimerRef.current = null;
+            clearInterval(qrCountdownTimerRef.current!);
+            qrCountdownTimerRef.current = null;
+            onConfigChange({
+              appId: pollResult.appId,
+              appSecret: pollResult.appSecret,
+              enabled: true,
+            });
+            await onSave({
+              appId: pollResult.appId,
+              appSecret: pollResult.appSecret,
+              enabled: true,
+            });
             setQrStatus('success');
-          } else if (pollResult.error && pollResult.error !== 'authorization_pending' && pollResult.error !== 'slow_down') {
-            clearInterval(qrPollTimerRef.current!); qrPollTimerRef.current = null;
-            clearInterval(qrCountdownTimerRef.current!); qrCountdownTimerRef.current = null;
+          } else if (
+            pollResult.error &&
+            pollResult.error !== 'authorization_pending' &&
+            pollResult.error !== 'slow_down'
+          ) {
+            clearInterval(qrPollTimerRef.current!);
+            qrPollTimerRef.current = null;
+            clearInterval(qrCountdownTimerRef.current!);
+            qrCountdownTimerRef.current = null;
             setQrStatus('error');
             setQrError(pollResult.error);
           }
-        } catch { /* keep retrying */ }
+        } catch {
+          /* keep retrying */
+        }
       }, intervalMs);
     } catch (err: any) {
       if (!isMountedRef.current) return;
@@ -250,11 +295,14 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
             <input
               type="text"
               value={nameValue}
-              onChange={(e) => setNameValue(e.target.value)}
+              onChange={e => setNameValue(e.target.value)}
               onBlur={handleNameBlur}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleNameBlur();
-                if (e.key === 'Escape') { setNameValue(instance.instanceName); setEditingName(false); }
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) handleNameBlur();
+                if (e.key === 'Escape') {
+                  setNameValue(instance.instanceName);
+                  setEditingName(false);
+                }
               }}
               autoFocus
               className="text-sm font-medium text-foreground bg-transparent border-b border-primary focus:outline-none px-0 py-0"
@@ -271,14 +319,14 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
         </div>
 
         {/* Status badge */}
-        <div className={`px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${
-          instanceStatus?.connected
-            ? 'bg-green-500/15 text-green-600 dark:text-green-400'
-            : 'bg-gray-500/15 text-gray-500 dark:text-gray-400'
-        }`}>
-          {instanceStatus?.connected
-            ? i18nService.t('connected')
-            : i18nService.t('disconnected')}
+        <div
+          className={`px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${
+            instanceStatus?.connected
+              ? 'bg-green-500/15 text-green-600 dark:text-green-400'
+              : 'bg-gray-500/15 text-gray-500 dark:text-gray-400'
+          }`}
+        >
+          {instanceStatus?.connected ? i18nService.t('connected') : i18nService.t('disconnected')}
         </div>
 
         {/* Enable toggle */}
@@ -288,18 +336,28 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
           disabled={!instance.enabled && !(instance.appId && instance.appSecret)}
           className={`relative inline-flex h-5 w-9 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out ${
             instance.enabled
-              ? (instanceStatus?.connected ? 'bg-green-500' : 'bg-yellow-500')
+              ? instanceStatus?.connected
+                ? 'bg-green-500'
+                : 'bg-yellow-500'
               : 'bg-gray-400 dark:bg-gray-600'
           } ${!instance.enabled && !(instance.appId && instance.appSecret) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-          title={instance.enabled
-            ? (language === 'zh' ? '禁用此实例' : 'Disable this instance')
-            : (!(instance.appId && instance.appSecret)
-              ? i18nService.t('imInstanceFillCredentials')
-              : (language === 'zh' ? '启用此实例' : 'Enable this instance'))}
+          title={
+            instance.enabled
+              ? language === 'zh'
+                ? '禁用此实例'
+                : 'Disable this instance'
+              : !(instance.appId && instance.appSecret)
+                ? i18nService.t('imInstanceFillCredentials')
+                : language === 'zh'
+                  ? '启用此实例'
+                  : 'Enable this instance'
+          }
         >
-          <span className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-            instance.enabled ? 'translate-x-4' : 'translate-x-0'
-          }`} />
+          <span
+            className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+              instance.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
         </button>
 
         {/* Delete button */}
@@ -339,7 +397,9 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
         {qrStatus === 'loading' && (
           <div className="flex flex-col items-center gap-2 py-2">
             <ArrowPathIcon className="h-7 w-7 text-primary animate-spin" />
-            <span className="text-xs text-secondary">{i18nService.t('feishuBotCreateWizardGenerating') || '正在生成二维码…'}</span>
+            <span className="text-xs text-secondary">
+              {i18nService.t('feishuBotCreateWizardGenerating') || '正在生成二维码…'}
+            </span>
           </div>
         )}
         {qrStatus === 'showing' && qrUrl && (
@@ -350,9 +410,7 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
             <p className="text-xs text-secondary max-w-[240px]">
               {i18nService.t('feishuBotCreateWizardQrcodeDesc')}
             </p>
-            <p className="text-xs text-secondary">
-              {qrTimeLeft}s
-            </p>
+            <p className="text-xs text-secondary">{qrTimeLeft}s</p>
           </div>
         )}
         {qrStatus === 'success' && (
@@ -374,23 +432,18 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
 
       {/* Guide */}
       <PlatformGuide
-        steps={[
-          i18nService.t('imFeishuGuideStep1'),
-          i18nService.t('imFeishuGuideStep2'),
-        ]}
+        steps={[i18nService.t('imFeishuGuideStep1'), i18nService.t('imFeishuGuideStep2')]}
         guideUrl={PlatformRegistry.guideUrl('feishu')}
       />
 
       {/* App ID */}
       <div className="space-y-1.5">
-        <label className="block text-xs font-medium text-secondary">
-          App ID
-        </label>
+        <label className="block text-xs font-medium text-secondary">App ID</label>
         <div className="relative">
           <input
             type="text"
             value={instance.appId}
-            onChange={(e) => onConfigChange({ appId: e.target.value })}
+            onChange={e => onConfigChange({ appId: e.target.value })}
             onBlur={() => void onSave()}
             className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-8 text-sm transition-colors"
             placeholder="cli_xxxxx"
@@ -399,7 +452,10 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
             <div className="absolute right-2 inset-y-0 flex items-center">
               <button
                 type="button"
-                onClick={() => { onConfigChange({ appId: '' }); void onSave({ appId: '' }); }}
+                onClick={() => {
+                  onConfigChange({ appId: '' });
+                  void onSave({ appId: '' });
+                }}
                 className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                 title={i18nService.t('clear') || 'Clear'}
               >
@@ -412,14 +468,12 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
 
       {/* App Secret */}
       <div className="space-y-1.5">
-        <label className="block text-xs font-medium text-secondary">
-          App Secret
-        </label>
+        <label className="block text-xs font-medium text-secondary">App Secret</label>
         <div className="relative">
           <input
             type={showSecrets['appSecret'] ? 'text' : 'password'}
             value={instance.appSecret}
-            onChange={(e) => onConfigChange({ appSecret: e.target.value })}
+            onChange={e => onConfigChange({ appSecret: e.target.value })}
             onBlur={() => void onSave()}
             className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-sm transition-colors"
             placeholder="••••••••••••"
@@ -428,7 +482,10 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
             {instance.appSecret && (
               <button
                 type="button"
-                onClick={() => { onConfigChange({ appSecret: '' }); void onSave({ appSecret: '' }); }}
+                onClick={() => {
+                  onConfigChange({ appSecret: '' });
+                  void onSave({ appSecret: '' });
+                }}
                 className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                 title={i18nService.t('clear') || 'Clear'}
               >
@@ -437,11 +494,19 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
             )}
             <button
               type="button"
-              onClick={() => setShowSecrets(prev => ({ ...prev, 'appSecret': !prev['appSecret'] }))}
+              onClick={() => setShowSecrets(prev => ({ ...prev, appSecret: !prev['appSecret'] }))}
               className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-              title={showSecrets['appSecret'] ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+              title={
+                showSecrets['appSecret']
+                  ? i18nService.t('hide') || 'Hide'
+                  : i18nService.t('show') || 'Show'
+              }
             >
-              {showSecrets['appSecret'] ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+              {showSecrets['appSecret'] ? (
+                <EyeIcon className="h-4 w-4" />
+              ) : (
+                <EyeSlashIcon className="h-4 w-4" />
+              )}
             </button>
           </div>
         </div>
@@ -449,12 +514,10 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
 
       {/* Domain */}
       <div className="space-y-1.5">
-        <label className="block text-xs font-medium text-secondary">
-          Domain
-        </label>
+        <label className="block text-xs font-medium text-secondary">Domain</label>
         <select
           value={instance.domain}
-          onChange={(e) => {
+          onChange={e => {
             const update = { domain: e.target.value };
             onConfigChange(update);
             void onSave(update);
@@ -474,12 +537,10 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
         <div className="mt-2 space-y-3 pl-2 border-l-2 border-border-subtle">
           {/* DM Policy */}
           <div className="space-y-1.5">
-            <label className="block text-xs font-medium text-secondary">
-              DM Policy
-            </label>
+            <label className="block text-xs font-medium text-secondary">DM Policy</label>
             <select
               value={instance.dmPolicy}
-              onChange={(e) => {
+              onChange={e => {
                 const update = { dmPolicy: e.target.value as FeishuOpenClawConfig['dmPolicy'] };
                 onConfigChange(update);
                 void onSave(update);
@@ -494,9 +555,7 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
           </div>
 
           {/* Pairing Requests (shown when dmPolicy is 'pairing') */}
-          {instance.dmPolicy === 'pairing' && (
-            <PairingSection platform="feishu" />
-          )}
+          {instance.dmPolicy === 'pairing' && <PairingSection platform="feishu" />}
 
           {/* Allow From (User IDs) */}
           <div className="space-y-1.5">
@@ -507,9 +566,9 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
               <input
                 type="text"
                 value={allowedUserIdInput}
-                onChange={(e) => setAllowedUserIdInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
+                onChange={e => setAllowedUserIdInput(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                     e.preventDefault();
                     const id = allowedUserIdInput.trim();
                     if (id && !instance.allowFrom.includes(id)) {
@@ -541,7 +600,7 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
             </div>
             {instance.allowFrom.length > 0 && (
               <div className="flex flex-wrap gap-1.5 mt-1.5">
-                {instance.allowFrom.map((id) => (
+                {instance.allowFrom.map(id => (
                   <span
                     key={id}
                     className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
@@ -550,7 +609,7 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
                     <button
                       type="button"
                       onClick={() => {
-                        const newIds = instance.allowFrom.filter((uid) => uid !== id);
+                        const newIds = instance.allowFrom.filter(uid => uid !== id);
                         onConfigChange({ allowFrom: newIds });
                         void onSave({ allowFrom: newIds });
                       }}
@@ -566,13 +625,13 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
 
           {/* Group Policy */}
           <div className="space-y-1.5">
-            <label className="block text-xs font-medium text-secondary">
-              Group Policy
-            </label>
+            <label className="block text-xs font-medium text-secondary">Group Policy</label>
             <select
               value={instance.groupPolicy}
-              onChange={(e) => {
-                const update = { groupPolicy: e.target.value as FeishuOpenClawConfig['groupPolicy'] };
+              onChange={e => {
+                const update = {
+                  groupPolicy: e.target.value as FeishuOpenClawConfig['groupPolicy'],
+                };
                 onConfigChange(update);
                 void onSave(update);
               }}
@@ -593,9 +652,9 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
               <input
                 type="text"
                 value={groupAllowIdInput}
-                onChange={(e) => setGroupAllowIdInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
+                onChange={e => setGroupAllowIdInput(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                     e.preventDefault();
                     const id = groupAllowIdInput.trim();
                     if (id && !instance.groupAllowFrom.includes(id)) {
@@ -627,7 +686,7 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
             </div>
             {instance.groupAllowFrom.length > 0 && (
               <div className="flex flex-wrap gap-1.5 mt-1.5">
-                {instance.groupAllowFrom.map((id) => (
+                {instance.groupAllowFrom.map(id => (
                   <span
                     key={id}
                     className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
@@ -636,7 +695,7 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
                     <button
                       type="button"
                       onClick={() => {
-                        const newIds = instance.groupAllowFrom.filter((gid) => gid !== id);
+                        const newIds = instance.groupAllowFrom.filter(gid => gid !== id);
                         onConfigChange({ groupAllowFrom: newIds });
                         void onSave({ groupAllowFrom: newIds });
                       }}
@@ -672,9 +731,11 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
                   instance.streaming ? 'bg-primary' : 'bg-gray-400 dark:bg-gray-600'
                 }`}
               >
-                <span className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                  instance.streaming ? 'translate-x-4' : 'translate-x-0'
-                }`} />
+                <span
+                  className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                    instance.streaming ? 'translate-x-4' : 'translate-x-0'
+                  }`}
+                />
               </button>
             </div>
           </div>
@@ -698,9 +759,11 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
                     instance.footer?.status ? 'bg-primary' : 'bg-gray-400 dark:bg-gray-600'
                   }`}
                 >
-                  <span className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                    instance.footer?.status ? 'translate-x-3' : 'translate-x-0'
-                  }`} />
+                  <span
+                    className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                      instance.footer?.status ? 'translate-x-3' : 'translate-x-0'
+                    }`}
+                  />
                 </button>
               </div>
               <div className="flex items-center justify-between">
@@ -719,9 +782,11 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
                     instance.footer?.elapsed ? 'bg-primary' : 'bg-gray-400 dark:bg-gray-600'
                   }`}
                 >
-                  <span className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                    instance.footer?.elapsed ? 'translate-x-3' : 'translate-x-0'
-                  }`} />
+                  <span
+                    className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                      instance.footer?.elapsed ? 'translate-x-3' : 'translate-x-0'
+                    }`}
+                  />
                 </button>
               </div>
             </div>
@@ -729,12 +794,10 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
 
           {/* Reply Mode */}
           <div className="space-y-1.5">
-            <label className="block text-xs font-medium text-secondary">
-              Reply Mode
-            </label>
+            <label className="block text-xs font-medium text-secondary">Reply Mode</label>
             <select
               value={instance.replyMode}
-              onChange={(e) => {
+              onChange={e => {
                 const update = { replyMode: e.target.value as FeishuOpenClawConfig['replyMode'] };
                 onConfigChange(update);
                 void onSave(update);
@@ -770,9 +833,11 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
                     instance.blockStreaming ? 'bg-primary' : 'bg-gray-400 dark:bg-gray-600'
                   }`}
                 >
-                  <span className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                    instance.blockStreaming ? 'translate-x-4' : 'translate-x-0'
-                  }`} />
+                  <span
+                    className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                      instance.blockStreaming ? 'translate-x-4' : 'translate-x-0'
+                    }`}
+                  />
                 </button>
               </div>
             </div>
@@ -780,13 +845,11 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
 
           {/* History Limit */}
           <div className="space-y-1.5">
-            <label className="block text-xs font-medium text-secondary">
-              History Limit
-            </label>
+            <label className="block text-xs font-medium text-secondary">History Limit</label>
             <input
               type="number"
               value={instance.historyLimit}
-              onChange={(e) => onConfigChange({ historyLimit: parseInt(e.target.value) || 50 })}
+              onChange={e => onConfigChange({ historyLimit: parseInt(e.target.value) || 50 })}
               onBlur={() => void onSave()}
               className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
               min="1"
@@ -796,13 +859,11 @@ const FeishuInstanceSettings: React.FC<FeishuInstanceSettingsProps> = ({
 
           {/* Media Max MB */}
           <div className="space-y-1.5">
-            <label className="block text-xs font-medium text-secondary">
-              Media Max (MB)
-            </label>
+            <label className="block text-xs font-medium text-secondary">Media Max (MB)</label>
             <input
               type="number"
               value={instance.mediaMaxMb}
-              onChange={(e) => onConfigChange({ mediaMaxMb: parseInt(e.target.value) || 30 })}
+              onChange={e => onConfigChange({ mediaMaxMb: parseInt(e.target.value) || 30 })}
               onBlur={() => void onSave()}
               className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
               min="1"

--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -5,13 +5,42 @@
 
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { SignalIcon, XMarkIcon, CheckCircleIcon, XCircleIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import {
+  SignalIcon,
+  XMarkIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+  ExclamationTriangleIcon,
+} from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
 import { RootState } from '../../store';
 import { imService } from '../../services/im';
-import { setDingTalkConfig, setDingTalkInstanceConfig, setFeishuConfig, setFeishuInstanceConfig, setTelegramOpenClawConfig, setQQConfig, setQQInstanceConfig, setDiscordConfig, setNimConfig, setNeteaseBeeChanConfig, setWecomConfig, setWeixinConfig, setPopoConfig, clearError } from '../../store/slices/imSlice';
+import {
+  setDingTalkConfig,
+  setDingTalkInstanceConfig,
+  setFeishuConfig,
+  setFeishuInstanceConfig,
+  setTelegramOpenClawConfig,
+  setQQConfig,
+  setQQInstanceConfig,
+  setDiscordConfig,
+  setNimConfig,
+  setNeteaseBeeChanConfig,
+  setWecomConfig,
+  setWeixinConfig,
+  setPopoConfig,
+  clearError,
+} from '../../store/slices/imSlice';
 import { i18nService } from '../../services/i18n';
-import type { IMConnectivityCheck, IMConnectivityTestResult, IMGatewayConfig, TelegramOpenClawConfig, DiscordOpenClawConfig, WecomOpenClawConfig, PopoOpenClawConfig } from '../../types/im';
+import type {
+  IMConnectivityCheck,
+  IMConnectivityTestResult,
+  IMGatewayConfig,
+  TelegramOpenClawConfig,
+  DiscordOpenClawConfig,
+  WecomOpenClawConfig,
+  PopoOpenClawConfig,
+} from '../../types/im';
 import { MAX_QQ_INSTANCES, MAX_FEISHU_INSTANCES, MAX_DINGTALK_INSTANCES } from '../../types/im';
 import QQInstanceSettings from './QQInstanceSettings';
 import FeishuInstanceSettings from './FeishuInstanceSettings';
@@ -26,8 +55,6 @@ import { SchemaForm } from './SchemaForm';
 import type { UiHint } from './SchemaForm';
 import Modal from '../common/Modal';
 
-
-
 // Reusable guide card component for platform setup instructions
 const PlatformGuide: React.FC<{
   title?: string;
@@ -36,9 +63,7 @@ const PlatformGuide: React.FC<{
   guideLabel?: string;
 }> = ({ title, steps, guideUrl, guideLabel }) => (
   <div className="mb-3 p-3 rounded-lg border border-dashed border-border-subtle">
-    {title && (
-      <p className="text-xs text-foreground leading-relaxed mb-1.5 font-medium">{title}</p>
-    )}
+    {title && <p className="text-xs text-foreground leading-relaxed mb-1.5 font-medium">{title}</p>}
     <ol className="text-xs text-secondary space-y-1 list-decimal list-inside">
       {steps.map((step, i) => (
         <li key={i}>{step}</li>
@@ -75,7 +100,7 @@ const checkLevelColorClass: Record<IMConnectivityCheck['level'], string> = {
 
 // Map of backend error messages to i18n keys
 const errorMessageI18nMap: Record<string, string> = {
-  '账号已在其它地方登录': 'kickedByOtherClient',
+  账号已在其它地方登录: 'kickedByOtherClient',
 };
 
 // Helper function to translate IM error messages
@@ -89,12 +114,16 @@ function translateIMError(error: string | null): string {
 }
 
 // Helper function to deep-set a value in nested object by dot path
-function deepSet(obj: Record<string, unknown>, path: string, value: unknown): Record<string, unknown> {
+function deepSet(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): Record<string, unknown> {
   const keys = path.split('.');
   const result = { ...obj };
   let current: Record<string, unknown> = result;
   for (let i = 0; i < keys.length - 1; i++) {
-    current[keys[i]] = { ...(current[keys[i]] as Record<string, unknown> || {}) };
+    current[keys[i]] = { ...((current[keys[i]] as Record<string, unknown>) || {}) };
     current = current[keys[i]] as Record<string, unknown>;
   }
   current[keys[keys.length - 1]] = value;
@@ -112,7 +141,9 @@ const IMSettings: React.FC = () => {
   const [activeDingTalkInstanceId, setActiveDingTalkInstanceId] = useState<string | null>(null);
   const [dingtalkExpanded, setDingtalkExpanded] = useState(false);
   const [testingPlatform, setTestingPlatform] = useState<Platform | null>(null);
-  const [connectivityResults, setConnectivityResults] = useState<Partial<Record<Platform, IMConnectivityTestResult>>>({});
+  const [connectivityResults, setConnectivityResults] = useState<
+    Partial<Record<Platform, IMConnectivityTestResult>>
+  >({});
   const [connectivityModalPlatform, setConnectivityModalPlatform] = useState<Platform | null>(null);
   const [language, setLanguage] = useState<'zh' | 'en'>(i18nService.getLanguage());
   const [allowedUserIdInput, setAllowedUserIdInput] = useState('');
@@ -122,10 +153,14 @@ const IMSettings: React.FC = () => {
   // Track visibility of password fields (eye toggle)
   const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
   // WeCom quick setup state
-  const [wecomQuickSetupStatus, setWecomQuickSetupStatus] = useState<'idle' | 'pending' | 'success' | 'error'>('idle');
+  const [wecomQuickSetupStatus, setWecomQuickSetupStatus] = useState<
+    'idle' | 'pending' | 'success' | 'error'
+  >('idle');
   const [wecomQuickSetupError, setWecomQuickSetupError] = useState<string>('');
   // Weixin QR login state
-  const [weixinQrStatus, setWeixinQrStatus] = useState<'idle' | 'loading' | 'showing' | 'waiting' | 'success' | 'error'>('idle');
+  const [weixinQrStatus, setWeixinQrStatus] = useState<
+    'idle' | 'loading' | 'showing' | 'waiting' | 'success' | 'error'
+  >('idle');
   const [weixinQrUrl, setWeixinQrUrl] = useState<string>('');
   const [weixinQrError, setWeixinQrError] = useState<string>('');
   const weixinTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -133,7 +168,10 @@ const IMSettings: React.FC = () => {
   const isMountedRef = useRef(true);
 
   // OpenClaw config schema for schema-driven forms
-  const [openclawSchema, setOpenclawSchema] = useState<{ schema: Record<string, unknown>; uiHints: Record<string, Record<string, unknown>> } | null>(null);
+  const [openclawSchema, setOpenclawSchema] = useState<{
+    schema: Record<string, unknown>;
+    uiHints: Record<string, Record<string, unknown>>;
+  } | null>(null);
 
   // Subscribe to language changes
   useEffect(() => {
@@ -146,14 +184,19 @@ const IMSettings: React.FC = () => {
   // Track component mounted state for async operations
   useEffect(() => {
     isMountedRef.current = true;
-    return () => { isMountedRef.current = false; };
+    return () => {
+      isMountedRef.current = false;
+    };
   }, []);
 
   // Fetch local IP for POPO webhook placeholder
   useEffect(() => {
-    window.electron?.im?.getLocalIp?.().then((ip: string) => {
-      if (isMountedRef.current) setLocalIp(ip);
-    }).catch(() => {});
+    window.electron?.im
+      ?.getLocalIp?.()
+      .then((ip: string) => {
+        if (isMountedRef.current) setLocalIp(ip);
+      })
+      .catch(() => {});
   }, []);
 
   // Cleanup feishu QR timers on unmount
@@ -167,8 +210,14 @@ const IMSettings: React.FC = () => {
   // Reset feishu QR state when switching away from feishu
   useEffect(() => {
     if (activePlatform !== 'feishu') {
-      if (feishuQrPollTimerRef.current) { clearInterval(feishuQrPollTimerRef.current); feishuQrPollTimerRef.current = null; }
-      if (feishuQrCountdownTimerRef.current) { clearInterval(feishuQrCountdownTimerRef.current); feishuQrCountdownTimerRef.current = null; }
+      if (feishuQrPollTimerRef.current) {
+        clearInterval(feishuQrPollTimerRef.current);
+        feishuQrPollTimerRef.current = null;
+      }
+      if (feishuQrCountdownTimerRef.current) {
+        clearInterval(feishuQrCountdownTimerRef.current);
+        feishuQrCountdownTimerRef.current = null;
+      }
       setFeishuQrStatus('idle');
       setFeishuQrUrl('');
       setFeishuQrError('');
@@ -192,11 +241,14 @@ const IMSettings: React.FC = () => {
 
       // Countdown
       feishuQrCountdownTimerRef.current = setInterval(() => {
-        setFeishuQrTimeLeft((prev) => {
+        setFeishuQrTimeLeft(prev => {
           if (prev <= 1) {
             clearInterval(feishuQrCountdownTimerRef.current!);
             feishuQrCountdownTimerRef.current = null;
-            if (feishuQrPollTimerRef.current) { clearInterval(feishuQrPollTimerRef.current); feishuQrPollTimerRef.current = null; }
+            if (feishuQrPollTimerRef.current) {
+              clearInterval(feishuQrPollTimerRef.current);
+              feishuQrPollTimerRef.current = null;
+            }
             setFeishuQrStatus('error');
             setFeishuQrError(i18nService.t('feishuBotCreateWizardQrcodeExpired'));
             return 0;
@@ -209,11 +261,15 @@ const IMSettings: React.FC = () => {
       const intervalMs = Math.max(result.interval ?? 5, 3) * 1000;
       feishuQrPollTimerRef.current = setInterval(async () => {
         try {
-          const pollResult = await window.electron.feishu.install.poll(feishuQrDeviceCodeRef.current);
+          const pollResult = await window.electron.feishu.install.poll(
+            feishuQrDeviceCodeRef.current,
+          );
           if (!isMountedRef.current) return;
           if (pollResult.done && pollResult.appId && pollResult.appSecret) {
-            clearInterval(feishuQrPollTimerRef.current!); feishuQrPollTimerRef.current = null;
-            clearInterval(feishuQrCountdownTimerRef.current!); feishuQrCountdownTimerRef.current = null;
+            clearInterval(feishuQrPollTimerRef.current!);
+            feishuQrPollTimerRef.current = null;
+            clearInterval(feishuQrCountdownTimerRef.current!);
+            feishuQrCountdownTimerRef.current = null;
             // QR flow creates a new instance with the scanned credentials
             const inst = await imService.addFeishuInstance('Feishu Bot');
             if (inst) {
@@ -225,15 +281,23 @@ const IMSettings: React.FC = () => {
               setActiveFeishuInstanceId(inst.instanceId);
               setFeishuExpanded(true);
             }
-            if (!isMountedRef.current) return;   // re-check after async updateConfig
+            if (!isMountedRef.current) return; // re-check after async updateConfig
             setFeishuQrStatus('success');
-          } else if (pollResult.error && pollResult.error !== 'authorization_pending' && pollResult.error !== 'slow_down') {
-            clearInterval(feishuQrPollTimerRef.current!); feishuQrPollTimerRef.current = null;
-            clearInterval(feishuQrCountdownTimerRef.current!); feishuQrCountdownTimerRef.current = null;
+          } else if (
+            pollResult.error &&
+            pollResult.error !== 'authorization_pending' &&
+            pollResult.error !== 'slow_down'
+          ) {
+            clearInterval(feishuQrPollTimerRef.current!);
+            feishuQrPollTimerRef.current = null;
+            clearInterval(feishuQrCountdownTimerRef.current!);
+            feishuQrCountdownTimerRef.current = null;
             setFeishuQrStatus('error');
             setFeishuQrError(pollResult.error);
           }
-        } catch { /* keep retrying */ }
+        } catch {
+          /* keep retrying */
+        }
       }, intervalMs);
     } catch (err: any) {
       if (!isMountedRef.current) return;
@@ -253,7 +317,10 @@ const IMSettings: React.FC = () => {
   // Reset weixin QR login state when switching away from weixin
   useEffect(() => {
     if (activePlatform !== 'weixin') {
-      if (weixinTimerRef.current) { clearTimeout(weixinTimerRef.current); weixinTimerRef.current = null; }
+      if (weixinTimerRef.current) {
+        clearTimeout(weixinTimerRef.current);
+        weixinTimerRef.current = null;
+      }
       setWeixinQrStatus('idle');
       setWeixinQrUrl('');
       setWeixinQrError('');
@@ -291,7 +358,11 @@ const IMSettings: React.FC = () => {
 
     // Find the NIM channel key — could be 'nim' or 'openclaw-nim'
     const channelsProps = (schema as any)?.properties?.channels?.properties ?? {};
-    const channelKey = channelsProps['openclaw-nim'] ? 'openclaw-nim' : channelsProps['nim'] ? 'nim' : null;
+    const channelKey = channelsProps['openclaw-nim']
+      ? 'openclaw-nim'
+      : channelsProps['nim']
+        ? 'nim'
+        : null;
     if (!channelKey) return null;
 
     const channelSchema = channelsProps[channelKey] as Record<string, unknown>;
@@ -318,7 +389,9 @@ const IMSettings: React.FC = () => {
   // Inline QR code state for feishu bot creation (mirroring WeCom quick-setup pattern)
   // These are used by handleFeishuStartQr which creates instances via QR flow
   // @ts-ignore: will be used when QR flow is wired to FeishuInstanceSettings
-  const [_feishuQrStatus, setFeishuQrStatus] = useState<'idle' | 'loading' | 'showing' | 'success' | 'error'>('idle');
+  const [_feishuQrStatus, setFeishuQrStatus] = useState<
+    'idle' | 'loading' | 'showing' | 'success' | 'error'
+  >('idle');
   // @ts-ignore
   const [_feishuQrUrl, setFeishuQrUrl] = useState<string>('');
   // @ts-ignore
@@ -332,15 +405,29 @@ const IMSettings: React.FC = () => {
 
   // Pairing state for OpenClaw platforms
   const [pairingCodeInput, setPairingCodeInput] = useState<Record<string, string>>({});
-  const [pairingStatus, setPairingStatus] = useState<Record<string, { type: 'success' | 'error'; message: string } | null>>({});
+  const [pairingStatus, setPairingStatus] = useState<
+    Record<string, { type: 'success' | 'error'; message: string } | null>
+  >({});
 
   const handleApprovePairing = async (platform: string, code: string) => {
-    setPairingStatus((prev) => ({ ...prev, [platform]: null }));
+    setPairingStatus(prev => ({ ...prev, [platform]: null }));
     const result = await imService.approvePairingCode(platform, code);
     if (result.success) {
-      setPairingStatus((prev) => ({ ...prev, [platform]: { type: 'success', message: i18nService.t('imPairingCodeApproved').replace('{code}', code) } }));
+      setPairingStatus(prev => ({
+        ...prev,
+        [platform]: {
+          type: 'success',
+          message: i18nService.t('imPairingCodeApproved').replace('{code}', code),
+        },
+      }));
     } else {
-      setPairingStatus((prev) => ({ ...prev, [platform]: { type: 'error', message: result.error || i18nService.t('imPairingCodeInvalid') } }));
+      setPairingStatus(prev => ({
+        ...prev,
+        [platform]: {
+          type: 'error',
+          message: result.error || i18nService.t('imPairingCodeInvalid'),
+        },
+      }));
     }
   };
   // Handle Telegram OpenClaw config change
@@ -350,9 +437,7 @@ const IMSettings: React.FC = () => {
   };
   const handleSaveTelegramOpenClawConfig = async (override?: Partial<TelegramOpenClawConfig>) => {
     if (!configLoaded) return;
-    const configToSave = override
-      ? { ...tgOpenClawConfig, ...override }
-      : tgOpenClawConfig;
+    const configToSave = override ? { ...tgOpenClawConfig, ...override } : tgOpenClawConfig;
     await imService.persistConfig({ telegram: configToSave });
   };
 
@@ -365,9 +450,7 @@ const IMSettings: React.FC = () => {
   };
   const handleSaveDiscordOpenClawConfig = async (override?: Partial<DiscordOpenClawConfig>) => {
     if (!configLoaded) return;
-    const configToSave = override
-      ? { ...dcOpenClawConfig, ...override }
-      : dcOpenClawConfig;
+    const configToSave = override ? { ...dcOpenClawConfig, ...override } : dcOpenClawConfig;
     await imService.persistConfig({ discord: configToSave });
   };
 
@@ -378,7 +461,6 @@ const IMSettings: React.FC = () => {
   // State for POPO allow-from inputs
   const [popoAllowedUserIdInput, setPopoAllowedUserIdInput] = useState('');
   const [popoGroupAllowIdInput, setPopoGroupAllowIdInput] = useState('');
-
 
   // Handle NetEase Bee config change
   const handleNeteaseBeeChanChange = (field: 'clientId' | 'secret', value: string) => {
@@ -392,9 +474,7 @@ const IMSettings: React.FC = () => {
   };
   const handleSaveWecomOpenClawConfig = async (override?: Partial<WecomOpenClawConfig>) => {
     if (!configLoaded) return;
-    const configToSave = override
-      ? { ...wecomOpenClawConfig, ...override }
-      : wecomOpenClawConfig;
+    const configToSave = override ? { ...wecomOpenClawConfig, ...override } : wecomOpenClawConfig;
     await imService.persistConfig({ wecom: configToSave });
   };
 
@@ -408,9 +488,7 @@ const IMSettings: React.FC = () => {
   };
   const handleSavePopoConfig = async (override?: Partial<PopoOpenClawConfig>) => {
     if (!configLoaded) return;
-    const configToSave = override
-      ? { ...popoConfig, ...override }
-      : popoConfig;
+    const configToSave = override ? { ...popoConfig, ...override } : popoConfig;
     await imService.persistConfig({ popo: configToSave });
   };
 
@@ -427,7 +505,12 @@ const IMSettings: React.FC = () => {
       // im:config:set handler in main process already calls
       // syncOpenClawConfig({ restartGatewayIfRunning: true }) when wecom config changes,
       // so we do NOT call stopGateway/startGateway here to avoid redundant gateway restarts.
-      const fullConfig = { ...wecomOpenClawConfig, botId: bot.botid, secret: bot.secret, enabled: true };
+      const fullConfig = {
+        ...wecomOpenClawConfig,
+        botId: bot.botid,
+        secret: bot.secret,
+        enabled: true,
+      };
       dispatch(setWecomConfig({ botId: bot.botid, secret: bot.secret, enabled: true }));
       dispatch(clearError());
       await imService.updateConfig({ wecom: fullConfig });
@@ -441,11 +524,13 @@ const IMSettings: React.FC = () => {
     } catch (error: unknown) {
       if (!isMountedRef.current) return;
       // Roll back optimistic Redux dispatch so UI matches persisted state
-      dispatch(setWecomConfig({
-        botId: wecomOpenClawConfig.botId,
-        secret: wecomOpenClawConfig.secret,
-        enabled: wecomOpenClawConfig.enabled,
-      }));
+      dispatch(
+        setWecomConfig({
+          botId: wecomOpenClawConfig.botId,
+          secret: wecomOpenClawConfig.secret,
+          enabled: wecomOpenClawConfig.enabled,
+        }),
+      );
       setWecomQuickSetupStatus('error');
       const err = error as { message?: string; code?: string };
       setWecomQuickSetupError(err.message || err.code || 'Unknown error');
@@ -479,7 +564,10 @@ const IMSettings: React.FC = () => {
       // Start polling for scan result
       setWeixinQrStatus('waiting');
       const waitResult = await window.electron.im.weixinQrLoginWait(startResult.sessionKey);
-      if (weixinTimerRef.current) { clearTimeout(weixinTimerRef.current); weixinTimerRef.current = null; }
+      if (weixinTimerRef.current) {
+        clearTimeout(weixinTimerRef.current);
+        weixinTimerRef.current = null;
+      }
       if (!isMountedRef.current) return;
 
       if (waitResult.success && waitResult.connected) {
@@ -496,13 +584,15 @@ const IMSettings: React.FC = () => {
         setWeixinQrError(waitResult.message || i18nService.t('imWeixinQrFailed'));
       }
     } catch (err) {
-      if (weixinTimerRef.current) { clearTimeout(weixinTimerRef.current); weixinTimerRef.current = null; }
+      if (weixinTimerRef.current) {
+        clearTimeout(weixinTimerRef.current);
+        weixinTimerRef.current = null;
+      }
       if (!isMountedRef.current) return;
       setWeixinQrStatus('error');
       setWeixinQrError(String(err));
     }
   };
-
 
   const handleSaveConfig = async () => {
     if (!configLoaded) return;
@@ -552,8 +642,6 @@ const IMSettings: React.FC = () => {
     await imService.persistConfig({ [activePlatform]: config[activePlatform] });
   };
 
-
-
   const getCheckTitle = (code: IMConnectivityCheck['code']): string => {
     return i18nService.t(`imConnectivityCheckTitle_${code}`);
   };
@@ -582,12 +670,12 @@ const IMSettings: React.FC = () => {
 
   const runConnectivityTest = async (
     platform: Platform,
-    configOverride?: Partial<IMGatewayConfig>
+    configOverride?: Partial<IMGatewayConfig>,
   ): Promise<IMConnectivityTestResult | null> => {
     setTestingPlatform(platform);
     const result = await imService.testGateway(platform, configOverride);
     if (result) {
-      setConnectivityResults((prev) => ({ ...prev, [platform]: result }));
+      setConnectivityResults(prev => ({ ...prev, [platform]: result }));
     }
     setTestingPlatform(null);
     return result;
@@ -609,7 +697,9 @@ const IMSettings: React.FC = () => {
       // backend debounces syncOpenClawConfig calls with a 600ms window.
       if (platform === 'telegram') {
         const newEnabled = !tgOpenClawConfig.enabled;
-        const success = await imService.updateConfig({ telegram: { ...tgOpenClawConfig, enabled: newEnabled } });
+        const success = await imService.updateConfig({
+          telegram: { ...tgOpenClawConfig, enabled: newEnabled },
+        });
         if (success) {
           dispatch(setTelegramOpenClawConfig({ enabled: newEnabled }));
           if (newEnabled) dispatch(clearError());
@@ -630,7 +720,9 @@ const IMSettings: React.FC = () => {
 
       if (platform === 'discord') {
         const newEnabled = !dcOpenClawConfig.enabled;
-        const success = await imService.updateConfig({ discord: { ...dcOpenClawConfig, enabled: newEnabled } });
+        const success = await imService.updateConfig({
+          discord: { ...dcOpenClawConfig, enabled: newEnabled },
+        });
         if (success) {
           dispatch(setDiscordConfig({ enabled: newEnabled }));
           if (newEnabled) dispatch(clearError());
@@ -646,7 +738,9 @@ const IMSettings: React.FC = () => {
 
       if (platform === 'wecom') {
         const newEnabled = !wecomOpenClawConfig.enabled;
-        const success = await imService.updateConfig({ wecom: { ...wecomOpenClawConfig, enabled: newEnabled } });
+        const success = await imService.updateConfig({
+          wecom: { ...wecomOpenClawConfig, enabled: newEnabled },
+        });
         if (success) {
           dispatch(setWecomConfig({ enabled: newEnabled }));
           if (newEnabled) dispatch(clearError());
@@ -657,7 +751,9 @@ const IMSettings: React.FC = () => {
 
       if (platform === 'weixin') {
         const newEnabled = !weixinOpenClawConfig.enabled;
-        const success = await imService.updateConfig({ weixin: { ...weixinOpenClawConfig, enabled: newEnabled } });
+        const success = await imService.updateConfig({
+          weixin: { ...weixinOpenClawConfig, enabled: newEnabled },
+        });
         if (success) {
           dispatch(setWeixinConfig({ enabled: newEnabled }));
           if (newEnabled) dispatch(clearError());
@@ -668,7 +764,9 @@ const IMSettings: React.FC = () => {
 
       if (platform === 'popo') {
         const newEnabled = !popoConfig.enabled;
-        const success = await imService.updateConfig({ popo: { ...popoConfig, enabled: newEnabled } });
+        const success = await imService.updateConfig({
+          popo: { ...popoConfig, enabled: newEnabled },
+        });
         if (success) {
           dispatch(setPopoConfig({ enabled: newEnabled }));
           if (newEnabled) dispatch(clearError());
@@ -678,7 +776,9 @@ const IMSettings: React.FC = () => {
       }
       if (platform === 'nim') {
         const newEnabled = !config.nim.enabled;
-        const success = await imService.updateConfig({ nim: { ...config.nim, enabled: newEnabled } });
+        const success = await imService.updateConfig({
+          nim: { ...config.nim, enabled: newEnabled },
+        });
         if (success) {
           dispatch(setNimConfig({ enabled: newEnabled }));
           if (newEnabled) dispatch(clearError());
@@ -770,9 +870,15 @@ const IMSettings: React.FC = () => {
       return true; // No credentials needed, connects via QR code in CLI
     }
     if (platform === 'popo') {
-      const effectiveMode = config.popo.connectionMode || (config.popo.token ? 'webhook' : 'websocket');
+      const effectiveMode =
+        config.popo.connectionMode || (config.popo.token ? 'webhook' : 'websocket');
       if (effectiveMode === 'webhook') {
-        return !!(config.popo.appKey && config.popo.appSecret && config.popo.token && config.popo.aesKey);
+        return !!(
+          config.popo.appKey &&
+          config.popo.appSecret &&
+          config.popo.token &&
+          config.popo.aesKey
+        );
       }
       return !!(config.popo.appKey && config.popo.appSecret && config.popo.aesKey);
     }
@@ -828,7 +934,7 @@ const IMSettings: React.FC = () => {
       } as Partial<IMGatewayConfig>);
       // Auto-enable: if OFF and auth_check passed, turn on automatically
       if (!tgOpenClawConfig.enabled && result) {
-        const authCheck = result.checks.find((c) => c.code === 'auth_check');
+        const authCheck = result.checks.find(c => c.code === 'auth_check');
         if (authCheck && authCheck.level === 'pass') {
           toggleGateway(platform);
         }
@@ -844,12 +950,21 @@ const IMSettings: React.FC = () => {
       } as Partial<IMGatewayConfig>);
       // Auto-enable: if the active instance is OFF and auth_check passed, turn on automatically
       if (activeDingTalkInstanceId && result) {
-        const inst = dingtalkMultiConfig.instances.find(i => i.instanceId === activeDingTalkInstanceId);
+        const inst = dingtalkMultiConfig.instances.find(
+          i => i.instanceId === activeDingTalkInstanceId,
+        );
         if (inst && !inst.enabled) {
-          const authCheck = result.checks.find((c) => c.code === 'auth_check');
+          const authCheck = result.checks.find(c => c.code === 'auth_check');
           if (authCheck && authCheck.level === 'pass') {
-            dispatch(setDingTalkInstanceConfig({ instanceId: activeDingTalkInstanceId, config: { enabled: true } }));
-            await imService.updateDingTalkInstanceConfig(activeDingTalkInstanceId, { enabled: true });
+            dispatch(
+              setDingTalkInstanceConfig({
+                instanceId: activeDingTalkInstanceId,
+                config: { enabled: true },
+              }),
+            );
+            await imService.updateDingTalkInstanceConfig(activeDingTalkInstanceId, {
+              enabled: true,
+            });
           }
         }
       }
@@ -866,9 +981,11 @@ const IMSettings: React.FC = () => {
       if (activeQQInstanceId && result) {
         const inst = qqMultiConfig.instances.find(i => i.instanceId === activeQQInstanceId);
         if (inst && !inst.enabled) {
-          const authCheck = result.checks.find((c) => c.code === 'auth_check');
+          const authCheck = result.checks.find(c => c.code === 'auth_check');
           if (authCheck && authCheck.level === 'pass') {
-            dispatch(setQQInstanceConfig({ instanceId: activeQQInstanceId, config: { enabled: true } }));
+            dispatch(
+              setQQInstanceConfig({ instanceId: activeQQInstanceId, config: { enabled: true } }),
+            );
             await imService.updateQQInstanceConfig(activeQQInstanceId, { enabled: true });
           }
         }
@@ -883,7 +1000,7 @@ const IMSettings: React.FC = () => {
         wecom: wecomOpenClawConfig,
       } as Partial<IMGatewayConfig>);
       if (!wecomOpenClawConfig.enabled && result) {
-        const authCheck = result.checks.find((c) => c.code === 'auth_check');
+        const authCheck = result.checks.find(c => c.code === 'auth_check');
         if (authCheck && authCheck.level === 'pass') {
           toggleGateway(platform);
         }
@@ -898,7 +1015,7 @@ const IMSettings: React.FC = () => {
         weixin: weixinOpenClawConfig,
       } as Partial<IMGatewayConfig>);
       if (!weixinOpenClawConfig.enabled && result) {
-        const authCheck = result.checks.find((c) => c.code === 'auth_check');
+        const authCheck = result.checks.find(c => c.code === 'auth_check');
         if (authCheck && authCheck.level === 'pass') {
           toggleGateway(platform);
         }
@@ -916,9 +1033,14 @@ const IMSettings: React.FC = () => {
       if (activeFeishuInstanceId && result) {
         const inst = feishuMultiConfig.instances.find(i => i.instanceId === activeFeishuInstanceId);
         if (inst && !inst.enabled) {
-          const authCheck = result.checks.find((c) => c.code === 'auth_check');
+          const authCheck = result.checks.find(c => c.code === 'auth_check');
           if (authCheck && authCheck.level === 'pass') {
-            dispatch(setFeishuInstanceConfig({ instanceId: activeFeishuInstanceId, config: { enabled: true } }));
+            dispatch(
+              setFeishuInstanceConfig({
+                instanceId: activeFeishuInstanceId,
+                config: { enabled: true },
+              }),
+            );
             await imService.updateFeishuInstanceConfig(activeFeishuInstanceId, { enabled: true });
           }
         }
@@ -951,7 +1073,7 @@ const IMSettings: React.FC = () => {
 
     // Auto-enable: if the platform was OFF but auth_check passed, start it automatically.
     if (!isEnabled && result) {
-      const authCheck = result.checks.find((c) => c.code === 'auth_check');
+      const authCheck = result.checks.find(c => c.code === 'auth_check');
       if (authCheck && authCheck.level === 'pass') {
         toggleGateway(platform);
       }
@@ -1026,17 +1148,17 @@ const IMSettings: React.FC = () => {
         <input
           type="text"
           value={pairingCodeInput[platform] || ''}
-          onChange={(e) => {
-            setPairingCodeInput((prev) => ({ ...prev, [platform]: e.target.value.toUpperCase() }));
-            if (pairingStatus[platform]) setPairingStatus((prev) => ({ ...prev, [platform]: null }));
+          onChange={e => {
+            setPairingCodeInput(prev => ({ ...prev, [platform]: e.target.value.toUpperCase() }));
+            if (pairingStatus[platform]) setPairingStatus(prev => ({ ...prev, [platform]: null }));
           }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
+          onKeyDown={e => {
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
               e.preventDefault();
               const code = (pairingCodeInput[platform] || '').trim();
               if (code) {
                 void handleApprovePairing(platform, code).then(() => {
-                  setPairingCodeInput((prev) => ({ ...prev, [platform]: '' }));
+                  setPairingCodeInput(prev => ({ ...prev, [platform]: '' }));
                 });
               }
             }
@@ -1051,7 +1173,7 @@ const IMSettings: React.FC = () => {
             const code = (pairingCodeInput[platform] || '').trim();
             if (code) {
               void handleApprovePairing(platform, code).then(() => {
-                setPairingCodeInput((prev) => ({ ...prev, [platform]: '' }));
+                setPairingCodeInput(prev => ({ ...prev, [platform]: '' }));
               });
             }
           }}
@@ -1061,8 +1183,11 @@ const IMSettings: React.FC = () => {
         </button>
       </div>
       {pairingStatus[platform] && (
-        <p className={`text-xs ${pairingStatus[platform]!.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-          {pairingStatus[platform]!.type === 'success' ? '\u2713' : '\u2717'} {pairingStatus[platform]!.message}
+        <p
+          className={`text-xs ${pairingStatus[platform]!.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+        >
+          {pairingStatus[platform]!.type === 'success' ? '\u2713' : '\u2717'}{' '}
+          {pairingStatus[platform]!.message}
         </p>
       )}
     </div>
@@ -1072,9 +1197,9 @@ const IMSettings: React.FC = () => {
     <div className="flex h-full gap-4">
       {/* Platform List - Left Side */}
       <div className="w-48 flex-shrink-0 border-r border-border pr-3 space-y-2 overflow-y-auto">
-        {platforms.map((platform) => {
-                const logo = PlatformRegistry.logo(platform);
-           const isEnabled = isPlatformEnabled(platform);
+        {platforms.map(platform => {
+          const logo = PlatformRegistry.logo(platform);
+          const isEnabled = isPlatformEnabled(platform);
           const isConnected = getPlatformConnected(platform) || getPlatformStarting(platform);
           const canToggle = isEnabled || canStart(platform);
 
@@ -1083,7 +1208,11 @@ const IMSettings: React.FC = () => {
               <div key="dingtalk">
                 {/* DingTalk Platform Header - clickable to expand/collapse */}
                 <div
-                  onClick={() => { setActivePlatform('dingtalk'); setActiveDingTalkInstanceId(null); setDingtalkExpanded(!dingtalkExpanded); }}
+                  onClick={() => {
+                    setActivePlatform('dingtalk');
+                    setActiveDingTalkInstanceId(null);
+                    setDingtalkExpanded(!dingtalkExpanded);
+                  }}
                   className={`flex items-center p-2 rounded-xl cursor-pointer transition-colors ${
                     activePlatform === 'dingtalk'
                       ? 'bg-primary-muted border border-primary shadow-subtle'
@@ -1092,25 +1221,44 @@ const IMSettings: React.FC = () => {
                 >
                   <div className="flex flex-1 items-center">
                     <div className="mr-2 flex h-7 w-7 items-center justify-center">
-                      <img src={PlatformRegistry.logo('dingtalk')} alt="DingTalk" className="w-6 h-6 object-contain rounded-md" />
+                      <img
+                        src={PlatformRegistry.logo('dingtalk')}
+                        alt="DingTalk"
+                        className="w-6 h-6 object-contain rounded-md"
+                      />
                     </div>
-                    <span className={`text-sm font-medium truncate ${activePlatform === 'dingtalk' ? 'text-primary' : 'text-foreground'}`}>
+                    <span
+                      className={`text-sm font-medium truncate ${activePlatform === 'dingtalk' ? 'text-primary' : 'text-foreground'}`}
+                    >
                       {i18nService.t('dingtalk')}
                     </span>
                   </div>
-                  <span className="text-xs opacity-50">{dingtalkExpanded ? '\u25BC' : '\u25B6'}</span>
+                  <span className="text-xs opacity-50">
+                    {dingtalkExpanded ? '\u25BC' : '\u25B6'}
+                  </span>
                 </div>
                 {/* DingTalk Instance Sub-items */}
                 {dingtalkExpanded && (
                   <div className="ml-5 mt-1 space-y-1">
-                    {config.dingtalk.instances.map((inst) => {
-                      const instStatus = status.dingtalk?.instances?.find(s => s.instanceId === inst.instanceId);
-                      const isSelected = activePlatform === 'dingtalk' && activeDingTalkInstanceId === inst.instanceId;
-                      const dotColor = !inst.enabled ? 'bg-gray-400' : (instStatus?.connected ? 'bg-green-500' : 'bg-yellow-500');
+                    {config.dingtalk.instances.map(inst => {
+                      const instStatus = status.dingtalk?.instances?.find(
+                        s => s.instanceId === inst.instanceId,
+                      );
+                      const isSelected =
+                        activePlatform === 'dingtalk' &&
+                        activeDingTalkInstanceId === inst.instanceId;
+                      const dotColor = !inst.enabled
+                        ? 'bg-gray-400'
+                        : instStatus?.connected
+                          ? 'bg-green-500'
+                          : 'bg-yellow-500';
                       return (
                         <div
                           key={inst.instanceId}
-                          onClick={() => { setActivePlatform('dingtalk'); setActiveDingTalkInstanceId(inst.instanceId); }}
+                          onClick={() => {
+                            setActivePlatform('dingtalk');
+                            setActiveDingTalkInstanceId(inst.instanceId);
+                          }}
                           className={`flex items-center p-1.5 pl-2 rounded-lg cursor-pointer transition-colors text-sm ${
                             isSelected
                               ? 'bg-primary/10 dark:bg-primary/20'
@@ -1118,7 +1266,9 @@ const IMSettings: React.FC = () => {
                           }`}
                         >
                           <span className={`w-2 h-2 rounded-full ${dotColor} mr-2 flex-shrink-0`} />
-                          <span className={`truncate flex-1 ${isSelected ? 'text-primary font-medium' : 'text-foreground'}`}>
+                          <span
+                            className={`truncate flex-1 ${isSelected ? 'text-primary font-medium' : 'text-foreground'}`}
+                          >
                             {inst.instanceName}
                           </span>
                         </div>
@@ -1135,7 +1285,11 @@ const IMSettings: React.FC = () => {
               <div key="feishu">
                 {/* Feishu Platform Header - clickable to expand/collapse */}
                 <div
-                  onClick={() => { setActivePlatform('feishu'); setActiveFeishuInstanceId(null); setFeishuExpanded(!feishuExpanded); }}
+                  onClick={() => {
+                    setActivePlatform('feishu');
+                    setActiveFeishuInstanceId(null);
+                    setFeishuExpanded(!feishuExpanded);
+                  }}
                   className={`flex items-center p-2 rounded-xl cursor-pointer transition-colors ${
                     activePlatform === 'feishu'
                       ? 'bg-primary-muted border border-primary shadow-subtle'
@@ -1144,9 +1298,15 @@ const IMSettings: React.FC = () => {
                 >
                   <div className="flex flex-1 items-center">
                     <div className="mr-2 flex h-7 w-7 items-center justify-center">
-                      <img src={PlatformRegistry.logo('feishu')} alt="Feishu" className="w-6 h-6 object-contain rounded-md" />
+                      <img
+                        src={PlatformRegistry.logo('feishu')}
+                        alt="Feishu"
+                        className="w-6 h-6 object-contain rounded-md"
+                      />
                     </div>
-                    <span className={`text-sm font-medium truncate ${activePlatform === 'feishu' ? 'text-primary' : 'text-foreground'}`}>
+                    <span
+                      className={`text-sm font-medium truncate ${activePlatform === 'feishu' ? 'text-primary' : 'text-foreground'}`}
+                    >
                       {i18nService.t('feishu')}
                     </span>
                   </div>
@@ -1155,14 +1315,24 @@ const IMSettings: React.FC = () => {
                 {/* Feishu Instance Sub-items */}
                 {feishuExpanded && (
                   <div className="ml-5 mt-1 space-y-1">
-                    {config.feishu.instances.map((inst) => {
-                      const instStatus = status.feishu?.instances?.find(s => s.instanceId === inst.instanceId);
-                      const isSelected = activePlatform === 'feishu' && activeFeishuInstanceId === inst.instanceId;
-                      const dotColor = !inst.enabled ? 'bg-gray-400' : (instStatus?.connected ? 'bg-green-500' : 'bg-yellow-500');
+                    {config.feishu.instances.map(inst => {
+                      const instStatus = status.feishu?.instances?.find(
+                        s => s.instanceId === inst.instanceId,
+                      );
+                      const isSelected =
+                        activePlatform === 'feishu' && activeFeishuInstanceId === inst.instanceId;
+                      const dotColor = !inst.enabled
+                        ? 'bg-gray-400'
+                        : instStatus?.connected
+                          ? 'bg-green-500'
+                          : 'bg-yellow-500';
                       return (
                         <div
                           key={inst.instanceId}
-                          onClick={() => { setActivePlatform('feishu'); setActiveFeishuInstanceId(inst.instanceId); }}
+                          onClick={() => {
+                            setActivePlatform('feishu');
+                            setActiveFeishuInstanceId(inst.instanceId);
+                          }}
                           className={`flex items-center p-1.5 pl-2 rounded-lg cursor-pointer transition-colors text-sm ${
                             isSelected
                               ? 'bg-primary/10 dark:bg-primary/20'
@@ -1170,7 +1340,9 @@ const IMSettings: React.FC = () => {
                           }`}
                         >
                           <span className={`w-2 h-2 rounded-full ${dotColor} mr-2 flex-shrink-0`} />
-                          <span className={`truncate flex-1 ${isSelected ? 'text-primary font-medium' : 'text-foreground'}`}>
+                          <span
+                            className={`truncate flex-1 ${isSelected ? 'text-primary font-medium' : 'text-foreground'}`}
+                          >
                             {inst.instanceName}
                           </span>
                         </div>
@@ -1187,7 +1359,11 @@ const IMSettings: React.FC = () => {
               <div key="qq">
                 {/* QQ Platform Header - clickable to expand/collapse */}
                 <div
-                  onClick={() => { setActivePlatform('qq'); setActiveQQInstanceId(null); setQqExpanded(!qqExpanded); }}
+                  onClick={() => {
+                    setActivePlatform('qq');
+                    setActiveQQInstanceId(null);
+                    setQqExpanded(!qqExpanded);
+                  }}
                   className={`flex items-center p-2 rounded-xl cursor-pointer transition-colors ${
                     activePlatform === 'qq'
                       ? 'bg-primary-muted border border-primary shadow-subtle'
@@ -1196,9 +1372,15 @@ const IMSettings: React.FC = () => {
                 >
                   <div className="flex flex-1 items-center">
                     <div className="mr-2 flex h-7 w-7 items-center justify-center">
-                      <img src={PlatformRegistry.logo('qq')} alt="QQ" className="w-6 h-6 object-contain rounded-md" />
+                      <img
+                        src={PlatformRegistry.logo('qq')}
+                        alt="QQ"
+                        className="w-6 h-6 object-contain rounded-md"
+                      />
                     </div>
-                    <span className={`text-sm font-medium truncate ${activePlatform === 'qq' ? 'text-primary' : 'text-foreground'}`}>
+                    <span
+                      className={`text-sm font-medium truncate ${activePlatform === 'qq' ? 'text-primary' : 'text-foreground'}`}
+                    >
                       {i18nService.t('qq')}
                     </span>
                   </div>
@@ -1207,14 +1389,24 @@ const IMSettings: React.FC = () => {
                 {/* QQ Instance Sub-items */}
                 {qqExpanded && (
                   <div className="ml-5 mt-1 space-y-1">
-                    {config.qq.instances.map((inst) => {
-                      const instStatus = status.qq?.instances?.find(s => s.instanceId === inst.instanceId);
-                      const isSelected = activePlatform === 'qq' && activeQQInstanceId === inst.instanceId;
-                      const dotColor = !inst.enabled ? 'bg-gray-400' : (instStatus?.connected ? 'bg-green-500' : 'bg-yellow-500');
+                    {config.qq.instances.map(inst => {
+                      const instStatus = status.qq?.instances?.find(
+                        s => s.instanceId === inst.instanceId,
+                      );
+                      const isSelected =
+                        activePlatform === 'qq' && activeQQInstanceId === inst.instanceId;
+                      const dotColor = !inst.enabled
+                        ? 'bg-gray-400'
+                        : instStatus?.connected
+                          ? 'bg-green-500'
+                          : 'bg-yellow-500';
                       return (
                         <div
                           key={inst.instanceId}
-                          onClick={() => { setActivePlatform('qq'); setActiveQQInstanceId(inst.instanceId); }}
+                          onClick={() => {
+                            setActivePlatform('qq');
+                            setActiveQQInstanceId(inst.instanceId);
+                          }}
                           className={`flex items-center p-1.5 pl-2 rounded-lg cursor-pointer transition-colors text-sm ${
                             isSelected
                               ? 'bg-primary/10 dark:bg-primary/20'
@@ -1222,7 +1414,9 @@ const IMSettings: React.FC = () => {
                           }`}
                         >
                           <span className={`w-2 h-2 rounded-full ${dotColor} mr-2 flex-shrink-0`} />
-                          <span className={`truncate flex-1 ${isSelected ? 'text-primary font-medium' : 'text-foreground'}`}>
+                          <span
+                            className={`truncate flex-1 ${isSelected ? 'text-primary font-medium' : 'text-foreground'}`}
+                          >
                             {inst.instanceName}
                           </span>
                         </div>
@@ -1252,11 +1446,11 @@ const IMSettings: React.FC = () => {
                     className="w-6 h-6 object-contain rounded-md"
                   />
                 </div>
-                <span className={`text-sm font-medium truncate ${
-                  activePlatform === platform
-                    ? 'text-primary'
-                    : 'text-foreground'
-                }`}>
+                <span
+                  className={`text-sm font-medium truncate ${
+                    activePlatform === platform ? 'text-primary' : 'text-foreground'
+                  }`}
+                >
                   {i18nService.t(platform)}
                 </span>
               </div>
@@ -1264,10 +1458,12 @@ const IMSettings: React.FC = () => {
                 <div
                   className={`w-7 h-4 rounded-full flex items-center transition-colors ${
                     isEnabled
-                      ? (isConnected ? 'bg-green-500' : 'bg-yellow-500')
+                      ? isConnected
+                        ? 'bg-green-500'
+                        : 'bg-yellow-500'
                       : 'bg-gray-400 dark:bg-gray-600'
-                  } ${(!canToggle || togglingPlatform === platform) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-                  onClick={(e) => {
+                  } ${!canToggle || togglingPlatform === platform ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                  onClick={e => {
                     e.stopPropagation();
                     handlePlatformToggle(platform);
                   }}
@@ -1287,51 +1483,67 @@ const IMSettings: React.FC = () => {
       {/* Platform Settings - Right Side */}
       <div className="flex-1 min-w-0 pl-4 pr-2 space-y-4 overflow-y-auto [scrollbar-gutter:stable]">
         {/* Header with status (hidden for QQ which has per-instance headers) */}
-        {activePlatform !== 'qq' && activePlatform !== 'feishu' && activePlatform !== 'dingtalk' && (
-        <div className="flex items-center gap-3 pb-3 border-b border-border-subtle">
-          <div className="flex items-center gap-2">
-             <div className="flex h-7 w-7 items-center justify-center rounded-md bg-surface border border-border-subtle p-1">
-               <img
-                src={PlatformRegistry.logo(activePlatform)}
-                 alt={i18nService.t(activePlatform)}
-                 className="w-4 h-4 object-contain rounded"
-               />
+        {activePlatform !== 'qq' &&
+          activePlatform !== 'feishu' &&
+          activePlatform !== 'dingtalk' && (
+            <div className="flex items-center gap-3 pb-3 border-b border-border-subtle">
+              <div className="flex items-center gap-2">
+                <div className="flex h-7 w-7 items-center justify-center rounded-md bg-surface border border-border-subtle p-1">
+                  <img
+                    src={PlatformRegistry.logo(activePlatform)}
+                    alt={i18nService.t(activePlatform)}
+                    className="w-4 h-4 object-contain rounded"
+                  />
+                </div>
+                <h3 className="text-sm font-medium text-foreground">
+                  {`${i18nService.t(activePlatform)}${i18nService.t('settings')}`}
+                </h3>
+              </div>
+              <div
+                className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                  getPlatformConnected(activePlatform) || getPlatformStarting(activePlatform)
+                    ? 'bg-green-500/15 text-green-600 dark:text-green-400'
+                    : 'bg-gray-500/15 text-gray-500 dark:text-gray-400'
+                }`}
+              >
+                {getPlatformConnected(activePlatform)
+                  ? i18nService.t('connected')
+                  : getPlatformStarting(activePlatform)
+                    ? i18nService.t('starting') || '启动中'
+                    : i18nService.t('disconnected')}
+              </div>
             </div>
-            <h3 className="text-sm font-medium text-foreground">
-              {`${i18nService.t(activePlatform)}${i18nService.t('settings')}`}
-            </h3>
-          </div>
-          <div className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-            getPlatformConnected(activePlatform) || getPlatformStarting(activePlatform)
-              ? 'bg-green-500/15 text-green-600 dark:text-green-400'
-              : 'bg-gray-500/15 text-gray-500 dark:text-gray-400'
-          }`}>
-            {getPlatformConnected(activePlatform)
-              ? i18nService.t('connected')
-              : getPlatformStarting(activePlatform)
-                ? (i18nService.t('starting') || '启动中')
-                : i18nService.t('disconnected')}
-          </div>
-        </div>
-        )}
-
+          )}
 
         {/* DingTalk Settings (multi-instance) */}
         {activePlatform === 'dingtalk' && !activeDingTalkInstanceId && (
           <div className="flex flex-col items-center justify-center py-12 text-center">
-            <img src={PlatformRegistry.logo('dingtalk')} alt="DingTalk" className="w-12 h-12 object-contain rounded-md mb-4 opacity-50" />
+            <img
+              src={PlatformRegistry.logo('dingtalk')}
+              alt="DingTalk"
+              className="w-12 h-12 object-contain rounded-md mb-4 opacity-50"
+            />
             <p className="text-sm text-secondary mb-4">
               {config.dingtalk.instances.length === 0
-                ? (language === 'zh' ? '尚未添加钉钉实例，点击下方按钮添加' : 'No DingTalk instances yet. Click below to add one.')
-                : (language === 'zh' ? '请在左侧选择一个钉钉实例' : 'Select a DingTalk instance from the sidebar.')}
+                ? language === 'zh'
+                  ? '尚未添加钉钉实例，点击下方按钮添加'
+                  : 'No DingTalk instances yet. Click below to add one.'
+                : language === 'zh'
+                  ? '请在左侧选择一个钉钉实例'
+                  : 'Select a DingTalk instance from the sidebar.'}
             </p>
             {config.dingtalk.instances.length < MAX_DINGTALK_INSTANCES && (
               <button
                 type="button"
-                onClick={async (e) => {
+                onClick={async e => {
                   e.stopPropagation();
-                  const inst = await imService.addDingTalkInstance(`DingTalk Bot ${config.dingtalk.instances.length + 1}`);
-                  if (inst) { setActiveDingTalkInstanceId(inst.instanceId); setDingtalkExpanded(true); }
+                  const inst = await imService.addDingTalkInstance(
+                    `DingTalk Bot ${config.dingtalk.instances.length + 1}`,
+                  );
+                  if (inst) {
+                    setActiveDingTalkInstanceId(inst.instanceId);
+                    setDingtalkExpanded(true);
+                  }
                 }}
                 className="px-4 py-2 rounded-lg text-sm font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
               >
@@ -1340,69 +1552,121 @@ const IMSettings: React.FC = () => {
             )}
           </div>
         )}
-        {activePlatform === 'dingtalk' && activeDingTalkInstanceId && (() => {
-          const selectedInstance = config.dingtalk.instances.find(i => i.instanceId === activeDingTalkInstanceId);
-          if (!selectedInstance) return null;
-          const selectedStatus = status.dingtalk?.instances?.find(s => s.instanceId === activeDingTalkInstanceId);
-          return (
-            <DingTalkInstanceSettings
-              instance={selectedInstance}
-              instanceStatus={selectedStatus}
-              onConfigChange={(update) => {
-                dispatch(setDingTalkInstanceConfig({ instanceId: activeDingTalkInstanceId, config: update }));
-              }}
-              onSave={async (override) => {
-                const configToSave = override ? { ...selectedInstance, ...override } : selectedInstance;
-                if (selectedInstance.enabled) {
-                  await imService.updateDingTalkInstanceConfig(activeDingTalkInstanceId, configToSave);
-                } else {
-                  await imService.persistDingTalkInstanceConfig(activeDingTalkInstanceId, configToSave);
-                }
-              }}
-              onRename={async (newName) => {
-                dispatch(setDingTalkInstanceConfig({ instanceId: activeDingTalkInstanceId, config: { instanceName: newName } as any }));
-                await imService.persistDingTalkInstanceConfig(activeDingTalkInstanceId, { instanceName: newName } as any);
-              }}
-              onDelete={async () => {
-                await imService.deleteDingTalkInstance(activeDingTalkInstanceId);
-                const remaining = config.dingtalk.instances.filter(i => i.instanceId !== activeDingTalkInstanceId);
-                setActiveDingTalkInstanceId(remaining.length > 0 ? remaining[0].instanceId : null);
-              }}
-              onToggleEnabled={async () => {
-                const newEnabled = !selectedInstance.enabled;
-                if (newEnabled && !(selectedInstance.clientId && selectedInstance.clientSecret)) return;
-                const success = await imService.updateDingTalkInstanceConfig(activeDingTalkInstanceId, { enabled: newEnabled });
-                if (success) {
-                  dispatch(setDingTalkInstanceConfig({ instanceId: activeDingTalkInstanceId, config: { enabled: newEnabled } }));
-                  if (newEnabled) dispatch(clearError());
-                }
-              }}
-              onTestConnectivity={() => {
-                void handleConnectivityTest('dingtalk');
-              }}
-              testingPlatform={testingPlatform}
-              connectivityResults={connectivityResults}
-              language={language}
-            />
-          );
-        })()}
+        {activePlatform === 'dingtalk' &&
+          activeDingTalkInstanceId &&
+          (() => {
+            const selectedInstance = config.dingtalk.instances.find(
+              i => i.instanceId === activeDingTalkInstanceId,
+            );
+            if (!selectedInstance) return null;
+            const selectedStatus = status.dingtalk?.instances?.find(
+              s => s.instanceId === activeDingTalkInstanceId,
+            );
+            return (
+              <DingTalkInstanceSettings
+                instance={selectedInstance}
+                instanceStatus={selectedStatus}
+                onConfigChange={update => {
+                  dispatch(
+                    setDingTalkInstanceConfig({
+                      instanceId: activeDingTalkInstanceId,
+                      config: update,
+                    }),
+                  );
+                }}
+                onSave={async override => {
+                  const configToSave = override
+                    ? { ...selectedInstance, ...override }
+                    : selectedInstance;
+                  if (selectedInstance.enabled) {
+                    await imService.updateDingTalkInstanceConfig(
+                      activeDingTalkInstanceId,
+                      configToSave,
+                    );
+                  } else {
+                    await imService.persistDingTalkInstanceConfig(
+                      activeDingTalkInstanceId,
+                      configToSave,
+                    );
+                  }
+                }}
+                onRename={async newName => {
+                  dispatch(
+                    setDingTalkInstanceConfig({
+                      instanceId: activeDingTalkInstanceId,
+                      config: { instanceName: newName } as any,
+                    }),
+                  );
+                  await imService.persistDingTalkInstanceConfig(activeDingTalkInstanceId, {
+                    instanceName: newName,
+                  } as any);
+                }}
+                onDelete={async () => {
+                  await imService.deleteDingTalkInstance(activeDingTalkInstanceId);
+                  const remaining = config.dingtalk.instances.filter(
+                    i => i.instanceId !== activeDingTalkInstanceId,
+                  );
+                  setActiveDingTalkInstanceId(
+                    remaining.length > 0 ? remaining[0].instanceId : null,
+                  );
+                }}
+                onToggleEnabled={async () => {
+                  const newEnabled = !selectedInstance.enabled;
+                  if (newEnabled && !(selectedInstance.clientId && selectedInstance.clientSecret))
+                    return;
+                  const success = await imService.updateDingTalkInstanceConfig(
+                    activeDingTalkInstanceId,
+                    { enabled: newEnabled },
+                  );
+                  if (success) {
+                    dispatch(
+                      setDingTalkInstanceConfig({
+                        instanceId: activeDingTalkInstanceId,
+                        config: { enabled: newEnabled },
+                      }),
+                    );
+                    if (newEnabled) dispatch(clearError());
+                  }
+                }}
+                onTestConnectivity={() => {
+                  void handleConnectivityTest('dingtalk');
+                }}
+                testingPlatform={testingPlatform}
+                connectivityResults={connectivityResults}
+                language={language}
+              />
+            );
+          })()}
 
         {/* Feishu Settings (multi-instance) */}
         {activePlatform === 'feishu' && !activeFeishuInstanceId && (
           <div className="flex flex-col items-center justify-center py-12 text-center">
-            <img src={PlatformRegistry.logo('feishu')} alt="Feishu" className="w-12 h-12 object-contain rounded-md mb-4 opacity-50" />
+            <img
+              src={PlatformRegistry.logo('feishu')}
+              alt="Feishu"
+              className="w-12 h-12 object-contain rounded-md mb-4 opacity-50"
+            />
             <p className="text-sm text-secondary mb-4">
               {config.feishu.instances.length === 0
-                ? (language === 'zh' ? '尚未添加飞书实例，点击下方按钮添加' : 'No Feishu instances yet. Click below to add one.')
-                : (language === 'zh' ? '请在左侧选择一个飞书实例' : 'Select a Feishu instance from the sidebar.')}
+                ? language === 'zh'
+                  ? '尚未添加飞书实例，点击下方按钮添加'
+                  : 'No Feishu instances yet. Click below to add one.'
+                : language === 'zh'
+                  ? '请在左侧选择一个飞书实例'
+                  : 'Select a Feishu instance from the sidebar.'}
             </p>
             {config.feishu.instances.length < MAX_FEISHU_INSTANCES && (
               <button
                 type="button"
-                onClick={async (e) => {
+                onClick={async e => {
                   e.stopPropagation();
-                  const inst = await imService.addFeishuInstance(`Feishu Bot ${config.feishu.instances.length + 1}`);
-                  if (inst) { setActiveFeishuInstanceId(inst.instanceId); setFeishuExpanded(true); }
+                  const inst = await imService.addFeishuInstance(
+                    `Feishu Bot ${config.feishu.instances.length + 1}`,
+                  );
+                  if (inst) {
+                    setActiveFeishuInstanceId(inst.instanceId);
+                    setFeishuExpanded(true);
+                  }
                 }}
                 className="px-4 py-2 rounded-lg text-sm font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
               >
@@ -1411,69 +1675,115 @@ const IMSettings: React.FC = () => {
             )}
           </div>
         )}
-        {activePlatform === 'feishu' && activeFeishuInstanceId && (() => {
-          const selectedInstance = config.feishu.instances.find(i => i.instanceId === activeFeishuInstanceId);
-          if (!selectedInstance) return null;
-          const selectedStatus = status.feishu?.instances?.find(s => s.instanceId === activeFeishuInstanceId);
-          return (
-            <FeishuInstanceSettings
-              instance={selectedInstance}
-              instanceStatus={selectedStatus}
-              onConfigChange={(update) => {
-                dispatch(setFeishuInstanceConfig({ instanceId: activeFeishuInstanceId, config: update }));
-              }}
-              onSave={async (override) => {
-                const configToSave = override ? { ...selectedInstance, ...override } : selectedInstance;
-                if (selectedInstance.enabled) {
-                  await imService.updateFeishuInstanceConfig(activeFeishuInstanceId, configToSave);
-                } else {
-                  await imService.persistFeishuInstanceConfig(activeFeishuInstanceId, configToSave);
-                }
-              }}
-              onRename={async (newName) => {
-                dispatch(setFeishuInstanceConfig({ instanceId: activeFeishuInstanceId, config: { instanceName: newName } as any }));
-                await imService.persistFeishuInstanceConfig(activeFeishuInstanceId, { instanceName: newName } as any);
-              }}
-              onDelete={async () => {
-                await imService.deleteFeishuInstance(activeFeishuInstanceId);
-                const remaining = config.feishu.instances.filter(i => i.instanceId !== activeFeishuInstanceId);
-                setActiveFeishuInstanceId(remaining.length > 0 ? remaining[0].instanceId : null);
-              }}
-              onToggleEnabled={async () => {
-                const newEnabled = !selectedInstance.enabled;
-                if (newEnabled && !(selectedInstance.appId && selectedInstance.appSecret)) return;
-                const success = await imService.updateFeishuInstanceConfig(activeFeishuInstanceId, { enabled: newEnabled });
-                if (success) {
-                  dispatch(setFeishuInstanceConfig({ instanceId: activeFeishuInstanceId, config: { enabled: newEnabled } }));
-                  if (newEnabled) dispatch(clearError());
-                }
-              }}
-              onTestConnectivity={() => {
-                void handleConnectivityTest('feishu');
-              }}
-              testingPlatform={testingPlatform}
-              connectivityResults={connectivityResults}
-              language={language}
-            />
-          );
-        })()}
+        {activePlatform === 'feishu' &&
+          activeFeishuInstanceId &&
+          (() => {
+            const selectedInstance = config.feishu.instances.find(
+              i => i.instanceId === activeFeishuInstanceId,
+            );
+            if (!selectedInstance) return null;
+            const selectedStatus = status.feishu?.instances?.find(
+              s => s.instanceId === activeFeishuInstanceId,
+            );
+            return (
+              <FeishuInstanceSettings
+                instance={selectedInstance}
+                instanceStatus={selectedStatus}
+                onConfigChange={update => {
+                  dispatch(
+                    setFeishuInstanceConfig({ instanceId: activeFeishuInstanceId, config: update }),
+                  );
+                }}
+                onSave={async override => {
+                  const configToSave = override
+                    ? { ...selectedInstance, ...override }
+                    : selectedInstance;
+                  if (selectedInstance.enabled) {
+                    await imService.updateFeishuInstanceConfig(
+                      activeFeishuInstanceId,
+                      configToSave,
+                    );
+                  } else {
+                    await imService.persistFeishuInstanceConfig(
+                      activeFeishuInstanceId,
+                      configToSave,
+                    );
+                  }
+                }}
+                onRename={async newName => {
+                  dispatch(
+                    setFeishuInstanceConfig({
+                      instanceId: activeFeishuInstanceId,
+                      config: { instanceName: newName } as any,
+                    }),
+                  );
+                  await imService.persistFeishuInstanceConfig(activeFeishuInstanceId, {
+                    instanceName: newName,
+                  } as any);
+                }}
+                onDelete={async () => {
+                  await imService.deleteFeishuInstance(activeFeishuInstanceId);
+                  const remaining = config.feishu.instances.filter(
+                    i => i.instanceId !== activeFeishuInstanceId,
+                  );
+                  setActiveFeishuInstanceId(remaining.length > 0 ? remaining[0].instanceId : null);
+                }}
+                onToggleEnabled={async () => {
+                  const newEnabled = !selectedInstance.enabled;
+                  if (newEnabled && !(selectedInstance.appId && selectedInstance.appSecret)) return;
+                  const success = await imService.updateFeishuInstanceConfig(
+                    activeFeishuInstanceId,
+                    { enabled: newEnabled },
+                  );
+                  if (success) {
+                    dispatch(
+                      setFeishuInstanceConfig({
+                        instanceId: activeFeishuInstanceId,
+                        config: { enabled: newEnabled },
+                      }),
+                    );
+                    if (newEnabled) dispatch(clearError());
+                  }
+                }}
+                onTestConnectivity={() => {
+                  void handleConnectivityTest('feishu');
+                }}
+                testingPlatform={testingPlatform}
+                connectivityResults={connectivityResults}
+                language={language}
+              />
+            );
+          })()}
 
         {/* QQ Settings (multi-instance) */}
         {activePlatform === 'qq' && !activeQQInstanceId && (
           <div className="flex flex-col items-center justify-center py-12 text-center">
-            <img src={PlatformRegistry.logo('qq')} alt="QQ" className="w-12 h-12 object-contain rounded-md mb-4 opacity-50" />
+            <img
+              src={PlatformRegistry.logo('qq')}
+              alt="QQ"
+              className="w-12 h-12 object-contain rounded-md mb-4 opacity-50"
+            />
             <p className="text-sm text-secondary mb-4">
               {config.qq.instances.length === 0
-                ? (language === 'zh' ? '尚未添加 QQ 实例，点击下方按钮添加' : 'No QQ instances yet. Click below to add one.')
-                : (language === 'zh' ? '请在左侧选择一个 QQ 实例' : 'Select a QQ instance from the sidebar.')}
+                ? language === 'zh'
+                  ? '尚未添加 QQ 实例，点击下方按钮添加'
+                  : 'No QQ instances yet. Click below to add one.'
+                : language === 'zh'
+                  ? '请在左侧选择一个 QQ 实例'
+                  : 'Select a QQ instance from the sidebar.'}
             </p>
             {config.qq.instances.length < MAX_QQ_INSTANCES && (
               <button
                 type="button"
-                onClick={async (e) => {
+                onClick={async e => {
                   e.stopPropagation();
-                  const inst = await imService.addQQInstance(`QQ Bot ${config.qq.instances.length + 1}`);
-                  if (inst) { setActiveQQInstanceId(inst.instanceId); setQqExpanded(true); }
+                  const inst = await imService.addQQInstance(
+                    `QQ Bot ${config.qq.instances.length + 1}`,
+                  );
+                  if (inst) {
+                    setActiveQQInstanceId(inst.instanceId);
+                    setQqExpanded(true);
+                  }
                 }}
                 className="px-4 py-2 rounded-lg text-sm font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
               >
@@ -1482,52 +1792,76 @@ const IMSettings: React.FC = () => {
             )}
           </div>
         )}
-        {activePlatform === 'qq' && activeQQInstanceId && (() => {
-          const selectedInstance = config.qq.instances.find(i => i.instanceId === activeQQInstanceId);
-          if (!selectedInstance) return null;
-          const selectedStatus = status.qq?.instances?.find(s => s.instanceId === activeQQInstanceId);
-          return (
-            <QQInstanceSettings
-              instance={selectedInstance}
-              instanceStatus={selectedStatus}
-              onConfigChange={(update) => {
-                dispatch(setQQInstanceConfig({ instanceId: activeQQInstanceId, config: update }));
-              }}
-              onSave={async (override) => {
-                const configToSave = override ? { ...selectedInstance, ...override } : selectedInstance;
-                if (selectedInstance.enabled) {
-                  await imService.updateQQInstanceConfig(activeQQInstanceId, configToSave);
-                } else {
-                  await imService.persistQQInstanceConfig(activeQQInstanceId, configToSave);
-                }
-              }}
-              onRename={async (newName) => {
-                dispatch(setQQInstanceConfig({ instanceId: activeQQInstanceId, config: { instanceName: newName } as any }));
-                await imService.persistQQInstanceConfig(activeQQInstanceId, { instanceName: newName } as any);
-              }}
-              onDelete={async () => {
-                await imService.deleteQQInstance(activeQQInstanceId);
-                const remaining = config.qq.instances.filter(i => i.instanceId !== activeQQInstanceId);
-                setActiveQQInstanceId(remaining.length > 0 ? remaining[0].instanceId : null);
-              }}
-              onToggleEnabled={async () => {
-                const newEnabled = !selectedInstance.enabled;
-                if (newEnabled && !(selectedInstance.appId && selectedInstance.appSecret)) return;
-                const success = await imService.updateQQInstanceConfig(activeQQInstanceId, { enabled: newEnabled });
-                if (success) {
-                  dispatch(setQQInstanceConfig({ instanceId: activeQQInstanceId, config: { enabled: newEnabled } }));
-                  if (newEnabled) dispatch(clearError());
-                }
-              }}
-              onTestConnectivity={() => {
-                void handleConnectivityTest('qq');
-              }}
-              testingPlatform={testingPlatform}
-              connectivityResults={connectivityResults}
-              language={language}
-            />
-          );
-        })()}
+        {activePlatform === 'qq' &&
+          activeQQInstanceId &&
+          (() => {
+            const selectedInstance = config.qq.instances.find(
+              i => i.instanceId === activeQQInstanceId,
+            );
+            if (!selectedInstance) return null;
+            const selectedStatus = status.qq?.instances?.find(
+              s => s.instanceId === activeQQInstanceId,
+            );
+            return (
+              <QQInstanceSettings
+                instance={selectedInstance}
+                instanceStatus={selectedStatus}
+                onConfigChange={update => {
+                  dispatch(setQQInstanceConfig({ instanceId: activeQQInstanceId, config: update }));
+                }}
+                onSave={async override => {
+                  const configToSave = override
+                    ? { ...selectedInstance, ...override }
+                    : selectedInstance;
+                  if (selectedInstance.enabled) {
+                    await imService.updateQQInstanceConfig(activeQQInstanceId, configToSave);
+                  } else {
+                    await imService.persistQQInstanceConfig(activeQQInstanceId, configToSave);
+                  }
+                }}
+                onRename={async newName => {
+                  dispatch(
+                    setQQInstanceConfig({
+                      instanceId: activeQQInstanceId,
+                      config: { instanceName: newName } as any,
+                    }),
+                  );
+                  await imService.persistQQInstanceConfig(activeQQInstanceId, {
+                    instanceName: newName,
+                  } as any);
+                }}
+                onDelete={async () => {
+                  await imService.deleteQQInstance(activeQQInstanceId);
+                  const remaining = config.qq.instances.filter(
+                    i => i.instanceId !== activeQQInstanceId,
+                  );
+                  setActiveQQInstanceId(remaining.length > 0 ? remaining[0].instanceId : null);
+                }}
+                onToggleEnabled={async () => {
+                  const newEnabled = !selectedInstance.enabled;
+                  if (newEnabled && !(selectedInstance.appId && selectedInstance.appSecret)) return;
+                  const success = await imService.updateQQInstanceConfig(activeQQInstanceId, {
+                    enabled: newEnabled,
+                  });
+                  if (success) {
+                    dispatch(
+                      setQQInstanceConfig({
+                        instanceId: activeQQInstanceId,
+                        config: { enabled: newEnabled },
+                      }),
+                    );
+                    if (newEnabled) dispatch(clearError());
+                  }
+                }}
+                onTestConnectivity={() => {
+                  void handleConnectivityTest('qq');
+                }}
+                testingPlatform={testingPlatform}
+                connectivityResults={connectivityResults}
+                language={language}
+              />
+            );
+          })()}
 
         {/* Telegram Settings */}
         {activePlatform === 'telegram' && (
@@ -1539,18 +1873,16 @@ const IMSettings: React.FC = () => {
                 i18nService.t('imTelegramGuideStep3'),
                 i18nService.t('imTelegramGuideStep4'),
               ]}
-                guideUrl={PlatformRegistry.guideUrl('telegram')}
+              guideUrl={PlatformRegistry.guideUrl('telegram')}
             />
             {/* Bot Token */}
             <div className="space-y-1.5">
-              <label className="block text-xs font-medium text-secondary">
-                Bot Token
-              </label>
+              <label className="block text-xs font-medium text-secondary">Bot Token</label>
               <div className="relative">
                 <input
                   type={showSecrets['telegram.botToken'] ? 'text' : 'password'}
                   value={tgOpenClawConfig.botToken}
-                  onChange={(e) => handleTelegramOpenClawChange({ botToken: e.target.value })}
+                  onChange={e => handleTelegramOpenClawChange({ botToken: e.target.value })}
                   onBlur={() => handleSaveTelegramOpenClawConfig()}
                   className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-sm transition-colors"
                   placeholder="123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
@@ -1559,7 +1891,12 @@ const IMSettings: React.FC = () => {
                   {tgOpenClawConfig.botToken && (
                     <button
                       type="button"
-                      onClick={() => { handleTelegramOpenClawChange({ botToken: '' }); void imService.persistConfig({ telegram: { ...tgOpenClawConfig, botToken: '' } }); }}
+                      onClick={() => {
+                        handleTelegramOpenClawChange({ botToken: '' });
+                        void imService.persistConfig({
+                          telegram: { ...tgOpenClawConfig, botToken: '' },
+                        });
+                      }}
                       className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                       title={i18nService.t('clear') || 'Clear'}
                     >
@@ -1568,17 +1905,28 @@ const IMSettings: React.FC = () => {
                   )}
                   <button
                     type="button"
-                    onClick={() => setShowSecrets(prev => ({ ...prev, 'telegram.botToken': !prev['telegram.botToken'] }))}
+                    onClick={() =>
+                      setShowSecrets(prev => ({
+                        ...prev,
+                        'telegram.botToken': !prev['telegram.botToken'],
+                      }))
+                    }
                     className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                    title={showSecrets['telegram.botToken'] ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                    title={
+                      showSecrets['telegram.botToken']
+                        ? i18nService.t('hide') || 'Hide'
+                        : i18nService.t('show') || 'Show'
+                    }
                   >
-                    {showSecrets['telegram.botToken'] ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                    {showSecrets['telegram.botToken'] ? (
+                      <EyeIcon className="h-4 w-4" />
+                    ) : (
+                      <EyeSlashIcon className="h-4 w-4" />
+                    )}
                   </button>
                 </div>
               </div>
-              <p className="text-xs text-secondary">
-                {i18nService.t('imTelegramTokenHint')}
-              </p>
+              <p className="text-xs text-secondary">{i18nService.t('imTelegramTokenHint')}</p>
             </div>
 
             {/* Advanced Settings (collapsible) */}
@@ -1589,13 +1937,13 @@ const IMSettings: React.FC = () => {
               <div className="mt-2 space-y-3 pl-2 border-l-2 border-border-subtle">
                 {/* DM Policy */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    DM Policy
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">DM Policy</label>
                   <select
                     value={tgOpenClawConfig.dmPolicy}
-                    onChange={(e) => {
-                      const update = { dmPolicy: e.target.value as TelegramOpenClawConfig['dmPolicy'] };
+                    onChange={e => {
+                      const update = {
+                        dmPolicy: e.target.value as TelegramOpenClawConfig['dmPolicy'],
+                      };
                       handleTelegramOpenClawChange(update);
                       void handleSaveTelegramOpenClawConfig(update);
                     }}
@@ -1620,16 +1968,18 @@ const IMSettings: React.FC = () => {
                     <input
                       type="text"
                       value={allowedUserIdInput}
-                      onChange={(e) => setAllowedUserIdInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
+                      onChange={e => setAllowedUserIdInput(e.target.value)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                           e.preventDefault();
                           const id = allowedUserIdInput.trim();
                           if (id && !tgOpenClawConfig.allowFrom.includes(id)) {
                             const newIds = [...tgOpenClawConfig.allowFrom, id];
                             handleTelegramOpenClawChange({ allowFrom: newIds });
                             setAllowedUserIdInput('');
-                            void imService.persistConfig({ telegram: { ...tgOpenClawConfig, allowFrom: newIds } });
+                            void imService.persistConfig({
+                              telegram: { ...tgOpenClawConfig, allowFrom: newIds },
+                            });
                           }
                         }
                       }}
@@ -1644,7 +1994,9 @@ const IMSettings: React.FC = () => {
                           const newIds = [...tgOpenClawConfig.allowFrom, id];
                           handleTelegramOpenClawChange({ allowFrom: newIds });
                           setAllowedUserIdInput('');
-                          void imService.persistConfig({ telegram: { ...tgOpenClawConfig, allowFrom: newIds } });
+                          void imService.persistConfig({
+                            telegram: { ...tgOpenClawConfig, allowFrom: newIds },
+                          });
                         }
                       }}
                       className="px-3 py-2 rounded-lg text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
@@ -1654,7 +2006,7 @@ const IMSettings: React.FC = () => {
                   </div>
                   {tgOpenClawConfig.allowFrom.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 mt-1.5">
-                      {tgOpenClawConfig.allowFrom.map((id) => (
+                      {tgOpenClawConfig.allowFrom.map(id => (
                         <span
                           key={id}
                           className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
@@ -1663,9 +2015,11 @@ const IMSettings: React.FC = () => {
                           <button
                             type="button"
                             onClick={() => {
-                              const newIds = tgOpenClawConfig.allowFrom.filter((uid) => uid !== id);
+                              const newIds = tgOpenClawConfig.allowFrom.filter(uid => uid !== id);
                               handleTelegramOpenClawChange({ allowFrom: newIds });
-                              void imService.persistConfig({ telegram: { ...tgOpenClawConfig, allowFrom: newIds } });
+                              void imService.persistConfig({
+                                telegram: { ...tgOpenClawConfig, allowFrom: newIds },
+                              });
                             }}
                             className="text-secondary hover:text-red-500 dark:hover:text-red-400 transition-colors"
                           >
@@ -1679,13 +2033,13 @@ const IMSettings: React.FC = () => {
 
                 {/* Streaming Mode */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Streaming
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Streaming</label>
                   <select
                     value={tgOpenClawConfig.streaming}
-                    onChange={(e) => {
-                      const update = { streaming: e.target.value as TelegramOpenClawConfig['streaming'] };
+                    onChange={e => {
+                      const update = {
+                        streaming: e.target.value as TelegramOpenClawConfig['streaming'],
+                      };
                       handleTelegramOpenClawChange(update);
                       void handleSaveTelegramOpenClawConfig(update);
                     }}
@@ -1700,13 +2054,11 @@ const IMSettings: React.FC = () => {
 
                 {/* Proxy */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Proxy
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Proxy</label>
                   <input
                     type="text"
                     value={tgOpenClawConfig.proxy}
-                    onChange={(e) => handleTelegramOpenClawChange({ proxy: e.target.value })}
+                    onChange={e => handleTelegramOpenClawChange({ proxy: e.target.value })}
                     onBlur={() => handleSaveTelegramOpenClawConfig()}
                     className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
                     placeholder="socks5://localhost:9050"
@@ -1715,13 +2067,13 @@ const IMSettings: React.FC = () => {
 
                 {/* Group Policy */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Group Policy
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Group Policy</label>
                   <select
                     value={tgOpenClawConfig.groupPolicy}
-                    onChange={(e) => {
-                      const update = { groupPolicy: e.target.value as TelegramOpenClawConfig['groupPolicy'] };
+                    onChange={e => {
+                      const update = {
+                        groupPolicy: e.target.value as TelegramOpenClawConfig['groupPolicy'],
+                      };
                       handleTelegramOpenClawChange(update);
                       void handleSaveTelegramOpenClawConfig(update);
                     }}
@@ -1735,13 +2087,13 @@ const IMSettings: React.FC = () => {
 
                 {/* Reply-to Mode */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Reply-to Mode
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Reply-to Mode</label>
                   <select
                     value={tgOpenClawConfig.replyToMode}
-                    onChange={(e) => {
-                      const update = { replyToMode: e.target.value as TelegramOpenClawConfig['replyToMode'] };
+                    onChange={e => {
+                      const update = {
+                        replyToMode: e.target.value as TelegramOpenClawConfig['replyToMode'],
+                      };
                       handleTelegramOpenClawChange(update);
                       void handleSaveTelegramOpenClawConfig(update);
                     }}
@@ -1755,13 +2107,13 @@ const IMSettings: React.FC = () => {
 
                 {/* History Limit */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    History Limit
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">History Limit</label>
                   <input
                     type="number"
                     value={tgOpenClawConfig.historyLimit}
-                    onChange={(e) => handleTelegramOpenClawChange({ historyLimit: parseInt(e.target.value) || 50 })}
+                    onChange={e =>
+                      handleTelegramOpenClawChange({ historyLimit: parseInt(e.target.value) || 50 })
+                    }
                     onBlur={() => handleSaveTelegramOpenClawConfig()}
                     className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
                     min="1"
@@ -1771,13 +2123,13 @@ const IMSettings: React.FC = () => {
 
                 {/* Media Max MB */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Media Max (MB)
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Media Max (MB)</label>
                   <input
                     type="number"
                     value={tgOpenClawConfig.mediaMaxMb}
-                    onChange={(e) => handleTelegramOpenClawChange({ mediaMaxMb: parseInt(e.target.value) || 5 })}
+                    onChange={e =>
+                      handleTelegramOpenClawChange({ mediaMaxMb: parseInt(e.target.value) || 5 })
+                    }
                     onBlur={() => handleSaveTelegramOpenClawConfig()}
                     className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
                     min="1"
@@ -1787,9 +2139,7 @@ const IMSettings: React.FC = () => {
 
                 {/* Link Preview */}
                 <div className="flex items-center justify-between">
-                  <label className="text-xs font-medium text-secondary">
-                    Link Preview
-                  </label>
+                  <label className="text-xs font-medium text-secondary">Link Preview</label>
                   <button
                     type="button"
                     onClick={() => {
@@ -1801,21 +2151,21 @@ const IMSettings: React.FC = () => {
                       tgOpenClawConfig.linkPreview ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
                     }`}
                   >
-                    <span className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                      tgOpenClawConfig.linkPreview ? 'translate-x-4' : 'translate-x-0'
-                    }`} />
+                    <span
+                      className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                        tgOpenClawConfig.linkPreview ? 'translate-x-4' : 'translate-x-0'
+                      }`}
+                    />
                   </button>
                 </div>
 
                 {/* Webhook URL */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Webhook URL
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Webhook URL</label>
                   <input
                     type="text"
                     value={tgOpenClawConfig.webhookUrl}
-                    onChange={(e) => handleTelegramOpenClawChange({ webhookUrl: e.target.value })}
+                    onChange={e => handleTelegramOpenClawChange({ webhookUrl: e.target.value })}
                     onBlur={() => handleSaveTelegramOpenClawConfig()}
                     className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
                     placeholder="https://example.com/telegram-webhook"
@@ -1831,7 +2181,9 @@ const IMSettings: React.FC = () => {
                     <input
                       type="password"
                       value={tgOpenClawConfig.webhookSecret}
-                      onChange={(e) => handleTelegramOpenClawChange({ webhookSecret: e.target.value })}
+                      onChange={e =>
+                        handleTelegramOpenClawChange({ webhookSecret: e.target.value })
+                      }
                       onBlur={() => handleSaveTelegramOpenClawConfig()}
                       className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
                       placeholder="webhook-secret"
@@ -1841,9 +2193,7 @@ const IMSettings: React.FC = () => {
               </div>
             </details>
 
-            <div className="pt-1">
-              {renderConnectivityTestButton('telegram')}
-            </div>
+            <div className="pt-1">{renderConnectivityTestButton('telegram')}</div>
           </div>
         )}
 
@@ -1859,18 +2209,16 @@ const IMSettings: React.FC = () => {
                 i18nService.t('imDiscordGuideStep5'),
                 i18nService.t('imDiscordGuideStep6'),
               ]}
-                guideUrl={PlatformRegistry.guideUrl('discord')}
+              guideUrl={PlatformRegistry.guideUrl('discord')}
             />
             {/* Bot Token */}
             <div className="space-y-1.5">
-              <label className="block text-xs font-medium text-secondary">
-                Bot Token
-              </label>
+              <label className="block text-xs font-medium text-secondary">Bot Token</label>
               <div className="relative">
                 <input
                   type={showSecrets['discord.botToken'] ? 'text' : 'password'}
                   value={dcOpenClawConfig.botToken}
-                  onChange={(e) => handleDiscordOpenClawChange({ botToken: e.target.value })}
+                  onChange={e => handleDiscordOpenClawChange({ botToken: e.target.value })}
                   onBlur={() => handleSaveDiscordOpenClawConfig()}
                   className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-sm transition-colors"
                   placeholder="MTIzNDU2Nzg5MDEyMzQ1Njc4OQ..."
@@ -1879,7 +2227,12 @@ const IMSettings: React.FC = () => {
                   {dcOpenClawConfig.botToken && (
                     <button
                       type="button"
-                      onClick={() => { handleDiscordOpenClawChange({ botToken: '' }); void imService.persistConfig({ discord: { ...dcOpenClawConfig, botToken: '' } }); }}
+                      onClick={() => {
+                        handleDiscordOpenClawChange({ botToken: '' });
+                        void imService.persistConfig({
+                          discord: { ...dcOpenClawConfig, botToken: '' },
+                        });
+                      }}
                       className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                       title={i18nService.t('clear') || 'Clear'}
                     >
@@ -1888,17 +2241,28 @@ const IMSettings: React.FC = () => {
                   )}
                   <button
                     type="button"
-                    onClick={() => setShowSecrets(prev => ({ ...prev, 'discord.botToken': !prev['discord.botToken'] }))}
+                    onClick={() =>
+                      setShowSecrets(prev => ({
+                        ...prev,
+                        'discord.botToken': !prev['discord.botToken'],
+                      }))
+                    }
                     className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                    title={showSecrets['discord.botToken'] ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                    title={
+                      showSecrets['discord.botToken']
+                        ? i18nService.t('hide') || 'Hide'
+                        : i18nService.t('show') || 'Show'
+                    }
                   >
-                    {showSecrets['discord.botToken'] ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                    {showSecrets['discord.botToken'] ? (
+                      <EyeIcon className="h-4 w-4" />
+                    ) : (
+                      <EyeSlashIcon className="h-4 w-4" />
+                    )}
                   </button>
                 </div>
               </div>
-              <p className="text-xs text-secondary">
-                {i18nService.t('imDiscordTokenHint')}
-              </p>
+              <p className="text-xs text-secondary">{i18nService.t('imDiscordTokenHint')}</p>
             </div>
 
             {/* Advanced Settings (collapsible) */}
@@ -1909,13 +2273,13 @@ const IMSettings: React.FC = () => {
               <div className="mt-2 space-y-3 pl-2 border-l-2 border-border-subtle">
                 {/* DM Policy */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    DM Policy
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">DM Policy</label>
                   <select
                     value={dcOpenClawConfig.dmPolicy}
-                    onChange={(e) => {
-                      const update = { dmPolicy: e.target.value as DiscordOpenClawConfig['dmPolicy'] };
+                    onChange={e => {
+                      const update = {
+                        dmPolicy: e.target.value as DiscordOpenClawConfig['dmPolicy'],
+                      };
                       handleDiscordOpenClawChange(update);
                       void handleSaveDiscordOpenClawConfig(update);
                     }}
@@ -1940,16 +2304,18 @@ const IMSettings: React.FC = () => {
                     <input
                       type="text"
                       value={discordAllowedUserIdInput}
-                      onChange={(e) => setDiscordAllowedUserIdInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
+                      onChange={e => setDiscordAllowedUserIdInput(e.target.value)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                           e.preventDefault();
                           const id = discordAllowedUserIdInput.trim();
                           if (id && !dcOpenClawConfig.allowFrom.includes(id)) {
                             const newIds = [...dcOpenClawConfig.allowFrom, id];
                             handleDiscordOpenClawChange({ allowFrom: newIds });
                             setDiscordAllowedUserIdInput('');
-                            void imService.persistConfig({ discord: { ...dcOpenClawConfig, allowFrom: newIds } });
+                            void imService.persistConfig({
+                              discord: { ...dcOpenClawConfig, allowFrom: newIds },
+                            });
                           }
                         }
                       }}
@@ -1964,7 +2330,9 @@ const IMSettings: React.FC = () => {
                           const newIds = [...dcOpenClawConfig.allowFrom, id];
                           handleDiscordOpenClawChange({ allowFrom: newIds });
                           setDiscordAllowedUserIdInput('');
-                          void imService.persistConfig({ discord: { ...dcOpenClawConfig, allowFrom: newIds } });
+                          void imService.persistConfig({
+                            discord: { ...dcOpenClawConfig, allowFrom: newIds },
+                          });
                         }
                       }}
                       className="px-3 py-2 rounded-lg text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
@@ -1974,7 +2342,7 @@ const IMSettings: React.FC = () => {
                   </div>
                   {dcOpenClawConfig.allowFrom.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 mt-1.5">
-                      {dcOpenClawConfig.allowFrom.map((id) => (
+                      {dcOpenClawConfig.allowFrom.map(id => (
                         <span
                           key={id}
                           className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
@@ -1983,9 +2351,11 @@ const IMSettings: React.FC = () => {
                           <button
                             type="button"
                             onClick={() => {
-                              const newIds = dcOpenClawConfig.allowFrom.filter((uid) => uid !== id);
+                              const newIds = dcOpenClawConfig.allowFrom.filter(uid => uid !== id);
                               handleDiscordOpenClawChange({ allowFrom: newIds });
-                              void imService.persistConfig({ discord: { ...dcOpenClawConfig, allowFrom: newIds } });
+                              void imService.persistConfig({
+                                discord: { ...dcOpenClawConfig, allowFrom: newIds },
+                              });
                             }}
                             className="text-secondary hover:text-red-500 transition-colors"
                           >
@@ -1999,13 +2369,13 @@ const IMSettings: React.FC = () => {
 
                 {/* Streaming */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Streaming
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Streaming</label>
                   <select
                     value={dcOpenClawConfig.streaming}
-                    onChange={(e) => {
-                      const update = { streaming: e.target.value as DiscordOpenClawConfig['streaming'] };
+                    onChange={e => {
+                      const update = {
+                        streaming: e.target.value as DiscordOpenClawConfig['streaming'],
+                      };
                       handleDiscordOpenClawChange(update);
                       void handleSaveDiscordOpenClawConfig(update);
                     }}
@@ -2020,13 +2390,11 @@ const IMSettings: React.FC = () => {
 
                 {/* Proxy */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Proxy
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Proxy</label>
                   <input
                     type="text"
                     value={dcOpenClawConfig.proxy}
-                    onChange={(e) => handleDiscordOpenClawChange({ proxy: e.target.value })}
+                    onChange={e => handleDiscordOpenClawChange({ proxy: e.target.value })}
                     onBlur={() => handleSaveDiscordOpenClawConfig()}
                     className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
                     placeholder="http://proxy:port"
@@ -2035,13 +2403,13 @@ const IMSettings: React.FC = () => {
 
                 {/* Group Policy */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Group Policy
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Group Policy</label>
                   <select
                     value={dcOpenClawConfig.groupPolicy}
-                    onChange={(e) => {
-                      const update = { groupPolicy: e.target.value as DiscordOpenClawConfig['groupPolicy'] };
+                    onChange={e => {
+                      const update = {
+                        groupPolicy: e.target.value as DiscordOpenClawConfig['groupPolicy'],
+                      };
                       handleDiscordOpenClawChange(update);
                       void handleSaveDiscordOpenClawConfig(update);
                     }}
@@ -2062,16 +2430,18 @@ const IMSettings: React.FC = () => {
                     <input
                       type="text"
                       value={discordServerAllowIdInput}
-                      onChange={(e) => setDiscordServerAllowIdInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
+                      onChange={e => setDiscordServerAllowIdInput(e.target.value)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                           e.preventDefault();
                           const id = discordServerAllowIdInput.trim();
                           if (id && !dcOpenClawConfig.groupAllowFrom.includes(id)) {
                             const newIds = [...dcOpenClawConfig.groupAllowFrom, id];
                             handleDiscordOpenClawChange({ groupAllowFrom: newIds });
                             setDiscordServerAllowIdInput('');
-                            void imService.persistConfig({ discord: { ...dcOpenClawConfig, groupAllowFrom: newIds } });
+                            void imService.persistConfig({
+                              discord: { ...dcOpenClawConfig, groupAllowFrom: newIds },
+                            });
                           }
                         }
                       }}
@@ -2086,7 +2456,9 @@ const IMSettings: React.FC = () => {
                           const newIds = [...dcOpenClawConfig.groupAllowFrom, id];
                           handleDiscordOpenClawChange({ groupAllowFrom: newIds });
                           setDiscordServerAllowIdInput('');
-                          void imService.persistConfig({ discord: { ...dcOpenClawConfig, groupAllowFrom: newIds } });
+                          void imService.persistConfig({
+                            discord: { ...dcOpenClawConfig, groupAllowFrom: newIds },
+                          });
                         }
                       }}
                       className="px-3 py-2 rounded-lg text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
@@ -2096,7 +2468,7 @@ const IMSettings: React.FC = () => {
                   </div>
                   {dcOpenClawConfig.groupAllowFrom.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 mt-1.5">
-                      {dcOpenClawConfig.groupAllowFrom.map((id) => (
+                      {dcOpenClawConfig.groupAllowFrom.map(id => (
                         <span
                           key={id}
                           className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
@@ -2105,9 +2477,13 @@ const IMSettings: React.FC = () => {
                           <button
                             type="button"
                             onClick={() => {
-                              const newIds = dcOpenClawConfig.groupAllowFrom.filter((gid) => gid !== id);
+                              const newIds = dcOpenClawConfig.groupAllowFrom.filter(
+                                gid => gid !== id,
+                              );
                               handleDiscordOpenClawChange({ groupAllowFrom: newIds });
-                              void imService.persistConfig({ discord: { ...dcOpenClawConfig, groupAllowFrom: newIds } });
+                              void imService.persistConfig({
+                                discord: { ...dcOpenClawConfig, groupAllowFrom: newIds },
+                              });
                             }}
                             className="text-secondary hover:text-red-500 transition-colors"
                           >
@@ -2121,15 +2497,13 @@ const IMSettings: React.FC = () => {
 
                 {/* History Limit */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    History Limit
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">History Limit</label>
                   <input
                     type="number"
                     min={1}
                     max={200}
                     value={dcOpenClawConfig.historyLimit}
-                    onChange={(e) => {
+                    onChange={e => {
                       const val = parseInt(e.target.value) || 50;
                       handleDiscordOpenClawChange({ historyLimit: val });
                     }}
@@ -2140,15 +2514,13 @@ const IMSettings: React.FC = () => {
 
                 {/* Media Max MB */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Media Max MB
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Media Max MB</label>
                   <input
                     type="number"
                     min={1}
                     max={100}
                     value={dcOpenClawConfig.mediaMaxMb}
-                    onChange={(e) => {
+                    onChange={e => {
                       const val = parseInt(e.target.value) || 25;
                       handleDiscordOpenClawChange({ mediaMaxMb: val });
                     }}
@@ -2159,9 +2531,7 @@ const IMSettings: React.FC = () => {
               </div>
             </details>
 
-            <div className="pt-1">
-              {renderConnectivityTestButton('discord')}
-            </div>
+            <div className="pt-1">{renderConnectivityTestButton('discord')}</div>
 
             {/* Bot username display */}
             {status.discord.botUsername && (
@@ -2198,12 +2568,16 @@ const IMSettings: React.FC = () => {
                 hints={nimSchemaData.hints}
                 value={config.nim as unknown as Record<string, unknown>}
                 onChange={(path, value) => {
-                  const updated = deepSet({ ...config.nim } as unknown as Record<string, unknown>, path, value);
+                  const updated = deepSet(
+                    { ...config.nim } as unknown as Record<string, unknown>,
+                    path,
+                    value,
+                  );
                   dispatch(setNimConfig(updated as any));
                 }}
                 onBlur={handleSaveConfig}
                 showSecrets={showSecrets}
-                onToggleSecret={(path) => setShowSecrets(prev => ({ ...prev, [path]: !prev[path] }))}
+                onToggleSecret={path => setShowSecrets(prev => ({ ...prev, [path]: !prev[path] }))}
               />
             ) : (
               /* Fallback: minimal credential inputs when schema not yet loaded */
@@ -2213,7 +2587,7 @@ const IMSettings: React.FC = () => {
                   <input
                     type="text"
                     value={config.nim.appKey}
-                    onChange={(e) => dispatch(setNimConfig({ appKey: e.target.value }))}
+                    onChange={e => dispatch(setNimConfig({ appKey: e.target.value }))}
                     onBlur={handleSaveConfig}
                     className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
                     placeholder="your_app_key"
@@ -2224,7 +2598,7 @@ const IMSettings: React.FC = () => {
                   <input
                     type="text"
                     value={config.nim.account}
-                    onChange={(e) => dispatch(setNimConfig({ account: e.target.value }))}
+                    onChange={e => dispatch(setNimConfig({ account: e.target.value }))}
                     onBlur={handleSaveConfig}
                     className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
                     placeholder="bot_account_id"
@@ -2235,7 +2609,7 @@ const IMSettings: React.FC = () => {
                   <input
                     type="password"
                     value={config.nim.token}
-                    onChange={(e) => dispatch(setNimConfig({ token: e.target.value }))}
+                    onChange={e => dispatch(setNimConfig({ token: e.target.value }))}
                     onBlur={handleSaveConfig}
                     className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
                     placeholder="••••••••••••"
@@ -2244,9 +2618,7 @@ const IMSettings: React.FC = () => {
               </div>
             )}
 
-            <div className="pt-1">
-              {renderConnectivityTestButton('nim')}
-            </div>
+            <div className="pt-1">{renderConnectivityTestButton('nim')}</div>
 
             {status.nim.botAccount && (
               <div className="text-xs text-green-600 dark:text-green-400 bg-green-500/10 px-3 py-2 rounded-lg">
@@ -2267,23 +2639,28 @@ const IMSettings: React.FC = () => {
           <div className="space-y-3">
             {/* Client ID */}
             <div className="space-y-1.5">
-              <label className="block text-xs font-medium text-secondary">
-                Client ID
-              </label>
+              <label className="block text-xs font-medium text-secondary">Client ID</label>
               <div className="relative">
                 <input
                   type="text"
                   value={config['netease-bee'].clientId}
-                  onChange={(e) => handleNeteaseBeeChanChange('clientId', e.target.value)}
+                  onChange={e => handleNeteaseBeeChanChange('clientId', e.target.value)}
                   onBlur={handleSaveConfig}
                   className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-8 text-sm transition-colors"
-                  placeholder={i18nService.t('neteaseBeeChanClientIdPlaceholder') || '您的Client ID'}
+                  placeholder={
+                    i18nService.t('neteaseBeeChanClientIdPlaceholder') || '您的Client ID'
+                  }
                 />
                 {config['netease-bee'].clientId && (
                   <div className="absolute right-2 inset-y-0 flex items-center">
                     <button
                       type="button"
-                      onClick={() => { handleNeteaseBeeChanChange('clientId', ''); void imService.persistConfig({ 'netease-bee': { ...config['netease-bee'], clientId: '' } }); }}
+                      onClick={() => {
+                        handleNeteaseBeeChanChange('clientId', '');
+                        void imService.persistConfig({
+                          'netease-bee': { ...config['netease-bee'], clientId: '' },
+                        });
+                      }}
                       className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                       title={i18nService.t('clear') || 'Clear'}
                     >
@@ -2296,14 +2673,12 @@ const IMSettings: React.FC = () => {
 
             {/* Client Secret */}
             <div className="space-y-1.5">
-              <label className="block text-xs font-medium text-secondary">
-                Client Secret
-              </label>
+              <label className="block text-xs font-medium text-secondary">Client Secret</label>
               <div className="relative">
                 <input
                   type={showSecrets['netease-bee.secret'] ? 'text' : 'password'}
                   value={config['netease-bee'].secret}
-                  onChange={(e) => handleNeteaseBeeChanChange('secret', e.target.value)}
+                  onChange={e => handleNeteaseBeeChanChange('secret', e.target.value)}
                   onBlur={handleSaveConfig}
                   className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-sm transition-colors"
                   placeholder="••••••••••••"
@@ -2312,7 +2687,12 @@ const IMSettings: React.FC = () => {
                   {config['netease-bee'].secret && (
                     <button
                       type="button"
-                      onClick={() => { handleNeteaseBeeChanChange('secret', ''); void imService.persistConfig({ 'netease-bee': { ...config['netease-bee'], secret: '' } }); }}
+                      onClick={() => {
+                        handleNeteaseBeeChanChange('secret', '');
+                        void imService.persistConfig({
+                          'netease-bee': { ...config['netease-bee'], secret: '' },
+                        });
+                      }}
                       className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                       title={i18nService.t('clear') || 'Clear'}
                     >
@@ -2321,19 +2701,30 @@ const IMSettings: React.FC = () => {
                   )}
                   <button
                     type="button"
-                    onClick={() => setShowSecrets(prev => ({ ...prev, 'netease-bee.secret': !prev['netease-bee.secret'] }))}
+                    onClick={() =>
+                      setShowSecrets(prev => ({
+                        ...prev,
+                        'netease-bee.secret': !prev['netease-bee.secret'],
+                      }))
+                    }
                     className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                    title={showSecrets['netease-bee.secret'] ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                    title={
+                      showSecrets['netease-bee.secret']
+                        ? i18nService.t('hide') || 'Hide'
+                        : i18nService.t('show') || 'Show'
+                    }
                   >
-                    {showSecrets['netease-bee.secret'] ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                    {showSecrets['netease-bee.secret'] ? (
+                      <EyeIcon className="h-4 w-4" />
+                    ) : (
+                      <EyeSlashIcon className="h-4 w-4" />
+                    )}
                   </button>
                 </div>
               </div>
             </div>
 
-            <div className="pt-1">
-              {renderConnectivityTestButton('netease-bee')}
-            </div>
+            <div className="pt-1">{renderConnectivityTestButton('netease-bee')}</div>
 
             {/* Bot account display */}
             {status['netease-bee']?.botAccount && (
@@ -2365,9 +2756,7 @@ const IMSettings: React.FC = () => {
                   >
                     {i18nService.t('imWeixinScanBtn')}
                   </button>
-                  <p className="text-xs text-secondary">
-                    {i18nService.t('imWeixinScanHint')}
-                  </p>
+                  <p className="text-xs text-secondary">{i18nService.t('imWeixinScanHint')}</p>
                   {weixinQrStatus === 'error' && weixinQrError && (
                     <div className="flex items-center justify-center gap-1.5 text-xs text-red-500 bg-red-500/10 px-3 py-2 rounded-lg">
                       <XCircleIcon className="h-4 w-4 flex-shrink-0" />
@@ -2411,13 +2800,11 @@ const IMSettings: React.FC = () => {
                 i18nService.t('imWeixinGuideStep2'),
                 i18nService.t('imWeixinGuideStep3'),
               ]}
-                guideUrl={PlatformRegistry.guideUrl('weixin')}
+              guideUrl={PlatformRegistry.guideUrl('weixin')}
             />
 
             {/* Connectivity test */}
-            <div className="pt-1">
-              {renderConnectivityTestButton('weixin')}
-            </div>
+            <div className="pt-1">{renderConnectivityTestButton('weixin')}</div>
 
             {/* Account ID display */}
             {weixinOpenClawConfig.accountId && (
@@ -2450,9 +2837,7 @@ const IMSettings: React.FC = () => {
                   ? i18nService.t('imWecomQuickSetupPending')
                   : i18nService.t('imWecomScanBtn')}
               </button>
-              <p className="text-xs text-secondary">
-                {i18nService.t('imWecomScanHint')}
-              </p>
+              <p className="text-xs text-secondary">{i18nService.t('imWecomScanHint')}</p>
               {wecomQuickSetupStatus === 'success' && (
                 <div className="flex items-center justify-center gap-1.5 text-xs text-green-600 dark:text-green-400 bg-green-500/10 px-3 py-2 rounded-lg">
                   <CheckCircleIcon className="h-4 w-4 flex-shrink-0" />
@@ -2483,18 +2868,16 @@ const IMSettings: React.FC = () => {
                 i18nService.t('imWecomGuideStep2'),
                 i18nService.t('imWecomGuideStep3'),
               ]}
-                guideUrl={PlatformRegistry.guideUrl('wecom')}
+              guideUrl={PlatformRegistry.guideUrl('wecom')}
             />
             {/* Bot ID */}
             <div className="space-y-1.5">
-              <label className="block text-xs font-medium text-secondary">
-                Bot ID
-              </label>
+              <label className="block text-xs font-medium text-secondary">Bot ID</label>
               <div className="relative">
                 <input
                   type="text"
                   value={wecomOpenClawConfig.botId}
-                  onChange={(e) => handleWecomOpenClawChange({ botId: e.target.value })}
+                  onChange={e => handleWecomOpenClawChange({ botId: e.target.value })}
                   onBlur={() => handleSaveWecomOpenClawConfig()}
                   className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-8 text-sm transition-colors"
                   placeholder={i18nService.t('imWecomBotIdPlaceholder')}
@@ -2503,7 +2886,12 @@ const IMSettings: React.FC = () => {
                   <div className="absolute right-2 inset-y-0 flex items-center">
                     <button
                       type="button"
-                      onClick={() => { handleWecomOpenClawChange({ botId: '' }); void imService.persistConfig({ wecom: { ...wecomOpenClawConfig, botId: '' } }); }}
+                      onClick={() => {
+                        handleWecomOpenClawChange({ botId: '' });
+                        void imService.persistConfig({
+                          wecom: { ...wecomOpenClawConfig, botId: '' },
+                        });
+                      }}
                       className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                       title={i18nService.t('clear') || 'Clear'}
                     >
@@ -2516,14 +2904,12 @@ const IMSettings: React.FC = () => {
 
             {/* Secret */}
             <div className="space-y-1.5">
-              <label className="block text-xs font-medium text-secondary">
-                Secret
-              </label>
+              <label className="block text-xs font-medium text-secondary">Secret</label>
               <div className="relative">
                 <input
                   type={showSecrets['wecom.secret'] ? 'text' : 'password'}
                   value={wecomOpenClawConfig.secret}
-                  onChange={(e) => handleWecomOpenClawChange({ secret: e.target.value })}
+                  onChange={e => handleWecomOpenClawChange({ secret: e.target.value })}
                   onBlur={() => handleSaveWecomOpenClawConfig()}
                   className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-sm transition-colors"
                   placeholder="••••••••••••"
@@ -2532,7 +2918,12 @@ const IMSettings: React.FC = () => {
                   {wecomOpenClawConfig.secret && (
                     <button
                       type="button"
-                      onClick={() => { handleWecomOpenClawChange({ secret: '' }); void imService.persistConfig({ wecom: { ...wecomOpenClawConfig, secret: '' } }); }}
+                      onClick={() => {
+                        handleWecomOpenClawChange({ secret: '' });
+                        void imService.persistConfig({
+                          wecom: { ...wecomOpenClawConfig, secret: '' },
+                        });
+                      }}
                       className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                       title={i18nService.t('clear') || 'Clear'}
                     >
@@ -2541,17 +2932,25 @@ const IMSettings: React.FC = () => {
                   )}
                   <button
                     type="button"
-                    onClick={() => setShowSecrets(prev => ({ ...prev, 'wecom.secret': !prev['wecom.secret'] }))}
+                    onClick={() =>
+                      setShowSecrets(prev => ({ ...prev, 'wecom.secret': !prev['wecom.secret'] }))
+                    }
                     className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                    title={showSecrets['wecom.secret'] ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                    title={
+                      showSecrets['wecom.secret']
+                        ? i18nService.t('hide') || 'Hide'
+                        : i18nService.t('show') || 'Show'
+                    }
                   >
-                    {showSecrets['wecom.secret'] ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                    {showSecrets['wecom.secret'] ? (
+                      <EyeIcon className="h-4 w-4" />
+                    ) : (
+                      <EyeSlashIcon className="h-4 w-4" />
+                    )}
                   </button>
                 </div>
               </div>
-              <p className="text-xs text-secondary">
-                {i18nService.t('imWecomCredentialHint')}
-              </p>
+              <p className="text-xs text-secondary">{i18nService.t('imWecomCredentialHint')}</p>
             </div>
 
             {/* Advanced Settings (collapsible) */}
@@ -2562,13 +2961,13 @@ const IMSettings: React.FC = () => {
               <div className="mt-2 space-y-3 pl-2 border-l-2 border-border-subtle">
                 {/* DM Policy */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    DM Policy
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">DM Policy</label>
                   <select
                     value={wecomOpenClawConfig.dmPolicy}
-                    onChange={(e) => {
-                      const update = { dmPolicy: e.target.value as WecomOpenClawConfig['dmPolicy'] };
+                    onChange={e => {
+                      const update = {
+                        dmPolicy: e.target.value as WecomOpenClawConfig['dmPolicy'],
+                      };
                       handleWecomOpenClawChange(update);
                       void handleSaveWecomOpenClawConfig(update);
                     }}
@@ -2593,16 +2992,18 @@ const IMSettings: React.FC = () => {
                     <input
                       type="text"
                       value={allowedUserIdInput}
-                      onChange={(e) => setAllowedUserIdInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
+                      onChange={e => setAllowedUserIdInput(e.target.value)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                           e.preventDefault();
                           const id = allowedUserIdInput.trim();
                           if (id && !wecomOpenClawConfig.allowFrom.includes(id)) {
                             const newIds = [...wecomOpenClawConfig.allowFrom, id];
                             handleWecomOpenClawChange({ allowFrom: newIds });
                             setAllowedUserIdInput('');
-                            void imService.persistConfig({ wecom: { ...wecomOpenClawConfig, allowFrom: newIds } });
+                            void imService.persistConfig({
+                              wecom: { ...wecomOpenClawConfig, allowFrom: newIds },
+                            });
                           }
                         }
                       }}
@@ -2617,7 +3018,9 @@ const IMSettings: React.FC = () => {
                           const newIds = [...wecomOpenClawConfig.allowFrom, id];
                           handleWecomOpenClawChange({ allowFrom: newIds });
                           setAllowedUserIdInput('');
-                          void imService.persistConfig({ wecom: { ...wecomOpenClawConfig, allowFrom: newIds } });
+                          void imService.persistConfig({
+                            wecom: { ...wecomOpenClawConfig, allowFrom: newIds },
+                          });
                         }
                       }}
                       className="px-3 py-2 rounded-lg text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
@@ -2627,7 +3030,7 @@ const IMSettings: React.FC = () => {
                   </div>
                   {wecomOpenClawConfig.allowFrom.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 mt-1.5">
-                      {wecomOpenClawConfig.allowFrom.map((id) => (
+                      {wecomOpenClawConfig.allowFrom.map(id => (
                         <span
                           key={id}
                           className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
@@ -2636,9 +3039,13 @@ const IMSettings: React.FC = () => {
                           <button
                             type="button"
                             onClick={() => {
-                              const newIds = wecomOpenClawConfig.allowFrom.filter((uid) => uid !== id);
+                              const newIds = wecomOpenClawConfig.allowFrom.filter(
+                                uid => uid !== id,
+                              );
                               handleWecomOpenClawChange({ allowFrom: newIds });
-                              void imService.persistConfig({ wecom: { ...wecomOpenClawConfig, allowFrom: newIds } });
+                              void imService.persistConfig({
+                                wecom: { ...wecomOpenClawConfig, allowFrom: newIds },
+                              });
                             }}
                             className="text-secondary hover:text-red-500 dark:hover:text-red-400 transition-colors"
                           >
@@ -2652,13 +3059,13 @@ const IMSettings: React.FC = () => {
 
                 {/* Group Policy */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Group Policy
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Group Policy</label>
                   <select
                     value={wecomOpenClawConfig.groupPolicy}
-                    onChange={(e) => {
-                      const update = { groupPolicy: e.target.value as WecomOpenClawConfig['groupPolicy'] };
+                    onChange={e => {
+                      const update = {
+                        groupPolicy: e.target.value as WecomOpenClawConfig['groupPolicy'],
+                      };
                       handleWecomOpenClawChange(update);
                       void handleSaveWecomOpenClawConfig(update);
                     }}
@@ -2678,26 +3085,30 @@ const IMSettings: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => {
-                      const update = { sendThinkingMessage: !wecomOpenClawConfig.sendThinkingMessage };
+                      const update = {
+                        sendThinkingMessage: !wecomOpenClawConfig.sendThinkingMessage,
+                      };
                       handleWecomOpenClawChange(update);
                       void handleSaveWecomOpenClawConfig(update);
                     }}
                     className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out ${
-                      wecomOpenClawConfig.sendThinkingMessage ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
+                      wecomOpenClawConfig.sendThinkingMessage
+                        ? 'bg-primary'
+                        : 'bg-gray-300 dark:bg-gray-600'
                     }`}
                   >
-                    <span className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                      wecomOpenClawConfig.sendThinkingMessage ? 'translate-x-4' : 'translate-x-0'
-                    }`} />
+                    <span
+                      className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                        wecomOpenClawConfig.sendThinkingMessage ? 'translate-x-4' : 'translate-x-0'
+                      }`}
+                    />
                   </button>
                 </div>
               </div>
             </details>
 
             {/* Connectivity test */}
-            <div className="pt-1">
-              {renderConnectivityTestButton('wecom')}
-            </div>
+            <div className="pt-1">{renderConnectivityTestButton('wecom')}</div>
 
             {/* Bot ID display */}
             {status.wecom?.botId && (
@@ -2724,7 +3135,7 @@ const IMSettings: React.FC = () => {
                 i18nService.t('imPopoGuideStep2'),
                 i18nService.t('imPopoGuideStep3'),
               ]}
-                guideUrl={PlatformRegistry.guideUrl('popo')}
+              guideUrl={PlatformRegistry.guideUrl('popo')}
             />
 
             {/* Connection Mode selector */}
@@ -2734,8 +3145,10 @@ const IMSettings: React.FC = () => {
               </label>
               <select
                 value={popoConfig.connectionMode || (popoConfig.token ? 'webhook' : 'websocket')}
-                onChange={(e) => {
-                  const update = { connectionMode: e.target.value as PopoOpenClawConfig['connectionMode'] };
+                onChange={e => {
+                  const update = {
+                    connectionMode: e.target.value as PopoOpenClawConfig['connectionMode'],
+                  };
                   handlePopoChange(update);
                   void handleSavePopoConfig(update);
                 }}
@@ -2747,9 +3160,7 @@ const IMSettings: React.FC = () => {
             </div>
 
             {/* Credential hint */}
-            <p className="text-xs text-secondary">
-              {i18nService.t('imPopoCredentialHint')}
-            </p>
+            <p className="text-xs text-secondary">{i18nService.t('imPopoCredentialHint')}</p>
 
             {/* AppKey input */}
             <div className="space-y-1.5">
@@ -2758,7 +3169,7 @@ const IMSettings: React.FC = () => {
                 <input
                   type="text"
                   value={popoConfig.appKey}
-                  onChange={(e) => handlePopoChange({ appKey: e.target.value })}
+                  onChange={e => handlePopoChange({ appKey: e.target.value })}
                   onBlur={() => void handleSavePopoConfig()}
                   placeholder="AppKey"
                   className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-8 text-sm transition-colors"
@@ -2788,7 +3199,7 @@ const IMSettings: React.FC = () => {
                 <input
                   type={showSecrets['popo.appSecret'] ? 'text' : 'password'}
                   value={popoConfig.appSecret}
-                  onChange={(e) => handlePopoChange({ appSecret: e.target.value })}
+                  onChange={e => handlePopoChange({ appSecret: e.target.value })}
                   onBlur={() => void handleSavePopoConfig()}
                   placeholder="••••••••••••"
                   className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-sm transition-colors"
@@ -2809,54 +3220,78 @@ const IMSettings: React.FC = () => {
                   )}
                   <button
                     type="button"
-                    onClick={() => setShowSecrets(prev => ({ ...prev, 'popo.appSecret': !prev['popo.appSecret'] }))}
+                    onClick={() =>
+                      setShowSecrets(prev => ({
+                        ...prev,
+                        'popo.appSecret': !prev['popo.appSecret'],
+                      }))
+                    }
                     className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                    title={showSecrets['popo.appSecret'] ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                    title={
+                      showSecrets['popo.appSecret']
+                        ? i18nService.t('hide') || 'Hide'
+                        : i18nService.t('show') || 'Show'
+                    }
                   >
-                    {showSecrets['popo.appSecret'] ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                    {showSecrets['popo.appSecret'] ? (
+                      <EyeIcon className="h-4 w-4" />
+                    ) : (
+                      <EyeSlashIcon className="h-4 w-4" />
+                    )}
                   </button>
                 </div>
               </div>
             </div>
 
             {/* Token input (webhook mode only) */}
-            {(popoConfig.connectionMode || (popoConfig.token ? 'webhook' : 'websocket')) === 'webhook' && (
-            <div className="space-y-1.5">
-              <label className="block text-xs font-medium text-secondary">Token</label>
-              <div className="relative">
-                <input
-                  type={showSecrets['popo.token'] ? 'text' : 'password'}
-                  value={popoConfig.token}
-                  onChange={(e) => handlePopoChange({ token: e.target.value })}
-                  onBlur={() => void handleSavePopoConfig()}
-                  placeholder="••••••••••••"
-                  className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-sm transition-colors"
-                />
-                <div className="absolute right-2 inset-y-0 flex items-center gap-1">
-                  {popoConfig.token && (
+            {(popoConfig.connectionMode || (popoConfig.token ? 'webhook' : 'websocket')) ===
+              'webhook' && (
+              <div className="space-y-1.5">
+                <label className="block text-xs font-medium text-secondary">Token</label>
+                <div className="relative">
+                  <input
+                    type={showSecrets['popo.token'] ? 'text' : 'password'}
+                    value={popoConfig.token}
+                    onChange={e => handlePopoChange({ token: e.target.value })}
+                    onBlur={() => void handleSavePopoConfig()}
+                    placeholder="••••••••••••"
+                    className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-sm transition-colors"
+                  />
+                  <div className="absolute right-2 inset-y-0 flex items-center gap-1">
+                    {popoConfig.token && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          handlePopoChange({ token: '' });
+                          void handleSavePopoConfig({ token: '' });
+                        }}
+                        className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
+                        title={i18nService.t('clear') || 'Clear'}
+                      >
+                        <XCircleIconSolid className="h-4 w-4" />
+                      </button>
+                    )}
                     <button
                       type="button"
-                      onClick={() => {
-                        handlePopoChange({ token: '' });
-                        void handleSavePopoConfig({ token: '' });
-                      }}
+                      onClick={() =>
+                        setShowSecrets(prev => ({ ...prev, 'popo.token': !prev['popo.token'] }))
+                      }
                       className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                      title={i18nService.t('clear') || 'Clear'}
+                      title={
+                        showSecrets['popo.token']
+                          ? i18nService.t('hide') || 'Hide'
+                          : i18nService.t('show') || 'Show'
+                      }
                     >
-                      <XCircleIconSolid className="h-4 w-4" />
+                      {showSecrets['popo.token'] ? (
+                        <EyeIcon className="h-4 w-4" />
+                      ) : (
+                        <EyeSlashIcon className="h-4 w-4" />
+                      )}
                     </button>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => setShowSecrets(prev => ({ ...prev, 'popo.token': !prev['popo.token'] }))}
-                    className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                    title={showSecrets['popo.token'] ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
-                  >
-                    {showSecrets['popo.token'] ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
-                  </button>
+                  </div>
                 </div>
               </div>
-            </div>
             )}
 
             {/* AES Key input */}
@@ -2866,7 +3301,7 @@ const IMSettings: React.FC = () => {
                 <input
                   type={showSecrets['popo.aesKey'] ? 'text' : 'password'}
                   value={popoConfig.aesKey}
-                  onChange={(e) => handlePopoChange({ aesKey: e.target.value })}
+                  onChange={e => handlePopoChange({ aesKey: e.target.value })}
                   onBlur={() => void handleSavePopoConfig()}
                   placeholder="••••••••••••"
                   className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-sm transition-colors"
@@ -2887,16 +3322,29 @@ const IMSettings: React.FC = () => {
                   )}
                   <button
                     type="button"
-                    onClick={() => setShowSecrets(prev => ({ ...prev, 'popo.aesKey': !prev['popo.aesKey'] }))}
+                    onClick={() =>
+                      setShowSecrets(prev => ({ ...prev, 'popo.aesKey': !prev['popo.aesKey'] }))
+                    }
                     className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                    title={showSecrets['popo.aesKey'] ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+                    title={
+                      showSecrets['popo.aesKey']
+                        ? i18nService.t('hide') || 'Hide'
+                        : i18nService.t('show') || 'Show'
+                    }
                   >
-                    {showSecrets['popo.aesKey'] ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+                    {showSecrets['popo.aesKey'] ? (
+                      <EyeIcon className="h-4 w-4" />
+                    ) : (
+                      <EyeSlashIcon className="h-4 w-4" />
+                    )}
                   </button>
                 </div>
               </div>
               {popoConfig.aesKey && popoConfig.aesKey.length !== 32 && (
-                <p className="text-xs text-amber-500">AES Key {i18nService.t('imPopoAesKeyLengthWarning')}（{i18nService.t('imPopoAesKeyLengthCurrent')} {popoConfig.aesKey.length}）</p>
+                <p className="text-xs text-amber-500">
+                  AES Key {i18nService.t('imPopoAesKeyLengthWarning')}（
+                  {i18nService.t('imPopoAesKeyLengthCurrent')} {popoConfig.aesKey.length}）
+                </p>
               )}
             </div>
 
@@ -2907,57 +3355,66 @@ const IMSettings: React.FC = () => {
               </summary>
               <div className="mt-2 space-y-3 pl-2 border-l-2 border-border-subtle">
                 {/* Webhook fields (webhook mode only) */}
-                {(popoConfig.connectionMode || (popoConfig.token ? 'webhook' : 'websocket')) === 'webhook' && (
-                <>
-                {/* Webhook Base URL */}
-                <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">Webhook Base URL</label>
-                  <input
-                    type="text"
-                    value={popoConfig.webhookBaseUrl}
-                    onChange={(e) => handlePopoChange({ webhookBaseUrl: e.target.value })}
-                    onBlur={() => void handleSavePopoConfig()}
-                    placeholder={localIp ? `http://${localIp}` : i18nService.t('imPopoWebhookPlaceholder')}
-                    className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
-                  />
-                </div>
+                {(popoConfig.connectionMode || (popoConfig.token ? 'webhook' : 'websocket')) ===
+                  'webhook' && (
+                  <>
+                    {/* Webhook Base URL */}
+                    <div className="space-y-1.5">
+                      <label className="block text-xs font-medium text-secondary">
+                        Webhook Base URL
+                      </label>
+                      <input
+                        type="text"
+                        value={popoConfig.webhookBaseUrl}
+                        onChange={e => handlePopoChange({ webhookBaseUrl: e.target.value })}
+                        onBlur={() => void handleSavePopoConfig()}
+                        placeholder={
+                          localIp ? `http://${localIp}` : i18nService.t('imPopoWebhookPlaceholder')
+                        }
+                        className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
+                      />
+                    </div>
 
-                {/* Webhook Path */}
-                <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">Webhook Path</label>
-                  <input
-                    type="text"
-                    value={popoConfig.webhookPath}
-                    onChange={(e) => handlePopoChange({ webhookPath: e.target.value })}
-                    onBlur={() => void handleSavePopoConfig()}
-                    placeholder="/popo/callback"
-                    className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
-                  />
-                </div>
+                    {/* Webhook Path */}
+                    <div className="space-y-1.5">
+                      <label className="block text-xs font-medium text-secondary">
+                        Webhook Path
+                      </label>
+                      <input
+                        type="text"
+                        value={popoConfig.webhookPath}
+                        onChange={e => handlePopoChange({ webhookPath: e.target.value })}
+                        onBlur={() => void handleSavePopoConfig()}
+                        placeholder="/popo/callback"
+                        className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
+                      />
+                    </div>
 
-                {/* Webhook Port */}
-                <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">Webhook Port</label>
-                  <input
-                    type="number"
-                    value={popoConfig.webhookPort}
-                    onChange={(e) => handlePopoChange({ webhookPort: parseInt(e.target.value) || 3100 })}
-                    onBlur={() => void handleSavePopoConfig()}
-                    placeholder="3100"
-                    className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
-                  />
-                </div>
-                </>
+                    {/* Webhook Port */}
+                    <div className="space-y-1.5">
+                      <label className="block text-xs font-medium text-secondary">
+                        Webhook Port
+                      </label>
+                      <input
+                        type="number"
+                        value={popoConfig.webhookPort}
+                        onChange={e =>
+                          handlePopoChange({ webhookPort: parseInt(e.target.value) || 3100 })
+                        }
+                        onBlur={() => void handleSavePopoConfig()}
+                        placeholder="3100"
+                        className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
+                      />
+                    </div>
+                  </>
                 )}
 
                 {/* DM Policy */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    DM Policy
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">DM Policy</label>
                   <select
                     value={popoConfig.dmPolicy}
-                    onChange={(e) => {
+                    onChange={e => {
                       const update = { dmPolicy: e.target.value as PopoOpenClawConfig['dmPolicy'] };
                       handlePopoChange(update);
                       void handleSavePopoConfig(update);
@@ -2983,16 +3440,18 @@ const IMSettings: React.FC = () => {
                     <input
                       type="text"
                       value={popoAllowedUserIdInput}
-                      onChange={(e) => setPopoAllowedUserIdInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
+                      onChange={e => setPopoAllowedUserIdInput(e.target.value)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                           e.preventDefault();
                           const id = popoAllowedUserIdInput.trim();
                           if (id && !popoConfig.allowFrom.includes(id)) {
                             const newIds = [...popoConfig.allowFrom, id];
                             handlePopoChange({ allowFrom: newIds });
                             setPopoAllowedUserIdInput('');
-                            void imService.persistConfig({ popo: { ...popoConfig, allowFrom: newIds } });
+                            void imService.persistConfig({
+                              popo: { ...popoConfig, allowFrom: newIds },
+                            });
                           }
                         }
                       }}
@@ -3007,7 +3466,9 @@ const IMSettings: React.FC = () => {
                           const newIds = [...popoConfig.allowFrom, id];
                           handlePopoChange({ allowFrom: newIds });
                           setPopoAllowedUserIdInput('');
-                          void imService.persistConfig({ popo: { ...popoConfig, allowFrom: newIds } });
+                          void imService.persistConfig({
+                            popo: { ...popoConfig, allowFrom: newIds },
+                          });
                         }
                       }}
                       className="px-3 py-2 rounded-lg text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
@@ -3017,7 +3478,7 @@ const IMSettings: React.FC = () => {
                   </div>
                   {popoConfig.allowFrom.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 mt-1.5">
-                      {popoConfig.allowFrom.map((id) => (
+                      {popoConfig.allowFrom.map(id => (
                         <span
                           key={id}
                           className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
@@ -3026,9 +3487,11 @@ const IMSettings: React.FC = () => {
                           <button
                             type="button"
                             onClick={() => {
-                              const newIds = popoConfig.allowFrom.filter((uid) => uid !== id);
+                              const newIds = popoConfig.allowFrom.filter(uid => uid !== id);
                               handlePopoChange({ allowFrom: newIds });
-                              void imService.persistConfig({ popo: { ...popoConfig, allowFrom: newIds } });
+                              void imService.persistConfig({
+                                popo: { ...popoConfig, allowFrom: newIds },
+                              });
                             }}
                             className="text-secondary hover:text-red-500 dark:hover:text-red-400 transition-colors"
                           >
@@ -3042,13 +3505,13 @@ const IMSettings: React.FC = () => {
 
                 {/* Group Policy */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">
-                    Group Policy
-                  </label>
+                  <label className="block text-xs font-medium text-secondary">Group Policy</label>
                   <select
                     value={popoConfig.groupPolicy}
-                    onChange={(e) => {
-                      const update = { groupPolicy: e.target.value as PopoOpenClawConfig['groupPolicy'] };
+                    onChange={e => {
+                      const update = {
+                        groupPolicy: e.target.value as PopoOpenClawConfig['groupPolicy'],
+                      };
                       handlePopoChange(update);
                       void handleSavePopoConfig(update);
                     }}
@@ -3069,16 +3532,18 @@ const IMSettings: React.FC = () => {
                     <input
                       type="text"
                       value={popoGroupAllowIdInput}
-                      onChange={(e) => setPopoGroupAllowIdInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
+                      onChange={e => setPopoGroupAllowIdInput(e.target.value)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                           e.preventDefault();
                           const id = popoGroupAllowIdInput.trim();
                           if (id && !popoConfig.groupAllowFrom.includes(id)) {
                             const newIds = [...popoConfig.groupAllowFrom, id];
                             handlePopoChange({ groupAllowFrom: newIds });
                             setPopoGroupAllowIdInput('');
-                            void imService.persistConfig({ popo: { ...popoConfig, groupAllowFrom: newIds } });
+                            void imService.persistConfig({
+                              popo: { ...popoConfig, groupAllowFrom: newIds },
+                            });
                           }
                         }
                       }}
@@ -3093,7 +3558,9 @@ const IMSettings: React.FC = () => {
                           const newIds = [...popoConfig.groupAllowFrom, id];
                           handlePopoChange({ groupAllowFrom: newIds });
                           setPopoGroupAllowIdInput('');
-                          void imService.persistConfig({ popo: { ...popoConfig, groupAllowFrom: newIds } });
+                          void imService.persistConfig({
+                            popo: { ...popoConfig, groupAllowFrom: newIds },
+                          });
                         }
                       }}
                       className="px-3 py-2 rounded-lg text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
@@ -3103,7 +3570,7 @@ const IMSettings: React.FC = () => {
                   </div>
                   {popoConfig.groupAllowFrom.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 mt-1.5">
-                      {popoConfig.groupAllowFrom.map((id) => (
+                      {popoConfig.groupAllowFrom.map(id => (
                         <span
                           key={id}
                           className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
@@ -3112,9 +3579,11 @@ const IMSettings: React.FC = () => {
                           <button
                             type="button"
                             onClick={() => {
-                              const newIds = popoConfig.groupAllowFrom.filter((gid) => gid !== id);
+                              const newIds = popoConfig.groupAllowFrom.filter(gid => gid !== id);
                               handlePopoChange({ groupAllowFrom: newIds });
-                              void imService.persistConfig({ popo: { ...popoConfig, groupAllowFrom: newIds } });
+                              void imService.persistConfig({
+                                popo: { ...popoConfig, groupAllowFrom: newIds },
+                              });
                             }}
                             className="text-secondary hover:text-red-500 dark:hover:text-red-400 transition-colors"
                           >
@@ -3128,11 +3597,15 @@ const IMSettings: React.FC = () => {
 
                 {/* Text Chunk Limit */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">Text Chunk Limit</label>
+                  <label className="block text-xs font-medium text-secondary">
+                    Text Chunk Limit
+                  </label>
                   <input
                     type="number"
                     value={popoConfig.textChunkLimit}
-                    onChange={(e) => handlePopoChange({ textChunkLimit: parseInt(e.target.value) || 3000 })}
+                    onChange={e =>
+                      handlePopoChange({ textChunkLimit: parseInt(e.target.value) || 3000 })
+                    }
                     onBlur={() => void handleSavePopoConfig()}
                     placeholder="3000"
                     className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
@@ -3141,11 +3614,15 @@ const IMSettings: React.FC = () => {
 
                 {/* Rich Text Chunk Limit */}
                 <div className="space-y-1.5">
-                  <label className="block text-xs font-medium text-secondary">Rich Text Chunk Limit</label>
+                  <label className="block text-xs font-medium text-secondary">
+                    Rich Text Chunk Limit
+                  </label>
                   <input
                     type="number"
                     value={popoConfig.richTextChunkLimit}
-                    onChange={(e) => handlePopoChange({ richTextChunkLimit: parseInt(e.target.value) || 5000 })}
+                    onChange={e =>
+                      handlePopoChange({ richTextChunkLimit: parseInt(e.target.value) || 5000 })
+                    }
                     onBlur={() => void handleSavePopoConfig()}
                     placeholder="5000"
                     className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
@@ -3166,18 +3643,18 @@ const IMSettings: React.FC = () => {
                       popoConfig.debug ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
                     }`}
                   >
-                    <span className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                      popoConfig.debug ? 'translate-x-4' : 'translate-x-0'
-                    }`} />
+                    <span
+                      className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                        popoConfig.debug ? 'translate-x-4' : 'translate-x-0'
+                      }`}
+                    />
                   </button>
                 </div>
               </div>
             </details>
 
             {/* Connectivity test */}
-            <div className="pt-1">
-              {renderConnectivityTestButton('popo')}
-            </div>
+            <div className="pt-1">{renderConnectivityTestButton('popo')}</div>
 
             {/* Error display */}
             {status.popo?.lastError && (
@@ -3189,75 +3666,81 @@ const IMSettings: React.FC = () => {
         )}
 
         {connectivityModalPlatform && (
-          <Modal onClose={() => setConnectivityModalPlatform(null)} overlayClassName="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" className="w-full max-w-2xl bg-surface rounded-2xl shadow-modal border border-border overflow-hidden">
-              <div className="px-4 py-3 border-b border-border flex items-center justify-between">
-                <div className="text-sm font-semibold text-foreground">
-                  {`${i18nService.t(connectivityModalPlatform)} ${i18nService.t('imConnectivitySectionTitle')}`}
+          <Modal
+            onClose={() => setConnectivityModalPlatform(null)}
+            overlayClassName="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
+            className="w-full max-w-2xl bg-surface rounded-2xl shadow-modal border border-border overflow-hidden"
+          >
+            <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+              <div className="text-sm font-semibold text-foreground">
+                {`${i18nService.t(connectivityModalPlatform)} ${i18nService.t('imConnectivitySectionTitle')}`}
+              </div>
+              <button
+                type="button"
+                aria-label={i18nService.t('close')}
+                onClick={() => setConnectivityModalPlatform(null)}
+                className="p-1 rounded-md hover:bg-surface-raised text-secondary"
+              >
+                <XMarkIcon className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="p-4 max-h-[65vh] overflow-y-auto">
+              {testingPlatform === connectivityModalPlatform ? (
+                <div className="text-sm text-secondary">
+                  {i18nService.t('imConnectivityTesting')}
                 </div>
-                <button
-                  type="button"
-                  aria-label={i18nService.t('close')}
-                  onClick={() => setConnectivityModalPlatform(null)}
-                  className="p-1 rounded-md hover:bg-surface-raised text-secondary"
-                >
-                  <XMarkIcon className="h-4 w-4" />
-                </button>
-              </div>
-
-              <div className="p-4 max-h-[65vh] overflow-y-auto">
-                {testingPlatform === connectivityModalPlatform ? (
-                  <div className="text-sm text-secondary">
-                    {i18nService.t('imConnectivityTesting')}
-                  </div>
-                ) : connectivityResults[connectivityModalPlatform] ? (
-                  <div className="space-y-3">
-                    <div className="flex items-center justify-between gap-2">
-                      <div className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${verdictColorClass[connectivityResults[connectivityModalPlatform]!.verdict]}`}>
-                        {connectivityResults[connectivityModalPlatform]!.verdict === 'pass' ? (
-                          <CheckCircleIcon className="h-3.5 w-3.5" />
-                        ) : connectivityResults[connectivityModalPlatform]!.verdict === 'warn' ? (
-                          <ExclamationTriangleIcon className="h-3.5 w-3.5" />
-                        ) : (
-                          <XCircleIcon className="h-3.5 w-3.5" />
-                        )}
-                        {i18nService.t(`imConnectivityVerdict_${connectivityResults[connectivityModalPlatform]!.verdict}`)}
-                      </div>
-                      <div className="text-[11px] text-secondary">
-                        {`${i18nService.t('imConnectivityLastChecked')}: ${formatTestTime(connectivityResults[connectivityModalPlatform]!.testedAt)}`}
-                      </div>
+              ) : connectivityResults[connectivityModalPlatform] ? (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <div
+                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${verdictColorClass[connectivityResults[connectivityModalPlatform]!.verdict]}`}
+                    >
+                      {connectivityResults[connectivityModalPlatform]!.verdict === 'pass' ? (
+                        <CheckCircleIcon className="h-3.5 w-3.5" />
+                      ) : connectivityResults[connectivityModalPlatform]!.verdict === 'warn' ? (
+                        <ExclamationTriangleIcon className="h-3.5 w-3.5" />
+                      ) : (
+                        <XCircleIcon className="h-3.5 w-3.5" />
+                      )}
+                      {i18nService.t(
+                        `imConnectivityVerdict_${connectivityResults[connectivityModalPlatform]!.verdict}`,
+                      )}
                     </div>
+                    <div className="text-[11px] text-secondary">
+                      {`${i18nService.t('imConnectivityLastChecked')}: ${formatTestTime(connectivityResults[connectivityModalPlatform]!.testedAt)}`}
+                    </div>
+                  </div>
 
-                    <div className="space-y-2">
-                      {connectivityResults[connectivityModalPlatform]!.checks.map((check, index) => (
-                        <div
-                          key={`${check.code}-${index}`}
-                          className="rounded-lg border border-border-subtle px-2.5 py-2 bg-surface"
-                        >
-                          <div className={`text-xs font-medium ${checkLevelColorClass[check.level]}`}>
-                            {getCheckTitle(check.code)}
-                          </div>
-                          <div className="mt-1 text-xs text-secondary">
-                            {check.message}
-                          </div>
-                          {getCheckSuggestion(check) && (
-                            <div className="mt-1 text-[11px] text-secondary">
-                              {`${i18nService.t('imConnectivitySuggestion')}: ${getCheckSuggestion(check)}`}
-                            </div>
-                          )}
+                  <div className="space-y-2">
+                    {connectivityResults[connectivityModalPlatform]!.checks.map((check, index) => (
+                      <div
+                        key={`${check.code}-${index}`}
+                        className="rounded-lg border border-border-subtle px-2.5 py-2 bg-surface"
+                      >
+                        <div className={`text-xs font-medium ${checkLevelColorClass[check.level]}`}>
+                          {getCheckTitle(check.code)}
                         </div>
-                      ))}
-                    </div>
+                        <div className="mt-1 text-xs text-secondary">{check.message}</div>
+                        {getCheckSuggestion(check) && (
+                          <div className="mt-1 text-[11px] text-secondary">
+                            {`${i18nService.t('imConnectivitySuggestion')}: ${getCheckSuggestion(check)}`}
+                          </div>
+                        )}
+                      </div>
+                    ))}
                   </div>
-                ) : (
-                  <div className="text-sm text-secondary">
-                    {i18nService.t('imConnectivityNoResult')}
-                  </div>
-                )}
-              </div>
+                </div>
+              ) : (
+                <div className="text-sm text-secondary">
+                  {i18nService.t('imConnectivityNoResult')}
+                </div>
+              )}
+            </div>
 
-              <div className="px-4 py-3 border-t border-border flex items-center justify-end">
-                {renderConnectivityTestButton(connectivityModalPlatform)}
-              </div>
+            <div className="px-4 py-3 border-t border-border flex items-center justify-end">
+              {renderConnectivityTestButton(connectivityModalPlatform)}
+            </div>
           </Modal>
         )}
       </div>

--- a/src/renderer/components/im/QQInstanceSettings.tsx
+++ b/src/renderer/components/im/QQInstanceSettings.tsx
@@ -7,7 +7,12 @@ import React, { useState } from 'react';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
 import { SignalIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import TrashIcon from '../icons/TrashIcon';
-import type { QQInstanceConfig, QQInstanceStatus, QQOpenClawConfig, IMConnectivityTestResult } from '../../types/im';
+import type {
+  QQInstanceConfig,
+  QQInstanceStatus,
+  QQOpenClawConfig,
+  IMConnectivityTestResult,
+} from '../../types/im';
 import { i18nService } from '../../services/i18n';
 import { PlatformRegistry } from '@shared/platform';
 
@@ -75,11 +80,14 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
             <input
               type="text"
               value={nameValue}
-              onChange={(e) => setNameValue(e.target.value)}
+              onChange={e => setNameValue(e.target.value)}
               onBlur={handleNameBlur}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleNameBlur();
-                if (e.key === 'Escape') { setNameValue(instance.instanceName); setEditingName(false); }
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) handleNameBlur();
+                if (e.key === 'Escape') {
+                  setNameValue(instance.instanceName);
+                  setEditingName(false);
+                }
               }}
               autoFocus
               className="text-sm font-medium text-foreground bg-transparent border-b border-primary focus:outline-none px-0 py-0"
@@ -96,14 +104,14 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
         </div>
 
         {/* Status badge */}
-        <div className={`px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${
-          instanceStatus?.connected
-            ? 'bg-green-500/15 text-green-600 dark:text-green-400'
-            : 'bg-gray-500/15 text-gray-500 dark:text-gray-400'
-        }`}>
-          {instanceStatus?.connected
-            ? i18nService.t('connected')
-            : i18nService.t('disconnected')}
+        <div
+          className={`px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${
+            instanceStatus?.connected
+              ? 'bg-green-500/15 text-green-600 dark:text-green-400'
+              : 'bg-gray-500/15 text-gray-500 dark:text-gray-400'
+          }`}
+        >
+          {instanceStatus?.connected ? i18nService.t('connected') : i18nService.t('disconnected')}
         </div>
 
         {/* Enable toggle */}
@@ -113,14 +121,24 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
           disabled={!instance.enabled && !(instance.appId && instance.appSecret)}
           className={`relative inline-flex h-5 w-9 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out ${
             instance.enabled
-              ? (instanceStatus?.connected ? 'bg-green-500' : 'bg-yellow-500')
+              ? instanceStatus?.connected
+                ? 'bg-green-500'
+                : 'bg-yellow-500'
               : 'bg-gray-400 dark:bg-gray-600'
           } ${!instance.enabled && !(instance.appId && instance.appSecret) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-          title={instance.enabled ? i18nService.t('imQQDisableInstance') : (!(instance.appId && instance.appSecret) ? i18nService.t('imInstanceFillCredentials') : i18nService.t('imQQEnableInstance'))}
+          title={
+            instance.enabled
+              ? i18nService.t('imQQDisableInstance')
+              : !(instance.appId && instance.appSecret)
+                ? i18nService.t('imInstanceFillCredentials')
+                : i18nService.t('imQQEnableInstance')
+          }
         >
-          <span className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-            instance.enabled ? 'translate-x-4' : 'translate-x-0'
-          }`} />
+          <span
+            className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+              instance.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
         </button>
 
         {/* Delete button */}
@@ -147,9 +165,11 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
           <button
             type="button"
             onClick={() => {
-              window.electron.shell.openExternal(PlatformRegistry.guideUrl('qq')!).catch((err: unknown) => {
-                console.error('[IM] Failed to open guide URL:', err);
-              });
+              window.electron.shell
+                .openExternal(PlatformRegistry.guideUrl('qq')!)
+                .catch((err: unknown) => {
+                  console.error('[IM] Failed to open guide URL:', err);
+                });
             }}
             className="mt-2 text-xs font-medium text-primary dark:text-primary hover:text-primary dark:hover:text-blue-200 underline underline-offset-2 transition-colors"
           >
@@ -160,14 +180,12 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
 
       {/* AppID */}
       <div className="space-y-1.5">
-        <label className="block text-xs font-medium text-secondary">
-          AppID
-        </label>
+        <label className="block text-xs font-medium text-secondary">AppID</label>
         <div className="relative">
           <input
             type="text"
             value={instance.appId}
-            onChange={(e) => onConfigChange({ appId: e.target.value })}
+            onChange={e => onConfigChange({ appId: e.target.value })}
             onBlur={() => void onSave()}
             className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-8 text-sm transition-colors"
             placeholder="102xxxxx"
@@ -176,7 +194,10 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
             <div className="absolute right-2 inset-y-0 flex items-center">
               <button
                 type="button"
-                onClick={() => { onConfigChange({ appId: '' }); void onSave({ appId: '' }); }}
+                onClick={() => {
+                  onConfigChange({ appId: '' });
+                  void onSave({ appId: '' });
+                }}
                 className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                 title={i18nService.t('clear') || 'Clear'}
               >
@@ -189,14 +210,12 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
 
       {/* AppSecret */}
       <div className="space-y-1.5">
-        <label className="block text-xs font-medium text-secondary">
-          AppSecret
-        </label>
+        <label className="block text-xs font-medium text-secondary">AppSecret</label>
         <div className="relative">
           <input
             type={showSecrets['appSecret'] ? 'text' : 'password'}
             value={instance.appSecret}
-            onChange={(e) => onConfigChange({ appSecret: e.target.value })}
+            onChange={e => onConfigChange({ appSecret: e.target.value })}
             onBlur={() => void onSave()}
             className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 pr-16 text-sm transition-colors"
             placeholder="••••••••••••"
@@ -205,7 +224,10 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
             {instance.appSecret && (
               <button
                 type="button"
-                onClick={() => { onConfigChange({ appSecret: '' }); void onSave({ appSecret: '' }); }}
+                onClick={() => {
+                  onConfigChange({ appSecret: '' });
+                  void onSave({ appSecret: '' });
+                }}
                 className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
                 title={i18nService.t('clear') || 'Clear'}
               >
@@ -214,17 +236,23 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
             )}
             <button
               type="button"
-              onClick={() => setShowSecrets(prev => ({ ...prev, 'appSecret': !prev['appSecret'] }))}
+              onClick={() => setShowSecrets(prev => ({ ...prev, appSecret: !prev['appSecret'] }))}
               className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-              title={showSecrets['appSecret'] ? (i18nService.t('hide') || 'Hide') : (i18nService.t('show') || 'Show')}
+              title={
+                showSecrets['appSecret']
+                  ? i18nService.t('hide') || 'Hide'
+                  : i18nService.t('show') || 'Show'
+              }
             >
-              {showSecrets['appSecret'] ? <EyeIcon className="h-4 w-4" /> : <EyeSlashIcon className="h-4 w-4" />}
+              {showSecrets['appSecret'] ? (
+                <EyeIcon className="h-4 w-4" />
+              ) : (
+                <EyeSlashIcon className="h-4 w-4" />
+              )}
             </button>
           </div>
         </div>
-        <p className="text-xs text-secondary">
-          {i18nService.t('imQQCredentialHint')}
-        </p>
+        <p className="text-xs text-secondary">{i18nService.t('imQQCredentialHint')}</p>
       </div>
 
       {/* Advanced Settings (collapsible) */}
@@ -235,12 +263,10 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
         <div className="mt-2 space-y-3 pl-2 border-l-2 border-border-subtle">
           {/* DM Policy */}
           <div className="space-y-1.5">
-            <label className="block text-xs font-medium text-secondary">
-              DM Policy
-            </label>
+            <label className="block text-xs font-medium text-secondary">DM Policy</label>
             <select
               value={instance.dmPolicy}
-              onChange={(e) => {
+              onChange={e => {
                 const update = { dmPolicy: e.target.value as QQOpenClawConfig['dmPolicy'] };
                 onConfigChange(update);
                 void onSave(update);
@@ -262,9 +288,9 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
               <input
                 type="text"
                 value={allowedUserIdInput}
-                onChange={(e) => setAllowedUserIdInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
+                onChange={e => setAllowedUserIdInput(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                     e.preventDefault();
                     const id = allowedUserIdInput.trim();
                     if (id && !instance.allowFrom.includes(id)) {
@@ -296,7 +322,7 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
             </div>
             {instance.allowFrom.length > 0 && (
               <div className="flex flex-wrap gap-1.5 mt-1.5">
-                {instance.allowFrom.map((id) => (
+                {instance.allowFrom.map(id => (
                   <span
                     key={id}
                     className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
@@ -305,7 +331,7 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
                     <button
                       type="button"
                       onClick={() => {
-                        const newIds = instance.allowFrom.filter((uid) => uid !== id);
+                        const newIds = instance.allowFrom.filter(uid => uid !== id);
                         onConfigChange({ allowFrom: newIds });
                         void onSave({ allowFrom: newIds });
                       }}
@@ -321,12 +347,10 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
 
           {/* Group Policy */}
           <div className="space-y-1.5">
-            <label className="block text-xs font-medium text-secondary">
-              Group Policy
-            </label>
+            <label className="block text-xs font-medium text-secondary">Group Policy</label>
             <select
               value={instance.groupPolicy}
-              onChange={(e) => {
+              onChange={e => {
                 const update = { groupPolicy: e.target.value as QQOpenClawConfig['groupPolicy'] };
                 onConfigChange(update);
                 void onSave(update);
@@ -346,7 +370,7 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
                 Group Allow From (Group IDs)
               </label>
               <div className="flex flex-wrap gap-1.5">
-                {instance.groupAllowFrom.map((id) => (
+                {instance.groupAllowFrom.map(id => (
                   <span
                     key={id}
                     className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
@@ -355,7 +379,7 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
                     <button
                       type="button"
                       onClick={() => {
-                        const newIds = instance.groupAllowFrom.filter((gid) => gid !== id);
+                        const newIds = instance.groupAllowFrom.filter(gid => gid !== id);
                         onConfigChange({ groupAllowFrom: newIds });
                         void onSave({ groupAllowFrom: newIds });
                       }}
@@ -371,13 +395,11 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
 
           {/* History Limit */}
           <div className="space-y-1.5">
-            <label className="block text-xs font-medium text-secondary">
-              History Limit
-            </label>
+            <label className="block text-xs font-medium text-secondary">History Limit</label>
             <input
               type="number"
               value={instance.historyLimit}
-              onChange={(e) => onConfigChange({ historyLimit: parseInt(e.target.value) || 50 })}
+              onChange={e => onConfigChange({ historyLimit: parseInt(e.target.value) || 50 })}
               onBlur={() => void onSave()}
               className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
               min="1"
@@ -387,9 +409,7 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
 
           {/* Markdown Support */}
           <div className="flex items-center justify-between">
-            <label className="text-xs font-medium text-secondary">
-              Markdown Support
-            </label>
+            <label className="text-xs font-medium text-secondary">Markdown Support</label>
             <button
               type="button"
               onClick={() => {
@@ -401,9 +421,11 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
                 instance.markdownSupport ? 'bg-primary' : 'bg-gray-300 dark:bg-gray-600'
               }`}
             >
-              <span className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                instance.markdownSupport ? 'translate-x-4' : 'translate-x-0'
-              }`} />
+              <span
+                className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  instance.markdownSupport ? 'translate-x-4' : 'translate-x-0'
+                }`}
+              />
             </button>
           </div>
 
@@ -415,14 +437,12 @@ const QQInstanceSettings: React.FC<QQInstanceSettingsProps> = ({
             <input
               type="text"
               value={instance.imageServerBaseUrl}
-              onChange={(e) => onConfigChange({ imageServerBaseUrl: e.target.value })}
+              onChange={e => onConfigChange({ imageServerBaseUrl: e.target.value })}
               onBlur={() => void onSave()}
               className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
               placeholder="http://your-ip:18765"
             />
-            <p className="text-xs text-secondary">
-              {i18nService.t('imQQImageServerHint')}
-            </p>
+            <p className="text-xs text-secondary">{i18nService.t('imQQImageServerHint')}</p>
           </div>
         </div>
       </details>


### PR DESCRIPTION
## Summary

- 修复在设置页输入框中按 Enter 键（包括 IME 输入法确认候选词）导致设置页意外保存并关闭的问题
- 在 `<form>` 级别拦截非按钮元素的 Enter 键提交，并为全项目 18 处 Enter 键处理器添加 `isComposing` 检查

## 问题

在设置页的模型配置、IM 配置等输入框中按下 Enter 键（包括输入法确认候选词时），会触发表单提交导致设置页保存并关闭。

## 根因

Settings 整个内容区被 `<form onSubmit={handleSubmit}>` 包裹，HTML 表单默认行为是在 input 中按 Enter 触发 `onSubmit`。`handleSubmit` 保存成功后调用 `onClose()` 关闭页面。所有 Enter 键处理器均未检查 IME composing 状态。

## 修复

| 文件 | 修复内容 |
|------|---------|
| `Settings.tsx` | `<form>` 添加 `onKeyDown` 拦截器阻止 Enter 提交；`handleModelDialogKeyDown` 添加 `isComposing` 检查 |
| `IMSettings.tsx` | 7 处 Enter handler 添加 `isComposing` 检查（配对码、Telegram/Discord/WeCom/POPO 的 allowFrom/groupAllowFrom） |
| `DingTalkInstanceSettings.tsx` | 3 处 Enter handler 添加 `isComposing` 检查（配对码、实例重命名、allowFrom） |
| `FeishuInstanceSettings.tsx` | 4 处 Enter handler 添加 `isComposing` 检查（配对码、实例重命名、allowFrom、groupAllowFrom） |
| `QQInstanceSettings.tsx` | 2 处 Enter handler 添加 `isComposing` 检查（实例重命名、allowFrom） |
| `CoworkSessionDetail.tsx` | 会话重命名 Enter handler 添加 `isComposing` 检查 |

## 复现路径

1. 打开设置页 → 模型配置 tab
2. 在 API Key 或 Base URL 输入框中按 Enter
3. 设置页会立即保存并关闭（预期不应关闭）
4. 使用中文输入法在任意输入框中选字时按 Enter 也会触发