### PR TITLE
fix(scheduled-task): 修复定时任务中错误显示"未配置 IM 通知通道"的提示

### DIFF
--- a/src/scheduledTask/enginePrompt.ts
+++ b/src/scheduledTask/enginePrompt.ts
@@ -24,7 +24,7 @@ export function buildScheduledTaskEnginePrompt(engine: CoworkAgentEngine): strin
       '- When running inside a scheduled-task (cron) session, **do NOT** call the `message` tool directly to send results to IM channels.',
       '- The cron system handles result delivery automatically based on the task\'s delivery configuration. Calling `message` from a cron session without an associated channel will fail with "Channel is required".',
       '- Instead, output your results as plain text in the session. If the task has a delivery channel configured, the cron system will forward the output automatically.',
-      '- If the user\'s prompt asks to "send" or "notify", and you are in a cron session, produce the content as session output rather than calling `message`. Append a note: "（此定时任务未配置 IM 通知通道，结果已保存在执行记录中。如需自动推送，请在定时任务设置中配置通知通道。）"',
+      '- If the user\'s prompt asks to "send" or "notify", and you are in a cron session, produce the content as session output rather than calling `message`. The cron system will handle delivery automatically based on the task\'s configuration.',
     ].join('\n');
   }
 


### PR DESCRIPTION
## 问题描述
定时任务执行时，即使已正确配置了 POPO 等 IM 通知通道且消息成功发送，仍会在输出内容末尾错误地追加以下文案：

（此定时任务未配置 IM 通知通道，结果已保存在执行记录中。如需自动推送，请在定时任务设置中配置通知通道。）

## 根因分析
src/scheduledTask/enginePrompt.ts 中的系统提示词逻辑缺陷：当 AI 判断用户提示词包含"发送"或"通知"语义时，无条件追加上述文案，未检查任务是否已配置 delivery 通道。

该问题由 2026-03-28 提交 1d0a99b（修复 gateway 崩溃）引入，已存在 12 天。

## 修复方案
移除错误的追加文案指令，替换为准确说明：由 cron 系统根据任务配置自动处理投递，AI 不再附加任何通道配置相关提示。

## 问题截图
<img width="870" height="342" alt="image" src="https://github.com/user-attachments/assets/732ad621-ef66-47e0-83f6-aa64d9eaa26a" />
<img width="749" height="603" alt="image" src="https://github.com/user-attachments/assets/528c8dde-cf0b-4e7d-83ca-af6f6c9b5839" />
