### PR TITLE
feat(cowork): 支持 AI 回复期间连续发送消息（客户端消息队列）

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1,7 +1,12 @@
 import { CheckIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
-import { ChevronDownIcon, FolderIcon, PaperAirplaneIcon, StopIcon } from '@heroicons/react/24/solid';
-import React, { useCallback,useEffect, useRef, useState } from 'react';
-import { useDispatch,useSelector } from 'react-redux';
+import {
+  ChevronDownIcon,
+  FolderIcon,
+  PaperAirplaneIcon,
+  StopIcon,
+} from '@heroicons/react/24/solid';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { defaultConfig } from '../../config';
 import { agentService } from '../../services/agent';
@@ -10,7 +15,13 @@ import { i18nService } from '../../services/i18n';
 import { skillService } from '../../services/skill';
 import { RootState } from '../../store';
 import { selectDraftPrompts } from '../../store/selectors/coworkSelectors';
-import { addDraftAttachment, clearDraftAttachments, type DraftAttachment, setDraftAttachments, setDraftPrompt } from '../../store/slices/coworkSlice';
+import {
+  addDraftAttachment,
+  clearDraftAttachments,
+  type DraftAttachment,
+  setDraftAttachments,
+  setDraftPrompt,
+} from '../../store/slices/coworkSlice';
 import { setSkills, toggleActiveSkill } from '../../store/slices/skillSlice';
 import { CoworkImageAttachment } from '../../types/cowork';
 import { Skill } from '../../types/skill';
@@ -19,7 +30,7 @@ import { getCompactFolderName } from '../../utils/path';
 import PaperClipIcon from '../icons/PaperClipIcon';
 import XMarkIcon from '../icons/XMarkIcon';
 import ModelSelector from '../ModelSelector';
-import { ActiveSkillBadge,SkillsButton } from '../skills';
+import { ActiveSkillBadge, SkillsButton } from '../skills';
 import { resolveAgentModelSelection } from './agentModelSelection';
 import AttachmentCard from './AttachmentCard';
 import FolderSelectorPopover from './FolderSelectorPopover';
@@ -28,8 +39,19 @@ import FolderSelectorPopover from './FolderSelectorPopover';
 // so that attachment state survives view switches (cowork ↔ skills, etc.)
 type CoworkAttachment = DraftAttachment;
 
-
-const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg', '.tiff', '.tif', '.ico', '.avif']);
+const IMAGE_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.svg',
+  '.tiff',
+  '.tif',
+  '.ico',
+  '.avif',
+]);
 
 const isImagePath = (filePath: string): boolean => {
   const dotIndex = filePath.lastIndexOf('.');
@@ -42,7 +64,9 @@ const isImageMimeType = (mimeType: string): boolean => {
   return mimeType.startsWith('image/');
 };
 
-const extractBase64FromDataUrl = (dataUrl: string): { mimeType: string; base64Data: string } | null => {
+const extractBase64FromDataUrl = (
+  dataUrl: string,
+): { mimeType: string; base64Data: string } | null => {
   const match = /^data:(.+);base64,(.*)$/.exec(dataUrl);
   if (!match) return null;
   return { mimeType: match[1], base64Data: match[2] };
@@ -100,7 +124,11 @@ export interface CoworkPromptInputRef {
 }
 
 interface CoworkPromptInputProps {
-  onSubmit: (prompt: string, skillPrompt?: string, imageAttachments?: CoworkImageAttachment[]) => boolean | void | Promise<boolean | void>;
+  onSubmit: (
+    prompt: string,
+    skillPrompt?: string,
+    imageAttachments?: CoworkImageAttachment[],
+  ) => boolean | void | Promise<boolean | void>;
   onStop?: () => void;
   isStreaming?: boolean;
   placeholder?: string;
@@ -135,8 +163,12 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     } = props;
     const dispatch = useDispatch();
     const draftKey = sessionId || '__home__';
-    const draftPrompt = useSelector((state: RootState) => selectDraftPrompts(state)[draftKey] || '');
-    const attachments = useSelector((state: RootState) => state.cowork.draftAttachments[draftKey] || []) as CoworkAttachment[];
+    const draftPrompt = useSelector(
+      (state: RootState) => selectDraftPrompts(state)[draftKey] || '',
+    );
+    const attachments = useSelector(
+      (state: RootState) => state.cowork.draftAttachments[draftKey] || [],
+    ) as CoworkAttachment[];
     const currentAgentId = useSelector((state: RootState) => state.agent.currentAgentId);
     const agents = useSelector((state: RootState) => state.agent.agents);
     const coworkAgentEngine = useSelector((state: RootState) => state.cowork.config.agentEngine);
@@ -154,651 +186,704 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const dragDepthRef = useRef(0);
     const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // 暴露方法给父组件
-  React.useImperativeHandle(ref, () => ({
-    setValue: (newValue: string) => {
-      setValue(newValue);
-      // 触发自动调整高度
-      requestAnimationFrame(() => {
-        const textarea = textareaRef.current;
-        if (textarea) {
-          textarea.style.height = 'auto';
-          textarea.style.height = `${Math.min(Math.max(textarea.scrollHeight, minHeight), maxHeight)}px`;
-        }
-      });
-    },
-    setImageAttachments: (images: CoworkImageAttachment[]) => {
-      const newAttachments: CoworkAttachment[] = images.map((img, idx) => ({
-        path: `inline:${img.name}:reedit-${Date.now()}-${idx}`,
-        name: img.name,
-        isImage: true,
-        dataUrl: `data:${img.mimeType};base64,${img.base64Data}`,
-      }));
-      dispatch(setDraftAttachments({ draftKey, attachments: newAttachments }));
-    },
-    focus: () => {
-      textareaRef.current?.focus();
-    },
-  }));
-
-  const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
-  const skills = useSelector((state: RootState) => state.skill.skills);
-  const currentAgent = agents.find((agent) => agent.id === currentAgentId);
-  const {
-    selectedModel: agentSelectedModel,
-    hasInvalidExplicitModel: agentModelIsInvalid,
-  } = resolveAgentModelSelection({
-    agentModel: currentAgent?.model ?? '',
-    availableModels,
-    fallbackModel: globalSelectedModel,
-    engine: coworkAgentEngine,
-  });
-
-  const isLarge = size === 'large';
-  const minHeight = isLarge ? 60 : 24;
-  const maxHeight = isLarge ? 200 : 200;
-
-  // Load skills on mount
-  useEffect(() => {
-    const loadSkills = async () => {
-      const loadedSkills = await skillService.loadSkills();
-      dispatch(setSkills(loadedSkills));
-    };
-    loadSkills();
-  }, [dispatch]);
-
-  useEffect(() => {
-    const unsubscribe = skillService.onSkillsChanged(async () => {
-      const loadedSkills = await skillService.loadSkills();
-      dispatch(setSkills(loadedSkills));
-    });
-    return () => {
-      unsubscribe();
-    };
-  }, [dispatch]);
-
-  // Auto-resize textarea
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (textarea) {
-      textarea.style.height = 'auto';
-      textarea.style.height = `${Math.min(Math.max(textarea.scrollHeight, minHeight), maxHeight)}px`;
-    }
-  }, [value, minHeight, maxHeight]);
-
-  useEffect(() => {
-    const handleFocusInput = (event: Event) => {
-      const detail = (event as CustomEvent<{ clear?: boolean }>).detail;
-      const shouldClear = detail?.clear ?? true;
-      if (shouldClear) {
-        setValue('');
-        dispatch(clearDraftAttachments(draftKey));
-      }
-      requestAnimationFrame(() => {
-        textareaRef.current?.focus();
-      });
-    };
-    window.addEventListener('cowork:focus-input', handleFocusInput);
-    return () => {
-      window.removeEventListener('cowork:focus-input', handleFocusInput);
-      if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
-    };
-  }, [dispatch, draftKey]);
-
-  useEffect(() => {
-    if (workingDirectory?.trim()) {
-      setShowFolderRequiredWarning(false);
-    }
-  }, [workingDirectory]);
-
-  // Sync value from draft when sessionId changes
-  useEffect(() => {
-    setValue(draftPrompt);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [draftKey]); // intentionally omit draftPrompt to only trigger on session switch
-
-  useEffect(() => {
-    if (value !== draftPrompt) {
-      const timer = setTimeout(() => {
-        dispatch(setDraftPrompt({ sessionId: draftKey, draft: value }));
-      }, 300);
-      return () => clearTimeout(timer);
-    }
-  }, [value, draftPrompt, dispatch, draftKey]);
-
-  const handleSubmit = useCallback(async () => {
-    if (showFolderSelector && !workingDirectory?.trim()) {
-      setShowFolderRequiredWarning(true);
-      if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
-      warningTimerRef.current = setTimeout(() => {
-        setShowFolderRequiredWarning(false);
-        warningTimerRef.current = null;
-      }, 3000);
-      return;
-    }
-
-    const trimmedValue = value.trim();
-    if ((!trimmedValue && attachments.length === 0) || isStreaming || disabled) return;
-    setShowFolderRequiredWarning(false);
-
-    // Get active skills prompts and combine them
-    const activeSkills = activeSkillIds
-      .map(id => skills.find(s => s.id === id))
-      .filter((s): s is Skill => s !== undefined);
-    const skillPrompt = activeSkills.length > 0
-      ? activeSkills.map(buildInlinedSkillPrompt).join('\n\n')
-      : undefined;
-
-    // Extract image attachments (with base64 data) for vision-capable models
-    const imageAtts: CoworkImageAttachment[] = [];
-    for (const attachment of attachments) {
-      if (attachment.isImage && attachment.dataUrl) {
-        const extracted = extractBase64FromDataUrl(attachment.dataUrl);
-        if (extracted) {
-          imageAtts.push({
-            name: attachment.name,
-            mimeType: extracted.mimeType,
-            base64Data: extracted.base64Data,
-          });
-        }
-      }
-    }
-
-    // Build prompt with ALL attachments that have real file paths (both regular files and images).
-    // Image attachments also need their file paths in the prompt so the model knows
-    // where the original files are located (e.g., for skills like seedream that need --image <path>).
-    // Note: inline/clipboard images have pseudo-paths starting with 'inline:' and are excluded.
-    const attachmentLines = attachments
-      .filter((a) => !a.path.startsWith('inline:'))
-      .map((attachment) => `${i18nService.t('inputFileLabel')}: ${attachment.path}`)
-      .join('\n');
-    const finalPrompt = trimmedValue
-      ? (attachmentLines ? `${trimmedValue}\n\n${attachmentLines}` : trimmedValue)
-      : attachmentLines;
-
-    if (imageAtts.length > 0) {
-      console.log('[CoworkPromptInput] handleSubmit: passing imageAtts to onSubmit', {
-        count: imageAtts.length,
-        names: imageAtts.map(a => a.name),
-        base64Lengths: imageAtts.map(a => a.base64Data.length),
-      });
-    }
-    const result = await onSubmit(finalPrompt, skillPrompt, imageAtts.length > 0 ? imageAtts : undefined);
-    if (result === false) return;
-    setValue('');
-    dispatch(setDraftPrompt({ sessionId: draftKey, draft: '' }));
-    dispatch(clearDraftAttachments(draftKey));
-    setImageVisionHint(false);
-  }, [value, isStreaming, disabled, onSubmit, activeSkillIds, skills, attachments, showFolderSelector, workingDirectory, dispatch, draftKey]);
-
-  const handleSelectSkill = useCallback((skill: Skill) => {
-    dispatch(toggleActiveSkill(skill.id));
-  }, [dispatch]);
-
-  const handleManageSkills = useCallback(() => {
-    if (onManageSkills) {
-      onManageSkills();
-    }
-  }, [onManageSkills]);
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    const isComposing = event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229;
-    if (event.key !== 'Enter' || isComposing) return;
-
-    // Use synced state (kept up-to-date via config-updated event) so that
-    // changes made in the Settings panel are reflected immediately without
-    // requiring a configService read at event time.
-    const sendKey = currentSendShortcut;
-
-    let isSendCombo = false;
-    switch (sendKey) {
-      case 'Enter':
-        isSendCombo = !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey;
-        break;
-      case 'Shift+Enter':
-        isSendCombo = event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey;
-        break;
-      case 'Ctrl+Enter':
-        isSendCombo = isMacPlatform
-          ? event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey
-          : event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey;
-        break;
-      case 'Alt+Enter':
-        isSendCombo = event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
-        break;
-      default:
-        // Unknown config value — fall back to bare Enter so the user can always send
-        isSendCombo = !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey;
-        break;
-    }
-
-    if (isSendCombo && !isStreaming && !disabled) {
-      event.preventDefault();
-      handleSubmit();
-    } else {
-      // Any non-send Enter combo inserts a newline.
-      // Shift+Enter inserts newline natively; for other combos use execCommand.
-      if (!event.shiftKey) {
-        event.preventDefault();
-        document.execCommand('insertText', false, '\n');
-      }
-    }
-  };
-
-  const handleStopClick = () => {
-    if (onStop) {
-      onStop();
-    }
-  };
-
-  const containerClass = isLarge
-    ? 'relative rounded-2xl border border-border bg-surface shadow-card focus-within:shadow-elevated focus-within:ring-1 focus-within:ring-primary/40 focus-within:border-primary'
-    : 'relative flex items-end gap-2 p-3 rounded-xl border border-border bg-surface';
-
-  const textareaClass = isLarge
-    ? `w-full resize-none bg-transparent px-4 pt-2.5 pb-2 text-foreground placeholder:dark:text-foregroundSecondary/60 placeholder:text-secondary/60 focus:outline-none text-[15px] leading-6 min-h-[${minHeight}px] max-h-[${maxHeight}px]`
-    : 'flex-1 resize-none bg-transparent text-foreground placeholder:placeholder:text-secondary focus:outline-none text-sm leading-relaxed min-h-[24px] max-h-[200px]';
-
-  const truncatePath = (path: string, maxLength = 30): string => {
-    if (!path) return i18nService.t('noFolderSelected');
-    return getCompactFolderName(path, maxLength) || i18nService.t('noFolderSelected');
-  };
-
-  const handleFolderSelect = (path: string) => {
-    if (onWorkingDirectoryChange) {
-      onWorkingDirectoryChange(path);
-    }
-  };
-
-  const effectiveSelectedModel = coworkAgentEngine === 'openclaw' ? agentSelectedModel : globalSelectedModel;
-  const modelSupportsImage = !!effectiveSelectedModel?.supportsImage;
-
-  const addAttachment = useCallback((filePath: string, imageInfo?: { isImage: boolean; dataUrl?: string }) => {
-    if (!filePath) return;
-    dispatch(addDraftAttachment({
-      draftKey,
-      attachment: {
-        path: filePath,
-        name: getFileNameFromPath(filePath),
-        isImage: imageInfo?.isImage,
-        dataUrl: imageInfo?.dataUrl,
-      },
-    }));
-  }, [dispatch, draftKey]);
-
-  const addImageAttachmentFromDataUrl = useCallback((name: string, dataUrl: string) => {
-    // Use the dataUrl as the unique key (no file path for inline images)
-    const pseudoPath = `inline:${name}:${Date.now()}`;
-    dispatch(addDraftAttachment({
-      draftKey,
-      attachment: {
-        path: pseudoPath,
-        name,
-        isImage: true,
-        dataUrl,
-      },
-    }));
-  }, [dispatch, draftKey]);
-
-  const fileToDataUrl = useCallback((file: File): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        const result = reader.result;
-        if (typeof result !== 'string') {
-          reject(new Error('Failed to read file'));
-          return;
-        }
-        resolve(result);
-      };
-      reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
-      reader.readAsDataURL(file);
-    });
-  }, []);
-
-  const fileToBase64 = useCallback((file: File): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        const result = reader.result;
-        if (typeof result !== 'string') {
-          reject(new Error('Failed to read file'));
-          return;
-        }
-        const commaIndex = result.indexOf(',');
-        resolve(commaIndex >= 0 ? result.slice(commaIndex + 1) : result);
-      };
-      reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
-      reader.readAsDataURL(file);
-    });
-  }, []);
-
-  const getNativeFilePath = useCallback((file: File): string | null => {
-    const maybePath = (file as File & { path?: string }).path;
-    if (typeof maybePath === 'string' && maybePath.trim()) {
-      return maybePath;
-    }
-    return null;
-  }, []);
-
-  const saveInlineFile = useCallback(async (file: File): Promise<string | null> => {
-    try {
-      const dataBase64 = await fileToBase64(file);
-      if (!dataBase64) {
-        return null;
-      }
-      const result = await window.electron.dialog.saveInlineFile({
-        dataBase64,
-        fileName: file.name,
-        mimeType: file.type,
-        cwd: workingDirectory,
-      });
-      if (result.success && result.path) {
-        return result.path;
-      }
-      return null;
-    } catch (error) {
-      console.error('Failed to save inline file:', error);
-      return null;
-    }
-  }, [fileToBase64, workingDirectory]);
-
-  const handleIncomingFiles = useCallback(async (fileList: FileList | File[]) => {
-    if (disabled || isStreaming) return;
-    const files = Array.from(fileList ?? []);
-    if (files.length === 0) return;
-
-    let hasImageWithoutVision = false;
-    for (const file of files) {
-      const nativePath = getNativeFilePath(file);
-
-      // Check if this is an image file and model supports images
-      const fileIsImage = nativePath
-        ? isImagePath(nativePath)
-        : isImageMimeType(file.type);
-
-      if (fileIsImage) {
-        if (modelSupportsImage) {
-          // For images on vision-capable models, read as data URL
-          if (nativePath) {
-            try {
-              const result = await window.electron.dialog.readFileAsDataUrl(nativePath);
-              if (result.success && result.dataUrl) {
-                addAttachment(nativePath, { isImage: true, dataUrl: result.dataUrl });
-                continue;
-              }
-            } catch (error) {
-              console.error('Failed to read image as data URL:', error);
-            }
-            // Fallback: add as regular file attachment
-            addAttachment(nativePath);
-          } else {
-            // No native path (clipboard/drag from browser):
-            // 1. Read as dataUrl for preview + base64 vision
-            // 2. Save to disk so the agent can access the file in later turns
-            let dataUrl: string | null = null;
-            try {
-              dataUrl = await fileToDataUrl(file);
-            } catch (error) {
-              console.error('Failed to read clipboard image as data URL:', error);
-            }
-
-            const stagedPath = await saveInlineFile(file);
-
-            if (stagedPath) {
-              addAttachment(stagedPath, {
-                isImage: true,
-                dataUrl: dataUrl ?? undefined,
-              });
-            } else if (dataUrl) {
-              console.warn('Clipboard image saved only in memory (disk save failed)');
-              addImageAttachmentFromDataUrl(file.name, dataUrl);
-            } else {
-              console.error('Failed to process clipboard image: both dataUrl and disk save failed');
-            }
+    // 暴露方法给父组件
+    React.useImperativeHandle(ref, () => ({
+      setValue: (newValue: string) => {
+        setValue(newValue);
+        // 触发自动调整高度
+        requestAnimationFrame(() => {
+          const textarea = textareaRef.current;
+          if (textarea) {
+            textarea.style.height = 'auto';
+            textarea.style.height = `${Math.min(Math.max(textarea.scrollHeight, minHeight), maxHeight)}px`;
           }
-          continue;
-        }
-        // Model doesn't support image input — add as file path and show hint
-        hasImageWithoutVision = true;
-      }
+        });
+      },
+      setImageAttachments: (images: CoworkImageAttachment[]) => {
+        const newAttachments: CoworkAttachment[] = images.map((img, idx) => ({
+          path: `inline:${img.name}:reedit-${Date.now()}-${idx}`,
+          name: img.name,
+          isImage: true,
+          dataUrl: `data:${img.mimeType};base64,${img.base64Data}`,
+        }));
+        dispatch(setDraftAttachments({ draftKey, attachments: newAttachments }));
+      },
+      focus: () => {
+        textareaRef.current?.focus();
+      },
+    }));
 
-      // Non-image file or model doesn't support images: use original flow
-      if (nativePath) {
-        addAttachment(nativePath);
-        continue;
-      }
-
-      const stagedPath = await saveInlineFile(file);
-      if (stagedPath) {
-        addAttachment(stagedPath);
-      }
-    }
-    if (hasImageWithoutVision) {
-      setImageVisionHint(true);
-    }
-  }, [addAttachment, addImageAttachmentFromDataUrl, disabled, fileToDataUrl, getNativeFilePath, isStreaming, modelSupportsImage, saveInlineFile]);
-
-  const handleAddFile = useCallback(async () => {
-    if (isAddingFile || disabled || isStreaming) return;
-    setIsAddingFile(true);
-    try {
-      const result = await window.electron.dialog.selectFiles({
-        title: i18nService.t('coworkAddFile'),
+    const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
+    const skills = useSelector((state: RootState) => state.skill.skills);
+    const currentAgent = agents.find(agent => agent.id === currentAgentId);
+    const { selectedModel: agentSelectedModel, hasInvalidExplicitModel: agentModelIsInvalid } =
+      resolveAgentModelSelection({
+        agentModel: currentAgent?.model ?? '',
+        availableModels,
+        fallbackModel: globalSelectedModel,
+        engine: coworkAgentEngine,
       });
-      if (!result.success || result.paths.length === 0) return;
-      let hasImageWithoutVision = false;
-      for (const filePath of result.paths) {
-        if (isImagePath(filePath)) {
-          if (modelSupportsImage) {
-            try {
-              const readResult = await window.electron.dialog.readFileAsDataUrl(filePath);
-              if (readResult.success && readResult.dataUrl) {
-                addAttachment(filePath, { isImage: true, dataUrl: readResult.dataUrl });
-                continue;
-              }
-            } catch (error) {
-              console.error('Failed to read image as data URL:', error);
 
+    const isLarge = size === 'large';
+    const minHeight = isLarge ? 60 : 24;
+    const maxHeight = isLarge ? 200 : 200;
+
+    // Load skills on mount
+    useEffect(() => {
+      const loadSkills = async () => {
+        const loadedSkills = await skillService.loadSkills();
+        dispatch(setSkills(loadedSkills));
+      };
+      loadSkills();
+    }, [dispatch]);
+
+    useEffect(() => {
+      const unsubscribe = skillService.onSkillsChanged(async () => {
+        const loadedSkills = await skillService.loadSkills();
+        dispatch(setSkills(loadedSkills));
+      });
+      return () => {
+        unsubscribe();
+      };
+    }, [dispatch]);
+
+    // Auto-resize textarea
+    useEffect(() => {
+      const textarea = textareaRef.current;
+      if (textarea) {
+        textarea.style.height = 'auto';
+        textarea.style.height = `${Math.min(Math.max(textarea.scrollHeight, minHeight), maxHeight)}px`;
+      }
+    }, [value, minHeight, maxHeight]);
+
+    useEffect(() => {
+      const handleFocusInput = (event: Event) => {
+        const detail = (event as CustomEvent<{ clear?: boolean }>).detail;
+        const shouldClear = detail?.clear ?? true;
+        if (shouldClear) {
+          setValue('');
+          dispatch(clearDraftAttachments(draftKey));
+        }
+        requestAnimationFrame(() => {
+          textareaRef.current?.focus();
+        });
+      };
+      window.addEventListener('cowork:focus-input', handleFocusInput);
+      return () => {
+        window.removeEventListener('cowork:focus-input', handleFocusInput);
+        if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
+      };
+    }, [dispatch, draftKey]);
+
+    useEffect(() => {
+      if (workingDirectory?.trim()) {
+        setShowFolderRequiredWarning(false);
+      }
+    }, [workingDirectory]);
+
+    // Sync value from draft when sessionId changes
+    useEffect(() => {
+      setValue(draftPrompt);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [draftKey]); // intentionally omit draftPrompt to only trigger on session switch
+
+    useEffect(() => {
+      if (value !== draftPrompt) {
+        const timer = setTimeout(() => {
+          dispatch(setDraftPrompt({ sessionId: draftKey, draft: value }));
+        }, 300);
+        return () => clearTimeout(timer);
+      }
+    }, [value, draftPrompt, dispatch, draftKey]);
+
+    const handleSubmit = useCallback(async () => {
+      if (showFolderSelector && !workingDirectory?.trim()) {
+        setShowFolderRequiredWarning(true);
+        if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
+        warningTimerRef.current = setTimeout(() => {
+          setShowFolderRequiredWarning(false);
+          warningTimerRef.current = null;
+        }, 3000);
+        return;
+      }
+
+      const trimmedValue = value.trim();
+      if ((!trimmedValue && attachments.length === 0) || disabled) return;
+      setShowFolderRequiredWarning(false);
+
+      // Get active skills prompts and combine them
+      const activeSkills = activeSkillIds
+        .map(id => skills.find(s => s.id === id))
+        .filter((s): s is Skill => s !== undefined);
+      const skillPrompt =
+        activeSkills.length > 0
+          ? activeSkills.map(buildInlinedSkillPrompt).join('\n\n')
+          : undefined;
+
+      // Extract image attachments (with base64 data) for vision-capable models
+      const imageAtts: CoworkImageAttachment[] = [];
+      for (const attachment of attachments) {
+        if (attachment.isImage && attachment.dataUrl) {
+          const extracted = extractBase64FromDataUrl(attachment.dataUrl);
+          if (extracted) {
+            imageAtts.push({
+              name: attachment.name,
+              mimeType: extracted.mimeType,
+              base64Data: extracted.base64Data,
+            });
+          }
+        }
+      }
+
+      // Build prompt with ALL attachments that have real file paths (both regular files and images).
+      // Image attachments also need their file paths in the prompt so the model knows
+      // where the original files are located (e.g., for skills like seedream that need --image <path>).
+      // Note: inline/clipboard images have pseudo-paths starting with 'inline:' and are excluded.
+      const attachmentLines = attachments
+        .filter(a => !a.path.startsWith('inline:'))
+        .map(attachment => `${i18nService.t('inputFileLabel')}: ${attachment.path}`)
+        .join('\n');
+      const finalPrompt = trimmedValue
+        ? attachmentLines
+          ? `${trimmedValue}\n\n${attachmentLines}`
+          : trimmedValue
+        : attachmentLines;
+
+      if (imageAtts.length > 0) {
+        console.log('[CoworkPromptInput] handleSubmit: passing imageAtts to onSubmit', {
+          count: imageAtts.length,
+          names: imageAtts.map(a => a.name),
+          base64Lengths: imageAtts.map(a => a.base64Data.length),
+        });
+      }
+      const result = await onSubmit(
+        finalPrompt,
+        skillPrompt,
+        imageAtts.length > 0 ? imageAtts : undefined,
+      );
+      if (result === false) return;
+      setValue('');
+      dispatch(setDraftPrompt({ sessionId: draftKey, draft: '' }));
+      dispatch(clearDraftAttachments(draftKey));
+      setImageVisionHint(false);
+    }, [
+      value,
+      disabled,
+      onSubmit,
+      activeSkillIds,
+      skills,
+      attachments,
+      showFolderSelector,
+      workingDirectory,
+      dispatch,
+      draftKey,
+    ]);
+
+    const handleSelectSkill = useCallback(
+      (skill: Skill) => {
+        dispatch(toggleActiveSkill(skill.id));
+      },
+      [dispatch],
+    );
+
+    const handleManageSkills = useCallback(() => {
+      if (onManageSkills) {
+        onManageSkills();
+      }
+    }, [onManageSkills]);
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      const isComposing = event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229;
+      if (event.key !== 'Enter' || isComposing) return;
+
+      // Use synced state (kept up-to-date via config-updated event) so that
+      // changes made in the Settings panel are reflected immediately without
+      // requiring a configService read at event time.
+      const sendKey = currentSendShortcut;
+
+      let isSendCombo = false;
+      switch (sendKey) {
+        case 'Enter':
+          isSendCombo = !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey;
+          break;
+        case 'Shift+Enter':
+          isSendCombo = event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey;
+          break;
+        case 'Ctrl+Enter':
+          isSendCombo = isMacPlatform
+            ? event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey
+            : event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey;
+          break;
+        case 'Alt+Enter':
+          isSendCombo = event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
+          break;
+        default:
+          // Unknown config value — fall back to bare Enter so the user can always send
+          isSendCombo = !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey;
+          break;
+      }
+
+      if (isSendCombo && !disabled) {
+        event.preventDefault();
+        handleSubmit();
+      } else {
+        // Any non-send Enter combo inserts a newline.
+        // Shift+Enter inserts newline natively; for other combos use execCommand.
+        if (!event.shiftKey) {
+          event.preventDefault();
+          document.execCommand('insertText', false, '\n');
+        }
+      }
+    };
+
+    const handleStopClick = () => {
+      if (onStop) {
+        onStop();
+      }
+    };
+
+    const containerClass = isLarge
+      ? 'relative rounded-2xl border border-border bg-surface shadow-card focus-within:shadow-elevated focus-within:ring-1 focus-within:ring-primary/40 focus-within:border-primary'
+      : 'relative flex items-end gap-2 p-3 rounded-xl border border-border bg-surface';
+
+    const textareaClass = isLarge
+      ? `w-full resize-none bg-transparent px-4 pt-2.5 pb-2 text-foreground placeholder:dark:text-foregroundSecondary/60 placeholder:text-secondary/60 focus:outline-none text-[15px] leading-6 min-h-[${minHeight}px] max-h-[${maxHeight}px]`
+      : 'flex-1 resize-none bg-transparent text-foreground placeholder:placeholder:text-secondary focus:outline-none text-sm leading-relaxed min-h-[24px] max-h-[200px]';
+
+    const truncatePath = (path: string, maxLength = 30): string => {
+      if (!path) return i18nService.t('noFolderSelected');
+      return getCompactFolderName(path, maxLength) || i18nService.t('noFolderSelected');
+    };
+
+    const handleFolderSelect = (path: string) => {
+      if (onWorkingDirectoryChange) {
+        onWorkingDirectoryChange(path);
+      }
+    };
+
+    const effectiveSelectedModel =
+      coworkAgentEngine === 'openclaw' ? agentSelectedModel : globalSelectedModel;
+    const modelSupportsImage = !!effectiveSelectedModel?.supportsImage;
+
+    const addAttachment = useCallback(
+      (filePath: string, imageInfo?: { isImage: boolean; dataUrl?: string }) => {
+        if (!filePath) return;
+        dispatch(
+          addDraftAttachment({
+            draftKey,
+            attachment: {
+              path: filePath,
+              name: getFileNameFromPath(filePath),
+              isImage: imageInfo?.isImage,
+              dataUrl: imageInfo?.dataUrl,
+            },
+          }),
+        );
+      },
+      [dispatch, draftKey],
+    );
+
+    const addImageAttachmentFromDataUrl = useCallback(
+      (name: string, dataUrl: string) => {
+        // Use the dataUrl as the unique key (no file path for inline images)
+        const pseudoPath = `inline:${name}:${Date.now()}`;
+        dispatch(
+          addDraftAttachment({
+            draftKey,
+            attachment: {
+              path: pseudoPath,
+              name,
+              isImage: true,
+              dataUrl,
+            },
+          }),
+        );
+      },
+      [dispatch, draftKey],
+    );
+
+    const fileToDataUrl = useCallback((file: File): Promise<string> => {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const result = reader.result;
+          if (typeof result !== 'string') {
+            reject(new Error('Failed to read file'));
+            return;
+          }
+          resolve(result);
+        };
+        reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
+        reader.readAsDataURL(file);
+      });
+    }, []);
+
+    const fileToBase64 = useCallback((file: File): Promise<string> => {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const result = reader.result;
+          if (typeof result !== 'string') {
+            reject(new Error('Failed to read file'));
+            return;
+          }
+          const commaIndex = result.indexOf(',');
+          resolve(commaIndex >= 0 ? result.slice(commaIndex + 1) : result);
+        };
+        reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
+        reader.readAsDataURL(file);
+      });
+    }, []);
+
+    const getNativeFilePath = useCallback((file: File): string | null => {
+      const maybePath = (file as File & { path?: string }).path;
+      if (typeof maybePath === 'string' && maybePath.trim()) {
+        return maybePath;
+      }
+      return null;
+    }, []);
+
+    const saveInlineFile = useCallback(
+      async (file: File): Promise<string | null> => {
+        try {
+          const dataBase64 = await fileToBase64(file);
+          if (!dataBase64) {
+            return null;
+          }
+          const result = await window.electron.dialog.saveInlineFile({
+            dataBase64,
+            fileName: file.name,
+            mimeType: file.type,
+            cwd: workingDirectory,
+          });
+          if (result.success && result.path) {
+            return result.path;
+          }
+          return null;
+        } catch (error) {
+          console.error('Failed to save inline file:', error);
+          return null;
+        }
+      },
+      [fileToBase64, workingDirectory],
+    );
+
+    const handleIncomingFiles = useCallback(
+      async (fileList: FileList | File[]) => {
+        if (disabled || isStreaming) return;
+        const files = Array.from(fileList ?? []);
+        if (files.length === 0) return;
+
+        let hasImageWithoutVision = false;
+        for (const file of files) {
+          const nativePath = getNativeFilePath(file);
+
+          // Check if this is an image file and model supports images
+          const fileIsImage = nativePath ? isImagePath(nativePath) : isImageMimeType(file.type);
+
+          if (fileIsImage) {
+            if (modelSupportsImage) {
+              // For images on vision-capable models, read as data URL
+              if (nativePath) {
+                try {
+                  const result = await window.electron.dialog.readFileAsDataUrl(nativePath);
+                  if (result.success && result.dataUrl) {
+                    addAttachment(nativePath, { isImage: true, dataUrl: result.dataUrl });
+                    continue;
+                  }
+                } catch (error) {
+                  console.error('Failed to read image as data URL:', error);
+                }
+                // Fallback: add as regular file attachment
+                addAttachment(nativePath);
+              } else {
+                // No native path (clipboard/drag from browser):
+                // 1. Read as dataUrl for preview + base64 vision
+                // 2. Save to disk so the agent can access the file in later turns
+                let dataUrl: string | null = null;
+                try {
+                  dataUrl = await fileToDataUrl(file);
+                } catch (error) {
+                  console.error('Failed to read clipboard image as data URL:', error);
+                }
+
+                const stagedPath = await saveInlineFile(file);
+
+                if (stagedPath) {
+                  addAttachment(stagedPath, {
+                    isImage: true,
+                    dataUrl: dataUrl ?? undefined,
+                  });
+                } else if (dataUrl) {
+                  console.warn('Clipboard image saved only in memory (disk save failed)');
+                  addImageAttachmentFromDataUrl(file.name, dataUrl);
+                } else {
+                  console.error(
+                    'Failed to process clipboard image: both dataUrl and disk save failed',
+                  );
+                }
+              }
+              continue;
             }
-          } else {
+            // Model doesn't support image input — add as file path and show hint
             hasImageWithoutVision = true;
           }
+
+          // Non-image file or model doesn't support images: use original flow
+          if (nativePath) {
+            addAttachment(nativePath);
+            continue;
+          }
+
+          const stagedPath = await saveInlineFile(file);
+          if (stagedPath) {
+            addAttachment(stagedPath);
+          }
         }
-        addAttachment(filePath);
+        if (hasImageWithoutVision) {
+          setImageVisionHint(true);
+        }
+      },
+      [
+        addAttachment,
+        addImageAttachmentFromDataUrl,
+        disabled,
+        fileToDataUrl,
+        getNativeFilePath,
+        isStreaming,
+        modelSupportsImage,
+        saveInlineFile,
+      ],
+    );
+
+    const handleAddFile = useCallback(async () => {
+      if (isAddingFile || disabled || isStreaming) return;
+      setIsAddingFile(true);
+      try {
+        const result = await window.electron.dialog.selectFiles({
+          title: i18nService.t('coworkAddFile'),
+        });
+        if (!result.success || result.paths.length === 0) return;
+        let hasImageWithoutVision = false;
+        for (const filePath of result.paths) {
+          if (isImagePath(filePath)) {
+            if (modelSupportsImage) {
+              try {
+                const readResult = await window.electron.dialog.readFileAsDataUrl(filePath);
+                if (readResult.success && readResult.dataUrl) {
+                  addAttachment(filePath, { isImage: true, dataUrl: readResult.dataUrl });
+                  continue;
+                }
+              } catch (error) {
+                console.error('Failed to read image as data URL:', error);
+              }
+            } else {
+              hasImageWithoutVision = true;
+            }
+          }
+          addAttachment(filePath);
+        }
+        if (hasImageWithoutVision) {
+          setImageVisionHint(true);
+        }
+      } catch (error) {
+        console.error('Failed to select file:', error);
+      } finally {
+        setIsAddingFile(false);
       }
-      if (hasImageWithoutVision) {
-        setImageVisionHint(true);
+    }, [addAttachment, isAddingFile, disabled, isStreaming, modelSupportsImage]);
 
+    const handleRemoveAttachment = useCallback(
+      (path: string) => {
+        dispatch(
+          setDraftAttachments({
+            draftKey,
+            attachments: attachments.filter(attachment => attachment.path !== path),
+          }),
+        );
+      },
+      [attachments, dispatch, draftKey],
+    );
+
+    const hasFileTransfer = (dataTransfer: DataTransfer | null): boolean => {
+      if (!dataTransfer) return false;
+      if (dataTransfer.files.length > 0) return true;
+      return Array.from(dataTransfer.types).includes('Files');
+    };
+
+    const handleDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
+      if (!hasFileTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      dragDepthRef.current += 1;
+      if (!disabled && !isStreaming) {
+        setIsDraggingFiles(true);
       }
-    } catch (error) {
-      console.error('Failed to select file:', error);
-    } finally {
-      setIsAddingFile(false);
-    }
-  }, [addAttachment, isAddingFile, disabled, isStreaming, modelSupportsImage]);
+    };
 
-  const handleRemoveAttachment = useCallback((path: string) => {
-    dispatch(setDraftAttachments({
-      draftKey,
-      attachments: attachments.filter((attachment) => attachment.path !== path),
-    }));
-  }, [attachments, dispatch, draftKey]);
+    const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+      if (!hasFileTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = disabled || isStreaming ? 'none' : 'copy';
+    };
 
-  const hasFileTransfer = (dataTransfer: DataTransfer | null): boolean => {
-    if (!dataTransfer) return false;
-    if (dataTransfer.files.length > 0) return true;
-    return Array.from(dataTransfer.types).includes('Files');
-  };
+    const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+      if (!hasFileTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+      if (dragDepthRef.current === 0) {
+        setIsDraggingFiles(false);
+      }
+    };
 
-  const handleDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!hasFileTransfer(event.dataTransfer)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    dragDepthRef.current += 1;
-    if (!disabled && !isStreaming) {
-      setIsDraggingFiles(true);
-    }
-  };
-
-  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!hasFileTransfer(event.dataTransfer)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    event.dataTransfer.dropEffect = disabled || isStreaming ? 'none' : 'copy';
-  };
-
-  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!hasFileTransfer(event.dataTransfer)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
-    if (dragDepthRef.current === 0) {
+    const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+      if (!hasFileTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      dragDepthRef.current = 0;
       setIsDraggingFiles(false);
-    }
-  };
-
-  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!hasFileTransfer(event.dataTransfer)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    dragDepthRef.current = 0;
-    setIsDraggingFiles(false);
-    if (disabled || isStreaming) return;
-    void handleIncomingFiles(event.dataTransfer.files);
-  };
-
-  const handlePaste = useCallback((event: React.ClipboardEvent<HTMLTextAreaElement>) => {
-    if (disabled || isStreaming) return;
-    const files = Array.from(event.clipboardData?.files ?? []);
-    if (files.length === 0) return;
-    event.preventDefault();
-    void handleIncomingFiles(files);
-  }, [disabled, handleIncomingFiles, isStreaming]);
-
-  const canSubmit = !disabled && !agentModelIsInvalid && (!!value.trim() || attachments.length > 0);
-  const enhancedContainerClass = isDraggingFiles
-    ? `${containerClass} ring-2 ring-primary/50 border-primary/60`
-    : containerClass;
-
-  const [showSendShortcutMenu, setShowSendShortcutMenu] = useState(false);
-  const sendShortcutMenuRef = useRef<HTMLDivElement>(null);
-  const sendShortcutBtnRef = useRef<HTMLButtonElement>(null);
-  const [currentSendShortcut, setCurrentSendShortcut] = useState(
-    () => configService.getConfig().shortcuts?.sendMessage ?? 'Enter'
-  );
-
-  // Sync when config is updated elsewhere (e.g. Settings panel)
-  useEffect(() => {
-    const syncFromConfig = () => {
-      const latest = configService.getConfig().shortcuts?.sendMessage ?? 'Enter';
-      setCurrentSendShortcut(latest);
+      if (disabled || isStreaming) return;
+      void handleIncomingFiles(event.dataTransfer.files);
     };
-    window.addEventListener('config-updated', syncFromConfig);
-    return () => window.removeEventListener('config-updated', syncFromConfig);
-  }, []);
-  useEffect(() => {
-    if (!showSendShortcutMenu) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        sendShortcutMenuRef.current && !sendShortcutMenuRef.current.contains(e.target as Node) &&
-        sendShortcutBtnRef.current && !sendShortcutBtnRef.current.contains(e.target as Node)
-      ) {
-        setShowSendShortcutMenu(false);
-      }
+
+    const handlePaste = useCallback(
+      (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+        if (disabled || isStreaming) return;
+        const files = Array.from(event.clipboardData?.files ?? []);
+        if (files.length === 0) return;
+        event.preventDefault();
+        void handleIncomingFiles(files);
+      },
+      [disabled, handleIncomingFiles, isStreaming],
+    );
+
+    const canSubmit =
+      !disabled && !agentModelIsInvalid && (!!value.trim() || attachments.length > 0);
+    const enhancedContainerClass = isDraggingFiles
+      ? `${containerClass} ring-2 ring-primary/50 border-primary/60`
+      : containerClass;
+
+    const [showSendShortcutMenu, setShowSendShortcutMenu] = useState(false);
+    const sendShortcutMenuRef = useRef<HTMLDivElement>(null);
+    const sendShortcutBtnRef = useRef<HTMLButtonElement>(null);
+    const [currentSendShortcut, setCurrentSendShortcut] = useState(
+      () => configService.getConfig().shortcuts?.sendMessage ?? 'Enter',
+    );
+
+    // Sync when config is updated elsewhere (e.g. Settings panel)
+    useEffect(() => {
+      const syncFromConfig = () => {
+        const latest = configService.getConfig().shortcuts?.sendMessage ?? 'Enter';
+        setCurrentSendShortcut(latest);
+      };
+      window.addEventListener('config-updated', syncFromConfig);
+      return () => window.removeEventListener('config-updated', syncFromConfig);
+    }, []);
+    useEffect(() => {
+      if (!showSendShortcutMenu) return;
+      const handleClickOutside = (e: MouseEvent) => {
+        if (
+          sendShortcutMenuRef.current &&
+          !sendShortcutMenuRef.current.contains(e.target as Node) &&
+          sendShortcutBtnRef.current &&
+          !sendShortcutBtnRef.current.contains(e.target as Node)
+        ) {
+          setShowSendShortcutMenu(false);
+        }
+      };
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [showSendShortcutMenu]);
+
+    const handleSendShortcutChange = async (value: string) => {
+      const config = configService.getConfig();
+      await configService.updateConfig({
+        shortcuts: {
+          ...(config.shortcuts ?? defaultConfig.shortcuts),
+          sendMessage: value,
+        } as NonNullable<typeof config.shortcuts>,
+      });
+      setCurrentSendShortcut(value);
+      setShowSendShortcutMenu(false);
     };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [showSendShortcutMenu]);
 
-  const handleSendShortcutChange = async (value: string) => {
-    const config = configService.getConfig();
-    await configService.updateConfig({
-      shortcuts: { ...(config.shortcuts ?? defaultConfig.shortcuts), sendMessage: value } as NonNullable<typeof config.shortcuts>,
-    });
-    setCurrentSendShortcut(value);
-    setShowSendShortcutMenu(false);
-  };
-
-  const sendShortcutDropdown = (
-    <div
-      ref={sendShortcutMenuRef}
-      className="absolute bottom-full mb-1 right-0 z-50 min-w-[160px] rounded-xl border border-border bg-surface shadow-elevated py-1"
-    >
-      {SEND_SHORTCUT_OPTIONS.map((option) => (
-        <button
-          key={option.value}
-          type="button"
-          onClick={() => handleSendShortcutChange(option.value)}
-          className="flex items-center justify-between w-full px-3 py-1.5 text-sm text-foreground hover:bg-surface-raised transition-colors"
-        >
-          <span>{isMacPlatform ? option.labelMac : option.label}</span>
-          {currentSendShortcut === option.value && (
-            <CheckIcon className="h-4 w-4 text-primary" />
-          )}
-        </button>
-      ))}
-    </div>
-  );
-
-  return (
-    <div className="relative">
-      {attachments.length > 0 && (
-        <div className="mb-2 flex flex-wrap gap-2">
-          {attachments.map((attachment) => (
-            <AttachmentCard
-              key={attachment.path}
-              attachment={attachment}
-              onRemove={handleRemoveAttachment}
-            />
-          ))}
-        </div>
-      )}
-      {imageVisionHint && (
-        <div className="mb-2 flex items-start gap-1.5 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 px-2.5 py-1.5 text-xs text-amber-700 dark:text-amber-400">
-          <ExclamationTriangleIcon className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
-          <span>
-            {i18nService.t('imageVisionHint')}
-          </span>
-          <button
-            type="button"
-            onClick={() => setImageVisionHint(false)}
-            className="ml-auto flex-shrink-0 rounded-full p-0.5 hover:bg-amber-200/50 dark:hover:bg-amber-800/50"
-          >
-            <XMarkIcon className="h-3 w-3" />
-          </button>
-        </div>
-      )}
+    const sendShortcutDropdown = (
       <div
-        className={enhancedContainerClass}
-        onDragEnter={handleDragEnter}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
+        ref={sendShortcutMenuRef}
+        className="absolute bottom-full mb-1 right-0 z-50 min-w-[160px] rounded-xl border border-border bg-surface shadow-elevated py-1"
       >
-        {isDraggingFiles && (
-          <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-[inherit] bg-primary/10 text-xs font-medium text-primary">
-            {i18nService.t('coworkDropFileHint')}
+        {SEND_SHORTCUT_OPTIONS.map(option => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => handleSendShortcutChange(option.value)}
+            className="flex items-center justify-between w-full px-3 py-1.5 text-sm text-foreground hover:bg-surface-raised transition-colors"
+          >
+            <span>{isMacPlatform ? option.labelMac : option.label}</span>
+            {currentSendShortcut === option.value && <CheckIcon className="h-4 w-4 text-primary" />}
+          </button>
+        ))}
+      </div>
+    );
+
+    return (
+      <div className="relative">
+        {attachments.length > 0 && (
+          <div className="mb-2 flex flex-wrap gap-2">
+            {attachments.map(attachment => (
+              <AttachmentCard
+                key={attachment.path}
+                attachment={attachment}
+                onRemove={handleRemoveAttachment}
+              />
+            ))}
           </div>
         )}
-        {isLarge ? (
-          <>
-            <textarea
-              ref={textareaRef}
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onPaste={handlePaste}
-              placeholder={placeholder}
-              disabled={disabled}
-              rows={isLarge ? 2 : 1}
-              className={textareaClass}
-              style={{ minHeight: `${minHeight}px` }}
-            />
-            <div className="flex items-center justify-between px-4 pb-2 pt-1.5">
-              <div className="flex items-center gap-2 relative">
-                {showFolderSelector && (
-                  <>
+        {imageVisionHint && (
+          <div className="mb-2 flex items-start gap-1.5 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 px-2.5 py-1.5 text-xs text-amber-700 dark:text-amber-400">
+            <ExclamationTriangleIcon className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
+            <span>{i18nService.t('imageVisionHint')}</span>
+            <button
+              type="button"
+              onClick={() => setImageVisionHint(false)}
+              className="ml-auto flex-shrink-0 rounded-full p-0.5 hover:bg-amber-200/50 dark:hover:bg-amber-800/50"
+            >
+              <XMarkIcon className="h-3 w-3" />
+            </button>
+          </div>
+        )}
+        <div
+          className={enhancedContainerClass}
+          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          {isDraggingFiles && (
+            <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-[inherit] bg-primary/10 text-xs font-medium text-primary">
+              {i18nService.t('coworkDropFileHint')}
+            </div>
+          )}
+          {isLarge ? (
+            <>
+              <textarea
+                ref={textareaRef}
+                value={value}
+                onChange={e => setValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
+                placeholder={placeholder}
+                disabled={disabled}
+                rows={isLarge ? 2 : 1}
+                className={textareaClass}
+                style={{ minHeight: `${minHeight}px` }}
+              />
+              <div className="flex items-center justify-between px-4 pb-2 pt-1.5">
+                <div className="flex items-center gap-2 relative">
+                  {showFolderSelector && (
+                    <>
                       <div className="flex items-center">
                         <button
                           ref={folderButtonRef as React.RefObject<HTMLButtonElement>}
@@ -818,7 +903,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                             <span
                               role="button"
                               tabIndex={-1}
-                              onClick={(e) => {
+                              onClick={e => {
                                 e.stopPropagation();
                                 handleFolderSelect('');
                               }}
@@ -829,80 +914,96 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                           )}
                         </button>
                       </div>
-                    <FolderSelectorPopover
-                      isOpen={showFolderMenu}
-                      onClose={() => setShowFolderMenu(false)}
-                      onSelectFolder={handleFolderSelect}
-                      anchorRef={folderButtonRef as React.RefObject<HTMLElement>}
-                    />
-                    {showFolderRequiredWarning && (
-                      <div className="absolute left-0 top-full mt-1 px-2 py-1 rounded-md bg-surface-raised text-warning text-xs whitespace-nowrap animate-fade-in-up shadow-subtle z-10">
-                        {i18nService.t('coworkSelectFolderFirst')}
-                      </div>
-                    )}
-                  </>
-                )}
-                {showModelSelector && !remoteManaged && (
-                  <div className="flex flex-col items-start gap-1">
-                    <ModelSelector
-                      dropdownDirection="up"
-                      value={coworkAgentEngine === 'openclaw' ? agentSelectedModel : null}
-                      onChange={coworkAgentEngine === 'openclaw'
-                        ? async (nextModel) => {
-                            if (!currentAgent || !nextModel) return;
-                            await agentService.updateAgent(currentAgent.id, { model: toOpenClawModelRef(nextModel) });
-                          }
-                        : undefined}
-                    />
-                    {coworkAgentEngine === 'openclaw' && agentModelIsInvalid && (
-                      <span className="max-w-60 text-[11px] leading-4 text-red-500">
-                        {i18nService.t('agentModelInvalidHint')}
-                      </span>
-                    )}
-                  </div>
-                )}
-                {!remoteManaged && (
-                  <button
-                    type="button"
-                    onClick={handleAddFile}
-                    className="flex items-center justify-center p-1.5 rounded-lg text-sm text-secondary hover:bg-surface-raised hover:text-foreground transition-colors"
-                    title={i18nService.t('coworkAddFile')}
-                    aria-label={i18nService.t('coworkAddFile')}
-                    disabled={disabled || isStreaming || isAddingFile}
-                  >
-                    <PaperClipIcon className="h-4 w-4" />
-                  </button>
-                )}
-                {!remoteManaged && (
-                  <>
-                    <SkillsButton
-                      onSelectSkill={handleSelectSkill}
-                      onManageSkills={handleManageSkills}
-                    />
-                    <ActiveSkillBadge />
-                  </>
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                {isStreaming ? (
-                  <button
-                    type="button"
-                    onClick={handleStopClick}
-                    className="p-2 rounded-xl bg-red-500 hover:bg-red-600 text-white transition-all shadow-subtle hover:shadow-card active:scale-95"
-                    aria-label="Stop"
-                  >
-                    <StopIcon className="h-5 w-5" />
-                  </button>
-                ) : (
+                      <FolderSelectorPopover
+                        isOpen={showFolderMenu}
+                        onClose={() => setShowFolderMenu(false)}
+                        onSelectFolder={handleFolderSelect}
+                        anchorRef={folderButtonRef as React.RefObject<HTMLElement>}
+                      />
+                      {showFolderRequiredWarning && (
+                        <div className="absolute left-0 top-full mt-1 px-2 py-1 rounded-md bg-surface-raised text-warning text-xs whitespace-nowrap animate-fade-in-up shadow-subtle z-10">
+                          {i18nService.t('coworkSelectFolderFirst')}
+                        </div>
+                      )}
+                    </>
+                  )}
+                  {showModelSelector && !remoteManaged && (
+                    <div className="flex flex-col items-start gap-1">
+                      <ModelSelector
+                        dropdownDirection="up"
+                        value={coworkAgentEngine === 'openclaw' ? agentSelectedModel : null}
+                        onChange={
+                          coworkAgentEngine === 'openclaw'
+                            ? async nextModel => {
+                                if (!currentAgent || !nextModel) return;
+                                await agentService.updateAgent(currentAgent.id, {
+                                  model: toOpenClawModelRef(nextModel),
+                                });
+                              }
+                            : undefined
+                        }
+                      />
+                      {coworkAgentEngine === 'openclaw' && agentModelIsInvalid && (
+                        <span className="max-w-60 text-[11px] leading-4 text-red-500">
+                          {i18nService.t('agentModelInvalidHint')}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                  {!remoteManaged && (
+                    <button
+                      type="button"
+                      onClick={handleAddFile}
+                      className="flex items-center justify-center p-1.5 rounded-lg text-sm text-secondary hover:bg-surface-raised hover:text-foreground transition-colors"
+                      title={i18nService.t('coworkAddFile')}
+                      aria-label={i18nService.t('coworkAddFile')}
+                      disabled={disabled || isStreaming || isAddingFile}
+                    >
+                      <PaperClipIcon className="h-4 w-4" />
+                    </button>
+                  )}
+                  {!remoteManaged && (
+                    <>
+                      <SkillsButton
+                        onSelectSkill={handleSelectSkill}
+                        onManageSkills={handleManageSkills}
+                      />
+                      <ActiveSkillBadge />
+                    </>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  {isStreaming && (
+                    <button
+                      type="button"
+                      onClick={handleStopClick}
+                      className="p-2 rounded-xl bg-red-500 hover:bg-red-600 text-white transition-all shadow-subtle hover:shadow-card active:scale-95"
+                      aria-label="Stop"
+                    >
+                      <StopIcon className="h-5 w-5" />
+                    </button>
+                  )}
                   <div className="relative">
-                    <div className={`flex items-stretch rounded-xl shadow-subtle hover:shadow-card ${!canSubmit ? 'opacity-50' : ''}`}>
+                    <div
+                      className={`flex items-stretch rounded-xl shadow-subtle hover:shadow-card ${!canSubmit ? 'opacity-50' : ''}`}
+                    >
                       <button
                         type="button"
                         onClick={handleSubmit}
                         disabled={!canSubmit}
-                        className="p-2 rounded-l-xl bg-primary hover:bg-primary-hover text-white transition-all active:scale-95 disabled:cursor-not-allowed"
-                        aria-label="Send"
-                        title={currentSendShortcut !== 'Enter' ? getSendShortcutLabel(currentSendShortcut) : undefined}
+                        className={`p-2 rounded-l-xl text-white transition-all active:scale-95 disabled:cursor-not-allowed ${
+                          isStreaming
+                            ? 'bg-amber-500 hover:bg-amber-600'
+                            : 'bg-primary hover:bg-primary-hover'
+                        }`}
+                        aria-label={isStreaming ? 'Queue' : 'Send'}
+                        title={
+                          isStreaming
+                            ? i18nService.t('coworkQueueSendHint')
+                            : currentSendShortcut !== 'Enter'
+                              ? getSendShortcutLabel(currentSendShortcut)
+                              : undefined
+                        }
                       >
                         <PaperAirplaneIcon className="h-5 w-5" />
                       </button>
@@ -910,7 +1011,11 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                         ref={sendShortcutBtnRef}
                         type="button"
                         onClick={() => setShowSendShortcutMenu(!showSendShortcutMenu)}
-                        className="px-1 flex items-center rounded-r-xl bg-primary hover:bg-primary-hover text-white transition-all active:scale-95 border-l border-white/20"
+                        className={`px-1 flex items-center rounded-r-xl text-white transition-all active:scale-95 border-l border-white/20 ${
+                          isStreaming
+                            ? 'bg-amber-500 hover:bg-amber-600'
+                            : 'bg-primary hover:bg-primary-hover'
+                        }`}
                         aria-label="Change send shortcut"
                       >
                         <ChevronDownIcon className="h-3 w-3" />
@@ -918,58 +1023,69 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                     </div>
                     {showSendShortcutMenu && sendShortcutDropdown}
                   </div>
-                )}
+                </div>
               </div>
-            </div>
-          </>
-        ) : (
-          <>
-            <textarea
-              ref={textareaRef}
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onPaste={handlePaste}
-              placeholder={placeholder}
-              disabled={disabled}
-              rows={1}
-              className={textareaClass}
-            />
+            </>
+          ) : (
+            <>
+              <textarea
+                ref={textareaRef}
+                value={value}
+                onChange={e => setValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
+                placeholder={placeholder}
+                disabled={disabled}
+                rows={1}
+                className={textareaClass}
+              />
 
-            {!remoteManaged && (
-              <div className="flex items-center gap-1">
+              {!remoteManaged && (
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={handleAddFile}
+                    className="flex-shrink-0 p-1.5 rounded-lg text-secondary hover:bg-surface-raised hover:text-foreground transition-colors"
+                    title={i18nService.t('coworkAddFile')}
+                    aria-label={i18nService.t('coworkAddFile')}
+                    disabled={disabled || isStreaming || isAddingFile}
+                  >
+                    <PaperClipIcon className="h-4 w-4" />
+                  </button>
+                </div>
+              )}
+
+              {isStreaming && (
                 <button
                   type="button"
-                  onClick={handleAddFile}
-                  className="flex-shrink-0 p-1.5 rounded-lg text-secondary hover:bg-surface-raised hover:text-foreground transition-colors"
-                  title={i18nService.t('coworkAddFile')}
-                  aria-label={i18nService.t('coworkAddFile')}
-                  disabled={disabled || isStreaming || isAddingFile}
+                  onClick={handleStopClick}
+                  className="flex-shrink-0 p-2 rounded-lg bg-red-500 hover:bg-red-600 text-white transition-all shadow-subtle hover:shadow-card active:scale-95"
+                  aria-label="Stop"
                 >
-                  <PaperClipIcon className="h-4 w-4" />
+                  <StopIcon className="h-4 w-4" />
                 </button>
-              </div>
-            )}
-
-            {isStreaming ? (
-              <button
-                type="button"
-                onClick={handleStopClick}
-                className="flex-shrink-0 p-2 rounded-lg bg-red-500 hover:bg-red-600 text-white transition-all shadow-subtle hover:shadow-card active:scale-95"
-                aria-label="Stop"
-              >
-                <StopIcon className="h-4 w-4" />
-              </button>
-            ) : (
+              )}
               <div className="relative flex-shrink-0">
-                <div className={`flex items-stretch rounded-lg shadow-subtle hover:shadow-card ${!canSubmit ? 'opacity-50' : ''}`}>
+                <div
+                  className={`flex items-stretch rounded-lg shadow-subtle hover:shadow-card ${!canSubmit ? 'opacity-50' : ''}`}
+                >
                   <button
                     type="button"
                     onClick={handleSubmit}
                     disabled={!canSubmit}
-                    className="p-2 rounded-l-lg bg-primary hover:bg-primary-hover text-white transition-all active:scale-95 disabled:cursor-not-allowed"
-                    aria-label="Send"
-                    title={currentSendShortcut !== 'Enter' ? getSendShortcutLabel(currentSendShortcut) : undefined}
+                    className={`p-2 rounded-l-lg text-white transition-all active:scale-95 disabled:cursor-not-allowed ${
+                      isStreaming
+                        ? 'bg-amber-500 hover:bg-amber-600'
+                        : 'bg-primary hover:bg-primary-hover'
+                    }`}
+                    aria-label={isStreaming ? 'Queue' : 'Send'}
+                    title={
+                      isStreaming
+                        ? i18nService.t('coworkQueueSendHint')
+                        : currentSendShortcut !== 'Enter'
+                          ? getSendShortcutLabel(currentSendShortcut)
+                          : undefined
+                    }
                   >
                     <PaperAirplaneIcon className="h-4 w-4" />
                   </button>
@@ -977,7 +1093,11 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                     ref={sendShortcutBtnRef}
                     type="button"
                     onClick={() => setShowSendShortcutMenu(!showSendShortcutMenu)}
-                    className="px-1 flex items-center rounded-r-lg bg-primary hover:bg-primary-hover text-white transition-all active:scale-95 border-l border-white/20"
+                    className={`px-1 flex items-center rounded-r-lg text-white transition-all active:scale-95 border-l border-white/20 ${
+                      isStreaming
+                        ? 'bg-amber-500 hover:bg-amber-600'
+                        : 'bg-primary hover:bg-primary-hover'
+                    }`}
                     aria-label="Change send shortcut"
                   >
                     <ChevronDownIcon className="h-3 w-3" />
@@ -985,13 +1105,12 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                 </div>
                 {showSendShortcutMenu && sendShortcutDropdown}
               </div>
-            )}
-          </>
-        )}
+            </>
+          )}
+        </div>
       </div>
-    </div>
-  );
-  }
+    );
+  },
 );
 
 CoworkPromptInput.displayName = 'CoworkPromptInput';

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1,6 +1,3 @@
-import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
-import { createPortal } from 'react-dom';
-import { useDispatch, useSelector } from 'react-redux';
 import { ShareIcon } from '@heroicons/react/20/solid';
 import {
   CheckIcon,
@@ -9,19 +6,27 @@ import {
   PhotoIcon,
 } from '@heroicons/react/24/outline';
 import { FolderIcon } from '@heroicons/react/24/solid';
-import {
-  selectCurrentSession,
-  selectIsStreaming,
-  selectRemoteManaged,
-  selectLastMessageContent,
-  selectCurrentMessagesLength,
-} from '../../store/selectors/coworkSelectors';
+import React, { useCallback, useEffect, useMemo,useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useDispatch, useSelector } from 'react-redux';
+
 import { getScheduledReminderDisplayText } from '../../../scheduledTask/reminderText';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { RootState } from '../../store';
+import {
+  selectCurrentMessagesLength,
+  selectCurrentSession,
+  selectIsStreaming,
+  selectLastMessageContent,
+  selectRemoteManaged,
+} from '../../store/selectors/coworkSelectors';
 import { setActiveSkillIds } from '../../store/slices/skillSlice';
-import type { CoworkMessage, CoworkMessageMetadata, CoworkImageAttachment } from '../../types/cowork';
+import type {
+  CoworkImageAttachment,
+  CoworkMessage,
+  CoworkMessageMetadata,
+} from '../../types/cowork';
 import type { Skill } from '../../types/skill';
 import { getCompactFolderName } from '../../utils/path';
 import Modal from '../common/Modal';
@@ -36,12 +41,17 @@ import TrashIcon from '../icons/TrashIcon';
 import MarkdownContent from '../MarkdownContent';
 import WindowTitleBar from '../window/WindowTitleBar';
 import CoworkPromptInput, { type CoworkPromptInputRef } from './CoworkPromptInput';
+import type { QueuedMessage } from './CoworkView';
 import DiffView, { extractDiffFromToolInput } from './DiffView';
 import LazyRenderTurn, { clearHeightCache } from './LazyRenderTurn';
 
 interface CoworkSessionDetailProps {
   onManageSkills?: () => void;
-  onContinue: (prompt: string, skillPrompt?: string, imageAttachments?: CoworkImageAttachment[]) => boolean | void | Promise<boolean | void>;
+  onContinue: (
+    prompt: string,
+    skillPrompt?: string,
+    imageAttachments?: CoworkImageAttachment[],
+  ) => boolean | void | Promise<boolean | void>;
   onStop: () => void;
   onDeleteSession?: (sessionId: string) => Promise<void>;
   onNavigateHome?: () => void;
@@ -49,6 +59,9 @@ interface CoworkSessionDetailProps {
   onToggleSidebar?: () => void;
   onNewChat?: () => void;
   updateBadge?: React.ReactNode;
+  queuedMessages?: QueuedMessage[];
+  onUpdateQueuedMessage?: (id: string, content: string) => void;
+  onRemoveQueuedMessage?: (id: string) => void;
 }
 
 const AUTO_SCROLL_THRESHOLD = 120;
@@ -72,7 +85,7 @@ const MAX_EXPORT_CANVAS_HEIGHT = 32760;
 const MAX_EXPORT_SEGMENTS = 240;
 
 const waitForNextFrame = (): Promise<void> =>
-  new Promise((resolve) => {
+  new Promise(resolve => {
     window.requestAnimationFrame(() => resolve());
   });
 
@@ -100,7 +113,11 @@ const formatExportDate = (ts: number): string => {
 /** Draw a rounded-rectangle path (for card clipping / filling). */
 const roundRectPath = (
   ctx: CanvasRenderingContext2D,
-  x: number, y: number, w: number, h: number, r: number,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
 ) => {
   ctx.beginPath();
   ctx.moveTo(x + r, y);
@@ -126,19 +143,20 @@ const composeExportCanvas = async (
 ): Promise<HTMLCanvasElement> => {
   const isDark = document.documentElement.classList.contains('dark');
   const dpr = window.devicePixelRatio || 1;
-  const fontStack = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif';
+  const fontStack =
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif';
 
-  const contentW = contentCanvas.width;   // CSS px
-  const contentH = contentCanvas.height;  // CSS px
+  const contentW = contentCanvas.width; // CSS px
+  const contentH = contentCanvas.height; // CSS px
 
   // ── Layout constants (CSS px) ──
-  const outerPadX = 24;          // horizontal breathing room around card
-  const outerPadTop = 28;        // top breathing room
-  const outerPadBottom = 28;     // bottom breathing room
-  const cardRadius = 16;         // card corner radius
-  const cardInnerPadX = 28;      // text indent inside card
-  const headerHeight = 80;       // header area inside card
-  const footerHeight = 80;       // footer area inside card
+  const outerPadX = 24; // horizontal breathing room around card
+  const outerPadTop = 28; // top breathing room
+  const outerPadBottom = 28; // bottom breathing room
+  const cardRadius = 16; // card corner radius
+  const cardInnerPadX = 28; // text indent inside card
+  const headerHeight = 80; // header area inside card
+  const footerHeight = 80; // footer area inside card
   const dividerThick = 1;
   const logoCssSize = 34;
 
@@ -186,8 +204,8 @@ const composeExportCanvas = async (
   ctx.clip();
 
   // card-local origin helpers
-  const cx = outerPadX;           // card left
-  const cy = outerPadTop;         // card top
+  const cx = outerPadX; // card left
+  const cy = outerPadTop; // card top
 
   // ── Header ──
   const titleFontSize = 17;
@@ -211,7 +229,11 @@ const composeExportCanvas = async (
   // Date
   ctx.fillStyle = dateColor;
   ctx.font = `400 ${dateFontSize}px ${fontStack}`;
-  ctx.fillText(formatExportDate(createdAt), cx + cardInnerPadX, headerCenterY + titleFontSize / 2 + 3);
+  ctx.fillText(
+    formatExportDate(createdAt),
+    cx + cardInnerPadX,
+    headerCenterY + titleFontSize / 2 + 3,
+  );
 
   // ── Top divider ──
   ctx.fillStyle = dividerColor;
@@ -264,7 +286,11 @@ const composeExportCanvas = async (
 
   ctx.fillStyle = subtitleColor;
   ctx.font = `400 ${taglineFontSize}px ${fontStack}`;
-  ctx.fillText('7×24 小时帮你干活的全场景个人助理，由网易有道开发', textX, footerCenterY + brandFontSize / 2 + 3);
+  ctx.fillText(
+    '7×24 小时帮你干活的全场景个人助理，由网易有道开发',
+    textX,
+    footerCenterY + brandFontSize / 2 + 3,
+  );
 
   ctx.restore(); // card clip
 
@@ -306,7 +332,7 @@ const formatUnknown = (value: unknown): string => {
 
 const getStringArray = (value: unknown): string | null => {
   if (!Array.isArray(value)) return null;
-  const lines = value.filter((item) => typeof item === 'string') as string[];
+  const lines = value.filter(item => typeof item === 'string') as string[];
   return lines.length > 0 ? lines.join('\n') : null;
 };
 
@@ -357,10 +383,7 @@ const isBashLikeToolName = (toolName: string | undefined): boolean => {
   return normalized === 'bash' || normalized === 'exec' || normalized === 'shell';
 };
 
-const getToolInputString = (
-  input: Record<string, unknown>,
-  keys: string[],
-): string | null => {
+const getToolInputString = (input: Record<string, unknown>, keys: string[]): string | null => {
   for (const key of keys) {
     const value = input[key];
     if (typeof value === 'string' && value.trim()) {
@@ -393,14 +416,11 @@ const getCronToolSummary = (input: Record<string, unknown>): string | null => {
   const action = getToolInputString(input, ['action']);
   if (!action) return null;
 
-  const job = input.job && typeof input.job === 'object'
-    ? input.job as Record<string, unknown>
-    : null;
-  const jobName = job
-    ? getToolInputString(job, ['name', 'id'])
-    : null;
-  const jobId = getToolInputString(input, ['jobId', 'id'])
-    ?? (job ? getToolInputString(job, ['id']) : null);
+  const job =
+    input.job && typeof input.job === 'object' ? (input.job as Record<string, unknown>) : null;
+  const jobName = job ? getToolInputString(job, ['name', 'id']) : null;
+  const jobId =
+    getToolInputString(input, ['jobId', 'id']) ?? (job ? getToolInputString(job, ['id']) : null);
   const wakeText = getToolInputString(input, ['text']);
 
   switch (action) {
@@ -431,14 +451,11 @@ const formatStructuredText = (value: string): string => {
   }
 };
 
-const toTrimmedString = (value: unknown): string | null => (
-  typeof value === 'string' && value.trim() ? value.trim() : null
-);
+const toTrimmedString = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim() ? value.trim() : null;
 
 const normalizeTodoStatus = (value: unknown): TodoStatus => {
-  const normalized = typeof value === 'string'
-    ? value.trim().toLowerCase().replace(/-/g, '_')
-    : '';
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase().replace(/-/g, '_') : '';
 
   if (normalized === 'completed') return 'completed';
   if (normalized === 'in_progress' || normalized === 'running') return 'in_progress';
@@ -452,7 +469,7 @@ const parseTodoWriteItems = (input: unknown): ParsedTodoItem[] | null => {
   if (!Array.isArray(record.todos)) return null;
 
   const parsedItems = record.todos
-    .map((rawTodo) => {
+    .map(rawTodo => {
       if (!rawTodo || typeof rawTodo !== 'object') {
         return null;
       }
@@ -475,8 +492,8 @@ const parseTodoWriteItems = (input: unknown): ParsedTodoItem[] | null => {
 };
 
 const getTodoWriteSummary = (items: ParsedTodoItem[]): string => {
-  const completedCount = items.filter((item) => item.status === 'completed').length;
-  const inProgressCount = items.filter((item) => item.status === 'in_progress').length;
+  const completedCount = items.filter(item => item.status === 'completed').length;
+  const inProgressCount = items.filter(item => item.status === 'in_progress').length;
   const pendingCount = items.length - completedCount - inProgressCount;
 
   const summary = [
@@ -486,7 +503,7 @@ const getTodoWriteSummary = (items: ParsedTodoItem[]): string => {
     `${pendingCount} ${i18nService.t('coworkTodoPending')}`,
   ];
 
-  const activeItem = items.find((item) => item.status === 'in_progress');
+  const activeItem = items.find(item => item.status === 'in_progress');
   if (activeItem) {
     summary.push(activeItem.primaryText);
   }
@@ -496,7 +513,7 @@ const getTodoWriteSummary = (items: ParsedTodoItem[]): string => {
 
 const getToolInputSummary = (
   toolName: string | undefined,
-  toolInput?: Record<string, unknown>
+  toolInput?: Record<string, unknown>,
 ): string | null => {
   if (!toolName || !toolInput) return null;
   const input = toolInput as Record<string, unknown>;
@@ -513,8 +530,9 @@ const getToolInputSummary = (
     case 'bash':
     case 'exec':
     case 'shell':
-      return getToolInputString(input, ['command', 'cmd', 'script'])
-        ?? getStringArray(input.commands);
+      return (
+        getToolInputString(input, ['command', 'cmd', 'script']) ?? getStringArray(input.commands)
+      );
     case 'read':
     case 'readfile':
     case 'write':
@@ -522,12 +540,12 @@ const getToolInputSummary = (
     case 'edit':
     case 'editfile':
     case 'multiedit':
-      return getToolInputString(input, ['file_path', 'path', 'filePath', 'target_file', 'targetFile'])
-        ?? (
-          typeof input.content === 'string' && input.content.trim()
-            ? truncatePreview(input.content.split('\n')[0].trim())
-            : null
-        );
+      return (
+        getToolInputString(input, ['file_path', 'path', 'filePath', 'target_file', 'targetFile']) ??
+        (typeof input.content === 'string' && input.content.trim()
+          ? truncatePreview(input.content.split('\n')[0].trim())
+          : null)
+      );
     case 'glob':
     case 'grep':
       return getToolInputString(input, ['pattern', 'query']);
@@ -548,7 +566,7 @@ const getToolInputSummary = (
 
 const formatToolInput = (
   toolName: string | undefined,
-  toolInput?: Record<string, unknown>
+  toolInput?: Record<string, unknown>,
 ): string | null => {
   if (!toolInput) return null;
   const summary = getToolInputSummary(toolName, toolInput);
@@ -594,9 +612,8 @@ const stripFileProtocol = (value: string): string => {
 
 const hasScheme = (value: string): boolean => /^[a-z][a-z0-9+.-]*:/i.test(value);
 
-const isAbsolutePath = (value: string): boolean => (
-  value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)
-);
+const isAbsolutePath = (value: string): boolean =>
+  value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value);
 
 const isRelativePath = (value: string): boolean => !isAbsolutePath(value) && !hasScheme(value);
 
@@ -622,7 +639,7 @@ const parseRootRelativePath = (value: string): string | null => {
 };
 
 const normalizeLocalPath = (
-  value: string
+  value: string,
 ): { path: string; isRelative: boolean; isAbsolute: boolean } | null => {
   const trimmed = value.trim();
   if (!trimmed) return null;
@@ -658,9 +675,7 @@ export type ToolGroupItem = {
   toolResult?: CoworkMessage | null;
 };
 
-export type DisplayItem =
-  | { type: 'message'; message: CoworkMessage }
-  | ToolGroupItem;
+export type DisplayItem = { type: 'message'; message: CoworkMessage } | ToolGroupItem;
 
 export type AssistantTurnItem =
   | { type: 'assistant'; message: CoworkMessage }
@@ -807,9 +822,8 @@ const isVisibleAssistantTurnItem = (item: AssistantTurnItem): boolean => {
 const getVisibleAssistantItems = (assistantItems: AssistantTurnItem[]): AssistantTurnItem[] =>
   assistantItems.filter(isVisibleAssistantTurnItem);
 
-export const hasRenderableAssistantContent = (turn: ConversationTurn): boolean => (
-  getVisibleAssistantItems(turn.assistantItems).length > 0
-);
+export const hasRenderableAssistantContent = (turn: ConversationTurn): boolean =>
+  getVisibleAssistantItems(turn.assistantItems).length > 0;
 
 const getToolResultLineCount = (result: string): number => {
   if (!result) return 0;
@@ -833,19 +847,18 @@ const TodoWriteInputView: React.FC<{ items: ParsedTodoItem[] }> = ({ items }) =>
   return (
     <div className="space-y-2">
       {items.map((item, index) => (
-        <div
-          key={`todo-item-${index}`}
-          className="flex items-start gap-2"
-        >
-          <span className={`mt-0.5 h-4 w-4 rounded-[4px] border flex-shrink-0 inline-flex items-center justify-center ${getStatusCheckboxClass(item.status)}`}>
+        <div key={`todo-item-${index}`} className="flex items-start gap-2">
+          <span
+            className={`mt-0.5 h-4 w-4 rounded-[4px] border flex-shrink-0 inline-flex items-center justify-center ${getStatusCheckboxClass(item.status)}`}
+          >
             {item.status === 'completed' && <CheckIcon className="h-3 w-3 stroke-[2.5]" />}
           </span>
           <div className="min-w-0 flex-1">
-            <div className={`text-xs whitespace-pre-wrap break-words leading-5 ${
-              item.status === 'completed'
-                ? 'text-muted'
-                : 'text-foreground'
-            }`}>
+            <div
+              className={`text-xs whitespace-pre-wrap break-words leading-5 ${
+                item.status === 'completed' ? 'text-muted' : 'text-foreground'
+              }`}
+            >
               {item.primaryText}
             </div>
           </div>
@@ -859,13 +872,10 @@ const ToolCallGroup: React.FC<{
   group: ToolGroupItem;
   isLastInSequence?: boolean;
   mapDisplayText?: (value: string) => string;
-}> = ({
-  group,
-  isLastInSequence = true,
-  mapDisplayText,
-}) => {
+}> = ({ group, isLastInSequence = true, mapDisplayText }) => {
   const { toolUse, toolResult } = group;
-  const rawToolName = typeof toolUse.metadata?.toolName === 'string' ? toolUse.metadata.toolName : 'Tool';
+  const rawToolName =
+    typeof toolUse.metadata?.toolName === 'string' ? toolUse.metadata.toolName : 'Tool';
   const toolName = getToolDisplayName(rawToolName);
   const toolInput = toolUse.metadata?.toolInput;
   const isCronTool = isCronToolName(rawToolName);
@@ -885,9 +895,10 @@ const ToolCallGroup: React.FC<{
   const displayToolResult = hasToolResultText ? toolResultDisplay : toolResultFallback;
   const [isExpanded, setIsExpanded] = useState(false);
   const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0;
-  const toolResultSummary = isCronTool && hasToolResultText
-    ? truncatePreview(toolResultDisplay.replace(/\s+/g, ' '))
-    : null;
+  const toolResultSummary =
+    isCronTool && hasToolResultText
+      ? truncatePreview(toolResultDisplay.replace(/\s+/g, ' '))
+      : null;
 
   // Check if this is a Bash-like tool that should show terminal style
   const isBashTool = isBashLikeToolName(rawToolName);
@@ -909,18 +920,14 @@ const ToolCallGroup: React.FC<{
         onClick={() => setIsExpanded(!isExpanded)}
         className="w-full flex items-start gap-2 text-left group relative z-10"
       >
-        <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
-          !toolResult
-            ? 'bg-blue-500 animate-pulse'
-            : isToolError
-              ? 'bg-red-500'
-              : 'bg-green-500'
-        }`} />
+        <span
+          className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
+            !toolResult ? 'bg-blue-500 animate-pulse' : isToolError ? 'bg-red-500' : 'bg-green-500'
+          }`}
+        />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-sm font-medium text-secondary">
-              {toolName}
-            </span>
+            <span className="text-sm font-medium text-secondary">{toolName}</span>
             {toolInputSummary && (
               <code className="text-xs text-muted font-mono truncate max-w-[400px]">
                 {toolInputSummary}
@@ -928,22 +935,23 @@ const ToolCallGroup: React.FC<{
             )}
           </div>
           {toolResult && !isTodoWriteTool && (hasToolResultText || showNoDetailError) && (
-            <div className={`text-xs mt-0.5 ${
-              hasToolResultText
-                ? 'text-muted'
-                : showNoDetailError
-                  ? 'text-red-500/80'
-                  : 'text-muted'
-            }`}>
+            <div
+              className={`text-xs mt-0.5 ${
+                hasToolResultText
+                  ? 'text-muted'
+                  : showNoDetailError
+                    ? 'text-red-500/80'
+                    : 'text-muted'
+              }`}
+            >
               {hasToolResultText
-                ? (toolResultSummary ?? `${resultLineCount} ${resultLineCount === 1 ? 'line' : 'lines'} of output`)
+                ? (toolResultSummary ??
+                  `${resultLineCount} ${resultLineCount === 1 ? 'line' : 'lines'} of output`)
                 : toolResultFallback}
             </div>
           )}
           {!toolResult && (
-            <div className="text-xs text-muted mt-0.5">
-              {i18nService.t('coworkToolRunning')}
-            </div>
+            <div className="text-xs text-muted mt-0.5">{i18nService.t('coworkToolRunning')}</div>
           )}
         </div>
       </button>
@@ -968,13 +976,15 @@ const ToolCallGroup: React.FC<{
                   </div>
                 )}
                 {toolResult && (hasToolResultText || showNoDetailError) && (
-                  <div className={`mt-1.5 whitespace-pre-wrap break-words ${
-                    isToolError
-                      ? 'text-red-400'
-                      : hasToolResultText
-                        ? 'text-secondary'
-                        : 'text-muted italic'
-                  }`}>
+                  <div
+                    className={`mt-1.5 whitespace-pre-wrap break-words ${
+                      isToolError
+                        ? 'text-red-400'
+                        : hasToolResultText
+                          ? 'text-secondary'
+                          : 'text-muted italic'
+                    }`}
+                  >
                     {displayToolResult}
                   </div>
                 )}
@@ -1004,13 +1014,15 @@ const ToolCallGroup: React.FC<{
                     {i18nService.t('coworkToolResult')}
                   </div>
                   <div className="max-h-32 overflow-y-auto">
-                    <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${
-                      isToolError
-                        ? 'text-red-500'
-                        : hasToolResultText
-                          ? 'dark:text-claude-darkText text-claude-text'
-                          : 'dark:text-claude-darkTextSecondary text-claude-textSecondary italic'
-                    }`}>
+                    <pre
+                      className={`text-xs whitespace-pre-wrap break-words font-mono ${
+                        isToolError
+                          ? 'text-red-500'
+                          : hasToolResultText
+                            ? 'dark:text-claude-darkText text-claude-text'
+                            : 'dark:text-claude-darkTextSecondary text-claude-textSecondary italic'
+                      }`}
+                    >
                       {displayToolResult}
                     </pre>
                   </div>
@@ -1038,13 +1050,15 @@ const ToolCallGroup: React.FC<{
                     {i18nService.t('coworkToolResult')}
                   </div>
                   <div className="max-h-64 overflow-y-auto">
-                    <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${
-                      isToolError
-                        ? 'text-red-500'
-                        : hasToolResultText
-                          ? 'text-foreground'
-                          : 'text-secondary italic'
-                    }`}>
+                    <pre
+                      className={`text-xs whitespace-pre-wrap break-words font-mono ${
+                        isToolError
+                          ? 'text-red-500'
+                          : hasToolResultText
+                            ? 'text-foreground'
+                            : 'text-secondary italic'
+                      }`}
+                    >
                       {displayToolResult}
                     </pre>
                   </div>
@@ -1129,7 +1143,7 @@ const ReEditButton: React.FC<{
 }> = ({ visible, onClick }) => {
   return (
     <button
-      onClick={(e) => {
+      onClick={e => {
         e.stopPropagation();
         onClick();
       }}
@@ -1173,7 +1187,8 @@ export const UserMessageItem: React.FC<{
     .filter((s): s is NonNullable<typeof s> => s !== undefined);
 
   // Get image attachments from metadata
-  const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ?? []) as CoworkImageAttachment[];
+  const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ??
+    []) as CoworkImageAttachment[];
 
   return (
     <div
@@ -1201,7 +1216,9 @@ export const UserMessageItem: React.FC<{
                           alt={img.name}
                           className="max-h-48 max-w-[16rem] rounded-lg object-contain cursor-pointer border border-border hover:border-primary transition-colors"
                           title={img.name}
-                          onClick={() => setExpandedImage(`data:${img.mimeType};base64,${img.base64Data}`)}
+                          onClick={() =>
+                            setExpandedImage(`data:${img.mimeType};base64,${img.base64Data}`)
+                          }
                         />
                         <div className="absolute bottom-1 left-1 right-1 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-black/50 text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity truncate pointer-events-none">
                           <PhotoIcon className="h-3 w-3 flex-shrink-0" />
@@ -1213,16 +1230,8 @@ export const UserMessageItem: React.FC<{
                 )}
               </div>
               <div className="flex items-center justify-end gap-1.5 mt-1">
-                {onReEdit && (
-                  <ReEditButton
-                    visible={isHovered}
-                    onClick={() => onReEdit(message)}
-                  />
-                )}
-                <CopyButton
-                  content={message.content}
-                  visible={isHovered}
-                />
+                {onReEdit && <ReEditButton visible={isHovered} onClick={() => onReEdit(message)} />}
+                <CopyButton content={message.content} visible={isHovered} />
                 {messageSkills.length > 0 && (
                   <div className="flex items-center gap-1.5 mr-1.5">
                     {messageSkills.map(skill => (
@@ -1254,7 +1263,7 @@ export const UserMessageItem: React.FC<{
             src={expandedImage}
             alt="Preview"
             className="max-h-[90vh] max-w-[90vw] object-contain rounded-lg shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
+            onClick={e => e.stopPropagation()}
           />
         </div>
       )}
@@ -1267,12 +1276,7 @@ const AssistantMessageItem: React.FC<{
   resolveLocalFilePath?: (href: string, text: string) => string | null;
   mapDisplayText?: (value: string) => string;
   showCopyButton?: boolean;
-}> = ({
-  message,
-  resolveLocalFilePath,
-  mapDisplayText,
-  showCopyButton = false,
-}) => {
+}> = ({ message, resolveLocalFilePath, mapDisplayText, showCopyButton = false }) => {
   const [isHovered, setIsHovered] = useState(false);
   const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content;
 
@@ -1292,10 +1296,7 @@ const AssistantMessageItem: React.FC<{
       </div>
       {showCopyButton && (
         <div className="flex items-center gap-1.5 mt-1">
-          <CopyButton
-            content={displayContent}
-            visible={isHovered}
-          />
+          <CopyButton content={displayContent} visible={isHovered} />
         </div>
       )}
     </div>
@@ -1321,7 +1322,8 @@ const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ message
       if (msg.type === 'tool_use') {
         const id = msg.metadata?.toolUseId;
         if (typeof id === 'string' && !toolResultIds.has(id)) {
-          const toolName = typeof msg.metadata?.toolName === 'string' ? msg.metadata.toolName : null;
+          const toolName =
+            typeof msg.metadata?.toolName === 'string' ? msg.metadata.toolName : null;
           if (toolName) {
             return `${i18nService.t('coworkToolRunning')} ${toolName}...`;
           }
@@ -1336,9 +1338,7 @@ const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ message
       <div className="max-w-3xl mx-auto">
         <div className="streaming-bar" />
         <div className="py-1">
-          <span className="text-xs text-secondary">
-            {getStatusText()}
-          </span>
+          <span className="text-xs text-secondary">{getStatusText()}</span>
         </div>
       </div>
     </div>
@@ -1347,9 +1347,18 @@ const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ message
 
 const TypingDots: React.FC = () => (
   <div className="flex items-center space-x-1.5 py-1">
-    <div className="w-2 h-2 rounded-full bg-primary animate-bounce" style={{ animationDelay: '0ms' }} />
-    <div className="w-2 h-2 rounded-full bg-primary animate-bounce" style={{ animationDelay: '150ms' }} />
-    <div className="w-2 h-2 rounded-full bg-primary animate-bounce" style={{ animationDelay: '300ms' }} />
+    <div
+      className="w-2 h-2 rounded-full bg-primary animate-bounce"
+      style={{ animationDelay: '0ms' }}
+    />
+    <div
+      className="w-2 h-2 rounded-full bg-primary animate-bounce"
+      style={{ animationDelay: '150ms' }}
+    />
+    <div
+      className="w-2 h-2 rounded-full bg-primary animate-bounce"
+      style={{ animationDelay: '300ms' }}
+    />
   </div>
 );
 
@@ -1381,9 +1390,7 @@ const ThinkingBlock: React.FC<{
             isExpanded ? 'rotate-90' : ''
           }`}
         />
-        <span className="text-xs font-medium text-secondary">
-          {i18nService.t('reasoning')}
-        </span>
+        <span className="text-xs font-medium text-secondary">{i18nService.t('reasoning')}</span>
         {isCurrentlyStreaming && (
           <span className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
         )}
@@ -1418,7 +1425,9 @@ export const AssistantTurnBlock: React.FC<{
     const isError = !hasText(message.content) && typeof message.metadata?.error === 'string';
     const rawContent = hasText(message.content)
       ? message.content
-      : (typeof message.metadata?.error === 'string' ? message.metadata.error : '');
+      : typeof message.metadata?.error === 'string'
+        ? message.metadata.error
+        : '';
     const normalizedContent = getScheduledReminderDisplayText(rawContent) ?? rawContent;
     const content = mapDisplayText ? mapDisplayText(normalizedContent) : normalizedContent;
     if (!content.trim()) return null;
@@ -1426,13 +1435,12 @@ export const AssistantTurnBlock: React.FC<{
     return (
       <div className="rounded-lg border border-border bg-background px-3 py-2">
         <div className="flex items-center gap-2">
-          {isError
-            ? <ExclamationTriangleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
-            : <InformationCircleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
-          }
-          <div className="text-xs whitespace-pre-wrap text-secondary">
-            {content}
-          </div>
+          {isError ? (
+            <ExclamationTriangleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
+          ) : (
+            <InformationCircleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
+          )}
+          <div className="text-xs whitespace-pre-wrap text-secondary">{content}</div>
         </div>
       </div>
     );
@@ -1440,7 +1448,9 @@ export const AssistantTurnBlock: React.FC<{
 
   const renderOrphanToolResult = (message: CoworkMessage) => {
     const toolResultDisplayRaw = getToolResultDisplay(message);
-    const toolResultDisplay = mapDisplayText ? mapDisplayText(toolResultDisplayRaw) : toolResultDisplayRaw;
+    const toolResultDisplay = mapDisplayText
+      ? mapDisplayText(toolResultDisplayRaw)
+      : toolResultDisplayRaw;
     const isToolError = Boolean(message.metadata?.isError || message.metadata?.error);
     const hasToolResultText = hasText(toolResultDisplay);
     const resultLineCount = hasToolResultText ? getToolResultLineCount(toolResultDisplay) : 0;
@@ -1450,9 +1460,11 @@ export const AssistantTurnBlock: React.FC<{
     return (
       <div className="py-1">
         <div className="flex items-start gap-2">
-          <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
-            isToolError ? 'bg-red-500' : 'bg-surface-raised'
-          }`} />
+          <span
+            className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 ${
+              isToolError ? 'bg-red-500' : 'bg-surface-raised'
+            }`}
+          />
           <div className="flex-1 min-w-0">
             <div className="text-sm font-medium text-secondary">
               {i18nService.t('coworkToolResult')}
@@ -1463,23 +1475,21 @@ export const AssistantTurnBlock: React.FC<{
               </div>
             )}
             {resultLineCount === 0 && showNoDetailError && (
-              <div className={`text-xs mt-0.5 ${
-                isToolError
-                  ? 'text-red-500/80'
-                  : 'text-muted'
-              }`}>
+              <div className={`text-xs mt-0.5 ${isToolError ? 'text-red-500/80' : 'text-muted'}`}>
                 {fallbackText}
               </div>
             )}
             {(hasToolResultText || showNoDetailError) && (
               <div className="mt-2 px-3 py-2 rounded-lg bg-surface-raised max-h-64 overflow-y-auto">
-                <pre className={`text-xs whitespace-pre-wrap break-words font-mono ${
-                  isToolError
-                    ? 'text-red-500'
-                    : hasToolResultText
-                      ? 'text-foreground'
-                      : 'text-secondary italic'
-                }`}>
+                <pre
+                  className={`text-xs whitespace-pre-wrap break-words font-mono ${
+                    isToolError
+                      ? 'text-red-500'
+                      : hasToolResultText
+                        ? 'text-foreground'
+                        : 'text-secondary italic'
+                  }`}
+                >
                   {displayText}
                 </pre>
               </div>
@@ -1540,20 +1550,130 @@ export const AssistantTurnBlock: React.FC<{
                 if (!systemMessage) {
                   return null;
                 }
-                return (
-                  <div key={item.message.id}>
-                    {systemMessage}
-                  </div>
-                );
+                return <div key={item.message.id}>{systemMessage}</div>;
               }
 
-              return (
-                <div key={item.message.id}>
-                  {renderOrphanToolResult(item.message)}
-                </div>
-              );
+              return <div key={item.message.id}>{renderOrphanToolResult(item.message)}</div>;
             })}
             {showTypingIndicator && <TypingDots />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// --- Queued Message Bubble ---
+const QueuedMessageBubble: React.FC<{
+  message: QueuedMessage;
+  position: number;
+  total: number;
+  onUpdate?: (id: string, content: string) => void;
+  onRemove?: (id: string) => void;
+}> = ({ message, position, total, onUpdate, onRemove }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(message.content);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 160)}px`;
+    }
+  }, [isEditing]);
+
+  const handleSave = () => {
+    const trimmed = editValue.trim();
+    if (trimmed && onUpdate) {
+      onUpdate(message.id, trimmed);
+    }
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditValue(message.content);
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSave();
+    }
+    if (e.key === 'Escape') {
+      handleCancel();
+    }
+  };
+
+  return (
+    <div className="py-2 px-4 animate-fade-in">
+      <div className="max-w-3xl mx-auto">
+        <div className="pl-4 sm:pl-8 md:pl-12">
+          <div className="flex items-start gap-3 flex-row-reverse">
+            <div className="w-full min-w-0 flex flex-col items-end">
+              <div className="w-fit max-w-[42rem] rounded-2xl px-4 py-2.5 border-2 border-dashed border-amber-400/60 bg-amber-50/50 dark:bg-amber-950/20 text-foreground shadow-subtle">
+                {isEditing ? (
+                  <div className="space-y-2">
+                    <textarea
+                      ref={textareaRef}
+                      value={editValue}
+                      onChange={e => {
+                        setEditValue(e.target.value);
+                        e.target.style.height = 'auto';
+                        e.target.style.height = `${Math.min(e.target.scrollHeight, 160)}px`;
+                      }}
+                      onKeyDown={handleKeyDown}
+                      className="w-full min-w-[200px] resize-none bg-transparent text-sm text-foreground focus:outline-none"
+                      rows={1}
+                    />
+                    <div className="flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={handleCancel}
+                        className="px-2 py-0.5 text-xs text-secondary hover:text-foreground transition-colors"
+                      >
+                        {i18nService.t('cancel')}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleSave}
+                        className="px-2 py-0.5 text-xs text-white bg-primary rounded-md hover:bg-primary-hover transition-colors"
+                      >
+                        {i18nService.t('save')}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="whitespace-pre-wrap break-words text-sm">{message.content}</div>
+                )}
+              </div>
+              <div className="flex items-center gap-1.5 mt-1">
+                <span className="text-[10px] text-amber-600 dark:text-amber-400 font-medium">
+                  {i18nService.t('coworkQueued')} ({position}/{total})
+                </span>
+                {!isEditing && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => setIsEditing(true)}
+                      className="p-1 rounded-md hover:bg-surface-raised transition-colors"
+                      title={i18nService.t('coworkQueueEdit')}
+                    >
+                      <PencilSquareIcon className="h-3.5 w-3.5 text-secondary" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onRemove?.(message.id)}
+                      className="p-1 rounded-md hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
+                      title={i18nService.t('coworkQueueRemove')}
+                    >
+                      <TrashIcon className="h-3.5 w-3.5 text-secondary hover:text-red-500" />
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -1571,6 +1691,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   onToggleSidebar,
   onNewChat,
   updateBadge,
+  queuedMessages = [],
+  onUpdateQueuedMessage,
+  onRemoveQueuedMessage,
 }) => {
   const dispatch = useDispatch();
   const isMac = window.electron.platform === 'darwin';
@@ -1604,7 +1727,12 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const [isScrollable, setIsScrollable] = useState(false);
   const [hoveredRailIndex, setHoveredRailIndex] = useState<number | null>(null);
   const [isRailHovered, setIsRailHovered] = useState(false);
-  const [railTooltip, setRailTooltip] = useState<{ label: string; top: number; right: number; isUser: boolean } | null>(null);
+  const [railTooltip, setRailTooltip] = useState<{
+    label: string;
+    top: number;
+    right: number;
+    isUser: boolean;
+  } | null>(null);
 
   // Menu and action states
   const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
@@ -1700,7 +1828,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     const padding = 8;
     const x = Math.min(
       Math.max(padding, rect.right - menuWidth),
-      window.innerWidth - menuWidth - padding
+      window.innerWidth - menuWidth - padding,
     );
     const y = Math.min(rect.bottom + 8, window.innerHeight - height - padding);
     return { x, y };
@@ -1795,7 +1923,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     const lines: string[] = [];
     lines.push(`# ${currentSession.title}`);
     lines.push('');
-    lines.push(`> ${i18nService.t('coworkExportCreatedAt')}: ${new Date(currentSession.createdAt).toLocaleString()}`);
+    lines.push(
+      `> ${i18nService.t('coworkExportCreatedAt')}: ${new Date(currentSession.createdAt).toLocaleString()}`,
+    );
     lines.push('');
     lines.push('---');
     lines.push('');
@@ -1823,7 +1953,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         lines.push('#### Tool Result');
         lines.push('');
         lines.push('```');
-        lines.push(msg.content.slice(0, 2000) + (msg.content.length > 2000 ? '\n... (truncated)' : ''));
+        lines.push(
+          msg.content.slice(0, 2000) + (msg.content.length > 2000 ? '\n... (truncated)' : ''),
+        );
         lines.push('```');
         lines.push('');
       }
@@ -1833,47 +1965,58 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
   const sessionToJSON = useCallback((): string => {
     if (!currentSession) return '{}';
-    return JSON.stringify({
-      title: currentSession.title,
-      createdAt: new Date(currentSession.createdAt).toISOString(),
-      updatedAt: new Date(currentSession.updatedAt).toISOString(),
-      status: currentSession.status,
-      messages: currentSession.messages.map(msg => ({
-        type: msg.type,
-        content: msg.content,
-        timestamp: new Date(msg.timestamp).toISOString(),
-        ...(msg.metadata?.toolName ? { toolName: msg.metadata.toolName } : {}),
-        ...(msg.metadata?.toolInput ? { toolInput: msg.metadata.toolInput } : {}),
-      })),
-    }, null, 2);
+    return JSON.stringify(
+      {
+        title: currentSession.title,
+        createdAt: new Date(currentSession.createdAt).toISOString(),
+        updatedAt: new Date(currentSession.updatedAt).toISOString(),
+        status: currentSession.status,
+        messages: currentSession.messages.map(msg => ({
+          type: msg.type,
+          content: msg.content,
+          timestamp: new Date(msg.timestamp).toISOString(),
+          ...(msg.metadata?.toolName ? { toolName: msg.metadata.toolName } : {}),
+          ...(msg.metadata?.toolInput ? { toolInput: msg.metadata.toolInput } : {}),
+        })),
+      },
+      null,
+      2,
+    );
   }, [currentSession]);
 
-  const handleExportText = useCallback(async (format: 'md' | 'json') => {
-    if (!currentSession) return;
-    closeMenu();
-    const content = format === 'md' ? sessionToMarkdown() : sessionToJSON();
-    const timestamp = new Date().toISOString().slice(0, 10);
-    const fileName = sanitizeExportFileName(`${currentSession.title}-${timestamp}.${format}`);
-    try {
-      const result = await window.electron.cowork.exportSessionText({
-        content,
-        defaultFileName: fileName,
-        fileExtension: format,
-      });
-      if (result.success && !result.canceled) {
-        window.dispatchEvent(new CustomEvent('app:showToast', {
-          detail: i18nService.t('coworkExportTextSuccess'),
-        }));
-      } else if (!result.success) {
-        throw new Error(result.error || 'Export failed');
+  const handleExportText = useCallback(
+    async (format: 'md' | 'json') => {
+      if (!currentSession) return;
+      closeMenu();
+      const content = format === 'md' ? sessionToMarkdown() : sessionToJSON();
+      const timestamp = new Date().toISOString().slice(0, 10);
+      const fileName = sanitizeExportFileName(`${currentSession.title}-${timestamp}.${format}`);
+      try {
+        const result = await window.electron.cowork.exportSessionText({
+          content,
+          defaultFileName: fileName,
+          fileExtension: format,
+        });
+        if (result.success && !result.canceled) {
+          window.dispatchEvent(
+            new CustomEvent('app:showToast', {
+              detail: i18nService.t('coworkExportTextSuccess'),
+            }),
+          );
+        } else if (!result.success) {
+          throw new Error(result.error || 'Export failed');
+        }
+      } catch (error) {
+        console.error('Failed to export session text:', error);
+        window.dispatchEvent(
+          new CustomEvent('app:showToast', {
+            detail: i18nService.t('coworkExportTextFailed'),
+          }),
+        );
       }
-    } catch (error) {
-      console.error('Failed to export session text:', error);
-      window.dispatchEvent(new CustomEvent('app:showToast', {
-        detail: i18nService.t('coworkExportTextFailed'),
-      }));
-    }
-  }, [currentSession, closeMenu, sessionToMarkdown, sessionToJSON]);
+    },
+    [currentSession, closeMenu, sessionToMarkdown, sessionToJSON],
+  );
 
   const handleShareClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1895,7 +2038,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               throw new Error('Invalid capture area');
             }
 
-            const scrollContentHeight = Math.max(scrollContainer.scrollHeight, scrollContainer.clientHeight);
+            const scrollContentHeight = Math.max(
+              scrollContainer.scrollHeight,
+              scrollContainer.clientHeight,
+            );
             if (scrollContentHeight <= 0) {
               throw new Error('Invalid content height');
             }
@@ -1905,8 +2051,12 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               return Math.max(0, Math.min(scrollContentHeight, y));
             };
 
-            const userAnchors = scrollContainer.querySelectorAll<HTMLElement>('[data-export-role="user-message"]');
-            const assistantAnchors = scrollContainer.querySelectorAll<HTMLElement>('[data-export-role="assistant-block"]');
+            const userAnchors = scrollContainer.querySelectorAll<HTMLElement>(
+              '[data-export-role="user-message"]',
+            );
+            const assistantAnchors = scrollContainer.querySelectorAll<HTMLElement>(
+              '[data-export-role="assistant-block"]',
+            );
 
             let contentStart = 0;
             let contentEnd = scrollContentHeight;
@@ -1927,7 +2077,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
             const maxStart = Math.max(0, scrollContentHeight - 1);
             contentStart = Math.max(0, Math.min(maxStart, Math.round(contentStart)));
-            contentEnd = Math.max(contentStart + 1, Math.min(scrollContentHeight, Math.round(contentEnd)));
+            contentEnd = Math.max(
+              contentStart + 1,
+              Math.min(scrollContentHeight, Math.round(contentEnd)),
+            );
 
             const outputHeight = contentEnd - contentStart;
 
@@ -1956,11 +2109,17 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               return loadImageFromBase64(chunk.pngBase64);
             };
 
-            scrollContainer.scrollTop = Math.min(contentStart, Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight));
+            scrollContainer.scrollTop = Math.min(
+              contentStart,
+              Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight),
+            );
             await waitForNextFrame();
             await waitForNextFrame();
 
-            const maxScrollTop = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
+            const maxScrollTop = Math.max(
+              0,
+              scrollContainer.scrollHeight - scrollContainer.clientHeight,
+            );
             let contentOffset = contentStart;
             while (contentOffset < contentEnd) {
               const targetScrollTop = Math.min(contentOffset, maxScrollTop);
@@ -1970,16 +2129,22 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
               const chunkImage = await captureAndLoad(scrollRect);
               const sourceYOffset = Math.max(0, contentOffset - targetScrollTop);
-              const drawableHeight = Math.min(scrollRect.height - sourceYOffset, contentEnd - contentOffset);
+              const drawableHeight = Math.min(
+                scrollRect.height - sourceYOffset,
+                contentEnd - contentOffset,
+              );
               if (drawableHeight <= 0) {
                 throw new Error('Failed to stitch export image');
               }
               const scaleY = chunkImage.naturalHeight / scrollRect.height;
               const sourceYInImage = Math.max(0, Math.round(sourceYOffset * scaleY));
-              const sourceHeightInImage = Math.max(1, Math.min(
-                chunkImage.naturalHeight - sourceYInImage,
-                Math.round(drawableHeight * scaleY),
-              ));
+              const sourceHeightInImage = Math.max(
+                1,
+                Math.min(
+                  chunkImage.naturalHeight - sourceYInImage,
+                  Math.round(drawableHeight * scaleY),
+                ),
+              );
 
               context.drawImage(
                 chunkImage,
@@ -2015,9 +2180,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               defaultFileName: sanitizeExportFileName(`${currentSession.title}-${timestamp}.png`),
             });
             if (saveResult.success && !saveResult.canceled) {
-              window.dispatchEvent(new CustomEvent('app:showToast', {
-                detail: i18nService.t('coworkExportImageSuccess'),
-              }));
+              window.dispatchEvent(
+                new CustomEvent('app:showToast', {
+                  detail: i18nService.t('coworkExportImageSuccess'),
+                }),
+              );
               return;
             }
             if (!saveResult.success) {
@@ -2028,9 +2195,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
           }
         } catch (error) {
           console.error('Failed to export session image:', error);
-          window.dispatchEvent(new CustomEvent('app:showToast', {
-            detail: i18nService.t('coworkExportImageFailed'),
-          }));
+          window.dispatchEvent(
+            new CustomEvent('app:showToast', {
+              detail: i18nService.t('coworkExportImageFailed'),
+            }),
+          );
         } finally {
           setIsExportingImage(false);
         }
@@ -2061,11 +2230,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     if (!container) return;
     const distanceToBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
     const isNearBottom = distanceToBottom <= AUTO_SCROLL_THRESHOLD;
-    setShouldAutoScroll((prev) => (prev === isNearBottom ? prev : isNearBottom));
+    setShouldAutoScroll(prev => (prev === isNearBottom ? prev : isNearBottom));
 
     // Check if content overflows the container (use functional updater to avoid redundant re-renders)
     const scrollable = container.scrollHeight > container.clientHeight;
-    setIsScrollable((prev) => (prev === scrollable ? prev : scrollable));
+    setIsScrollable(prev => (prev === scrollable ? prev : scrollable));
     if (!scrollable) return;
 
     // Skip index recalculation during programmatic navigation
@@ -2104,9 +2273,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     let railIdx = range.first;
     if (range.first !== range.last) {
       const turnEl = turnEls[currentTurn];
-      const nextTurnTop = currentTurn + 1 < turnEls.length
-        ? turnEls[currentTurn + 1].offsetTop
-        : container.scrollHeight;
+      const nextTurnTop =
+        currentTurn + 1 < turnEls.length
+          ? turnEls[currentTurn + 1].offsetTop
+          : container.scrollHeight;
       const turnMid = turnEl.offsetTop + (nextTurnTop - turnEl.offsetTop) / 2;
       if (scrollTop + 80 >= turnMid) {
         railIdx = range.last;
@@ -2134,7 +2304,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
     isNavigatingRef.current = true;
     if (navigatingTimerRef.current) clearTimeout(navigatingTimerRef.current);
-    navigatingTimerRef.current = setTimeout(() => { isNavigatingRef.current = false; }, NAV_SCROLL_LOCK_DURATION);
+    navigatingTimerRef.current = setTimeout(() => {
+      isNavigatingRef.current = false;
+    }, NAV_SCROLL_LOCK_DURATION);
 
     // Try to scroll to the exact data-rail-index element if it's in the DOM
     const container = scrollContainerRef.current;
@@ -2159,77 +2331,87 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   // selectors (selectLastMessageContent / selectCurrentMessagesLength)
   // so there is no need to derive them from currentSession here.
 
-  const resolveLocalFilePath = useCallback((href: string, text: string) => {
-    const hrefValue = typeof href === 'string' ? href.trim() : '';
-    const textValue = typeof text === 'string' ? text.trim() : '';
-    if (!hrefValue && !textValue) return null;
+  const resolveLocalFilePath = useCallback(
+    (href: string, text: string) => {
+      const hrefValue = typeof href === 'string' ? href.trim() : '';
+      const textValue = typeof text === 'string' ? text.trim() : '';
+      if (!hrefValue && !textValue) return null;
 
-    const hrefRootRelative = hrefValue ? parseRootRelativePath(hrefValue) : null;
-    if (hrefRootRelative) {
-      return hrefRootRelative;
-    }
-
-    const hrefPath = hrefValue ? normalizeLocalPath(hrefValue) : null;
-    if (hrefPath) {
-      if (hrefPath.isRelative && currentSession?.cwd) {
-        return toAbsolutePathFromCwd(hrefPath.path, currentSession.cwd);
+      const hrefRootRelative = hrefValue ? parseRootRelativePath(hrefValue) : null;
+      if (hrefRootRelative) {
+        return hrefRootRelative;
       }
-      if (hrefPath.isAbsolute) {
-        return hrefPath.path;
-      }
-    }
 
-    const textRootRelative = textValue ? parseRootRelativePath(textValue) : null;
-    if (textRootRelative) {
-      return textRootRelative;
-    }
-
-    const textPath = textValue ? normalizeLocalPath(textValue) : null;
-    if (textPath) {
-      if (textPath.isRelative && currentSession?.cwd) {
-        return toAbsolutePathFromCwd(textPath.path, currentSession.cwd);
+      const hrefPath = hrefValue ? normalizeLocalPath(hrefValue) : null;
+      if (hrefPath) {
+        if (hrefPath.isRelative && currentSession?.cwd) {
+          return toAbsolutePathFromCwd(hrefPath.path, currentSession.cwd);
+        }
+        if (hrefPath.isAbsolute) {
+          return hrefPath.path;
+        }
       }
-      if (textPath.isAbsolute) {
-        return textPath.path;
-      }
-    }
 
-    return null;
-  }, [currentSession?.cwd]);
+      const textRootRelative = textValue ? parseRootRelativePath(textValue) : null;
+      if (textRootRelative) {
+        return textRootRelative;
+      }
+
+      const textPath = textValue ? normalizeLocalPath(textValue) : null;
+      if (textPath) {
+        if (textPath.isRelative && currentSession?.cwd) {
+          return toAbsolutePathFromCwd(textPath.path, currentSession.cwd);
+        }
+        if (textPath.isAbsolute) {
+          return textPath.path;
+        }
+      }
+
+      return null;
+    },
+    [currentSession?.cwd],
+  );
 
   const mapDisplayText = useCallback((value: string): string => {
     return value;
   }, []);
 
-  const handleReEdit = useCallback((message: CoworkMessage) => {
-    const ref = promptInputRef.current;
-    if (!ref) return;
-    // Set text content
-    if (message.content?.trim()) {
-      ref.setValue(message.content);
-    }
-    // Restore image attachments (always call to clear previous attachments)
-    const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ?? []) as CoworkImageAttachment[];
-    ref.setImageAttachments(imageAttachments);
-    // Restore active skills
-    const skillIds = (message.metadata as CoworkMessageMetadata)?.skillIds;
-    if (skillIds && skillIds.length > 0) {
-      dispatch(setActiveSkillIds(skillIds));
-    }
-    // Focus the input
-    ref.focus();
-  }, [dispatch]);
+  const handleReEdit = useCallback(
+    (message: CoworkMessage) => {
+      const ref = promptInputRef.current;
+      if (!ref) return;
+      // Set text content
+      if (message.content?.trim()) {
+        ref.setValue(message.content);
+      }
+      // Restore image attachments (always call to clear previous attachments)
+      const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ??
+        []) as CoworkImageAttachment[];
+      ref.setImageAttachments(imageAttachments);
+      // Restore active skills
+      const skillIds = (message.metadata as CoworkMessageMetadata)?.skillIds;
+      if (skillIds && skillIds.length > 0) {
+        dispatch(setActiveSkillIds(skillIds));
+      }
+      // Focus the input
+      ref.focus();
+    },
+    [dispatch],
+  );
 
   const messages = currentSession?.messages;
-  const displayItems = useMemo(() => messages ? buildDisplayItems(messages) : [], [messages]);
+  const displayItems = useMemo(() => (messages ? buildDisplayItems(messages) : []), [messages]);
   const turns = useMemo(() => buildConversationTurns(displayItems), [displayItems]);
 
   // Cache turn-level DOM elements (data-turn-index, always in DOM even for lazy turns)
   useEffect(() => {
     const container = scrollContainerRef.current;
-    if (!container) { turnElsCacheRef.current = []; return; }
+    if (!container) {
+      turnElsCacheRef.current = [];
+      return;
+    }
     turnElsCacheRef.current = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-turn-index]')
+      container.querySelectorAll<HTMLElement>('[data-turn-index]'),
     );
   }, [turns]);
 
@@ -2286,7 +2468,6 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     }
   }, [messagesLength, lastMessageContent, isStreaming, shouldAutoScroll, turns.length]);
 
-
   if (!currentSession) {
     return null;
   }
@@ -2329,14 +2510,29 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       const asstRailIdx = asstContent ? railCounter++ : -1;
 
       return (
-        <LazyRenderTurn key={turn.id} turnId={turn.id} alwaysRender={alwaysRender} data-turn-index={index}>
+        <LazyRenderTurn
+          key={turn.id}
+          turnId={turn.id}
+          alwaysRender={alwaysRender}
+          data-turn-index={index}
+        >
           {turn.userMessage && (
-            <div data-export-role="user-message" {...(userRailIdx >= 0 ? { 'data-rail-index': userRailIdx } : undefined)}>
-              <UserMessageItem message={turn.userMessage} skills={skills} onReEdit={remoteManaged ? undefined : handleReEdit} />
+            <div
+              data-export-role="user-message"
+              {...(userRailIdx >= 0 ? { 'data-rail-index': userRailIdx } : undefined)}
+            >
+              <UserMessageItem
+                message={turn.userMessage}
+                skills={skills}
+                onReEdit={remoteManaged ? undefined : handleReEdit}
+              />
             </div>
           )}
           {showAssistantBlock && (
-            <div data-export-role="assistant-block" {...(asstRailIdx >= 0 ? { 'data-rail-index': asstRailIdx } : undefined)}>
+            <div
+              data-export-role="assistant-block"
+              {...(asstRailIdx >= 0 ? { 'data-rail-index': asstRailIdx } : undefined)}
+            >
               <AssistantTurnBlock
                 turn={turn}
                 resolveLocalFilePath={resolveLocalFilePath}
@@ -2380,9 +2576,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             <input
               ref={renameInputRef}
               value={renameValue}
-              onChange={(e) => setRenameValue(e.target.value)}
-              onClick={(e) => e.stopPropagation()}
-              onKeyDown={(e) => {
+              onChange={e => setRenameValue(e.target.value)}
+              onClick={e => e.stopPropagation()}
+              onKeyDown={e => {
                 if (e.key === 'Enter') {
                   handleRenameSave(e);
                 }
@@ -2454,11 +2650,17 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               slashed={currentSession.pinned}
               className={`h-[18px] w-[18px] text-secondary ${currentSession.pinned ? 'opacity-60' : ''}`}
             />
-            {currentSession.pinned ? i18nService.t('coworkUnpinSession') : i18nService.t('coworkPinSession')}
+            {currentSession.pinned
+              ? i18nService.t('coworkUnpinSession')
+              : i18nService.t('coworkPinSession')}
           </button>
           <button
             type="button"
-            onClick={(e) => { e.stopPropagation(); closeMenu(); setShowExportOptions(true); }}
+            onClick={e => {
+              e.stopPropagation();
+              closeMenu();
+              setShowExportOptions(true);
+            }}
             disabled={isExportingImage}
             className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm dark:text-claude-darkText text-claude-text hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors"
           >
@@ -2484,7 +2686,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         >
           <div
             className="w-full max-w-xs mx-4 dark:bg-claude-darkSurface bg-claude-surface rounded-2xl shadow-modal overflow-hidden modal-content"
-            onClick={(e) => e.stopPropagation()}
+            onClick={e => e.stopPropagation()}
           >
             <div className="px-5 py-4 border-b dark:border-claude-darkBorder border-claude-border">
               <h3 className="text-base font-semibold dark:text-claude-darkText text-claude-text">
@@ -2494,36 +2696,51 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             <div className="py-1">
               <button
                 type="button"
-                onClick={(e) => { setShowExportOptions(false); handleShareClick(e); }}
+                onClick={e => {
+                  setShowExportOptions(false);
+                  handleShareClick(e);
+                }}
                 disabled={isExportingImage}
                 className="w-full flex items-center gap-3 px-5 py-3 text-left text-sm dark:text-claude-darkText text-claude-text hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors disabled:opacity-50"
               >
                 <PhotoIcon className="h-5 w-5 dark:text-claude-darkTextSecondary text-claude-textSecondary" />
                 <div>
                   <div className="font-medium">{i18nService.t('coworkExportImage')}</div>
-                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">{i18nService.t('coworkExportImageDesc')}</div>
+                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                    {i18nService.t('coworkExportImageDesc')}
+                  </div>
                 </div>
               </button>
               <button
                 type="button"
-                onClick={() => { setShowExportOptions(false); handleExportText('md'); }}
+                onClick={() => {
+                  setShowExportOptions(false);
+                  handleExportText('md');
+                }}
                 className="w-full flex items-center gap-3 px-5 py-3 text-left text-sm dark:text-claude-darkText text-claude-text hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors"
               >
                 <DocumentArrowDownIcon className="h-5 w-5 dark:text-claude-darkTextSecondary text-claude-textSecondary" />
                 <div>
                   <div className="font-medium">Markdown</div>
-                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">{i18nService.t('coworkExportMarkdownDesc')}</div>
+                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                    {i18nService.t('coworkExportMarkdownDesc')}
+                  </div>
                 </div>
               </button>
               <button
                 type="button"
-                onClick={() => { setShowExportOptions(false); handleExportText('json'); }}
+                onClick={() => {
+                  setShowExportOptions(false);
+                  handleExportText('json');
+                }}
                 className="w-full flex items-center gap-3 px-5 py-3 text-left text-sm dark:text-claude-darkText text-claude-text hover:bg-claude-surfaceHover dark:hover:bg-claude-darkSurfaceHover transition-colors"
               >
                 <DocumentArrowDownIcon className="h-5 w-5 dark:text-claude-darkTextSecondary text-claude-textSecondary" />
                 <div>
                   <div className="font-medium">JSON</div>
-                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">{i18nService.t('coworkExportJSONDesc')}</div>
+                  <div className="text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">
+                    {i18nService.t('coworkExportJSONDesc')}
+                  </div>
                 </div>
               </button>
             </div>
@@ -2533,39 +2750,41 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
       {/* Delete Confirmation Modal */}
       {showConfirmDelete && (
-        <Modal onClose={handleCancelDelete} overlayClassName="fixed inset-0 z-50 flex items-center justify-center modal-backdrop" className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden modal-content">
-            {/* Header */}
-            <div className="flex items-center gap-3 px-5 py-4">
-              <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
-                <ExclamationTriangleIcon className="h-5 w-5 text-red-600 dark:text-red-500" />
-              </div>
-              <h2 className="text-base font-semibold text-foreground">
-                {i18nService.t('deleteTaskConfirmTitle')}
-              </h2>
+        <Modal
+          onClose={handleCancelDelete}
+          overlayClassName="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
+          className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden modal-content"
+        >
+          {/* Header */}
+          <div className="flex items-center gap-3 px-5 py-4">
+            <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
+              <ExclamationTriangleIcon className="h-5 w-5 text-red-600 dark:text-red-500" />
             </div>
+            <h2 className="text-base font-semibold text-foreground">
+              {i18nService.t('deleteTaskConfirmTitle')}
+            </h2>
+          </div>
 
-            {/* Content */}
-            <div className="px-5 pb-4">
-              <p className="text-sm text-secondary">
-                {i18nService.t('deleteTaskConfirmMessage')}
-              </p>
-            </div>
+          {/* Content */}
+          <div className="px-5 pb-4">
+            <p className="text-sm text-secondary">{i18nService.t('deleteTaskConfirmMessage')}</p>
+          </div>
 
-            {/* Footer */}
-            <div className="flex items-center justify-end gap-3 px-5 py-4 border-t border-border">
-              <button
-                onClick={handleCancelDelete}
-                className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                {i18nService.t('cancel')}
-              </button>
-              <button
-                onClick={handleConfirmDelete}
-                className="px-4 py-2 text-sm font-medium rounded-lg bg-red-500 hover:bg-red-600 text-white transition-colors"
-              >
-                {i18nService.t('deleteSession')}
-              </button>
-            </div>
+          {/* Footer */}
+          <div className="flex items-center justify-end gap-3 px-5 py-4 border-t border-border">
+            <button
+              onClick={handleCancelDelete}
+              className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
+            >
+              {i18nService.t('cancel')}
+            </button>
+            <button
+              onClick={handleConfirmDelete}
+              className="px-4 py-2 text-sm font-medium rounded-lg bg-red-500 hover:bg-red-600 text-white transition-colors"
+            >
+              {i18nService.t('deleteSession')}
+            </button>
+          </div>
         </Modal>
       )}
       <div className="relative flex-1 min-h-0">
@@ -2594,19 +2813,31 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             <button
               type="button"
               onClick={() => {
-                const resolvedRail = currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex;
+                const resolvedRail =
+                  currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex;
                 if (resolvedRail <= 0) return;
                 navigateToRailItem(resolvedRail - 1);
               }}
-              onMouseEnter={() => { setHoveredRailIndex(null); }}
+              onMouseEnter={() => {
+                setHoveredRailIndex(null);
+              }}
               className={`shrink-0 flex items-center justify-center w-5 h-5 mb-2 -mr-[5px] rounded-full transition-all text-neutral-600 dark:text-neutral-400
-                ${!isRailHovered
-                  ? 'opacity-0 pointer-events-none'
-                  : (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) <= 0
-                    ? 'opacity-30 cursor-default'
-                    : 'cursor-pointer hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60'}`}
+                ${
+                  !isRailHovered
+                    ? 'opacity-0 pointer-events-none'
+                    : (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) <= 0
+                      ? 'opacity-30 cursor-default'
+                      : 'cursor-pointer hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60'
+                }`}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-3.5 h-3.5">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2.5}
+                stroke="currentColor"
+                className="w-3.5 h-3.5"
+              >
                 <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
               </svg>
             </button>
@@ -2617,112 +2848,123 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               className="overflow-y-auto min-h-0 flex-1"
               style={{ scrollbarWidth: 'none' }}
             >
-            {(() => {
-              // Build flat list of messages with their content length and turn index
-              const MIN_W = 6;  // px
-              const MAX_W = 16; // px
-              // Strip common markdown syntax for tooltip display
-              const stripMd = (s: string) => s
-                .replace(/^#+\s+/gm, '')
-                .replace(/```[\s\S]*?```/g, ' ')
-                .replace(/`[^`]*`/g, ' ')
-                .replace(/[*_~>]/g, '')
-                .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-                .replace(/\s+/g, ' ')
-                .trim();
-              // Get first meaningful text snippet from content
-              const getLabel = (content: string, fallback: string) => {
-                const stripped = stripMd(content);
-                return stripped.slice(0, 50) || fallback;
-              };
-              type RailItem = { key: string; turnIndex: number; label: string; contentLen: number; isUser: boolean };
-              const items: RailItem[] = [];
-              for (let i = 0; i < turns.length; i++) {
-                const turn = turns[i];
-                if (turn.userMessage) {
-                  const content = turn.userMessage.content ?? '';
-                  items.push({
-                    key: `${turn.id}-user`,
-                    turnIndex: i,
-                    label: getLabel(content, `Turn ${i + 1}`),
-                    contentLen: content.length,
-                    isUser: true,
-                  });
-                }
-                // Aggregate all assistant content into one line per turn
-                let asstContent = '';
-                for (const item of turn.assistantItems) {
-                  if (item.type === 'assistant' && item.message?.content) {
-                    asstContent += item.message.content;
+              {(() => {
+                // Build flat list of messages with their content length and turn index
+                const MIN_W = 6; // px
+                const MAX_W = 16; // px
+                // Strip common markdown syntax for tooltip display
+                const stripMd = (s: string) =>
+                  s
+                    .replace(/^#+\s+/gm, '')
+                    .replace(/```[\s\S]*?```/g, ' ')
+                    .replace(/`[^`]*`/g, ' ')
+                    .replace(/[*_~>]/g, '')
+                    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+                    .replace(/\s+/g, ' ')
+                    .trim();
+                // Get first meaningful text snippet from content
+                const getLabel = (content: string, fallback: string) => {
+                  const stripped = stripMd(content);
+                  return stripped.slice(0, 50) || fallback;
+                };
+                type RailItem = {
+                  key: string;
+                  turnIndex: number;
+                  label: string;
+                  contentLen: number;
+                  isUser: boolean;
+                };
+                const items: RailItem[] = [];
+                for (let i = 0; i < turns.length; i++) {
+                  const turn = turns[i];
+                  if (turn.userMessage) {
+                    const content = turn.userMessage.content ?? '';
+                    items.push({
+                      key: `${turn.id}-user`,
+                      turnIndex: i,
+                      label: getLabel(content, `Turn ${i + 1}`),
+                      contentLen: content.length,
+                      isUser: true,
+                    });
+                  }
+                  // Aggregate all assistant content into one line per turn
+                  let asstContent = '';
+                  for (const item of turn.assistantItems) {
+                    if (item.type === 'assistant' && item.message?.content) {
+                      asstContent += item.message.content;
+                    }
+                  }
+                  if (asstContent) {
+                    items.push({
+                      key: `${turn.id}-asst`,
+                      turnIndex: i,
+                      label: getLabel(asstContent, 'LobsterAI'),
+                      contentLen: asstContent.length,
+                      isUser: false,
+                    });
                   }
                 }
-                if (asstContent) {
-                  items.push({
-                    key: `${turn.id}-asst`,
-                    turnIndex: i,
-                    label: getLabel(asstContent, 'LobsterAI'),
-                    contentLen: asstContent.length,
-                    isUser: false,
-                  });
+                const maxLen = items.reduce((acc, m) => Math.max(acc, m.contentLen), 1);
+                // Sync rail item count and turn-to-rail mapping
+                railItemCountRef.current = items.length;
+                const rangeMap: { first: number; last: number }[] = [];
+                for (let ri = 0; ri < items.length; ri++) {
+                  const ti = items[ri].turnIndex;
+                  if (!rangeMap[ti]) {
+                    rangeMap[ti] = { first: ri, last: ri };
+                  } else {
+                    rangeMap[ti].last = ri;
+                  }
                 }
-              }
-              const maxLen = items.reduce((acc, m) => Math.max(acc, m.contentLen), 1);
-              // Sync rail item count and turn-to-rail mapping
-              railItemCountRef.current = items.length;
-              const rangeMap: { first: number; last: number }[] = [];
-              for (let ri = 0; ri < items.length; ri++) {
-                const ti = items[ri].turnIndex;
-                if (!rangeMap[ti]) {
-                  rangeMap[ti] = { first: ri, last: ri };
-                } else {
-                  rangeMap[ti].last = ri;
-                }
-              }
-              turnToRailRangeRef.current = rangeMap;
+                turnToRailRangeRef.current = rangeMap;
 
-              // Clamp rail index to valid range
-              const resolvedRailIndex = currentRailIndex < 0 || currentRailIndex >= items.length
-                ? items.length - 1
-                : currentRailIndex;
+                // Clamp rail index to valid range
+                const resolvedRailIndex =
+                  currentRailIndex < 0 || currentRailIndex >= items.length
+                    ? items.length - 1
+                    : currentRailIndex;
 
-              return items.map((msg, idx) => {
-                const isActive = idx === resolvedRailIndex;
-                const isHovered = idx === hoveredRailIndex;
-                const ratio = msg.contentLen / maxLen;
-                const lineW = Math.round(MIN_W + ratio * (MAX_W - MIN_W));
-                return (
-                  <button
-                    key={msg.key}
-                    type="button"
-                    onClick={() => {
-                      navigateToRailItem(idx);
-                    }}
-                    onMouseEnter={(e) => {
-                      setHoveredRailIndex(idx);
-                      const rect = e.currentTarget.getBoundingClientRect();
-                      const top = Math.max(8, Math.min(rect.top + rect.height / 2, window.innerHeight - 8));
-                      setRailTooltip({
-                        label: msg.label,
-                        top,
-                        right: window.innerWidth - rect.left + 8,
-                        isUser: msg.isUser,
-                      });
-                    }}
-                    onMouseLeave={() => setRailTooltip(null)}
-                    className="flex items-center justify-end cursor-pointer w-5 py-[5px]"
-                  >
-                    <div
-                      className={`h-[2px] rounded-full transition-all ${
-                        isActive || isHovered
-                          ? 'bg-neutral-800 dark:bg-neutral-200'
-                          : 'bg-neutral-300 dark:bg-neutral-600'
-                      }`}
-                      style={{ width: isActive || isHovered ? MAX_W : lineW }}
-                    />
-                  </button>
-                );
-              });
-            })()}
+                return items.map((msg, idx) => {
+                  const isActive = idx === resolvedRailIndex;
+                  const isHovered = idx === hoveredRailIndex;
+                  const ratio = msg.contentLen / maxLen;
+                  const lineW = Math.round(MIN_W + ratio * (MAX_W - MIN_W));
+                  return (
+                    <button
+                      key={msg.key}
+                      type="button"
+                      onClick={() => {
+                        navigateToRailItem(idx);
+                      }}
+                      onMouseEnter={e => {
+                        setHoveredRailIndex(idx);
+                        const rect = e.currentTarget.getBoundingClientRect();
+                        const top = Math.max(
+                          8,
+                          Math.min(rect.top + rect.height / 2, window.innerHeight - 8),
+                        );
+                        setRailTooltip({
+                          label: msg.label,
+                          top,
+                          right: window.innerWidth - rect.left + 8,
+                          isUser: msg.isUser,
+                        });
+                      }}
+                      onMouseLeave={() => setRailTooltip(null)}
+                      className="flex items-center justify-end cursor-pointer w-5 py-[5px]"
+                    >
+                      <div
+                        className={`h-[2px] rounded-full transition-all ${
+                          isActive || isHovered
+                            ? 'bg-neutral-800 dark:bg-neutral-200'
+                            : 'bg-neutral-300 dark:bg-neutral-600'
+                        }`}
+                        style={{ width: isActive || isHovered ? MAX_W : lineW }}
+                      />
+                    </button>
+                  );
+                });
+              })()}
             </div>
 
             {/* Down Arrow */}
@@ -2734,60 +2976,94 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 if (resolvedRail >= maxRail) return;
                 navigateToRailItem(resolvedRail + 1);
               }}
-              onMouseEnter={() => { setHoveredRailIndex(null); }}
+              onMouseEnter={() => {
+                setHoveredRailIndex(null);
+              }}
               className={`shrink-0 flex items-center justify-center w-5 h-5 mt-2 -mr-[5px] rounded-full transition-all text-neutral-600 dark:text-neutral-400
-                ${!isRailHovered
-                  ? 'opacity-0 pointer-events-none'
-                  : (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) >= railItemCountRef.current - 1
-                    ? 'opacity-30 cursor-default'
-                    : 'cursor-pointer hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60'}`}
+                ${
+                  !isRailHovered
+                    ? 'opacity-0 pointer-events-none'
+                    : (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) >=
+                        railItemCountRef.current - 1
+                      ? 'opacity-30 cursor-default'
+                      : 'cursor-pointer hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60'
+                }`}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-3.5 h-3.5">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2.5}
+                stroke="currentColor"
+                className="w-3.5 h-3.5"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+                />
               </svg>
             </button>
           </div>
         )}
 
-        {railTooltip && createPortal(
-          <div
-            className={`fixed z-[100] px-3.5 py-2 text-[13px] leading-snug pointer-events-none overflow-hidden
+        {railTooltip &&
+          createPortal(
+            <div
+              className={`fixed z-[100] px-3.5 py-2 text-[13px] leading-snug pointer-events-none overflow-hidden
               max-w-[240px] shadow-[0_2px_12px_rgba(0,0,0,0.12)]
               border dark:shadow-[0_2px_12px_rgba(0,0,0,0.4)]
-              ${railTooltip.isUser
-                ? 'rounded-[12px_12px_4px_12px] bg-white border-neutral-200/80 dark:bg-neutral-800 dark:border-neutral-700'
-                : 'rounded-xl bg-neutral-50 border-neutral-200/80 dark:bg-neutral-800 dark:border-neutral-700'
+              ${
+                railTooltip.isUser
+                  ? 'rounded-[12px_12px_4px_12px] bg-white border-neutral-200/80 dark:bg-neutral-800 dark:border-neutral-700'
+                  : 'rounded-xl bg-neutral-50 border-neutral-200/80 dark:bg-neutral-800 dark:border-neutral-700'
               }`}
-            style={{
-              top: railTooltip.top,
-              right: railTooltip.right,
-              transform: 'translateY(-50%)',
-            }}
-          >
-            {!railTooltip.isUser && (
-              <div className="text-[12px] font-medium mb-0.5 text-neutral-800 dark:text-neutral-200">
-                LobsterAI:
-              </div>
-            )}
-            <div
-              className="text-neutral-600 dark:text-neutral-300"
               style={{
-                display: '-webkit-box',
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: 'vertical',
-                overflow: 'hidden',
-                wordBreak: 'break-all',
+                top: railTooltip.top,
+                right: railTooltip.right,
+                transform: 'translateY(-50%)',
               }}
             >
-              {railTooltip.label}
-            </div>
-          </div>,
-          document.body
-        )}
+              {!railTooltip.isUser && (
+                <div className="text-[12px] font-medium mb-0.5 text-neutral-800 dark:text-neutral-200">
+                  LobsterAI:
+                </div>
+              )}
+              <div
+                className="text-neutral-600 dark:text-neutral-300"
+                style={{
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  wordBreak: 'break-all',
+                }}
+              >
+                {railTooltip.label}
+              </div>
+            </div>,
+            document.body,
+          )}
       </div>
 
       {/* Streaming Activity Bar */}
       {isStreaming && <StreamingActivityBar messages={currentSession.messages} />}
+
+      {/* Queued Messages */}
+      {queuedMessages.length > 0 && (
+        <div className="shrink-0">
+          {queuedMessages.map((msg, idx) => (
+            <QueuedMessageBubble
+              key={msg.id}
+              message={msg}
+              position={idx + 1}
+              total={queuedMessages.length}
+              onUpdate={onUpdateQueuedMessage}
+              onRemove={onRemoveQueuedMessage}
+            />
+          ))}
+        </div>
+      )}
 
       {/* Input Area */}
       <div className="p-4 shrink-0">
@@ -2797,7 +3073,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             onSubmit={onContinue}
             onStop={onStop}
             isStreaming={isStreaming}
-            placeholder={i18nService.t(remoteManaged ? 'coworkRemoteManagedPlaceholder' : 'coworkContinuePlaceholder')}
+            placeholder={i18nService.t(
+              remoteManaged ? 'coworkRemoteManagedPlaceholder' : 'coworkContinuePlaceholder',
+            )}
             disabled={remoteManaged}
             size="large"
             remoteManaged={remoteManaged}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -1,6 +1,6 @@
 import { ShieldCheckIcon } from '@heroicons/react/24/outline';
-import React, { useEffect, useRef,useState } from 'react';
-import { useDispatch,useSelector } from 'react-redux';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { agentService } from '../../services/agent';
 import { coworkService } from '../../services/cowork';
@@ -14,15 +14,33 @@ import {
   selectIsOpenClawEngine,
   selectIsStreaming,
 } from '../../store/selectors/coworkSelectors';
-import { addMessage, clearCurrentSession, setCurrentSession, setStreaming, updateSessionStatus } from '../../store/slices/coworkSlice';
-import { clearSelection,selectAction, setActions } from '../../store/slices/quickActionSlice';
+import {
+  addMessage,
+  clearCurrentSession,
+  setCurrentSession,
+  setStreaming,
+  updateSessionStatus,
+} from '../../store/slices/coworkSlice';
+import { clearSelection, selectAction, setActions } from '../../store/slices/quickActionSlice';
 import { clearActiveSkills, setActiveSkillIds } from '../../store/slices/skillSlice';
-import type { CoworkImageAttachment, CoworkSession, OpenClawEngineStatus } from '../../types/cowork';
+import type {
+  CoworkImageAttachment,
+  CoworkSession,
+  OpenClawEngineStatus,
+} from '../../types/cowork';
 import { toOpenClawModelRef } from '../../utils/openclawModelRef';
+
+export interface QueuedMessage {
+  id: string;
+  content: string;
+  skillPrompt?: string;
+  imageAttachments?: CoworkImageAttachment[];
+}
+
 import ComposeIcon from '../icons/ComposeIcon';
 import SidebarToggleIcon from '../icons/SidebarToggleIcon';
 import ModelSelector from '../ModelSelector';
-import { PromptPanel,QuickActionBar } from '../quick-actions';
+import { PromptPanel, QuickActionBar } from '../quick-actions';
 import type { SettingsOpenOptions } from '../Settings';
 import WindowTitleBar from '../window/WindowTitleBar';
 import { resolveAgentModelSelection } from './agentModelSelection';
@@ -38,7 +56,14 @@ export interface CoworkViewProps {
   updateBadge?: React.ReactNode;
 }
 
-const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSkills, isSidebarCollapsed, onToggleSidebar, onNewChat, updateBadge }) => {
+const CoworkView: React.FC<CoworkViewProps> = ({
+  onRequestAppSettings,
+  onShowSkills,
+  isSidebarCollapsed,
+  onToggleSidebar,
+  onNewChat,
+  updateBadge,
+}) => {
   const dispatch = useDispatch();
   const isMac = window.electron.platform === 'darwin';
   const [isInitialized, setIsInitialized] = useState(false);
@@ -57,6 +82,11 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   // Ref for CoworkPromptInput
   const promptInputRef = useRef<CoworkPromptInputRef>(null);
 
+  // Message queue: holds messages submitted while AI is still streaming
+  const [messageQueue, setMessageQueue] = useState<QueuedMessage[]>([]);
+  const messageQueueRef = useRef<QueuedMessage[]>([]);
+  messageQueueRef.current = messageQueue;
+
   const currentSession = useSelector(selectCurrentSession);
   const isStreaming = useSelector(selectIsStreaming);
   const config = useSelector(selectCoworkConfig);
@@ -70,25 +100,25 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   const agents = useSelector((state: RootState) => state.agent.agents);
   const availableModels = useSelector((state: RootState) => state.model.availableModels);
   const globalSelectedModel = useSelector((state: RootState) => state.model.selectedModel);
-  const currentAgent = agents.find((agent) => agent.id === currentAgentId);
-  const {
-    selectedModel: headerSelectedModel,
-  } = resolveAgentModelSelection({
+  const currentAgent = agents.find(agent => agent.id === currentAgentId);
+  const { selectedModel: headerSelectedModel } = resolveAgentModelSelection({
     agentModel: currentAgent?.model ?? '',
     availableModels,
     fallbackModel: globalSelectedModel,
     engine: config.agentEngine,
   });
 
-  const buildApiConfigNotice = (error?: string): { noticeI18nKey: string; noticeExtra?: string } => {
+  const buildApiConfigNotice = (
+    error?: string,
+  ): { noticeI18nKey: string; noticeExtra?: string } => {
     const key = 'coworkModelSettingsRequired';
     if (!error) {
       return { noticeI18nKey: key };
     }
     const normalizedError = error.trim();
     if (
-      normalizedError.startsWith('No enabled provider found for model:')
-      || normalizedError === 'No available model configured in enabled providers.'
+      normalizedError.startsWith('No enabled provider found for model:') ||
+      normalizedError === 'No available model configured in enabled providers.'
     ) {
       return { noticeI18nKey: key };
     }
@@ -160,7 +190,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     };
     init();
 
-    const unsubscribeOpenClawStatus = coworkService.onOpenClawEngineStatus((status) => {
+    const unsubscribeOpenClawStatus = coworkService.onOpenClawEngineStatus(status => {
       setOpenClawStatus(status);
     });
 
@@ -178,12 +208,18 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       unsubscribe();
       unsubscribeOpenClawStatus();
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
 
-  const handleStartSession = async (prompt: string, skillPrompt?: string, imageAttachments?: CoworkImageAttachment[]): Promise<boolean | void> => {
+  const handleStartSession = async (
+    prompt: string,
+    skillPrompt?: string,
+    imageAttachments?: CoworkImageAttachment[],
+  ): Promise<boolean | void> => {
     if (isOpenClawEngine && openClawStatus && !isOpenClawReadyForSession(openClawStatus)) {
-      window.dispatchEvent(new CustomEvent('app:showToast', { detail: i18nService.t('coworkErrorEngineNotReady') }));
+      window.dispatchEvent(
+        new CustomEvent('app:showToast', { detail: i18nService.t('coworkErrorEngineNotReady') }),
+      );
       return false;
     }
     // Prevent duplicate submissions
@@ -245,12 +281,15 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
             type: 'user',
             content: prompt,
             timestamp: now,
-            metadata: (sessionSkillIds.length > 0 || (imageAttachments && imageAttachments.length > 0))
-              ? {
-                ...(sessionSkillIds.length > 0 ? { skillIds: sessionSkillIds } : {}),
-                ...(imageAttachments && imageAttachments.length > 0 ? { imageAttachments } : {}),
-              }
-              : undefined,
+            metadata:
+              sessionSkillIds.length > 0 || (imageAttachments && imageAttachments.length > 0)
+                ? {
+                    ...(sessionSkillIds.length > 0 ? { skillIds: sessionSkillIds } : {}),
+                    ...(imageAttachments && imageAttachments.length > 0
+                      ? { imageAttachments }
+                      : {}),
+                  }
+                : undefined,
           },
         ],
       };
@@ -271,11 +310,11 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       // tool calls, producing empty tool names and err=true failures).
       let effectiveSkillPrompt = skillPrompt;
       if (!skillPrompt && !isOpenClawEngine) {
-        effectiveSkillPrompt = await skillService.getAutoRoutingPrompt() || undefined;
+        effectiveSkillPrompt = (await skillService.getAutoRoutingPrompt()) || undefined;
       }
-      const combinedSystemPrompt = [effectiveSkillPrompt, config.systemPrompt]
-        .filter(p => p?.trim())
-        .join('\n\n') || undefined;
+      const combinedSystemPrompt =
+        [effectiveSkillPrompt, config.systemPrompt].filter(p => p?.trim()).join('\n\n') ||
+        undefined;
 
       // Start the actual session immediately with fallback title
       const { session: startedSession, error: startError } = await coworkService.startSession({
@@ -290,29 +329,36 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
 
       if (!startedSession && startError) {
         // Show the error as a system message in the temp session
-        dispatch(addMessage({
-          sessionId: tempSessionId,
-          message: {
-            id: `error-${Date.now()}`,
-            type: 'system',
-            content: i18nService.t('coworkErrorSessionStartFailed').replace('{error}', startError),
-            timestamp: Date.now(),
-          },
-        }));
+        dispatch(
+          addMessage({
+            sessionId: tempSessionId,
+            message: {
+              id: `error-${Date.now()}`,
+              type: 'system',
+              content: i18nService
+                .t('coworkErrorSessionStartFailed')
+                .replace('{error}', startError),
+              timestamp: Date.now(),
+            },
+          }),
+        );
         dispatch(updateSessionStatus({ sessionId: tempSessionId, status: 'error' }));
         return;
       }
 
       // Generate title in the background and update when ready
       if (startedSession) {
-        coworkService.generateSessionTitle(prompt).then(generatedTitle => {
-          const betterTitle = generatedTitle?.trim();
-          if (betterTitle && betterTitle !== fallbackTitle) {
-            coworkService.renameSession(startedSession.id, betterTitle);
-          }
-        }).catch(error => {
-          console.error('Failed to generate cowork session title:', error);
-        });
+        coworkService
+          .generateSessionTitle(prompt)
+          .then(generatedTitle => {
+            const betterTitle = generatedTitle?.trim();
+            if (betterTitle && betterTitle !== fallbackTitle) {
+              coworkService.renameSession(startedSession.id, betterTitle);
+            }
+          })
+          .catch(error => {
+            console.error('Failed to generate cowork session title:', error);
+          });
       }
 
       // Stop immediately if user cancelled while startup request was in flight.
@@ -330,14 +376,33 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     }
   };
 
-  const handleContinueSession = async (prompt: string, skillPrompt?: string, imageAttachments?: CoworkImageAttachment[]) => {
+  const handleContinueSession = async (
+    prompt: string,
+    skillPrompt?: string,
+    imageAttachments?: CoworkImageAttachment[],
+  ) => {
     if (!currentSession) return;
-    // Prevent duplicate submissions
-    if (isContinuingRef.current) return;
     if (isOpenClawEngine && openClawStatus && !isOpenClawReadyForSession(openClawStatus)) {
-      window.dispatchEvent(new CustomEvent('app:showToast', { detail: i18nService.t('coworkErrorEngineNotReady') }));
+      window.dispatchEvent(
+        new CustomEvent('app:showToast', { detail: i18nService.t('coworkErrorEngineNotReady') }),
+      );
       return false;
     }
+
+    // If AI is still streaming, enqueue the message instead of sending immediately
+    if (isStreaming) {
+      const queued: QueuedMessage = {
+        id: `queued-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        content: prompt,
+        skillPrompt,
+        imageAttachments,
+      };
+      setMessageQueue(prev => [...prev, queued]);
+      return;
+    }
+
+    // Prevent duplicate submissions
+    if (isContinuingRef.current) return;
 
     isContinuingRef.current = true;
     try {
@@ -360,11 +425,11 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       // Skip auto-routing prompt for OpenClaw — skills are loaded natively.
       let effectiveSkillPrompt = skillPrompt;
       if (!skillPrompt && !isOpenClawEngine) {
-        effectiveSkillPrompt = await skillService.getAutoRoutingPrompt() || undefined;
+        effectiveSkillPrompt = (await skillService.getAutoRoutingPrompt()) || undefined;
       }
-      const combinedSystemPrompt = [effectiveSkillPrompt, config.systemPrompt]
-        .filter(p => p?.trim())
-        .join('\n\n') || undefined;
+      const combinedSystemPrompt =
+        [effectiveSkillPrompt, config.systemPrompt].filter(p => p?.trim()).join('\n\n') ||
+        undefined;
 
       await coworkService.continueSession({
         sessionId: currentSession.id,
@@ -394,6 +459,39 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     }
     await coworkService.deleteSession(sessionId);
   };
+
+  // --- Message Queue Management ---
+
+  // Consume the next queued message when streaming finishes
+  useEffect(() => {
+    if (isStreaming) return;
+    if (messageQueueRef.current.length === 0) return;
+    if (!currentSession) return;
+
+    const [next, ...rest] = messageQueueRef.current;
+    setMessageQueue(rest);
+
+    // Defer so Redux state is fully settled
+    setTimeout(() => {
+      void handleContinueSession(next.content, next.skillPrompt, next.imageAttachments);
+    }, 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isStreaming]);
+
+  // Clear queue when navigating away from session
+  useEffect(() => {
+    if (!currentSession) {
+      setMessageQueue([]);
+    }
+  }, [currentSession]);
+
+  const handleUpdateQueuedMessage = useCallback((id: string, content: string) => {
+    setMessageQueue(prev => prev.map(msg => (msg.id === id ? { ...msg, content } : msg)));
+  }, []);
+
+  const handleRemoveQueuedMessage = useCallback((id: string) => {
+    setMessageQueue(prev => prev.filter(msg => msg.id !== id));
+  }, []);
 
   // Get selected quick action
   const selectedAction = React.useMemo(() => {
@@ -435,9 +533,11 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     const handleNewSession = () => {
       dispatch(clearCurrentSession());
       dispatch(clearSelection());
-      window.dispatchEvent(new CustomEvent('cowork:focus-input', {
-        detail: { clear: true },
-      }));
+      window.dispatchEvent(
+        new CustomEvent('cowork:focus-input', {
+          detail: { clear: true },
+        }),
+      );
     };
     window.addEventListener('cowork:shortcut:new-session', handleNewSession);
     return () => {
@@ -467,19 +567,17 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
           <WindowTitleBar inline />
         </div>
         <div className="flex-1 flex items-center justify-center">
-          <div className="text-secondary">
-            {i18nService.t('loading')}
-          </div>
+          <div className="text-secondary">{i18nService.t('loading')}</div>
         </div>
       </div>
     );
   }
 
-  const shouldShowEngineStatus = Boolean(isOpenClawEngine && openClawStatus && openClawStatus.phase !== 'running');
+  const shouldShowEngineStatus = Boolean(
+    isOpenClawEngine && openClawStatus && openClawStatus.phase !== 'running',
+  );
   const isEngineError = openClawStatus?.phase === 'error';
-  const isEngineReady = isOpenClawEngine
-    ? isOpenClawReadyForSession(openClawStatus)
-    : true;
+  const isEngineReady = isOpenClawEngine ? isOpenClawReadyForSession(openClawStatus) : true;
 
   const homeHeader = (
     <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border shrink-0">
@@ -505,12 +603,16 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         )}
         <ModelSelector
           value={isOpenClawEngine ? headerSelectedModel : undefined}
-          onChange={isOpenClawEngine
-            ? async (nextModel) => {
-                if (!currentAgent || !nextModel) return;
-                await agentService.updateAgent(currentAgent.id, { model: toOpenClawModelRef(nextModel) });
-              }
-            : undefined}
+          onChange={
+            isOpenClawEngine
+              ? async nextModel => {
+                  if (!currentAgent || !nextModel) return;
+                  await agentService.updateAgent(currentAgent.id, {
+                    model: toOpenClawModelRef(nextModel),
+                  });
+                }
+              : undefined
+          }
         />
       </div>
       <div className="non-draggable flex items-center">
@@ -526,30 +628,35 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   );
 
   // Engine status banner for error/non-running states (starting overlay is now global in App.tsx)
-  const engineStatusBanner = shouldShowEngineStatus && openClawStatus && openClawStatus.phase !== 'starting' ? (
-    <div className={`shrink-0 flex items-center justify-between px-4 py-2 text-xs ${isEngineError
-      ? 'bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-300'
-      : 'bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-300'
-    }`}>
-      <div className="flex items-center gap-2">
-        <span>{resolveEngineStatusText(openClawStatus)}</span>
-        {typeof openClawStatus.progressPercent === 'number' && (
-          <span className="opacity-70">({Math.round(openClawStatus.progressPercent)}%)</span>
-        )}
-      </div>
-      <button
-        type="button"
-        onClick={handleRestartGateway}
-        disabled={isRestartingGateway}
-        className={`shrink-0 rounded px-2 py-0.5 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${isEngineError
-          ? 'bg-red-600 text-white hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600'
-          : 'bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-700 dark:hover:bg-amber-600'
+  const engineStatusBanner =
+    shouldShowEngineStatus && openClawStatus && openClawStatus.phase !== 'starting' ? (
+      <div
+        className={`shrink-0 flex items-center justify-between px-4 py-2 text-xs ${
+          isEngineError
+            ? 'bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-300'
+            : 'bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-300'
         }`}
       >
-        {i18nService.t('coworkOpenClawRestartGateway')}
-      </button>
-    </div>
-  ) : null;
+        <div className="flex items-center gap-2">
+          <span>{resolveEngineStatusText(openClawStatus)}</span>
+          {typeof openClawStatus.progressPercent === 'number' && (
+            <span className="opacity-70">({Math.round(openClawStatus.progressPercent)}%)</span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={handleRestartGateway}
+          disabled={isRestartingGateway}
+          className={`shrink-0 rounded px-2 py-0.5 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+            isEngineError
+              ? 'bg-red-600 text-white hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600'
+              : 'bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-700 dark:hover:bg-amber-600'
+          }`}
+        >
+          {i18nService.t('coworkOpenClawRestartGateway')}
+        </button>
+      </div>
+    ) : null;
 
   // When there's a current session, show the session detail view
   if (currentSession) {
@@ -566,6 +673,9 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
           onToggleSidebar={onToggleSidebar}
           onNewChat={onNewChat}
           updateBadge={updateBadge}
+          queuedMessages={messageQueue}
+          onUpdateQueuedMessage={handleUpdateQueuedMessage}
+          onRemoveQueuedMessage={handleRemoveQueuedMessage}
         />
       </div>
     );
@@ -618,10 +728,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
           {/* Quick Actions */}
           <div className="space-y-4">
             {selectedAction ? (
-              <PromptPanel
-                action={selectedAction}
-                onPromptSelect={handleQuickActionPromptSelect}
-              />
+              <PromptPanel action={selectedAction} onPromptSelect={handleQuickActionPromptSelect} />
             ) : (
               <QuickActionBar actions={quickActions} onActionSelect={handleActionSelect} />
             )}

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -19,7 +19,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: '用户',
     login: '登录',
     inDevelopment: '正在开发中',
-    
+
     // 设置
     settings: '设置',
     general: '通用',
@@ -46,7 +46,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: '主题色',
     chinese: '中文',
     english: 'English',
-    
+
     // API设置
     apiKey: 'API Key',
     apiKeyPlaceholder: '输入你的 API Key',
@@ -61,7 +61,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: '当前模型',
     availableModels: '可用模型列表',
     modelSwitchHint: '在聊天界面可以切换使用的模型',
-    
+
     // 模型提供商设置
     enabled: '已启用',
     disabled: '已禁用',
@@ -88,7 +88,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelSuffixSecure: '（安全）',
     codingPlanSubscriptionBadge: '订阅套餐',
     inputFileLabel: '输入文件',
-    imageVisionHint: '当前模型未启用图片输入，图片将以文件路径形式发送。若该模型本身支持图片理解，可在模型配置中开启图片输入选项。',
+    imageVisionHint:
+      '当前模型未启用图片输入，图片将以文件路径形式发送。若该模型本身支持图片理解，可在模型配置中开启图片输入选项。',
     copied: '已复制',
     copyrightHolder: '网易有道 版权所有',
     noModelsAvailable: '暂无可用模型',
@@ -169,7 +170,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: '两次输入的密码不一致',
     passwordTooShort: '密码长度至少为4位',
     wrongPassword: '密码错误，请检查后重试',
-    
+
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
     shortcutNotSet: '未设置',
@@ -193,7 +194,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     authLogout: '退出登录',
     authLoginRequired: '请先登录后再开始对话。',
     authLoginRequiredBtn: '登录',
-    authQuotaExhausted: '今日免费额度已用完。您可以登录 LobsterAI Portal 购买套餐或积分包继续使用，或在设置中配置自己的 API Key。',
+    authQuotaExhausted:
+      '今日免费额度已用完。您可以登录 LobsterAI Portal 购买套餐或积分包继续使用，或在设置中配置自己的 API Key。',
     authTopUpLink: '充值',
     authSettingsLink: '设置',
     authLoginToChat: '登录后即可开始聊天',
@@ -208,10 +210,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // 错误信息
     failedToLoadSettings: '加载设置失败',
     failedToSaveSettings: '保存设置失败',
-    
+
     // 加载状态
     loading: '加载中...',
-    
+
     // 侧边栏
     conversations: '对话',
     noConversations: '暂无对话',
@@ -249,7 +251,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: '工作',
     folderIconCode: '代码',
     folderIconIdea: '灵感',
-    
+
     // 聊天窗口
     sendMessage: '发送消息',
     typeMessage: '询问任何问题...',
@@ -279,17 +281,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: '最多上传 10 张图片',
     imageReadError: '读取图片失败',
     imageInputNotSupported: '当前模型不支持图像输入',
-    
+
     // 模型选择
     selectModel: '选择模型',
-    
+
     // 错误提示
     errorOccurred: '发生错误',
     tryAgain: '请重试',
     networkError: '网络错误',
     apiKeyRequired: '需要设置API密钥',
     configureApiKey: '请在设置中配置您的API密钥',
-    
+
     // 初始化
     initializationError: '初始化应用程序失败。请检查您的配置。',
     apiKeyNotConfigured: 'API密钥未配置。请在设置中设置您的API密钥。',
@@ -318,7 +320,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelGroupUser: '自定义模型',
     modelSelectorNoModels: '请先在设置中配置模型',
     coworkApiConfigTitle: 'API 配置',
-    coworkApiConfigHint: '支持 Anthropic 兼容与 OpenAI 兼容协议（OpenAI 兼容通过本地转换服务接入）。',
+    coworkApiConfigHint:
+      '支持 Anthropic 兼容与 OpenAI 兼容协议（OpenAI 兼容通过本地转换服务接入）。',
     coworkAgentEngine: 'Agent 引擎',
     coworkAgentEngineOpenClaw: 'OpenClaw（默认）',
     coworkAgentEngineOpenClawHint: '个人 AI 助理',
@@ -331,7 +334,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkOpenClawInstallHint: 'OpenClaw 运行时已内置。切换到该引擎或启动任务时会自动拉起网关。',
     coworkOpenClawGoToSettingsInstall: '查看引擎设置',
     coworkOpenClawRestartGateway: '重新启动网关',
-    coworkOpenClawNotInstalledNotice: '未检测到内置 OpenClaw runtime（cfmind），请先执行打包前构建脚本。',
+    coworkOpenClawNotInstalledNotice:
+      '未检测到内置 OpenClaw runtime（cfmind），请先执行打包前构建脚本。',
     coworkOpenClawReadyNotice: 'OpenClaw runtime 已就绪。开始任务时会自动启动网关。',
     coworkOpenClawStarting: 'AI 引擎正在启动网关...',
     coworkOpenClawRunning: 'AI 引擎已就绪。',
@@ -351,7 +355,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryEnabledHint: 'OpenClaw 会自动索引 MEMORY.md 文件，为 Agent 提供长期记忆检索。',
     coworkMemoryFilePath: '记忆文件路径',
     coworkMemoryLlmJudgeEnabled: '启用 LLM 二级判定',
-    coworkMemoryLlmJudgeEnabledHint: '仅对规则边界样本调用模型复核，提升准确率（会增加少量 API 调用）。',
+    coworkMemoryLlmJudgeEnabledHint:
+      '仅对规则边界样本调用模型复核，提升准确率（会增加少量 API 调用）。',
     coworkMemoryLegacyNotice: '当前为 OpenClaw 引擎模式。本页功能仅对 Cowork 生效。',
     coworkMemoryAutoWrite: '自动写入记忆',
     coworkMemoryCaptureEachTurn: '启用隐式更新',
@@ -392,14 +397,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryEmbeddingEnabled: '启用本地 embedding 重排',
     coworkMemoryEmbeddingEnabledHint: '在词法检索基础上用本地向量相似度重排结果，提升召回质量',
     coworkMemoryEmbeddingModel: 'Embedding 模型',
-    coworkMemoryEmbeddingModelHint: '推荐 BAAI/bge-m3；可改为你已下载的其他 sentence-transformers 模型',
+    coworkMemoryEmbeddingModelHint:
+      '推荐 BAAI/bge-m3；可改为你已下载的其他 sentence-transformers 模型',
     coworkMemoryEmbeddingLocalModelPath: '本地模型目录（可选）',
     coworkMemoryEmbeddingLocalModelPathHint: '填写后优先加载本地目录；留空时按模型名加载',
     coworkMemoryEmbeddingAutoDownload: '允许自动下载模型',
     coworkMemoryEmbeddingAutoDownloadHint: '关闭后必须提供本地模型目录',
     coworkMemoryEmbeddingDownload: '下载 / 校验模型',
     coworkMemoryEmbeddingDownloading: '下载中...',
-    coworkMemoryEmbeddingDownloadHint: '手动触发模型下载（或校验本地模型目录），下载过程可能较慢，请等待进度完成',
+    coworkMemoryEmbeddingDownloadHint:
+      '手动触发模型下载（或校验本地模型目录），下载过程可能较慢，请等待进度完成',
     coworkMemoryEmbeddingDownloadSuccess: 'Embedding 模型已就绪',
     coworkMemoryEmbeddingDownloadFailed: 'Embedding 模型下载失败',
     coworkMemoryEmbeddingProgressPreparing: '准备下载任务',
@@ -478,10 +485,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     customCreate: '自定义创建',
     choosePreset: '选择预设',
     agentSettings: 'Agent 设置',
-     agentName: '名称',
-     agentNamePlaceholder: 'Agent 名称',
-     emojiPickerTitle: '选择图标',
-     emojiCustomInput: '或者直接输入 Emoji',
+    agentName: '名称',
+    agentNamePlaceholder: 'Agent 名称',
+    emojiPickerTitle: '选择图标',
+    emojiCustomInput: '或者直接输入 Emoji',
     agentDescription: '描述',
     agentDescriptionPlaceholder: '简短描述',
     agentIdentity: '身份',
@@ -521,6 +528,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkNewSession: '新会话',
     coworkContinuePlaceholder: '继续对话...',
     coworkRemoteManagedPlaceholder: '该会话由 IM 通道创建，请在对应的 IM 平台操作',
+    coworkQueued: '排队中',
+    coworkQueueEdit: '编辑排队消息',
+    coworkQueueRemove: '移除排队消息',
+    coworkQueueSendHint: '消息将在当前回复完成后发送',
     aiGeneratedDisclaimer: '内容由 AI 生成，仅供参考',
     updateAvailablePill: '有新版本',
     updateAvailableTitle: '检测到新版本',
@@ -577,7 +588,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noFolderSelected: '未选择文件夹',
     coworkSelectFolderFirst: '请选择任务目录后再提交',
     noRecentFolders: '暂无最近文件夹',
-    folderDriveRootNotAllowed: '不支持使用磁盘根目录作为工作目录，请选择一个子文件夹（例如 D:\\Projects）。',
+    folderDriveRootNotAllowed:
+      '不支持使用磁盘根目录作为工作目录，请选择一个子文件夹（例如 D:\\Projects）。',
     coworkOpenFolder: '打开文件夹',
 
     // Cowork 错误消息
@@ -610,21 +622,24 @@ const translations: Record<LanguageType, Record<string, string>> = {
     remoteImport: '远程导入',
     remoteImportTitle: '远程导入',
     createSkillByChat: '通过对话创建',
-    skillCreatorPrompt: '使用你的skill-creator技能，来创建一个技能。首先，请询问我这个技能需要干什么。',
+    skillCreatorPrompt:
+      '使用你的skill-creator技能，来创建一个技能。首先，请询问我这个技能需要干什么。',
     skillCreatorNotInstalled: '请先安装 skill-creator 技能',
     skillCreatorNotEnabled: '请先启用 skill-creator 技能',
     githubTabLabel: 'GitHub',
     githubImportDescription: '支持仓库链接与子目录链接；若仓库内有多个技能，将自动全部导入。',
     githubImportUrlLabel: 'URL',
     githubSkillPlaceholder: '例如：owner/repo 或 GitHub tree/blob 链接',
-    githubImportExamples: '示例：owner/repo；https://github.com/owner/repo/tree/main/SKILLs/my-skill',
+    githubImportExamples:
+      '示例：owner/repo；https://github.com/owner/repo/tree/main/SKILLs/my-skill',
     clawhubTabLabel: 'ClawHub',
     clawhubImportDescription: '粘贴 clawhub.ai 的技能页面链接，将自动安装对应技能。',
     clawhubImportUrlLabel: 'ClawHub URL',
     clawhubSkillPlaceholder: '例如：https://clawhub.ai/skills/owner/skill-name',
     clawhubImportExamples: '示例：https://clawhub.ai/skills/owner/skill-name',
     importSourceMismatchClawhub: '请输入 clawhub.ai 的链接，或切换到 GitHub 标签页导入。',
-    importSourceMismatchGithub: '请输入 GitHub 链接或 owner/repo 格式，或切换到 ClawHub 标签页导入。',
+    importSourceMismatchGithub:
+      '请输入 GitHub 链接或 owner/repo 格式，或切换到 ClawHub 标签页导入。',
     importSkill: '导入',
     importingSkill: '导入中...',
     official: '官方',
@@ -783,7 +798,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpInstallFromUrl: '通过 URL 安装',
     mcpInstallFromUrlTitle: '通过 URL 安装 MCP',
     mcpInstallFromUrlPlaceholder: '输入 npm 包名或 URL',
-    mcpInstallFromUrlHint: '支持 npm 包名（如 @modelcontextprotocol/server-filesystem）、npx 命令或 HTTP/HTTPS URL',
+    mcpInstallFromUrlHint:
+      '支持 npm 包名（如 @modelcontextprotocol/server-filesystem）、npx 命令或 HTTP/HTTPS URL',
     mcpRequiredConfig: '必填配置',
     mcpEnvRequired: '此字段为必填项',
     mcpOptionalConfig: '可选配置',
@@ -895,15 +911,20 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imConnectivityCheckTitle_nim_p2p_only_hint: '云信私聊模式',
     imConnectivityCheckSuggestion_missing_credentials: '补全必填配置项后重试。',
     imConnectivityCheckSuggestion_auth_check: '核对平台凭证、应用权限和发布状态。',
-    imConnectivityCheckSuggestion_gateway_running: '若显示未启用，请点击对应 IM 渠道胶囊按钮启用；启用后确认网络可访问平台服务。',
+    imConnectivityCheckSuggestion_gateway_running:
+      '若显示未启用，请点击对应 IM 渠道胶囊按钮启用；启用后确认网络可访问平台服务。',
     imConnectivityCheckSuggestion_inbound_activity: '向机器人发一条测试消息；群聊场景请 @机器人。',
-    imConnectivityCheckSuggestion_outbound_activity: '检查机器人发消息权限、可见范围和会话回包权限。',
+    imConnectivityCheckSuggestion_outbound_activity:
+      '检查机器人发消息权限、可见范围和会话回包权限。',
     imConnectivityCheckSuggestion_platform_last_error: '根据错误提示修复后再重测。',
     imConnectivityCheckSuggestion_feishu_group_requires_mention: '在群聊中使用 @机器人 + 内容。',
-    imConnectivityCheckSuggestion_feishu_event_subscription_required: '在飞书后台开启 im.message.receive_v1 并发布版本。',
+    imConnectivityCheckSuggestion_feishu_event_subscription_required:
+      '在飞书后台开启 im.message.receive_v1 并发布版本。',
     imConnectivityCheckSuggestion_discord_group_requires_mention: '在频道中使用 @机器人 + 内容。',
-    imConnectivityCheckSuggestion_telegram_privacy_mode_hint: '在 @BotFather 调整 Privacy Mode 设置。',
-    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint: '确认机器人已加入目标会话并允许收发消息。',
+    imConnectivityCheckSuggestion_telegram_privacy_mode_hint:
+      '在 @BotFather 调整 Privacy Mode 设置。',
+    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint:
+      '确认机器人已加入目标会话并允许收发消息。',
     imConnectivityCheckSuggestion_nim_p2p_only_hint: '通过私聊方式向机器人账号发送消息。',
     nimAccountPlaceholder: '机器人账号ID',
     nimAccountHint: '在云信控制台"账号管理"中创建的 IM 账号 ID',
@@ -915,7 +936,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimAppKeyHint: '从云信控制台应用信息中获取',
     nimTokenHint: '为该账号生成的访问凭证（建议设置为长期有效）',
     nimAccountWhitelist: '白名单账号',
-    nimAccountWhitelistHint: '填写允许与机器人对话的云信账号，多个账号用逗号分隔。留空则不限制，响应所有账号的消息。',
+    nimAccountWhitelistHint:
+      '填写允许与机器人对话的云信账号，多个账号用逗号分隔。留空则不限制，响应所有账号的消息。',
     nimTeamPolicy: '群消息策略',
     nimTeamPolicyDisabled: '禁用 - 不响应群消息',
     nimTeamPolicyOpen: '开放 - 响应所有群的@消息',
@@ -927,7 +949,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimQChatEnabledHint: '订阅圈组消息，仅响应@机器人的消息',
     nimQChatServerIds: '圈组服务器 ID',
     nimQChatServerIdsPlaceholder: '留空自动发现所有已加入的服务器',
-    nimQChatServerIdsHint: '指定要订阅的服务器 ID，多个用逗号分隔。留空则自动订阅所有已加入的服务器。',
+    nimQChatServerIdsHint:
+      '指定要订阅的服务器 ID，多个用逗号分隔。留空则自动订阅所有已加入的服务器。',
     neteaseBeeChanClientIdPlaceholder: '小蜜蜂助理Client ID',
 
     // IM 设置页面 - POPO 配置
@@ -1023,7 +1046,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     feishuBotCreateWizardOrManual: '或 手动填写、修改已有机器人信息',
     feishuBotCreateWizardOptionNew: '新建机器人',
     feishuBotCreateWizardOptionExisting: '关联已有机器人',
-    feishuBotCreateWizardQrcodeDesc: '使用飞书客户端扫描二维码，选择「一键创建飞书机器人」完成配置。',
+    feishuBotCreateWizardQrcodeDesc:
+      '使用飞书客户端扫描二维码，选择「一键创建飞书机器人」完成配置。',
     feishuBotCreateWizardQrcodeExpired: '二维码已过期，请点击刷新',
     feishuBotCreateWizardQrcodeRefresh: '刷新二维码',
     feishuBotCreateWizardVerify: '验证',
@@ -1183,7 +1207,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormValidationDatetimeFuture: '执行时间必须在未来',
     scheduledTasksFormValidationIntervalPositive: '间隔时间必须大于 0',
     scheduledTasksFormValidationCronRequired: '请输入 Cron 表达式',
-    scheduledTasksFormValidationPayloadMismatch: '主会话只能使用系统事件，隔离会话只能使用 Agent 对话',
+    scheduledTasksFormValidationPayloadMismatch:
+      '主会话只能使用系统事件，隔离会话只能使用 Agent 对话',
     scheduledTasksFormValidationWebhookRequired: '请输入 Webhook URL',
     scheduledTasksFormValidationTimeout: '超时秒数必须是大于等于 0 的整数',
     scheduledTasksFormSubmitError: '保存失败：',
@@ -1288,7 +1313,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormNotifyConversationNone: '无可用会话',
     scheduledTasksToggleWarningAtPast: '该任务的执行时间已过，启用后将不会运行',
     scheduledTasksToggleWarningExpired: '该任务已过期，启用后将不会运行',
-    scheduledTasksDataAnomalyWarning: '定时任务「{name}」存在异常数据，已自动修正显示，建议重新编辑该任务',
+    scheduledTasksDataAnomalyWarning:
+      '定时任务「{name}」存在异常数据，已自动修正显示，建议重新编辑该任务',
 
     // 隐私协议弹窗
     privacyDialogTitle: '网易有道LobsterAI服务协议',
@@ -1328,7 +1354,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: 'User',
     login: 'Login',
     inDevelopment: 'In development',
-    
+
     // Settings
     settings: 'Settings',
     general: 'General',
@@ -1355,7 +1381,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: 'Color Themes',
     chinese: 'Chinese',
     english: 'English',
-    
+
     // API Settings
     apiKey: 'API Key',
     apiKeyPlaceholder: 'Enter your API Key',
@@ -1370,7 +1396,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: 'Current Model',
     availableModels: 'Available Models',
     modelSwitchHint: 'You can switch models in the chat interface',
-    
+
     // Model Provider Settings
     enabled: 'Enabled',
     disabled: 'Disabled',
@@ -1386,10 +1412,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelNameAndIdRequired: 'Model name and model ID are required',
     modelIdExists: 'Model ID already exists. Use a different one',
     ollamaModelName: 'Model Name',
-    ollamaModelNameHint: 'Enter the name of a model installed in Ollama, e.g. qwen3:8b, lfm2:latest',
+    ollamaModelNameHint:
+      'Enter the name of a model installed in Ollama, e.g. qwen3:8b, lfm2:latest',
     ollamaModelNamePlaceholder: 'qwen3:8b',
     ollamaDisplayName: 'Display Name (optional)',
-    ollamaDisplayNameHint: 'Custom name shown in the model list. Leave empty to use the model name.',
+    ollamaDisplayNameHint:
+      'Custom name shown in the model list. Leave empty to use the model name.',
     ollamaDisplayNamePlaceholder: 'My Qwen3 Model',
     ollamaModelNameRequired: 'Model name is required',
     supportsImageInput: 'Supports image input',
@@ -1397,7 +1425,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelSuffixSecure: '(Secure)',
     codingPlanSubscriptionBadge: 'Subscription',
     inputFileLabel: 'Input Files',
-    imageVisionHint: 'Image input is not enabled for the current model. Images will be sent as file paths. If the model supports vision, you can enable image input in the model configuration.',
+    imageVisionHint:
+      'Image input is not enabled for the current model. Images will be sent as file paths. If the model supports vision, you can enable image input in the model configuration.',
     copied: 'Copied',
     copyrightHolder: 'NetEase Youdao. All rights reserved.',
     noModelsAvailable: 'No models available',
@@ -1413,9 +1442,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     apiFormatOpenAI: 'OpenAI Compatible',
     apiFormatHint: 'Select protocol compatibility: Anthropic Compatible or OpenAI Compatible',
     zhipuCodingPlanHint: 'When enabled, uses the GLM Coding Plan dedicated API endpoint',
-    zhipuCodingPlanEndpointHint: 'When using GLM Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
-    qwenCodingPlanHint: 'When enabled, uses the Alibaba Cloud Bailian Coding Plan dedicated API endpoint',
-    qwenCodingPlanEndpointHint: 'When using Coding Plan, you need a dedicated API Key (format: sk-sp-xxxxx)',
+    zhipuCodingPlanEndpointHint:
+      'When using GLM Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
+    qwenCodingPlanHint:
+      'When enabled, uses the Alibaba Cloud Bailian Coding Plan dedicated API endpoint',
+    qwenCodingPlanEndpointHint:
+      'When using Coding Plan, you need a dedicated API Key (format: sk-sp-xxxxx)',
     qwenOAuthTab: 'OAuth Login',
     qwenOAuthLogin: 'OAuth Login',
     qwenOAuthLoginFree: 'OAuth Login',
@@ -1428,12 +1460,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     qwenAuthMethod: 'Authentication Method',
     qwenApiKeyOptional: 'API Key (Optional)',
     qwenApiKeyPriority: 'sk-xxxxx (Traditional method, higher priority than OAuth)',
-    qwenAuthPriorityHint: '💡 Authentication Priority: API Key > OAuth. If both are configured, API Key will be used first.',
+    qwenAuthPriorityHint:
+      '💡 Authentication Priority: API Key > OAuth. If both are configured, API Key will be used first.',
     qwenOrUseApiKey: 'Or use API Key',
-    volcengineCodingPlanHint: 'When enabled, uses the Volcengine Coding Plan dedicated API endpoint',
-    volcengineCodingPlanEndpointHint: 'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
+    volcengineCodingPlanHint:
+      'When enabled, uses the Volcengine Coding Plan dedicated API endpoint',
+    volcengineCodingPlanEndpointHint:
+      'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
     moonshotCodingPlanHint: 'When enabled, uses the Moonshot Coding Plan dedicated API endpoint',
-    moonshotCodingPlanEndpointHint: 'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
+    moonshotCodingPlanEndpointHint:
+      'When using Coding Plan, the system will automatically switch to the dedicated Coding endpoint',
     minimaxOAuthTabApiKey: 'API Key',
     minimaxOAuthTabOAuth: 'OAuth',
     minimaxOAuthRegionLabel: 'Region',
@@ -1446,7 +1482,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     minimaxOAuthStatusSuccess: 'OAuth login successful',
     minimaxOAuthStatusError: 'OAuth login failed',
     minimaxOAuthUserCode: 'Authorization code',
-    minimaxOAuthOpenBrowserHint: 'Browser opened, please enter the authorization code and complete login',
+    minimaxOAuthOpenBrowserHint:
+      'Browser opened, please enter the authorization code and complete login',
     minimaxOAuthLoggedIn: 'Logged in via MiniMax OAuth',
     minimaxOAuthRelogin: 'Re-login',
     minimaxOAuthLogout: 'Log out',
@@ -1462,8 +1499,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     importProvidersFailed: 'Failed to import providers',
     exportProvidersFailed: 'Failed to export providers',
     invalidProvidersFile: 'Invalid providers file',
-    decryptProvidersFailed: 'Failed to decrypt API key. Make sure the file was exported on this device.',
-    decryptProvidersPartial: 'Some keys could not be decrypted. Existing keys were kept or left blank.',
+    decryptProvidersFailed:
+      'Failed to decrypt API key. Make sure the file was exported on this device.',
+    decryptProvidersPartial:
+      'Some keys could not be decrypted. Existing keys were kept or left blank.',
 
     // Password related
     password: 'Password',
@@ -1472,13 +1511,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     enterPasswordAgain: 'Enter password again',
     exportPasswordTitle: 'Set Export Password',
     importPasswordTitle: 'Enter Import Password',
-    exportPasswordHint: 'This password encrypts your API keys. Use the same password when importing.',
+    exportPasswordHint:
+      'This password encrypts your API keys. Use the same password when importing.',
     importPasswordHint: 'Enter the password you set when exporting',
     passwordRequired: 'Password is required',
     passwordMismatch: 'Passwords do not match',
     passwordTooShort: 'Password must be at least 4 characters',
     wrongPassword: 'Wrong password, please try again',
-    
+
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
     shortcutNotSet: 'Not set',
@@ -1502,7 +1542,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     authLogout: 'Log Out',
     authLoginRequired: 'Please log in to start a conversation.',
     authLoginRequiredBtn: 'Log In',
-    authQuotaExhausted: 'Daily free quota exhausted. Visit LobsterAI Portal to purchase a plan or credits, or configure your own API Key in Settings.',
+    authQuotaExhausted:
+      'Daily free quota exhausted. Visit LobsterAI Portal to purchase a plan or credits, or configure your own API Key in Settings.',
     authTopUpLink: 'Top Up',
     authSettingsLink: 'Settings',
     authLoginToChat: 'Log in to start chatting',
@@ -1517,10 +1558,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',
-    
+
     // Loading State
     loading: 'Loading...',
-    
+
     // Sidebar
     conversations: 'Conversations',
     noConversations: 'No conversations',
@@ -1533,7 +1574,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noProject: 'No project',
     noProjects: 'No projects',
     confirmDelete: 'Confirm Delete',
-    confirmDeleteMessage: 'Are you sure you want to delete this conversation? This action cannot be undone.',
+    confirmDeleteMessage:
+      'Are you sure you want to delete this conversation? This action cannot be undone.',
     searchChats: 'Search Chats',
     searchConversations: 'Search tasks...',
     searchNoResults: 'No matching tasks',
@@ -1550,7 +1592,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     projectSettings: 'Project settings',
     projectNameLabel: 'Project name',
     deleteProject: 'Delete project',
-    confirmDeleteProject: 'Are you sure you want to delete this project? Chats in this project will be moved to your chat list. This action cannot be undone.',
+    confirmDeleteProject:
+      'Are you sure you want to delete this project? Chats in this project will be moved to your chat list. This action cannot be undone.',
     folderIconDefault: 'Default',
     folderIconHealth: 'Health',
     folderIconStudy: 'Study',
@@ -1558,7 +1601,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: 'Work',
     folderIconCode: 'Code',
     folderIconIdea: 'Ideas',
-    
+
     // Chat Window
     sendMessage: 'Send Message',
     typeMessage: 'Type a message...',
@@ -1568,7 +1611,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkReEdit: 'Re-edit',
     messageCopied: 'Message copied',
     clearConversation: 'Clear Conversation',
-    confirmClearConversation: 'Are you sure you want to clear the current conversation? This action cannot be undone.',
+    confirmClearConversation:
+      'Are you sure you want to clear the current conversation? This action cannot be undone.',
     today: 'Today',
     yesterday: 'Yesterday',
     daysAgo: 'days ago',
@@ -1588,17 +1632,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: 'Up to 10 images',
     imageReadError: 'Failed to read image',
     imageInputNotSupported: 'Current model does not support images',
-    
+
     // Model Selection
     selectModel: 'Select Model',
-    
+
     // Error Messages
     errorOccurred: 'An error occurred',
     tryAgain: 'Please try again',
     networkError: 'Network error',
     apiKeyRequired: 'API Key Required',
     configureApiKey: 'Please configure your API key in settings',
-    
+
     // Initialization
     initializationError: 'Failed to initialize application. Please check your configuration.',
     apiKeyNotConfigured: 'API key not configured. Please set up your API key in settings.',
@@ -1618,30 +1662,36 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkWorkingDirectoryHint: 'LobsterAI will execute commands in this directory',
     coworkSystemPrompt: 'System Prompt',
     coworkSystemPromptPlaceholder: 'Set custom instructions for LobsterAI...',
-    coworkSystemPromptHint: 'Optional system prompt to customize LobsterAI\'s behavior',
+    coworkSystemPromptHint: "Optional system prompt to customize LobsterAI's behavior",
     coworkModelSettingsRequired: 'Please configure models and API keys in Model Settings first.',
     coworkModelSettingsTitle: 'Model Settings',
-    coworkModelSettingsHint: 'LobsterAI uses the current model and provider configuration from Model Settings.',
+    coworkModelSettingsHint:
+      'LobsterAI uses the current model and provider configuration from Model Settings.',
     coworkModelSettingsAction: 'Go to Model Settings',
     modelGroupServer: 'Plan Models',
     modelGroupUser: 'Custom Models',
     modelSelectorNoModels: 'Please configure models in settings first',
     coworkApiConfigTitle: 'API Configuration',
-    coworkApiConfigHint: 'Supports Anthropic-compatible and OpenAI-compatible APIs (OpenAI compatibility is bridged by a local adapter).',
+    coworkApiConfigHint:
+      'Supports Anthropic-compatible and OpenAI-compatible APIs (OpenAI compatibility is bridged by a local adapter).',
     coworkAgentEngine: 'Agent Engine',
     coworkAgentEngineOpenClaw: 'OpenClaw (Default)',
     coworkAgentEngineOpenClawHint: 'Personal AI assistant',
     coworkAgentEngineClaudeLegacy: 'Cowork',
-    coworkAgentEngineClaudeLegacyHint: 'Built-in engine, ready out of the box, recommended for daily tasks.',
+    coworkAgentEngineClaudeLegacyHint:
+      'Built-in engine, ready out of the box, recommended for daily tasks.',
     coworkOpenClawInstall: 'Start OpenClaw',
     coworkOpenClawRetryInstall: 'Retry OpenClaw Startup',
     coworkOpenClawStart: 'Start OpenClaw',
     coworkOpenClawInstalling: 'Starting OpenClaw...',
-    coworkOpenClawInstallHint: 'OpenClaw runtime is bundled. Switching to this engine or starting a task will auto-start the gateway.',
+    coworkOpenClawInstallHint:
+      'OpenClaw runtime is bundled. Switching to this engine or starting a task will auto-start the gateway.',
     coworkOpenClawGoToSettingsInstall: 'View Engine Settings',
     coworkOpenClawRestartGateway: 'Restart Gateway',
-    coworkOpenClawNotInstalledNotice: 'Bundled OpenClaw runtime (cfmind) was not found. Build the runtime before packaging.',
-    coworkOpenClawReadyNotice: 'OpenClaw runtime is ready. The gateway will auto-start when you run a task.',
+    coworkOpenClawNotInstalledNotice:
+      'Bundled OpenClaw runtime (cfmind) was not found. Build the runtime before packaging.',
+    coworkOpenClawReadyNotice:
+      'OpenClaw runtime is ready. The gateway will auto-start when you run a task.',
     coworkOpenClawStarting: 'AI engine is starting the gateway...',
     coworkOpenClawRunning: 'AI engine is ready.',
     coworkOpenClawError: 'OpenClaw gateway failed to become healthy in time.',
@@ -1651,16 +1701,20 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkBootstrapIdentityTitle: 'Agent Identity',
     coworkBootstrapIdentityHint: 'Agent metadata (name, emoji, avatar, etc.)',
     coworkBootstrapUserTitle: 'User Profile',
-    coworkBootstrapUserHint: 'Information about yourself (name, preferences, etc.) that the Agent will remember.',
+    coworkBootstrapUserHint:
+      'Information about yourself (name, preferences, etc.) that the Agent will remember.',
     coworkBootstrapSoulTitle: 'Agent Persona',
-    coworkBootstrapSoulHint: 'Agent personality, tone, and behavior guidelines. The Agent will be instructed to follow this.',
+    coworkBootstrapSoulHint:
+      'Agent personality, tone, and behavior guidelines. The Agent will be instructed to follow this.',
     coworkBootstrapStoragePath: 'Storage path',
     coworkBootstrapSaveFailed: 'Failed to save agent settings',
     coworkMemoryEnabled: 'Enable user memories',
-    coworkMemoryEnabledHint: 'OpenClaw automatically indexes MEMORY.md for long-term memory retrieval by the Agent.',
+    coworkMemoryEnabledHint:
+      'OpenClaw automatically indexes MEMORY.md for long-term memory retrieval by the Agent.',
     coworkMemoryFilePath: 'Memory file path',
     coworkMemoryLlmJudgeEnabled: 'Enable LLM secondary judge',
-    coworkMemoryLlmJudgeEnabledHint: 'Only borderline rule cases are reviewed by the model for better accuracy (adds a small number of API calls).',
+    coworkMemoryLlmJudgeEnabledHint:
+      'Only borderline rule cases are reviewed by the model for better accuracy (adds a small number of API calls).',
     coworkMemoryLegacyNotice: 'OpenClaw engine mode is active. This page only applies to Cowork.',
     coworkMemoryAutoWrite: 'Auto-write memory',
     coworkMemoryCaptureEachTurn: 'Enable implicit updates',
@@ -1699,16 +1753,20 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryAdvancedShow: 'Show advanced settings',
     coworkMemoryAdvancedHide: 'Hide advanced settings',
     coworkMemoryEmbeddingEnabled: 'Enable local embedding rerank',
-    coworkMemoryEmbeddingEnabledHint: 'Rerank lexical hits with local vector similarity for better recall quality',
+    coworkMemoryEmbeddingEnabledHint:
+      'Rerank lexical hits with local vector similarity for better recall quality',
     coworkMemoryEmbeddingModel: 'Embedding model',
-    coworkMemoryEmbeddingModelHint: 'Recommended: BAAI/bge-m3. You can switch to any downloaded sentence-transformers model',
+    coworkMemoryEmbeddingModelHint:
+      'Recommended: BAAI/bge-m3. You can switch to any downloaded sentence-transformers model',
     coworkMemoryEmbeddingLocalModelPath: 'Local model path (optional)',
-    coworkMemoryEmbeddingLocalModelPathHint: 'If set, load model from this directory first; if empty, load by model id',
+    coworkMemoryEmbeddingLocalModelPathHint:
+      'If set, load model from this directory first; if empty, load by model id',
     coworkMemoryEmbeddingAutoDownload: 'Allow auto model download',
     coworkMemoryEmbeddingAutoDownloadHint: 'When disabled, you must provide a local model path',
     coworkMemoryEmbeddingDownload: 'Download / Validate model',
     coworkMemoryEmbeddingDownloading: 'Downloading...',
-    coworkMemoryEmbeddingDownloadHint: 'Manually trigger model download (or validate local path). This can take a while, wait for progress to finish',
+    coworkMemoryEmbeddingDownloadHint:
+      'Manually trigger model download (or validate local path). This can take a while, wait for progress to finish',
     coworkMemoryEmbeddingDownloadSuccess: 'Embedding model is ready',
     coworkMemoryEmbeddingDownloadFailed: 'Failed to download embedding model',
     coworkMemoryEmbeddingProgressPreparing: 'Preparing download task',
@@ -1719,11 +1777,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryEmbeddingProgressDone: 'Completed',
     coworkMemoryEmbeddingProgressError: 'Failed',
     coworkMemoryEmbeddingWeight: 'Semantic rerank weight',
-    coworkMemoryEmbeddingWeightHint: 'Range 0-1. Higher means more embedding influence. Recommended: 0.62',
+    coworkMemoryEmbeddingWeightHint:
+      'Range 0-1. Higher means more embedding influence. Recommended: 0.62',
     coworkConfigSaveFailed: 'Failed to save LobsterAI settings. Please try again.',
     coworkApiProviderModel: 'Select from provider models',
     coworkApiProviderModelCustom: 'Custom',
-    coworkApiProviderModelHint: 'Only shows enabled providers with configured API key and base URL.',
+    coworkApiProviderModelHint:
+      'Only shows enabled providers with configured API key and base URL.',
     coworkApiBaseUrl: 'API Base URL',
     coworkApiKey: 'API Key',
     coworkApiModel: 'Model Name',
@@ -1753,9 +1813,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkTodoPending: 'pending',
     coworkTodoUntitled: 'Untitled todo',
     coworkTodoUnknownStatus: 'Unknown status',
-    coworkDangerousOperation: 'Warning: This operation may modify files or execute system commands. Please review carefully.',
-    coworkDestructiveOperation: 'Destructive operation: This command may cause irreversible data loss. Please confirm carefully.',
-    coworkCautionOperation: 'Caution: This command may modify files or system state. Please review carefully.',
+    coworkDangerousOperation:
+      'Warning: This operation may modify files or execute system commands. Please review carefully.',
+    coworkDestructiveOperation:
+      'Destructive operation: This command may cause irreversible data loss. Please confirm carefully.',
+    coworkCautionOperation:
+      'Caution: This command may modify files or system state. Please review carefully.',
     dangerReasonRecursiveDelete: 'Recursive file deletion',
     dangerReasonGitForcePush: 'Git force push',
     dangerReasonGitResetHard: 'Git hard reset',
@@ -1787,19 +1850,21 @@ const translations: Record<LanguageType, Record<string, string>> = {
     customCreate: 'Custom Create',
     choosePreset: 'Choose Preset',
     agentSettings: 'Agent Settings',
-     agentName: 'Name',
-     agentNamePlaceholder: 'Agent name',
-     emojiPickerTitle: 'Choose icon',
-     emojiCustomInput: 'Or type an emoji',
+    agentName: 'Name',
+    agentNamePlaceholder: 'Agent name',
+    emojiPickerTitle: 'Choose icon',
+    emojiCustomInput: 'Or type an emoji',
     agentDescription: 'Description',
     agentDescriptionPlaceholder: 'Brief description',
     agentIdentity: 'Identity',
     agentIdentityPlaceholder: 'Identity description (IDENTITY.md)...',
     agentDefaultModel: 'Agent Default Model',
     agentModelOpenClawOnly: 'This setting only applies to the OpenClaw engine',
-    agentModelInvalidHint: 'The model bound to this Agent is no longer available. Please choose a valid model for this Agent first',
+    agentModelInvalidHint:
+      'The model bound to this Agent is no longer available. Please choose a valid model for this Agent first',
     agentSkills: 'Skills',
-    agentSkillsHint: 'Select skills available to this Agent. Leave empty to use all enabled skills.',
+    agentSkillsHint:
+      'Select skills available to this Agent. Leave empty to use all enabled skills.',
     agentSkillsSearch: 'Search skills...',
     agentSkillsNone: 'Click to select skills',
     agentsSubtitle: 'Custom personas and skill sets for your AI agents',
@@ -1820,7 +1885,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     agentCreateFailed: 'Failed to create Agent',
     agentSaveFailed: 'Failed to save Agent settings',
     agentDeleteConfirmTitle: 'Confirm Delete Agent',
-    agentDeleteConfirmMessage: 'Are you sure you want to delete Agent "{name}"? This action cannot be undone.',
+    agentDeleteConfirmMessage:
+      'Are you sure you want to delete Agent "{name}"? This action cannot be undone.',
     agentUnsavedTitle: 'Unsaved Changes',
     agentUnsavedMessage: 'You have unsaved changes. Are you sure you want to discard them?',
     discard: 'Discard',
@@ -1829,11 +1895,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     coworkNewSession: 'New Session',
     coworkContinuePlaceholder: 'Continue the conversation...',
-    coworkRemoteManagedPlaceholder: 'This session was created via IM. Please use the corresponding IM platform.',
+    coworkRemoteManagedPlaceholder:
+      'This session was created via IM. Please use the corresponding IM platform.',
+    coworkQueued: 'Queued',
+    coworkQueueEdit: 'Edit queued message',
+    coworkQueueRemove: 'Remove queued message',
+    coworkQueueSendHint: 'Message will be sent after the current response completes',
     aiGeneratedDisclaimer: 'Content generated by AI, for reference only.',
     updateAvailablePill: 'New update',
     updateAvailableTitle: 'New version available',
-    updateAvailableMessage: 'A new version is available. Please download it from the official website and install over the current version.',
+    updateAvailableMessage:
+      'A new version is available. Please download it from the official website and install over the current version.',
     updateAvailableConfirm: 'Update Now',
     updateAvailableCancel: 'Cancel',
     updateOpenFailed: 'Failed to open download page',
@@ -1872,13 +1944,15 @@ const translations: Record<LanguageType, Record<string, string>> = {
     deleteSession: 'Delete Task',
     turnIndex: 'Turn index',
     deleteTaskConfirmTitle: 'Confirm Deletion',
-    deleteTaskConfirmMessage: 'This action cannot be undone. All messages in this task will be permanently deleted.',
+    deleteTaskConfirmMessage:
+      'This action cannot be undone. All messages in this task will be permanently deleted.',
     batchOperations: 'Batch Operations',
     batchSelectAll: 'Select All',
     batchDelete: 'Delete',
     batchCancel: 'Cancel',
     batchDeleteConfirmTitle: 'Confirm Batch Deletion',
-    batchDeleteConfirmMessage: 'Are you sure you want to delete {count} selected tasks? This action cannot be undone.',
+    batchDeleteConfirmMessage:
+      'Are you sure you want to delete {count} selected tasks? This action cannot be undone.',
     back: 'Back',
     browse: 'Browse',
     addFolder: 'Add Folder',
@@ -1886,26 +1960,35 @@ const translations: Record<LanguageType, Record<string, string>> = {
     noFolderSelected: 'No folder selected',
     coworkSelectFolderFirst: 'Please select a task folder before submitting',
     noRecentFolders: 'No recent folders',
-    folderDriveRootNotAllowed: 'Drive root directories are not supported as working directories. Please select a subfolder (e.g. D:\\Projects).',
+    folderDriveRootNotAllowed:
+      'Drive root directories are not supported as working directories. Please select a subfolder (e.g. D:\\Projects).',
     coworkOpenFolder: 'Open folder',
 
     // Cowork error messages
-    coworkErrorAuthInvalid: 'Invalid or expired API key. Please check and update your API key in settings.',
+    coworkErrorAuthInvalid:
+      'Invalid or expired API key. Please check and update your API key in settings.',
     coworkErrorInsufficientBalance: 'Insufficient API balance. Please top up and try again.',
-    coworkErrorInputTooLong: 'Input too long, exceeding model context limit. Please shorten the conversation and try again.',
-    coworkErrorCouldNotProcessPdf: 'Unable to process the PDF file. Please try converting the PDF to text format and resend.',
-    coworkErrorModelNotFound: 'The requested model does not exist or is unavailable. Please check the model configuration in settings.',
-    coworkErrorGatewayDisconnected: 'AI engine connection lost. Please retry. If the issue persists, try restarting the app.',
+    coworkErrorInputTooLong:
+      'Input too long, exceeding model context limit. Please shorten the conversation and try again.',
+    coworkErrorCouldNotProcessPdf:
+      'Unable to process the PDF file. Please try converting the PDF to text format and resend.',
+    coworkErrorModelNotFound:
+      'The requested model does not exist or is unavailable. Please check the model configuration in settings.',
+    coworkErrorGatewayDisconnected:
+      'AI engine connection lost. Please retry. If the issue persists, try restarting the app.',
     coworkErrorServiceRestart: 'AI engine is restarting. Please try again later.',
     coworkErrorGatewayDraining: 'AI engine is restarting. Please wait a moment and try again.',
-    coworkErrorNetworkError: 'Network connection failed. Please check your network settings and try again.',
+    coworkErrorNetworkError:
+      'Network connection failed. Please check your network settings and try again.',
     coworkErrorRateLimit: 'Too many requests. Please try again later.',
-    coworkErrorContentFiltered: 'Content did not pass the safety review. Please modify and try again.',
+    coworkErrorContentFiltered:
+      'Content did not pass the safety review. Please modify and try again.',
     coworkErrorServerError: 'Server error occurred. Please try again later.',
     coworkErrorSessionStartFailed: 'Failed to start session: {error}',
     coworkErrorSessionContinueFailed: 'Failed to send message: {error}',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
-    coworkErrorUnknown: 'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
+    coworkErrorUnknown:
+      'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
 
     // Skills
     skills: 'Skills',
@@ -1919,21 +2002,26 @@ const translations: Record<LanguageType, Record<string, string>> = {
     remoteImport: 'Remote Import',
     remoteImportTitle: 'Remote Import',
     createSkillByChat: 'Create via Conversation',
-    skillCreatorPrompt: 'Use your skill-creator skill to create a new skill. First, please ask me what this skill should do.',
+    skillCreatorPrompt:
+      'Use your skill-creator skill to create a new skill. First, please ask me what this skill should do.',
     skillCreatorNotInstalled: 'Please install the skill-creator skill first',
     skillCreatorNotEnabled: 'Please enable the skill-creator skill first',
     githubTabLabel: 'GitHub',
-    githubImportDescription: 'Supports both repository and subdirectory links. If a repo contains multiple skills, all will be imported.',
+    githubImportDescription:
+      'Supports both repository and subdirectory links. If a repo contains multiple skills, all will be imported.',
     githubImportUrlLabel: 'URL',
     githubSkillPlaceholder: 'e.g. owner/repo or a GitHub tree/blob URL',
-    githubImportExamples: 'Examples: owner/repo; https://github.com/owner/repo/tree/main/SKILLs/my-skill',
+    githubImportExamples:
+      'Examples: owner/repo; https://github.com/owner/repo/tree/main/SKILLs/my-skill',
     clawhubTabLabel: 'ClawHub',
-    clawhubImportDescription: 'Paste a clawhub.ai skill page URL to automatically install the skill.',
+    clawhubImportDescription:
+      'Paste a clawhub.ai skill page URL to automatically install the skill.',
     clawhubImportUrlLabel: 'ClawHub URL',
     clawhubSkillPlaceholder: 'e.g. https://clawhub.ai/skills/owner/skill-name',
     clawhubImportExamples: 'Example: https://clawhub.ai/skills/owner/skill-name',
     importSourceMismatchClawhub: 'Please enter a clawhub.ai URL, or switch to the GitHub tab.',
-    importSourceMismatchGithub: 'Please enter a GitHub URL or owner/repo, or switch to the ClawHub tab.',
+    importSourceMismatchGithub:
+      'Please enter a GitHub URL or owner/repo, or switch to the ClawHub tab.',
     importSkill: 'Import',
     importingSkill: 'Importing...',
     official: 'Official',
@@ -2045,7 +2133,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // MCP Servers
     mcpServers: 'MCP',
-    mcpDescription: 'Configure and manage MCP (Model Context Protocol) servers to extend your agent\'s tool capabilities',
+    mcpDescription:
+      "Configure and manage MCP (Model Context Protocol) servers to extend your agent's tool capabilities",
     searchMcpServers: 'Search MCP servers',
     addMcpServer: 'Custom',
     editMcpServer: 'Edit MCP Server',
@@ -2092,7 +2181,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpInstallFromUrl: 'Install from URL',
     mcpInstallFromUrlTitle: 'Install MCP from URL',
     mcpInstallFromUrlPlaceholder: 'Enter npm package name or URL',
-    mcpInstallFromUrlHint: 'Supports npm package names (e.g. @modelcontextprotocol/server-filesystem), npx commands, or HTTP/HTTPS URLs',
+    mcpInstallFromUrlHint:
+      'Supports npm package names (e.g. @modelcontextprotocol/server-filesystem), npx commands, or HTTP/HTTPS URLs',
     mcpRequiredConfig: 'Required Configuration',
     mcpEnvRequired: 'This field is required',
     mcpOptionalConfig: 'Optional Configuration',
@@ -2109,7 +2199,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpDesc_github: 'GitHub platform integration: repos, issues, PRs, Actions management',
     mcpDesc_gitlab: 'GitLab API integration: project management, merge requests, pipelines',
     mcpDesc_context7: 'Up-to-date library documentation and code examples for AI coding',
-    mcpDesc_google_drive: 'Google Drive file access and search with auto-export for Workspace files',
+    mcpDesc_google_drive:
+      'Google Drive file access and search with auto-export for Workspace files',
     mcpDesc_gmail: 'Gmail management: read, send, search emails with auto authentication',
     mcpDesc_google_calendar: 'Google Calendar management: create, query, update calendar events',
     mcpDesc_notion: 'Notion API: search, create/update pages, manage databases',
@@ -2117,7 +2208,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpDesc_todoist: 'Task management: create, update, complete and organize to-do items',
     mcpDesc_playwright: 'Advanced browser automation supporting Chromium/Firefox/WebKit',
     mcpDesc_canva: 'Canva design platform: create and manage designs, template operations',
-    mcpDesc_firecrawl: 'Web scraping and data extraction: batch processing, structured extraction and content analysis',
+    mcpDesc_firecrawl:
+      'Web scraping and data extraction: batch processing, structured extraction and content analysis',
     mcpDesc_fetch: 'Web content fetching and HTML-to-markdown conversion for LLM consumption',
 
     // Email Skill Config
@@ -2131,13 +2223,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     emailPasswordPlaceholder: 'Password or app-specific password',
     emailAdvancedSettings: 'Advanced Settings',
     emailAllowInsecureCert: 'Allow insecure certificates',
-    emailAllowInsecureCertHint: 'Skip TLS certificate verification, useful when proxy/VPN causes self-signed certificate errors',
+    emailAllowInsecureCertHint:
+      'Skip TLS certificate verification, useful when proxy/VPN causes self-signed certificate errors',
     emailMailbox: 'Default Mailbox',
     emailConfigSaved: 'Email configuration saved',
     emailConfigError: 'Failed to save configuration',
     emailHintGmail: 'If 2FA is enabled, use an App Password instead of your account password',
-    emailHint163: 'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
-    emailHintQQ: 'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
+    emailHint163:
+      'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
+    emailHintQQ:
+      'Use an authorization code, not your account password. Enable IMAP/SMTP in web settings first',
 
     // File operations
     openFile: 'Open File',
@@ -2158,12 +2253,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nim: 'NetEase IM',
     'netease-bee': 'Netease Bee',
     weixin: 'WeChat',
-    wecom: 'WeCom',    popo: 'POPO',
+    wecom: 'WeCom',
+    popo: 'POPO',
     connected: 'Connected',
     disconnected: 'Disconnected',
     imAgentBinding: 'Responding Agent',
     imAgentBindingDefault: 'Default (main)',
-    imAgentBindingHint: 'Select the Agent that responds to messages on this platform. Different Agents have different personas and skill configurations.',
+    imAgentBindingHint:
+      'Select the Agent that responds to messages on this platform. Different Agents have different personas and skill configurations.',
     kickedByOtherClient: 'Account logged in elsewhere',
     starting: 'Starting',
     start: 'Start',
@@ -2196,23 +2293,35 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imConnectivityCheckTitle_outbound_activity: 'Outbound Message Activity',
     imConnectivityCheckTitle_platform_last_error: 'Recent Platform Error',
     imConnectivityCheckTitle_feishu_group_requires_mention: 'Feishu Group Trigger Rule',
-    imConnectivityCheckTitle_feishu_event_subscription_required: 'Feishu Event Subscription Requirement',
+    imConnectivityCheckTitle_feishu_event_subscription_required:
+      'Feishu Event Subscription Requirement',
     imConnectivityCheckTitle_discord_group_requires_mention: 'Discord Group Trigger Rule',
     imConnectivityCheckTitle_telegram_privacy_mode_hint: 'Telegram Privacy Mode',
     imConnectivityCheckTitle_dingtalk_bot_membership_hint: 'DingTalk Conversation Permission',
     imConnectivityCheckTitle_nim_p2p_only_hint: 'NetEase IM P2P Mode',
     imConnectivityCheckSuggestion_missing_credentials: 'Fill required credentials and test again.',
-    imConnectivityCheckSuggestion_auth_check: 'Verify credentials, permissions, and app release status.',
-    imConnectivityCheckSuggestion_gateway_running: 'If disabled, click the IM channel pill to enable it, then verify platform endpoints are reachable.',
-    imConnectivityCheckSuggestion_inbound_activity: 'Send a test message to the bot; mention it in group chats.',
-    imConnectivityCheckSuggestion_outbound_activity: 'Check bot send permissions and conversation reply scope.',
-    imConnectivityCheckSuggestion_platform_last_error: 'Fix the reported error and run diagnostics again.',
-    imConnectivityCheckSuggestion_feishu_group_requires_mention: 'Use @bot plus your message in group chats.',
-    imConnectivityCheckSuggestion_feishu_event_subscription_required: 'Enable im.message.receive_v1 and publish app version.',
-    imConnectivityCheckSuggestion_discord_group_requires_mention: 'Use @bot plus your message in channels.',
-    imConnectivityCheckSuggestion_telegram_privacy_mode_hint: 'Review Privacy Mode in @BotFather settings.',
-    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint: 'Ensure the bot is in the target conversation with send/receive rights.',
-    imConnectivityCheckSuggestion_nim_p2p_only_hint: 'Send messages via direct chat to the bot account.',
+    imConnectivityCheckSuggestion_auth_check:
+      'Verify credentials, permissions, and app release status.',
+    imConnectivityCheckSuggestion_gateway_running:
+      'If disabled, click the IM channel pill to enable it, then verify platform endpoints are reachable.',
+    imConnectivityCheckSuggestion_inbound_activity:
+      'Send a test message to the bot; mention it in group chats.',
+    imConnectivityCheckSuggestion_outbound_activity:
+      'Check bot send permissions and conversation reply scope.',
+    imConnectivityCheckSuggestion_platform_last_error:
+      'Fix the reported error and run diagnostics again.',
+    imConnectivityCheckSuggestion_feishu_group_requires_mention:
+      'Use @bot plus your message in group chats.',
+    imConnectivityCheckSuggestion_feishu_event_subscription_required:
+      'Enable im.message.receive_v1 and publish app version.',
+    imConnectivityCheckSuggestion_discord_group_requires_mention:
+      'Use @bot plus your message in channels.',
+    imConnectivityCheckSuggestion_telegram_privacy_mode_hint:
+      'Review Privacy Mode in @BotFather settings.',
+    imConnectivityCheckSuggestion_dingtalk_bot_membership_hint:
+      'Ensure the bot is in the target conversation with send/receive rights.',
+    imConnectivityCheckSuggestion_nim_p2p_only_hint:
+      'Send messages via direct chat to the bot account.',
     nimAccountPlaceholder: 'Bot account ID',
     nimAccountHint: 'IM account ID (accid) created in NetEase IM console account management',
     nimCredentialsGuide: 'How to obtain NetEase IM credentials:',
@@ -2223,7 +2332,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimAppKeyHint: 'Obtain from app information in NetEase IM console',
     nimTokenHint: 'Access credential generated for this account (long-term validity recommended)',
     nimAccountWhitelist: 'Account Whitelist',
-    nimAccountWhitelistHint: 'Enter NIM accounts allowed to chat with the bot, separated by commas. Leave empty to allow all accounts.',
+    nimAccountWhitelistHint:
+      'Enter NIM accounts allowed to chat with the bot, separated by commas. Leave empty to allow all accounts.',
     nimTeamPolicy: 'Team Message Policy',
     nimTeamPolicyDisabled: 'Disabled - Do not respond to team messages',
     nimTeamPolicyOpen: 'Open - Respond to @mentions in all teams',
@@ -2235,7 +2345,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     nimQChatEnabledHint: 'Subscribe to QChat messages, only responds to @mentions',
     nimQChatServerIds: 'QChat Server IDs',
     nimQChatServerIdsPlaceholder: 'Leave empty to auto-discover all joined servers',
-    nimQChatServerIdsHint: 'Specify server IDs to subscribe, separated by commas. Leave empty to auto-subscribe all joined servers.',
+    nimQChatServerIdsHint:
+      'Specify server IDs to subscribe, separated by commas. Leave empty to auto-subscribe all joined servers.',
     neteaseBeeChanClientIdPlaceholder: 'Netease Bee IM Client ID',
 
     // IM settings page - POPO config
@@ -2255,12 +2366,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imDebugMode: 'Debug Mode',
     imSessionTimeout: 'Session Timeout (min, deprecated)',
     imSeparateSessionByConversation: 'Separate Session by Conversation',
-    imSeparateSessionByConversationDesc: 'Maintain independent sessions for DMs, groups, and different groups',
+    imSeparateSessionByConversationDesc:
+      'Maintain independent sessions for DMs, groups, and different groups',
     imGroupSessionScope: 'Group Session Scope',
     imGroupSessionScopeGroup: 'Shared in group',
     imGroupSessionScopeGroupSender: 'Per user in group',
     imSharedMemoryAcrossConversations: 'Share Memory Across Conversations',
-    imSharedMemoryAcrossConversationsDesc: 'Share memory across different conversations (isolated by default)',
+    imSharedMemoryAcrossConversationsDesc:
+      'Share memory across different conversations (isolated by default)',
     imGatewayBaseUrl: 'Custom Gateway URL',
     imGatewayBaseUrlPlaceholder: 'e.g. https://proxy.example.com',
     imSendThinkingMessage: 'Send "thinking" message',
@@ -2279,7 +2392,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imReplyModeStatic: 'Static',
     imReplyModeStreaming: 'Streaming',
     imFeishuStreaming: 'Streaming Output',
-    imFeishuStreamingDesc: 'When enabled, auto mode uses streaming cards for DMs and static replies for groups',
+    imFeishuStreamingDesc:
+      'When enabled, auto mode uses streaming cards for DMs and static replies for groups',
     imFeishuBlockStreaming: 'Block Streaming',
     imFeishuBlockStreamingDesc: 'In static mode, flush text immediately during tool calls',
     imFeishuFooterStatus: 'Show Status Indicator',
@@ -2319,19 +2433,25 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imWecomQuickSetupSuccess: 'Bot created successfully, credentials auto-filled',
     imWecomQuickSetupError: 'Creation failed',
     imViewGuide: 'Setup Manual',
-    imDingtalkGuideStep1: 'Go to DingTalk Open Platform, create or pick an enterprise app under "App Development > Bot"',
-    imDingtalkGuideStep2: 'Copy the Client ID (AppKey) and Client Secret (AppSecret) from the credentials page',
-    imDingtalkGuideStep3: 'Turn on the "Bot" capability and enter Client ID and Client Secret below',
+    imDingtalkGuideStep1:
+      'Go to DingTalk Open Platform, create or pick an enterprise app under "App Development > Bot"',
+    imDingtalkGuideStep2:
+      'Copy the Client ID (AppKey) and Client Secret (AppSecret) from the credentials page',
+    imDingtalkGuideStep3:
+      'Turn on the "Bot" capability and enter Client ID and Client Secret below',
     imDingtalkGuideStep4: 'Once saved, the bot will auto-connect via Stream mode',
     imFeishuGuideStep1: 'Enter the Feishu bot App ID and App Secret below to complete setup',
-    imFeishuGuideStep2: 'App credentials are available on the Feishu Open Platform. See the setup manual for details.',
+    imFeishuGuideStep2:
+      'App credentials are available on the Feishu Open Platform. See the setup manual for details.',
     feishuBotCreateWizardTitle: 'Create Bot',
     feishuBotCreateWizardScanBtn: 'Scan QR Code to Create Bot',
-    feishuBotCreateWizardScanHint: 'Scan the QR code with your Feishu app to create and configure a bot in one step',
+    feishuBotCreateWizardScanHint:
+      'Scan the QR code with your Feishu app to create and configure a bot in one step',
     feishuBotCreateWizardOrManual: 'or manually enter / edit bot credentials',
     feishuBotCreateWizardOptionNew: 'Create a new bot',
     feishuBotCreateWizardOptionExisting: 'Use an existing bot',
-    feishuBotCreateWizardQrcodeDesc: 'Scan the QR code with your Feishu app and select "One-click create Feishu bot" to complete setup.',
+    feishuBotCreateWizardQrcodeDesc:
+      'Scan the QR code with your Feishu app and select "One-click create Feishu bot" to complete setup.',
     feishuBotCreateWizardQrcodeExpired: 'QR code expired, please refresh',
     feishuBotCreateWizardQrcodeRefresh: 'Refresh QR Code',
     feishuBotCreateWizardVerify: 'Verify',
@@ -2373,8 +2493,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imTelegramGuideStep4: 'Paste the token into the field below',
     imDiscordGuideStep1: 'Open Discord Developer Portal and create a new application',
     imDiscordGuideStep2: 'Under the Bot section, add a bot and copy its token',
-    imDiscordGuideStep3: 'Under Bot – Privileged Gateway Intents, enable Message Content and Server Members intents',
-    imDiscordGuideStep4: 'In the OAuth2 URL Generator, select "bot" and "applications.commands" with messaging permissions',
+    imDiscordGuideStep3:
+      'Under Bot – Privileged Gateway Intents, enable Message Content and Server Members intents',
+    imDiscordGuideStep4:
+      'In the OAuth2 URL Generator, select "bot" and "applications.commands" with messaging permissions',
     imDiscordGuideStep5: 'Invite the bot to your server using the generated URL',
     imDiscordGuideStep6: 'Paste the bot token into the field below',
 
@@ -2382,11 +2504,13 @@ const translations: Record<LanguageType, Record<string, string>> = {
     autoLaunch: 'Launch at Login',
     autoLaunchDescription: 'Automatically start the app when you log in',
     useSystemProxy: 'Use System Proxy',
-    useSystemProxyDescription: 'When enabled, network requests follow system proxy settings (applies after Save)',
+    useSystemProxyDescription:
+      'When enabled, network requests follow system proxy settings (applies after Save)',
     preventSleep: 'Prevent Sleep',
     preventSleepDescription: 'Prevent the system from sleeping while the app is running',
     skipMissedJobs: 'Skip Missed Scheduled Jobs',
-    skipMissedJobsDescription: 'Skip jobs that were missed while the app was offline (applies after Save)',
+    skipMissedJobsDescription:
+      'Skip jobs that were missed while the app was offline (applies after Save)',
 
     // Scheduled Tasks
     scheduledTasks: 'Scheduled Tasks',
@@ -2491,13 +2615,15 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormValidationDatetimeFuture: 'Execution time must be in the future',
     scheduledTasksFormValidationIntervalPositive: 'Interval must be greater than 0',
     scheduledTasksFormValidationCronRequired: 'Cron expression is required',
-    scheduledTasksFormValidationPayloadMismatch: 'Main sessions require system events, isolated sessions require agent turns',
+    scheduledTasksFormValidationPayloadMismatch:
+      'Main sessions require system events, isolated sessions require agent turns',
     scheduledTasksFormValidationWebhookRequired: 'Webhook URL is required',
     scheduledTasksFormValidationTimeout: 'Timeout must be an integer greater than or equal to 0',
     scheduledTasksFormSubmitError: 'Save failed: ',
     scheduledTasksEdit: 'Edit',
     scheduledTasksDelete: 'Delete',
-    scheduledTasksDeleteConfirm: 'Are you sure you want to delete task "{name}"? This cannot be undone.',
+    scheduledTasksDeleteConfirm:
+      'Are you sure you want to delete task "{name}"? This cannot be undone.',
     scheduledTasksRun: 'Run Now',
     scheduledTasksStop: 'Stop',
     scheduledTasksEnabled: 'Enabled',
@@ -2594,13 +2720,16 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksFormNotifyConversationPlaceholder: 'Select target conversation',
     scheduledTasksFormNotifyConversationLoading: 'Loading conversations...',
     scheduledTasksFormNotifyConversationNone: 'No conversations available',
-    scheduledTasksToggleWarningAtPast: 'The execution time of this task has passed. It will not run after enabling',
+    scheduledTasksToggleWarningAtPast:
+      'The execution time of this task has passed. It will not run after enabling',
     scheduledTasksToggleWarningExpired: 'This task has expired. It will not run after enabling',
-    scheduledTasksDataAnomalyWarning: 'Scheduled task "{name}" has abnormal data. Display has been auto-corrected. Consider re-editing this task',
+    scheduledTasksDataAnomalyWarning:
+      'Scheduled task "{name}" has abnormal data. Display has been auto-corrected. Consider re-editing this task',
 
     // Privacy dialog
     privacyDialogTitle: 'NetEase Youdao LobsterAI Terms of Service',
-    privacyDialogDesc: 'Before using NetEase Youdao LobsterAI, please carefully read the {link} and confirm.',
+    privacyDialogDesc:
+      'Before using NetEase Youdao LobsterAI, please carefully read the {link} and confirm.',
     privacyDialogLinkText: 'NetEase Youdao LobsterAI Terms of Service',
     privacyDialogAccept: 'I have read and agree',
     privacyDialogReject: 'Decline',
@@ -2608,7 +2737,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     githubCopilotSignIn: 'Sign in with GitHub',
     githubCopilotSignOut: 'Sign Out',
     githubCopilotRequesting: 'Requesting device code...',
-    githubCopilotEnterCode: 'Open the link below in your browser and enter the device code to authorize:',
+    githubCopilotEnterCode:
+      'Open the link below in your browser and enter the device code to authorize:',
     githubCopilotWaiting: 'Waiting for authorization...',
     githubCopilotConnected: 'Connected',
     githubCopilotNoSubscription: 'You do not have an active GitHub Copilot subscription',
@@ -2621,18 +2751,18 @@ const translations: Record<LanguageType, Record<string, string>> = {
     taskFormLeaveConfirm: 'Your changes will be lost if you leave. Are you sure you want to leave?',
     taskFormLeave: 'Leave',
     taskFormStay: 'Keep Editing',
-  }
+  },
 };
 
 class I18nService {
   private currentLanguage: LanguageType = 'zh';
   private listeners = new Set<() => void>();
-  
+
   constructor() {
     // 默认使用中文
     this.currentLanguage = 'zh';
   }
-  
+
   // 初始化语言设置
   async initialize(): Promise<void> {
     try {
@@ -2652,7 +2782,7 @@ class I18nService {
           this.currentLanguage = config.language;
           configService.updateConfig({
             ...config,
-            language_initialized: true
+            language_initialized: true,
           });
         } else {
           // 新用户或使用默认中文的旧用户:检测系统语言
@@ -2660,7 +2790,9 @@ class I18nService {
             const systemLocale = await window.electron.appInfo.getSystemLocale();
             const defaultLanguage = this.inferLanguageFromLocale(systemLocale);
 
-            console.log(`[i18n] First run detected. System locale: ${systemLocale}, default language: ${defaultLanguage}`);
+            console.log(
+              `[i18n] First run detected. System locale: ${systemLocale}, default language: ${defaultLanguage}`,
+            );
 
             this.currentLanguage = defaultLanguage;
 
@@ -2668,7 +2800,7 @@ class I18nService {
             configService.updateConfig({
               ...config,
               language: defaultLanguage,
-              language_initialized: true
+              language_initialized: true,
             });
           } catch (error) {
             console.error('Failed to get system locale:', error);
@@ -2677,7 +2809,7 @@ class I18nService {
             configService.updateConfig({
               ...config,
               language: 'en',
-              language_initialized: true
+              language_initialized: true,
             });
           }
         }
@@ -2690,7 +2822,7 @@ class I18nService {
           this.currentLanguage = 'en';
           configService.updateConfig({
             ...config,
-            language: 'en'
+            language: 'en',
           });
         }
       }
@@ -2709,7 +2841,7 @@ class I18nService {
     }
     return 'en'; // 默认英文 (包括 zh-TW, zh-HK, en-*, 以及其他所有语言)
   }
-  
+
   // 设置语言
   setLanguage(language: LanguageType, options: { persist?: boolean } = {}): void {
     const { persist = true } = options;
@@ -2717,7 +2849,7 @@ class I18nService {
     this.currentLanguage = language;
 
     if (hasChanged) {
-      this.listeners.forEach((listener) => listener());
+      this.listeners.forEach(listener => listener());
     }
 
     if (!persist) {
@@ -2729,18 +2861,18 @@ class I18nService {
       const config = configService.getConfig();
       configService.updateConfig({
         ...config,
-        language
+        language,
       });
     } catch (error) {
       console.error('Failed to save language setting:', error);
     }
   }
-  
+
   // 获取当前语言
   getLanguage(): LanguageType {
     return this.currentLanguage;
   }
-  
+
   // 获取翻译文本
   t(key: string): string {
     const translation = translations[this.currentLanguage][key];
@@ -2761,4 +2893,4 @@ class I18nService {
   }
 }
 
-export const i18nService = new I18nService(); 
+export const i18nService = new I18nService();


### PR DESCRIPTION
## 概述

在 AI 回复期间允许用户继续发送后续消息。消息在客户端本地排队，每个 turn 完成后自动串行消费。排队中的消息支持编辑和删除。

## 改动内容

- **CoworkPromptInput**: 移除 streaming 时的提交拦截；streaming 期间同时显示停止按钮（红色）和发送按钮（琥珀色），发送按钮 tooltip 提示"消息将在当前回复完成后发送"
- **CoworkView**: 新增 `QueuedMessage` 类型和 `messageQueue` 状态；`handleContinueSession` 在 streaming 时将消息入队而非直接发送；监听 `isStreaming` 变为 false 时自动消费队列头部消息；切换 session 时清空队列
- **CoworkSessionDetail**: 新增 `QueuedMessageBubble` 组件（琥珀色虚线边框气泡），显示排队序号，支持行内编辑和删除；在 streaming 活动条和输入框之间渲染排队消息列表
- **i18n**: 新增 4 个双语 key（`coworkQueued`、`coworkQueueEdit`、`coworkQueueRemove`、`coworkQueueSendHint`）

## 消费机制

```
用户发送 → isStreaming?
  ├─ false → 正常走 continueSession（行为不变）
  └─ true  → 入队 messageQueue
              → streaming 活动条下方显示排队气泡
              → 用户可以继续输入更多消息、编辑或删除排队消息
              → AI 回复完成 → isStreaming 变 false
              → useEffect 自动取出队列头 → continueSession
              → 循环直到队列为空
```

## 设计决策

- **纯客户端方案**：队列仅在 renderer 层管理，不改动引擎层的 `activeTurns` 互斥逻辑
- **串行消费**：严格一次一个 turn，复用现有 `continueSession` 流程
- **与 #1089 的关系**：本 PR 从 UI 层面规避了并发 `continueSession` 调用的风险，是 #1089 在客户端侧的互补方案

## 效果截图
<img width="1396" height="1520" alt="image" src="https://github.com/user-attachments/assets/f39612d8-c398-4e00-accf-9440e9e665d7" />
<img width="1390" height="1000" alt="image" src="https://github.com/user-attachments/assets/3d1d6f09-181a-4c99-815b-3e611cc3b4aa" />
<img width="1380" height="1408" alt="image" src="https://github.com/user-attachments/assets/0246150c-c9d5-458c-a791-233c13f5af99" />


## 测试

- 发送消息后在 AI 回复期间继续发送多条消息 → 排队气泡正确显示
- 编辑排队消息 → 内容更新
- 删除排队消息 → 从队列移除
- AI 回复完成后 → 自动发送队列中下一条
- 停止当前 turn → 队列保留，用户可手动管理
- 切换/离开 session → 队列清空