### PR TITLE
fix(sqlite): 仅在迁移成功时标记 legacy memory 迁移完成

### DIFF
--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -428,11 +428,10 @@ export class SqliteStore {
 
     try {
       migrate();
+      this.set(USER_MEMORIES_MIGRATION_KEY, '1');
     } catch (error) {
-      console.warn('Failed to migrate legacy MEMORY.md entries:', error);
+      console.warn('[SqliteStore] legacy MEMORY.md migration failed, will retry on next launch:', error);
     }
-
-    this.set(USER_MEMORIES_MIGRATION_KEY, '1');
   }
 
   private migrateFromElectronStore(userDataPath: string) {


### PR DESCRIPTION
## 概要

- 修复 `migrateLegacyMemoryFileToUserMemories` 中的缺陷：迁移事务失败后仍无条件标记迁移已完成，导致失败的迁移无法在下次启动时重试。
- 将 `USER_MEMORIES_MIGRATION_KEY` 标记写入移到 `try` 块内部，仅在事务成功时才持久化完成标记。
- 改进警告日志，添加 `[SqliteStore]` 模块标签并说明将在下次启动时重试。

## 测试计划

- [x] 验证正常的 legacy memory 迁移成功后仍会设置完成标记（迁移仅执行一次）
- [x] 模拟迁移失败（如数据损坏），确认完成标记未被设置，下次启动时可以重试
- [x] 确认不存在 legacy memory 文件时的正常启动流程无回归