### PR TITLE
fix(sqlite): 启用外键约束，修复级联删除失效问题

### DIFF
--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -36,6 +36,7 @@ export class SqliteStore {
     db.pragma('synchronous = NORMAL');
     db.pragma('cache_size = -8000'); // 8 MB; negative value = kibibytes
     db.pragma('wal_autocheckpoint = 1000'); // checkpoint every ~4 MB of WAL writes
+    db.pragma('foreign_keys = ON');
 
     const store = new SqliteStore(db, dbPath);
     store.initializeTables(basePath);


### PR DESCRIPTION
## 问题

SQLite 默认关闭外键约束（`PRAGMA foreign_keys` 默认为 `OFF`）。当前代码中 `cowork_messages` 和 `user_memory_sources` 两张表虽然声明了 `FOREIGN KEY ... ON DELETE CASCADE`，但由于未启用该 pragma，实际效果为：

- 删除 `cowork_sessions` 记录时，关联的 `cowork_messages` **不会**被级联删除，产生孤儿数据
- 删除 `user_memories` 记录时，关联的 `user_memory_sources` 同样残留
- 插入引用不存在父记录的子记录时不会报错，破坏数据完整性

## 修复

在 `SqliteStore.create()` 中，紧随其他 pragma 语句之后添加：

```typescript
db.pragma('foreign_keys = ON');
```

与 `journal_mode = WAL` 不同，`foreign_keys` 是**按连接**生效的设置，不会持久化到数据库文件，因此必须在每次打开连接时设置。放在 `create()` 方法中可确保应用启动时立即生效。

## 影响范围

- `cowork_messages.session_id` → `cowork_sessions.id`（ON DELETE CASCADE）
- `user_memory_sources.memory_id` → `user_memories.id`（ON DELETE CASCADE）

## 测试计划

- [x] 启动应用，确认数据库正常初始化无报错
- [x] 创建 cowork session 并发送消息，删除该 session 后确认 messages 被级联删除
- [x] 确认现有数据读取、写入流程无异常

Made with [Cursor](https://cursor.com)