### PR TITLE
fix(cowork): 修复 getConfig() 中 executionMode 硬编码为 'local' 的问题

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -344,6 +344,13 @@ export interface UpdateAgentRequest {
 
 const COWORK_AGENT_ENGINE = 'openclaw';
 
+function normalizeCoworkExecutionModeValue(value?: string | null): CoworkExecutionMode {
+  if (value === 'auto' || value === 'local' || value === 'sandbox') {
+    return value;
+  }
+  return 'local';
+}
+
 function normalizeCoworkAgentEngineValue(value?: string | null): CoworkAgentEngine {
   if (value === COWORK_AGENT_ENGINE || value === 'openclaw') {
     return value;
@@ -1057,7 +1064,7 @@ export class CoworkStore {
     return {
       workingDirectory: cfg.get('workingDirectory') || getDefaultWorkingDirectory(),
       systemPrompt: getDefaultSystemPrompt(),
-      executionMode: 'local' as CoworkExecutionMode,
+      executionMode: normalizeCoworkExecutionModeValue(cfg.get('executionMode')),
       agentEngine: normalizeCoworkAgentEngineValue(cfg.get('agentEngine')),
       memoryEnabled: parseBooleanConfig(cfg.get('memoryEnabled'), DEFAULT_MEMORY_ENABLED),
       memoryImplicitUpdateEnabled: parseBooleanConfig(


### PR DESCRIPTION
## 概述

- `coworkStore.getConfig()` 始终返回 `executionMode: 'local'`，忽略了数据库 `cowork_config` 表中存储的实际值
- 虽然 `setConfig()` 能正确持久化用户对 `executionMode` 的修改，但 `getConfig()` 读取时直接使用硬编码值，导致 UI 显示与运行时行为不一致
- 新增 `normalizeCoworkExecutionModeValue()` 校验函数，接受合法值（`auto`/`local`/`sandbox`），非法值安全回退为 `'local'`，与现有 `normalizeCoworkAgentEngineValue()` 保持一致的模式

## 改动内容

**文件：** `src/main/coworkStore.ts`

1. 新增 `normalizeCoworkExecutionModeValue()` 函数用于校验和规范化 `executionMode` 值
2. 将 `getConfig()` 中的 `executionMode: 'local' as CoworkExecutionMode` 替换为 `normalizeCoworkExecutionModeValue(cfg.get('executionMode'))`

## 测试计划

- [x] 启动应用，在设置中修改 `executionMode`，重启后确认设置被正确保留
- [x] 确认未配置过 `executionMode` 时默认回退为 `'local'`
- [x] 确认数据库中存在非法值时能安全回退为 `'local'`