### PR TITLE
fix(cowork): 修复权限响应被广播到两个引擎的问题

### DIFF
--- a/src/main/libs/agentEngine/coworkEngineRouter.ts
+++ b/src/main/libs/agentEngine/coworkEngineRouter.ts
@@ -96,17 +96,16 @@ export class CoworkEngineRouter extends EventEmitter implements CoworkRuntime {
 
   respondToPermission(requestId: string, result: PermissionResult): void {
     const engine = this.requestEngine.get(requestId);
-    if (engine) {
-      this.runtimeByEngine[engine].respondToPermission(requestId, result);
-      if (result.behavior === 'allow' || result.behavior === 'deny') {
-        this.requestEngine.delete(requestId);
-        this.requestSession.delete(requestId);
-      }
+    if (!engine) {
+      console.warn('[CoworkEngineRouter] permission response for unknown requestId, ignoring:', requestId);
       return;
     }
 
-    this.runtimeByEngine.openclaw.respondToPermission(requestId, result);
-    this.runtimeByEngine.yd_cowork.respondToPermission(requestId, result);
+    this.runtimeByEngine[engine].respondToPermission(requestId, result);
+    if (result.behavior === 'allow' || result.behavior === 'deny') {
+      this.requestEngine.delete(requestId);
+      this.requestSession.delete(requestId);
+    }
   }
 
   isSessionActive(sessionId: string): boolean {


### PR DESCRIPTION
## 问题描述

`CoworkEngineRouter.respondToPermission()` 在 `requestEngine` 中找不到 `requestId` 时，会将权限响应**同时转发给 openclaw 和 yd_cowork 两个引擎**，而非仅发送给发起该请求的引擎。

这可能导致：
- 非预期的引擎收到不属于自己的权限响应，产生混乱行为
- 与 `ensureActiveTurn` 配合时，已停止的 session 可能被 IM 消息意外复活

## 修复方案

将 fallback 逻辑改为：当 `requestId` 未被追踪时，记录一条 `console.warn` 并直接返回，不再盲目广播。权限响应只会发送给最初发出 `permissionRequest` 事件的引擎。

## 变更内容

- `src/main/libs/agentEngine/coworkEngineRouter.ts`：重构 `respondToPermission` 方法，用 early return 替代双引擎广播

## 测试方案

- [ ] 启动 cowork session，触发需要权限确认的工具调用，验证审批/拒绝正常工作
- [ ] 检查日志中不出现 "unknown requestId" 的警告（正常流程下 requestId 应始终被追踪）
- [ ] 切换引擎配置后重复测试，确认权限响应不会发送到错误的引擎


Made with [Cursor](https://cursor.com)