### PR TITLE
fix(scheduled-task): skip dirty check when navigating after successful save

### DIFF
--- a/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
@@ -139,7 +139,7 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
           )}
           {viewMode !== 'list' && (
             <button
-              onClick={handleBackToList}
+              onClick={() => handleBackToList()}
               className="non-draggable p-2 rounded-lg hover:bg-surface-raised text-secondary transition-colors"
               aria-label={i18nService.t('back')}
             >

--- a/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
@@ -1,18 +1,19 @@
-import React, { useCallback, useEffect, useState, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import { RootState } from '../../store';
-import { setViewMode, selectTask } from '../../store/slices/scheduledTaskSlice';
-import { scheduledTaskService } from '../../services/scheduledTask';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import React, { useCallback, useEffect, useRef,useState } from 'react';
+import { useDispatch,useSelector } from 'react-redux';
+
 import { i18nService } from '../../services/i18n';
-import TaskList from './TaskList';
-import TaskForm from './TaskForm';
-import TaskDetail from './TaskDetail';
+import { scheduledTaskService } from '../../services/scheduledTask';
+import { RootState } from '../../store';
+import { selectTask,setViewMode } from '../../store/slices/scheduledTaskSlice';
+import ComposeIcon from '../icons/ComposeIcon';
+import SidebarToggleIcon from '../icons/SidebarToggleIcon';
+import WindowTitleBar from '../window/WindowTitleBar';
 import AllRunsHistory from './AllRunsHistory';
 import DeleteConfirmModal from './DeleteConfirmModal';
-import { ArrowLeftIcon } from '@heroicons/react/24/outline';
-import SidebarToggleIcon from '../icons/SidebarToggleIcon';
-import ComposeIcon from '../icons/ComposeIcon';
-import WindowTitleBar from '../window/WindowTitleBar';
+import TaskDetail from './TaskDetail';
+import TaskForm from './TaskForm';
+import TaskList from './TaskList';
 
 interface ScheduledTasksViewProps {
   isSidebarCollapsed?: boolean;
@@ -81,17 +82,21 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
     }
   }, []);
 
-  const handleBackToList = () => {
+  const handleBackToList = useCallback((skipDirtyCheck = false) => {
     const action = () => {
       dispatch(selectTask(null));
       dispatch(setViewMode('list'));
     };
-    if (viewMode === 'create' || viewMode === 'edit') {
+    if (!skipDirtyCheck && (viewMode === 'create' || viewMode === 'edit')) {
       requestLeave(action);
     } else {
       action();
     }
-  };
+  }, [viewMode, requestLeave, dispatch]);
+
+  const handleSaved = useCallback(() => {
+    handleBackToList(true);
+  }, [handleBackToList]);
 
   const handleEditCancel = useCallback(() => {
     requestLeave(() => dispatch(setViewMode('detail')));
@@ -204,7 +209,7 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
               <TaskForm
                 mode="create"
                 onCancel={handleBackToList}
-                onSaved={handleBackToList}
+                onSaved={handleSaved}
                 onDirtyChange={handleFormDirtyChange}
               />
             )}

--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -152,7 +152,9 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved, onDi
   const showConversationSelector = isIMChannel(form.notifyChannel);
 
   useEffect(() => {
-    setForm(createFormState(task));
+    const next = createFormState(task);
+    setForm(next);
+    initialFormRef.current = JSON.stringify(next);
   }, [task]);
 
   useEffect(() => {
@@ -270,6 +272,10 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved, onDi
       } else if (task) {
         await scheduledTaskService.updateTaskById(task.id, input);
       }
+      // Reset dirty-state baseline so the navigation guard does not
+      // show an "unsaved changes" dialog after a successful save.
+      initialFormRef.current = JSON.stringify(form);
+
       onSaved();
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## 问题描述
在定时任务页面，创建或编辑任务成功后点击保存，会错误地弹出"有未保存的修改，离开后修改将丢失，确认离开吗？"的确认对话框。实际上任务已经保存成功，不应该出现此提示。

## 根因分析
存在两个导致表单脏状态误判的问题：
onSaved 回调未绕过脏检查：保存成功后调用的 onSaved 绑定的是 handleBackToList，该函数会检查表单脏状态。由于 React 状态更新是异步的，isFormDirtyRef 在导航时仍为 true。
异步 Effect 导致假脏状态：表单初始化后，异步加载通知通道列表和自动选择联系人会修改 form 状态，但 initialFormRef 未同步更新，导致即使用户没有编辑任何内容，isDirty 也为 true。

## 修复方案
ScheduledTasksView.tsx：新增 handleSaved 回调，保存成功后直接绕过脏检查导航回列表页
TaskForm.tsx：当 task prop 变化触发表单重新初始化时，同步更新 initialFormRef 基准值

##  问题截图
<img width="880" height="663" alt="image" src="https://github.com/user-attachments/assets/df8f398c-5e09-4a24-b978-0fcbf0963efc" />
