### PR TITLE
fix(cowork): 修复网关重连后 session 停止冷却丢失的问题

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1548,7 +1548,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     this.channelSessionSync?.clearCache();
     this.knownChannelSessionIds.clear();
     this.heartbeatSessionKeys.clear();
-    this.stoppedSessions.clear();
     this.browserPrewarmAttempted = false;
     this.lastTickTimestamp = 0;
     // Clear messageUpdate throttle state


### PR DESCRIPTION
## 问题

`stopGatewayClient()` 在清理网关状态时会调用 `this.stoppedSessions.clear()`，将所有 session 的停止冷却记录一并清除。

当网关 WebSocket 意外断开并自动重连后，`ensureActiveTurn` 无法判断哪些 session 处于停止冷却期，来自 IM 通道（POPO/Telegram 等）的迟到事件可以为已停止的 session 重新创建 `ActiveTurn`，导致用户明确停止的 session 被意外复活。

## 修复

从 `stopGatewayClient()` 中移除 `this.stoppedSessions.clear()`。这样做是安全的，因为：

- 条目通过 `isSessionInStopCooldown()` 中的 10 秒 TTL 自动过期
- `continueSession()` 和 `deleteSession()` 已显式清理对应条目
- 在重连过程中保留冷却状态正是期望行为

## 变更文件

- `src/main/libs/agentEngine/openclawRuntimeAdapter.ts`：移除 `stopGatewayClient` 中的 `stoppedSessions.clear()` 调用

## 测试计划

- [ ] 启动 Cowork session 后手动停止，确认 session 进入 idle 状态
- [ ] 模拟网关断开重连（可断开网络后恢复），确认已停止的 session 不会被 IM 消息复活
- [ ] 正常使用 `continueSession` 继续已停止的 session，确认功能不受影响

Made with [Cursor](https://cursor.com)