### PR TITLE
fix(cowork): 修复 addMessage 序列号并发竞争

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -845,31 +845,33 @@ export class CoworkStore {
     const id = uuidv4();
     const now = Date.now();
 
-    const seqRow = this.db
-      .prepare(
-        'SELECT COALESCE(MAX(sequence), 0) + 1 as next_seq FROM cowork_messages WHERE session_id = ?',
-      )
-      .get(sessionId) as { next_seq: number } | undefined;
-    const sequence = seqRow?.next_seq ?? 1;
+    this.db.transaction(() => {
+      const seqRow = this.db
+        .prepare(
+          'SELECT COALESCE(MAX(sequence), 0) + 1 as next_seq FROM cowork_messages WHERE session_id = ?',
+        )
+        .get(sessionId) as { next_seq: number } | undefined;
+      const sequence = seqRow?.next_seq ?? 1;
 
-    this.db
-      .prepare(
-        `
-      INSERT INTO cowork_messages (id, session_id, type, content, metadata, created_at, sequence)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
-    `,
-      )
-      .run(
-        id,
-        sessionId,
-        message.type,
-        message.content,
-        message.metadata ? JSON.stringify(message.metadata) : null,
-        now,
-        sequence,
-      );
+      this.db
+        .prepare(
+          `
+        INSERT INTO cowork_messages (id, session_id, type, content, metadata, created_at, sequence)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `,
+        )
+        .run(
+          id,
+          sessionId,
+          message.type,
+          message.content,
+          message.metadata ? JSON.stringify(message.metadata) : null,
+          now,
+          sequence,
+        );
 
-    this.db.prepare('UPDATE cowork_sessions SET updated_at = ? WHERE id = ?').run(now, sessionId);
+      this.db.prepare('UPDATE cowork_sessions SET updated_at = ? WHERE id = ?').run(now, sessionId);
+    })();
 
     return {
       id,


### PR DESCRIPTION
## 概述

- `addMessage` 中 `SELECT MAX(sequence)` 和 `INSERT` 是两条独立语句，并发调用可能读到相同的 `next_seq`，导致消息序列号重复
- 将序列号读取、消息插入、session 时间戳更新三个操作包裹在 `db.transaction()` 中，确保原子执行
- 与 `insertMessageBeforeId` 已有的事务处理模式保持一致

## 测试计划

- [x] 启动应用，发起 cowork 会话，验证消息顺序正常
- [x] 快速连续发送多条消息，确认 sequence 无重复
- [x] IM 通道场景下并发写入消息，验证顺序正确


Made with [Cursor](https://cursor.com)