### PR TITLE
fix(cowork): 修复 continueSession 重复错误消息与 start/continueSession 异常吞没问题

### DIFF
--- a/src/main/libs/coworkRunner.ts
+++ b/src/main/libs/coworkRunner.ts
@@ -1521,7 +1521,13 @@ export class CoworkRunner extends EventEmitter {
       setCoworkProxySessionId(sessionId);
       await this.runClaudeCode(activeSession, effectivePrompt, sessionCwd, effectiveSystemPrompt, options.imageAttachments);
     } catch (error) {
-      console.error('Cowork session error:', error);
+      console.error('[CoworkRunner] session start failed:', error);
+      if (this.activeSessions.has(sessionId)) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        this.handleError(sessionId, errorMessage);
+        this.clearPendingPermissions(sessionId);
+        this.activeSessions.delete(sessionId);
+      }
     }
   }
 
@@ -1607,7 +1613,13 @@ export class CoworkRunner extends EventEmitter {
       setCoworkProxySessionId(sessionId);
       await this.runClaudeCode(activeSession, effectivePrompt, sessionCwd, effectiveSystemPrompt, options.imageAttachments);
     } catch (error) {
-      console.error('Cowork continue error:', error);
+      console.error('[CoworkRunner] session continue failed:', error);
+      if (this.activeSessions.has(sessionId)) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        this.handleError(sessionId, errorMessage);
+        this.clearPendingPermissions(sessionId);
+        this.activeSessions.delete(sessionId);
+      }
     }
   }
 

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -292,19 +292,7 @@ class CoworkService {
       }
       if (result.code !== 'ENGINE_NOT_READY') {
         store.dispatch(updateSessionStatus({ sessionId: options.sessionId, status: 'error' }));
-        if (result.error) {
-          store.dispatch(addMessage({
-            sessionId: options.sessionId,
-            message: {
-              id: `error-${Date.now()}`,
-              type: 'system',
-              content: i18nService.t('coworkErrorSessionContinueFailed').replace('{error}', result.error),
-              timestamp: Date.now(),
-            },
-          }));
-        }
       }
-      // Show a user-visible error message in the session
       if (result.error) {
         const errorContent = result.code === 'ENGINE_NOT_READY'
           ? i18nService.t('coworkErrorEngineNotReady')


### PR DESCRIPTION
## 概述

- **修复 `continueSession` 失败时重复显示错误消息**：renderer 层 `cowork.ts` 中，`continueSession` 失败时先 dispatch 了一条错误消息，后面又 dispatch 了第二条，导致用户看到重复的错误提示。移除了第一次冗余的 dispatch。
- **修复 `coworkRunner` 中 `startSession`/`continueSession` 异常被静默吞掉**：两个方法的 catch 块仅 `console.error` 打印日志，未调用 `handleError` 发射 error 事件、未更新 session 状态、未清理 `activeSessions`。当异常发生在 `runClaudeCode` 调用之前（如 `buildPromptPrefix()`、`injectLocalHistoryPrompt()` 抛出）时，UI 会永远卡在 "running" 状态。现在 catch 块会检查 session 是否仍在 `activeSessions` 中（排除已由 `runClaudeCodeLocal` 处理的情况），若仍存在则正确执行错误处理和资源清理。

## 测试计划

- [ ] 启动 cowork 会话，正常交互无回归
- [ ] 模拟 `buildPromptPrefix()` 抛出异常，确认 UI 显示错误消息且 session 状态回到 idle/error
- [ ] `continueSession` 失败时确认只显示一条错误消息，不再重复