### PR TITLE
fix(im): NetEase Bee 密钥使用环境变量占位符替代明文写入

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -1324,7 +1324,7 @@ export class OpenClawConfigSync {
       managedConfig.channels = { ...(managedConfig.channels as Record<string, unknown> || {}), 'netease-bee': {
         enabled: true,
         clientId: neteaseBeeChanConfig.clientId,
-        secret: neteaseBeeChanConfig.secret,
+        secret: '${LOBSTER_NETEASE_BEE_SECRET}',
       }};
     }
 
@@ -1530,6 +1530,12 @@ export class OpenClawConfigSync {
     const nimConfig = this.getNimConfig();
     if (nimConfig?.enabled && nimConfig.token) {
       env.LOBSTER_NIM_TOKEN = nimConfig.token;
+    }
+
+    // NetEase Bee
+    const neteaseBeeChanConfig = this.getNeteaseBeeChanConfig();
+    if (neteaseBeeChanConfig?.enabled && neteaseBeeChanConfig.secret) {
+      env.LOBSTER_NETEASE_BEE_SECRET = neteaseBeeChanConfig.secret;
     }
 
     return env;


### PR DESCRIPTION
## 概要

- 将 NetEase Bee 在 openclaw.json 中的 `secret` 明文值替换为 `${LOBSTER_NETEASE_BEE_SECRET}` 占位符
- 在网关启动时通过 `collectSecretEnvVars()` 注入真实密钥，与其他所有 IM 频道（Telegram、Discord、飞书、钉钉、QQ、企业微信、POPO、NIM）保持一致
- 防止凭据以明文形式暴露在磁盘配置文件中

## 测试计划

- [x] 配置 NetEase Bee 频道，验证网关能正常启动
- [x] 检查生成的 `openclaw.json`，确认 `secret` 字段包含 `${LOBSTER_NETEASE_BEE_SECRET}` 而非真实值
- [x] 验证 NetEase Bee 消息收发端到端正常工作