### PR TITLE
fix(api): 为 Anthropic 和 Gemini 流式请求添加 SSE 行缓冲

### DIFF
--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -454,12 +454,15 @@ class ApiService {
 
       return new Promise((resolve, reject) => {
         let aborted = false;
+        let sseBuffer = '';
 
-        // 设置流式监听器
         const removeDataListener = window.electron.api.onStreamData(requestId, (chunk) => {
-          const lines = chunk.split('\n');
+          sseBuffer += chunk;
+          const lines = sseBuffer.split('\n');
+          sseBuffer = lines.pop() ?? '';
 
-          for (const line of lines) {
+          for (const rawLine of lines) {
+            const line = rawLine.replace(/\r$/, '');
             if (line.startsWith('data: ')) {
               const data = line.slice(6);
               if (data === '[DONE]') continue;
@@ -467,7 +470,6 @@ class ApiService {
               try {
                 const parsed = JSON.parse(data);
 
-                // Anthropic SSE 事件处理
                 if (parsed.type === 'content_block_delta') {
                   const delta = parsed.delta;
                   if (delta.type === 'text_delta') {
@@ -622,11 +624,15 @@ class ApiService {
 
       return new Promise((resolve, reject) => {
         let aborted = false;
+        let sseBuffer = '';
 
         const removeDataListener = window.electron.api.onStreamData(requestId, (chunk) => {
-          const lines = chunk.split('\n');
+          sseBuffer += chunk;
+          const lines = sseBuffer.split('\n');
+          sseBuffer = lines.pop() ?? '';
 
-          for (const line of lines) {
+          for (const rawLine of lines) {
+            const line = rawLine.replace(/\r$/, '');
             if (line.startsWith('data: ')) {
               const data = line.slice(6);
               if (data === '[DONE]') continue;


### PR DESCRIPTION
## 概要

- 为 `chatWithAnthropic` 和 `chatWithGemini` 的 SSE 处理添加滚动 `sseBuffer`，与 `chatWithOpenAICompatible` 中已有的模式保持一致
- 如果不做缓冲，当 `data: {...}` JSON 行被拆分到两个网络分块中时，`JSON.parse` 会失败，导致事件被静默丢弃，造成内容缺失或流式中断
- 同时去除行尾的 `\r`，与 OpenAI 路径保持一致

## 测试计划

- [x] 测试 Anthropic 长响应流式输出 — 确认无内容丢失
- [x] 测试 Gemini 长响应流式输出 — 确认无内容丢失
- [x] 验证 OpenAI 流式输出仍正常工作（未修改）