### PR TITLE
fix(cowork): read persisted executionMode from database in getConfig

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -351,6 +351,15 @@ function normalizeCoworkAgentEngineValue(value?: string | null): CoworkAgentEngi
   return COWORK_AGENT_ENGINE;
 }
 
+const VALID_EXECUTION_MODES: readonly CoworkExecutionMode[] = ['auto', 'local', 'sandbox'];
+
+function normalizeExecutionMode(value?: string | null): CoworkExecutionMode {
+  if (value && (VALID_EXECUTION_MODES as readonly string[]).includes(value)) {
+    return value as CoworkExecutionMode;
+  }
+  return 'local';
+}
+
 export interface CoworkMessageMetadata {
   toolName?: string;
   toolInput?: Record<string, unknown>;
@@ -1057,7 +1066,7 @@ export class CoworkStore {
     return {
       workingDirectory: cfg.get('workingDirectory') || getDefaultWorkingDirectory(),
       systemPrompt: getDefaultSystemPrompt(),
-      executionMode: 'local' as CoworkExecutionMode,
+      executionMode: normalizeExecutionMode(cfg.get('executionMode')),
       agentEngine: normalizeCoworkAgentEngineValue(cfg.get('agentEngine')),
       memoryEnabled: parseBooleanConfig(cfg.get('memoryEnabled'), DEFAULT_MEMORY_ENABLED),
       memoryImplicitUpdateEnabled: parseBooleanConfig(


### PR DESCRIPTION
## Summary

- Fix `getConfig()` to read the persisted `executionMode` value from `cowork_config` table instead of hardcoding `'local'`
- Add `normalizeExecutionMode()` validator that accepts `'auto' | 'local' | 'sandbox'` and falls back to `'local'` for invalid/missing values
- Previously, `setConfig()` correctly saved the user's choice but `getConfig()` always returned `'local'`, causing UI/runtime mismatch

## Test plan

- [ ] Change executionMode in settings, restart app, verify it persists correctly
- [ ] Verify default is still `'local'` for fresh installs
- [ ] Verify invalid values in DB gracefully fall back to `'local'`


Made with [Cursor](https://cursor.com)