### PR TITLE
fix(sqlite): only mark memory migration complete on success

### DIFF
--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -428,11 +428,10 @@ export class SqliteStore {
 
     try {
       migrate();
+      this.set(USER_MEMORIES_MIGRATION_KEY, '1');
     } catch (error) {
-      console.warn('Failed to migrate legacy MEMORY.md entries:', error);
+      console.error('[SqliteStore] legacy MEMORY.md migration failed, will retry on next launch:', error);
     }
-
-    this.set(USER_MEMORIES_MIGRATION_KEY, '1');
   }
 
   private migrateFromElectronStore(userDataPath: string) {


### PR DESCRIPTION
## Summary

- Move `USER_MEMORIES_MIGRATION_KEY` write inside the try block so it only executes after a successful transaction
- Previously, a failed `migrate()` would still mark the migration as complete, preventing retries on subsequent launches and potentially losing data
- Upgrade log level from `warn` to `error` for better visibility of migration failures

## Test plan

- [ ] Verify normal migration completes and sets the flag
- [ ] Simulate a migration failure (e.g. corrupt DB) and confirm the flag is not set, allowing retry on next launch