### PR TITLE
fix(scheduled-tasks): reset dirty state after saving task

### DIFF
--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -152,7 +152,9 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved, onDi
   const showConversationSelector = isIMChannel(form.notifyChannel);
 
   useEffect(() => {
-    setForm(createFormState(task));
+    const nextForm = createFormState(task);
+    initialFormRef.current = JSON.stringify(nextForm);
+    setForm(nextForm);
   }, [task]);
 
   useEffect(() => {
@@ -270,6 +272,8 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, task, onCancel, onSaved, onDi
       } else if (task) {
         await scheduledTaskService.updateTaskById(task.id, input);
       }
+      initialFormRef.current = JSON.stringify(form);
+      onDirtyChange?.(false);
       onSaved();
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

reset dirty state after saving task

## Changes Made

  - Fixed the scheduled task create/edit form dirty-state baseline so it stays in sync when the form is initialized from task data.
  - Reset the form dirty state immediately after a successful save before navigating away.
  - Prevented the unsaved-changes confirmation dialog from appearing after successfully creating a scheduled task.

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you've performed -->
- [ ] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

## Checklist
<!-- Mark the completed items with [x] -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes
<!-- If your PR includes Electron-specific changes, describe them here -->
- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None
