### PR TITLE
fix(build): fix Windows packaging failures from npm v11 compat issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "preview": "vite preview",
     "compile:electron": "tsc --project electron-tsconfig.json",
     "precompile:electron": "electron-builder install-app-deps",
-    "build:skill:web-search": "npm install --prefix SKILLs/web-search && npx tsc -p SKILLs/web-search/tsconfig.json && rm -f SKILLs/web-search/.connection SKILLs/web-search/.server.log SKILLs/web-search/.server.pid",
+    "build:skill:web-search": "npm install --prefix SKILLs/web-search && npx tsc -p SKILLs/web-search/tsconfig.json && node -e \"const fs=require('fs');['.connection','.server.log','.server.pid'].forEach(f=>{try{fs.unlinkSync('SKILLs/web-search/'+f)}catch(e){}});\"",
     "build:skill:tech-news": "node scripts/build-skill-tech-news.js",
     "build:skill:email": "cd SKILLs/imap-smtp-email && npm install --production",
     "build:skills": "npm run build:skill:web-search && npm run build:skill:tech-news && npm run build:skill:email",

--- a/scripts/electron-builder-hooks.cjs
+++ b/scripts/electron-builder-hooks.cjs
@@ -101,7 +101,7 @@ function verifyPreinstalledPlugins(runtimeRoot, buildHint) {
     return;
   }
 
-  const extensionsDir = path.join(runtimeRoot, 'extensions');
+  const extensionsDir = path.join(runtimeRoot, 'third-party-extensions');
   const missing = [];
 
   for (const plugin of plugins) {
@@ -127,7 +127,7 @@ function ensureBundledOpenClawRuntime(context) {
   const { runtimeRoot, targetId } = syncCurrentOpenClawRuntimeForTarget(context);
   const buildHint = getOpenClawRuntimeBuildHint(targetId);
 
-  const localMcpBridgeDir = path.join(runtimeRoot, 'extensions', 'mcp-bridge');
+  const localMcpBridgeDir = path.join(runtimeRoot, 'dist', 'extensions', 'mcp-bridge');
   if (!existsSync(localMcpBridgeDir)) {
     syncLocalOpenClawExtensions(runtimeRoot);
   }

--- a/scripts/patches/v2026.4.8/openclaw-ui-js-win32-space-in-path.patch
+++ b/scripts/patches/v2026.4.8/openclaw-ui-js-win32-space-in-path.patch
@@ -1,0 +1,37 @@
+--- a/scripts/ui.js
++++ b/scripts/ui.js
+@@ -89,10 +89,21 @@ function createSpawnOptions(cmd, args, envOverride) {
+   };
+ }
+
++function quoteIfNeeded(cmd) {
++  // On Windows with shell: true, cmd.exe splits unquoted paths at spaces.
++  // Wrap the command in double-quotes when the resolved path contains spaces.
++  if (process.platform === "win32" && cmd.includes(" ")) {
++    return `"${cmd}"`;
++  }
++  return cmd;
++}
++
+ function run(cmd, args) {
+   let child;
++  const opts = createSpawnOptions(cmd, args);
++  const effectiveCmd = opts.shell ? quoteIfNeeded(cmd) : cmd;
+   try {
+-    child = spawn(cmd, args, createSpawnOptions(cmd, args));
++    child = spawn(effectiveCmd, args, opts);
+   } catch (err) {
+     console.error(`Failed to launch ${cmd}:`, err);
+     process.exit(1);
+@@ -111,8 +122,10 @@ function run(cmd, args) {
+
+ function runSync(cmd, args, envOverride) {
+   let result;
++  const opts = createSpawnOptions(cmd, args, envOverride);
++  const effectiveCmd = opts.shell ? quoteIfNeeded(cmd) : cmd;
+   try {
+-    result = spawnSync(cmd, args, createSpawnOptions(cmd, args, envOverride));
++    result = spawnSync(effectiveCmd, args, opts);
+   } catch (err) {
+     console.error(`Failed to launch ${cmd}:`, err);
+     process.exit(1);


### PR DESCRIPTION
## Summary
- Replace `rm -f` with cross-platform Node.js inline script in `build:skill:web-search` — npm v11 no longer uses Git Bash sh as script-shell on Windows, so Unix commands fail under cmd.exe
- Fix plugin verification path in electron-builder-hooks: plugins are installed to `third-party-extensions/` but the hook checked `extensions/`, causing false "plugins missing" errors during packaging
- Fix mcp-bridge existence check path: local extensions live under `dist/extensions/`, not `extensions/`
- Patch openclaw `scripts/ui.js` to quote command paths containing spaces on Windows — fixes `ui:build` failure when pnpm is installed under `C:\Program Files\` (upstream issues: openclaw/openclaw#55101, openclaw/openclaw#45275, openclaw/openclaw#52282)

## Root cause
- `rm -f` issue introduced in #1539, worked previously because older npm versions used Git Bash sh as script-shell on Windows. npm v11 (bundled with Node v24) defaults to cmd.exe
- `extensions/` vs `third-party-extensions/` mismatch: plugin install script was updated to use `third-party-extensions/` but the electron-builder hook verification was not updated accordingly
- openclaw `ui.js` sets `shell: true` for `.cmd` files on Windows but does not quote the resolved command path — when it contains spaces, cmd.exe splits at the space. This is an upstream bug (still open), patched locally via `scripts/patches/v2026.4.8/`

## Test plan
- [ ] Run `npm run dist:win` on Windows with Node v24 / npm v11 — should complete without `rm`, "plugins missing", or `C:\Program` errors
- [ ] Verify packaged app launches and OpenClaw plugins load correctly
- [ ] Test on a machine where pnpm is installed under a path with spaces (e.g. `C:\Program Files\nodejs\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)