### PR TITLE
fix(build): fix Windows build failures and reduce package size

### DIFF
--- a/scripts/install-openclaw-channel-deps.cjs
+++ b/scripts/install-openclaw-channel-deps.cjs
@@ -71,14 +71,21 @@ function main() {
 
   console.log(`${LABEL} Installing ${missing.length} missing channel dep(s): ${missing.join(', ')}`);
 
-  const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const isWin = process.platform === 'win32';
+  const npmCmd = isWin ? 'npm.cmd' : 'npm';
   const result = spawnSync(npmCmd, ['install', '--no-save', ...missing], {
     cwd: runtimeRoot,
     encoding: 'utf-8',
     stdio: 'pipe',
+    shell: isWin,
+    windowsVerbatimArguments: isWin,
     timeout: 5 * 60 * 1000,
   });
 
+  if (result.error) {
+    console.error(`${LABEL} npm install failed: ${result.error.message}`);
+    process.exit(1);
+  }
   if (result.status !== 0) {
     console.error(`${LABEL} npm install failed (exit ${result.status})`);
     if (result.stderr) {

--- a/scripts/prune-openclaw-runtime.cjs
+++ b/scripts/prune-openclaw-runtime.cjs
@@ -196,6 +196,23 @@ function cleanDir(dirPath, stats) {
   }
 }
 
+// ─── Helpers ───
+
+function getDirSize(dirPath) {
+  let total = 0;
+  try {
+    for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        total += getDirSize(fullPath);
+      } else {
+        try { total += fs.statSync(fullPath).size; } catch { /* ignore */ }
+      }
+    }
+  } catch { /* ignore */ }
+  return total;
+}
+
 // ─── Main ───
 
 function main() {
@@ -252,6 +269,32 @@ function main() {
         }
       }
     } catch { /* ignore */ }
+  }
+
+  // Step 2c: Remove openclaw SDK duplicates from third-party-extensions.
+  // Plugins like openclaw-qqbot declare openclaw as a peerDependency, and
+  // npm v7+ auto-installs it into the plugin's own node_modules (~226 MB).
+  // At runtime the host gateway already provides the SDK on the module path,
+  // so this copy is redundant and safe to remove.
+  const thirdPartyDir = path.join(runtimeRoot, 'third-party-extensions');
+  if (fs.existsSync(thirdPartyDir)) {
+    try {
+      for (const plugin of fs.readdirSync(thirdPartyDir, { withFileTypes: true })) {
+        if (!plugin.isDirectory()) continue;
+        const dupeOC = path.join(thirdPartyDir, plugin.name, 'node_modules', 'openclaw');
+        if (fs.existsSync(dupeOC)) {
+          const size = getDirSize(dupeOC);
+          fs.rmSync(dupeOC, { recursive: true, force: true });
+          stats.bytesFreed += size;
+          stats.dirsRemoved++;
+          console.log(
+            `[prune-openclaw-runtime] Removed duplicate openclaw SDK from ${plugin.name} (${(size / 1024 / 1024).toFixed(1)} MB)`
+          );
+        }
+      }
+    } catch (err) {
+      console.warn(`[prune-openclaw-runtime] Failed to prune openclaw from third-party-extensions: ${err.message}`);
+    }
   }
 
   // Step 3: Clean unnecessary files from node_modules only


### PR DESCRIPTION
## Summary
- Fix `spawnSync npm.cmd` EINVAL error on Node 24 + Windows by adding `shell: true` and `windowsVerbatimArguments` flags to `install-openclaw-channel-deps.cjs` (matching the pattern in `ensure-openclaw-plugins.cjs`)
- Prune duplicate openclaw SDK (~226 MB) from `third-party-extensions/*/node_modules/openclaw` — plugins like `openclaw-qqbot` declare `openclaw` as a peerDependency, npm v7+ auto-installs it, but the host gateway already provides the SDK at runtime

## Commits
1. **fix(build): fix spawnSync EINVAL for npm.cmd on Node 24 + Windows** — adds `shell`/`windowsVerbatimArguments` and `result.error` check
2. **fix(build): prune duplicate openclaw SDK from third-party-extensions** — adds Step 2c to `prune-openclaw-runtime.cjs`

## Test plan
- [x] `node scripts/install-openclaw-channel-deps.cjs` succeeds on Windows (was EINVAL)
- [x] `node scripts/prune-openclaw-runtime.cjs vendor/openclaw-runtime/win-x64` removes ~179 MB duplicate
- [ ] Full `npm run openclaw:runtime:win-x64` pipeline completes
- [ ] Packaged installer size reduced compared to previous build

🤖 Generated with [Claude Code](https://claude.com/claude-code)