### PR TITLE
fix(build): skip openclaw peerDep auto-install to reduce package size

### DIFF
--- a/scripts/ensure-openclaw-plugins.cjs
+++ b/scripts/ensure-openclaw-plugins.cjs
@@ -218,7 +218,15 @@ for (const plugin of plugins) {
       runOpenClawCli(
         ['plugins', 'install', installSpec, '--force', '--dangerously-force-unsafe-install'],
         {
-          env: { OPENCLAW_STATE_DIR: stagingDir },
+          env: {
+            OPENCLAW_STATE_DIR: stagingDir,
+            // Prevent npm from auto-installing peerDependencies (npm v7+).
+            // Channel plugins declare openclaw as a peerDep, but the host
+            // gateway already provides the SDK at runtime.  Without this,
+            // npm installs the full openclaw SDK + transitive deps (~738 MB)
+            // into each plugin's node_modules.
+            npm_config_legacy_peer_deps: 'true',
+          },
           stdio: 'inherit',
         }
       );


### PR DESCRIPTION
## Summary
- Channel plugins (openclaw-qqbot, dingtalk, etc.) declare `openclaw` as a peerDependency
- npm v7+ auto-installs the full openclaw SDK + all transitive deps (~738 MB) into each plugin's `node_modules`
- The host gateway already provides the SDK at runtime, so these copies are entirely redundant
- Set `npm_config_legacy_peer_deps=true` in the OpenClaw CLI subprocess environment during plugin installation to prevent this
- Scoped to the plugin install subprocess only — does not affect other npm operations

## Context
- Supersedes the prune-based approach in #1624 with a simpler, source-level fix
- All current plugins' peerDependencies are exclusively `openclaw` (verified across all 10 plugins in `vendor/openclaw-plugins/`)
- Expected installer size reduction: ~100 MB (compressed) back toward the pre-upgrade baseline of ~261 MB

## Test plan
- [ ] Delete `vendor/openclaw-plugins/` cache to force re-download
- [ ] Run `npm run openclaw:runtime:win-x64` — verify plugins install without openclaw in their `node_modules`
- [ ] Build installer — verify size is reduced
- [ ] Start gateway — verify plugins load and function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)