### PR TITLE
feat(avatar): add user avatar settings feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "form-data": "^4.0.5",
     "js-yaml": "^4.1.1",
     "katex": "^0.16.21",
+    "lucide-react": "^1.8.0",
     "mermaid": "^10.9.5",
     "nim-web-sdk-ng": "10.9.77-alpha.4",
     "npm": "^11.11.0",

--- a/src/renderer/components/AvatarDisplay.tsx
+++ b/src/renderer/components/AvatarDisplay.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { avatarService } from '../services/avatar';
+import type { RootState } from '../store';
+import type { PresetAvatarId, UserAvatarConfig } from '../types/avatar';
+import { PRESET_AVATAR_COMPONENTS } from './avatars/presets';
+
+// 随机预置头像选择（基于用户ID或昵称的哈希，保证同一用户始终得到相同头像）
+const getRandomPresetAvatar = (seed: string): PresetAvatarId => {
+  const presetIds = Object.keys(PRESET_AVATAR_COMPONENTS) as PresetAvatarId[];
+  const hash = seed.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
+  return presetIds[hash % presetIds.length];
+};
+
+interface AvatarDisplayProps {
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  showBorder?: boolean;
+  className?: string;
+  onClick?: (e: React.MouseEvent) => void;
+}
+
+const sizeMap = {
+  sm: 'w-7 h-7 text-xs',
+  md: 'w-10 h-10 text-sm',
+  lg: 'w-16 h-16 text-base',
+  xl: 'w-24 h-24 text-xl',
+};
+
+export const AvatarDisplay: React.FC<AvatarDisplayProps> = ({
+  size = 'sm',
+  showBorder = true,
+  className = '',
+  onClick,
+}) => {
+  const [avatarConfig, setAvatarConfig] = useState<UserAvatarConfig | null>(null);
+  const user = useSelector((state: RootState) => state.auth.user);
+  const nickname = user?.nickname || '';
+
+  useEffect(() => {
+    loadAvatarConfig();
+
+    // Listen for avatar updates
+    const handleAvatarUpdate = () => {
+      loadAvatarConfig();
+    };
+
+    window.addEventListener('avatar-updated', handleAvatarUpdate);
+    return () => {
+      window.removeEventListener('avatar-updated', handleAvatarUpdate);
+    };
+  }, []);
+
+  const loadAvatarConfig = async () => {
+    const config = await avatarService.getAvatarConfig();
+    setAvatarConfig(config);
+  };
+
+  const renderAvatar = () => {
+    // If no config, show random preset avatar based on nickname
+    if (!avatarConfig) {
+      const randomPresetId = getRandomPresetAvatar(nickname);
+      const PresetComponent = PRESET_AVATAR_COMPONENTS[randomPresetId];
+      if (PresetComponent) {
+        return <PresetComponent className="w-full h-full" />;
+      }
+      return renderDefaultAvatar();
+    }
+
+    switch (avatarConfig.type) {
+      case 'preset':
+        return renderPresetAvatar();
+      case 'custom':
+        return renderCustomAvatar();
+      case 'default':
+      default:
+        return renderDefaultAvatar();
+    }
+  };
+
+  const renderPresetAvatar = () => {
+    const presetId = avatarConfig?.presetId;
+    if (!presetId) return renderDefaultAvatar();
+
+    const PresetComponent = PRESET_AVATAR_COMPONENTS[presetId];
+    if (!PresetComponent) return renderDefaultAvatar();
+
+    return <PresetComponent className="w-full h-full" />;
+  };
+
+  const renderCustomAvatar = () => {
+    const customUrl = avatarConfig?.customUrl;
+    if (!customUrl) return renderDefaultAvatar();
+
+    return (
+      <img
+        src={customUrl}
+        alt="Avatar"
+        className="w-full h-full object-cover"
+      />
+    );
+  };
+
+  const renderDefaultAvatar = () => {
+    const { bg, text } = avatarService.generateDefaultAvatar(nickname);
+
+    return (
+      <div
+        className={`w-full h-full bg-gradient-to-br ${bg} flex items-center justify-center text-white font-medium`}
+      >
+        {text}
+      </div>
+    );
+  };
+
+  const sizeClass = sizeMap[size];
+  const borderClass = showBorder ? 'border border-border' : '';
+  const cursorClass = onClick ? 'cursor-pointer' : '';
+
+  return (
+    <div
+      className={`${sizeClass} ${borderClass} ${cursorClass} rounded-full overflow-hidden flex-shrink-0 transition-transform hover:scale-105 ${className}`}
+      onClick={onClick}
+      title={onClick ? '点击设置头像' : ''}
+    >
+      {renderAvatar()}
+    </div>
+  );
+};
+
+export default AvatarDisplay;

--- a/src/renderer/components/AvatarSettingsModal.tsx
+++ b/src/renderer/components/AvatarSettingsModal.tsx
@@ -1,0 +1,263 @@
+import { Camera, Trash2, X } from 'lucide-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { avatarService } from '../services/avatar';
+import { i18nService } from '../services/i18n';
+import type { PresetAvatarId, UserAvatarConfig } from '../types/avatar';
+import { PRESET_AVATAR_COMPONENTS } from './avatars/presets';
+
+interface AvatarSettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const AvatarSettingsModal: React.FC<AvatarSettingsModalProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const [savedConfig, setSavedConfig] = useState<UserAvatarConfig | null>(null);
+  const [selectedPreset, setSelectedPreset] = useState<PresetAvatarId | null>(null);
+  const [customUrl, setCustomUrl] = useState<string | null>(null);
+  const [isHoveringPreview, setIsHoveringPreview] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Load current avatar config when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      loadCurrentConfig();
+    }
+  }, [isOpen]);
+
+  const loadCurrentConfig = async () => {
+    const config = await avatarService.getAvatarConfig();
+    setSavedConfig(config);
+    setSelectedPreset(config?.type === 'preset' ? config.presetId || null : null);
+    setCustomUrl(config?.type === 'custom' ? config.customUrl || null : null);
+    setUploadError(null);
+    setIsHoveringPreview(false);
+  };
+
+  const handlePresetSelect = (presetId: PresetAvatarId) => {
+    setSelectedPreset(presetId);
+    setCustomUrl(null);
+    setUploadError(null);
+  };
+
+  const handleFileSelect = async (file: File) => {
+    setUploadError(null);
+
+    const result = await avatarService.uploadImage(file);
+
+    if (result.success && result.config) {
+      setCustomUrl(result.config.customUrl || null);
+      setSelectedPreset(null);
+    } else if (result.error) {
+      setUploadError(i18nService.t(result.error as keyof typeof i18nService.t));
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      handleFileSelect(file);
+    }
+  };
+
+  const handlePreviewClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleSave = async () => {
+    try {
+      if (selectedPreset) {
+        await avatarService.setPresetAvatar(selectedPreset);
+      } else if (customUrl) {
+        await avatarService.setCustomAvatar(customUrl);
+      } else {
+        await avatarService.removeAvatarConfig();
+      }
+      onClose();
+    } catch (error) {
+      console.error('Failed to save avatar:', error);
+    }
+  };
+
+  const handleRemove = () => {
+    setSelectedPreset(null);
+    setCustomUrl(null);
+    setUploadError(null);
+  };
+
+  const handleCancel = () => {
+    onClose();
+  };
+
+  // Render preview content based on current selection
+  const renderPreview = () => {
+    if (customUrl) {
+      return (
+        <img
+          src={customUrl}
+          alt="Custom Avatar"
+          className="w-full h-full object-cover"
+        />
+      );
+    }
+
+    if (selectedPreset) {
+      const PresetComponent = PRESET_AVATAR_COMPONENTS[selectedPreset];
+      if (PresetComponent) {
+        return <PresetComponent className="w-full h-full" />;
+      }
+    }
+
+    // Default empty state
+    return (
+      <div className="w-full h-full bg-muted flex items-center justify-center">
+        <span className="text-4xl text-muted-foreground">?</span>
+      </div>
+    );
+  };
+
+  // Check if current selection differs from saved config
+  const hasChanges = (() => {
+    if (!savedConfig) {
+      return selectedPreset !== null || customUrl !== null;
+    }
+
+    if (savedConfig.type === 'preset') {
+      return selectedPreset !== savedConfig.presetId || customUrl !== null;
+    }
+
+    if (savedConfig.type === 'custom') {
+      return selectedPreset !== null || customUrl !== savedConfig.customUrl;
+    }
+
+    return selectedPreset !== null || customUrl !== null;
+  })();
+
+  const hasSelection = selectedPreset !== null || customUrl !== null;
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-background rounded-xl shadow-2xl w-[420px] max-w-[90vw] overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+          <h2 className="text-base font-semibold">{i18nService.t('avatarSettings')}</h2>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-muted transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="px-5 py-5">
+          {/* Main Preview - Large with hover camera */}
+          <div className="flex justify-center mb-5">
+            <div
+              className="relative w-28 h-28 rounded-full overflow-hidden ring-2 ring-border ring-offset-2 ring-offset-background cursor-pointer group"
+              onMouseEnter={() => setIsHoveringPreview(true)}
+              onMouseLeave={() => setIsHoveringPreview(false)}
+              onClick={handlePreviewClick}
+            >
+              {renderPreview()}
+
+              {/* Hover overlay with camera icon */}
+              <div
+                className={`absolute inset-0 bg-black/50 flex flex-col items-center justify-center transition-opacity duration-200 ${
+                  isHoveringPreview ? 'opacity-100' : 'opacity-0'
+                }`}
+              >
+                <Camera className="w-8 h-8 text-white mb-1" />
+                <span className="text-xs text-white font-medium">
+                  {i18nService.t('avatarChangePhoto')}
+                </span>
+              </div>
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/gif,image/webp"
+                onChange={handleInputChange}
+                className="hidden"
+              />
+            </div>
+          </div>
+
+          {/* Upload hint */}
+          <p className="text-center text-xs text-muted-foreground mb-5">
+            {i18nService.t('avatarUploadHint')}
+          </p>
+
+          {/* Error message */}
+          {uploadError && (
+            <p className="text-sm text-destructive text-center mb-4">{uploadError}</p>
+          )}
+
+          {/* Preset Avatars */}
+          <div className="mb-4">
+            <h3 className="text-sm font-medium mb-3 text-muted-foreground">
+              {i18nService.t('avatarPreset')}
+            </h3>
+            <div className="grid grid-cols-6 gap-2">
+              {(Object.keys(PRESET_AVATAR_COMPONENTS) as PresetAvatarId[]).map((presetId) => {
+                const PresetComponent = PRESET_AVATAR_COMPONENTS[presetId];
+                const isSelected = selectedPreset === presetId;
+                const presetNameKey = `avatar${presetId.charAt(0).toUpperCase() + presetId.slice(1)}` as keyof typeof i18nService.t;
+                return (
+                  <button
+                    key={presetId}
+                    onClick={() => handlePresetSelect(presetId)}
+                    className={`relative aspect-square rounded-xl overflow-hidden transition-all duration-200 ${
+                      isSelected
+                        ? 'ring-2 ring-primary ring-offset-2 scale-105'
+                        : 'hover:scale-105 hover:opacity-90'
+                    }`}
+                    title={i18nService.t(presetNameKey)}
+                  >
+                    <PresetComponent className="w-full h-full" />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Remove Button - only show if there's a selection */}
+          {hasSelection && (
+            <button
+              onClick={handleRemove}
+              className="w-full flex items-center justify-center gap-2 py-2.5 text-sm text-destructive hover:bg-destructive/5 rounded-lg transition-colors"
+            >
+              <Trash2 className="w-4 h-4" />
+              {i18nService.t('avatarRemove')}
+            </button>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 px-5 py-4 border-t border-border bg-muted/30">
+          <button
+            onClick={handleCancel}
+            className="px-4 py-2 text-sm font-medium rounded-lg border border-border hover:bg-background transition-colors"
+          >
+            {i18nService.t('avatarCancel')}
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!hasChanges}
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {i18nService.t('avatarSave')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AvatarSettingsModal;

--- a/src/renderer/components/LoginButton.tsx
+++ b/src/renderer/components/LoginButton.tsx
@@ -4,6 +4,8 @@ import { RootState } from '../store';
 import { authService } from '../services/auth';
 import { i18nService } from '../services/i18n';
 import type { CreditItem } from '../store/slices/authSlice';
+import { AvatarDisplay } from './AvatarDisplay';
+import { AvatarSettingsModal } from './AvatarSettingsModal';
 
 const getSubscriptionBadge = (label: string) => {
   // Determine badge style based on label
@@ -224,6 +226,7 @@ const UserMenu: React.FC<{ onClose: () => void }> = ({ onClose }) => {
 const LoginButton: React.FC = () => {
   const { isLoggedIn, isLoading, user } = useSelector((state: RootState) => state.auth);
   const [showMenu, setShowMenu] = useState(false);
+  const [showAvatarModal, setShowAvatarModal] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -252,34 +255,48 @@ const LoginButton: React.FC = () => {
     }
   };
 
+  const handleAvatarClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isLoggedIn) {
+      setShowAvatarModal(true);
+    }
+  };
+
   const phoneSuffix = user?.phone ? user.phone.slice(-4) : '';
 
   return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        onClick={handleClick}
-        className="inline-flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm font-medium text-secondary hover:text-foreground hover:bg-surface-raised transition-colors cursor-pointer"
-      >
-        {isLoggedIn ? (
-          <>
-            {user?.avatarUrl ? (
-              <img src={user.avatarUrl} alt="" className="h-4 w-4 rounded-full" />
-            ) : (
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4"><circle cx="12" cy="8" r="5" /><path d="M20 21a8 8 0 0 0-16 0" /></svg>
-            )}
-            <span className="truncate max-w-[80px]">{user?.nickname || `****${phoneSuffix}`}</span>
-          </>
-        ) : (
-          <>
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4"><circle cx="12" cy="8" r="5" /><path d="M20 21a8 8 0 0 0-16 0" /></svg>
-            {i18nService.t('login')}
-          </>
+    <>
+      <div ref={containerRef} className="relative flex items-center gap-2">
+        {isLoggedIn && (
+          <AvatarDisplay
+            size="sm"
+            onClick={handleAvatarClick}
+          />
         )}
-      </button>
-      {showMenu && <UserMenu onClose={() => setShowMenu(false)} />}
-    </div>
+        <button
+          type="button"
+          onClick={handleClick}
+          className="inline-flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm font-medium text-secondary hover:text-foreground hover:bg-surface-raised transition-colors cursor-pointer"
+        >
+          {isLoggedIn ? (
+            <>
+              <span className="truncate max-w-[80px]">{user?.nickname || `****${phoneSuffix}`}</span>
+            </>
+          ) : (
+            <>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4"><circle cx="12" cy="8" r="5" /><path d="M20 21a8 8 0 0 0-16 0" /></svg>
+              {i18nService.t('login')}
+            </>
+          )}
+        </button>
+        {showMenu && <UserMenu onClose={() => setShowMenu(false)} />}
+      </div>
+      <AvatarSettingsModal
+        isOpen={showAvatarModal}
+        onClose={() => setShowAvatarModal(false)}
+      />
+    </>
   );
-};
+}
 
 export default LoginButton;

--- a/src/renderer/components/avatars/presets/AuroraAvatar.tsx
+++ b/src/renderer/components/avatars/presets/AuroraAvatar.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+/**
+ * Aurora Avatar - 极光
+ * 紫蓝粉渐变 + 流动波浪线
+ */
+const AuroraAvatar: React.FC<{ className?: string }> = ({ className }) => {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <linearGradient id="aurora-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#6366f1" />
+          <stop offset="50%" stopColor="#a855f7" />
+          <stop offset="100%" stopColor="#ec4899" />
+        </linearGradient>
+      </defs>
+      <rect width="100" height="100" fill="url(#aurora-gradient)" />
+      {/* 三条波浪线 */}
+      <path
+        d="M0,55 Q20,45 40,55 T80,55 T100,55"
+        fill="none"
+        stroke="rgba(255,255,255,0.4)"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M0,65 Q25,50 50,65 T100,65"
+        fill="none"
+        stroke="rgba(255,255,255,0.25)"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M0,75 Q30,60 60,75 T100,75"
+        fill="none"
+        stroke="rgba(255,255,255,0.15)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};
+
+export default AuroraAvatar;

--- a/src/renderer/components/avatars/presets/FlameAvatar.tsx
+++ b/src/renderer/components/avatars/presets/FlameAvatar.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * Flame Avatar - 火焰
+ * 橙红渐变 + 火焰形状
+ */
+const FlameAvatar: React.FC<{ className?: string }> = ({ className }) => {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <linearGradient id="flame-gradient" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%" stopColor="#dc2626" />
+          <stop offset="50%" stopColor="#f97316" />
+          <stop offset="100%" stopColor="#fbbf24" />
+        </linearGradient>
+      </defs>
+      <rect width="100" height="100" fill="url(#flame-gradient)" />
+      {/* 火焰形状 */}
+      <path
+        d="M50,15 Q65,40 60,55 Q70,50 65,65 Q75,60 70,75 Q65,90 50,90 Q35,90 30,75 Q25,60 35,65 Q30,50 40,55 Q35,40 50,15"
+        fill="rgba(255,255,255,0.25)"
+      />
+      <path
+        d="M50,35 Q58,50 55,60 Q60,58 57,68 Q62,65 58,75 Q55,85 50,85 Q45,85 42,75 Q38,65 43,68 Q40,58 45,60 Q42,50 50,35"
+        fill="rgba(255,255,255,0.4)"
+      />
+    </svg>
+  );
+};
+
+export default FlameAvatar;

--- a/src/renderer/components/avatars/presets/ForestAvatar.tsx
+++ b/src/renderer/components/avatars/presets/ForestAvatar.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+/**
+ * Forest Avatar - 森林
+ * 绿色渐变 + 抽象叶子形状
+ */
+const ForestAvatar: React.FC<{ className?: string }> = ({ className }) => {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <linearGradient id="forest-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#34d399" />
+          <stop offset="50%" stopColor="#22c55e" />
+          <stop offset="100%" stopColor="#0d9488" />
+        </linearGradient>
+      </defs>
+      <rect width="100" height="100" fill="url(#forest-gradient)" />
+      {/* 抽象叶子形状 */}
+      <ellipse
+        cx="35"
+        cy="50"
+        rx="12"
+        ry="20"
+        fill="rgba(255,255,255,0.25)"
+        transform="rotate(-20 35 50)"
+      />
+      <ellipse
+        cx="65"
+        cy="50"
+        rx="12"
+        ry="20"
+        fill="rgba(255,255,255,0.25)"
+        transform="rotate(20 65 50)"
+      />
+      <ellipse
+        cx="50"
+        cy="45"
+        rx="10"
+        ry="18"
+        fill="rgba(255,255,255,0.35)"
+      />
+      {/* 叶脉 */}
+      <line
+        x1="50"
+        y1="30"
+        x2="50"
+        y2="60"
+        stroke="rgba(255,255,255,0.2)"
+        strokeWidth="1"
+      />
+    </svg>
+  );
+};
+
+export default ForestAvatar;

--- a/src/renderer/components/avatars/presets/NebulaAvatar.tsx
+++ b/src/renderer/components/avatars/presets/NebulaAvatar.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+/**
+ * Nebula Avatar - 星云
+ * 紫黑径向渐变 + 星点和连线
+ */
+const NebulaAvatar: React.FC<{ className?: string }> = ({ className }) => {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <radialGradient id="nebula-gradient" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="#c026d3" />
+          <stop offset="50%" stopColor="#7c3aed" />
+          <stop offset="100%" stopColor="#312e81" />
+        </radialGradient>
+      </defs>
+      <rect width="100" height="100" fill="url(#nebula-gradient)" />
+      {/* 星星 */}
+      <circle cx="25" cy="30" r="2" fill="rgba(255,255,255,0.8)" />
+      <circle cx="75" cy="25" r="1.5" fill="rgba(255,255,255,0.6)" />
+      <circle cx="80" cy="60" r="2" fill="rgba(255,255,255,0.7)" />
+      <circle cx="30" cy="70" r="1.5" fill="rgba(255,255,255,0.5)" />
+      <circle cx="55" cy="40" r="1" fill="rgba(255,255,255,0.4)" />
+      <circle cx="20" cy="55" r="1" fill="rgba(255,255,255,0.5)" />
+      <circle cx="70" cy="75" r="1.5" fill="rgba(255,255,255,0.6)" />
+      {/* 星座连线 */}
+      <line
+        x1="25"
+        y1="30"
+        x2="55"
+        y2="40"
+        stroke="rgba(255,255,255,0.2)"
+        strokeWidth="0.5"
+      />
+      <line
+        x1="55"
+        y1="40"
+        x2="80"
+        y2="60"
+        stroke="rgba(255,255,255,0.2)"
+        strokeWidth="0.5"
+      />
+      <line
+        x1="30"
+        y1="70"
+        x2="55"
+        y2="40"
+        stroke="rgba(255,255,255,0.15)"
+        strokeWidth="0.5"
+      />
+    </svg>
+  );
+};
+
+export default NebulaAvatar;

--- a/src/renderer/components/avatars/presets/OceanAvatar.tsx
+++ b/src/renderer/components/avatars/presets/OceanAvatar.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+/**
+ * Ocean Avatar - 深海
+ * 深蓝渐变 + 同心圆波纹
+ */
+const OceanAvatar: React.FC<{ className?: string }> = ({ className }) => {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <linearGradient id="ocean-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stopColor="#0891b2" />
+          <stop offset="50%" stopColor="#2563eb" />
+          <stop offset="100%" stopColor="#4338ca" />
+        </linearGradient>
+      </defs>
+      <rect width="100" height="100" fill="url(#ocean-gradient)" />
+      {/* 同心圆波纹 */}
+      <circle
+        cx="50"
+        cy="50"
+        r="15"
+        fill="none"
+        stroke="rgba(255,255,255,0.3)"
+        strokeWidth="1.5"
+      />
+      <circle
+        cx="50"
+        cy="50"
+        r="25"
+        fill="none"
+        stroke="rgba(255,255,255,0.2)"
+        strokeWidth="1.5"
+      />
+      <circle
+        cx="50"
+        cy="50"
+        r="35"
+        fill="none"
+        stroke="rgba(255,255,255,0.1)"
+        strokeWidth="1.5"
+      />
+      <circle
+        cx="50"
+        cy="50"
+        r="45"
+        fill="none"
+        stroke="rgba(255,255,255,0.05)"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+};
+
+export default OceanAvatar;

--- a/src/renderer/components/avatars/presets/SunsetAvatar.tsx
+++ b/src/renderer/components/avatars/presets/SunsetAvatar.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+/**
+ * Sunset Avatar - 日落
+ * 暖色渐变 + 太阳和光线
+ */
+const SunsetAvatar: React.FC<{ className?: string }> = ({ className }) => {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <linearGradient id="sunset-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stopColor="#fb7185" />
+          <stop offset="50%" stopColor="#fb923c" />
+          <stop offset="100%" stopColor="#fcd34d" />
+        </linearGradient>
+      </defs>
+      <rect width="100" height="100" fill="url(#sunset-gradient)" />
+      {/* 太阳 */}
+      <circle cx="50" cy="55" r="18" fill="rgba(255,255,255,0.3)" />
+      <circle cx="50" cy="55" r="12" fill="rgba(255,255,255,0.5)" />
+      {/* 光线 */}
+      <line
+        x1="50"
+        y1="20"
+        x2="50"
+        y2="10"
+        stroke="rgba(255,255,255,0.3)"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <line
+        x1="25"
+        y1="30"
+        x2="18"
+        y2="22"
+        stroke="rgba(255,255,255,0.3)"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <line
+        x1="75"
+        y1="30"
+        x2="82"
+        y2="22"
+        stroke="rgba(255,255,255,0.3)"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};
+
+export default SunsetAvatar;

--- a/src/renderer/components/avatars/presets/index.ts
+++ b/src/renderer/components/avatars/presets/index.ts
@@ -1,0 +1,27 @@
+import AuroraAvatar from './AuroraAvatar';
+import OceanAvatar from './OceanAvatar';
+import FlameAvatar from './FlameAvatar';
+import ForestAvatar from './ForestAvatar';
+import SunsetAvatar from './SunsetAvatar';
+import NebulaAvatar from './NebulaAvatar';
+
+export {
+  AuroraAvatar,
+  OceanAvatar,
+  FlameAvatar,
+  ForestAvatar,
+  SunsetAvatar,
+  NebulaAvatar,
+};
+
+// 预置头像组件映射
+export const PRESET_AVATAR_COMPONENTS = {
+  aurora: AuroraAvatar,
+  ocean: OceanAvatar,
+  flame: FlameAvatar,
+  forest: ForestAvatar,
+  sunset: SunsetAvatar,
+  nebula: NebulaAvatar,
+} as const;
+
+export type PresetAvatarComponent = typeof PRESET_AVATAR_COMPONENTS[keyof typeof PRESET_AVATAR_COMPONENTS];

--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -332,6 +332,7 @@ export const CONFIG_KEYS = {
   CONVERSATIONS: 'conversations',
   PROVIDERS_EXPORT_KEY: 'providers_export_key',
   SKILLS: 'skills',
+  USER_AVATAR: 'user_avatar_config',
 };
 
 // Provider lists derived from ProviderRegistry — single source of truth

--- a/src/renderer/config/avatars.ts
+++ b/src/renderer/config/avatars.ts
@@ -1,0 +1,46 @@
+import type { PresetAvatarId } from '../types/avatar';
+
+export interface PresetAvatarConfig {
+  id: PresetAvatarId;
+  name: string;
+  nameEn: string;
+}
+
+// 预置头像配置列表
+export const PRESET_AVATARS: PresetAvatarConfig[] = [
+  {
+    id: 'aurora',
+    name: '极光',
+    nameEn: 'Aurora',
+  },
+  {
+    id: 'ocean',
+    name: '深海',
+    nameEn: 'Ocean',
+  },
+  {
+    id: 'flame',
+    name: '火焰',
+    nameEn: 'Flame',
+  },
+  {
+    id: 'forest',
+    name: '森林',
+    nameEn: 'Forest',
+  },
+  {
+    id: 'sunset',
+    name: '日落',
+    nameEn: 'Sunset',
+  },
+  {
+    id: 'nebula',
+    name: '星云',
+    nameEn: 'Nebula',
+  },
+];
+
+// 获取预置头像配置
+export const getPresetAvatarConfig = (id: PresetAvatarId): PresetAvatarConfig | undefined => {
+  return PRESET_AVATARS.find(avatar => avatar.id === id);
+};

--- a/src/renderer/services/avatar.ts
+++ b/src/renderer/services/avatar.ts
@@ -1,0 +1,146 @@
+import { CONFIG_KEYS } from '../config';
+import type { PresetAvatarId,UserAvatarConfig } from '../types/avatar';
+import { localStore } from './store';
+
+class AvatarService {
+  /**
+   * 获取当前头像配置
+   */
+  async getAvatarConfig(): Promise<UserAvatarConfig | null> {
+    try {
+      const config = await localStore.getItem<UserAvatarConfig>(CONFIG_KEYS.USER_AVATAR);
+      return config;
+    } catch (error) {
+      console.error('[AvatarService] Failed to get avatar config:', error);
+      return null;
+    }
+  }
+
+  /**
+   * 保存头像配置
+   */
+  async saveAvatarConfig(config: UserAvatarConfig): Promise<void> {
+    try {
+      const configWithTimestamp: UserAvatarConfig = {
+        ...config,
+        updatedAt: Date.now(),
+      };
+      await localStore.setItem(CONFIG_KEYS.USER_AVATAR, configWithTimestamp);
+      // 触发配置更新事件
+      window.dispatchEvent(new CustomEvent('avatar-updated'));
+    } catch (error) {
+      console.error('[AvatarService] Failed to save avatar config:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 删除头像配置（恢复默认）
+   */
+  async removeAvatarConfig(): Promise<void> {
+    try {
+      await localStore.removeItem(CONFIG_KEYS.USER_AVATAR);
+      window.dispatchEvent(new CustomEvent('avatar-updated'));
+    } catch (error) {
+      console.error('[AvatarService] Failed to remove avatar config:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 上传图片并转换为配置
+   */
+  async uploadImage(file: File): Promise<{ success: boolean; config?: UserAvatarConfig; error?: string }> {
+    try {
+      // 动态导入图片处理工具
+      const { processAvatarImage, isValidImageType, isValidImageSize } = await import('../utils/imageUtils');
+
+      // 验证文件类型
+      if (!isValidImageType(file)) {
+        return {
+          success: false,
+          error: 'avatarUploadErrorType',
+        };
+      }
+
+      // 验证文件大小
+      if (!isValidImageSize(file, 2)) {
+        return {
+          success: false,
+          error: 'avatarUploadErrorSize',
+        };
+      }
+
+      // 处理图片
+      const result = await processAvatarImage(file, {
+        maxSize: 2 * 1024 * 1024,
+        targetSize: 256,
+        quality: 0.8,
+      });
+
+      const config: UserAvatarConfig = {
+        type: 'custom',
+        customUrl: result.dataUrl,
+      };
+
+      return {
+        success: true,
+        config,
+      };
+    } catch (error) {
+      console.error('[AvatarService] Failed to upload image:', error);
+      return {
+        success: false,
+        error: 'avatarUploadErrorProcess',
+      };
+    }
+  }
+
+  /**
+   * 设置预置头像
+   */
+  async setPresetAvatar(presetId: PresetAvatarId): Promise<void> {
+    const config: UserAvatarConfig = {
+      type: 'preset',
+      presetId,
+    };
+    await this.saveAvatarConfig(config);
+  }
+
+  /**
+   * 设置自定义头像
+   */
+  async setCustomAvatar(dataUrl: string): Promise<void> {
+    const config: UserAvatarConfig = {
+      type: 'custom',
+      customUrl: dataUrl,
+    };
+    await this.saveAvatarConfig(config);
+  }
+
+  /**
+   * 生成默认头像配置
+   */
+  generateDefaultAvatar(nickname: string): { bg: string; text: string } {
+    // 使用昵称首字母或默认字符
+    const firstChar = nickname?.charAt(0)?.toUpperCase() || '?';
+
+    // 生成基于昵称的渐变色
+    const gradients = [
+      'from-blue-500 to-indigo-600',
+      'from-emerald-500 to-teal-600',
+      'from-violet-500 to-purple-600',
+      'from-rose-500 to-pink-600',
+      'from-amber-500 to-orange-600',
+      'from-cyan-500 to-blue-600',
+    ];
+
+    // 根据昵称哈希选择渐变色
+    const hash = nickname?.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0) || 0;
+    const bg = gradients[hash % gradients.length];
+
+    return { bg, text: firstChar };
+  }
+}
+
+export const avatarService = new AvatarService();

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1313,6 +1313,26 @@ const translations: Record<LanguageType, Record<string, string>> = {
     taskFormLeaveConfirm: '离开后修改将丢失，确认离开吗？',
     taskFormLeave: '离开',
     taskFormStay: '继续编辑',
+
+    // Avatar settings
+    avatarSettings: '设置头像',
+    avatarPreset: '系统头像',
+    avatarUpload: '上传图片',
+    avatarUploadHint: '支持 JPG、PNG、GIF，最大 2MB',
+    avatarDragHint: '拖拽图片到此处，或点击上传',
+    avatarRemove: '恢复默认',
+    avatarSave: '保存',
+    avatarCancel: '取消',
+    avatarUploadErrorSize: '图片大小超过 2MB 限制',
+    avatarUploadErrorType: '不支持的图片格式',
+    avatarUploadErrorProcess: '图片处理失败，请重试',
+    avatarAurora: '极光',
+    avatarOcean: '深海',
+    avatarFlame: '火焰',
+    avatarForest: '森林',
+    avatarSunset: '日落',
+    avatarNebula: '星云',
+    avatarChangePhoto: '更换照片',
   },
   en: {
     // Common
@@ -2621,6 +2641,26 @@ const translations: Record<LanguageType, Record<string, string>> = {
     taskFormLeaveConfirm: 'Your changes will be lost if you leave. Are you sure you want to leave?',
     taskFormLeave: 'Leave',
     taskFormStay: 'Keep Editing',
+
+    // Avatar settings
+    avatarSettings: 'Set Avatar',
+    avatarPreset: 'Preset Avatars',
+    avatarUpload: 'Upload Image',
+    avatarUploadHint: 'JPG, PNG, GIF supported, max 2MB',
+    avatarDragHint: 'Drag image here or click to upload',
+    avatarRemove: 'Reset to Default',
+    avatarSave: 'Save',
+    avatarCancel: 'Cancel',
+    avatarUploadErrorSize: 'Image size exceeds 2MB limit',
+    avatarUploadErrorType: 'Unsupported image format',
+    avatarUploadErrorProcess: 'Image processing failed, please try again',
+    avatarAurora: 'Aurora',
+    avatarOcean: 'Ocean',
+    avatarFlame: 'Flame',
+    avatarForest: 'Forest',
+    avatarSunset: 'Sunset',
+    avatarNebula: 'Nebula',
+    avatarChangePhoto: 'Change Photo',
   }
 };
 

--- a/src/renderer/store/slices/authSlice.ts
+++ b/src/renderer/store/slices/authSlice.ts
@@ -1,10 +1,13 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { UserAvatarConfig } from '../../types/avatar';
 
 export interface UserProfile {
   userId: string;
   phone: string;
   nickname: string;
   avatarUrl: string;
+  // 本地头像配置（优先于服务器头像）
+  localAvatar?: UserAvatarConfig;
 }
 
 export interface UserQuota {

--- a/src/renderer/types/avatar.ts
+++ b/src/renderer/types/avatar.ts
@@ -1,0 +1,16 @@
+// 头像类型
+export type AvatarType = 'preset' | 'custom' | 'default';
+
+// 预置头像ID
+export type PresetAvatarId = 'aurora' | 'ocean' | 'flame' | 'forest' | 'sunset' | 'nebula';
+
+// 用户头像配置
+export interface UserAvatarConfig {
+  type: AvatarType;
+  // 预置头像时存储ID
+  presetId?: PresetAvatarId;
+  // 自定义头像时存储DataUrl
+  customUrl?: string;
+  // 最后更新时间
+  updatedAt?: number;
+}

--- a/src/renderer/utils/imageUtils.ts
+++ b/src/renderer/utils/imageUtils.ts
@@ -1,0 +1,131 @@
+/**
+ * 图片处理工具函数
+ */
+
+export interface ProcessAvatarImageOptions {
+  maxSize?: number;      // 最大文件大小（字节），默认 2MB
+  targetSize?: number;   // 输出尺寸，默认 256x256
+  quality?: number;      // 压缩质量，默认 0.8
+}
+
+export interface ProcessedImageResult {
+  dataUrl: string;
+  width: number;
+  height: number;
+}
+
+// 默认配置
+const DEFAULT_OPTIONS: Required<ProcessAvatarImageOptions> = {
+  maxSize: 2 * 1024 * 1024,  // 2MB
+  targetSize: 256,
+  quality: 0.8,
+};
+
+// 支持的图片类型
+const VALID_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+/**
+ * 检查文件类型是否有效
+ */
+export function isValidImageType(file: File): boolean {
+  return VALID_IMAGE_TYPES.includes(file.type);
+}
+
+/**
+ * 检查文件大小是否有效
+ */
+export function isValidImageSize(file: File, maxSizeMB: number = 2): boolean {
+  return file.size <= maxSizeMB * 1024 * 1024;
+}
+
+/**
+ * 压缩并裁剪图片为正方形
+ */
+export async function processAvatarImage(
+  file: File,
+  options: ProcessAvatarImageOptions = {}
+): Promise<ProcessedImageResult> {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const reader = new FileReader();
+
+    reader.onload = (e) => {
+      img.src = e.target?.result as string;
+    };
+
+    reader.onerror = () => {
+      reject(new Error('Failed to read file'));
+    };
+
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+
+        if (!ctx) {
+          reject(new Error('Failed to get canvas context'));
+          return;
+        }
+
+        // 设置画布尺寸为目标尺寸
+        canvas.width = opts.targetSize;
+        canvas.height = opts.targetSize;
+
+        // 计算裁剪区域（居中裁剪为正方形）
+        const minDimension = Math.min(img.width, img.height);
+        const sourceX = (img.width - minDimension) / 2;
+        const sourceY = (img.height - minDimension) / 2;
+
+        // 绘制图片（裁剪并缩放）
+        ctx.drawImage(
+          img,
+          sourceX,
+          sourceY,
+          minDimension,
+          minDimension,
+          0,
+          0,
+          opts.targetSize,
+          opts.targetSize
+        );
+
+        // 转换为 Data URL
+        const dataUrl = canvas.toDataURL('image/jpeg', opts.quality);
+
+        resolve({
+          dataUrl,
+          width: opts.targetSize,
+          height: opts.targetSize,
+        });
+      } catch (error) {
+        reject(error);
+      }
+    };
+
+    img.onerror = () => {
+      reject(new Error('Failed to load image'));
+    };
+
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * 获取文件扩展名
+ */
+export function getFileExtension(file: File): string {
+  return file.name.split('.').pop()?.toLowerCase() || '';
+}
+
+/**
+ * 格式化文件大小
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}


### PR DESCRIPTION
用户头像设置功能

  功能概述

  新增用户头像设置功能，支持预置头像选择和本地图片上传，首次使用自动分配随机预置头像。

  主要变更

  新增组件
  - AvatarDisplay - 头像展示组件，支持预置/自定义/默认三种模式
  - AvatarSettingsModal - 头像设置弹框，支持选择和上传
  - 6 款 SVG 预置头像：极光、深海、火焰、森林、日落、星云

  新增服务
  - avatarService - 头像配置管理（本地存储）
  - imageUtils - 图片处理工具（压缩、裁剪、格式验证）

  功能特性
  1. 首次登录自动分配随机预置头像（基于昵称哈希，保证同一用户始终相同）
  2. 点击头像打开设置弹框
  3. 支持 6 款精美 SVG 预置头像
  4. 支持本地上传（JPG/PNG/GIF/WebP，最大 2MB，自动压缩至 256px）
  5. 头像悬停显示相机图标，点击可快速更换
  6. 支持恢复默认头像

  UI 优化
  - 弹框一屏展示，无需滚动
  - 大头像预览 + 悬停遮罩效果
  - 预置头像网格布局，选中高亮

  国际化
  - 新增 17 个 i18n 键，支持中英文

  测试要点

  - 首次登录显示随机预置头像
  - 点击头像打开设置弹框
  - 选择预置头像实时预览
  - 上传本地图片正常显示
  - 保存后头像更新
  - 恢复默认功能正常
  
<img width="2368" height="1582" alt="image" src="https://github.com/user-attachments/assets/374cb78b-4c9a-43c5-b976-39fafffaec02" />