### PR TITLE
feat(mcp): mcp support quick add templates

### DIFF
--- a/src/renderer/components/mcp/McpManager.tsx
+++ b/src/renderer/components/mcp/McpManager.tsx
@@ -221,6 +221,7 @@ const McpManager: React.FC = () => {
     setIsFormOpen(false);
     setEditingServer(null);
     setInstallingRegistry(null);
+    setQuickTemplateData(null);
   };
 
   const handleSaveForm = async (data: McpServerFormData) => {
@@ -250,6 +251,42 @@ const McpManager: React.FC = () => {
   const handleOpenCreateForm = () => {
     setEditingServer(null);
     setInstallingRegistry(null);
+    setIsFormOpen(true);
+  };
+
+  const [quickTemplateData, setQuickTemplateData] = useState<McpServerFormData | null>(null);
+
+  const handleQuickAddTemplate = (template: 'filesystem' | 'sqlite' | 'bravesearch') => {
+    const templates: Record<string, McpServerFormData> = {
+      filesystem: {
+        name: 'file-system',
+        description: '文件系统操作',
+        transportType: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '~/Desktop'],
+      },
+      sqlite: {
+        name: 'sqlite',
+        description: 'Sqlite数据库操作',
+        transportType: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-sqlite', '--db-path', './data.db'],
+      },
+      bravesearch: {
+        name: 'brave-search',
+        description: 'Brave搜索',
+        transportType: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-brave-search'],
+        env: { BRAVE_API_KEY: 'XXX' },
+      },
+    };
+
+    const data = templates[template];
+    if (!data) return;
+
+    setActionError('');
+    setQuickTemplateData(data);
     setIsFormOpen(true);
   };
 
@@ -599,6 +636,41 @@ const McpManager: React.FC = () => {
       {/* ── Tab: Custom ─────────────────────────────────── */}
       {activeTab === 'custom' && (
         <div className="space-y-6">
+          {/* Quick Templates Section */}
+          <div className="rounded-xl border border-border bg-surface p-4">
+            <div className="flex items-center gap-2 mb-3">
+              <h3 className="text-sm font-medium text-foreground">
+                快速添加模版
+              </h3>
+              <span className="text-xs text-secondary">
+                一键添加常用 MCP 服务
+              </span>
+            </div>
+            <div className="flex items-center gap-2 flex-wrap">
+              <button
+                type="button"
+                onClick={() => handleQuickAddTemplate('filesystem')}
+                className="px-3 py-1.5 text-xs rounded-lg bg-surface-raised text-foreground hover:bg-primary hover:text-white transition-colors border border-border"
+              >
+                + File System
+              </button>
+              <button
+                type="button"
+                onClick={() => handleQuickAddTemplate('sqlite')}
+                className="px-3 py-1.5 text-xs rounded-lg bg-surface-raised text-foreground hover:bg-primary hover:text-white transition-colors border border-border"
+              >
+                + SQLite
+              </button>
+              <button
+                type="button"
+                onClick={() => handleQuickAddTemplate('bravesearch')}
+                className="px-3 py-1.5 text-xs rounded-lg bg-surface-raised text-foreground hover:bg-primary hover:text-white transition-colors border border-border"
+              >
+                + Brave Search
+              </button>
+            </div>
+          </div>
+
           {/* Custom servers grid (add button + server cards) */}
           <div className="grid grid-cols-2 gap-3">
             {/* Add custom server card */}
@@ -725,11 +797,12 @@ const McpManager: React.FC = () => {
         </Modal>
       )}
 
-      {/* Edit / Registry-install form modal */}
+      {/* Edit / Registry-install / Quick template form modal */}
       <McpServerFormModal
         isOpen={isFormOpen}
         server={editingServer}
         registryEntry={installingRegistry}
+        initialData={quickTemplateData}
         existingNames={existingNames}
         onClose={handleCloseForm}
         onSave={handleSaveForm}

--- a/src/renderer/components/mcp/McpServerFormModal.tsx
+++ b/src/renderer/components/mcp/McpServerFormModal.tsx
@@ -7,6 +7,7 @@ interface McpServerFormModalProps {
   isOpen: boolean;
   server?: McpServerConfig | null; // null = create mode, defined = edit mode
   registryEntry?: McpRegistryEntry | null; // install from registry mode
+  initialData?: McpServerFormData | null; // quick template prefill data
   existingNames: string[];
   onClose: () => void;
   onSave: (data: McpServerFormData) => void;
@@ -16,12 +17,14 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
   isOpen,
   server,
   registryEntry,
+  initialData,
   existingNames,
   onClose,
   onSave,
 }) => {
   const isEdit = !!server;
   const isRegistry = !!registryEntry && !isEdit;
+  const isQuickTemplate = !!initialData && !isEdit && !isRegistry;
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -89,6 +92,28 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
       setEnvRows(envEntries);
       setUrl('');
       setHeaderRows([]);
+    } else if (initialData) {
+      // Quick template mode — pre-fill from initial data
+      setName(initialData.name);
+      setDescription(initialData.description);
+      setTransportType(initialData.transportType);
+      setCommand(initialData.command || '');
+      setArgsText((initialData.args || []).join('\n'));
+      setEnvRows(
+        initialData.env
+          ? Object.entries(initialData.env).map(([key, value]) => ({
+              key,
+              value,
+              required: value === 'XXX' ? true : undefined,
+            }))
+          : []
+      );
+      setUrl(initialData.url || '');
+      setHeaderRows(
+        initialData.headers
+          ? Object.entries(initialData.headers).map(([key, value]) => ({ key, value }))
+          : []
+      );
     } else {
       // Create mode
       setName('');
@@ -102,7 +127,7 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
     }
     setError('');
     setEnvErrors({});
-  }, [isOpen, server, registryEntry]);
+  }, [isOpen, server, registryEntry, initialData]);
 
   const handleSave = () => {
     const trimmedName = name.trim();
@@ -237,7 +262,9 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
     ? i18nService.t('editMcpServer')
     : isRegistry
       ? `${i18nService.t('mcpInstall')} ${registryEntry!.name}`
-      : i18nService.t('addMcpServer');
+      : isQuickTemplate
+        ? '添加 MCP 服务'
+        : i18nService.t('addMcpServer');
 
   // Save button text
   const saveText = isRegistry && !isEdit


### PR DESCRIPTION
### 概览

  在 MCP 模块的"自定义"标签页中新增"快速添加模版"功能，提供三个常用 MCP 服务（File
  System、SQLite、Brave
  Search）的快捷添加按钮。点击按钮后弹出预填充的表单，用户可预览和修改配置后再保存。

###  修改内容

  - McpManager.tsx:
    - 在 Custom 标签页新增"快速添加模版"区域，包含标题、提示文字和三个快捷按钮
    - 新增 handleQuickAddTemplate 函数处理模版点击，打开预填充的表单弹窗
    - 新增 quickTemplateData state 存储当前选中的模版数据
  - McpServerFormModal.tsx:
    - 新增 initialData prop 支持接收预填充数据
    - 表单初始化时根据 initialData 预填充字段
    - 为快速模版模式添加中文标题"添加 MCP 服务"

### 验证
  - 切换到"自定义"标签页，验证"快速添加模版"区域显示正确
  - 验证标题为"快速添加模版"，提示文字为"一键添加常用 MCP 服务"且位于标题右侧
  - 点击 "+ File System" 按钮，验证弹出表单且字段已预填充
  - 点击 "+ SQLite" 按钮，验证弹出表单且字段已预填充
  - 点击 "+ Brave Search" 按钮，验证弹出表单且字段已预填充，包含环境变量 BRAVE_API_KEY
  - 在预填充表单中修改配置后保存，验证 MCP 服务正确创建
  - 验证重复名称检测：尝试添加同名服务时显示错误提示
  
<img width="2324" height="1458" alt="image" src="https://github.com/user-attachments/assets/775081f7-ed43-4a4c-92be-ad34632c0d24" />
<img width="2306" height="1520" alt="image" src="https://github.com/user-attachments/assets/e1670d29-d031-48f1-9369-e54a9ccf748c" />
