### PR TITLE
feat(cowork): 聊天窗口新增悬浮「滚动到底部」按钮

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1,5 +1,6 @@
 import { ShareIcon } from '@heroicons/react/20/solid';
 import {
+  ArrowDownIcon,
   CheckIcon,
   ChevronRightIcon,
   DocumentArrowDownIcon,
@@ -1861,6 +1862,13 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     setShowConfirmDelete(false);
   };
 
+  const handleScrollToBottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+    setShouldAutoScroll(true);
+  }, []);
+
   const handleMessagesScroll = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
@@ -2380,6 +2388,20 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
           {renderConversationTurns()}
           <div className="h-20" />
         </div>
+
+        {/* Scroll to bottom FAB */}
+        <button
+          type="button"
+          onClick={handleScrollToBottom}
+          className={`absolute bottom-20 left-1/2 -translate-x-1/2 z-20 flex h-9 w-9 items-center justify-center rounded-full border border-border bg-white shadow-md transition-opacity duration-200 hover:text-foreground dark:bg-gray-700 text-secondary ${
+            shouldAutoScroll
+              ? 'opacity-0 pointer-events-none'
+              : 'opacity-100 pointer-events-auto'
+          }`}
+          aria-label="Scroll to bottom"
+        >
+          <ArrowDownIcon className="h-4 w-4" />
+        </button>
 
         {/* Turn Navigation Rail — to the left of scrollbar */}
         {turns.length > 1 && isScrollable && (


### PR DESCRIPTION
## 概述

用户在 Cowork 聊天窗口向上滚动查看历史消息后，缺少快速回到最新消息的途径。当前只有自动滚动机制（新消息到来时自动滚底），但一旦用户手动上滚后自动滚动会被禁用，只能手动拖动滚动条才能回到底部。长对话场景下这严重影响使用效率。

这是聊天类应用的标准交互模式（微信、Slack、Discord、ChatGPT 均有此功能），当前缺失。

## 改动内容

在消息区域底部中央新增一个悬浮的圆形按钮（↓ 箭头图标）：

- **显示条件**：用户向上滚动超过 `AUTO_SCROLL_THRESHOLD` 时显示（淡入），处于底部时隐藏（淡出）
- **点击行为**：`scrollTo({ top: scrollHeight, behavior: 'smooth' })` 平滑滚动到底部，同时恢复 `shouldAutoScroll = true` 确保后续新消息自动滚底
- **视觉设计**：圆形（`rounded-full`）、`h-9 w-9`、阴影（`shadow-md`）、主题适配（`bg-white dark:bg-gray-700`）
- **动画**：`transition-opacity duration-200` + `pointer-events-none/auto` 切换

## 技术方案

- **零新增状态**：完全复用已有的 `shouldAutoScroll` 状态（`handleMessagesScroll` 已经在跟踪用户是否在底部），按钮显示条件 = `!shouldAutoScroll`
- **仅修改 1 个文件**：`CoworkSessionDetail.tsx`（+22 行）
- **零新增依赖**：使用已有的 `@heroicons/react/ArrowDownIcon` 和 Tailwind CSS
- **不影响现有功能**：自动滚动、导航 Rail、消息渲染均无改动

## 按钮位置

```text
┌─────────────────────────┐
│  消息区域               │
│                         │
│  [历史消息...]          │
│                         │
│         [ ↓ ]           │  ← 悬浮按钮（absolute bottom-20）
├─────────────────────────┤
│  输入框                 │
└─────────────────────────┘
```

## 影响范围

- 仅修改 `src/renderer/components/cowork/CoworkSessionDetail.tsx`（+22 行）
- 纯 UI 展示层改动，不影响消息数据流和滚动性能逻辑
- 无新增依赖

## 测试验证

1. 向上滚动 → 按钮出现 → 点击 → 平滑滚到底部 → 按钮消失
2. 流式响应进行中 → 向上滚动 → 点击按钮 → 回到底部后自动滚动恢复
3. 切换新会话 → 按钮不显示
4. 暗色主题下按钮视觉正常