### PR TITLE
feat(cowork): AI 回复消息新增「重新生成」按钮

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { ShareIcon } from '@heroicons/react/20/solid';
 import {
+  ArrowPathIcon,
   CheckIcon,
   ChevronRightIcon,
   DocumentArrowDownIcon,
@@ -1267,11 +1268,13 @@ const AssistantMessageItem: React.FC<{
   resolveLocalFilePath?: (href: string, text: string) => string | null;
   mapDisplayText?: (value: string) => string;
   showCopyButton?: boolean;
+  onRegenerate?: () => void;
 }> = ({
   message,
   resolveLocalFilePath,
   mapDisplayText,
   showCopyButton = false,
+  onRegenerate,
 }) => {
   const [isHovered, setIsHovered] = useState(false);
   const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content;
@@ -1296,6 +1299,17 @@ const AssistantMessageItem: React.FC<{
             content={displayContent}
             visible={isHovered}
           />
+          {onRegenerate && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onRegenerate(); }}
+              className={`p-1.5 rounded-md hover:bg-surface-raised transition-all duration-200 ${
+                isHovered ? 'opacity-100' : 'opacity-0 pointer-events-none'
+              }`}
+              title={i18nService.t('regenerateResponse')}
+            >
+              <ArrowPathIcon className="w-4 h-4 text-[var(--icon-secondary)]" />
+            </button>
+          )}
         </div>
       )}
     </div>
@@ -1405,12 +1419,14 @@ export const AssistantTurnBlock: React.FC<{
   mapDisplayText?: (value: string) => string;
   showTypingIndicator?: boolean;
   showCopyButtons?: boolean;
+  onRegenerate?: () => void;
 }> = ({
   turn,
   resolveLocalFilePath,
   mapDisplayText,
   showTypingIndicator = false,
   showCopyButtons = true,
+  onRegenerate,
 }) => {
   const visibleAssistantItems = getVisibleAssistantItems(turn.assistantItems);
 
@@ -1511,6 +1527,11 @@ export const AssistantTurnBlock: React.FC<{
                   .slice(index + 1)
                   .some(laterItem => laterItem.type === 'tool_group');
 
+                // Only show regenerate on the last assistant message item in the turn
+                const isLastAssistant = !visibleAssistantItems
+                  .slice(index + 1)
+                  .some(laterItem => laterItem.type === 'assistant' && !laterItem.message.metadata?.isThinking);
+
                 return (
                   <AssistantMessageItem
                     key={item.message.id}
@@ -1518,6 +1539,7 @@ export const AssistantTurnBlock: React.FC<{
                     resolveLocalFilePath={resolveLocalFilePath}
                     mapDisplayText={mapDisplayText}
                     showCopyButton={showCopyButtons && !hasToolGroupAfter}
+                    onRegenerate={isLastAssistant && !hasToolGroupAfter ? onRegenerate : undefined}
                   />
                 );
               }
@@ -2224,6 +2246,15 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const displayItems = useMemo(() => messages ? buildDisplayItems(messages) : [], [messages]);
   const turns = useMemo(() => buildConversationTurns(displayItems), [displayItems]);
 
+  const handleRegenerate = useCallback(() => {
+    if (!turns.length) return;
+    const lastTurn = turns[turns.length - 1];
+    const userMsg = lastTurn.userMessage;
+    if (!userMsg || !userMsg.content?.trim()) return;
+    const imageAttachments = ((userMsg.metadata as CoworkMessageMetadata)?.imageAttachments ?? []) as CoworkImageAttachment[];
+    onContinue(userMsg.content, undefined, imageAttachments.length > 0 ? imageAttachments : undefined);
+  }, [turns, onContinue]);
+
   // Cache turn-level DOM elements (data-turn-index, always in DOM even for lazy turns)
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -2343,6 +2374,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 mapDisplayText={mapDisplayText}
                 showTypingIndicator={showTypingIndicator}
                 showCopyButtons={!isStreaming}
+                onRegenerate={isLastTurn && !isStreaming && !remoteManaged ? handleRegenerate : undefined}
               />
             </div>
           )}

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -19,7 +19,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: '用户',
     login: '登录',
     inDevelopment: '正在开发中',
-    
+
     // 设置
     settings: '设置',
     general: '通用',
@@ -46,7 +46,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: '主题色',
     chinese: '中文',
     english: 'English',
-    
+
     // API设置
     apiKey: 'API Key',
     apiKeyPlaceholder: '输入你的 API Key',
@@ -61,7 +61,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: '当前模型',
     availableModels: '可用模型列表',
     modelSwitchHint: '在聊天界面可以切换使用的模型',
-    
+
     // 模型提供商设置
     enabled: '已启用',
     disabled: '已禁用',
@@ -169,7 +169,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: '两次输入的密码不一致',
     passwordTooShort: '密码长度至少为4位',
     wrongPassword: '密码错误，请检查后重试',
-    
+
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
     shortcutNotSet: '未设置',
@@ -208,10 +208,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // 错误信息
     failedToLoadSettings: '加载设置失败',
     failedToSaveSettings: '保存设置失败',
-    
+
     // 加载状态
     loading: '加载中...',
-    
+
     // 侧边栏
     conversations: '对话',
     noConversations: '暂无对话',
@@ -249,13 +249,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: '工作',
     folderIconCode: '代码',
     folderIconIdea: '灵感',
-    
+
     // 聊天窗口
     sendMessage: '发送消息',
     typeMessage: '询问任何问题...',
     quickPrompt: '询问任何问题',
     regenerateResponse: '重新生成回复',
     copyToClipboard: '复制到剪贴板',
+    regenerateResponse: '重新生成',
     coworkReEdit: '重新编辑',
     messageCopied: '消息已复制',
     clearConversation: '清空对话',
@@ -279,17 +280,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: '最多上传 10 张图片',
     imageReadError: '读取图片失败',
     imageInputNotSupported: '当前模型不支持图像输入',
-    
+
     // 模型选择
     selectModel: '选择模型',
-    
+
     // 错误提示
     errorOccurred: '发生错误',
     tryAgain: '请重试',
     networkError: '网络错误',
     apiKeyRequired: '需要设置API密钥',
     configureApiKey: '请在设置中配置您的API密钥',
-    
+
     // 初始化
     initializationError: '初始化应用程序失败。请检查您的配置。',
     apiKeyNotConfigured: 'API密钥未配置。请在设置中设置您的API密钥。',
@@ -1328,7 +1329,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: 'User',
     login: 'Login',
     inDevelopment: 'In development',
-    
+
     // Settings
     settings: 'Settings',
     general: 'General',
@@ -1355,7 +1356,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: 'Color Themes',
     chinese: 'Chinese',
     english: 'English',
-    
+
     // API Settings
     apiKey: 'API Key',
     apiKeyPlaceholder: 'Enter your API Key',
@@ -1370,7 +1371,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: 'Current Model',
     availableModels: 'Available Models',
     modelSwitchHint: 'You can switch models in the chat interface',
-    
+
     // Model Provider Settings
     enabled: 'Enabled',
     disabled: 'Disabled',
@@ -1478,7 +1479,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: 'Passwords do not match',
     passwordTooShort: 'Password must be at least 4 characters',
     wrongPassword: 'Wrong password, please try again',
-    
+
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
     shortcutNotSet: 'Not set',
@@ -1517,10 +1518,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',
-    
+
     // Loading State
     loading: 'Loading...',
-    
+
     // Sidebar
     conversations: 'Conversations',
     noConversations: 'No conversations',
@@ -1558,13 +1559,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: 'Work',
     folderIconCode: 'Code',
     folderIconIdea: 'Ideas',
-    
+
     // Chat Window
     sendMessage: 'Send Message',
     typeMessage: 'Type a message...',
     quickPrompt: 'Ask anything...',
     regenerateResponse: 'Regenerate Response',
     copyToClipboard: 'Copy to Clipboard',
+    regenerateResponse: 'Regenerate',
     coworkReEdit: 'Re-edit',
     messageCopied: 'Message copied',
     clearConversation: 'Clear Conversation',
@@ -1588,17 +1590,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: 'Up to 10 images',
     imageReadError: 'Failed to read image',
     imageInputNotSupported: 'Current model does not support images',
-    
+
     // Model Selection
     selectModel: 'Select Model',
-    
+
     // Error Messages
     errorOccurred: 'An error occurred',
     tryAgain: 'Please try again',
     networkError: 'Network error',
     apiKeyRequired: 'API Key Required',
     configureApiKey: 'Please configure your API key in settings',
-    
+
     // Initialization
     initializationError: 'Failed to initialize application. Please check your configuration.',
     apiKeyNotConfigured: 'API key not configured. Please set up your API key in settings.',
@@ -2627,12 +2629,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
 class I18nService {
   private currentLanguage: LanguageType = 'zh';
   private listeners = new Set<() => void>();
-  
+
   constructor() {
     // 默认使用中文
     this.currentLanguage = 'zh';
   }
-  
+
   // 初始化语言设置
   async initialize(): Promise<void> {
     try {
@@ -2709,7 +2711,7 @@ class I18nService {
     }
     return 'en'; // 默认英文 (包括 zh-TW, zh-HK, en-*, 以及其他所有语言)
   }
-  
+
   // 设置语言
   setLanguage(language: LanguageType, options: { persist?: boolean } = {}): void {
     const { persist = true } = options;
@@ -2735,12 +2737,12 @@ class I18nService {
       console.error('Failed to save language setting:', error);
     }
   }
-  
+
   // 获取当前语言
   getLanguage(): LanguageType {
     return this.currentLanguage;
   }
-  
+
   // 获取翻译文本
   t(key: string): string {
     const translation = translations[this.currentLanguage][key];
@@ -2761,4 +2763,4 @@ class I18nService {
   }
 }
 
-export const i18nService = new I18nService(); 
+export const i18nService = new I18nService();


### PR DESCRIPTION
## 概述

在 AI 回复消息的操作栏（CopyButton 旁边）新增「重新生成」按钮。
鼠标悬停时显示，点击后重新发送最后一条用户消息，触发 AI 重新回复。

## 改动内容

### 交互设计

- 按钮位置：最后一轮 AI 回复的最后一条 assistant 消息，CopyButton 右侧
- 图标：`ArrowPathIcon`（循环箭头，来自 `@heroicons/react/24/outline`）
- 显示条件：hover 时淡入，与 CopyButton 保持一致的显隐动画
- 点击行为：取最后一轮的 `userMessage.content` 和图片附件，
  调用 `onContinue` 重新发送

### 隐藏条件

| 条件 | 是否显示 |
|------|----------|
| 最后一轮 AI 回复、非 streaming | ✅ 显示 |
| 中间轮次的 AI 回复 | ❌ 不显示 |
| streaming 进行中 | ❌ 不显示 |
| 远程管理会话（IM 来源） | ❌ 不显示 |
| 回复后还有 tool_group | ❌ 不显示（复用 CopyButton 同逻辑） |

### 多语言支持

| 语言 | 文案 |
|------|------|
| 中文 | 重新生成 |
| English | Regenerate |

## 文件改动

| 文件 | 改动 |
|------|------|
| `CoworkSessionDetail.tsx` | +30 行：导入图标、新增 props、渲染按钮、handleRegenerate |
| `i18n.ts` | +2 行：`regenerateResponse` 中英文键 |

## 技术实现

- `handleRegenerate`：从 `turns` 数组取最后一轮的 userMessage，
  连同图片附件一起传给 `onContinue`（与手动发送走同一路径）
- Props 传递链：`CoworkSessionDetail` → `AssistantTurnBlock`（仅 isLastTurn）
  → `AssistantMessageItem`（仅 isLastAssistant && !hasToolGroupAfter）
- 无新增状态变量，无新增依赖