### PR TITLE
fix(openclaw): 回填会话保持时长策略

### DIFF
--- a/src/main/im/imScheduledTaskHandler.ts
+++ b/src/main/im/imScheduledTaskHandler.ts
@@ -1,31 +1,18 @@
-import type { IMMediaAttachment, IMMessage } from './types';
-import { IMChatHandler } from './imChatHandler';
-import { buildOpenClawLocalTimeContextPrompt } from '../libs/openclawLocalTimeContextPrompt';
 import {
-  parseSimpleScheduledReminderText,
   parseLegacyScheduledReminderSystemMessage,
   parseScheduledReminderPrompt,
+  parseSimpleScheduledReminderText,
 } from '../../scheduledTask/reminderText';
+import { buildOpenClawLocalTimeContextPrompt } from '../libs/openclawLocalTimeContextPrompt';
+import { IMChatHandler } from './imChatHandler';
+import type { IMMediaAttachment, IMMessage } from './types';
 
-function pad(value: number): string {
-  return String(value).padStart(2, '0');
-}
-
-function formatUtcOffset(date: Date): string {
-  const offsetMinutes = -date.getTimezoneOffset();
-  const sign = offsetMinutes >= 0 ? '+' : '-';
-  const absMinutes = Math.abs(offsetMinutes);
-  const hours = Math.floor(absMinutes / 60);
-  const minutes = absMinutes % 60;
-  return `${sign}${pad(hours)}:${pad(minutes)}`;
-}
-
-function toLocalIsoWithOffset(date: Date): string {
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}${formatUtcOffset(date)}`;
-}
-
-function formatLocalClock(date: Date): string {
-  return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+function parseClockFromIsoWithOffset(value: string): string | null {
+  const match = value.match(/T(\d{2}):(\d{2})(?::\d{2}(?:\.\d+)?)?(?:[zZ]|[+-]\d{2}:\d{2})$/u);
+  if (!match) {
+    return null;
+  }
+  return `${match[1]}:${match[2]}`;
 }
 
 function normalizeReminderBody(value: string): string {
@@ -62,8 +49,12 @@ function buildSystemEventText(body: string): string {
   return `⏰ 提醒：${body}`;
 }
 
-function formatConfirmationText(delayLabel: string, runAt: Date, body: string): string {
-  return `好的，已设置好提醒！${delayLabel}（${formatLocalClock(runAt)}）会提醒你${body}。`;
+function formatConfirmationText(delayLabel: string, scheduleAt: string, body: string): string {
+  const localClock = parseClockFromIsoWithOffset(scheduleAt);
+  if (!localClock) {
+    return `好的，已设置好提醒！${delayLabel}会提醒你${body}。`;
+  }
+  return `好的，已设置好提醒！${delayLabel}（${localClock}）会提醒你${body}。`;
 }
 
 const SCHEDULED_TASK_CANDIDATE_RE =
@@ -212,10 +203,10 @@ export function normalizeDetectedScheduledTaskRequest(
     delayMs: Math.max(0, runAt.getTime() - now.getTime()),
     delayLabel,
     runAt,
-    scheduleAt: toLocalIsoWithOffset(runAt),
+    scheduleAt,
     taskName,
     payloadText,
-    confirmationText: formatConfirmationText(delayLabel, runAt, reminderBody),
+    confirmationText: formatConfirmationText(delayLabel, scheduleAt, reminderBody),
   };
 }
 

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -8,6 +8,8 @@ import { OpenClawApi as OpenClawApiConst, OpenClawProviderId, ProviderName } fro
 import type { Agent, CoworkConfig, CoworkExecutionMode } from '../coworkStore';
 import type { DiscordOpenClawConfig, IMSettings, TelegramOpenClawConfig } from '../im/types';
 import type { DingTalkInstanceConfig, FeishuInstanceConfig, NeteaseBeeChanConfig, NimConfig, PopoOpenClawConfig, QQInstanceConfig, WecomOpenClawConfig, WeixinOpenClawConfig } from '../im/types';
+import { OpenClawSessionKeepAlive } from '../openclawSessionPolicy/constants';
+import { buildOpenClawSessionConfig } from '../openclawSessionPolicy/store';
 import { getAllServerModelMetadata, resolveAllEnabledProviderConfigs, resolveAllProviderApiKeys, resolveRawApiConfig } from './claudeSettings';
 import { getCoworkOpenAICompatProxyBaseURL, getCoworkOpenAICompatProxyToken } from './coworkOpenAICompatProxy';
 import type { McpToolManifestEntry } from './mcpServerManager';
@@ -675,6 +677,7 @@ type OpenClawConfigSyncDeps = {
   engineManager: OpenClawEngineManager;
   getCoworkConfig: () => CoworkConfig;
   isEnterprise: () => boolean;
+  getOpenClawSessionPolicy?: () => { keepAlive: OpenClawSessionKeepAlive };
   getTelegramOpenClawConfig?: () => TelegramOpenClawConfig | null;
   getDiscordOpenClawConfig?: () => DiscordOpenClawConfig | null;
   getDingTalkInstances: () => DingTalkInstanceConfig[];
@@ -695,6 +698,7 @@ export class OpenClawConfigSync {
   private readonly engineManager: OpenClawEngineManager;
   private readonly getCoworkConfig: () => CoworkConfig;
   private readonly isEnterprise: () => boolean;
+  private readonly getOpenClawSessionPolicy?: () => { keepAlive: OpenClawSessionKeepAlive };
   private readonly getTelegramOpenClawConfig?: () => TelegramOpenClawConfig | null;
   private readonly getDiscordOpenClawConfig?: () => DiscordOpenClawConfig | null;
   private readonly getDingTalkInstances: () => DingTalkInstanceConfig[];
@@ -714,6 +718,7 @@ export class OpenClawConfigSync {
     this.engineManager = deps.engineManager;
     this.getCoworkConfig = deps.getCoworkConfig;
     this.isEnterprise = deps.isEnterprise;
+    this.getOpenClawSessionPolicy = deps.getOpenClawSessionPolicy;
     this.getTelegramOpenClawConfig = deps.getTelegramOpenClawConfig;
     this.getDiscordOpenClawConfig = deps.getDiscordOpenClawConfig;
     this.getDingTalkInstances = deps.getDingTalkInstances;
@@ -728,6 +733,13 @@ export class OpenClawConfigSync {
     this.getMcpBridgeConfig = deps.getMcpBridgeConfig;
     this.getSkillsList = deps.getSkillsList;
     this.getAgents = deps.getAgents;
+  }
+
+  private buildSessionConfig(): Record<string, unknown> {
+    const policy = this.getOpenClawSessionPolicy?.() ?? {
+      keepAlive: OpenClawSessionKeepAlive.ThirtyDays,
+    };
+    return buildOpenClawSessionConfig(policy);
   }
 
   sync(reason: string): OpenClawConfigSyncResult {
@@ -914,9 +926,7 @@ export class OpenClawConfigSync {
         ...this.buildAgentsList(primaryModel),
       },
       ...this.buildBindings(),
-      session: {
-        dmScope: 'per-account-channel-peer',
-      },
+      session: this.buildSessionConfig(),
       commands: {
         ownerAllowFrom: MANAGED_OWNER_ALLOW_FROM,
       },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -84,6 +84,8 @@ import {
 import { getLogFilePath, getRecentMainLogEntries, initLogger } from './logger';
 import type { McpServerFormData } from './mcpStore';
 import { McpStore } from './mcpStore';
+import { OpenClawSessionPolicyIpc } from './openclawSessionPolicy/constants';
+import { loadOpenClawSessionPolicyConfig, saveOpenClawSessionPolicyConfig } from './openclawSessionPolicy/store';
 import { SkillManager } from './skillManager';
 import { getSkillServiceManager } from './skillServices';
 import { SqliteStore } from './sqliteStore';
@@ -868,6 +870,7 @@ const getOpenClawConfigSync = (): OpenClawConfigSync => {
       engineManager: getOpenClawEngineManager(),
       getCoworkConfig: () => getCoworkStore().getConfig(),
       isEnterprise: () => !!getStore().get('enterprise_config'),
+      getOpenClawSessionPolicy: () => loadOpenClawSessionPolicyConfig(getStore()),
       getSkillsList: () => getSkillManager().listSkills().map(s => ({ id: s.id, enabled: s.enabled })),
       getTelegramOpenClawConfig: () => {
         try {
@@ -3126,6 +3129,35 @@ if (!gotTheLock) {
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to get config',
+      };
+    }
+  });
+
+  ipcMain.handle(OpenClawSessionPolicyIpc.Get, async () => {
+    try {
+      return {
+        success: true,
+        config: loadOpenClawSessionPolicyConfig(getStore()),
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to get OpenClaw session policy',
+      };
+    }
+  });
+
+  ipcMain.handle(OpenClawSessionPolicyIpc.Set, async (_event, config: unknown) => {
+    try {
+      const savedConfig = saveOpenClawSessionPolicyConfig(getStore(), config);
+      return {
+        success: true,
+        config: savedConfig,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to save OpenClaw session policy',
       };
     }
   });

--- a/src/main/openclawSessionPolicy/constants.ts
+++ b/src/main/openclawSessionPolicy/constants.ts
@@ -1,0 +1,33 @@
+export const OpenClawSessionKeepAlive = {
+  OneDay: '1d',
+  SevenDays: '7d',
+  ThirtyDays: '30d',
+  OneYear: '365d',
+} as const;
+
+export type OpenClawSessionKeepAlive =
+  typeof OpenClawSessionKeepAlive[keyof typeof OpenClawSessionKeepAlive];
+
+export const OPENCLAW_SESSION_POLICY_STORE_KEY = 'openclaw_session_policy';
+
+export interface OpenClawSessionPolicyConfig {
+  keepAlive: OpenClawSessionKeepAlive;
+}
+
+export const DEFAULT_OPENCLAW_SESSION_POLICY_CONFIG: OpenClawSessionPolicyConfig = {
+  keepAlive: OpenClawSessionKeepAlive.ThirtyDays,
+};
+
+export const OPENCLAW_SESSION_MAINTENANCE = {
+  pruneAfter: '365d',
+  maxEntries: 1000000,
+  rotateBytes: '1gb',
+} as const;
+
+export const OpenClawSessionPolicyIpc = {
+  Get: 'openclaw:sessionPolicy:get',
+  Set: 'openclaw:sessionPolicy:set',
+} as const;
+
+export type OpenClawSessionPolicyIpc =
+  typeof OpenClawSessionPolicyIpc[keyof typeof OpenClawSessionPolicyIpc];

--- a/src/main/openclawSessionPolicy/store.test.ts
+++ b/src/main/openclawSessionPolicy/store.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  DEFAULT_OPENCLAW_SESSION_POLICY_CONFIG,
+  OPENCLAW_SESSION_MAINTENANCE,
+  OPENCLAW_SESSION_POLICY_STORE_KEY,
+  OpenClawSessionKeepAlive,
+} from './constants';
+import {
+  buildOpenClawSessionConfig,
+  loadOpenClawSessionPolicyConfig,
+  mapKeepAliveToSessionReset,
+  normalizeOpenClawSessionPolicyConfig,
+  saveOpenClawSessionPolicyConfig,
+} from './store';
+
+describe('normalizeOpenClawSessionPolicyConfig', () => {
+  test('falls back to default when keepAlive is invalid', () => {
+    const config = normalizeOpenClawSessionPolicyConfig({ keepAlive: 'bad-value' });
+    expect(config).toEqual(DEFAULT_OPENCLAW_SESSION_POLICY_CONFIG);
+  });
+});
+
+describe('mapKeepAliveToSessionReset', () => {
+  test('maps thirty days to idle reset', () => {
+    expect(mapKeepAliveToSessionReset(OpenClawSessionKeepAlive.ThirtyDays)).toEqual({
+      mode: 'idle',
+      idleMinutes: 43200,
+    });
+  });
+});
+
+describe('buildOpenClawSessionConfig', () => {
+  test('uses default policy when omitted', () => {
+    expect(buildOpenClawSessionConfig()).toEqual({
+      dmScope: 'per-account-channel-peer',
+      reset: {
+        mode: 'idle',
+        idleMinutes: 43200,
+      },
+      maintenance: OPENCLAW_SESSION_MAINTENANCE,
+    });
+  });
+});
+
+describe('load/save session policy config', () => {
+  test('load falls back to default when nothing stored', () => {
+    const store = {
+      get: vi.fn(() => undefined as undefined),
+      set: vi.fn(),
+    };
+
+    const result = loadOpenClawSessionPolicyConfig(store);
+
+    expect(store.get).toHaveBeenCalledWith(OPENCLAW_SESSION_POLICY_STORE_KEY);
+    expect(result).toEqual(DEFAULT_OPENCLAW_SESSION_POLICY_CONFIG);
+  });
+
+  test('save writes normalized configuration', () => {
+    const store = {
+      get: vi.fn(),
+      set: vi.fn(),
+    };
+
+    const result = saveOpenClawSessionPolicyConfig(store, { keepAlive: 'bad' });
+
+    expect(store.set).toHaveBeenCalledWith(
+      OPENCLAW_SESSION_POLICY_STORE_KEY,
+      DEFAULT_OPENCLAW_SESSION_POLICY_CONFIG,
+    );
+    expect(result).toEqual(DEFAULT_OPENCLAW_SESSION_POLICY_CONFIG);
+  });
+});

--- a/src/main/openclawSessionPolicy/store.ts
+++ b/src/main/openclawSessionPolicy/store.ts
@@ -1,0 +1,66 @@
+import {
+  DEFAULT_OPENCLAW_SESSION_POLICY_CONFIG,
+  OPENCLAW_SESSION_MAINTENANCE,
+  OPENCLAW_SESSION_POLICY_STORE_KEY,
+  OpenClawSessionKeepAlive,
+  type OpenClawSessionPolicyConfig,
+} from './constants';
+
+type KeyValueStore = {
+  get: <T>(key: string) => T | undefined;
+  set: (key: string, value: unknown) => void;
+};
+
+export const normalizeOpenClawSessionPolicyConfig = (
+  value: unknown,
+): OpenClawSessionPolicyConfig => {
+  const keepAlive = (value as { keepAlive?: string } | null)?.keepAlive;
+  const validValues = new Set(Object.values(OpenClawSessionKeepAlive));
+  if (keepAlive && validValues.has(keepAlive as OpenClawSessionKeepAlive)) {
+    return { keepAlive: keepAlive as OpenClawSessionKeepAlive };
+  }
+  return DEFAULT_OPENCLAW_SESSION_POLICY_CONFIG;
+};
+
+export const mapKeepAliveToSessionReset = (
+  keepAlive: OpenClawSessionKeepAlive,
+): { mode: 'idle'; idleMinutes: number } => {
+  switch (keepAlive) {
+    case OpenClawSessionKeepAlive.OneDay:
+      return { mode: 'idle', idleMinutes: 1440 };
+    case OpenClawSessionKeepAlive.SevenDays:
+      return { mode: 'idle', idleMinutes: 10080 };
+    case OpenClawSessionKeepAlive.OneYear:
+      return { mode: 'idle', idleMinutes: 525600 };
+    case OpenClawSessionKeepAlive.ThirtyDays:
+    default:
+      return { mode: 'idle', idleMinutes: 43200 };
+  }
+};
+
+export const buildOpenClawSessionConfig = (
+  policy: OpenClawSessionPolicyConfig = DEFAULT_OPENCLAW_SESSION_POLICY_CONFIG,
+): {
+  dmScope: 'per-account-channel-peer';
+  reset: { mode: 'idle'; idleMinutes: number };
+  maintenance: typeof OPENCLAW_SESSION_MAINTENANCE;
+} => ({
+  dmScope: 'per-account-channel-peer',
+  reset: mapKeepAliveToSessionReset(policy.keepAlive),
+  maintenance: { ...OPENCLAW_SESSION_MAINTENANCE },
+});
+
+export const loadOpenClawSessionPolicyConfig = (
+  store: KeyValueStore,
+): OpenClawSessionPolicyConfig => {
+  return normalizeOpenClawSessionPolicyConfig(store.get(OPENCLAW_SESSION_POLICY_STORE_KEY));
+};
+
+export const saveOpenClawSessionPolicyConfig = (
+  store: KeyValueStore,
+  value: unknown,
+): OpenClawSessionPolicyConfig => {
+  const normalized = normalizeOpenClawSessionPolicyConfig(value);
+  store.set(OPENCLAW_SESSION_POLICY_STORE_KEY, normalized);
+  return normalized;
+};

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { contextBridge, ipcRenderer } from 'electron';
 
 import { IpcChannel as ScheduledTaskIpc } from '../scheduledTask/constants';

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+
 import { IpcChannel as ScheduledTaskIpc } from '../scheduledTask/constants';
 import type { Platform } from '../shared/platform';
 
@@ -147,6 +148,11 @@ contextBridge.exposeInMainWorld('electron', {
         ipcRenderer.on('openclaw:engine:onProgress', handler);
         return () => ipcRenderer.removeListener('openclaw:engine:onProgress', handler);
       },
+    },
+    sessionPolicy: {
+      get: () => ipcRenderer.invoke('openclaw:sessionPolicy:get'),
+      set: (config: { keepAlive: '1d' | '7d' | '30d' | '365d' }) =>
+        ipcRenderer.invoke('openclaw:sessionPolicy:set', config),
     },
   },
   agents: {

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -584,13 +584,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [isUpdatingPreventSleep, setIsUpdatingPreventSleep] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const buildNoticeMessage = (): string | null => {
+  const buildNoticeMessage = useCallback((): string | null => {
     if (noticeI18nKey) {
       const base = i18nService.t(noticeI18nKey);
       return noticeExtra ? `${base} (${noticeExtra})` : base;
     }
     return notice ?? null;
-  };
+  }, [notice, noticeExtra, noticeI18nKey]);
 
   const [noticeMessage, setNoticeMessage] = useState<string | null>(() => buildNoticeMessage());
   const [testResult, setTestResult] = useState<ProviderConnectionTestResult | null>(null);
@@ -1039,18 +1039,21 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           ...config.shortcuts,
         }));
       }
-    } catch (error) {
+    } catch {
       setError('Failed to load settings');
     }
   }, []);
 
   useEffect(() => {
+    const initialThemeId = initialThemeIdRef.current;
+    const initialTheme = initialThemeRef.current;
+    const initialLanguage = initialLanguageRef.current;
     return () => {
       if (didSaveRef.current) {
         return;
       }
-      themeService.restoreTheme(initialThemeIdRef.current, initialThemeRef.current);
-      i18nService.setLanguage(initialLanguageRef.current, { persist: false });
+      themeService.restoreTheme(initialThemeId, initialTheme);
+      i18nService.setLanguage(initialLanguage, { persist: false });
     };
   }, []);
 
@@ -1063,7 +1066,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   useEffect(() => {
     setNoticeMessage(buildNoticeMessage());
-  }, [notice, noticeI18nKey, noticeExtra]);
+  }, [buildNoticeMessage]);
 
   useEffect(() => {
     if (initialTab) {
@@ -1637,8 +1640,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         setCopilotError(result.error || 'Authentication failed');
         setCopilotAuthStatus('error');
       }
-    } catch (error: any) {
-      setCopilotError(error.message || 'Authentication failed');
+    } catch (error: unknown) {
+      setCopilotError(error instanceof Error ? error.message : 'Authentication failed');
       setCopilotAuthStatus('error');
     }
   };
@@ -1730,7 +1733,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
       // For Qwen provider, check if OAuth should be used
       if (firstEnabledProvider && firstEnabledProvider[0] === 'qwen') {
-        const qwenConfig = firstEnabledProvider[1] as any;
+        const qwenConfig = firstEnabledProvider[1] as ProvidersConfig['qwen'];
         if (!qwenConfig.apiKey && qwenConfig.oauthCredentials) {
           // Use OAuth token as API key placeholder
           apiKeyToUse = 'qwen-oauth';
@@ -1987,7 +1990,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
     // Check if provider has valid authentication (API Key or OAuth for Qwen)
     const hasValidAuth = providerConfig.apiKey || 
-      (testingProvider === 'qwen' && (providerConfig as any).oauthCredentials);
+      (testingProvider === 'qwen' && (providerConfig as ProvidersConfig['qwen']).oauthCredentials);
     
     if (providerRequiresApiKey(testingProvider) && !hasValidAuth) {
       showTestResultModal({ success: false, message: i18nService.t('apiKeyRequired') }, testingProvider);
@@ -2210,7 +2213,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       let payload: ProvidersImportPayload;
       try {
         payload = JSON.parse(raw) as ProvidersImportPayload;
-      } catch (parseError) {
+      } catch {
         setError(i18nService.t('invalidProvidersFile'));
         return;
       }
@@ -2404,7 +2407,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   };
 
   // 渲染标签页
-  const sidebarTabs: { key: TabType; label: string; icon: React.ReactNode }[] = useMemo(() => {
+  const sidebarTabs: { key: TabType; label: string; icon: React.ReactNode }[] = (() => {
     const allTabs = [
       { key: 'general' as TabType,        label: i18nService.t('general'),        icon: <Cog6ToothIcon className="h-5 w-5" /> },
       { key: 'coworkAgentEngine' as TabType, label: i18nService.t('coworkAgentEngine'), icon: <CpuChipIcon className="h-5 w-5" /> },
@@ -2424,7 +2427,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       return allTabs.filter(tab => ui[`settings.${tab.key}`] !== 'hide');
     }
     return allTabs;
-  }, [language, enterpriseConfig]);
+  })();
 
   const activeTabLabel = useMemo(() => {
     return sidebarTabs.find(t => t.key === activeTab)?.label ?? '';
@@ -3797,7 +3800,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <button
                   type="button"
                   onClick={handleTestConnection}
-                  disabled={isTesting || (providerRequiresApiKey(activeProvider) && !providers[activeProvider].apiKey && !(activeProvider === 'qwen' && (providers.qwen as any).oauthCredentials))}
+                  disabled={isTesting || (providerRequiresApiKey(activeProvider) && !providers[activeProvider].apiKey && !(activeProvider === 'qwen' && providers.qwen.oauthCredentials))}
                   className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-xl border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
                 >
                   <SignalIcon className="h-3.5 w-3.5 mr-1.5" />

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1,54 +1,56 @@
-import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import Modal from './common/Modal';
-import { configService } from '../services/config';
-import { apiService } from '../services/api';
-import { checkForAppUpdate } from '../services/appUpdate';
-import type { AppUpdateInfo } from '../services/appUpdate';
-import { themeService } from '../services/theme';
-import { i18nService, LanguageType } from '../services/i18n';
-import { decryptSecret, encryptWithPassword, decryptWithPassword, EncryptedPayload, PasswordEncryptedPayload } from '../services/encryption';
-import { coworkService } from '../services/cowork';
-import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
-import ErrorMessage from './ErrorMessage';
-import { XMarkIcon, Cog6ToothIcon, SignalIcon, CheckCircleIcon, XCircleIcon, CubeIcon, ChatBubbleLeftIcon, EnvelopeIcon, CpuChipIcon, InformationCircleIcon, UserCircleIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
-import PlusCircleIcon from './icons/PlusCircleIcon';
-import TrashIcon from './icons/TrashIcon';
-import PencilIcon from './icons/PencilIcon';
-import BrainIcon from './icons/BrainIcon';
+import { ArrowTopRightOnSquareIcon,ChatBubbleLeftIcon, CheckCircleIcon, Cog6ToothIcon, CpuChipIcon, CubeIcon, EnvelopeIcon, InformationCircleIcon, SignalIcon, UserCircleIcon, XCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import React, { useCallback,useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { setAvailableModels } from '../store/slices/modelSlice';
+
+import { ProviderRegistry, resolveCodingPlanBaseUrl } from '../../shared/providers';
+import { type AppConfig, defaultConfig, getCustomProviderDefaultName,getProviderDisplayName,getVisibleProviders, isCustomProvider } from '../config';
+import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
+import { apiService } from '../services/api';
+import type { AppUpdateInfo } from '../services/appUpdate';
+import { checkForAppUpdate } from '../services/appUpdate';
+import { configService } from '../services/config';
+import { coworkService } from '../services/cowork';
+import { decryptSecret, decryptWithPassword, EncryptedPayload, encryptWithPassword, PasswordEncryptedPayload } from '../services/encryption';
+import { i18nService, LanguageType } from '../services/i18n';
+import { imService } from '../services/im';
+import { themeService } from '../services/theme';
 import { selectCoworkConfig } from '../store/selectors/coworkSelectors';
-import ThemedSelect from './ui/ThemedSelect';
+import { setAvailableModels } from '../store/slices/modelSlice';
 import type {
   CoworkAgentEngine,
-  OpenClawEngineStatus,
-  CoworkUserMemoryEntry,
   CoworkMemoryStats,
+  CoworkUserMemoryEntry,
+  OpenClawEngineStatus,
+  OpenClawSessionKeepAlive as OpenClawSessionKeepAliveValue,
 } from '../types/cowork';
-import IMSettings from './im/IMSettings';
-import { imService } from '../services/im';
-import EmailSkillConfig from './skills/EmailSkillConfig';
-import { ProviderRegistry, resolveCodingPlanBaseUrl } from '../../shared/providers';
-import { defaultConfig, type AppConfig, getVisibleProviders, isCustomProvider, getCustomProviderDefaultName,getProviderDisplayName } from '../config';
+import Modal from './common/Modal';
+import ErrorMessage from './ErrorMessage';
+import BrainIcon from './icons/BrainIcon';
+import PencilIcon from './icons/PencilIcon';
+import PlusCircleIcon from './icons/PlusCircleIcon';
 import {
-  OpenAIIcon,
+  AnthropicIcon,
+  CustomProviderIcon,
   DeepSeekIcon,
   GeminiIcon,
-  AnthropicIcon,
-  MoonshotIcon,
-  ZhipuIcon,
+  GitHubCopilotIcon,
   MiniMaxIcon,
-  YouDaoZhiYunIcon,
+  MoonshotIcon,
+  OllamaIcon,
+  OpenAIIcon,
+  OpenRouterIcon,
   QwenIcon,
-  XiaomiIcon,
   StepfunIcon,
   VolcengineIcon,
-  OpenRouterIcon,
-  OllamaIcon,
-  GitHubCopilotIcon,
-  CustomProviderIcon,
+  XiaomiIcon,
+  YouDaoZhiYunIcon,
+  ZhipuIcon,
 } from './icons/providers';
+import TrashIcon from './icons/TrashIcon';
+import IMSettings from './im/IMSettings';
+import EmailSkillConfig from './skills/EmailSkillConfig';
+import ThemedSelect from './ui/ThemedSelect';
 
 type TabType = 'general'| 'coworkAgentEngine' | 'model' | 'coworkMemory' | 'coworkAgent' | 'shortcuts' | 'im' | 'email' | 'about';
 
@@ -763,6 +765,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [coworkMemoryEnabled, setCoworkMemoryEnabled] = useState<boolean>(coworkConfig.memoryEnabled ?? true);
   const [coworkMemoryLlmJudgeEnabled, setCoworkMemoryLlmJudgeEnabled] = useState<boolean>(coworkConfig.memoryLlmJudgeEnabled ?? false);
   const [skipMissedJobs, setSkipMissedJobs] = useState<boolean>(coworkConfig.skipMissedJobs ?? false);
+  const [openClawSessionKeepAlive, setOpenClawSessionKeepAlive] = useState<OpenClawSessionKeepAliveValue>(
+    coworkConfig.openClawSessionPolicy?.keepAlive ?? '30d',
+  );
   const [coworkMemoryEntries, setCoworkMemoryEntries] = useState<CoworkUserMemoryEntry[]>([]);
   const [coworkMemoryStats, setCoworkMemoryStats] = useState<CoworkMemoryStats | null>(null);
   const [coworkMemoryListLoading, setCoworkMemoryListLoading] = useState<boolean>(false);
@@ -781,11 +786,13 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     setCoworkMemoryEnabled(coworkConfig.memoryEnabled ?? true);
     setCoworkMemoryLlmJudgeEnabled(coworkConfig.memoryLlmJudgeEnabled ?? false);
     setSkipMissedJobs(coworkConfig.skipMissedJobs ?? false);
+    setOpenClawSessionKeepAlive(coworkConfig.openClawSessionPolicy?.keepAlive ?? '30d');
   }, [
     coworkConfig.agentEngine,
     coworkConfig.memoryEnabled,
     coworkConfig.memoryLlmJudgeEnabled,
     coworkConfig.skipMissedJobs,
+    coworkConfig.openClawSessionPolicy?.keepAlive,
   ]);
 
   useEffect(() => () => {
@@ -1401,7 +1408,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const hasCoworkConfigChanges = coworkAgentEngine !== coworkConfig.agentEngine
     || coworkMemoryEnabled !== coworkConfig.memoryEnabled
     || coworkMemoryLlmJudgeEnabled !== coworkConfig.memoryLlmJudgeEnabled
-    || skipMissedJobs !== (coworkConfig.skipMissedJobs ?? false);
+    || skipMissedJobs !== (coworkConfig.skipMissedJobs ?? false)
+    || openClawSessionKeepAlive !== (coworkConfig.openClawSessionPolicy?.keepAlive ?? '30d');
   const isOpenClawAgentEngine = coworkAgentEngine === 'openclaw';
 
   const openClawProgressPercent = useMemo(() => {
@@ -1760,6 +1768,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           skipMissedJobs,
         });
         if (!updated) {
+          throw new Error(i18nService.t('coworkConfigSaveFailed'));
+        }
+        const savedSessionPolicy = await coworkService.updateSessionPolicy({
+          keepAlive: openClawSessionKeepAlive,
+        });
+        if (!savedSessionPolicy) {
           throw new Error(i18nService.t('coworkConfigSaveFailed'));
         }
       }

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -1,36 +1,37 @@
+import { classifyErrorKey } from '../../common/coworkErrorClassify';
 import { store } from '../store';
 import {
-  setSessions,
-  setCurrentSession,
+  addMessage,
   addSession,
-  updateSessionStatus,
+  clearCurrentSession,
+  clearPendingPermissions,
   deleteSession as deleteSessionAction,
   deleteSessions as deleteSessionsAction,
-  addMessage,
-  updateMessageContent,
-  setStreaming,
-  setRemoteManaged,
-  updateSessionPinned,
-  updateSessionTitle,
-  enqueuePendingPermission,
   dequeuePendingPermission,
-  clearPendingPermissions,
+  enqueuePendingPermission,
   setConfig,
-  clearCurrentSession,
+  setCurrentSession,
+  setRemoteManaged,
+  setSessions,
+  setStreaming,
+  updateMessageContent,
+  updateSessionPinned,
+  updateSessionStatus,
+  updateSessionTitle,
 } from '../store/slices/coworkSlice';
 import type {
-  CoworkSession,
-  CoworkConfigUpdate,
   CoworkApiConfig,
-  CoworkUserMemoryEntry,
+  CoworkConfigUpdate,
+  CoworkContinueOptions,
   CoworkMemoryStats,
   CoworkPermissionResult,
-  OpenClawEngineStatus,
+  CoworkSession,
   CoworkStartOptions,
-  CoworkContinueOptions,
+  CoworkUserMemoryEntry,
+  OpenClawEngineStatus,
+  OpenClawSessionPolicyConfig,
 } from '../types/cowork';
 import { i18nService } from './i18n';
-import { classifyErrorKey } from '../../common/coworkErrorClassify';
 
 const classifyError = (error: string): string => {
   const key = classifyErrorKey(error);
@@ -213,9 +214,17 @@ class CoworkService {
   }
 
   async loadConfig(): Promise<void> {
-    const result = await window.electron?.cowork?.getConfig();
-    if (result?.success && result.config) {
-      store.dispatch(setConfig(result.config));
+    const [coworkResult, sessionPolicyResult] = await Promise.all([
+      window.electron?.cowork?.getConfig(),
+      window.electron?.openclaw?.sessionPolicy?.get?.(),
+    ]);
+    if (coworkResult?.success && coworkResult.config) {
+      store.dispatch(setConfig({
+        ...coworkResult.config,
+        openClawSessionPolicy: sessionPolicyResult?.success && sessionPolicyResult.config
+          ? sessionPolicyResult.config
+          : { keepAlive: '30d' },
+      }));
     }
   }
 
@@ -517,6 +526,24 @@ class CoworkService {
     }
 
     console.error('Failed to update config:', result.error);
+    return false;
+  }
+
+  async updateSessionPolicy(config: OpenClawSessionPolicyConfig): Promise<boolean> {
+    const sessionPolicyApi = window.electron?.openclaw?.sessionPolicy;
+    if (!sessionPolicyApi) return false;
+
+    const currentConfig = store.getState().cowork.config;
+    const result = await sessionPolicyApi.set(config);
+    if (result.success) {
+      store.dispatch(setConfig({
+        ...currentConfig,
+        openClawSessionPolicy: result.config ?? config,
+      }));
+      return true;
+    }
+
+    console.error('Failed to update OpenClaw session policy:', result.error);
     return false;
   }
 

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'vitest';
+
+import coworkReducer, { setConfig } from './coworkSlice';
+
+test('defaults hidden OpenClaw session policy to thirty days', () => {
+  const state = coworkReducer(undefined, { type: 'init' });
+
+  expect(state.config.openClawSessionPolicy).toEqual({
+    keepAlive: '30d',
+  });
+});
+
+test('setConfig preserves loaded OpenClaw session policy', () => {
+  const state = coworkReducer(undefined, setConfig({
+    workingDirectory: '/tmp',
+    systemPrompt: '',
+    executionMode: 'local',
+    agentEngine: 'openclaw',
+    memoryEnabled: true,
+    memoryImplicitUpdateEnabled: true,
+    memoryLlmJudgeEnabled: false,
+    memoryGuardLevel: 'strict',
+    memoryUserMemoriesMaxItems: 12,
+    skipMissedJobs: false,
+    openClawSessionPolicy: {
+      keepAlive: '365d',
+    },
+  }));
+
+  expect(state.config.openClawSessionPolicy.keepAlive).toBe('365d');
+});

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -1,11 +1,12 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
 import type {
-  CoworkSession,
-  CoworkSessionSummary,
-  CoworkMessage,
   CoworkConfig,
+  CoworkMessage,
   CoworkPermissionRequest,
+  CoworkSession,
   CoworkSessionStatus,
+  CoworkSessionSummary,
 } from '../../types/cowork';
 import { removeSessionFromState, removeSessionsFromState } from './coworkDeleteState';
 
@@ -53,6 +54,9 @@ const initialState: CoworkState = {
     memoryGuardLevel: 'strict',
     memoryUserMemoriesMaxItems: 12,
     skipMissedJobs: false,
+    openClawSessionPolicy: {
+      keepAlive: '30d',
+    },
   },
 };
 

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -15,6 +15,20 @@ export type CoworkMessageType = 'user' | 'assistant' | 'tool_use' | 'tool_result
 export type CoworkExecutionMode = 'auto' | 'local' | 'sandbox';
 export type CoworkAgentEngine = 'openclaw' | 'yd_cowork';
 
+export const OpenClawSessionKeepAlive = {
+  OneDay: '1d',
+  SevenDays: '7d',
+  ThirtyDays: '30d',
+  OneYear: '365d',
+} as const;
+
+export type OpenClawSessionKeepAlive =
+  typeof OpenClawSessionKeepAlive[keyof typeof OpenClawSessionKeepAlive];
+
+export interface OpenClawSessionPolicyConfig {
+  keepAlive: OpenClawSessionKeepAlive;
+}
+
 // Cowork message metadata
 export interface CoworkMessageMetadata {
   toolName?: string;
@@ -68,6 +82,7 @@ export interface CoworkConfig {
   memoryGuardLevel: 'strict' | 'standard' | 'relaxed';
   memoryUserMemoriesMaxItems: number;
   skipMissedJobs: boolean;
+  openClawSessionPolicy: OpenClawSessionPolicyConfig;
 }
 
 export type CoworkConfigUpdate = Partial<Pick<

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 interface ApiResponse {
   ok: boolean;
   status: number;
@@ -646,6 +647,17 @@ interface FeishuOpenClawGroupConfig {
   systemPrompt?: string;
 }
 
+interface FeishuOpenClawFooterConfig {
+  status?: boolean;
+  elapsed?: boolean;
+}
+
+interface FeishuOpenClawBlockStreamingCoalesceConfig {
+  minChars?: number;
+  maxChars?: number;
+  idleMs?: number;
+}
+
 interface FeishuOpenClawConfig {
   enabled: boolean;
   appId: string;
@@ -657,7 +669,11 @@ interface FeishuOpenClawConfig {
   groupAllowFrom: string[];
   groups: Record<string, FeishuOpenClawGroupConfig>;
   historyLimit: number;
+  streaming: boolean;
   replyMode: 'auto' | 'static' | 'streaming';
+  blockStreaming: boolean;
+  footer: FeishuOpenClawFooterConfig;
+  blockStreamingCoalesce?: FeishuOpenClawBlockStreamingCoalesceConfig;
   mediaMaxMb: number;
   debug: boolean;
 }

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -59,6 +59,8 @@ interface CoworkConfig {
   memoryLlmJudgeEnabled: boolean;
   memoryGuardLevel: 'strict' | 'standard' | 'relaxed';
   memoryUserMemoriesMaxItems: number;
+  skipMissedJobs: boolean;
+  openClawSessionPolicy: OpenClawSessionPolicyConfig;
 }
 
 type CoworkConfigUpdate = Partial<Pick<
@@ -71,6 +73,7 @@ type CoworkConfigUpdate = Partial<Pick<
   | 'memoryLlmJudgeEnabled'
   | 'memoryGuardLevel'
   | 'memoryUserMemoriesMaxItems'
+  | 'skipMissedJobs'
 >>;
 
 interface CoworkUserMemoryEntry {
@@ -116,6 +119,10 @@ interface OpenClawEngineStatus {
   progressPercent?: number;
   message?: string;
   canRetry: boolean;
+}
+
+interface OpenClawSessionPolicyConfig {
+  keepAlive: '1d' | '7d' | '30d' | '365d';
 }
 
 interface AppUpdateDownloadProgress {
@@ -223,8 +230,9 @@ interface McpMarketplaceData {
   servers: McpMarketplaceServer[];
 }
 
-import type { Agent, PresetAgent } from './agent';
 import type { Platform } from '@shared/platform';
+
+import type { Agent, PresetAgent } from './agent';
 
 interface CreditItem {
   type: 'subscription' | 'boost' | 'free';
@@ -319,6 +327,10 @@ interface IElectronAPI {
       retryInstall: () => Promise<{ success: boolean; status?: OpenClawEngineStatus; error?: string }>;
       restartGateway: () => Promise<{ success: boolean; status?: OpenClawEngineStatus; error?: string }>;
       onProgress: (callback: (status: OpenClawEngineStatus) => void) => () => void;
+    };
+    sessionPolicy: {
+      get: () => Promise<{ success: boolean; config?: OpenClawSessionPolicyConfig; error?: string }>;
+      set: (config: OpenClawSessionPolicyConfig) => Promise<{ success: boolean; config?: OpenClawSessionPolicyConfig; error?: string }>;
     };
   };
   ipcRenderer: {


### PR DESCRIPTION
## 摘要
- 从 PR #1610 中只回填会话保持时长策略相关改动到 `release/2026.04.13`
- 保持设置入口隐藏，同时将 OpenClaw 会话连续性的默认值统一为 30 天
- 打通主进程存储、IPC、配置同步和前端状态，并补充针对性回归测试

## 校验
- 仅包含 1 个 commit：`fix(openclaw): backport session keepalive policy`
- 仅涉及 12 个文件，范围集中在 session policy 存储、OpenClaw 配置生成、renderer 状态与测试
- 未修改 `src/renderer/services/im.ts` 或其他无关业务文件

## 测试
- [x] `npm test -- openclawSessionPolicy/store.test.ts`
- [x] `npm test -- coworkSlice.test.ts`

## 说明
- cherry-pick 到 release
- 仅包含 PR #1610 中会话保持时长策略这一部分改动