### PR TITLE
fix(i18n): 修复多处按钮 tooltip 硬编码英文未国际化

### DIFF
--- a/src/renderer/components/cowork/CoworkPermissionModal.tsx
+++ b/src/renderer/components/cowork/CoworkPermissionModal.tsx
@@ -363,7 +363,7 @@ const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({
           <button
             onClick={handleDeny}
             className="p-2 rounded-lg hover:bg-surface-raised text-secondary transition-colors"
-            aria-label="Close"
+            aria-label={i18nService.t('close')}
           >
             <XMarkIcon className="h-5 w-5" />
           </button>

--- a/src/renderer/components/im/SchemaForm.tsx
+++ b/src/renderer/components/im/SchemaForm.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import i18nService from '../../services/i18n';
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
 import { XCircleIcon as XCircleIconSolid, ChevronRightIcon } from '@heroicons/react/20/solid';
 
@@ -176,7 +177,7 @@ export const SchemaForm: React.FC<SchemaFormProps> = ({
                   type="button"
                   onClick={() => handleChange('')}
                   className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                  title="Clear"
+                  title={i18nService.t('clear')}
                 >
                   <XCircleIconSolid className="h-4 w-4" />
                 </button>
@@ -216,7 +217,7 @@ export const SchemaForm: React.FC<SchemaFormProps> = ({
                   type="button"
                   onClick={() => handleChange('')}
                   className="p-0.5 rounded text-secondary hover:text-primary transition-colors"
-                  title="Clear"
+                  title={i18nService.t('clear')}
                 >
                   <XCircleIconSolid className="h-4 w-4" />
                 </button>

--- a/src/renderer/components/skills/SkillsButton.tsx
+++ b/src/renderer/components/skills/SkillsButton.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import PuzzleIcon from '../icons/PuzzleIcon';
 import SkillsPopover from './SkillsPopover';
 import { Skill } from '../../types/skill';
+import i18nService from '../../services/i18n';
 
 interface SkillsButtonProps {
   onSelectSkill: (skill: Skill) => void;
@@ -32,7 +33,7 @@ const SkillsButton: React.FC<SkillsButtonProps> = ({
         type="button"
         onClick={handleButtonClick}
         className={`p-2 rounded-xl bg-surface text-secondary hover:text-primary dark:hover:text-primary hover:bg-surface-raised transition-colors ${className}`}
-        title="Skills"
+        title={i18nService.t('skills')}
       >
         <PuzzleIcon className="h-5 w-5" />
       </button>

--- a/src/renderer/components/window/WindowTitleBar.tsx
+++ b/src/renderer/components/window/WindowTitleBar.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import i18nService from '../../services/i18n';
 
 interface WindowTitleBarProps {
   isOverlayActive?: boolean;
@@ -95,8 +96,8 @@ const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
         type="button"
         onClick={handleMinimize}
         className="non-draggable h-8 w-8 inline-flex items-center justify-center rounded-lg transition-colors text-secondary hover:hover:bg-surface-raised"
-        aria-label="Minimize"
-        title="Minimize"
+        aria-label={i18nService.t('minimize')}
+        title={i18nService.t('minimize')}
       >
         <svg viewBox="0 0 12 12" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
           <path d="M2 6h8" />
@@ -106,8 +107,8 @@ const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
         type="button"
         onClick={handleToggleMaximize}
         className="non-draggable h-8 w-8 inline-flex items-center justify-center rounded-lg transition-colors text-secondary hover:hover:bg-surface-raised"
-        aria-label={state.isMaximized ? 'Restore' : 'Maximize'}
-        title={state.isMaximized ? 'Restore' : 'Maximize'}
+        aria-label={state.isMaximized ? i18nService.t('restore') : i18nService.t('maximize')}
+        title={state.isMaximized ? i18nService.t('restore') : i18nService.t('maximize')}
       >
         {state.isMaximized ? (
           <svg viewBox="0 0 12 12" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
@@ -124,8 +125,8 @@ const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
         type="button"
         onClick={handleClose}
         className="non-draggable h-8 w-8 inline-flex items-center justify-center rounded-lg transition-colors text-secondary hover:bg-red-500 hover:text-white dark:hover:bg-red-500"
-        aria-label="Close"
-        title="Close"
+        aria-label={i18nService.t('close')}
+        title={i18nService.t('close')}
       >
         <svg viewBox="0 0 12 12" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
           <path d="M3 3l6 6" />

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -19,7 +19,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: '用户',
     login: '登录',
     inDevelopment: '正在开发中',
-    
+
     // 设置
     settings: '设置',
     general: '通用',
@@ -46,7 +46,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: '主题色',
     chinese: '中文',
     english: 'English',
-    
+
     // API设置
     apiKey: 'API Key',
     apiKeyPlaceholder: '输入你的 API Key',
@@ -61,7 +61,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: '当前模型',
     availableModels: '可用模型列表',
     modelSwitchHint: '在聊天界面可以切换使用的模型',
-    
+
     // 模型提供商设置
     enabled: '已启用',
     disabled: '已禁用',
@@ -169,7 +169,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: '两次输入的密码不一致',
     passwordTooShort: '密码长度至少为4位',
     wrongPassword: '密码错误，请检查后重试',
-    
+
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
     shortcutNotSet: '未设置',
@@ -179,6 +179,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     sendMessageShortcut: '发送消息',
     shortcutConflict: '快捷键 "{0}" 已被 "{1}" 使用',
     close: '关闭',
+    minimize: '最小化',
+    maximize: '最大化',
+    restore: '还原',
     loginNotAvailable: '登录功能暂未开放',
     collapse: '收起',
     expand: '展开',
@@ -208,10 +211,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // 错误信息
     failedToLoadSettings: '加载设置失败',
     failedToSaveSettings: '保存设置失败',
-    
+
     // 加载状态
     loading: '加载中...',
-    
+
     // 侧边栏
     conversations: '对话',
     noConversations: '暂无对话',
@@ -249,7 +252,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: '工作',
     folderIconCode: '代码',
     folderIconIdea: '灵感',
-    
+
     // 聊天窗口
     sendMessage: '发送消息',
     typeMessage: '询问任何问题...',
@@ -279,17 +282,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: '最多上传 10 张图片',
     imageReadError: '读取图片失败',
     imageInputNotSupported: '当前模型不支持图像输入',
-    
+
     // 模型选择
     selectModel: '选择模型',
-    
+
     // 错误提示
     errorOccurred: '发生错误',
     tryAgain: '请重试',
     networkError: '网络错误',
     apiKeyRequired: '需要设置API密钥',
     configureApiKey: '请在设置中配置您的API密钥',
-    
+
     // 初始化
     initializationError: '初始化应用程序失败。请检查您的配置。',
     apiKeyNotConfigured: 'API密钥未配置。请在设置中设置您的API密钥。',
@@ -1328,7 +1331,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: 'User',
     login: 'Login',
     inDevelopment: 'In development',
-    
+
     // Settings
     settings: 'Settings',
     general: 'General',
@@ -1355,7 +1358,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: 'Color Themes',
     chinese: 'Chinese',
     english: 'English',
-    
+
     // API Settings
     apiKey: 'API Key',
     apiKeyPlaceholder: 'Enter your API Key',
@@ -1370,7 +1373,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: 'Current Model',
     availableModels: 'Available Models',
     modelSwitchHint: 'You can switch models in the chat interface',
-    
+
     // Model Provider Settings
     enabled: 'Enabled',
     disabled: 'Disabled',
@@ -1478,7 +1481,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: 'Passwords do not match',
     passwordTooShort: 'Password must be at least 4 characters',
     wrongPassword: 'Wrong password, please try again',
-    
+
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
     shortcutNotSet: 'Not set',
@@ -1488,6 +1491,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     sendMessageShortcut: 'Send Message',
     shortcutConflict: 'Shortcut "{0}" is already used by "{1}"',
     close: 'Close',
+    minimize: 'Minimize',
+    maximize: 'Maximize',
+    restore: 'Restore',
     loginNotAvailable: 'Login is not available yet',
     collapse: 'Collapse',
     expand: 'Expand',
@@ -1517,10 +1523,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',
-    
+
     // Loading State
     loading: 'Loading...',
-    
+
     // Sidebar
     conversations: 'Conversations',
     noConversations: 'No conversations',
@@ -1558,7 +1564,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: 'Work',
     folderIconCode: 'Code',
     folderIconIdea: 'Ideas',
-    
+
     // Chat Window
     sendMessage: 'Send Message',
     typeMessage: 'Type a message...',
@@ -1588,17 +1594,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: 'Up to 10 images',
     imageReadError: 'Failed to read image',
     imageInputNotSupported: 'Current model does not support images',
-    
+
     // Model Selection
     selectModel: 'Select Model',
-    
+
     // Error Messages
     errorOccurred: 'An error occurred',
     tryAgain: 'Please try again',
     networkError: 'Network error',
     apiKeyRequired: 'API Key Required',
     configureApiKey: 'Please configure your API key in settings',
-    
+
     // Initialization
     initializationError: 'Failed to initialize application. Please check your configuration.',
     apiKeyNotConfigured: 'API key not configured. Please set up your API key in settings.',
@@ -2627,12 +2633,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
 class I18nService {
   private currentLanguage: LanguageType = 'zh';
   private listeners = new Set<() => void>();
-  
+
   constructor() {
     // 默认使用中文
     this.currentLanguage = 'zh';
   }
-  
+
   // 初始化语言设置
   async initialize(): Promise<void> {
     try {
@@ -2709,7 +2715,7 @@ class I18nService {
     }
     return 'en'; // 默认英文 (包括 zh-TW, zh-HK, en-*, 以及其他所有语言)
   }
-  
+
   // 设置语言
   setLanguage(language: LanguageType, options: { persist?: boolean } = {}): void {
     const { persist = true } = options;
@@ -2735,12 +2741,12 @@ class I18nService {
       console.error('Failed to save language setting:', error);
     }
   }
-  
+
   // 获取当前语言
   getLanguage(): LanguageType {
     return this.currentLanguage;
   }
-  
+
   // 获取翻译文本
   t(key: string): string {
     const translation = translations[this.currentLanguage][key];
@@ -2761,4 +2767,4 @@ class I18nService {
   }
 }
 
-export const i18nService = new I18nService(); 
+export const i18nService = new I18nService();


### PR DESCRIPTION
## 问题

多处按钮的 `title` tooltip 属性使用了硬编码英文字符串，中文环境下鼠标悬停时显示英文提示，与项目 i18n 规范不一致。

## 影响范围

| 文件 | 硬编码值 | 修复方式 |
|------|---------|---------|
| `WindowTitleBar.tsx` | Minimize / Maximize / Restore / Close | `i18nService.t()` |
| `SkillsButton.tsx` | Skills | `i18nService.t('skills')` |
| `SchemaForm.tsx` (2处) | Clear | `i18nService.t('clear')` |
| `CoworkPermissionModal.tsx` | Close (aria-label) | `i18nService.t('close')` |

## 改动内容

- 新增 i18n key：`minimize`(最小化)、`maximize`(最大化)、`restore`(还原)
- 将 5 个文件中共 6 处硬编码替换为 `i18nService.t()` 调用
- 中英文翻译均已补充

## 复现方式

1. Windows 下悬停窗口右上角最小化/最大化/关闭按钮 → tooltip 显示 "Minimize" 而非 "最小化"
2. 聊天输入框悬停 Skills 拼图图标 → tooltip 显示 "Skills" 而非 "技能"
3. IM 设置中输入框悬停清除按钮 → tooltip 显示 "Clear" 而非 "清除"