### PR TITLE
feat(modal): 所有弹窗统一支持 Esc 键关闭

### DIFF
--- a/src/renderer/components/common/Modal.tsx
+++ b/src/renderer/components/common/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 interface ModalProps {
   isOpen?: boolean;
@@ -7,6 +7,8 @@ interface ModalProps {
   overlayClassName?: string;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   children: React.ReactNode;
+  /** Set to false to disable closing the modal with the Escape key. Defaults to true. */
+  closeOnEscape?: boolean;
 }
 
 /**
@@ -14,6 +16,7 @@ interface ModalProps {
  *
  * Only closes when the user clicks the backdrop directly (mousedown + mouseup both on backdrop).
  * Dragging text from inside the modal to outside will NOT close the modal.
+ * Pressing Escape will close the modal (unless closeOnEscape is false).
  */
 const Modal: React.FC<ModalProps> = ({
   isOpen,
@@ -22,8 +25,20 @@ const Modal: React.FC<ModalProps> = ({
   overlayClassName,
   onClick,
   children,
+  closeOnEscape = true,
 }) => {
   const mouseDownOnBackdropRef = useRef(false);
+
+  useEffect(() => {
+    if (isOpen === false || !closeOnEscape) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose, closeOnEscape]);
 
   if (isOpen === false) return null;
 

--- a/src/renderer/components/cowork/CoworkPermissionModal.tsx
+++ b/src/renderer/components/cowork/CoworkPermissionModal.tsx
@@ -340,6 +340,17 @@ const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({
     });
   };
 
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handleDeny();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  });
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop">
       <div className="modal-content w-full max-w-lg mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden">

--- a/src/renderer/components/cowork/CoworkSearchModal.tsx
+++ b/src/renderer/components/cowork/CoworkSearchModal.tsx
@@ -49,16 +49,7 @@ const CoworkSearchModal: React.FC<CoworkSearchModalProps> = ({
     setSearchQuery('');
   }, [isOpen]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen, onClose]);
+  // Escape key handling is now provided by the Modal component
 
   const handleSelectSession = async (sessionId: string) => {
     await onSelectSession(sessionId);

--- a/src/renderer/components/mcp/McpServerFormModal.tsx
+++ b/src/renderer/components/mcp/McpServerFormModal.tsx
@@ -216,14 +216,7 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
     setHeaderRows(updated);
   };
 
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen, onClose]);
+  // Escape key handling is now provided by the Modal component
 
   if (!isOpen) return null;
 


### PR DESCRIPTION
## 背景

项目中部分弹窗（权限确认、Agent 创建、更新提示、安全报告等）不支持 Esc 键关闭，与搜索弹窗、MCP 表单等已支持 Esc 的弹窗行为不一致。

## 改动内容

### 1. Modal 底层组件统一支持 Esc
- 在 `Modal.tsx` 中新增 Escape 键监听，默认开启
- 新增 `closeOnEscape` prop，可按需关闭
- 所有使用 Modal 的弹窗自动获得 Esc 关闭能力

### 2. 移除重复的 Esc 监听
- `CoworkSearchModal`：移除自有 Esc handler，改由 Modal 统一处理
- `McpServerFormModal`：同上

### 3. 权限弹窗单独处理
- `CoworkPermissionModal` 未使用 Modal 组件，单独添加 Esc 监听
- 按 Esc 等同于拒绝（deny）

## 受益弹窗

| 弹窗 | 修改前 | 修改后 |
|------|--------|--------|
| 权限确认弹窗 | ❌ 不支持 Esc | ✅ 支持 |
| Agent 创建弹窗 | ❌ 不支持 Esc | ✅ 支持 |
| Agent 设置删除确认 | ❌ 不支持 Esc | ✅ 支持 |
| 应用更新弹窗 | ❌ 不支持 Esc | ✅ 支持 |
| Skill 安全报告 | ❌ 不支持 Esc | ✅ 支持 |
| 搜索弹窗 | 自有实现 | 改由 Modal 统一 |
| MCP 服务器表单 | 自有实现 | 改由 Modal 统一 |