### PR TITLE
feat: add right click menu

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -22,6 +22,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     traySettings: '设置',
     trayQuit: '退出',
 
+    // Windows Explorer context menu
+    contextMenuLabel: '使用有道龙虾打开',
+
     // Session titles (created by ChannelSessionSync)
     cronSessionPrefix: '定时',
     channelPrefixFeishu: '飞书',
@@ -196,6 +199,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     trayNewTask: 'New Task',
     traySettings: 'Settings',
     trayQuit: 'Quit',
+
+    // Windows Explorer context menu
+    contextMenuLabel: 'Open with LobsterAI',
 
     // Session titles
     cronSessionPrefix: 'Cron',

--- a/src/main/libs/windowsContextMenu.ts
+++ b/src/main/libs/windowsContextMenu.ts
@@ -1,0 +1,80 @@
+/**
+ * Windows Explorer context-menu integration.
+ *
+ * Registers / unregisters a "Open with LobsterAI" entry under
+ *   HKCU\Software\Classes\Directory\shell\LobsterAI
+ * (current-user hive — no admin privileges required).
+ *
+ * The entry passes the selected folder path via the
+ *   --open-directory=<path>
+ * command-line argument so that main.ts can pick it up on startup
+ * or via the second-instance event.
+ */
+
+import { execFile } from 'child_process';
+import path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/** Registry key root (current-user, no elevation required). */
+const REG_BASE = 'HKCU\\Software\\Classes\\Directory\\shell\\LobsterAI';
+const REG_COMMAND = `${REG_BASE}\\command`;
+
+/**
+ * Run `reg.exe` with the given arguments.
+ * Throws on non-zero exit code.
+ */
+async function reg(...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('reg', args, {
+    windowsHide: true,
+    encoding: 'utf8',
+  });
+  return stdout;
+}
+
+/**
+ * Register the Windows Explorer right-click menu entry.
+ *
+ * @param exePath  Absolute path to the application executable.
+ * @param menuLabel  Display text shown in the context menu.
+ */
+export async function registerContextMenu(exePath: string, menuLabel: string): Promise<void> {
+  // Normalise slashes — Windows registry expects backslashes in icon path
+  const exeNorm = path.normalize(exePath);
+
+  // Create the shell key with display name
+  await reg('add', REG_BASE, '/ve', '/d', menuLabel, '/f');
+
+  // Set icon to the exe itself (first icon resource)
+  await reg('add', REG_BASE, '/v', 'Icon', '/d', `"${exeNorm}"`, '/f');
+
+  // Set the command: exe --open-directory="%V"
+  // %V is the selected folder path provided by Explorer.
+  const command = `"${exeNorm}" --open-directory="%V"`;
+  await reg('add', REG_COMMAND, '/ve', '/d', command, '/f');
+}
+
+/**
+ * Remove the Windows Explorer right-click menu entry.
+ * Silently succeeds if the key does not exist.
+ */
+export async function unregisterContextMenu(): Promise<void> {
+  try {
+    await reg('delete', REG_BASE, '/f');
+  } catch {
+    // Key may not exist — treat as success.
+  }
+}
+
+/**
+ * Return true if the context-menu entry currently exists in the registry.
+ */
+export async function isContextMenuRegistered(): Promise<boolean> {
+  try {
+    await reg('query', REG_COMMAND, '/ve');
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -74,6 +74,11 @@ import {
   writeBootstrapFile,
 } from './libs/openclawMemoryFile';
 import { startOpenClawTokenProxy, stopOpenClawTokenProxy } from './libs/openclawTokenProxy';
+import {
+  isContextMenuRegistered,
+  registerContextMenu,
+  unregisterContextMenu,
+} from './libs/windowsContextMenu';
 import { ensurePythonRuntimeReady } from './libs/pythonRuntime';
 import {
   applySystemProxyEnv,
@@ -1807,22 +1812,76 @@ if (!gotTheLock) {
     return code;
   });
 
+  /**
+   * Parse --open-directory=<path> from a command-line argument array and, if
+   * found, apply it as the cowork working directory and focus the main window.
+   * Can be called both at first launch (process.argv) and on second-instance.
+   */
+  const handleOpenDirectoryArg = async (args: string[]): Promise<void> => {
+    const arg = args.find(a => a.startsWith('--open-directory='));
+    if (!arg) return;
+    const dirPath = arg.slice('--open-directory='.length).replace(/^"|"$/g, '');
+    if (!dirPath) return;
+    try {
+      const resolved = resolveTaskWorkingDirectory(dirPath);
+      console.log('[Main] opening directory from context menu:', resolved);
+      // Reuse the same setConfig path that the UI uses, so memory sync etc. fires.
+      const previousConfig = getCoworkStore().getConfig();
+      const previousWorkingDir = previousConfig.workingDirectory;
+      getCoworkStore().setConfig({ workingDirectory: resolved });
+      if (resolved !== previousWorkingDir) {
+        getSkillManager().handleWorkingDirectoryChange();
+        const syncResult = syncMemoryFileOnWorkspaceChange(previousWorkingDir, resolved);
+        if (syncResult.error) {
+          console.warn('[OpenClaw Memory] Workspace sync failed:', syncResult.error);
+        }
+        try {
+          ensureDefaultIdentity(resolved);
+        } catch (err) {
+          console.warn('[OpenClaw] ensureDefaultIdentity failed (non-fatal):', err);
+        }
+        await syncOpenClawConfig({ reason: 'open-directory-arg' }).catch((err) => {
+          console.warn('[Main] OpenClaw config sync failed after open-directory:', err);
+        });
+      }
+      // Notify renderer that config has changed so the UI reflects the new directory.
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('cowork:config:changed');
+      }
+    } catch (err) {
+      console.error('[Main] Failed to open directory from context menu:', err);
+    }
+    // Always bring the window to the front.
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      if (!mainWindow.isVisible()) mainWindow.show();
+      mainWindow.focus();
+    }
+  };
+
   // macOS: handle open-url event for deep links
   app.on('open-url', (event, url) => {
     event.preventDefault();
     handleDeepLink(url);
   });
 
-  app.on('second-instance', (_event, commandLine, workingDirectory) => {
-    console.debug('[Main] second-instance event', { commandLine, workingDirectory });
+  app.on('second-instance', (_event, commandLine, _cwd) => {
+    console.debug('[Main] second-instance event received');
 
     // Check for deep link in command line args (Windows/Linux)
     const deepLink = commandLine.find(arg => arg.startsWith('lobsterai://'));
     if (deepLink) {
       handleDeepLink(deepLink);
+      return;
     }
 
-    // Focus main window
+    // Handle --open-directory from Windows Explorer context menu
+    if (commandLine.some(a => a.startsWith('--open-directory='))) {
+      void handleOpenDirectoryArg(commandLine);
+      return;
+    }
+
+    // Focus main window (no special argument)
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore();
       if (!mainWindow.isVisible()) mainWindow.show();
@@ -1951,6 +2010,52 @@ if (!gotTheLock) {
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to set auto-launch',
+      };
+    }
+  });
+
+  // ── Windows Explorer context-menu integration ───────────────────────────
+  ipcMain.handle('app:contextMenu:isRegistered', async () => {
+    if (process.platform !== 'win32') return { registered: false };
+    try {
+      const registered = await isContextMenuRegistered();
+      return { registered };
+    } catch (error) {
+      console.error('[Main] Failed to query context menu registration:', error);
+      return { registered: false };
+    }
+  });
+
+  ipcMain.handle('app:contextMenu:register', async () => {
+    if (process.platform !== 'win32') {
+      return { success: false, error: 'Context menu registration is only supported on Windows' };
+    }
+    try {
+      const exePath = app.getPath('exe');
+      const menuLabel = t('contextMenuLabel');
+      await registerContextMenu(exePath, menuLabel);
+      return { success: true };
+    } catch (error) {
+      console.error('[Main] Failed to register context menu:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to register context menu',
+      };
+    }
+  });
+
+  ipcMain.handle('app:contextMenu:unregister', async () => {
+    if (process.platform !== 'win32') {
+      return { success: false, error: 'Context menu is only supported on Windows' };
+    }
+    try {
+      await unregisterContextMenu();
+      return { success: true };
+    } catch (error) {
+      console.error('[Main] Failed to unregister context menu:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to unregister context menu',
       };
     }
   });
@@ -5159,6 +5264,14 @@ if (!gotTheLock) {
       } catch (e) {
         console.error('[Main] Failed to parse cold-start deep link:', e);
       }
+    }
+
+    // Windows cold start: handle --open-directory from Explorer context menu.
+    // Defer until the renderer is ready so config:changed can be forwarded.
+    if (process.platform === 'win32' && process.argv.some(a => a.startsWith('--open-directory='))) {
+      mainWindow?.webContents.once('did-finish-load', () => {
+        void handleOpenDirectoryArg(process.argv);
+      });
     }
 
     // Auto-reconnect IM bots that were enabled before restart

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -294,6 +294,11 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.on('cowork:sessions:changed', handler);
       return () => ipcRenderer.removeListener('cowork:sessions:changed', handler);
     },
+    onConfigChanged: (callback: () => void) => {
+      const handler = () => callback();
+      ipcRenderer.on('cowork:config:changed', handler);
+      return () => ipcRenderer.removeListener('cowork:config:changed', handler);
+    },
   },
   dialog: {
     selectDirectory: () => ipcRenderer.invoke('dialog:selectDirectory'),
@@ -314,6 +319,11 @@ contextBridge.exposeInMainWorld('electron', {
   autoLaunch: {
     get: () => ipcRenderer.invoke('app:getAutoLaunch'),
     set: (enabled: boolean) => ipcRenderer.invoke('app:setAutoLaunch', enabled),
+  },
+  contextMenu: {
+    isRegistered: () => ipcRenderer.invoke('app:contextMenu:isRegistered'),
+    register: () => ipcRenderer.invoke('app:contextMenu:register'),
+    unregister: () => ipcRenderer.invoke('app:contextMenu:unregister'),
   },
   preventSleep: {
     get: () => ipcRenderer.invoke('app:getPreventSleep'),

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -576,8 +576,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [themeId, setThemeId] = useState<string>(themeService.getThemeId());
   const [language, setLanguage] = useState<LanguageType>('zh');
   const [autoLaunch, setAutoLaunchState] = useState(false);
-  const [useSystemProxy, setUseSystemProxy] = useState(false);
   const [isUpdatingAutoLaunch, setIsUpdatingAutoLaunch] = useState(false);
+  const [contextMenuRegistered, setContextMenuRegistered] = useState(false);
+  const [isUpdatingContextMenu, setIsUpdatingContextMenu] = useState(false);
+  const [useSystemProxy, setUseSystemProxy] = useState(false);
   const [preventSleep, setPreventSleepState] = useState(false);
   const [isUpdatingPreventSleep, setIsUpdatingPreventSleep] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -833,6 +835,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       }).catch(err => {
         console.error('Failed to load auto-launch setting:', err);
       });
+
+      // Load Windows Explorer context-menu registration state
+      if (window.electron.platform === 'win32') {
+        window.electron.contextMenu.isRegistered().then(({ registered }: { registered: boolean }) => {
+          setContextMenuRegistered(registered);
+        }).catch((err: unknown) => {
+          console.error('Failed to load context menu state:', err);
+        });
+      }
 
       // Load prevent-sleep setting
       window.electron.preventSleep.get().then(({ enabled }) => {
@@ -2491,6 +2502,59 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 </button>
               </label>
             </div>
+
+            {/* Windows Explorer Context Menu Section */}
+            {window.electron.platform === 'win32' && (
+              <div>
+                <h4 className="text-sm font-medium text-foreground mb-3">
+                  {i18nService.t('contextMenuIntegration')}
+                </h4>
+                <label className="flex items-center justify-between cursor-pointer">
+                  <span className="text-sm text-secondary">
+                    {i18nService.t('contextMenuIntegrationDescription')}
+                  </span>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={contextMenuRegistered}
+                    onClick={async () => {
+                      if (isUpdatingContextMenu) return;
+                      const next = !contextMenuRegistered;
+                      setIsUpdatingContextMenu(true);
+                      try {
+                        const result = next
+                          ? await window.electron.contextMenu.register()
+                          : await window.electron.contextMenu.unregister();
+                        if (result.success) {
+                          setContextMenuRegistered(next);
+                        } else {
+                          setError(result.error || 'Failed to update context menu setting');
+                        }
+                      } catch (err) {
+                        console.error('Failed to set context menu:', err);
+                        setError('Failed to update context menu setting');
+                      } finally {
+                        setIsUpdatingContextMenu(false);
+                      }
+                    }}
+                    disabled={isUpdatingContextMenu}
+                    className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
+                      isUpdatingContextMenu ? 'opacity-50 cursor-not-allowed' : ''
+                    } ${
+                      contextMenuRegistered
+                        ? 'bg-primary'
+                        : 'bg-gray-300 dark:bg-gray-600'
+                    }`}
+                  >
+                    <span
+                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                        contextMenuRegistered ? 'translate-x-6' : 'translate-x-1'
+                      }`}
+                    />
+                  </button>
+                </label>
+              </div>
+            )}
 
             {/* Prevent Sleep Section */}
             <div>

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -172,6 +172,15 @@ class CoworkService {
       });
     });
     this.streamListenerCleanups.push(sessionsChangedCleanup);
+
+    // Config changed listener - triggered when working directory is set via Explorer context menu
+    const configChangedCleanup = cowork.onConfigChanged(() => {
+      console.debug('[CoworkService] onConfigChanged: reloading config from main process');
+      void this.loadConfig().catch((err) => {
+        console.error('[CoworkService] onConfigChanged: loadConfig failed:', err);
+      });
+    });
+    this.streamListenerCleanups.push(configChangedCleanup);
   }
 
   private setupOpenClawEngineListeners(): void {

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1073,6 +1073,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // 通用设置
     autoLaunch: '开机自启动',
     autoLaunchDescription: '系统启动时自动运行应用',
+    contextMenuIntegration: '资源管理器右键菜单',
+    contextMenuIntegrationDescription: '在文件夹右键菜单中添加"使用有道龙虾打开"选项',
     useSystemProxy: '使用系统代理',
     useSystemProxyDescription: '开启后网络请求将跟随系统代理（保存后生效）',
     preventSleep: '防止休眠',
@@ -2381,6 +2383,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // General Settings
     autoLaunch: 'Launch at Login',
     autoLaunchDescription: 'Automatically start the app when you log in',
+    contextMenuIntegration: 'Explorer Context Menu',
+    contextMenuIntegrationDescription: 'Add "Open with LobsterAI" to the folder right-click menu',
     useSystemProxy: 'Use System Proxy',
     useSystemProxyDescription: 'When enabled, network requests follow system proxy settings (applies after Save)',
     preventSleep: 'Prevent Sleep',

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -59,6 +59,7 @@ interface CoworkConfig {
   memoryLlmJudgeEnabled: boolean;
   memoryGuardLevel: 'strict' | 'standard' | 'relaxed';
   memoryUserMemoriesMaxItems: number;
+  skipMissedJobs: boolean;
 }
 
 type CoworkConfigUpdate = Partial<Pick<
@@ -71,6 +72,7 @@ type CoworkConfigUpdate = Partial<Pick<
   | 'memoryLlmJudgeEnabled'
   | 'memoryGuardLevel'
   | 'memoryUserMemoriesMaxItems'
+  | 'skipMissedJobs'
 >>;
 
 interface CoworkUserMemoryEntry {
@@ -386,6 +388,7 @@ interface IElectronAPI {
     onStreamComplete: (callback: (data: { sessionId: string; claudeSessionId: string | null }) => void) => () => void;
     onStreamError: (callback: (data: { sessionId: string; error: string }) => void) => () => void;
     onSessionsChanged: (callback: () => void) => () => void;
+    onConfigChanged: (callback: () => void) => () => void;
   };
   dialog: {
     selectDirectory: () => Promise<{ success: boolean; path: string | null }>;
@@ -402,6 +405,11 @@ interface IElectronAPI {
   autoLaunch: {
     get: () => Promise<{ enabled: boolean }>;
     set: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;
+  };
+  contextMenu: {
+    isRegistered: () => Promise<{ registered: boolean }>;
+    register: () => Promise<{ success: boolean; error?: string }>;
+    unregister: () => Promise<{ success: boolean; error?: string }>;
   };
   preventSleep: {
     get: () => Promise<{ enabled: boolean }>;
@@ -634,6 +642,17 @@ interface FeishuOpenClawGroupConfig {
   systemPrompt?: string;
 }
 
+interface FeishuOpenClawFooterConfig {
+  status?: boolean;
+  elapsed?: boolean;
+}
+
+interface FeishuOpenClawBlockStreamingCoalesceConfig {
+  minChars?: number;
+  maxChars?: number;
+  idleMs?: number;
+}
+
 interface FeishuOpenClawConfig {
   enabled: boolean;
   appId: string;
@@ -645,7 +664,11 @@ interface FeishuOpenClawConfig {
   groupAllowFrom: string[];
   groups: Record<string, FeishuOpenClawGroupConfig>;
   historyLimit: number;
+  streaming: boolean;
   replyMode: 'auto' | 'static' | 'streaming';
+  blockStreaming: boolean;
+  footer: FeishuOpenClawFooterConfig;
+  blockStreamingCoalesce?: FeishuOpenClawBlockStreamingCoalesceConfig;
   mediaMaxMb: number;
   debug: boolean;
 }


### PR DESCRIPTION
## 改动说明

共改动了 **6 个文件**，新增了 **1 个文件**，以下是完整总结：

### 新增文件

**`src/main/libs/windowsContextMenu.ts`**
- `registerContextMenu(exePath, label)` — 写注册表，在 `HKCU\Software\Classes\Directory\shell\LobsterAI` 注册右键菜单，命令为 `"<exe>" --open-directory="%V"`
- `unregisterContextMenu()` — 清除注册表条目
- `isContextMenuRegistered()` — 查询是否已注册

> 使用 `HKCU`（当前用户）而非 `HKLM`，**不需要管理员权限**

### 修改文件

| 文件 | 改动内容 |
|---|---|
| `src/main/main.ts` | 引入工具函数；添加 `handleOpenDirectoryArg()` 函数（解析参数、更新工作目录、通知渲染层）；在 `second-instance` 中响应 `--open-directory=`；在冷启动后响应参数；添加 3 个 IPC handler |
| `src/main/preload.ts` | 暴露 `window.electron.contextMenu.{ isRegistered, register, unregister }`；新增 `window.electron.cowork.onConfigChanged()` 监听器，将 `cowork:config:changed` IPC 事件透传给渲染进程 |
| `src/main/i18n.ts` | 新增 `contextMenuLabel` 中英文翻译 |
| `src/renderer/services/i18n.ts` | 新增 `contextMenuIntegration` / `contextMenuIntegrationDescription` 中英文翻译 |
| `src/renderer/types/electron.d.ts` | 新增 `contextMenu` 类型声明；在 `CoworkConfig` 中补充 `skipMissedJobs: boolean` 字段；在 `CoworkConfigUpdate` 中补充 `skipMissedJobs` 选项；在 `FeishuOpenClawConfig` 中补充 `streaming`、`blockStreaming`、`footer` 字段，并新增 `FeishuOpenClawFooterConfig` 和 `FeishuOpenClawBlockStreamingCoalesceConfig` 接口；新增 `onConfigChanged` 类型声明 |
| `src/renderer/components/Settings.tsx` | 新增状态变量；在 useEffect 中加载注册状态；在 UI 的「开机自启动」下方渲染 Toggle 开关（仅 `win32` 平台可见） |
| `src/renderer/services/cowork.ts` | 在 `setupStreamListeners()` 中注册 `onConfigChanged` 回调，收到事件后调用 `loadConfig()` 重新拉取最新配置并更新 Redux store |
| `package.json` | 将 `build:skill:web-search` 脚本中的 `rm -f` 替换为跨平台的 `rimraf`，修复 Windows 下 `npm run dist:win` 编译失败的问题 |

### Bug 修复

#### 1. `npm run dist:win` 构建失败

**原因**：`build:skill:web-search` 脚本末尾使用了 Unix 专属的 `rm -f` 命令，Windows `cmd.exe` 不识别该命令。

**修复**：将 `rm -f` 替换为项目已依赖的跨平台工具 `rimraf`，同时保留「文件不存在也不报错」的语义。

#### 2. TypeScript 构建类型不匹配

**原因**：`src/renderer/types/electron.d.ts` 中的 `CoworkConfig` 和 `FeishuOpenClawConfig` 未与主进程类型定义同步，导致 `tsc` 报 TS2345 / TS2322 / TS2739 错误。

**修复**：在 `electron.d.ts` 中补全缺失字段，使渲染进程类型与主进程保持一致。

### 使用流程

1. 打开应用 → 设置 → 通用 → 开启「资源管理器右键菜单」
2. 在任意文件夹右键 → 点击「使用有道龙虾打开」
3. 应用自动启动（或从后台唤起），并将该文件夹设置为工作目录

### 效果图
<img width="1191" height="805" alt="image" src="https://github.com/user-attachments/assets/eb2ffbe0-6588-4204-9a58-464ff9718470" />
<img width="701" height="74" alt="image" src="https://github.com/user-attachments/assets/8cee7876-79d0-4cd9-b37f-1afbcde6950c" />

