### PR TITLE
fix: resolve MCP Bridge 401 auth mismatch on startup

### DIFF
--- a/src/main/libs/mcpBridgeServer.ts
+++ b/src/main/libs/mcpBridgeServer.ts
@@ -5,9 +5,10 @@
  * OpenClaw's ask-user-question plugin calls /askuser for user confirmation dialogs.
  * Binds to 127.0.0.1 only (local traffic).
  */
+import crypto from 'crypto';
 import http from 'http';
 import net from 'net';
-import crypto from 'crypto';
+
 import type { McpServerManager } from './mcpServerManager';
 
 const log = (level: string, msg: string) => {

--- a/src/main/libs/mcpBridgeServer.ts
+++ b/src/main/libs/mcpBridgeServer.ts
@@ -11,7 +11,7 @@ import crypto from 'crypto';
 import type { McpServerManager } from './mcpServerManager';
 
 const log = (level: string, msg: string) => {
-  const formatted = `[McpBridge][${level}] ${msg}`;
+  const formatted = `[McpBridge:HTTP][${level}] ${msg}`;
   if (level === 'ERROR') {
     console.error(formatted);
   } else if (level === 'WARN') {
@@ -54,6 +54,7 @@ export class McpBridgeServer {
   constructor(mcpManager: McpServerManager, secret: string) {
     this.mcpManager = mcpManager;
     this.secret = secret;
+    log('INFO', `McpBridgeServer created, secret prefix="${secret.slice(0, 8)}…"`);
   }
 
   get port(): number | null {
@@ -107,7 +108,13 @@ export class McpBridgeServer {
 
     return new Promise((resolve, reject) => {
       const srv = http.createServer((req, res) => {
-        this.handleRequest(req, res);
+        this.handleRequest(req, res).catch((err) => {
+          log('ERROR', `Unhandled error in handleRequest: ${err instanceof Error ? err.message : String(err)}`);
+          if (!res.headersSent) {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Internal server error' }));
+          }
+        });
       });
 
       srv.on('error', (err) => {
@@ -145,6 +152,8 @@ export class McpBridgeServer {
   }
 
   private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    log('DEBUG', `HTTP ${req.method} ${req.url}`);
+
     if (req.method !== 'POST') {
       res.writeHead(404, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Not found' }));
@@ -154,6 +163,7 @@ export class McpBridgeServer {
     // Verify secret token (accept either header name)
     const authHeader = req.headers['x-mcp-bridge-secret'] || req.headers['x-ask-user-secret'];
     if (authHeader !== this.secret) {
+      log('WARN', `Auth rejected for ${req.url}: header=${authHeader ? 'present-but-mismatch' : 'missing'}`);
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
       return;
@@ -235,13 +245,17 @@ export class McpBridgeServer {
         args: Record<string, unknown>;
       };
 
+      log('INFO', `Execute request: server="${server}" tool="${tool}"`);
+
       if (!server || !tool) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'Missing "server" or "tool" field' }));
         return;
       }
 
+      const t0 = Date.now();
       const result = await this.mcpManager.callTool(server, tool, args || {});
+      log('INFO', `Execute done: server="${server}" tool="${tool}" isError=${result.isError} elapsed=${Date.now() - t0}ms`);
 
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(result));

--- a/src/main/libs/mcpServerManager.ts
+++ b/src/main/libs/mcpServerManager.ts
@@ -33,7 +33,14 @@ interface ManagedMcpServer {
 }
 
 const log = (level: string, msg: string) => {
-  console.log(`[McpBridge][${level}] ${msg}`);
+  const formatted = `[McpBridge:SDK][${level}] ${msg}`;
+  if (level === 'ERROR') {
+    console.error(formatted);
+  } else if (level === 'WARN') {
+    console.warn(formatted);
+  } else {
+    console.log(formatted);
+  }
 };
 
 // ── Windows hidden-subprocess init script ────────────────────────
@@ -433,6 +440,13 @@ export class McpServerManager {
       const content = Array.isArray(result.content)
         ? (result.content as Array<{ type: string; text?: string }>)
         : [{ type: 'text', text: String(result.content) }];
+      if (result.isError === true) {
+        const preview = content
+          .map((c) => c.text ?? '')
+          .join(' ')
+          .slice(0, 300);
+        log('WARN', `Tool "${toolName}" on "${serverName}" returned isError: ${preview}`);
+      }
       return { content, isError: result.isError === true };
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -696,6 +696,7 @@ type OpenClawConfigSyncDeps = {
   getWeixinConfig: () => WeixinOpenClawConfig | null;
   getIMSettings?: () => IMSettings | null;
   getMcpBridgeConfig?: () => McpBridgeConfig | null;
+  getMcpBridgeSecret?: () => string;
   getSkillsList?: () => Array<{ id: string; enabled: boolean }>;
   getAgents?: () => Agent[];
 };
@@ -717,6 +718,7 @@ export class OpenClawConfigSync {
   private readonly getWeixinConfig: () => WeixinOpenClawConfig | null;
   private readonly getIMSettings?: () => IMSettings | null;
   private readonly getMcpBridgeConfig?: () => McpBridgeConfig | null;
+  private readonly getMcpBridgeSecret?: () => string;
   private readonly getSkillsList?: () => Array<{ id: string; enabled: boolean }>;
   private readonly getAgents?: () => Agent[];
   private previousBindingsJson?: string;
@@ -739,6 +741,7 @@ export class OpenClawConfigSync {
     this.getWeixinConfig = deps.getWeixinConfig;
     this.getIMSettings = deps.getIMSettings;
     this.getMcpBridgeConfig = deps.getMcpBridgeConfig;
+    this.getMcpBridgeSecret = deps.getMcpBridgeSecret;
     this.getSkillsList = deps.getSkillsList;
     this.getAgents = deps.getAgents;
   }
@@ -1483,8 +1486,11 @@ export class OpenClawConfigSync {
 
     // MCP Bridge Secret — always set so stale openclaw.json with
     // ${LOBSTER_MCP_BRIDGE_SECRET} placeholder doesn't crash the gateway.
+    // Prefer getMcpBridgeSecret() which is available immediately (eagerly
+    // generated at module load), over getMcpBridgeConfig() which requires
+    // the full McpBridgeServer to be started.
     const mcpBridgeCfg = this.getMcpBridgeConfig?.();
-    env.LOBSTER_MCP_BRIDGE_SECRET = mcpBridgeCfg?.secret || 'unconfigured';
+    env.LOBSTER_MCP_BRIDGE_SECRET = this.getMcpBridgeSecret?.() || mcpBridgeCfg?.secret || 'unconfigured';
 
     // Telegram
     const tgConfig = this.getTelegramOpenClawConfig?.();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -651,7 +651,10 @@ let skillManager: SkillManager | null = null;
 let mcpStore: McpStore | null = null;
 let mcpServerManager: McpServerManager | null = null;
 let mcpBridgeServer: McpBridgeServer | null = null;
-let mcpBridgeSecret: string | null = null;
+// Generated eagerly so the secret is available before the first syncOpenClawConfig
+// call — the gateway process inherits it via LOBSTER_MCP_BRIDGE_SECRET env var at
+// spawn time, avoiding a restart just to pick up the correct secret.
+let mcpBridgeSecret: string = require('crypto').randomUUID();
 let mcpBridgeStartPromise: Promise<McpBridgeConfig | null> | null = null;
 let imGatewayManager: IMGatewayManager | null = null;
 let storeInitPromise: Promise<SqliteStore> | null = null;
@@ -955,6 +958,7 @@ const getOpenClawConfigSync = (): OpenClawConfigSync => {
           tools: mcpServerManager?.toolManifest ?? [],
         };
       },
+      getMcpBridgeSecret: () => mcpBridgeSecret,
       getAgents: () => getCoworkStore().listAgents(),
     });
   }
@@ -1255,12 +1259,6 @@ const startMcpBridge = (): Promise<McpBridgeConfig | null> => {
   mcpBridgeStartPromise = (async (): Promise<McpBridgeConfig | null> => {
   try {
     console.log('[McpBridge] startMcpBridge called');
-
-    // Generate a per-session secret for bridge auth
-    if (!mcpBridgeSecret) {
-      const crypto = await import('crypto');
-      mcpBridgeSecret = crypto.randomUUID();
-    }
 
     // Discover MCP tools (may be empty if no servers configured)
     const enabledServers = getMcpStore().getEnabledServers();


### PR DESCRIPTION
## Summary

- Add debug logging to MCP Bridge HTTP server and SDK manager for better observability
- Fix race condition where gateway launches with `LOBSTER_MCP_BRIDGE_SECRET=unconfigured` because the secret was generated lazily after the first `syncOpenClawConfig()` call

**Root cause**: `collectSecretEnvVars()` relied on `getMcpBridgeConfig()` which returns `null` until the full `McpBridgeServer` is started. The gateway forks before that, inheriting stale env vars → all MCP tool calls fail with 401.

**Fix**:
1. Generate `mcpBridgeSecret` eagerly at module load time
2. Add `getMcpBridgeSecret()` callback to `OpenClawConfigSync` so the secret is available immediately without waiting for the bridge server

## Test plan

- [ ] Fresh start the app with MCP servers configured (e.g. Tavily)
- [ ] Verify no `401 auth mismatch` in logs
- [ ] Verify MCP tools execute successfully on first use
- [ ] Check logs for `[McpBridge:HTTP]` and `[McpBridge:SDK]` prefixed entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)