### PR TITLE
fix(openclaw): non-main agent persona files not loaded due to workspace path mismatch

### DIFF
--- a/src/main/libs/openclawAgentModels.test.ts
+++ b/src/main/libs/openclawAgentModels.test.ts
@@ -118,6 +118,36 @@ describe('buildManagedAgentEntries', () => {
       model: { primary: 'anthropic/claude-sonnet-4' },
     });
   });
+
+  test('sets explicit workspace for non-main agents when stateDir is provided', () => {
+    const result = buildManagedAgentEntries({
+      agents: [
+        {
+          id: 'crab-boss',
+          name: 'CrabBoss',
+          description: '',
+          systemPrompt: '',
+          identity: '',
+          model: 'openai/gpt-4o',
+          icon: '🦀',
+          skillIds: [],
+          enabled: true,
+          isDefault: false,
+          source: 'custom',
+          presetId: '',
+          createdAt: 0,
+          updatedAt: 0,
+        },
+      ],
+      fallbackPrimaryModel: 'anthropic/claude-sonnet-4',
+      stateDir: '/mock/state',
+    });
+
+    expect(result[0]).toMatchObject({
+      id: 'crab-boss',
+      workspace: expect.stringContaining('workspace-crab-boss'),
+    });
+  });
 });
 
 describe('parsePrimaryModelRef', () => {

--- a/src/main/libs/openclawAgentModels.ts
+++ b/src/main/libs/openclawAgentModels.ts
@@ -1,8 +1,11 @@
+import path from 'node:path';
+
 import type { Agent } from '../coworkStore';
 
 type BuildManagedAgentEntriesInput = {
   agents: Agent[];
   fallbackPrimaryModel: string;
+  stateDir?: string;
 };
 
 type ProviderModelCatalog = Record<string, { models: Array<{ id: string }> }>;
@@ -150,6 +153,7 @@ export function resolveQualifiedAgentModelRef(options: {
 export function buildAgentEntry(
   agent: Agent,
   fallbackPrimaryModel: string,
+  options?: { workspace?: string },
 ): Record<string, unknown> {
   const primaryModel = parsePrimaryModelRef(agent.model.trim())?.primaryModel || fallbackPrimaryModel;
 
@@ -163,6 +167,7 @@ export function buildAgentEntry(
       },
     } : {}),
     ...(agent.skillIds && agent.skillIds.length > 0 ? { skills: agent.skillIds } : {}),
+    ...(options?.workspace ? { workspace: options.workspace } : {}),
     model: {
       primary: primaryModel,
     },
@@ -172,8 +177,12 @@ export function buildAgentEntry(
 export function buildManagedAgentEntries({
   agents,
   fallbackPrimaryModel,
+  stateDir,
 }: BuildManagedAgentEntriesInput): Array<Record<string, unknown>> {
   return agents
     .filter((agent) => agent.id !== 'main' && agent.enabled)
-    .map((agent) => buildAgentEntry(agent, fallbackPrimaryModel));
+    .map((agent) => buildAgentEntry(agent, fallbackPrimaryModel, stateDir
+      ? { workspace: path.join(stateDir, `workspace-${agent.id}`) }
+      : undefined,
+    ));
 }

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -965,7 +965,7 @@ export class OpenClawConfigSync {
           },
           ...(workspaceDir ? { workspace: path.resolve(workspaceDir) } : {}),
         },
-        ...this.buildAgentsList(primaryModel),
+        ...this.buildAgentsList(primaryModel, this.engineManager.getStateDir()),
       },
       ...this.currentBindingsObj,
       session: this.buildSessionConfig(),
@@ -1933,7 +1933,7 @@ export class OpenClawConfigSync {
    * Per-agent `identity` (name, emoji) is set from the agent database so
    * OpenClaw picks it up natively.
    */
-  private buildAgentsList(defaultPrimaryModel: string): { list?: Array<Record<string, unknown>> } {
+  private buildAgentsList(defaultPrimaryModel: string, stateDir?: string): { list?: Array<Record<string, unknown>> } {
     const agents = this.getAgents?.() ?? [];
     const mainAgent = agents.find((agent) => agent.id === 'main');
 
@@ -1950,6 +1950,7 @@ export class OpenClawConfigSync {
       ...buildManagedAgentEntries({
         agents,
         fallbackPrimaryModel: defaultPrimaryModel,
+        stateDir,
       }),
     ];
 


### PR DESCRIPTION
## Summary

- Non-main agents (e.g. custom agents like 蟹老板) inherited `agents.defaults.workspace` from the OpenClaw config, causing persona files (SOUL.md, IDENTITY.md) to be read from the wrong directory
- `syncPerAgentWorkspaces` writes to `{STATE_DIR}/workspace-{agentId}/`, but OpenClaw looked in `{workingDirectory}/{agentId}/` due to defaults inheritance
- Fix: pass `stateDir` through to `buildManagedAgentEntries` so each non-main agent gets an explicit `workspace` matching the actual sync path

## Test plan

- [ ] Create a custom agent with distinctive SOUL.md/IDENTITY.md content (e.g. 蟹Bro with 🦀 emoji)
- [ ] Start a new session with that agent
- [ ] Send a normal message (not "你是谁") and verify persona is active from the first reply
- [ ] Verify main agent persona still works correctly
- [ ] Check OpenClaw admin panel (`/agents`) shows correct workspace path for the custom agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)