### PR TITLE
chore(diag): add [AbortDiag] logging for premature timeout investigation

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -110,6 +110,8 @@ type ActiveTurn = {
   sessionKey: string;
   runId: string;
   turnToken: number;
+  /** Timestamp when this turn was created (for abort diagnostics). */
+  startedAtMs: number;
   knownRunIds: Set<string>;
   assistantMessageId: string | null;
   committedAssistantText: string;
@@ -1235,6 +1237,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       toolUseMessageIdByToolCallId: new Map(),
       toolResultMessageIdByToolCallId: new Map(),
       toolResultTextByToolCallId: new Map(),
+      startedAtMs: Date.now(),
       stopRequested: false,
       pendingUserSync: false,
       bufferedChatPayloads: [],
@@ -2425,6 +2428,18 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
 
     if (state === 'aborted') {
+      const elapsedSec = ((Date.now() - turn.startedAtMs) / 1000).toFixed(1);
+      console.warn(
+        `[AbortDiag] chat aborted event received`,
+        `sessionId=${sessionId}`,
+        `runId=${turn.runId}`,
+        `sessionKey=${turn.sessionKey}`,
+        `elapsed=${elapsedSec}s`,
+        `stopReason=${(chatPayload as Record<string, unknown>).stopReason ?? 'unknown'}`,
+        `stopRequested=${turn.stopRequested}`,
+        `manuallyStoppedSession=${this.manuallyStoppedSessions.has(sessionId)}`,
+        `payload=${JSON.stringify(chatPayload).slice(0, 500)}`,
+      );
       this.handleChatAborted(sessionId, turn);
       return;
     }
@@ -2819,10 +2834,18 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   private handleChatAborted(sessionId: string, turn: ActiveTurn): void {
+    const elapsedSec = ((Date.now() - turn.startedAtMs) / 1000).toFixed(1);
     this.store.updateSession(sessionId, { status: 'idle' });
     if (!turn.stopRequested && !this.manuallyStoppedSessions.has(sessionId)) {
       // The run was aborted without user request — most likely a timeout.
       // Add a visible hint so the user knows the task was interrupted.
+      console.warn(
+        `[AbortDiag] showing timeout hint to user`,
+        `sessionId=${sessionId}`,
+        `runId=${turn.runId}`,
+        `elapsed=${elapsedSec}s`,
+        `turnToken=${turn.turnToken}`,
+      );
       const hintMessage = this.store.addMessage(sessionId, {
         type: 'assistant',
         content: t('taskTimedOut'),
@@ -3770,9 +3793,14 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     turn.timeoutTimer = setTimeout(() => {
       const currentTurn = this.activeTurns.get(sessionId);
       if (!currentTurn || currentTurn.turnToken !== turn.turnToken) return;
+      const elapsedSec = ((Date.now() - currentTurn.startedAtMs) / 1000).toFixed(1);
       console.warn(
-        `[OpenClawRuntime] Client-side timeout watchdog fired for session ${sessionId}, `
-        + `runId=${currentTurn.runId} after ${timeoutMs}ms — gateway did not deliver abort event`,
+        `[AbortDiag] client-side timeout watchdog fired`,
+        `sessionId=${sessionId}`,
+        `runId=${currentTurn.runId}`,
+        `elapsed=${elapsedSec}s`,
+        `watchdogMs=${timeoutMs}`,
+        `— gateway did not deliver abort event`,
       );
       this.handleChatAborted(sessionId, currentTurn);
     }, timeoutMs);
@@ -3882,6 +3910,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       toolUseMessageIdByToolCallId: new Map(),
       toolResultMessageIdByToolCallId: new Map(),
       toolResultTextByToolCallId: new Map(),
+      startedAtMs: Date.now(),
       stopRequested: false,
       pendingUserSync: !!isChannel,
       bufferedChatPayloads: [],


### PR DESCRIPTION
## Summary

- **不修复**偶现的"任务超时"提前触发问题，仅增加诊断日志用于下次复现时定位根因
- 在 `openclawRuntimeAdapter.ts` 的三个 abort 相关代码路径添加 `[AbortDiag]` 前缀日志，记录 elapsed time、stopReason、session state 等关键信息
- 为 `ActiveTurn` 增加 `startedAtMs` 字段以计算实际经过时间

## 背景

QA 反馈偶现两次：对话中途提示"任务超时"，但实际对话时长远未达到超时阈值（3600s）。由于无法稳定复现，先埋点诊断日志，待下次复现时通过日志中的 `[AbortDiag]` 前缀搜索定位是 gateway 重启、WebSocket 重连竞态还是超时计算异常。

## Test plan

- [x] TypeScript 编译通过（`npx tsc --noEmit`）
- [ ] 正常对话不应出现 `[AbortDiag]` 日志（已验证）
- [ ] 等待 bug 复现后检查日志中 `[AbortDiag]` 条目

🤖 Generated with [Claude Code](https://claude.com/claude-code)