### PR TITLE
fix(openclaw): surface lifecycle phase=error when chat error event is missing

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -2201,6 +2201,33 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         void this.completeChannelTurnFallback(sessionId, turn);
       }, FALLBACK_DELAY_MS);
     }
+
+    if (phase === 'error') {
+      // Deferred error fallback: the gateway should also send a `chat state=error`
+      // event that triggers handleChatError().  But after the OpenClaw upgrade, this
+      // event may not arrive reliably — similar to the phase=end / chat final gap.
+      // Wait a short window for handleChatError() to run first; if the turn is still
+      // active after that, surface the error ourselves.
+      const errorMessage = typeof data.error === 'string' ? data.error.trim() : 'OpenClaw run failed';
+      const ERROR_FALLBACK_DELAY_MS = 2000;
+      setTimeout(() => {
+        const turn = this.activeTurns.get(sessionId);
+        if (!turn) return; // Already handled by handleChatError
+        console.log('[OpenClawRuntime] agent lifecycle error fallback: surfacing error that missed chat error event, sessionId:', sessionId, 'error:', errorMessage);
+        const erroredSessionKey = turn.sessionKey;
+        this.store.updateSession(sessionId, { status: 'error' });
+        const errorMsg = this.store.addMessage(sessionId, {
+          type: 'system',
+          content: errorMessage,
+          metadata: { error: errorMessage },
+        });
+        this.emit('message', sessionId, errorMsg);
+        this.emit('error', sessionId, errorMessage);
+        this.cleanupSessionTurn(sessionId);
+        this.rejectTurn(sessionId, new Error(errorMessage));
+        void this.reconcileWithHistory(sessionId, erroredSessionKey);
+      }, ERROR_FALLBACK_DELAY_MS);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- 修复 OpenClaw 升级后，模型不可达（如 402 认证错误）时错误未传递到前端、会话卡在"执行中"的问题
- 根因：`handleAgentLifecycleEvent` 只处理了 `phase=start` 和 `phase=end`，遗漏了 `phase=error`；旧版 gateway 会同时发 `chat state=error` 兜底，升级后该事件不再可靠发出
- 采用与 `phase=end` 相同的延迟 fallback 策略：先等 `handleChatError()` 处理，超时后 turn 仍存活则自行兜底（更新状态、持久化错误消息、通知前端、清理 turn）

## Test plan
- [ ] 配置一个不可达的模型（如过期 API key），发送消息，确认错误信息正常展示而非卡在执行中
- [ ] 配置正常模型，确认正常对话不受影响
- [ ] 确认 IM 渠道（钉钉/飞书等）同样能正确展示模型错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)