### PR TITLE
Restore fix: non-main agent persona files not loaded due to workspace path mismatch

### DIFF
--- a/src/main/libs/openclawAgentModels.test.ts
+++ b/src/main/libs/openclawAgentModels.test.ts
@@ -118,6 +118,36 @@ describe('buildManagedAgentEntries', () => {
       model: { primary: 'anthropic/claude-sonnet-4' },
     });
   });
+
+  test('sets explicit workspace for non-main agents when stateDir is provided', () => {
+    const result = buildManagedAgentEntries({
+      agents: [
+        {
+          id: 'crab-boss',
+          name: 'CrabBoss',
+          description: '',
+          systemPrompt: '',
+          identity: '',
+          model: 'openai/gpt-4o',
+          icon: '🦀',
+          skillIds: [],
+          enabled: true,
+          isDefault: false,
+          source: 'custom',
+          presetId: '',
+          createdAt: 0,
+          updatedAt: 0,
+        },
+      ],
+      fallbackPrimaryModel: 'anthropic/claude-sonnet-4',
+      stateDir: '/mock/state',
+    });
+
+    expect(result[0]).toMatchObject({
+      id: 'crab-boss',
+      workspace: expect.stringContaining('workspace-crab-boss'),
+    });
+  });
 });
 
 describe('parsePrimaryModelRef', () => {

--- a/src/main/libs/openclawAgentModels.ts
+++ b/src/main/libs/openclawAgentModels.ts
@@ -1,8 +1,11 @@
+import path from 'node:path';
+
 import type { Agent } from '../coworkStore';
 
 type BuildManagedAgentEntriesInput = {
   agents: Agent[];
   fallbackPrimaryModel: string;
+  stateDir?: string;
 };
 
 type ProviderModelCatalog = Record<string, { models: Array<{ id: string }> }>;
@@ -150,6 +153,7 @@ export function resolveQualifiedAgentModelRef(options: {
 export function buildAgentEntry(
   agent: Agent,
   fallbackPrimaryModel: string,
+  options?: { workspace?: string },
 ): Record<string, unknown> {
   const primaryModel = parsePrimaryModelRef(agent.model.trim())?.primaryModel || fallbackPrimaryModel;
 
@@ -163,6 +167,7 @@ export function buildAgentEntry(
       },
     } : {}),
     ...(agent.skillIds && agent.skillIds.length > 0 ? { skills: agent.skillIds } : {}),
+    ...(options?.workspace ? { workspace: options.workspace } : {}),
     model: {
       primary: primaryModel,
     },
@@ -172,8 +177,12 @@ export function buildAgentEntry(
 export function buildManagedAgentEntries({
   agents,
   fallbackPrimaryModel,
+  stateDir,
 }: BuildManagedAgentEntriesInput): Array<Record<string, unknown>> {
   return agents
     .filter((agent) => agent.id !== 'main' && agent.enabled)
-    .map((agent) => buildAgentEntry(agent, fallbackPrimaryModel));
+    .map((agent) => buildAgentEntry(agent, fallbackPrimaryModel, stateDir
+      ? { workspace: path.join(stateDir, `workspace-${agent.id}`) }
+      : undefined,
+    ));
 }

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -965,7 +965,7 @@ export class OpenClawConfigSync {
           },
           ...(workspaceDir ? { workspace: path.resolve(workspaceDir) } : {}),
         },
-        ...this.buildAgentsList(primaryModel),
+        ...this.buildAgentsList(primaryModel, this.engineManager.getStateDir()),
       },
       ...this.currentBindingsObj,
       session: this.buildSessionConfig(),
@@ -1933,7 +1933,7 @@ export class OpenClawConfigSync {
    * Per-agent `identity` (name, emoji) is set from the agent database so
    * OpenClaw picks it up natively.
    */
-  private buildAgentsList(defaultPrimaryModel: string): { list?: Array<Record<string, unknown>> } {
+  private buildAgentsList(defaultPrimaryModel: string, stateDir?: string): { list?: Array<Record<string, unknown>> } {
     const agents = this.getAgents?.() ?? [];
     const mainAgent = agents.find((agent) => agent.id === 'main');
 
@@ -1950,6 +1950,7 @@ export class OpenClawConfigSync {
       ...buildManagedAgentEntries({
         agents,
         fallbackPrimaryModel: defaultPrimaryModel,
+        stateDir,
       }),
     ];
 


### PR DESCRIPTION
## Summary
- Restores #1651 which was accidentally reverted in #1655
- Reapplies the fix for non-main agent persona files not being loaded due to workspace path mismatch

## Test plan
- [ ] Verify non-main agent persona files load correctly
- [ ] Confirm workspace path is set properly for non-main agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)