### PR TITLE
fix(openclaw): allow silent scope-upgrade for loopback cron connections

### DIFF
--- a/scripts/patches/v2026.4.8/openclaw-allow-loopback-scope-upgrade-silent-pairing.patch
+++ b/scripts/patches/v2026.4.8/openclaw-allow-loopback-scope-upgrade-silent-pairing.patch
@@ -1,0 +1,17 @@
+--- a/src/gateway/server/ws-connection/message-handler.ts
++++ b/src/gateway/server/ws-connection/message-handler.ts
+@@ -893,7 +893,13 @@
+               ...clientPairingMetadata,
+               ...(bootstrapPairingRoles ? { roles: bootstrapPairingRoles } : {}),
+               silent:
+-                reason === "scope-upgrade"
++                // LobsterAI patch: allow silent scope-upgrade for non-browser
++                // loopback connections (internal tool-bind clients like cron).
++                // PR #54694 blocked ALL silent scope-upgrades to fix a Control UI
++                // escalation vulnerability (#50640), but that also broke internal
++                // loopback tool calls that need operator.admin.  Only force
++                // interactive approval when the request has a browser origin.
++                reason === "scope-upgrade" && hasBrowserOriginHeader
+                   ? false
+                   : allowSilentLocalPairing || allowSilentBootstrapPairing,
+             });


### PR DESCRIPTION
## Summary

- PR #54694 in openclaw fixed a CVSS 9.2 escalation vulnerability (openclaw#50640) by blocking **all** silent scope-upgrades, but this inadvertently broke internal loopback tool-bind clients (e.g. `cron`) that need `operator.admin` scope
- The root cause of openclaw/openclaw#57688: cron's bind client hardcodes a narrow scope, triggering a `scope-upgrade` flow that now requires interactive approval — but there's no UI mechanism for loopback connections to complete that approval
- openclaw/openclaw#64421 surfaces the same breakage with a misleading "pairing required" error when the real issue is insufficient scopes

## Fix

Adds a runtime patch (`scripts/patches/v2026.4.8/openclaw-allow-loopback-scope-upgrade-silent-pairing.patch`) to `message-handler.ts` in the openclaw gateway:

```diff
- silent: reason === "scope-upgrade"
+ // Only force interactive approval when the request has a browser origin header.
+ // Internal loopback connections (cron bind clients) must be able to scope-upgrade silently.
+ silent: reason === "scope-upgrade" && hasBrowserOriginHeader
    ? false
    : allowSilentLocalPairing || allowSilentBootstrapPairing,
```

This preserves the security fix for browser-origin escalation attacks while restoring silent scope-upgrade for trusted loopback/internal connections.

## Test plan

- [ ] `openclaw cron add` via CLI completes without "pairing required" error
- [ ] `cron add` via agent tool (loopback) works with `operator.admin` scope
- [ ] Browser-origin scope-upgrade still prompts for interactive approval (security regression test)
- [ ] `cron list` / `cron status` (read-only operations) unaffected

Fixes: openclaw/openclaw#57688, openclaw/openclaw#64421

🤖 Generated with [Claude Code](https://claude.com/claude-code)