### PR TITLE
feat(cowork): 非 main agent 首页欢迎区域显示 agent 名称和描述

### DIFF
--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -587,10 +587,14 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
           <div className="text-center space-y-5">
             <img src="logo.png" alt="logo" className="w-16 h-16 mx-auto" />
             <h2 className="text-3xl font-bold tracking-tight text-foreground">
-              {i18nService.t('coworkWelcome')}
+              {currentAgentId !== 'main' && currentAgent?.name
+                ? i18nService.t('coworkAgentWelcome').replace('{name}', currentAgent.name)
+                : i18nService.t('coworkWelcome')}
             </h2>
             <p className="text-sm text-secondary max-w-md mx-auto">
-              {i18nService.t('coworkDescription')}
+              {currentAgentId !== 'main' && currentAgent?.description
+                ? currentAgent.description
+                : i18nService.t('coworkDescription')}
             </p>
           </div>
 

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -470,6 +470,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkQuestionWizardSelectAtLeastOne: '请至少选择一个选项',
     coworkQuestionWizardAnswerRequired: '请选择或输入答案',
     coworkWelcome: '开始协作',
+    coworkAgentWelcome: 'Hi，我是{name}',
     coworkDescription: '7×24 小时帮你干活的全场景个人助理 Agent',
 
     // Multi-Agent 管理
@@ -1779,6 +1780,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkQuestionWizardSelectAtLeastOne: 'Please select at least one option',
     coworkQuestionWizardAnswerRequired: 'Please select or enter an answer',
     coworkWelcome: 'Start Collaborating',
+    coworkAgentWelcome: 'Hi, I\'m {name}',
     coworkDescription: 'A 24/7 personal assistant agent that gets work done for you',
 
     // Multi-Agent management


### PR DESCRIPTION
### 变更内容
当用户切换到非 main agent 时，首页欢迎区域由固定文案改为动态显示当前 agent 的名称和描述，提供更个性化的体验。
### 具体改动
1. **标题**：「开始协作」→「Hi，我是{agent名称}」
   - 例如：切换到"内容总结助手"时显示 **Hi，我是内容总结助手**
   - main agent 保持原有「开始协作」不变

2. **描述**：「7×24 小时帮你干活的全场景个人助理 Agent」→ agent 自身的描述
   - 例如：**支持音视频、链接、文档摘要。自动识别会议、讲座、访谈等内容类型。**
   - 若 agent 描述为空或在 main agent 下，保持默认文案

### 涉及文件
| 文件 | 说明 |
|------|------|
| `src/renderer/components/cowork/CoworkView.tsx` | Welcome Section 标题和描述根据当前 agent 动态渲染 |
| `src/renderer/services/i18n.ts` | 新增 `coworkAgentWelcome` 国际化键（中文 / 英文） |

### 效果对比
| 场景 | 修改前 | 修改后 |
|------|--------|--------|
| main agent | 开始协作 | 开始协作（不变） |
| 非 main agent（有名称） | 开始协作 | Hi，我是内容总结助手 |
| 非 main agent（有描述） | 7×24 小时帮你干活... | 支持音视频、链接、文档摘要... |
| 非 main agent（无描述） | 7×24 小时帮你干活... | 7×24 小时帮你干活...（回退默认） |