### PR TITLE
fix(log): 脱敏导出日志中的敏感信息

### DIFF
--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../scheduledTask/constants';
 import { PlatformRegistry } from '../../../shared/platform';
 import type { CronJobService } from '../../../scheduledTask/cronJobService';
+import { sanitizeLogPayload } from '../../libs/apiFetchLog';
 import { listScheduledTaskChannels } from './helpers';
 
 export interface ScheduledTaskHandlerDeps {
@@ -111,7 +112,7 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
   ipcMain.handle(ScheduledTaskIpc.Create, async (_event, input: any) => {
     try {
       const normalizedInput = input && typeof input === 'object' ? { ...input } : {};
-      console.debug('[ScheduledTask] create input:', JSON.stringify(normalizedInput, null, 2));
+      console.debug('[ScheduledTask] create input:', sanitizeLogPayload(normalizedInput));
       await applyAnnounceDeliveryNormalization(normalizedInput, getIMGatewayManager);
 
       const task = await getCronJobService().addJob(normalizedInput);
@@ -125,7 +126,7 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
   ipcMain.handle(ScheduledTaskIpc.Update, async (_event, id: string, input: any) => {
     try {
       const normalizedInput = input && typeof input === 'object' ? { ...input } : {};
-      console.debug('[ScheduledTask] update input id:', id, JSON.stringify(normalizedInput, null, 2));
+      console.debug('[ScheduledTask] update input:', sanitizeLogPayload({ id, input: normalizedInput }));
       await applyAnnounceDeliveryNormalization(normalizedInput, getIMGatewayManager);
 
       const task = await getCronJobService().updateJob(id, normalizedInput);

--- a/src/main/libs/apiFetchLog.test.ts
+++ b/src/main/libs/apiFetchLog.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from 'vitest';
+
+import {
+  sanitizeLogPayload,
+  summarizeApiFetchRequest,
+  summarizeApiFetchResponse,
+  summarizeLogText,
+} from './apiFetchLog';
+
+test('api fetch request summary redacts credentials and omits body content', () => {
+  const summary = summarizeApiFetchRequest({
+    method: 'POST',
+    url: 'https://api.example.com/v1/messages',
+    headers: {
+      Authorization: 'Bearer sk-lobster-log-test-DO-NOT-USE-123456',
+      'x-api-key': 'sk-anthropic-test-123456',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ access_token: 'secret-access-token', prompt: 'hello' }),
+  });
+
+  const serialized = JSON.stringify(summary);
+
+  expect(summary.headers.Authorization).toBe('[redacted]');
+  expect(summary.headers['x-api-key']).toBe('[redacted]');
+  expect(summary.headers['Content-Type']).toBe('application/json');
+  expect(summary.body).toEqual({ type: 'string', length: 55 });
+  expect(serialized).not.toContain('sk-lobster-log-test-DO-NOT-USE-123456');
+  expect(serialized).not.toContain('sk-anthropic-test-123456');
+  expect(serialized).not.toContain('secret-access-token');
+  expect(serialized).not.toContain('hello');
+});
+
+test('api fetch response summary omits response payload content', () => {
+  const summary = summarizeApiFetchResponse({
+    method: 'POST',
+    url: 'https://api.example.com/oauth/token',
+    status: 200,
+    statusText: 'OK',
+    data: {
+      access_token: 'secret-access-token',
+      refresh_token: 'secret-refresh-token',
+    },
+  });
+
+  const serialized = JSON.stringify(summary);
+
+  expect(summary.data.type).toBe('json');
+  expect(summary.data.length).toBeGreaterThan(0);
+  expect(serialized).not.toContain('secret-access-token');
+  expect(serialized).not.toContain('secret-refresh-token');
+});
+
+test('generic log sanitizer redacts nested secret fields', () => {
+  const summary = sanitizeLogPayload({
+    payload: {
+      message: 'daily reminder',
+      apiKey: 'sk-provider-secret',
+      oauthRefreshToken: 'refresh-token-secret',
+      clientSecret: 'client-secret-value',
+    },
+    delivery: {
+      to: 'user@example.com',
+      accountId: 'bot-main',
+    },
+  });
+
+  const serialized = JSON.stringify(summary);
+
+  expect(serialized).toContain('daily reminder');
+  expect(serialized).toContain('user@example.com');
+  expect(serialized).not.toContain('sk-provider-secret');
+  expect(serialized).not.toContain('refresh-token-secret');
+  expect(serialized).not.toContain('client-secret-value');
+});
+
+test('text log sanitizer redacts bearer tokens and truncates long provider errors', () => {
+  const sanitized = summarizeLogText(`failed Authorization: Bearer sk-provider-secret ${'x'.repeat(600)}`);
+
+  expect(sanitized).toContain('Bearer [redacted]');
+  expect(sanitized).toContain('[truncated]');
+  expect(sanitized).not.toContain('sk-provider-secret');
+});

--- a/src/main/libs/apiFetchLog.ts
+++ b/src/main/libs/apiFetchLog.ts
@@ -1,0 +1,122 @@
+export type ApiFetchLogDataSummary = {
+  type: 'none' | 'string' | 'json';
+  length?: number;
+};
+
+export type ApiFetchRequestLogSummary = {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: ApiFetchLogDataSummary;
+};
+
+export type ApiFetchResponseLogSummary = {
+  method: string;
+  url: string;
+  status: number;
+  statusText: string;
+  data: ApiFetchLogDataSummary;
+};
+
+const REDACTED = '[redacted]';
+const MAX_LOG_PREVIEW_CHARS = 500;
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'proxy-authorization',
+  'x-api-key',
+  'x-goog-api-key',
+  'api-key',
+  'apikey',
+  'cookie',
+  'set-cookie',
+]);
+
+const SENSITIVE_FIELD_NAME_RE = /(?:api[_-]?key|authorization|token|access[_-]?token|refresh[_-]?token|secret|client[_-]?secret|app[_-]?secret|bot[_-]?token|cookie)/i;
+
+export function summarizeApiFetchRequest(options: {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+}): ApiFetchRequestLogSummary {
+  return {
+    method: options.method,
+    url: options.url,
+    headers: redactHeaders(options.headers),
+    body: summarizeLogData(options.body),
+  };
+}
+
+export function summarizeApiFetchResponse(result: {
+  method: string;
+  url: string;
+  status: number;
+  statusText: string;
+  data: string | object;
+}): ApiFetchResponseLogSummary {
+  return {
+    method: result.method,
+    url: result.url,
+    status: result.status,
+    statusText: result.statusText,
+    data: summarizeLogData(result.data),
+  };
+}
+
+export function sanitizeLogPayload(value: unknown, seen?: WeakSet<object>): unknown {
+  if (
+    value === null
+    || typeof value === 'number'
+    || typeof value === 'boolean'
+    || typeof value === 'undefined'
+  ) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    return summarizeLogText(value);
+  }
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeLogPayload(entry, seen));
+  }
+  if (typeof value === 'object') {
+    const localSeen = seen ?? new WeakSet<object>();
+    if (localSeen.has(value)) {
+      return '[circular]';
+    }
+    localSeen.add(value);
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      sanitized[key] = SENSITIVE_FIELD_NAME_RE.test(key) ? REDACTED : sanitizeLogPayload(entry, localSeen);
+    }
+    return sanitized;
+  }
+  return String(value);
+}
+
+export function summarizeLogText(value: string): string {
+  const trimmed = value.length > MAX_LOG_PREVIEW_CHARS
+    ? `${value.slice(0, MAX_LOG_PREVIEW_CHARS)}...[truncated]`
+    : value;
+  return trimmed.replace(/(Bearer\s+)[^\s"'\\]+/gi, `$1${REDACTED}`);
+}
+
+function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  const redacted: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    redacted[key] = SENSITIVE_HEADER_NAMES.has(key.toLowerCase()) ? REDACTED : value;
+  }
+  return redacted;
+}
+
+function summarizeLogData(data: string | object | undefined): ApiFetchLogDataSummary {
+  if (typeof data === 'undefined') {
+    return { type: 'none' };
+  }
+  if (typeof data === 'string') {
+    return { type: 'string', length: data.length };
+  }
+  return { type: 'json', length: JSON.stringify(data).length };
+}

--- a/src/main/libs/coworkOpenAICompatProxy.ts
+++ b/src/main/libs/coworkOpenAICompatProxy.ts
@@ -9,6 +9,7 @@ import {
   openAIToAnthropic,
   type OpenAIStreamChunk,
 } from './coworkFormatTransform';
+import { summarizeLogText } from './apiFetchLog';
 
 export type OpenAICompatUpstreamConfig = {
   baseURL: string;
@@ -2697,7 +2698,7 @@ async function handleRequest(
 
     if (!upstreamResponse.ok) {
       const firstErrorText = await upstreamResponse.text();
-      console.error(`[CoworkProxy] Upstream error: status=${upstreamResponse.status}, body=${firstErrorText.slice(0, 500)}`);
+      console.error(`[CoworkProxy] Upstream error: status=${upstreamResponse.status}, body=${summarizeLogText(firstErrorText)}`);
       let firstErrorMessage = extractErrorMessage(firstErrorText);
       if (firstErrorMessage === 'Upstream API request failed') {
         firstErrorMessage = `Upstream API request failed (${upstreamResponse.status}) ${currentTargetURL}`;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -34,6 +34,7 @@ import {
   OpenClawRuntimeAdapter,
 } from './libs/agentEngine';
 import { cancelActiveDownload, downloadUpdate, installUpdate } from './libs/appUpdateInstaller';
+import { summarizeApiFetchRequest, summarizeApiFetchResponse } from './libs/apiFetchLog';
 import { clearServerModelMetadata, getCurrentApiConfig, resolveAllEnabledProviderConfigs, resolveCurrentApiConfig, resolveRawApiConfig, setAuthTokensGetter, setServerBaseUrlGetter, setStoreGetter, updateServerModelMetadata } from './libs/claudeSettings';
 import {
   clearCopilotTokenState,
@@ -4216,7 +4217,7 @@ if (!gotTheLock) {
     headers: Record<string, string>;
     body?: string;
   }) => {
-    console.log(`[api:fetch] ${options.method} ${options.url}, headers: ${JSON.stringify(options.headers)}, body: ${options.body}`);
+    console.log('[api:fetch] request:', summarizeApiFetchRequest(options));
 
     const doFetch = async (headers: Record<string, string>) => {
       const response = await session.defaultSession.fetch(options.url, {
@@ -4247,7 +4248,13 @@ if (!gotTheLock) {
 
     try {
       let result = await doFetch(options.headers);
-      console.log(`[api:fetch] ${options.method} ${options.url} -> ${result.status} ${result.statusText}`, typeof result.data === 'object' ? JSON.stringify(result.data) : result.data);
+      console.log('[api:fetch] response:', summarizeApiFetchResponse({
+        method: options.method,
+        url: options.url,
+        status: result.status,
+        statusText: result.statusText,
+        data: result.data,
+      }));
 
       // Auto-retry once for Copilot 401/403
       if (!result.ok && (result.status === 401 || result.status === 403) && isCopilotUrl(options.url)) {

--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -9,6 +9,7 @@ import type {
   ScheduledTaskRunWithName,
   TaskState,
 } from './types';
+import { sanitizeLogPayload } from '../main/libs/apiFetchLog';
 import { parseChannelSessionKey } from '../main/libs/openclawChannelSessionSync';
 import { PlatformRegistry } from '../shared/platform';
 import {
@@ -244,9 +245,9 @@ function toGatewayPayload(payload: ScheduledTaskPayload): GatewayPayload {
 }
 
 function toGatewayDelivery(delivery?: ScheduledTaskDelivery): GatewayDelivery | undefined {
-  console.log('[CronJobService][toGatewayDelivery] input delivery:', JSON.stringify(delivery, null, 2));
+  console.debug('[CronJobService] converting delivery:', sanitizeLogPayload(delivery));
   if (!delivery) {
-    console.log('[CronJobService][toGatewayDelivery] no delivery, returning undefined');
+    console.debug('[CronJobService] delivery is empty, skipping');
     return undefined;
   }
   if (delivery.mode === DeliveryMode.None) {
@@ -257,7 +258,7 @@ function toGatewayDelivery(delivery?: ScheduledTaskDelivery): GatewayDelivery | 
       ...(delivery.channel ? { channel: delivery.channel } : {}),
       ...(delivery.to ? { to: delivery.to } : {}),
     } as GatewayDelivery;
-    console.log('[CronJobService][toGatewayDelivery] mode=none with preserved channel/to:', JSON.stringify(result));
+    console.debug('[CronJobService] converted disabled delivery:', sanitizeLogPayload(result));
     return result;
   }
 
@@ -279,7 +280,7 @@ function toGatewayDelivery(delivery?: ScheduledTaskDelivery): GatewayDelivery | 
       ? { bestEffort: delivery.bestEffort }
       : {}),
   };
-  console.log('[CronJobService][toGatewayDelivery] output gatewayDelivery:', JSON.stringify(result, null, 2));
+  console.debug('[CronJobService] converted delivery:', sanitizeLogPayload(result));
   return result;
 }
 
@@ -461,18 +462,20 @@ export class CronJobService {
   }
 
   async addJob(input: ScheduledTaskInput): Promise<ScheduledTask> {
-    console.log('[CronJobService][addJob] full input:', JSON.stringify(input, null, 2));
-    console.log('[CronJobService][addJob] delivery details:', JSON.stringify({
+    console.debug('[CronJobService] creating job:', sanitizeLogPayload({
+      name: input.name,
+      schedule: input.schedule,
+      payload: input.payload,
       deliveryMode: input.delivery?.mode,
       deliveryChannel: input.delivery?.channel,
       deliveryTo: input.delivery?.to,
       deliveryAccountId: input.delivery?.accountId,
       sessionTarget: input.sessionTarget,
       sessionKey: input.sessionKey,
-    }, null, 2));
+    }));
     const client = await this.client();
     const gatewayDelivery = toGatewayDelivery(input.delivery);
-    console.log('[CronJobService][addJob] resolved gatewayDelivery:', JSON.stringify(gatewayDelivery));
+    console.debug('[CronJobService] resolved gateway delivery:', sanitizeLogPayload(gatewayDelivery));
     const job = await client.request<GatewayJob>('cron.add', {
       name: input.name,
       description: input.description || undefined,
@@ -492,15 +495,18 @@ export class CronJobService {
   }
 
   async updateJob(id: string, input: Partial<ScheduledTaskInput>): Promise<ScheduledTask> {
-    console.log('[CronJobService][updateJob] id:', id, 'input:', JSON.stringify(input, null, 2));
-    console.log('[CronJobService][updateJob] delivery details:', JSON.stringify({
+    console.debug('[CronJobService] updating job:', sanitizeLogPayload({
+      id,
+      name: input.name,
+      schedule: input.schedule,
+      payload: input.payload,
       deliveryMode: input.delivery?.mode,
       deliveryChannel: input.delivery?.channel,
       deliveryTo: input.delivery?.to,
       deliveryAccountId: input.delivery?.accountId,
       sessionTarget: input.sessionTarget,
       sessionKey: input.sessionKey,
-    }, null, 2));
+    }));
     const client = await this.client();
     const patch: Record<string, unknown> = {};
 
@@ -517,7 +523,7 @@ export class CronJobService {
     if (input.agentId !== undefined) patch.agentId = input.agentId?.trim() || null;
     if (input.sessionKey !== undefined) patch.sessionKey = input.sessionKey?.trim() || null;
 
-    console.log('[CronJobService][updateJob] final patch:', JSON.stringify(patch, null, 2));
+    console.debug('[CronJobService] update patch:', sanitizeLogPayload(patch));
     const job = await client.request<GatewayJob>('cron.update', { id, patch });
     const mapped = mapGatewayJob(job);
     console.log('[CronJobService][updateJob] updated job id:', mapped.id, 'name:', mapped.name);


### PR DESCRIPTION
## 问题描述
- 导出日志中存在明文密钥
<img width="1548" height="608" alt="image" src="https://github.com/user-attachments/assets/ac1cb813-9ee8-4843-a364-e58a6992f514" />


## 修改说明
- 修复主进程日志中可能出现明文敏感信息的问题，避免用户导出日志时带出 API Key、Bearer token、OAuth token、请求体或响应体内容。
- 新增主进程日志脱敏工具，集中处理敏感 header、token/secret/apiKey 类字段、Bearer token 文本和长错误文本截断。

## 效果验证
<img width="1506" height="412" alt="image" src="https://github.com/user-attachments/assets/dd17e63a-0bad-4908-8e1e-28b41ac0852c" />
