### PR TITLE
feat(openclaw): upgrade OpenClaw to v2026.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "version": "2026.4.13",
   "openclaw": {
-    "version": "v2026.3.2",
+    "version": "v2026.4.12",
     "repo": "https://github.com/openclaw/openclaw.git",
     "plugins": [
       {
@@ -34,7 +34,7 @@
       {
         "id": "openclaw-weixin",
         "npm": "@tencent-weixin/openclaw-weixin",
-        "version": "1.0.3"
+        "version": "2.1.8"
       },
       {
         "id": "moltbot-popo",

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -991,7 +991,6 @@ export class OpenClawConfigSync {
         enabled: true,
         maxConcurrentRuns: 3,
         sessionRetention: '7d',
-        skipMissedJobs: coworkConfig.skipMissedJobs ?? false
       },
       ...((() => {
         const pluginEntries: Record<string, unknown> = {

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -999,6 +999,15 @@ export class OpenClawEngineManager extends EventEmitter {
       const candidates = fs.readdirSync(distRoot)
         .filter((name) => /^client(?:-.*)?\.js$/i.test(name))
         .sort();
+      // When multiple client-*.js files exist (v2026.4+), probe each one
+      // to find the file that actually exports the GatewayClient class.
+      for (const name of candidates) {
+        const candidatePath = path.join(distRoot, name);
+        if (this.isGatewayClientModule(candidatePath)) {
+          return candidatePath;
+        }
+      }
+      // Fallback: return first candidate if none matched the probe
       if (candidates.length > 0) {
         return path.join(distRoot, candidates[0]);
       }
@@ -1007,6 +1016,28 @@ export class OpenClawEngineManager extends EventEmitter {
     }
 
     return null;
+  }
+
+  private isGatewayClientModule(filePath: string): boolean {
+    try {
+      const loaded = require(filePath) as Record<string, unknown>;
+      if (typeof loaded.GatewayClient === 'function') return true;
+      for (const val of Object.values(loaded)) {
+        if (typeof val !== 'function') continue;
+        const fn = val as { name?: string; prototype?: Record<string, unknown> };
+        if (fn.name === 'GatewayClient') return true;
+        const proto = fn.prototype;
+        if (proto
+          && typeof proto.start === 'function'
+          && typeof proto.stop === 'function'
+          && typeof proto.request === 'function') {
+          return true;
+        }
+      }
+    } catch {
+      // ignore require errors
+    }
+    return false;
   }
 
   private ensureGatewayToken(): string {


### PR DESCRIPTION
## Summary
- Upgrade OpenClaw runtime from v2026.3.2 to v2026.4.12
- Upgrade openclaw-weixin plugin from 1.0.3 to 2.1.8 (fixes `resolvePreferredOpenClawTmpDir is not a function` error with new plugin-sdk)
- Remove `skipMissedJobs` from config sync — this key was removed from the OpenClaw config schema in v2026.4.x and causes gateway startup failure (`Config invalid: cron: Unrecognized key: "skipMissedJobs"`)
- Fix gateway client module resolution for v2026.4+: the new version ships multiple `client-*.js` files in `dist/` (Slack client, bootstrap files, etc.); the previous alphabetical-first heuristic picked the wrong file, causing `Invalid OpenClaw gateway client module` errors. Now probes each candidate's exports to find the real `GatewayClient` class.

## Test plan
- [ ] Run `npm run electron:dev:openclaw` — OpenClaw runtime builds and gateway starts without errors
- [ ] Send a message in Cowork — no `Invalid OpenClaw gateway client module` error
- [ ] Verify gateway logs show `gateway ready` without `Config invalid` warnings
- [ ] Verify openclaw-weixin plugin loads without `resolvePreferredOpenClawTmpDir` error