### PR TITLE
feat(cowork): add openclaw session patch support

### DIFF
--- a/docs/openclaw-session-model-override-plan.md
+++ b/docs/openclaw-session-model-override-plan.md
@@ -1,0 +1,556 @@
+# OpenClaw 会话级模型 Override 方案
+
+## 背景
+
+当前 Cowork 发送框和页面头部的模型选择器，改的是当前 `agent` 的默认模型配置，不是当前会话的模型 override。
+
+这和期望行为不一致。你希望的是：
+
+- 切换模型时，仅影响当前会话
+- 底层通过 OpenClaw 的 `sessions.patch` 能力落到会话级别
+- 不要把这次切换写回 `agents.model`
+
+## 现状分析
+
+### 1. 当前 UI 选择模型后，直接写 agent
+
+发送框里的模型切换逻辑在：
+
+- [src/renderer/components/cowork/CoworkPromptInput.tsx](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/components/cowork/CoworkPromptInput.tsx)
+
+核心行为：
+
+- `ModelSelector.value` 使用 `resolveAgentModelSelection(...)`
+- `resolveAgentModelSelection(...)` 读的是 `currentAgent.model`
+- `onChange` 里直接执行 `agentService.updateAgent(currentAgent.id, { model: toOpenClawModelRef(nextModel) })`
+
+页面头部也是同样逻辑：
+
+- [src/renderer/components/cowork/CoworkView.tsx](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/components/cowork/CoworkView.tsx)
+
+因此现在的“切换模型”本质是：
+
+1. 修改 agent 默认模型
+2. 后续所有新会话都可能跟着变
+3. 当前已存在会话并没有显式 session override 概念
+
+### 2. 当前 Cowork 本地状态没有 session-level model 字段
+
+LobsterAI 的会话结构目前没有会话 override 模型字段：
+
+- [src/renderer/types/cowork.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/types/cowork.ts)
+- [src/main/coworkStore.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/coworkStore.ts)
+
+`CoworkSession` / `CoworkSessionSummary` 里只有：
+
+- `agentId`
+- `systemPrompt`
+- `cwd`
+- `status`
+- `messages`
+
+没有这些字段：
+
+- `modelOverride`
+- `modelProviderOverride`
+- `effectiveModel`
+
+所以前端只能退回去读 `agent.model`，这也是现在逻辑会绑定到 agent 的根本原因。
+
+### 3. OpenClaw 已经支持会话级模型 patch
+
+OpenClaw 客户端已经直接暴露：
+
+- [/Users/yunxin/Documents/open-source/openclaw/src/tui/gateway-chat.ts](/Users/yunxin/Documents/open-source/openclaw/src/tui/gateway-chat.ts)
+
+```ts
+async patchSession(opts: SessionsPatchParams): Promise<SessionsPatchResult> {
+  return await this.client.request<SessionsPatchResult>("sessions.patch", opts);
+}
+```
+
+真正的服务端 patch 逻辑在：
+
+- [/Users/yunxin/Documents/open-source/openclaw/src/gateway/sessions-patch.ts](/Users/yunxin/Documents/open-source/openclaw/src/gateway/sessions-patch.ts)
+- [/Users/yunxin/Documents/open-source/openclaw/src/sessions/model-overrides.ts](/Users/yunxin/Documents/open-source/openclaw/src/sessions/model-overrides.ts)
+
+它的关键行为是：
+
+- `patch.model = "provider/model"` 或 alias 时，会解析并校验为 allowlisted model
+- patch 成功后，写入 `providerOverride` / `modelOverride`
+- 如果 patch 到默认模型，会清掉 override，而不是冗余保存
+- 切模型时会清掉旧的 `authProfileOverride`
+- 还会清掉已记录的 runtime model 字段，保证状态显示及时切换到新的 override
+
+OpenClaw 会话模型解析优先级也已经明确：
+
+- [/Users/yunxin/Documents/open-source/openclaw/src/gateway/session-utils.ts](/Users/yunxin/Documents/open-source/openclaw/src/gateway/session-utils.ts)
+
+优先级是：
+
+1. 最近一次 runtime model
+2. session override (`providerOverride` / `modelOverride`)
+3. agent/default model
+
+这正是你要的能力。
+
+## 当前调用链
+
+### 新建会话
+
+入口：
+
+- [src/renderer/components/cowork/CoworkView.tsx](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/components/cowork/CoworkView.tsx)
+- [src/renderer/services/cowork.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/services/cowork.ts)
+- [src/main/main.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/main.ts)
+- [src/main/libs/agentEngine/coworkEngineRouter.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/libs/agentEngine/coworkEngineRouter.ts)
+- [src/main/libs/agentEngine/openclawRuntimeAdapter.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/libs/agentEngine/openclawRuntimeAdapter.ts)
+
+OpenClaw runtime 在 `runTurn()` 里按 `sessionId + agentId` 生成 managed `sessionKey`：
+
+- `agentId = options.agentId || session.agentId || 'main'`
+- `sessionKey = this.toSessionKey(sessionId, agentId)`
+
+也就是说，LobsterAI 其实已经能稳定定位到对应的 OpenClaw session，只是没有暴露 “patch 当前 session” 这条能力。
+
+### 继续会话
+
+继续会话时走的仍然是同一个 `sessionId`，最终会映射到同一个 managed `sessionKey`。
+
+这意味着：
+
+- 只要在发送前或切换时调用一次 `sessions.patch`
+- 后续 `chat.send` 就会自动落到该会话的 override 模型
+
+## 问题拆解
+
+### 问题 1：UI 的模型来源错了
+
+现在 UI 读的是：
+
+- `currentAgent.model`
+- 若为空则回退到 `globalSelectedModel`
+
+正确的会话级语义应该是：
+
+1. 当前 session 的 override model
+2. 若无 override，则显示当前 agent/default effective model
+3. Home 空态下没有 session 时，才允许显示 agent/default model
+
+### 问题 2：缺少 session patch IPC
+
+现在已有：
+
+- `openclaw:sessionPolicy:get`
+- `openclaw:sessionPolicy:set`
+
+但没有：
+
+- `openclaw:session:getModelOverride`
+- `openclaw:session:setModelOverride`
+
+或者更通用的：
+
+- `openclaw:session:patch`
+
+### 问题 3：本地会话元数据没有同步面
+
+即便主进程把 `sessions.patch` 调成功了，前端如果没有本地 session 元数据字段，仍然没法正确显示“当前会话已切到哪个模型”。
+
+### 问题 4：新会话首次发送前的时序
+
+“新对话页面还没真正创建 session 时”就点了模型切换，会有两种语义：
+
+1. 改 agent 默认模型
+2. 仅把这次即将创建的会话的初始 override 设好
+
+既然目标是“会话级”，则推荐第二种，但这要求在新会话创建前先保留一个“待应用的 session override model”。
+
+## 推荐方案
+
+## 总体原则
+
+- 保留 `agent.model` 作为 agent 默认模型
+- 新增 `session.modelOverride` 作为会话级模型
+- 通信接口设计成通用 `session patch`，模型只是第一批落地字段之一
+- Cowork 区的模型选择器默认操作 session override，不再直接改 agent
+- 只有 Agent 设置页才改 `agent.model`
+
+## 方案分层
+
+### A. 先补会话模型字段
+
+需要在 LobsterAI 本地会话模型里加字段：
+
+- `modelOverride?: string`
+- `effectiveModel?: string`
+
+建议 renderer/main 两侧类型同时补：
+
+- [src/renderer/types/cowork.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/types/cowork.ts)
+- [src/main/coworkStore.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/coworkStore.ts)
+
+推荐语义：
+
+- `modelOverride`
+  表示用户显式设置到当前 session 的 OpenClaw model ref，例如 `anthropic/claude-sonnet-4-6`
+- `effectiveModel`
+  表示当前 UI 用来展示的有效模型。可等于 override，也可等于 agent/default fallback
+
+更稳妥的做法是只持久化 `modelOverride`，`effectiveModel` 在读取时计算，避免双写漂移。
+
+### B. 在 SQLite 的 `cowork_sessions` 表新增列
+
+建议新增：
+
+- `model_override TEXT NOT NULL DEFAULT ''`
+
+原因：
+
+- 当前会话列表和详情都依赖本地 SQLite
+- 需要在重启应用后保留会话级 override 展示
+- 仅存在于内存中的 sessionKey -> override 映射不够
+
+`effectiveModel` 不建议入库，运行时由：
+
+1. `model_override`
+2. `agent.model`
+3. `globalSelectedModel`
+
+共同计算即可。
+
+### C. 新增通用 OpenClaw session patch IPC
+
+建议直接设计成通用 patch 接口，遵守仓库的字符串常量规则，不要直接写裸字符串。
+
+例如新增模块：
+
+- `src/main/openclawSession/constants.ts`
+
+建议至少包含：
+
+```ts
+export const OpenClawSessionIpc = {
+  Patch: 'openclaw:session:patch',
+  Get: 'openclaw:session:get',
+} as const;
+```
+
+建议 patch payload 也定义成通用结构，而不是模型专用结构。例如：
+
+```ts
+export interface OpenClawSessionPatchInput {
+  sessionId: string;
+  patch: {
+    model?: string | null;
+    thinkingLevel?: string | null;
+    reasoningLevel?: string | null;
+    elevatedLevel?: string | null;
+    responseUsage?: 'off' | 'tokens' | 'full' | null;
+    sendPolicy?: 'allow' | 'deny' | null;
+  };
+}
+```
+
+这里的字段不需要第一版一次性全做完，但接口形态应当从一开始就是通用 patch。
+
+主进程职责：
+
+1. 根据 `sessionId` 找到本地会话
+2. 用 `agentId` 推导 managed `sessionKey`
+3. 将 `sessionId + patch` 转成 OpenClaw `sessions.patch` 所需参数
+4. patch 成功后同步更新 LobsterAI 本地已持久化的 session 元数据
+5. 返回给 renderer 最新 session 数据
+
+第一版即便只真正落地 `patch.model`，接口层也应设计成通用 patch，而不是 `setModel`/`clearModel` 风格的专用接口。
+
+### D. 在 OpenClawRuntimeAdapter 内增加通用 patch helper
+
+建议在：
+
+- [src/main/libs/agentEngine/openclawRuntimeAdapter.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/libs/agentEngine/openclawRuntimeAdapter.ts)
+
+新增类似能力：
+
+```ts
+async patchSession(
+  sessionId: string,
+  patch: {
+    model?: string | null;
+    thinkingLevel?: string | null;
+    reasoningLevel?: string | null;
+    elevatedLevel?: string | null;
+    responseUsage?: 'off' | 'tokens' | 'full' | null;
+    sendPolicy?: 'allow' | 'deny' | null;
+  },
+): Promise<void>
+```
+
+内部逻辑：
+
+1. `const session = this.store.getSession(sessionId)`
+2. `const agentId = session?.agentId || 'main'`
+3. `const sessionKey = this.toSessionKey(sessionId, agentId)`
+4. `await this.ensureGatewayClientReady()`
+5. `await client.request('sessions.patch', { key: sessionKey, ...patch })`
+
+为什么放在 runtime adapter 合适：
+
+- `sessionKey` 生成逻辑已经在这里
+- 以后若要查询 OpenClaw 当前 session 的更多元数据，也能继续收敛在这一层
+- 主进程 IPC handler 不需要了解 OpenClaw 内部 sessionKey 拼法
+
+### E. CoworkEngineRouter 补一个可选 patch 能力
+
+当前 `CoworkRuntime` 接口只有：
+
+- `startSession`
+- `continueSession`
+- `stopSession`
+
+建议增加可选方法：
+
+```ts
+patchSession?(
+  sessionId: string,
+  patch: {
+    model?: string | null;
+    thinkingLevel?: string | null;
+    reasoningLevel?: string | null;
+    elevatedLevel?: string | null;
+    responseUsage?: 'off' | 'tokens' | 'full' | null;
+    sendPolicy?: 'allow' | 'deny' | null;
+  },
+): Promise<void>;
+```
+
+然后：
+
+- `openclawRuntimeAdapter` 实现它
+- `claudeRuntimeAdapter` 返回 unsupported 或 no-op
+- `coworkEngineRouter` 透传到当前 engine
+
+这样主进程 IPC 不需要直接耦合具体 runtime 实现。
+
+### F. renderer 增加 session-level service 方法
+
+在：
+
+- [src/renderer/services/cowork.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/services/cowork.ts)
+
+新增：
+
+- `patchSession(sessionId: string, patch: OpenClawSessionPatch)`
+- 可以在其上再封装 `setSessionModelOverride(...)`
+
+职责：
+
+1. 调 preload 暴露的 `window.electron.openclaw.session.patch`
+2. 拿到返回的 session
+3. 更新 Redux `currentSession` / `sessions`
+
+### G. preload 和类型声明同步扩展
+
+需要修改：
+
+- [src/main/preload.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/preload.ts)
+- [src/renderer/types/electron.d.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/types/electron.d.ts)
+
+在 `window.electron.openclaw` 下新增：
+
+- `session.get`
+- `session.patch`
+
+## UI 行为建议
+
+### 1. 有当前 session 时，模型选择器改为通过通用 patch 操作 session override
+
+适用位置：
+
+- [src/renderer/components/cowork/CoworkPromptInput.tsx](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/components/cowork/CoworkPromptInput.tsx)
+- [src/renderer/components/cowork/CoworkView.tsx](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/components/cowork/CoworkView.tsx)
+
+建议行为：
+
+- 如果 `currentSession` 存在，`onChange` 改为 `coworkService.patchSession(currentSession.id, { model: toOpenClawModelRef(nextModel) })`
+- 不再调用 `agentService.updateAgent(...)`
+
+### 2. 无当前 session 时，不直接改 agent，改为“待创建会话 override”
+
+这是最符合“会话级”的空态行为。
+
+建议新增一个 Home 草稿态字段：
+
+- `draftSessionModelOverrideByDraftKey`
+
+至少支持：
+
+- `__home__` 的新会话草稿 override
+- 会话草稿切换时保留对应选择
+
+新建会话成功后：
+
+1. 先创建本地 session
+2. 在真正 `startSession()` 前调用一次 `patchSession(session.id, { model: draftModelOverride })`
+3. 再执行首条 `chat.send`
+
+这样第一轮就会用对模型。
+
+如果你想先降低改造范围，也可以采用过渡方案：
+
+- 空态下仍显示 agent/default model
+- 只有进入 session 后，模型选择器才改为 session override
+
+但这会留下一个语义不一致点：空态选的仍不是会话级。
+
+### 3. 显示逻辑改为 resolveSessionModelSelection
+
+当前用的是：
+
+- `resolveAgentModelSelection(...)`
+
+建议抽出新的选择逻辑：
+
+```ts
+resolveSessionModelSelection({
+  sessionModelOverride,
+  agentModel,
+  availableModels,
+  fallbackModel,
+  engine,
+})
+```
+
+优先级：
+
+1. `sessionModelOverride`
+2. `agentModel`
+3. `fallbackModel`
+
+并区分两类异常：
+
+- session override 无效
+- agent model 无效
+
+这样 UI 才能给对提示，不会把“session override 丢失”误报成 agent 配置问题。
+
+## 推荐实施顺序
+
+### 第一阶段：打通主链路
+
+1. 给 `cowork_sessions` 增加 `model_override`
+2. 扩展 `CoworkSession` 类型
+3. 新增 `openclaw.session.patch`
+4. 在 `openclawRuntimeAdapter` 内实现通用 `patchSession(...)`
+5. 有 session 时，两个模型选择器都改成操作 session override
+
+这一阶段完成后，已有会话内切模型就会符合预期。
+
+### 第二阶段：补齐新会话空态体验
+
+1. 为 `__home__` 草稿增加 `draftSessionModelOverride`
+2. 新建会话时先 patch 再首发消息
+3. 空态模型显示改为草稿 override
+
+这一阶段完成后，整个 Cowork 区模型语义才彻底统一为“会话级”。
+
+### 第三阶段：补齐可视化与容错
+
+1. UI 增加“已覆盖当前会话模型”的提示
+2. 增加“恢复为 agent 默认模型”的 clear 操作
+3. 无效 override 时展示明确错误
+4. 给切换后刷新失败、gateway catalog 不可用等情况补错误提示
+
+## 风险与注意点
+
+### 1. 不要把 session override 和 agent 默认模型混写
+
+最重要的边界：
+
+- Cowork 会话内的模型切换，只能改 session
+- Agent 管理页里的模型设置，才改 `agent.model`
+
+### 2. `sessions.patch` 可能失败于模型校验
+
+OpenClaw 会校验：
+
+- 空字符串非法
+- model catalog 不可用时会返回 unavailable
+- 不在 allowlist 内的 model 会被拒绝
+
+所以 renderer 不能做“乐观更新后不回滚”，应该以后端返回成功为准。
+
+### 3. 需要考虑 currentSession 为空但已有 draft 的情况
+
+这是当前交互最容易被忽略的缺口。只改“已存在 session”路径，会导致：
+
+- 进入新会话前选模型没有效果
+- 用户仍然觉得模型切换是坏的
+
+### 4. 如果保留 header 和 input 两处选择器，必须共用同一状态源
+
+否则会出现：
+
+- 顶部显示 session override
+- 底部还在显示 agent model
+
+或相反。
+
+### 5. `effectiveModel` 最好不要持久化
+
+因为它是导出值，不是真实 source of truth。
+
+真实 source 建议只有：
+
+- `session.modelOverride`
+- `agent.model`
+- `globalSelectedModel`
+
+## 最小可行改造
+
+如果只做最小闭环，我建议范围控制在：
+
+1. 数据层新增 `model_override`
+2. OpenClaw runtime 新增通用 `patchSession`
+3. `currentSession` 存在时，Cowork 顶部和输入框模型切换都改用 session patch
+4. Agent 设置页保持不变
+
+这个版本已经能解决你提的核心问题：
+
+- 当前会话改模型，不再污染 agent 默认模型
+
+## 建议变更文件清单
+
+高优先级：
+
+- [src/renderer/components/cowork/CoworkPromptInput.tsx](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/components/cowork/CoworkPromptInput.tsx)
+- [src/renderer/components/cowork/CoworkView.tsx](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/components/cowork/CoworkView.tsx)
+- [src/renderer/services/cowork.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/services/cowork.ts)
+- [src/renderer/types/cowork.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/types/cowork.ts)
+- [src/renderer/types/electron.d.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/renderer/types/electron.d.ts)
+- [src/main/preload.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/preload.ts)
+- [src/main/main.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/main.ts)
+- [src/main/coworkStore.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/coworkStore.ts)
+- [src/main/libs/agentEngine/types.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/libs/agentEngine/types.ts)
+- [src/main/libs/agentEngine/coworkEngineRouter.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/libs/agentEngine/coworkEngineRouter.ts)
+- [src/main/libs/agentEngine/openclawRuntimeAdapter.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/libs/agentEngine/openclawRuntimeAdapter.ts)
+
+建议新增：
+
+- [src/main/openclawSession/constants.ts](/Users/yunxin/Documents/open-source/LobsterAI/src/main/openclawSession/constants.ts)
+
+可选优化：
+
+- `src/renderer/components/cowork/agentModelSelection.ts`
+  可改名或新增 `sessionModelSelection.ts`
+
+## 结论
+
+当前实现确实是“改当前 agent 的模型”，不是“改当前会话的模型”。从 OpenClaw 的现有能力看，正确方向不是继续沿用 `agentService.updateAgent()`，而是让 LobsterAI 显式接入 `sessions.patch`，并在本地会话结构里持久化 `model_override`。
+
+最合理的目标架构是：
+
+- `agent.model` 负责默认值
+- `session.modelOverride` 负责会话覆盖
+- Cowork 内模型选择器优先操作 session override
+- Agent 管理界面继续操作 agent 默认模型

--- a/spec/features/openclaw-session-patch/2026-04-14-openclaw-session-patch-history.md
+++ b/spec/features/openclaw-session-patch/2026-04-14-openclaw-session-patch-history.md
@@ -1,0 +1,184 @@
+# OpenClaw Session Patch History
+
+**Feature ID**: openclaw-session-patch
+**Created**: 2026-04-14
+**Status**: Implemented
+**Last Updated**: 2026-04-14
+
+## Background
+
+Cowork 区之前的模型切换逻辑并不是会话级能力。
+
+在以下位置，模型选择器会直接写回当前 agent 的默认模型：
+
+- `src/renderer/components/cowork/CoworkPromptInput.tsx`
+- `src/renderer/components/cowork/CoworkView.tsx`
+
+这带来两个问题：
+
+1. 用户在某个会话里切换模型，实际上污染了 `agent.model`
+2. OpenClaw 已经提供 `sessions.patch` 的会话级 override，但 LobsterAI 没有接这条能力
+
+同时，channel / IM 创建的 remote-managed 会话原本不显示模型选择器，导致这些会话无法在 UI 上改当前会话模型。
+
+## Goals
+
+本次改动的目标是：
+
+1. 引入通用的 OpenClaw session patch 能力，而不是仅为模型做专用接口
+2. 先把 `model` 作为 patch 的首个落地字段
+3. 让 active session 的模型选择器改为 patch 当前会话，不再改 agent 默认模型
+4. 让 remote-managed / channel 会话也能在 UI 中切换当前会话模型
+
+## Key Design Decisions
+
+## 1. 接口设计成通用 patch
+
+没有新增 `setSessionModel()` 这种专用接口，而是新增了：
+
+- `src/common/openclawSession.ts`
+- `src/main/openclawSession/constants.ts`
+
+核心抽象是：
+
+- `OpenClawSessionPatch`
+- IPC `openclaw:session:patch`
+- runtime `patchSession(sessionId, patch)`
+
+这样后续如果要支持：
+
+- `thinkingLevel`
+- `reasoningLevel`
+- `elevatedLevel`
+- `responseUsage`
+- `sendPolicy`
+
+不需要重做接口层。
+
+## 2. 本地会话持久化 `modelOverride`
+
+为了让 UI 在应用重启、会话切换、重新载入时仍能显示会话级模型，给 `cowork_sessions` 加了：
+
+- `model_override TEXT NOT NULL DEFAULT ''`
+
+并在 renderer / main 的 `CoworkSession` 类型里补了：
+
+- `modelOverride: string`
+
+这里没有持久化“effectiveModel”，因为它是派生值，不是 source of truth。
+
+## 3. Active session 优先读取会话 override
+
+`resolveAgentModelSelection(...)` 被扩展为优先考虑：
+
+1. `sessionModel`
+2. `agentModel`
+3. `fallbackModel`
+
+所以详情页输入框中的模型选择器现在优先反映当前会话的 override。
+
+## 4. remote-managed 会话只放开模型切换，不放开发消息
+
+对于 channel / IM 创建的会话，仍然保持：
+
+- 输入框 disabled
+- 附件按钮隐藏
+- 技能按钮隐藏
+
+但模型选择器改为可见且可用。
+
+这确保：
+
+- UI 不能向 remote-managed 会话主动发消息
+- 但可以修改该会话后续在 OpenClaw 中使用的模型
+
+## 5. patch 必须命中真实 channel sessionKey
+
+这是本次实现里最关键的修正。
+
+初版 `patchSession()` 使用：
+
+- `toSessionKey(sessionId, agentId)`
+
+这对本地 managed 会话可行，但对 channel 会话不对。channel 会话真正执行时使用的是类似：
+
+- `agent:main:openclaw-weixin:...`
+
+的真实 channel `sessionKey`。
+
+这导致一个隐蔽 bug：
+
+1. UI 执行 `sessions.patch` 返回成功
+2. 但 patch 到的是 managed key，而不是正在跑的 channel key
+3. IM 通道后续 `/new` 或继续对话时，实际仍然走旧模型
+
+修复后，`OpenClawRuntimeAdapter.patchSession()` 的 key 选择顺序变成：
+
+1. 当前 active turn 的 `sessionKey`
+2. 已记住的非 managed `sessionKey`
+3. `toSessionKey(sessionId, agentId)` 作为兜底
+
+也就是说，channel 会话优先 patch 到真实 channel key。
+
+## Files Changed
+
+核心新增：
+
+- `src/common/openclawSession.ts`
+- `src/main/openclawSession/constants.ts`
+- `docs/openclaw-session-model-override-plan.md`
+
+主进程与 runtime：
+
+- `src/main/main.ts`
+- `src/main/preload.ts`
+- `src/main/sqliteStore.ts`
+- `src/main/coworkStore.ts`
+- `src/main/libs/agentEngine/types.ts`
+- `src/main/libs/agentEngine/claudeRuntimeAdapter.ts`
+- `src/main/libs/agentEngine/coworkEngineRouter.ts`
+- `src/main/libs/agentEngine/openclawRuntimeAdapter.ts`
+
+Renderer：
+
+- `src/renderer/services/cowork.ts`
+- `src/renderer/types/cowork.ts`
+- `src/renderer/types/electron.d.ts`
+- `src/renderer/components/cowork/CoworkPromptInput.tsx`
+- `src/renderer/components/cowork/CoworkSessionDetail.tsx`
+- `src/renderer/components/cowork/CoworkView.tsx`
+- `src/renderer/components/cowork/agentModelSelection.ts`
+- `src/renderer/components/cowork/agentModelSelection.test.ts`
+
+测试补充：
+
+- `src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts`
+
+## Verification
+
+本次改动完成后做过的验证：
+
+- `./node_modules/.bin/vitest run src/renderer/components/cowork/agentModelSelection.test.ts`
+- `npx tsc -p tsconfig.json --noEmit`
+- `npx tsc -p electron-tsconfig.json --noEmit`
+
+定向 eslint 只剩仓库原本就存在于 `openclawRuntimeAdapter.ts` 的 warning，没有新增 error。
+
+## Known Gaps
+
+本次没有一起完成的部分：
+
+1. Home 空态的新会话草稿模型选择，还没有完全切到“草稿态 session override”语义
+2. 主进程目前只把 `patch.model` 同步回本地 SQLite；其他 patch 字段虽然接口预留了，但还没做本地持久化展示
+3. 没有补一条专门覆盖“channel 会话 patch 后 IM `/new` 继续沿用 override”的自动化测试
+
+## Why This Matters
+
+从行为上看，这次改动把“模型切换”从 agent 级别拉回到了真正的会话级别。
+
+对用户来说，最重要的结果是：
+
+- 在普通 cowork 会话里切换模型，不再改 agent 默认模型
+- 在 remote-managed/channel 会话里，即使不能回复消息，也能改当前会话模型
+- 对 channel 会话，patch 现在会命中真实运行中的 sessionKey，而不是写到错误的 managed key 上
+

--- a/src/common/openclawSession.ts
+++ b/src/common/openclawSession.ts
@@ -1,0 +1,25 @@
+export const OpenClawSessionResponseUsage = {
+  Off: 'off',
+  Tokens: 'tokens',
+  Full: 'full',
+} as const;
+
+export type OpenClawSessionResponseUsage =
+  typeof OpenClawSessionResponseUsage[keyof typeof OpenClawSessionResponseUsage];
+
+export const OpenClawSessionSendPolicy = {
+  Allow: 'allow',
+  Deny: 'deny',
+} as const;
+
+export type OpenClawSessionSendPolicy =
+  typeof OpenClawSessionSendPolicy[keyof typeof OpenClawSessionSendPolicy];
+
+export interface OpenClawSessionPatch {
+  model?: string | null;
+  thinkingLevel?: string | null;
+  reasoningLevel?: string | null;
+  elevatedLevel?: string | null;
+  responseUsage?: OpenClawSessionResponseUsage | null;
+  sendPolicy?: OpenClawSessionSendPolicy | null;
+}

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -380,6 +380,7 @@ export interface CoworkSession {
   pinned: boolean;
   cwd: string;
   systemPrompt: string;
+  modelOverride: string;
   executionMode: CoworkExecutionMode;
   activeSkillIds: string[];
   agentId: string;
@@ -557,8 +558,8 @@ export class CoworkStore {
     this.db
       .prepare(
         `
-      INSERT INTO cowork_sessions (id, title, claude_session_id, status, cwd, system_prompt, execution_mode, active_skill_ids, agent_id, pinned, created_at, updated_at)
-      VALUES (?, ?, NULL, 'idle', ?, ?, ?, ?, ?, 0, ?, ?)
+      INSERT INTO cowork_sessions (id, title, claude_session_id, status, cwd, system_prompt, model_override, execution_mode, active_skill_ids, agent_id, pinned, created_at, updated_at)
+      VALUES (?, ?, NULL, 'idle', ?, ?, '', ?, ?, ?, 0, ?, ?)
     `,
       )
       .run(
@@ -581,6 +582,7 @@ export class CoworkStore {
       pinned: false,
       cwd,
       systemPrompt,
+      modelOverride: '',
       executionMode,
       activeSkillIds,
       agentId,
@@ -599,6 +601,7 @@ export class CoworkStore {
       pinned?: number | null;
       cwd: string;
       system_prompt: string;
+      model_override?: string | null;
       execution_mode?: string | null;
       active_skill_ids?: string | null;
       agent_id?: string | null;
@@ -608,7 +611,7 @@ export class CoworkStore {
 
     const row = this.getOne<SessionRow>(
       `
-      SELECT id, title, claude_session_id, status, pinned, cwd, system_prompt, execution_mode, active_skill_ids, agent_id, created_at, updated_at
+      SELECT id, title, claude_session_id, status, pinned, cwd, system_prompt, model_override, execution_mode, active_skill_ids, agent_id, created_at, updated_at
       FROM cowork_sessions
       WHERE id = ?
     `,
@@ -637,6 +640,7 @@ export class CoworkStore {
       pinned: Boolean(row.pinned),
       cwd: row.cwd,
       systemPrompt: row.system_prompt,
+      modelOverride: row.model_override || '',
       executionMode: (row.execution_mode as CoworkExecutionMode) || 'local',
       activeSkillIds,
       agentId: row.agent_id || 'main',
@@ -651,7 +655,7 @@ export class CoworkStore {
     updates: Partial<
       Pick<
         CoworkSession,
-        'title' | 'claudeSessionId' | 'status' | 'cwd' | 'systemPrompt' | 'executionMode'
+        'title' | 'claudeSessionId' | 'status' | 'cwd' | 'systemPrompt' | 'modelOverride' | 'executionMode'
       >
     >,
   ): void {
@@ -678,6 +682,10 @@ export class CoworkStore {
     if (updates.systemPrompt !== undefined) {
       setClauses.push('system_prompt = ?');
       values.push(updates.systemPrompt);
+    }
+    if (updates.modelOverride !== undefined) {
+      setClauses.push('model_override = ?');
+      values.push(updates.modelOverride);
     }
     if (updates.executionMode !== undefined) {
       setClauses.push('execution_mode = ?');

--- a/src/main/libs/agentEngine/claudeRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/claudeRuntimeAdapter.ts
@@ -1,5 +1,7 @@
-import { EventEmitter } from 'events';
 import type { PermissionResult } from '@anthropic-ai/claude-agent-sdk';
+import { EventEmitter } from 'events';
+
+import type { OpenClawSessionPatch } from '../../../common/openclawSession';
 import type { CoworkRunner } from '../coworkRunner';
 import type {
   CoworkContinueOptions,
@@ -37,6 +39,10 @@ export class ClaudeRuntimeAdapter extends EventEmitter implements CoworkRuntime 
 
   async continueSession(sessionId: string, prompt: string, options: CoworkContinueOptions = {}): Promise<void> {
     await this.runner.continueSession(sessionId, prompt, options);
+  }
+
+  async patchSession(_sessionId: string, _patch: OpenClawSessionPatch): Promise<void> {
+    throw new Error('Session patch is only supported by the OpenClaw engine.');
   }
 
   stopSession(sessionId: string): void {

--- a/src/main/libs/agentEngine/coworkEngineRouter.ts
+++ b/src/main/libs/agentEngine/coworkEngineRouter.ts
@@ -1,5 +1,7 @@
-import { EventEmitter } from 'events';
 import type { PermissionResult } from '@anthropic-ai/claude-agent-sdk';
+import { EventEmitter } from 'events';
+
+import type { OpenClawSessionPatch } from '../../../common/openclawSession';
 import type {
   CoworkAgentEngine,
   CoworkContinueOptions,
@@ -72,6 +74,16 @@ export class CoworkEngineRouter extends EventEmitter implements CoworkRuntime {
       this.clearRequestEngineBySession(sessionId);
       throw error;
     }
+  }
+
+  async patchSession(sessionId: string, patch: OpenClawSessionPatch): Promise<void> {
+    const engine = this.safeResolveEngine();
+    this.sessionEngine.set(sessionId, engine);
+    const runtime = this.runtimeByEngine[engine];
+    if (!runtime.patchSession) {
+      throw new Error(`Session patch is not supported by engine: ${engine}`);
+    }
+    await runtime.patchSession(sessionId, patch);
   }
 
   stopSession(sessionId: string): void {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 vi.mock('electron', () => ({
   app: {
@@ -23,6 +23,7 @@ function createReconcileStore(messages: Array<Record<string, unknown>>) {
     pinned: false,
     cwd: '',
     systemPrompt: '',
+    modelOverride: '',
     executionMode: 'local',
     activeSkillIds: [],
     messages: [...messages],

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1,15 +1,34 @@
+import type { PermissionResult } from '@anthropic-ai/claude-agent-sdk';
 import { randomUUID } from 'crypto';
 import { app, BrowserWindow } from 'electron';
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
-import type { PermissionResult } from '@anthropic-ai/claude-agent-sdk';
-import type { CoworkMessage, CoworkSession, CoworkSessionStatus, CoworkExecutionMode, CoworkStore } from '../../coworkStore';
+
+import type { OpenClawSessionPatch } from '../../../common/openclawSession';
+import type { CoworkExecutionMode, CoworkMessage, CoworkSession, CoworkSessionStatus, CoworkStore } from '../../coworkStore';
+import { t } from '../../i18n';
+import { getCommandDangerLevel,isDeleteCommand } from '../commandSafety';
+import { setCoworkProxySessionId } from '../coworkOpenAICompatProxy';
+import { extractOpenClawAssistantStreamText } from '../openclawAssistantText';
+import {
+  buildManagedSessionKey,
+  isManagedSessionKey,
+  type OpenClawChannelSessionSync,
+  parseChannelSessionKey,
+  parseManagedSessionKey,
+} from '../openclawChannelSessionSync';
+import { OPENCLAW_AGENT_TIMEOUT_SECONDS } from '../openclawConfigSync';
 import {
   OpenClawEngineManager,
   type OpenClawGatewayConnectionInfo,
 } from '../openclawEngineManager';
+import {
+  extractGatewayHistoryEntries,
+  extractGatewayMessageText,
+} from '../openclawHistory';
+import { buildOpenClawLocalTimeContextPrompt } from '../openclawLocalTimeContextPrompt';
 import type {
   CoworkContinueOptions,
   CoworkRuntime,
@@ -17,23 +36,6 @@ import type {
   CoworkStartOptions,
   PermissionRequest,
 } from './types';
-import {
-  buildManagedSessionKey,
-  type OpenClawChannelSessionSync,
-  isManagedSessionKey,
-  parseManagedSessionKey,
-  parseChannelSessionKey,
-} from '../openclawChannelSessionSync';
-import {
-  extractGatewayHistoryEntries,
-  extractGatewayMessageText,
-} from '../openclawHistory';
-import { extractOpenClawAssistantStreamText } from '../openclawAssistantText';
-import { buildOpenClawLocalTimeContextPrompt } from '../openclawLocalTimeContextPrompt';
-import { isDeleteCommand, getCommandDangerLevel } from '../commandSafety';
-import { setCoworkProxySessionId } from '../coworkOpenAICompatProxy';
-import { OPENCLAW_AGENT_TIMEOUT_SECONDS } from '../openclawConfigSync';
-import { t } from '../../i18n';
 
 const OPENCLAW_GATEWAY_TOOL_EVENTS_CAP = 'tool-events';
 const BRIDGE_MAX_MESSAGES = 20;
@@ -705,6 +707,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         pinned: false,
         cwd: '',
         systemPrompt: '',
+        modelOverride: '',
         executionMode: 'local' as CoworkExecutionMode,
         activeSkillIds: [],
         messages,
@@ -803,6 +806,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         pinned: false,
         cwd: '',
         systemPrompt: '',
+        modelOverride: '',
         executionMode: 'local' as CoworkExecutionMode,
         activeSkillIds: [],
         messages,
@@ -1021,6 +1025,29 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       systemPrompt: options.systemPrompt,
       skillIds: options.skillIds,
       imageAttachments: options.imageAttachments,
+    });
+  }
+
+  async patchSession(sessionId: string, patch: OpenClawSessionPatch): Promise<void> {
+    const session = this.store.getSession(sessionId);
+    if (!session) {
+      throw new Error(`Session ${sessionId} not found`);
+    }
+
+    const activeTurnSessionKey = this.activeTurns.get(sessionId)?.sessionKey?.trim();
+    const rememberedSessionKey = this.getSessionKeysForSession(sessionId)
+      .find((key) => !isManagedSessionKey(key));
+    const agentId = session.agentId || 'main';
+    const sessionKey = activeTurnSessionKey
+      || rememberedSessionKey
+      || this.toSessionKey(sessionId, agentId);
+    this.rememberSessionKey(sessionId, sessionKey);
+    await this.ensureGatewayClientReady();
+
+    const client = this.requireGatewayClient();
+    await client.request('sessions.patch', {
+      key: sessionKey,
+      ...patch,
     });
   }
 

--- a/src/main/libs/agentEngine/types.ts
+++ b/src/main/libs/agentEngine/types.ts
@@ -1,4 +1,6 @@
 import type { PermissionResult } from '@anthropic-ai/claude-agent-sdk';
+
+import type { OpenClawSessionPatch } from '../../../common/openclawSession';
 import type { CoworkMessage } from '../../coworkStore';
 
 export type CoworkAgentEngine = 'openclaw' | 'yd_cowork';
@@ -55,6 +57,7 @@ export interface CoworkRuntime {
   ): this;
   startSession(sessionId: string, prompt: string, options?: CoworkStartOptions): Promise<void>;
   continueSession(sessionId: string, prompt: string, options?: CoworkContinueOptions): Promise<void>;
+  patchSession?(sessionId: string, patch: OpenClawSessionPatch): Promise<void>;
   stopSession(sessionId: string): void;
   stopAllSessions(): void;
   respondToPermission(requestId: string, result: PermissionResult): void;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import type { OpenClawSessionPatch } from '../common/openclawSession';
 import { buildScheduledTaskEnginePrompt } from '../scheduledTask/enginePrompt';
 import { migrateScheduledTaskRunsToOpenclaw, migrateScheduledTasksToOpenclaw } from '../scheduledTask/migrate';
 import { PlatformRegistry } from '../shared/platform';
@@ -84,6 +85,7 @@ import {
 import { getLogFilePath, getRecentMainLogEntries, initLogger } from './logger';
 import type { McpServerFormData } from './mcpStore';
 import { McpStore } from './mcpStore';
+import { OpenClawSessionIpc } from './openclawSession/constants';
 import { OpenClawSessionPolicyIpc } from './openclawSessionPolicy/constants';
 import { loadOpenClawSessionPolicyConfig, saveOpenClawSessionPolicyConfig } from './openclawSessionPolicy/store';
 import { SkillManager } from './skillManager';
@@ -119,6 +121,55 @@ const MIME_EXTENSION_MAP: Record<string, string> = {
   'application/json': '.json',
   'text/csv': '.csv',
 };
+
+function sanitizeOptionalPatchValue(
+  value: unknown,
+  maxChars = IPC_STRING_MAX_CHARS,
+): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== 'string') {
+    throw new Error('Session patch value must be a string or null.');
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > maxChars) {
+    throw new Error('Session patch value is too long.');
+  }
+  return trimmed;
+}
+
+function sanitizeOpenClawSessionPatch(input: unknown): OpenClawSessionPatch {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Invalid session patch payload.');
+  }
+
+  const source = input as Record<string, unknown>;
+  const patch: OpenClawSessionPatch = {};
+
+  const model = sanitizeOptionalPatchValue(source.model);
+  if (model !== undefined) patch.model = model;
+
+  const thinkingLevel = sanitizeOptionalPatchValue(source.thinkingLevel);
+  if (thinkingLevel !== undefined) patch.thinkingLevel = thinkingLevel;
+
+  const reasoningLevel = sanitizeOptionalPatchValue(source.reasoningLevel);
+  if (reasoningLevel !== undefined) patch.reasoningLevel = reasoningLevel;
+
+  const elevatedLevel = sanitizeOptionalPatchValue(source.elevatedLevel);
+  if (elevatedLevel !== undefined) patch.elevatedLevel = elevatedLevel;
+
+  const responseUsage = sanitizeOptionalPatchValue(source.responseUsage);
+  if (responseUsage !== undefined) patch.responseUsage = responseUsage as OpenClawSessionPatch['responseUsage'];
+
+  const sendPolicy = sanitizeOptionalPatchValue(source.sendPolicy);
+  if (sendPolicy !== undefined) patch.sendPolicy = sendPolicy as OpenClawSessionPatch['sendPolicy'];
+
+  if (Object.keys(patch).length === 0) {
+    throw new Error('Session patch is empty.');
+  }
+
+  return patch;
+}
 
 const sanitizeExportFileName = (value: string): string => {
   const sanitized = value.replace(INVALID_FILE_NAME_PATTERN, ' ').replace(/\s+/g, ' ').trim();
@@ -3160,6 +3211,45 @@ if (!gotTheLock) {
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to save OpenClaw session policy',
+      };
+    }
+  });
+
+  ipcMain.handle(OpenClawSessionIpc.Patch, async (_event, input: unknown) => {
+    try {
+      if (!input || typeof input !== 'object' || Array.isArray(input)) {
+        throw new Error('Invalid OpenClaw session patch input.');
+      }
+
+      const request = input as { sessionId?: unknown; patch?: unknown };
+      const sessionId = typeof request.sessionId === 'string' ? request.sessionId.trim() : '';
+      if (!sessionId) {
+        throw new Error('Session ID is required.');
+      }
+
+      const patch = sanitizeOpenClawSessionPatch(request.patch);
+      const runtime = getCoworkEngineRouter();
+      await runtime.patchSession(sessionId, patch);
+
+      if (patch.model !== undefined) {
+        getCoworkStore().updateSession(sessionId, {
+          modelOverride: patch.model ?? '',
+        });
+      }
+
+      const session = getCoworkStore().getSession(sessionId);
+      if (!session) {
+        throw new Error(`Session ${sessionId} not found`);
+      }
+
+      return {
+        success: true,
+        session,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to patch OpenClaw session',
       };
     }
   });

--- a/src/main/openclawSession/constants.ts
+++ b/src/main/openclawSession/constants.ts
@@ -1,0 +1,6 @@
+export const OpenClawSessionIpc = {
+  Patch: 'openclaw:session:patch',
+} as const;
+
+export type OpenClawSessionIpc =
+  typeof OpenClawSessionIpc[keyof typeof OpenClawSessionIpc];

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -3,6 +3,8 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 import { IpcChannel as ScheduledTaskIpc } from '../scheduledTask/constants';
 import type { Platform } from '../shared/platform';
+import { OpenClawSessionIpc } from './openclawSession/constants';
+import { OpenClawSessionPolicyIpc } from './openclawSessionPolicy/constants';
 
 // 暴露安全的 API 到渲染进程
 contextBridge.exposeInMainWorld('electron', {
@@ -151,9 +153,22 @@ contextBridge.exposeInMainWorld('electron', {
       },
     },
     sessionPolicy: {
-      get: () => ipcRenderer.invoke('openclaw:sessionPolicy:get'),
+      get: () => ipcRenderer.invoke(OpenClawSessionPolicyIpc.Get),
       set: (config: { keepAlive: '1d' | '7d' | '30d' | '365d' }) =>
-        ipcRenderer.invoke('openclaw:sessionPolicy:set', config),
+        ipcRenderer.invoke(OpenClawSessionPolicyIpc.Set, config),
+    },
+    session: {
+      patch: (options: {
+        sessionId: string;
+        patch: {
+          model?: string | null;
+          thinkingLevel?: string | null;
+          reasoningLevel?: string | null;
+          elevatedLevel?: string | null;
+          responseUsage?: 'off' | 'tokens' | 'full' | null;
+          sendPolicy?: 'allow' | 'deny' | null;
+        };
+      }) => ipcRenderer.invoke(OpenClawSessionIpc.Patch, options),
     },
   },
   agents: {

--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -1,9 +1,10 @@
+import Database from 'better-sqlite3';
+import crypto from 'crypto';
 import { app } from 'electron';
 import { EventEmitter } from 'events';
-import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import Database from 'better-sqlite3';
+
 import { DB_FILENAME } from './appConstants';
 
 type ChangePayload<T = unknown> = {
@@ -61,6 +62,7 @@ export class SqliteStore {
         pinned INTEGER NOT NULL DEFAULT 0,
         cwd TEXT NOT NULL,
         system_prompt TEXT NOT NULL DEFAULT '',
+        model_override TEXT NOT NULL DEFAULT '',
         execution_mode TEXT,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
@@ -186,6 +188,10 @@ export class SqliteStore {
 
       if (!colNames.includes('active_skill_ids')) {
         this.db.exec('ALTER TABLE cowork_sessions ADD COLUMN active_skill_ids TEXT;');
+      }
+
+      if (!colNames.includes('model_override')) {
+        this.db.exec("ALTER TABLE cowork_sessions ADD COLUMN model_override TEXT NOT NULL DEFAULT '';");
       }
 
       // Migration: Add sequence column to cowork_messages

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -6,6 +6,7 @@ import { useDispatch,useSelector } from 'react-redux';
 import { defaultConfig } from '../../config';
 import { agentService } from '../../services/agent';
 import { configService } from '../../services/config';
+import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { skillService } from '../../services/skill';
 import { RootState } from '../../store';
@@ -142,6 +143,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const coworkAgentEngine = useSelector((state: RootState) => state.cowork.config.agentEngine);
     const availableModels = useSelector((state: RootState) => state.model.availableModels);
     const globalSelectedModel = useSelector((state: RootState) => state.model.selectedModel);
+    const currentSession = useSelector((state: RootState) => state.cowork.currentSession);
     const [value, setValue] = useState(draftPrompt);
     const [showFolderMenu, setShowFolderMenu] = useState(false);
     const [showFolderRequiredWarning, setShowFolderRequiredWarning] = useState(false);
@@ -188,6 +190,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     selectedModel: agentSelectedModel,
     hasInvalidExplicitModel: agentModelIsInvalid,
   } = resolveAgentModelSelection({
+    sessionModel: currentSession && currentSession.id === sessionId ? currentSession.modelOverride : '',
     agentModel: currentAgent?.model ?? '',
     availableModels,
     fallbackModel: globalSelectedModel,
@@ -842,13 +845,18 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                     )}
                   </>
                 )}
-                {showModelSelector && !remoteManaged && (
+                {showModelSelector && (
                   <div className="flex flex-col items-start gap-1">
                     <ModelSelector
                       dropdownDirection="up"
                       value={coworkAgentEngine === 'openclaw' ? agentSelectedModel : null}
                       onChange={coworkAgentEngine === 'openclaw'
                         ? async (nextModel) => {
+                            if (sessionId) {
+                              if (!nextModel) return;
+                              await coworkService.patchSession(sessionId, { model: toOpenClawModelRef(nextModel) });
+                              return;
+                            }
                             if (!currentAgent || !nextModel) return;
                             await agentService.updateAgent(currentAgent.id, { model: toOpenClawModelRef(nextModel) });
                           }

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1,6 +1,3 @@
-import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
-import { createPortal } from 'react-dom';
-import { useDispatch, useSelector } from 'react-redux';
 import { ShareIcon } from '@heroicons/react/20/solid';
 import {
   CheckIcon,
@@ -9,19 +6,23 @@ import {
   PhotoIcon,
 } from '@heroicons/react/24/outline';
 import { FolderIcon } from '@heroicons/react/24/solid';
-import {
-  selectCurrentSession,
-  selectIsStreaming,
-  selectRemoteManaged,
-  selectLastMessageContent,
-  selectCurrentMessagesLength,
-} from '../../store/selectors/coworkSelectors';
+import React, { useCallback, useEffect, useMemo,useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useDispatch, useSelector } from 'react-redux';
+
 import { getScheduledReminderDisplayText } from '../../../scheduledTask/reminderText';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { RootState } from '../../store';
+import {
+  selectCurrentMessagesLength,
+  selectCurrentSession,
+  selectIsStreaming,
+  selectLastMessageContent,
+  selectRemoteManaged,
+} from '../../store/selectors/coworkSelectors';
 import { setActiveSkillIds } from '../../store/slices/skillSlice';
-import type { CoworkMessage, CoworkMessageMetadata, CoworkImageAttachment } from '../../types/cowork';
+import type { CoworkImageAttachment,CoworkMessage, CoworkMessageMetadata } from '../../types/cowork';
 import type { Skill } from '../../types/skill';
 import { getCompactFolderName } from '../../utils/path';
 import Modal from '../common/Modal';
@@ -2802,7 +2803,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             size="large"
             remoteManaged={remoteManaged}
             onManageSkills={remoteManaged ? undefined : onManageSkills}
-            showModelSelector={!remoteManaged}
+            showModelSelector={true}
             sessionId={currentSession?.id}
           />
         </div>

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -236,6 +236,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         updatedAt: now,
         cwd: config.workingDirectory || '',
         systemPrompt: '',
+        modelOverride: '',
         executionMode: config.executionMode || 'local',
         activeSkillIds: sessionSkillIds,
         agentId: currentAgentId,

--- a/src/renderer/components/cowork/agentModelSelection.test.ts
+++ b/src/renderer/components/cowork/agentModelSelection.test.ts
@@ -24,6 +24,20 @@ describe('resolveAgentModelSelection', () => {
     expect(result.hasInvalidExplicitModel).toBe(false);
   });
 
+  test('prefers explicit session model override over agent model', () => {
+    const result = resolveAgentModelSelection({
+      sessionModel: 'openai/gpt-4o',
+      agentModel: 'anthropic/claude-sonnet-4',
+      availableModels: models,
+      fallbackModel: models[0],
+      engine: 'openclaw',
+    });
+
+    expect(result.selectedModel?.id).toBe('gpt-4o');
+    expect(result.usesFallback).toBe(false);
+    expect(result.hasInvalidExplicitModel).toBe(false);
+  });
+
   test('falls back to the global model in openclaw when agent model is empty', () => {
     const result = resolveAgentModelSelection({
       agentModel: '',

--- a/src/renderer/components/cowork/agentModelSelection.ts
+++ b/src/renderer/components/cowork/agentModelSelection.ts
@@ -3,6 +3,7 @@ import type { CoworkAgentEngine } from '../../types/cowork';
 import { resolveOpenClawModelRef } from '../../utils/openclawModelRef';
 
 type ResolveAgentModelSelectionInput = {
+  sessionModel?: string;
   agentModel: string;
   availableModels: Model[];
   fallbackModel: Model | null;
@@ -16,6 +17,7 @@ type ResolveAgentModelSelectionResult = {
 };
 
 export function resolveAgentModelSelection({
+  sessionModel,
   agentModel,
   availableModels,
   fallbackModel,
@@ -23,6 +25,16 @@ export function resolveAgentModelSelection({
 }: ResolveAgentModelSelectionInput): ResolveAgentModelSelectionResult {
   if (engine !== 'openclaw') {
     return { selectedModel: fallbackModel, usesFallback: false, hasInvalidExplicitModel: false };
+  }
+
+  const normalizedSessionModel = sessionModel?.trim() ?? '';
+  if (normalizedSessionModel) {
+    const explicitSessionModel = resolveOpenClawModelRef(normalizedSessionModel, availableModels) ?? null;
+    if (explicitSessionModel) {
+      return { selectedModel: explicitSessionModel, usesFallback: false, hasInvalidExplicitModel: false };
+    }
+
+    return { selectedModel: fallbackModel, usesFallback: true, hasInvalidExplicitModel: true };
   }
 
   const normalizedAgentModel = agentModel.trim();

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -1,4 +1,5 @@
 import { classifyErrorKey } from '../../common/coworkErrorClassify';
+import type { OpenClawSessionPatch } from '../../common/openclawSession';
 import { store } from '../store';
 import {
   addMessage,
@@ -491,6 +492,24 @@ class CoworkService {
     }
 
     console.error('Failed to load session:', result.error);
+    return null;
+  }
+
+  async patchSession(sessionId: string, patch: OpenClawSessionPatch): Promise<CoworkSession | null> {
+    const sessionApi = window.electron?.openclaw?.session;
+    if (!sessionApi?.patch) {
+      console.error('OpenClaw session patch API not available');
+      return null;
+    }
+
+    const result = await sessionApi.patch({ sessionId, patch });
+    if (result.success && result.session) {
+      store.dispatch(setCurrentSession(result.session));
+      store.dispatch(setStreaming(result.session.status === 'running'));
+      return result.session;
+    }
+
+    console.error('Failed to patch session:', result.error);
     return null;
   }
 

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -62,6 +62,7 @@ export interface CoworkSession {
   pinned: boolean;
   cwd: string;
   systemPrompt: string;
+  modelOverride: string;
   executionMode: CoworkExecutionMode;
   activeSkillIds: string[];
   agentId: string;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { OpenClawSessionPatch } from '../../common/openclawSession';
 interface ApiResponse {
   ok: boolean;
   status: number;
@@ -24,6 +25,7 @@ interface CoworkSession {
   pinned: boolean;
   cwd: string;
   systemPrompt: string;
+  modelOverride: string;
   executionMode: 'auto' | 'local' | 'sandbox';
   activeSkillIds: string[];
   agentId: string;
@@ -325,6 +327,12 @@ interface IElectronAPI {
     sessionPolicy: {
       get: () => Promise<{ success: boolean; config?: OpenClawSessionPolicyConfig; error?: string }>;
       set: (config: OpenClawSessionPolicyConfig) => Promise<{ success: boolean; config?: OpenClawSessionPolicyConfig; error?: string }>;
+    };
+    session: {
+      patch: (options: {
+        sessionId: string;
+        patch: OpenClawSessionPatch;
+      }) => Promise<{ success: boolean; session?: CoworkSession; error?: string }>;
     };
   };
   ipcRenderer: {


### PR DESCRIPTION
## Summary
  Add generic OpenClaw session patch support to Cowork so active sessions can be updated at the session level instead of mutating the current agent config. This also
  enables model switching for remote-managed/channel sessions while keeping reply input disabled.

  ## Changes Made
  - Added a generic `openclaw:session:patch` IPC flow and runtime/router support for session-level patch operations
  - Persisted `modelOverride` on local cowork sessions and updated renderer typing/state so active sessions resolve model selection from session override first
  - Switched active-session model selection to patch the current session, including remote-managed/channel sessions, and documented the implementation background in
  `docs/` and `spec/features/`

  ## Type of Change
  <!-- Mark the relevant option with an [x] -->
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Code refactoring
  - [x] Documentation update
  - [ ] Performance improvement
  - [ ] Other (please describe):

  ## Testing
  <!-- Describe the tests you've performed -->
  - [x] Tested locally
  - [x] Added new tests
  - [ ] Updated existing tests
  - [x] Manual testing performed

  ## Screenshots (if applicable)
  <!-- Add screenshots for UI changes -->

  ## Checklist
  <!-- Mark the completed items with [x] -->
  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes

  ## Electron-Specific Changes
  <!-- If your PR includes Electron-specific changes, describe them here -->
  - [x] Changes to main process (src/main/)
  - [x] Changes to preload script (src/main/preload.ts)
  - [x] Changes to IPC communication
  - [ ] Changes to window management
  - [ ] None

  ## Additional Notes
  <!-- Any additional information that reviewers should know -->
  - Verified with:
    - `./node_modules/.bin/vitest run src/renderer/components/cowork/agentModelSelection.test.ts`
    - `npx tsc -p tsconfig.json --noEmit`
    - `npx tsc -p electron-tsconfig.json --noEmit`
  - Targeted eslint on changed files passes except for pre-existing warnings in `src/main/libs/agentEngine/openclawRuntimeAdapter.ts`
  - A detailed implementation/history note was added at `spec/features/openclaw-session-patch/2026-04-14-openclaw-session-patch-history.md`
  - The Home empty-state model selector still uses the old non-session-draft behavior; this PR focuses on active session patching