### PR TITLE
fix(Settings): 将 Qwen 控制台链接从灵积迁移至百炼 

### DIFF
--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -218,8 +218,8 @@ const PROVIDER_DEFINITIONS = [
   {
     id: ProviderName.Qwen,
     label: 'Qwen',
-    website: 'https://dashscope.console.aliyun.com',
-    apiKeyUrl: 'https://dashscope.console.aliyun.com/apiKey',
+    website: 'https://bailian.console.aliyun.com',
+    apiKeyUrl: 'https://bailian.console.aliyun.com/?tab=model#/api-key',
     openClawProviderId: OpenClawProviderId.Qwen,
     defaultBaseUrl: 'https://dashscope.aliyuncs.com/apps/anthropic',
     defaultApiFormat: ApiFormat.Anthropic,


### PR DESCRIPTION
## Summary

阿里云已将灵积（DashScope）控制台迁移至大模型服务平台百炼，旧控制台不再维护并将下线。本次将应用内 Qwen 提供方的「官网」与「获取 API Key」链接更新为百炼控制台对应入口，避免用户点到即将失效的页面、减少配置受阻与客服咨询。调用地址仍使用既有 DashScope 兼容端点，不改变现有密钥与接入方式，仅修正文档与入口路径，属于零行为变更的体验与可维护性改进。

<img width="2926" height="1852" alt="image" src="https://github.com/user-attachments/assets/267fad8b-a94c-44b2-850a-c97b08c359c4" />
