### PR TITLE
feat: 修复设置页模型提供商体验问题

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -568,6 +568,16 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const minimaxIsOAuthMode = providers.minimax.authType !== 'apikey';
   const isBaseUrlLocked = (activeProvider === 'zhipu' && providers.zhipu.codingPlanEnabled) || (activeProvider === 'qwen' && providers.qwen.codingPlanEnabled) || (activeProvider === 'volcengine' && providers.volcengine.codingPlanEnabled) || (activeProvider === 'moonshot' && providers.moonshot.codingPlanEnabled) || (activeProvider === 'minimax' && minimaxIsOAuthMode);
 
+  // Disable "Test Connection" when essential provider config is incomplete
+  const isTestConnectionDisabled = useMemo(() => {
+    const providerConfig = providers[activeProvider];
+    const missingModels = !providerConfig.models?.length;
+    const missingApiKey = providerRequiresApiKey(activeProvider) && !providerConfig.apiKey;
+    const effectiveApiFormat = getEffectiveApiFormat(activeProvider, providerConfig.apiFormat);
+    const missingBaseUrl = !resolveBaseUrl(activeProvider, providerConfig.baseUrl, effectiveApiFormat);
+    return isTesting || missingApiKey || missingModels || missingBaseUrl;
+  }, [activeProvider, providers, isTesting]);
+
   // 创建引用来确保内容区域的滚动
   const contentRef = useRef<HTMLDivElement>(null);
   const importInputRef = useRef<HTMLInputElement>(null);
@@ -1952,7 +1962,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       // Apply Coding Plan endpoint switch
       let effectiveBaseUrl = resolveBaseUrl(testingProvider, providerConfig.baseUrl, getEffectiveApiFormat(testingProvider, providerConfig.apiFormat));
       let effectiveApiFormat = getEffectiveApiFormat(testingProvider, providerConfig.apiFormat);
-
       // Handle Coding Plan endpoint switch for supported providers
       if ((providerConfig as { codingPlanEnabled?: boolean }).codingPlanEnabled && (effectiveApiFormat === 'anthropic' || effectiveApiFormat === 'openai')) {
         const resolved = resolveCodingPlanBaseUrl(testingProvider, true, effectiveApiFormat, effectiveBaseUrl);
@@ -3768,7 +3777,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 <button
                   type="button"
                   onClick={handleTestConnection}
-                  disabled={isTesting || (providerRequiresApiKey(activeProvider) && !providers[activeProvider].apiKey)}
+                  disabled={isTestConnectionDisabled}
                   className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-xl border dark:border-claude-darkBorder border-claude-border dark:text-claude-darkText text-claude-text dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-[0.98]"
                 >
                   <SignalIcon className="h-3.5 w-3.5 mr-1.5" />

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -4220,7 +4220,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               </div>
 
               <div className="flex items-center gap-2 text-xs text-secondary">
-                <span>{ProviderRegistry.get(testResult.provider)?.label ?? testResult.provider}</span>
+                <span>{isCustomProvider(testResult.provider)
+                  ? ((providers[testResult.provider] as ProviderConfig)?.displayName || getCustomProviderDefaultName(testResult.provider))
+                  : (ProviderRegistry.get(testResult.provider)?.label ?? getProviderDisplayName(testResult.provider))
+                }</span>
                 <span className="text-[11px]">•</span>
                 <span className={`inline-flex items-center gap-1 ${testResult.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
                   {testResult.success ? (


### PR DESCRIPTION
### 改动内容

1. **修复"测试连接"按钮的禁用逻辑**
   - 将禁用条件抽离为 `useMemo`（`isTestConnectionDisabled`），提升可读性
   - 新增缺少模型（`missingModels`）和缺少 BaseURL（`missingBaseUrl`）的禁用判断，避免用户在配置不完整时点击测试

2. **修复测试结果弹窗中自定义提供商名称显示**
   - 自定义提供商的测试结果弹窗原先显示 `custom_0` 等内部 key，现改为优先显示用户填写的 `displayName`，与设置页其他位置逻辑保持一致

修复前：
<img width="2078" height="1578" alt="image" src="https://github.com/user-attachments/assets/f2b1c79b-8c61-4631-9336-185ea79b8081" />

<img width="1820" height="1412" alt="image" src="https://github.com/user-attachments/assets/5ded32bd-aafb-4cfd-a38a-be3e250c3eff" />



修复后：
<img width="1926" height="1338" alt="image" src="https://github.com/user-attachments/assets/8fc224df-8a5e-4646-bc3d-fb98aa83f4fb" />


### 说明

原有"测试连接"按钮在模型列表为空或 BaseURL 缺失时仍可点击，用户点击后才会收到错误提示，体验不佳且易造成困惑。同时，测试结果弹窗对自定义提供商显示的是内部标识符而非用户自定义的名称，降低了信息可读性。本次修复完善了按钮禁用条件并统一了名称展示逻辑，提升了设置页的交互一致性与用户体验。