### PR TITLE
feat(cowork): group session list by time period

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionList.tsx
+++ b/src/renderer/components/cowork/CoworkSessionList.tsx
@@ -6,6 +6,8 @@ import CoworkSessionItem from './CoworkSessionItem';
 import { i18nService } from '../../services/i18n';
 import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+
 interface CoworkSessionListProps {
   sessions: CoworkSessionSummary[];
   isLoading?: boolean;
@@ -20,6 +22,100 @@ interface CoworkSessionListProps {
   onToggleSelection: (sessionId: string) => void;
   onEnterBatchMode: (sessionId: string) => void;
 }
+
+type GroupKey = 'pinned' | 'today' | 'yesterday' | 'last7Days' | 'last30Days' | 'earlier';
+
+interface SessionGroup {
+  key: GroupKey | string; // 'earlier' 下可能细分为 'YYYY-MM'
+  label: string;
+  sessions: CoworkSessionSummary[];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function getGroupKey(updatedAt: number, now: Date): GroupKey | string {
+  const d = new Date(updatedAt);
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const yesterdayStart = todayStart - 86_400_000;
+  const day7Start = todayStart - 6 * 86_400_000;
+  const day30Start = todayStart - 29 * 86_400_000;
+
+  if (updatedAt >= todayStart) return 'today';
+  if (updatedAt >= yesterdayStart) return 'yesterday';
+  if (updatedAt >= day7Start) return 'last7Days';
+  if (updatedAt >= day30Start) return 'last30Days';
+  // 更早：按 "YYYY年MM月" / "MMMM YYYY" 细分
+  return `earlier_${d.getFullYear()}_${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function getEarlierLabel(key: string): string {
+  // key 格式：earlier_YYYY_MM
+  const parts = key.split('_');
+  const year = parseInt(parts[1], 10);
+  const month = parseInt(parts[2], 10);
+  const lang = i18nService.getLanguage();
+  if (lang === 'zh') {
+    return `${year}年${month}月`;
+  }
+  const date = new Date(year, month - 1, 1);
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long' });
+}
+
+function getGroupLabel(key: GroupKey | string): string {
+  if (key === 'pinned') return i18nService.t('pinned');
+  if (key === 'today') return i18nService.t('today');
+  if (key === 'yesterday') return i18nService.t('yesterday');
+  if (key === 'last7Days') return i18nService.t('last7Days');
+  if (key === 'last30Days') return i18nService.t('last30Days');
+  if (key.startsWith('earlier_')) return getEarlierLabel(key);
+  return i18nService.t('earlier');
+}
+
+// 按 key 定义排列顺序（earlier_YYYY_MM 根据时间倒序排在最后）
+const GROUP_ORDER: (GroupKey | 'earlier')[] = [
+  'pinned', 'today', 'yesterday', 'last7Days', 'last30Days', 'earlier',
+];
+
+function sortGroupKey(a: string, b: string): number {
+  const aIsEarlier = a.startsWith('earlier_');
+  const bIsEarlier = b.startsWith('earlier_');
+
+  if (!aIsEarlier && !bIsEarlier) {
+    return GROUP_ORDER.indexOf(a as GroupKey) - GROUP_ORDER.indexOf(b as GroupKey);
+  }
+  // 两者都是 earlier_YYYY_MM，按时间倒序（新的月份在前）
+  if (aIsEarlier && bIsEarlier) {
+    return b.localeCompare(a);
+  }
+  // earlier 类型排在固定分组后面
+  return aIsEarlier ? 1 : -1;
+}
+
+function buildGroups(sessions: CoworkSessionSummary[]): SessionGroup[] {
+  const now = new Date();
+  const sortByRecentActivity = (a: CoworkSessionSummary, b: CoworkSessionSummary) => {
+    if (b.updatedAt !== a.updatedAt) return b.updatedAt - a.updatedAt;
+    return b.createdAt - a.createdAt;
+  };
+
+  const groupMap = new Map<string, CoworkSessionSummary[]>();
+
+  for (const session of sessions) {
+    const key = session.pinned ? 'pinned' : getGroupKey(session.updatedAt, now);
+    if (!groupMap.has(key)) groupMap.set(key, []);
+    groupMap.get(key)!.push(session);
+  }
+
+  return Array.from(groupMap.entries())
+    .sort(([a], [b]) => sortGroupKey(a, b))
+    .map(([key, list]) => ({
+      key,
+      label: getGroupLabel(key),
+      sessions: list.sort(sortByRecentActivity),
+    }));
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
 
 const CoworkSessionList: React.FC<CoworkSessionListProps> = ({
   sessions,
@@ -38,22 +134,7 @@ const CoworkSessionList: React.FC<CoworkSessionListProps> = ({
   const unreadSessionIds = useSelector(selectUnreadSessionIds);
   const unreadSessionIdSet = useMemo(() => new Set(unreadSessionIds), [unreadSessionIds]);
 
-  const sortedSessions = useMemo(() => {
-    const sortByRecentActivity = (a: CoworkSessionSummary, b: CoworkSessionSummary) => {
-      if (b.updatedAt !== a.updatedAt) {
-        return b.updatedAt - a.updatedAt;
-      }
-      return b.createdAt - a.createdAt;
-    };
-
-    const pinnedSessions = sessions
-      .filter((session) => session.pinned)
-      .sort(sortByRecentActivity);
-    const unpinnedSessions = sessions
-      .filter((session) => !session.pinned)
-      .sort(sortByRecentActivity);
-    return [...pinnedSessions, ...unpinnedSessions];
-  }, [sessions]);
+  const groups = useMemo(() => buildGroups(sessions), [sessions]);
 
   if (sessions.length === 0) {
     if (isLoading) {
@@ -80,23 +161,36 @@ const CoworkSessionList: React.FC<CoworkSessionListProps> = ({
   }
 
   return (
-    <div className="space-y-2">
-      {sortedSessions.map((session) => (
-        <CoworkSessionItem
-          key={session.id}
-          session={session}
-          hasUnread={unreadSessionIdSet.has(session.id)}
-          isActive={session.id === currentSessionId}
-          isBatchMode={isBatchMode}
-          isSelected={selectedIds.has(session.id)}
-          showBatchOption={showBatchOption}
-          onSelect={() => onSelectSession(session.id)}
-          onDelete={() => onDeleteSession(session.id)}
-          onTogglePin={(pinned) => onTogglePin(session.id, pinned)}
-          onRename={(title) => onRenameSession(session.id, title)}
-          onToggleSelection={() => onToggleSelection(session.id)}
-          onEnterBatchMode={() => onEnterBatchMode(session.id)}
-        />
+    <div className="space-y-1">
+      {groups.map((group) => (
+        <div key={group.key}>
+          {/* 分组标题 */}
+          <div className="px-2 pt-3 pb-1">
+            <span className="text-[11px] font-semibold uppercase tracking-wide text-secondary/60 select-none">
+              {group.label}
+            </span>
+          </div>
+          {/* 分组内会话列表 */}
+          <div className="space-y-0.5">
+            {group.sessions.map((session) => (
+              <CoworkSessionItem
+                key={session.id}
+                session={session}
+                hasUnread={unreadSessionIdSet.has(session.id)}
+                isActive={session.id === currentSessionId}
+                isBatchMode={isBatchMode}
+                isSelected={selectedIds.has(session.id)}
+                showBatchOption={showBatchOption}
+                onSelect={() => onSelectSession(session.id)}
+                onDelete={() => onDeleteSession(session.id)}
+                onTogglePin={(pinned) => onTogglePin(session.id, pinned)}
+                onRename={(title) => onRenameSession(session.id, title)}
+                onToggleSelection={() => onToggleSelection(session.id)}
+                onEnterBatchMode={() => onEnterBatchMode(session.id)}
+              />
+            ))}
+          </div>
+        </div>
       ))}
     </div>
   );

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -19,7 +19,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: '用户',
     login: '登录',
     inDevelopment: '正在开发中',
-    
+
     // 设置
     settings: '设置',
     general: '通用',
@@ -46,7 +46,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: '主题色',
     chinese: '中文',
     english: 'English',
-    
+
     // API设置
     apiKey: 'API Key',
     apiKeyPlaceholder: '输入你的 API Key',
@@ -61,7 +61,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: '当前模型',
     availableModels: '可用模型列表',
     modelSwitchHint: '在聊天界面可以切换使用的模型',
-    
+
     // 模型提供商设置
     enabled: '已启用',
     disabled: '已禁用',
@@ -158,7 +158,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: '两次输入的密码不一致',
     passwordTooShort: '密码长度至少为4位',
     wrongPassword: '密码错误，请检查后重试',
-    
+
     // 快捷键
     keyboardShortcuts: '键盘快捷键',
     shortcutNotSet: '未设置',
@@ -197,10 +197,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // 错误信息
     failedToLoadSettings: '加载设置失败',
     failedToSaveSettings: '保存设置失败',
-    
+
     // 加载状态
     loading: '加载中...',
-    
+
     // 侧边栏
     conversations: '对话',
     noConversations: '暂无对话',
@@ -238,7 +238,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: '工作',
     folderIconCode: '代码',
     folderIconIdea: '灵感',
-    
+
     // 聊天窗口
     sendMessage: '发送消息',
     typeMessage: '询问任何问题...',
@@ -249,8 +249,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     messageCopied: '消息已复制',
     clearConversation: '清空对话',
     confirmClearConversation: '确定要清空当前对话吗？此操作不可撤销。',
+    pinned: '置顶',
     today: '今天',
     yesterday: '昨天',
+    last7Days: '7 天内',
+    last30Days: '30 天内',
+    earlier: '更早',
     daysAgo: '天前',
     justNow: '刚刚',
     minutesAgo: '分钟前',
@@ -268,17 +272,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: '最多上传 10 张图片',
     imageReadError: '读取图片失败',
     imageInputNotSupported: '当前模型不支持图像输入',
-    
+
     // 模型选择
     selectModel: '选择模型',
-    
+
     // 错误提示
     errorOccurred: '发生错误',
     tryAgain: '请重试',
     networkError: '网络错误',
     apiKeyRequired: '需要设置API密钥',
     configureApiKey: '请在设置中配置您的API密钥',
-    
+
     // 初始化
     initializationError: '初始化应用程序失败。请检查您的配置。',
     apiKeyNotConfigured: 'API密钥未配置。请在设置中设置您的API密钥。',
@@ -1317,7 +1321,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     user: 'User',
     login: 'Login',
     inDevelopment: 'In development',
-    
+
     // Settings
     settings: 'Settings',
     general: 'General',
@@ -1344,7 +1348,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     themeColor: 'Color Themes',
     chinese: 'Chinese',
     english: 'English',
-    
+
     // API Settings
     apiKey: 'API Key',
     apiKeyPlaceholder: 'Enter your API Key',
@@ -1359,7 +1363,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     currentModel: 'Current Model',
     availableModels: 'Available Models',
     modelSwitchHint: 'You can switch models in the chat interface',
-    
+
     // Model Provider Settings
     enabled: 'Enabled',
     disabled: 'Disabled',
@@ -1456,7 +1460,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     passwordMismatch: 'Passwords do not match',
     passwordTooShort: 'Password must be at least 4 characters',
     wrongPassword: 'Wrong password, please try again',
-    
+
     // Shortcuts
     keyboardShortcuts: 'Keyboard Shortcuts',
     shortcutNotSet: 'Not set',
@@ -1495,10 +1499,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',
-    
+
     // Loading State
     loading: 'Loading...',
-    
+
     // Sidebar
     conversations: 'Conversations',
     noConversations: 'No conversations',
@@ -1536,7 +1540,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderIconWork: 'Work',
     folderIconCode: 'Code',
     folderIconIdea: 'Ideas',
-    
+
     // Chat Window
     sendMessage: 'Send Message',
     typeMessage: 'Type a message...',
@@ -1547,8 +1551,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
     messageCopied: 'Message copied',
     clearConversation: 'Clear Conversation',
     confirmClearConversation: 'Are you sure you want to clear the current conversation? This action cannot be undone.',
+    pinned: 'Pinned',
     today: 'Today',
     yesterday: 'Yesterday',
+    last7Days: 'Last 7 Days',
+    last30Days: 'Last 30 Days',
+    earlier: 'Earlier',
     daysAgo: 'days ago',
     justNow: 'Just now',
     minutesAgo: 'minutes ago',
@@ -1566,17 +1574,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: 'Up to 10 images',
     imageReadError: 'Failed to read image',
     imageInputNotSupported: 'Current model does not support images',
-    
+
     // Model Selection
     selectModel: 'Select Model',
-    
+
     // Error Messages
     errorOccurred: 'An error occurred',
     tryAgain: 'Please try again',
     networkError: 'Network error',
     apiKeyRequired: 'API Key Required',
     configureApiKey: 'Please configure your API key in settings',
-    
+
     // Initialization
     initializationError: 'Failed to initialize application. Please check your configuration.',
     apiKeyNotConfigured: 'API key not configured. Please set up your API key in settings.',
@@ -2605,12 +2613,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
 class I18nService {
   private currentLanguage: LanguageType = 'zh';
   private listeners = new Set<() => void>();
-  
+
   constructor() {
     // 默认使用中文
     this.currentLanguage = 'zh';
   }
-  
+
   // 初始化语言设置
   async initialize(): Promise<void> {
     try {
@@ -2687,7 +2695,7 @@ class I18nService {
     }
     return 'en'; // 默认英文 (包括 zh-TW, zh-HK, en-*, 以及其他所有语言)
   }
-  
+
   // 设置语言
   setLanguage(language: LanguageType, options: { persist?: boolean } = {}): void {
     const { persist = true } = options;
@@ -2713,12 +2721,12 @@ class I18nService {
       console.error('Failed to save language setting:', error);
     }
   }
-  
+
   // 获取当前语言
   getLanguage(): LanguageType {
     return this.currentLanguage;
   }
-  
+
   // 获取翻译文本
   t(key: string): string {
     const translation = translations[this.currentLanguage][key];
@@ -2739,4 +2747,4 @@ class I18nService {
   }
 }
 
-export const i18nService = new I18nService(); 
+export const i18nService = new I18nService();


### PR DESCRIPTION
[问题]
会话列表所有会话平铺展示，仅区分置顶与普通两类，会话数量增多后难以快速定位历史记录。

[根因]
CoworkSessionList 只按 pinned + updatedAt 做简单排序，
没有按时间区间做分组聚合，缺少分组标题渲染逻辑。

[修复]
- CoworkSessionList.tsx 新增 buildGroups() 纯函数，将会话按 updatedAt 归入以下分组： 置顶 → 今天 → 昨天 → 7 天内 → 30 天内 → 更早（按月细分）
- 更早分组以 "YYYY年M月" / "Month YYYY" 格式细分到月， 同语言自动适配（调用 i18nService.getLanguage()）
- 分组内会话仍按最近活动时间倒序排列，与原行为一致
- 新增 i18n key：pinned / last7Days / last30Days / earlier（中英双语）
- CoworkSessionList 渲染层改为分组标题 + 组内列表的两层结构， 标题使用 text-[11px] uppercase tracking-wide 样式与 ChatGPT 风格对齐

[复现路径]
1. 创建若干跨越今天、昨天、7 天内、30 天内、更早时间段的会话
2. 打开 Cowork 侧边栏，观察会话列表是否按时间段显示分组标题
3. 置顶一条会话，确认其出现在「置顶」分组且不参与时间分组