### PR TITLE
fix(ui): register QianfanIcon in provider icon map

### DIFF
--- a/src/renderer/providers/uiRegistry.tsx
+++ b/src/renderer/providers/uiRegistry.tsx
@@ -12,6 +12,7 @@ import {
   OllamaIcon,
   OpenAIIcon,
   OpenRouterIcon,
+  QianfanIcon,
   QwenIcon,
   StepfunIcon,
   VolcengineIcon,
@@ -36,6 +37,7 @@ const PROVIDER_ICON_MAP: Record<string, React.ReactNode> = {
   [ProviderName.OpenRouter]:   <OpenRouterIcon />,
   [ProviderName.Copilot]:      <GitHubCopilotIcon />,
   [ProviderName.Ollama]:       <OllamaIcon />,
+  [ProviderName.Qianfan]:      <QianfanIcon />,
 };
 
 export function getProviderIcon(id: string): React.ReactNode {


### PR DESCRIPTION
## Summary

- `QianfanIcon` 组件已存在并已从 `providers/index.ts` 导出，但未注册到 `uiRegistry.tsx` 的 `PROVIDER_ICON_MAP` 中
- 导致模型设置列表中千帆提供商显示通用 `CustomProviderIcon` 而非专属图标
- 修复：在导入列表和 `PROVIDER_ICON_MAP` 中各补一行

## Test plan

- [ ] 打开设置 → 模型，确认千帆行显示专属图标（蓝色渐变"千"字）
- [ ] 确认其他提供商图标不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)