### PR TITLE
fix(openclaw): prevent gateway retry from spawning duplicate error messages

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -587,6 +587,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private readonly pendingAgentEventsByRunId = new Map<string, AgentEventPayload[]>();
   private readonly lastChatSeqByRunId = new Map<string, number>();
   private readonly lastAgentSeqByRunId = new Map<string, number>();
+  // Tracks runIds that have received a lifecycle phase=error, so gateway retries
+  // (which reuse the same runId) don't re-create an ActiveTurn and surface duplicate errors.
+  private readonly terminatedRunIds = new Set<string>();
   private readonly pendingApprovals = new Map<string, PendingApprovalEntry>();
   private readonly pendingTurns = new Map<string, { resolve: () => void; reject: (error: Error) => void }>();
   private readonly confirmationModeBySession = new Map<string, 'modal' | 'text'>();
@@ -1962,7 +1965,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     // Re-create ActiveTurn for channel session follow-up turns.
     // Exclude stream=error events (e.g. seq gap notifications) — they are diagnostic alerts,
     // not new run events, and must not create a ghost ActiveTurn that blocks the next user turn.
-    if (sessionId && !this.activeTurns.has(sessionId) && sessionKey && stream !== 'error') {
+    // Also exclude runIds that have already been terminated (lifecycle phase=error received),
+    // which prevents gateway retries from spawning new turns and surfacing duplicate errors.
+    if (sessionId && !this.activeTurns.has(sessionId) && sessionKey && stream !== 'error' && !this.terminatedRunIds.has(runId)) {
       console.log('[Debug:handleAgentEvent] re-creating ActiveTurn for follow-up turn, sessionId:', sessionId);
       this.ensureActiveTurn(sessionId, sessionKey, runId);
     }
@@ -2063,6 +2068,13 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       return;
     }
     if (stream === 'lifecycle') {
+      // Mark runId as terminated immediately on phase=error so that subsequent retries
+      // (which reuse the same runId) are blocked from re-creating an ActiveTurn.
+      const lifecycleData = agentPayload.data;
+      const lifecycleRunId = typeof agentPayload.runId === 'string' ? agentPayload.runId.trim() : '';
+      if (isRecord(lifecycleData) && typeof lifecycleData.phase === 'string' && lifecycleData.phase.trim() === 'error' && lifecycleRunId) {
+        this.terminatedRunIds.add(lifecycleRunId);
+      }
       this.handleAgentLifecycleEvent(sessionId, agentPayload.data);
     }
   }


### PR DESCRIPTION
## 问题

当 provider 返回错误后（如 MiniMax HTTP 500 / 错误码 2061「套餐不支持该模型」），openclaw-runtime gateway 会用**相同的 runId** 做指数退避重试。每次重试失败都会发出 lifecycle `phase=error` 事件。

由于 `phase=error` 走的是 `stream='lifecycle'`（而非 `stream='error'`），`handleAgentEvent` 的现有排除条件无法拦截这些事件重建 `ActiveTurn`。结果是每次重试都走了完整的错误处理流程，UI 中不断追加错误消息（原始错误 + 本地化「服务端出现错误」），每次重试新增一对。

**已通过 gateway 日志确认：**
- 所有重试复用同一 `runId`（openclaw/openclaw#63335）
- 每次 `phase=error` → ActiveTurn 重建 → 消息追加

## 修复方案

引入 `terminatedRunIds: Set<string>`。`dispatchAgentEvent` 在收到 lifecycle `phase=error` 事件时立即将 runId 记录到该集合；`handleAgentEvent` 在重建 ActiveTurn 前检查该集合，命中则丢弃后续所有事件。

## 已知风险与取舍

openclaw gateway 在重试时固定复用同一 runId，无论最终成功还是失败。若某次重试**成功**（如真实瞬时网络抖动），因 runId 已在 `terminatedRunIds` 中，成功的事件会被静默丢弃，用户看到任务无输出结束（ghost output）。

**可接受的原因：**
- 永久性错误（套餐限制、鉴权失败）重试永远不会成功，无数据丢失
- 正确的上游修法是 openclaw 在可恢复 lifecycle 错误中携带 `retrying: true`，届时前端可区分可恢复与最终失败（openclaw/openclaw#64051，目前 open）
- 待 openclaw-runtime 更新支持 `retrying` 语义后，本 workaround 应替换为检查该字段

## 相关 openclaw issues

- openclaw/openclaw#64051 — lifecycle 合约 bug：可恢复错误与最终失败被混淆，导致 ghost output 和 UI 过早结束（权威说明）
- openclaw/openclaw#63335 — 所有重试复用同一 runId（已确认行为）
- openclaw/openclaw#62141 — gateway 对 503 无限重试而非 fallback（同类误分类重试问题）

## 测试

使用未订阅套餐的 MiniMax 账号发送消息，确认错误消息不再随重试不断追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)