### PR TITLE
fix(skills): validate URL format before remote import

### DIFF
--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -367,6 +367,12 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
         setSkillActionError(i18nService.t('importSourceMismatchClawhub'));
         return;
       }
+      // GitHub tab: 校验 owner/repo 格式
+      const ownerRepoPattern = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
+      if (!ownerRepoPattern.test(trimmed)) {
+        setSkillActionError(i18nService.t('importSourceMismatchGithub'));
+        return;
+      }
     }
 
     await handleAddSkillFromSource(trimmed);


### PR DESCRIPTION
## Problem
远程导入技能时（GitHub tab），输入 `111` 等无效格式没有前置校验，
直接走下载流程后才报错 "来源中未找到 SKILL.md"，体验不友好。

## Solution
在 `handleImportFromDialog` 的 catch 分支中新增 `owner/repo` 格式校验，
正则 `/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/` 与后端 `normalizeGitSource` 对齐。
无效输入立即提示错误，不再发起下载请求。

## Changes
- `src/renderer/components/skills/SkillsManager.tsx`: catch 分支增加 owner/repo 正则校验

<img width="505" height="604" alt="image" src="https://github.com/user-attachments/assets/6d217d69-d42d-4035-a24a-f97c257e35e7" />