### PR TITLE
fix(popo): strip system header from POPO channel messages in display

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -205,6 +205,24 @@ const stripFeishuSystemHeader = (text: string): string => {
 };
 
 /**
+ * Strip the POPO plugin's system header line from user messages.
+ *
+ * The moltbot-popo plugin calls enqueueSystemEvent on every inbound message,
+ * prepending a one-line header before the user's actual text:
+ *   System: [2026-04-14 19:57:42 GMT+8] POPO DM received from user@corp.com
+ *   System: [2026-04-14 19:57:42 GMT+8] POPO message received in group <id>
+ *
+ * Strip it so only the real user text is stored and displayed locally.
+ */
+const stripPopoSystemHeader = (text: string): string => {
+  // Match: "System: [timestamp] POPO DM received from ..." or
+  //        "System: [timestamp] POPO message received in group ..."
+  const match = text.match(/^System:\s*\[.*?\]\s+POPO\b.*$/m);
+  if (!match) return text;
+  return text.slice(match.index! + match[0].length).replace(/^\n+/, '').trim();
+};
+
+/**
  * Strip the QQ Bot plugin's injected system prompt prefix from user messages.
  *
  * The QQ plugin prepends context info and capability instructions before the
@@ -3172,6 +3190,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         && this.channelSessionSync.isChannelSessionKey(sessionKey);
       const isDiscord = sessionKey.includes(':discord:');
       const isQQ = sessionKey.includes(':qqbot:');
+      const isPopo = sessionKey.includes(':moltbot-popo:');
       const isFeishu = sessionKey.includes(':feishu:');
 
       // Extract authoritative user/assistant entries from gateway history
@@ -3184,6 +3203,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         if (!text) continue;
         if (isDiscord) text = stripDiscordMentions(text);
         if (isQQ && role === 'user') text = stripQQBotSystemPrompt(text);
+        if (isPopo && role === 'user') text = stripPopoSystemHeader(text);
         if (isFeishu && role === 'user') text = stripFeishuSystemHeader(text);
         authoritativeEntries.push({ role: role as 'user' | 'assistant', text });
       }
@@ -3454,6 +3474,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       // POPO's moltbot-popo plugin converts newlines to HTML break tags (<br />),
       // causing raw <br /> to appear in the UI and AI conversation.
       if (isPopo) text = text.replace(/<br\s*\/?>/gi, '\n');
+      if (isPopo && role === 'user') text = stripPopoSystemHeader(text);
       if (isDiscord) text = stripDiscordMentions(text);
       if (isQQ && role === 'user') text = stripQQBotSystemPrompt(text);
       if (isFeishu && role === 'user') text = stripFeishuSystemHeader(text);


### PR DESCRIPTION
## Summary

- The `moltbot-popo` plugin unconditionally calls `enqueueSystemEvent` on every inbound message, prepending a header (`System: [timestamp] POPO DM received from ...`) before the user's actual text
- This header is useful context for the LLM, but it clutters the local chat history display
- Add `stripPopoSystemHeader` in `openclawRuntimeAdapter.ts`, mirroring the existing `stripFeishuSystemHeader` pattern, and apply it in both history-sync paths (`authoritativeEntries` block and `collectChannelHistoryEntries`)

## Changes

- `src/main/libs/agentEngine/openclawRuntimeAdapter.ts`
  - New function `stripPopoSystemHeader` — regex strips the `System: [timestamp] POPO ...` first line
  - First history block: added `isPopo = sessionKey.includes(':moltbot-popo:')` and apply strip
  - `collectChannelHistoryEntries`: apply strip after the existing `<br />` → `\n` conversion

## Test plan

- [ ] Send a DM on POPO and confirm the `System: [timestamp] POPO DM received from ...` line no longer appears in chat history UI
- [ ] Send a group message mentioning the bot and confirm `System: [timestamp] POPO message received in group ...` is also stripped
- [ ] Confirm the LLM still receives the full original message (stripping is display-only)
- [ ] Confirm Feishu, QQ, WeCom channels are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)