### PR TITLE
feat(cowork): improve model setup entry and preserve draft input

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,42 +1,49 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import AgentsView from './components/agent/AgentsView';
+import { CoworkView } from './components/cowork';
+import CoworkPermissionModal from './components/cowork/CoworkPermissionModal';
+import CoworkQuestionWizard from './components/cowork/CoworkQuestionWizard';
+import EngineStartupOverlay from './components/cowork/EngineStartupOverlay';
+import { McpView } from './components/mcp';
+import PrivacyDialog from './components/PrivacyDialog';
+import { ScheduledTasksView } from './components/scheduledTasks';
+import Settings, { type SettingsOpenOptions } from './components/Settings';
+import Sidebar from './components/Sidebar';
+import { SkillsView } from './components/skills';
+import Toast from './components/Toast';
+import AppUpdateBadge from './components/update/AppUpdateBadge';
+import AppUpdateModal from './components/update/AppUpdateModal';
+import WindowTitleBar from './components/window/WindowTitleBar';
+import { defaultConfig, getProviderDisplayName } from './config';
+import { SettingsProvider } from './contexts/SettingsContext';
+import type { ApiConfig } from './services/api';
+import { apiService } from './services/api';
+import {
+  type AppUpdateDownloadProgress,
+  type AppUpdateInfo,
+  checkForAppUpdate,
+  UPDATE_HEARTBEAT_INTERVAL_MS,
+  UPDATE_POLL_INTERVAL_MS,
+} from './services/appUpdate';
+import { authService } from './services/auth';
+import { configService } from './services/config';
+import { coworkService } from './services/cowork';
+import { i18nService } from './services/i18n';
+import { scheduledTaskService } from './services/scheduledTask';
+import { matchesShortcut } from './services/shortcuts';
+import { themeService } from './services/theme';
 import { RootState, store } from './store';
 import {
   selectCurrentSessionId,
   selectFirstPendingPermission,
 } from './store/selectors/coworkSelectors';
-import Settings, { type SettingsOpenOptions } from './components/Settings';
-import Sidebar from './components/Sidebar';
-import Toast from './components/Toast';
-import WindowTitleBar from './components/window/WindowTitleBar';
-import { CoworkView } from './components/cowork';
-import { SkillsView } from './components/skills';
-import { ScheduledTasksView } from './components/scheduledTasks';
-import { McpView } from './components/mcp';
-import AgentsView from './components/agent/AgentsView';
-import { SettingsProvider } from './contexts/SettingsContext';
-import CoworkPermissionModal from './components/cowork/CoworkPermissionModal';
-import CoworkQuestionWizard from './components/cowork/CoworkQuestionWizard';
-import EngineStartupOverlay from './components/cowork/EngineStartupOverlay';
-import { configService } from './services/config';
-import { apiService } from './services/api';
-import { themeService } from './services/theme';
-import { coworkService } from './services/cowork';
-import { authService } from './services/auth';
-import { scheduledTaskService } from './services/scheduledTask';
-import { checkForAppUpdate, type AppUpdateInfo, type AppUpdateDownloadProgress, UPDATE_POLL_INTERVAL_MS, UPDATE_HEARTBEAT_INTERVAL_MS } from './services/appUpdate';
-import { defaultConfig, getProviderDisplayName } from './config';
+import { setDraftPrompt } from './store/slices/coworkSlice';
 import { setAvailableModels, setSelectedModel } from './store/slices/modelSlice';
 import { clearSelection } from './store/slices/quickActionSlice';
-import { setDraftPrompt } from './store/slices/coworkSlice';
-import type { ApiConfig } from './services/api';
 import type { CoworkPermissionResult } from './types/cowork';
-import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
-import { i18nService } from './services/i18n';
-import { matchesShortcut } from './services/shortcuts';
-import AppUpdateBadge from './components/update/AppUpdateBadge';
-import AppUpdateModal from './components/update/AppUpdateModal';
-import PrivacyDialog from './components/PrivacyDialog';
 
 const App: React.FC = () => {
   const [showSettings, setShowSettings] = useState(false);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,6 +14,7 @@ import { SkillsView } from './components/skills';
 import { ScheduledTasksView } from './components/scheduledTasks';
 import { McpView } from './components/mcp';
 import AgentsView from './components/agent/AgentsView';
+import { SettingsProvider } from './contexts/SettingsContext';
 import CoworkPermissionModal from './components/cowork/CoworkPermissionModal';
 import CoworkQuestionWizard from './components/cowork/CoworkQuestionWizard';
 import EngineStartupOverlay from './components/cowork/EngineStartupOverlay';
@@ -263,6 +264,10 @@ const App: React.FC = () => {
     });
     setShowSettings(true);
   }, []);
+
+  const settingsContextValue = useMemo(() => ({
+    openSettings: handleShowSettings,
+  }), [handleShowSettings]);
 
   const handleShowSkills = useCallback(() => {
     setMainView('skills');
@@ -674,112 +679,114 @@ const App: React.FC = () => {
   }
 
   return (
-    <div className="h-screen overflow-hidden flex flex-col bg-surface-raised">
-      {toastMessage && (
-        <Toast message={toastMessage} onClose={() => setToastMessage(null)} />
-      )}
-      <div className="flex flex-1 min-h-0 overflow-hidden">
-        <Sidebar
-          onShowLogin={handleShowLogin}
-          onShowSettings={handleShowSettings}
-          activeView={mainView}
-          onShowSkills={handleShowSkills}
-          onShowCowork={handleShowCowork}
-          onShowScheduledTasks={handleShowScheduledTasks}
-          onShowMcp={handleShowMcp}
-          onShowAgents={handleShowAgents}
-          onNewChat={handleNewChat}
-          isCollapsed={isSidebarCollapsed}
-          onToggleCollapse={handleToggleSidebar}
-          updateBadge={!isSidebarCollapsed ? updateBadge : null}
-          hideLogin={enterpriseConfig?.ui?.login === 'hide'}
-        />
-        <div className={`flex-1 min-w-0 py-1.5 pr-1.5 ${isSidebarCollapsed ? 'pl-1.5' : ''}`}>
-          <div className="relative h-full min-h-0 rounded-xl bg-background overflow-hidden">
-            <EngineStartupOverlay />
-            {mainView === 'skills' ? (
-              <SkillsView
-                isSidebarCollapsed={isSidebarCollapsed}
-                onToggleSidebar={handleToggleSidebar}
-                onNewChat={handleNewChat}
-                onCreateSkillByChat={handleCreateSkillByChat}
-                updateBadge={isSidebarCollapsed ? updateBadge : null}
-                readOnly={enterpriseConfig?.ui?.skills === 'readonly'}
-              />
-            ) : mainView === 'scheduledTasks' ? (
-              <ScheduledTasksView
-                isSidebarCollapsed={isSidebarCollapsed}
-                onToggleSidebar={handleToggleSidebar}
-                onNewChat={handleNewChat}
-                updateBadge={isSidebarCollapsed ? updateBadge : null}
-              />
-            ) : mainView === 'mcp' ? (
-              <McpView
-                isSidebarCollapsed={isSidebarCollapsed}
-                onToggleSidebar={handleToggleSidebar}
-                onNewChat={handleNewChat}
-                updateBadge={isSidebarCollapsed ? updateBadge : null}
-              />
-            ) : mainView === 'agents' ? (
-              <AgentsView
-                isSidebarCollapsed={isSidebarCollapsed}
-                onToggleSidebar={handleToggleSidebar}
-                onNewChat={handleNewChat}
-                onShowCowork={handleShowCowork}
-                updateBadge={isSidebarCollapsed ? updateBadge : null}
-              />
-            ) : (
-              <CoworkView
-                onRequestAppSettings={handleShowSettings}
-                onShowSkills={handleShowSkills}
-                isSidebarCollapsed={isSidebarCollapsed}
-                onToggleSidebar={handleToggleSidebar}
-                onNewChat={handleNewChat}
-                updateBadge={isSidebarCollapsed ? updateBadge : null}
-              />
-            )}
+    <SettingsProvider value={settingsContextValue}>
+      <div className="h-screen overflow-hidden flex flex-col bg-surface-raised">
+        {toastMessage && (
+          <Toast message={toastMessage} onClose={() => setToastMessage(null)} />
+        )}
+        <div className="flex flex-1 min-h-0 overflow-hidden">
+          <Sidebar
+            onShowLogin={handleShowLogin}
+            onShowSettings={handleShowSettings}
+            activeView={mainView}
+            onShowSkills={handleShowSkills}
+            onShowCowork={handleShowCowork}
+            onShowScheduledTasks={handleShowScheduledTasks}
+            onShowMcp={handleShowMcp}
+            onShowAgents={handleShowAgents}
+            onNewChat={handleNewChat}
+            isCollapsed={isSidebarCollapsed}
+            onToggleCollapse={handleToggleSidebar}
+            updateBadge={!isSidebarCollapsed ? updateBadge : null}
+            hideLogin={enterpriseConfig?.ui?.login === 'hide'}
+          />
+          <div className={`flex-1 min-w-0 py-1.5 pr-1.5 ${isSidebarCollapsed ? 'pl-1.5' : ''}`}>
+            <div className="relative h-full min-h-0 rounded-xl bg-background overflow-hidden">
+              <EngineStartupOverlay />
+              {mainView === 'skills' ? (
+                <SkillsView
+                  isSidebarCollapsed={isSidebarCollapsed}
+                  onToggleSidebar={handleToggleSidebar}
+                  onNewChat={handleNewChat}
+                  onCreateSkillByChat={handleCreateSkillByChat}
+                  updateBadge={isSidebarCollapsed ? updateBadge : null}
+                  readOnly={enterpriseConfig?.ui?.skills === 'readonly'}
+                />
+              ) : mainView === 'scheduledTasks' ? (
+                <ScheduledTasksView
+                  isSidebarCollapsed={isSidebarCollapsed}
+                  onToggleSidebar={handleToggleSidebar}
+                  onNewChat={handleNewChat}
+                  updateBadge={isSidebarCollapsed ? updateBadge : null}
+                />
+              ) : mainView === 'mcp' ? (
+                <McpView
+                  isSidebarCollapsed={isSidebarCollapsed}
+                  onToggleSidebar={handleToggleSidebar}
+                  onNewChat={handleNewChat}
+                  updateBadge={isSidebarCollapsed ? updateBadge : null}
+                />
+              ) : mainView === 'agents' ? (
+                <AgentsView
+                  isSidebarCollapsed={isSidebarCollapsed}
+                  onToggleSidebar={handleToggleSidebar}
+                  onNewChat={handleNewChat}
+                  onShowCowork={handleShowCowork}
+                  updateBadge={isSidebarCollapsed ? updateBadge : null}
+                />
+              ) : (
+                <CoworkView
+                  onRequestAppSettings={handleShowSettings}
+                  onShowSkills={handleShowSkills}
+                  isSidebarCollapsed={isSidebarCollapsed}
+                  onToggleSidebar={handleToggleSidebar}
+                  onNewChat={handleNewChat}
+                  updateBadge={isSidebarCollapsed ? updateBadge : null}
+                />
+              )}
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* 设置窗口显示在所有主内容之上，但不影响主界面的交互 */}
-      {showSettings && (
-        <Settings
-          onClose={handleCloseSettings}
-          initialTab={settingsOptions.initialTab}
-          notice={settingsOptions.notice}
-          onUpdateFound={handleUpdateFound}
-          enterpriseConfig={enterpriseConfig}
-        />
-      )}
-      {showUpdateModal && updateInfo && (
-        <AppUpdateModal
-          updateInfo={updateInfo}
-          onCancel={() => {
-            if (updateModalState === 'info' || updateModalState === 'error') {
-              setShowUpdateModal(false);
-              setUpdateModalState('info');
-              setUpdateError(null);
-              setDownloadProgress(null);
-            }
-          }}
-          onConfirm={handleConfirmUpdate}
-          modalState={updateModalState}
-          downloadProgress={downloadProgress}
-          errorMessage={updateError}
-          onCancelDownload={handleCancelDownload}
-          onRetry={handleRetryUpdate}
-        />
-      )}
-      {permissionModal}
-      {privacyAgreed === false && (
-        <PrivacyDialog
-          onAccept={handlePrivacyAccept}
-          onReject={handlePrivacyReject}
-        />
-      )}
-    </div>
+        {/* 设置窗口显示在所有主内容之上，但不影响主界面的交互 */}
+        {showSettings && (
+          <Settings
+            onClose={handleCloseSettings}
+            initialTab={settingsOptions.initialTab}
+            notice={settingsOptions.notice}
+            onUpdateFound={handleUpdateFound}
+            enterpriseConfig={enterpriseConfig}
+          />
+        )}
+        {showUpdateModal && updateInfo && (
+          <AppUpdateModal
+            updateInfo={updateInfo}
+            onCancel={() => {
+              if (updateModalState === 'info' || updateModalState === 'error') {
+                setShowUpdateModal(false);
+                setUpdateModalState('info');
+                setUpdateError(null);
+                setDownloadProgress(null);
+              }
+            }}
+            onConfirm={handleConfirmUpdate}
+            modalState={updateModalState}
+            downloadProgress={downloadProgress}
+            errorMessage={updateError}
+            onCancelDownload={handleCancelDownload}
+            onRetry={handleRetryUpdate}
+          />
+        )}
+        {permissionModal}
+        {privacyAgreed === false && (
+          <PrivacyDialog
+            onAccept={handlePrivacyAccept}
+            onReject={handlePrivacyReject}
+          />
+        )}
+      </div>
+    </SettingsProvider>
   );
 };
 
-export default App; 
+export default App;

--- a/src/renderer/components/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector.tsx
@@ -2,6 +2,7 @@ import { CheckIcon,ChevronDownIcon } from '@heroicons/react/24/outline';
 import React from 'react';
 import { useDispatch,useSelector } from 'react-redux';
 
+import { useSettings } from '../contexts/SettingsContext';
 import { i18nService } from '../services/i18n';
 import { RootState } from '../store';
 import type { Model } from '../store/slices/modelSlice';
@@ -27,6 +28,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
   defaultLabel,
 }) => {
   const dispatch = useDispatch();
+  const { openSettings } = useSettings();
   const [isOpen, setIsOpen] = React.useState(false);
   const containerRef = React.useRef<HTMLDivElement>(null);
 
@@ -61,12 +63,16 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
     setIsOpen(false);
   };
 
-  // 如果没有可用模型，显示提示
+  // 如果没有可用模型，点击跳转设置
   if (availableModels.length === 0) {
     return (
-      <div className="px-3 py-1.5 rounded-xl bg-surface text-secondary text-sm">
+      <button
+        type="button"
+        onClick={() => openSettings({ initialTab: 'model' })}
+        className="px-3 py-1.5 rounded-xl bg-surface text-secondary text-sm hover:bg-surface-raised transition-colors cursor-pointer"
+      >
         {i18nService.t('modelSelectorNoModels')}
-      </div>
+      </button>
     );
   }
 

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -212,7 +212,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
             ...buildApiConfigNotice(apiConfig.error),
           });
           isStartingRef.current = false;
-          return;
+          return false;
         }
       } catch (error) {
         console.error('Failed to check cowork API config:', error);

--- a/src/renderer/contexts/SettingsContext.tsx
+++ b/src/renderer/contexts/SettingsContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+
+import type { SettingsOpenOptions } from '@/components/Settings';
+
+type SettingsContextValue = {
+  openSettings: (options?: SettingsOpenOptions) => void;
+};
+
+const SettingsContext = createContext<SettingsContextValue>({
+  openSettings: () => {},
+});
+
+export const SettingsProvider = SettingsContext.Provider;
+
+export function useSettings(): SettingsContextValue {
+  return useContext(SettingsContext);
+}


### PR DESCRIPTION
## Summary
优化 `ModelSelector` 组件交互体验，并修复未配置模型时发送消息导致输入内容丢失的问题。

此前用户未配置模型时，`ModelSelector` 仅显示不可交互的提示文字，用户需自行寻找设置入口，路径长且不直观；同时若直接点击发送，输入内容会被意外清空，造成内容丢失。本 PR 将提示区域改为一键直达模型设置页的按钮，并修复输入丢失 bug，显著降低新用户上手门槛，避免因操作受挫而流失。

## Changes Made

**feat: ModelSelector 无模型时点击跳转设置页**
- 新增 `SettingsContext`，通过 Context 向组件树暴露 `openSettings` 方法
- `ModelSelector` 在无可用模型时，将静态文本替换为可点击按钮，点击后打开设置页的模型 Tab
- `App.tsx` 顶层包裹 `SettingsProvider`

**fix: 未配置模型时发送消息不再清空输入框**
- `CoworkView` 中 `handleSend` 在 API 配置检查失败时返回 `false`，阻止调用方清空输入内容

**chore: 补充 cherry-pick 后的 import 排序修复**
- 调整 `App.tsx` import 排序，确保本次涉及文件通过 focused eslint 校验

## Validation
- `npx eslint src/renderer/App.tsx src/renderer/components/ModelSelector.tsx src/renderer/contexts/SettingsContext.tsx src/renderer/components/cowork/CoworkView.tsx`
- `npm run lint` 仍因仓库内既有的全局 lint 问题失败（与本 PR 无关）
