### PR TITLE
fix(providers): align Copilot openClawProviderId with lobsterai-copilot runtime id

### DIFF
--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -405,7 +405,7 @@ const PROVIDER_DEFINITIONS = [
   {
     id: ProviderName.Copilot,
     label: 'GitHub Copilot',
-    openClawProviderId: OpenClawProviderId.Copilot,
+    openClawProviderId: OpenClawProviderId.LobsteraiCopilot,
     defaultBaseUrl: 'https://api.individual.githubcopilot.com',
     defaultApiFormat: ApiFormat.OpenAI,
     codingPlanSupported: false,


### PR DESCRIPTION
## Summary

Follow-up to #1694 (d475aeb).

PR #1694 migrated stale agent model DB entries from `github-copilot/…` to `lobsterai-copilot/…` to match the provider ID used in `openclawConfigSync.ts`.  However, the Copilot provider definition in `PROVIDER_DEFINITIONS` (`constants.ts`) was not updated alongside the migration — it still carried `openClawProviderId: OpenClawProviderId.Copilot` (= `'github-copilot'`).

This caused a mismatch in the renderer:

| Layer | Provider prefix used |
|-------|----------------------|
| `openclawConfigSync.ts` – openclaw.json registration | `lobsterai-copilot` |
| DB after #1694 migration | `lobsterai-copilot` |
| `toOpenClawModelRef()` via `PROVIDER_DEFINITIONS` | **`github-copilot`** ← stale |

`resolveOpenClawModelRef("lobsterai-copilot/gpt-5-mini", availableModels)` could never find a match, so every Copilot agent model was reported as invalid (`hasInvalidExplicitModel: true`), and the send button was disabled.

## Change

- `constants.ts` line 408: `openClawProviderId: OpenClawProviderId.Copilot` → `OpenClawProviderId.LobsteraiCopilot`

No logic changes — one-line alignment so all three layers share the same `lobsterai-copilot` prefix.

## Test plan

- [ ] Start dev, select a Copilot model (e.g. `gpt-5-mini`) for an Agent
- [ ] Restart dev — agent model should resolve without the "model no longer available" error
- [ ] Confirm a conversation can be started with the Copilot agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)