### PR TITLE
fix(cowork): default skip missed jobs to enabled

### DIFF
--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -222,6 +222,12 @@ test('no console.warn when all metadata is valid or null', () => {
   warnSpy.mockRestore();
 });
 
+test('getConfig defaults skipMissedJobs to true when config is missing', () => {
+  const config = store.getConfig();
+
+  expect(config.skipMissedJobs).toBe(true);
+});
+
 test('backfillEmptyAgentModels assigns the current default model to empty agents only', () => {
   const now = Date.now();
   db.prepare(

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -1064,7 +1064,7 @@ export class CoworkStore {
       memoryUserMemoriesMaxItems: clampMemoryUserMemoriesMaxItems(
         Number(cfg.get('memoryUserMemoriesMaxItems')),
       ),
-      skipMissedJobs: parseBooleanConfig(cfg.get('skipMissedJobs'), false),
+      skipMissedJobs: parseBooleanConfig(cfg.get('skipMissedJobs'), true),
     };
   }
 

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -714,7 +714,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [coworkAgentEngine, setCoworkAgentEngine] = useState<CoworkAgentEngine>(coworkConfig.agentEngine || 'openclaw');
   const [coworkMemoryEnabled, setCoworkMemoryEnabled] = useState<boolean>(coworkConfig.memoryEnabled ?? true);
   const [coworkMemoryLlmJudgeEnabled, setCoworkMemoryLlmJudgeEnabled] = useState<boolean>(coworkConfig.memoryLlmJudgeEnabled ?? false);
-  const [skipMissedJobs, setSkipMissedJobs] = useState<boolean>(coworkConfig.skipMissedJobs ?? false);
+  const [skipMissedJobs, setSkipMissedJobs] = useState<boolean>(coworkConfig.skipMissedJobs ?? true);
   const [openClawSessionKeepAlive, setOpenClawSessionKeepAlive] = useState<OpenClawSessionKeepAlive>(
     coworkConfig.openClawSessionPolicy?.keepAlive || OpenClawSessionKeepAliveValues.ThirtyDays,
   );
@@ -735,7 +735,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     setCoworkAgentEngine(coworkConfig.agentEngine || 'openclaw');
     setCoworkMemoryEnabled(coworkConfig.memoryEnabled ?? true);
     setCoworkMemoryLlmJudgeEnabled(coworkConfig.memoryLlmJudgeEnabled ?? false);
-    setSkipMissedJobs(coworkConfig.skipMissedJobs ?? false);
+    setSkipMissedJobs(coworkConfig.skipMissedJobs ?? true);
     setOpenClawSessionKeepAlive(coworkConfig.openClawSessionPolicy?.keepAlive || OpenClawSessionKeepAliveValues.ThirtyDays);
   }, [
     coworkConfig.agentEngine,
@@ -1364,7 +1364,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const hasCoworkConfigChanges = coworkAgentEngine !== coworkConfig.agentEngine
     || coworkMemoryEnabled !== coworkConfig.memoryEnabled
     || coworkMemoryLlmJudgeEnabled !== coworkConfig.memoryLlmJudgeEnabled
-    || skipMissedJobs !== (coworkConfig.skipMissedJobs ?? false)
+    || skipMissedJobs !== (coworkConfig.skipMissedJobs ?? true)
     || openClawSessionKeepAlive !== (coworkConfig.openClawSessionPolicy?.keepAlive || OpenClawSessionKeepAliveValues.ThirtyDays);
   const isOpenClawAgentEngine = coworkAgentEngine === 'openclaw';
 

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -8,6 +8,7 @@ test('defaults hidden OpenClaw session policy to thirty days', () => {
   expect(state.config.openClawSessionPolicy).toEqual({
     keepAlive: '30d',
   });
+  expect(state.config.skipMissedJobs).toBe(true);
 });
 
 test('setConfig preserves loaded OpenClaw session policy', () => {

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -53,7 +53,7 @@ const initialState: CoworkState = {
     memoryLlmJudgeEnabled: false,
     memoryGuardLevel: 'strict',
     memoryUserMemoriesMaxItems: 12,
-    skipMissedJobs: false,
+    skipMissedJobs: true,
     openClawSessionPolicy: {
       keepAlive: '30d',
     },


### PR DESCRIPTION
## Summary
Set `skipMissedJobs` to default to enabled in Cowork settings and config loading, including backward compatibility for older installs that do not have this config persisted yet.

## Related Issue
N/A

## Changes Made
- Changed the Settings UI fallback value for `skipMissedJobs` from `false` to `true`
- Changed the renderer Cowork slice initial config so new local state defaults to `skipMissedJobs: true`
- Changed `CoworkStore.getConfig()` to treat missing persisted `skipMissedJobs` as `true` for historical configs
- Added/updated unit tests to lock the new default behavior in both renderer and main-process config loading

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing
- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] Manual testing performed

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes
- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes
Validated with:
- `npm run test -- coworkStore`
- `npm run test -- coworkSlice`

The behavior change is intentionally backward-compatible: if older versions do not have `skipMissedJobs` stored in `cowork_config`, the app now treats it as enabled by default.