### PR TITLE
fix(cowork): suppress leaked HEARTBEAT_OK replies

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -414,6 +414,22 @@ test('prefetchChannelUserMessages also consumes existing reminder history backlo
   expect(getSystemMessages(session).length).toBe(0);
 });
 
+test('syncSystemMessagesFromHistory skips pure heartbeat ack system messages', () => {
+  const { session, store } = createHistoryStore([]);
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const historyMessages = [
+    { role: 'system', content: 'HEARTBEAT_OK' },
+    { role: 'system', content: 'Reminder fired' },
+  ];
+
+  adapter.syncSystemMessagesFromHistory(session.id, historyMessages, {
+    previousCountKnown: false,
+    previousCount: 0,
+  });
+
+  expect(getSystemMessages(session).map((message) => message.content)).toEqual(['Reminder fired']);
+});
+
 test('getSessionKeysForSession prefers channel keys before managed fallback', () => {
   const { store } = createHistoryStore([]);
   const adapter = new OpenClawRuntimeAdapter(store, {});

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -25,6 +25,7 @@ import {
 import {
   extractGatewayHistoryEntries,
   extractGatewayMessageText,
+  isHeartbeatAckText,
 } from '../openclawHistory';
 import { buildOpenClawLocalTimeContextPrompt } from '../openclawLocalTimeContextPrompt';
 import type {
@@ -2613,6 +2614,17 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     return normalizedFullText;
   }
 
+  private deleteAssistantMessage(sessionId: string, messageId: string): void {
+    this.clearPendingStoreUpdate(messageId);
+    this.clearPendingMessageUpdate(messageId);
+    this.store.deleteMessage(sessionId, messageId);
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) {
+        win.webContents.send('cowork:sessions:changed');
+      }
+    }
+  }
+
   /**
    * Process agent assistant-stream text directly from handleGatewayEvent.
    * This bypasses handleAgentEvent's session resolution (which may enqueue events),
@@ -2663,6 +2675,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           'turn:',
           !!turn
         );
+      }
+      return;
+    }
+    if (isHeartbeatAckText(text)) {
+      turn.currentText = text;
+      turn.currentAssistantSegmentText = '';
+      if (turn.assistantMessageId) {
+        this.deleteAssistantMessage(sessionId, turn.assistantMessageId);
+        turn.assistantMessageId = null;
       }
       return;
     }
@@ -2765,6 +2786,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
 
     if (!streamedText) return;
+    if (isHeartbeatAckText(streamedText)) {
+      turn.currentAssistantSegmentText = '';
+      return;
+    }
     const segmentText = this.resolveAssistantSegmentText(turn, streamedText);
     if (!segmentText) return;
     if (segmentText === previousSegmentText && streamedText === previousText) return;
@@ -2804,6 +2829,19 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       `finalTextLen=${finalText.length}`,
       `finalText="${truncate(finalText, 200)}"`
     );
+    if (isHeartbeatAckText(finalText)) {
+      turn.currentText = finalText;
+      turn.currentAssistantSegmentText = '';
+      if (turn.assistantMessageId) {
+        this.deleteAssistantMessage(sessionId, turn.assistantMessageId);
+        turn.assistantMessageId = null;
+      }
+      this.store.updateSession(sessionId, { status: 'completed' });
+      this.emit('complete', sessionId, payload.runId ?? turn.runId);
+      this.cleanupSessionTurn(sessionId);
+      this.resolveTurn(sessionId);
+      return;
+    }
     turn.currentText = finalText;
     if (finalText && turn.currentContentBlocks.length === 0) {
       turn.currentContentText = finalText;
@@ -3129,6 +3167,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     );
 
     for (const entry of systemEntries) {
+      if (isHeartbeatAckText(entry.text)) {
+        continue;
+      }
       if (existingSystemTexts.has(entry.text)) {
         continue;
       }

--- a/src/main/libs/openclawHistory.test.ts
+++ b/src/main/libs/openclawHistory.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest';
-import { extractGatewayHistoryEntry, extractGatewayHistoryEntries, extractGatewayMessageText, buildScheduledReminderSystemMessage } from './openclawHistory';
+import {
+  buildScheduledReminderSystemMessage,
+  extractGatewayHistoryEntries,
+  extractGatewayHistoryEntry,
+  extractGatewayMessageText,
+  isHeartbeatAckText,
+} from './openclawHistory';
 
 describe('openclawHistory', () => {
   test('extracts plain text content blocks', () => {
@@ -63,6 +69,22 @@ describe('openclawHistory', () => {
     expect(entry).toEqual({ role: 'system', text: 'Reminder fired' });
   });
 
+  test('filters pure heartbeat ack assistant messages', () => {
+    const entry = extractGatewayHistoryEntry({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'HEARTBEAT_OK' }],
+    });
+    expect(entry).toBeNull();
+  });
+
+  test('filters pure heartbeat ack system messages with punctuation wrappers', () => {
+    const entry = extractGatewayHistoryEntry({
+      role: 'system',
+      content: [{ type: 'text', text: '("HEARTBEAT_OK")' }],
+    });
+    expect(entry).toBeNull();
+  });
+
   test('filters unsupported roles and empty messages', () => {
     const entries = extractGatewayHistoryEntries([
       { role: 'user', content: 'Set a reminder' },
@@ -101,5 +123,11 @@ Current time: Sunday, March 15th, 2026 — 11:27 (Asia/Shanghai)`,
 
   test('buildScheduledReminderSystemMessage returns null for regular user text', () => {
     expect(buildScheduledReminderSystemMessage('普通聊天消息')).toBeNull();
+  });
+
+  test('isHeartbeatAckText matches token with lightweight wrappers only', () => {
+    expect(isHeartbeatAckText('HEARTBEAT_OK')).toBe(true);
+    expect(isHeartbeatAckText('`HEARTBEAT_OK`')).toBe(true);
+    expect(isHeartbeatAckText('HEARTBEAT_OK: all clear')).toBe(false);
   });
 });

--- a/src/main/libs/openclawHistory.ts
+++ b/src/main/libs/openclawHistory.ts
@@ -10,6 +10,8 @@ export interface GatewayHistoryEntry {
   text: string;
 }
 
+const HEARTBEAT_ACK_RE = /^[`*_~"'“”‘’()[\]{}<>.,!?;:，。！？；：\s-]{0,8}HEARTBEAT_OK[`*_~"'“”‘’()[\]{}<>.,!?;:，。！？；：\s-]{0,8}$/i;
+
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 };
@@ -85,6 +87,8 @@ export const buildScheduledReminderSystemMessage = (text: string): string | null
   return parsed.reminderText;
 };
 
+export const isHeartbeatAckText = (text: string): boolean => HEARTBEAT_ACK_RE.test(text.trim());
+
 export const extractGatewayHistoryEntry = (message: unknown): GatewayHistoryEntry | null => {
   if (!isRecord(message)) {
     return null;
@@ -97,6 +101,9 @@ export const extractGatewayHistoryEntry = (message: unknown): GatewayHistoryEntr
 
   const text = extractGatewayMessageText(message).trim();
   if (!text) {
+    return null;
+  }
+  if ((role === 'assistant' || role === 'system') && isHeartbeatAckText(text)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
Prevent leaked `HEARTBEAT_OK` responses from appearing in Cowork sessions when upstream suppression misses OpenClaw background heartbeats or follow-up system-event turns.

## Related Issue
N/A

## Changes Made
- Added local heartbeat-ack detection in `openclawHistory` and filtered pure `HEARTBEAT_OK` messages from parsed gateway history entries.
- Filtered heartbeat acknowledgements in `OpenClawRuntimeAdapter` during system-message sync, assistant stream handling, and final assistant completion cleanup.
- Added regression tests covering heartbeat-ack filtering in history parsing and adapter system-message sync behavior.

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you've performed -->
- [ ] Tested locally
- [x] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

## Screenshots (if applicable)
N/A

## Checklist
<!-- Mark the completed items with [x] -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes
<!-- If your PR includes Electron-specific changes, describe them here -->
- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes
- This change is intentionally limited to filtering pure heartbeat acknowledgements and should not affect normal assistant replies.
- The filtering covers both parsed gateway history and runtime streaming/finalization paths to avoid transient UI leakage.