### PR TITLE
fix(mcp): force gateway restart when mcp-bridge config changes

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -706,6 +706,7 @@ export type OpenClawConfigSyncResult = {
   error?: string;
   agentsMdWarning?: string;
   bindingsChanged?: boolean;
+  mcpBridgeConfigChanged?: boolean;
 };
 
 const buildStreamingModeConfig = (
@@ -1120,6 +1121,7 @@ export class OpenClawConfigSync {
     // Sync MCP Bridge config into the plugin's own config section
     // (root-level keys are rejected by OpenClaw's strict schema validation)
     const mcpBridgeCfg = this.getMcpBridgeConfig?.();
+    console.log(`[OpenClawConfigSync] getMcpBridgeConfig: callbackUrl=${mcpBridgeCfg?.callbackUrl ?? 'null'}, tools=${mcpBridgeCfg?.tools?.length ?? 0}`);
     if (hasMcpBridgePlugin && mcpBridgeCfg && mcpBridgeCfg.tools.length > 0 && managedConfig.plugins) {
       const plugins = managedConfig.plugins as Record<string, unknown>;
       const entries = plugins.entries as Record<string, Record<string, unknown>>;
@@ -1476,6 +1478,29 @@ export class OpenClawConfigSync {
 
     const configChanged = currentContent !== nextContent;
 
+    // Detect mcp-bridge config changes (callbackUrl, tools) separately.
+    // Even when the overall plugins section appears "UNCHANGED" in the
+    // diagnostic, the mcp-bridge sub-config may have changed — and that
+    // requires a hard gateway restart because the gateway pins its config
+    // snapshot at startup.
+    let mcpBridgeConfigChanged = false;
+    try {
+      const currentObj = currentContent ? JSON.parse(currentContent) : {};
+      const nextObj = JSON.parse(nextContent);
+      const curMcpBridge = currentObj?.plugins?.entries?.['mcp-bridge'];
+      const nxtMcpBridge = nextObj?.plugins?.entries?.['mcp-bridge'];
+      const curCallbackUrl = curMcpBridge?.config?.callbackUrl;
+      const nxtCallbackUrl = nxtMcpBridge?.config?.callbackUrl;
+      const curToolNames = (curMcpBridge?.config?.tools as Array<{ name?: string }> | undefined)
+        ?.map((t) => t.name).sort().join(',') ?? '';
+      const nxtToolNames = (nxtMcpBridge?.config?.tools as Array<{ name?: string }> | undefined)
+        ?.map((t) => t.name).sort().join(',') ?? '';
+      mcpBridgeConfigChanged = curCallbackUrl !== nxtCallbackUrl || curToolNames !== nxtToolNames;
+      if (mcpBridgeConfigChanged) {
+        console.log(`[GW-RESTART-DIAG] mcp-bridge config CHANGED: callbackUrl ${curCallbackUrl ?? 'null'} → ${nxtCallbackUrl ?? 'null'}, tools ${curToolNames.split(',').length} → ${nxtToolNames.split(',').length}`);
+      }
+    } catch { /* ignore parse errors */ }
+
     if (configChanged) {
       // Diagnostic: diff gateway and plugins sections to identify what triggers OpenClaw restart
       try {
@@ -1543,6 +1568,7 @@ export class OpenClawConfigSync {
       changed: configChanged || sessionStoreChanged,
       configPath,
       ...(bindingsChanged ? { bindingsChanged } : {}),
+      ...(mcpBridgeConfigChanged ? { mcpBridgeConfigChanged } : {}),
       ...(agentsMdWarning ? { agentsMdWarning } : {}),
     };
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1106,7 +1106,7 @@ const scheduleDeferredGatewayRestart = (reason: string) => {
 
 const syncOpenClawConfig = async (
   options: { reason: string; restartGatewayIfRunning?: boolean } = { reason: 'unknown' },
-): Promise<{ success: boolean; changed: boolean; status?: OpenClawEngineStatus; error?: string }> => {
+): Promise<{ success: boolean; changed: boolean; mcpBridgeConfigChanged?: boolean; status?: OpenClawEngineStatus; error?: string }> => {
   const D = '[GW-RESTART-DIAG]';
   console.log(`${D} ──── syncOpenClawConfig START reason=${options.reason} restartIfRunning=${!!options.restartGatewayIfRunning}`);
 
@@ -1160,15 +1160,21 @@ const syncOpenClawConfig = async (
     console.log(`${D} secretEnvVars unchanged (${Object.keys(nextSecretEnvVars).length} keys)`);
   }
 
-  const needsHardRestart = secretEnvVarsChanged || syncResult.bindingsChanged || (syncResult.changed && options.restartGatewayIfRunning);
+  // Force a hard restart when the mcp-bridge callbackUrl or tools changed,
+  // regardless of the restartGatewayIfRunning flag.  The OpenClaw gateway
+  // pins its config snapshot at startup, so a hot-reload alone won't pick
+  // up a new callbackUrl — the gateway must be fully restarted.
+  const mcpBridgeForceRestart = !!syncResult.mcpBridgeConfigChanged;
+  const needsHardRestart = secretEnvVarsChanged || syncResult.bindingsChanged || mcpBridgeForceRestart || (syncResult.changed && options.restartGatewayIfRunning);
 
-  console.log(`${D} needsHardRestart=${needsHardRestart} (envChanged=${secretEnvVarsChanged} bindingsChanged=${!!syncResult.bindingsChanged} configChanged=${syncResult.changed} restartFlag=${!!options.restartGatewayIfRunning})`);
+  console.log(`${D} needsHardRestart=${needsHardRestart} (envChanged=${secretEnvVarsChanged} bindingsChanged=${!!syncResult.bindingsChanged} mcpBridgeChanged=${mcpBridgeForceRestart} configChanged=${syncResult.changed} restartFlag=${!!options.restartGatewayIfRunning})`);
 
   if (!needsHardRestart) {
     console.log(`${D} ──── NO RESTART, hot-reload only. reason=${options.reason}`);
     return {
       success: true,
       changed: syncResult.changed,
+      mcpBridgeConfigChanged: syncResult.mcpBridgeConfigChanged,
     };
   }
 
@@ -1494,8 +1500,9 @@ const refreshMcpBridge = (): Promise<{ tools: number; error?: string }> => {
       const toolCount = bridgeConfig?.tools.length ?? 0;
       console.log(`[McpBridge] refresh: ${toolCount} tools discovered`);
 
-      // 3. Sync openclaw.json — OpenClaw's file watcher will hot-reload;
-      // hard restart only happens when secret env vars change.
+      // 3. Sync openclaw.json — the gateway will hard-restart when the
+      // mcp-bridge callbackUrl or tools change, ensuring the gateway picks
+      // up the new config (it pins a snapshot at startup).
       const syncResult = await syncOpenClawConfig({
         reason: 'mcp-server-changed',
       });
@@ -1504,7 +1511,7 @@ const refreshMcpBridge = (): Promise<{ tools: number; error?: string }> => {
         return { tools: toolCount, error: syncResult.error };
       }
 
-      console.log(`[McpBridge] refresh complete: ${toolCount} tools, gateway restarted=${syncResult.changed}`);
+      console.log(`[McpBridge] refresh complete: ${toolCount} tools, configChanged=${syncResult.changed}, mcpBridgeChanged=${!!syncResult.mcpBridgeConfigChanged}`);
       return { tools: toolCount };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
MCP bridge 的 callbackUrl 和 tools 在启动时序竞态下未能同步到
OpenClaw gateway，导致部分用户 MCP 功能不可用。gateway 启动时
pin 住 config snapshot，后续 hot-reload 无法更新 mcp-bridge 插件配置。

新增 mcpBridgeConfigChanged 检测，当 callbackUrl 或 tools 变化时 强制触发 gateway hard restart，不依赖 restartGatewayIfRunning 标志。