### PR TITLE
fix(cowork): suppress heartbeat prompt history leaks

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -127,6 +127,40 @@ test('reconcileWithHistory: missing assistant message — triggers replace', asy
   ]);
 });
 
+test('reconcileWithHistory: filters heartbeat prompt and ack entries', async () => {
+  const { session, store, getReplaceCallCount, getLastReplaceArgs } = createReconcileStore([
+    { id: 'msg-1', type: 'user', content: 'Hello', timestamp: 1, metadata: {} },
+  ]);
+
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  adapter.gatewayClient = {
+    start: () => {},
+    stop: () => {},
+    request: async () => ({
+      messages: [
+        { role: 'user', content: 'Hello' },
+        {
+          role: 'user',
+          content: `Read HEARTBEAT.md if it exists.
+When reading HEARTBEAT.md, use workspace file /tmp/HEARTBEAT.md.
+Do not infer or repeat old tasks from prior chats.
+If nothing needs attention, reply HEARTBEAT_OK.`,
+        },
+        { role: 'assistant', content: 'HEARTBEAT_OK' },
+        { role: 'assistant', content: 'Real answer' },
+      ],
+    }),
+  };
+
+  await adapter.reconcileWithHistory(session.id, 'managed:session-1');
+
+  expect(getReplaceCallCount()).toBe(1);
+  expect(getLastReplaceArgs()?.authoritative).toEqual([
+    { role: 'user', text: 'Hello' },
+    { role: 'assistant', text: 'Real answer' },
+  ]);
+});
+
 test('reconcileWithHistory: duplicate messages locally — skips replace to preserve local history', async () => {
   const { session, store, getReplaceCallCount } = createReconcileStore([
     { id: 'msg-1', type: 'user', content: 'Hello', timestamp: 1, metadata: {} },
@@ -428,6 +462,29 @@ test('syncSystemMessagesFromHistory skips pure heartbeat ack system messages', (
   });
 
   expect(getSystemMessages(session).map((message) => message.content)).toEqual(['Reminder fired']);
+});
+
+test('collectChannelHistoryEntries skips heartbeat prompt and ack messages', () => {
+  const { store } = createHistoryStore([]);
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+
+  const entries = adapter.collectChannelHistoryEntries([
+    { role: 'user', content: 'regular user' },
+    {
+      role: 'user',
+      content: `Read HEARTBEAT.md if it exists.
+When reading HEARTBEAT.md, use workspace file /tmp/HEARTBEAT.md.
+Do not infer or repeat old tasks from prior chats.
+If nothing needs attention, reply HEARTBEAT_OK.`,
+    },
+    { role: 'assistant', content: 'HEARTBEAT_OK' },
+    { role: 'assistant', content: 'regular assistant' },
+  ]);
+
+  expect(entries).toEqual([
+    { role: 'user', text: 'regular user' },
+    { role: 'assistant', text: 'regular assistant' },
+  ]);
 });
 
 test('getSessionKeysForSession prefers channel keys before managed fallback', () => {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -26,6 +26,7 @@ import {
   extractGatewayHistoryEntries,
   extractGatewayMessageText,
   isHeartbeatAckText,
+  shouldSuppressHeartbeatText,
 } from '../openclawHistory';
 import { buildOpenClawLocalTimeContextPrompt } from '../openclawLocalTimeContextPrompt';
 import type {
@@ -419,7 +420,7 @@ const extractCurrentTurnAssistantText = (messages: unknown[]): string => {
     const role = typeof msg.role === 'string' ? msg.role.trim().toLowerCase() : '';
     if (role !== 'assistant') continue;
     const text = extractMessageText(msg).trim();
-    if (text) {
+    if (text && !shouldSuppressHeartbeatText('assistant', text)) {
       textParts.push(text);
     }
   }
@@ -3270,16 +3271,16 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
       // Extract authoritative user/assistant entries from gateway history
       const authoritativeEntries: Array<{ role: 'user' | 'assistant'; text: string }> = [];
-      for (const message of history.messages) {
-        if (!isRecord(message)) continue;
-        const role = typeof message.role === 'string' ? message.role.trim().toLowerCase() : '';
+      for (const entry of extractGatewayHistoryEntries(history.messages)) {
+        const role = entry.role;
         if (role !== 'user' && role !== 'assistant') continue;
-        let text = extractMessageText(message).trim();
+        let text = entry.text.trim();
         if (!text) continue;
         if (isDiscord) text = stripDiscordMentions(text);
         if (isQQ && role === 'user') text = stripQQBotSystemPrompt(text);
         if (isPopo && role === 'user') text = stripPopoSystemHeader(text);
         if (isFeishu && role === 'user') text = stripFeishuSystemHeader(text);
+        if (!text || shouldSuppressHeartbeatText(role, text)) continue;
         authoritativeEntries.push({ role: role as 'user' | 'assistant', text });
       }
 
@@ -3448,6 +3449,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
             const role = typeof message.role === 'string' ? message.role.trim().toLowerCase() : '';
             if (role !== 'assistant') continue;
             canonicalText = extractMessageText(message).trim();
+            if (canonicalText && shouldSuppressHeartbeatText('assistant', canonicalText)) {
+              canonicalText = '';
+              continue;
+            }
             if (canonicalText) {
               break;
             }
@@ -3542,10 +3547,11 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   ): ChannelHistorySyncEntry[] {
     const historyEntries: ChannelHistorySyncEntry[] = [];
     for (const message of historyMessages) {
-      if (!isRecord(message)) continue;
-      const role = typeof message.role === 'string' ? message.role.trim().toLowerCase() : '';
+      const entry = extractGatewayHistoryEntries([message])[0];
+      if (!entry) continue;
+      const role = entry.role;
       if (role !== 'user' && role !== 'assistant') continue;
-      let text = extractMessageText(message).trim();
+      let text = entry.text.trim();
       // POPO's moltbot-popo plugin converts newlines to HTML break tags (<br />),
       // causing raw <br /> to appear in the UI and AI conversation.
       if (isPopo) text = text.replace(/<br\s*\/?>/gi, '\n');
@@ -3553,7 +3559,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       if (isDiscord) text = stripDiscordMentions(text);
       if (isQQ && role === 'user') text = stripQQBotSystemPrompt(text);
       if (isFeishu && role === 'user') text = stripFeishuSystemHeader(text);
-      if (text) {
+      if (text && !shouldSuppressHeartbeatText(role, text)) {
         historyEntries.push({ role: role as 'user' | 'assistant', text });
       }
     }

--- a/src/main/libs/openclawHistory.test.ts
+++ b/src/main/libs/openclawHistory.test.ts
@@ -5,6 +5,7 @@ import {
   extractGatewayHistoryEntry,
   extractGatewayMessageText,
   isHeartbeatAckText,
+  isHeartbeatPromptText,
 } from './openclawHistory';
 
 describe('openclawHistory', () => {
@@ -85,6 +86,16 @@ describe('openclawHistory', () => {
     expect(entry).toBeNull();
   });
 
+  test('filters heartbeat prompt user messages', () => {
+    const entry = extractGatewayHistoryEntry({
+      role: 'user',
+      content: `Read HEARTBEAT.md if it exists (workspace context). Follow it strictly.
+When reading HEARTBEAT.md, use workspace file /tmp/HEARTBEAT.md.
+Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`,
+    });
+    expect(entry).toBeNull();
+  });
+
   test('filters unsupported roles and empty messages', () => {
     const entries = extractGatewayHistoryEntries([
       { role: 'user', content: 'Set a reminder' },
@@ -129,5 +140,15 @@ Current time: Sunday, March 15th, 2026 — 11:27 (Asia/Shanghai)`,
     expect(isHeartbeatAckText('HEARTBEAT_OK')).toBe(true);
     expect(isHeartbeatAckText('`HEARTBEAT_OK`')).toBe(true);
     expect(isHeartbeatAckText('HEARTBEAT_OK: all clear')).toBe(false);
+  });
+
+  test('isHeartbeatPromptText matches canonical heartbeat instructions only', () => {
+    expect(
+      isHeartbeatPromptText(`Read HEARTBEAT.md if it exists.
+When reading HEARTBEAT.md, use workspace file /tmp/HEARTBEAT.md.
+Do not infer or repeat old tasks from prior chats.
+If nothing needs attention, reply HEARTBEAT_OK.`)
+    ).toBe(true);
+    expect(isHeartbeatPromptText('Please read README.md and reply OK.')).toBe(false);
   });
 });

--- a/src/main/libs/openclawHistory.ts
+++ b/src/main/libs/openclawHistory.ts
@@ -11,6 +11,12 @@ export interface GatewayHistoryEntry {
 }
 
 const HEARTBEAT_ACK_RE = /^[`*_~"'“”‘’()[\]{}<>.,!?;:，。！？；：\s-]{0,8}HEARTBEAT_OK[`*_~"'“”‘’()[\]{}<>.,!?;:，。！？；：\s-]{0,8}$/i;
+const HEARTBEAT_PROMPT_MARKERS = [
+  'read heartbeat.md if it exists',
+  'when reading heartbeat.md',
+  'reply heartbeat_ok',
+  'do not infer or repeat old tasks from prior chats',
+] as const;
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -89,6 +95,24 @@ export const buildScheduledReminderSystemMessage = (text: string): string | null
 
 export const isHeartbeatAckText = (text: string): boolean => HEARTBEAT_ACK_RE.test(text.trim());
 
+export const isHeartbeatPromptText = (text: string): boolean => {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return HEARTBEAT_PROMPT_MARKERS.every((marker) => normalized.includes(marker));
+};
+
+export const shouldSuppressHeartbeatText = (role: GatewayHistoryRole, text: string): boolean => {
+  if ((role === 'assistant' || role === 'system') && isHeartbeatAckText(text)) {
+    return true;
+  }
+  if (role === 'user' && isHeartbeatPromptText(text)) {
+    return true;
+  }
+  return false;
+};
+
 export const extractGatewayHistoryEntry = (message: unknown): GatewayHistoryEntry | null => {
   if (!isRecord(message)) {
     return null;
@@ -103,7 +127,7 @@ export const extractGatewayHistoryEntry = (message: unknown): GatewayHistoryEntr
   if (!text) {
     return null;
   }
-  if ((role === 'assistant' || role === 'system') && isHeartbeatAckText(text)) {
+  if (shouldSuppressHeartbeatText(role, text)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
Fix leaked heartbeat prompt and acknowledgement messages from reappearing in Cowork session UI after history reconciliation.

## Related Issue
N/A

## Changes Made
- Added shared heartbeat filtering helpers to recognize both `HEARTBEAT_OK` acknowledgements and canonical `HEARTBEAT.md` prompt instructions
- Reused the shared filtering in gateway history parsing, `reconcileWithHistory`, current-turn assistant text extraction, and channel history collection
- Added regression tests to verify heartbeat prompt/ack entries are suppressed while normal assistant replies are preserved

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing
- [x] Tested locally
- [x] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes
- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes
Local test run:
- `npx vitest run src/main/libs/openclawHistory.test.ts src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts`

This PR focuses on LobsterAI-side suppression. It does not change upstream OpenClaw heartbeat behavior; it prevents leaked heartbeat prompt/ack history from being surfaced back into
Cowork sessions during post-stream sync.