### PR TITLE
fix(cowork): 修复 OpenClaw 服务端代理请求缺失 session_id

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -32,8 +32,10 @@ import { extractOpenClawAssistantStreamText } from '../openclawAssistantText';
 import { buildOpenClawLocalTimeContextPrompt } from '../openclawLocalTimeContextPrompt';
 import { isDeleteCommand, getCommandDangerLevel } from '../commandSafety';
 import { setCoworkProxySessionId } from '../coworkOpenAICompatProxy';
+import { buildCoworkSessionIdMarker } from '../openclawTokenProxy';
 import { OPENCLAW_AGENT_TIMEOUT_SECONDS } from '../openclawConfigSync';
 import { t } from '../../i18n';
+import { OpenClawProviderId } from '../../../shared/providers';
 
 const OPENCLAW_GATEWAY_TOOL_EVENTS_CAP = 'tool-events';
 const BRIDGE_MAX_MESSAGES = 20;
@@ -1179,12 +1181,13 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     const runId = randomUUID();
     const turnToken = this.nextTurnToken(sessionId);
-    const outboundMessage = await this.buildOutboundPrompt(
+    const outboundPrompt = await this.buildOutboundPrompt(
       sessionId,
       prompt,
       options.systemPrompt ?? session.systemPrompt,
       agentId,
     );
+    const outboundMessage = this.buildOutboundMessageForProvider(sessionId, agentId, outboundPrompt);
     const completionPromise = new Promise<void>((resolve, reject) => {
       this.pendingTurns.set(sessionId, { resolve, reject });
     });
@@ -1374,6 +1377,19 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       'Use this prior context for continuity. Focus your final answer on the current request.',
       ...lines,
     ].join('\n');
+  }
+
+  private buildOutboundMessageForProvider(sessionId: string, agentId: string, message: string): string {
+    if (!this.shouldAttachCoworkSessionMarker(agentId)) {
+      return message;
+    }
+    return `${buildCoworkSessionIdMarker(sessionId)}\n\n${message}`;
+  }
+
+  private shouldAttachCoworkSessionMarker(agentId: string): boolean {
+    const agent = this.store.getAgent(agentId);
+    const model = agent?.model?.trim();
+    return !model || model.startsWith(`${OpenClawProviderId.LobsteraiServer}/`);
   }
 
   private async ensureGatewayClientReady(): Promise<void> {

--- a/src/main/libs/openclawTokenProxy.test.ts
+++ b/src/main/libs/openclawTokenProxy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  net: {
+    fetch: vi.fn(),
+  },
+}));
+
+import { __openClawTokenProxyTestUtils } from './openclawTokenProxy';
+
+describe('OpenClaw token proxy cowork session body handling', () => {
+  test('injects session_id from a hidden text marker and removes the marker', () => {
+    const sessionId = '11111111-2222-3333-4444-555555555555';
+    const body = Buffer.from(JSON.stringify({
+      model: 'deepseek-v3.2',
+      messages: [
+        {
+          role: 'user',
+          content: `<!-- lobsterai:cowork-session-id:${sessionId} -->\n\nhello`,
+        },
+      ],
+    }));
+
+    const rewritten = __openClawTokenProxyTestUtils.rewriteCoworkSessionBody(body);
+    const parsed = JSON.parse(rewritten.toString('utf8')) as {
+      session_id?: string;
+      messages?: Array<{ content?: string }>;
+    };
+
+    expect(parsed.session_id).toBe(sessionId);
+    expect(parsed.messages?.[0]?.content).toBe('hello');
+  });
+
+  test('injects session_id from an OpenAI text content part and removes the marker', () => {
+    const sessionId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const body = Buffer.from(JSON.stringify({
+      model: 'deepseek-v3.2',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: `<!-- lobsterai:cowork-session-id:${sessionId} -->\n\nhello`,
+            },
+            {
+              type: 'image_url',
+              image_url: { url: 'data:image/png;base64,abc' },
+            },
+          ],
+        },
+      ],
+    }));
+
+    const rewritten = __openClawTokenProxyTestUtils.rewriteCoworkSessionBody(body);
+    const parsed = JSON.parse(rewritten.toString('utf8')) as {
+      session_id?: string;
+      messages?: Array<{ content?: Array<{ text?: string }> }>;
+    };
+
+    expect(parsed.session_id).toBe(sessionId);
+    expect(parsed.messages?.[0]?.content?.[0]?.text).toBe('hello');
+    expect(parsed.messages?.[0]?.content?.[1]).toEqual({
+      type: 'image_url',
+      image_url: { url: 'data:image/png;base64,abc' },
+    });
+  });
+});

--- a/src/main/libs/openclawTokenProxy.ts
+++ b/src/main/libs/openclawTokenProxy.ts
@@ -2,6 +2,7 @@ import http from 'http';
 import { net } from 'electron';
 
 const PROXY_BIND_HOST = '127.0.0.1';
+const COWORK_SESSION_ID_MARKER_PATTERN = /<!--\s*lobsterai:cowork-session-id:([0-9a-fA-F-]{36})\s*-->\s*/g;
 
 let proxyServer: http.Server | null = null;
 let proxyPort: number | null = null;
@@ -67,6 +68,10 @@ export function getOpenClawTokenProxyPort(): number | null {
   return proxyPort;
 }
 
+export function buildCoworkSessionIdMarker(sessionId: string): string {
+  return `<!-- lobsterai:cowork-session-id:${sessionId} -->`;
+}
+
 function collectRequestBody(req: http.IncomingMessage): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -88,19 +93,20 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
     }
 
     const body = await collectRequestBody(req);
+    const upstreamBody = rewriteCoworkSessionBody(body);
 
     // Build upstream URL: serverBaseUrl + request path
     // OpenClaw sends to /v1/chat/completions, upstream is /api/proxy/v1/chat/completions
     const upstreamPath = `/api/proxy${req.url || '/'}`;
     const upstreamUrl = `${serverBaseUrl}${upstreamPath}`;
 
-    const result = await forwardRequest(upstreamUrl, req.method || 'POST', tokens.accessToken, body, req.headers);
+    const result = await forwardRequest(upstreamUrl, req.method || 'POST', tokens.accessToken, upstreamBody, req.headers);
 
     if ((result.status === 401 || result.status === 403) && tokenRefresher) {
       console.log(`[OpenClawTokenProxy] received ${result.status}, attempting token refresh`);
       const newToken = await tokenRefresher('openclaw-proxy');
       if (newToken) {
-        const retryResult = await forwardRequest(upstreamUrl, req.method || 'POST', newToken, body, req.headers);
+        const retryResult = await forwardRequest(upstreamUrl, req.method || 'POST', newToken, upstreamBody, req.headers);
         pipeResponse(retryResult, res);
         return;
       }
@@ -115,6 +121,93 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
     }
   }
 }
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+};
+
+function stripCoworkSessionMarker(text: string): { text: string; sessionId: string | null; changed: boolean } {
+  let sessionId: string | null = null;
+  COWORK_SESSION_ID_MARKER_PATTERN.lastIndex = 0;
+  const nextText = text.replace(COWORK_SESSION_ID_MARKER_PATTERN, (_match, matchedSessionId: string) => {
+    if (!sessionId) {
+      sessionId = matchedSessionId;
+    }
+    return '';
+  });
+
+  return {
+    text: nextText,
+    sessionId,
+    changed: nextText !== text,
+  };
+}
+
+function rewriteMessagesForCoworkSession(messages: unknown[]): { sessionId: string | null; changed: boolean } {
+  let sessionId: string | null = null;
+  let changed = false;
+
+  for (const message of messages) {
+    if (!isRecord(message)) continue;
+
+    if (typeof message.content === 'string') {
+      const stripped = stripCoworkSessionMarker(message.content);
+      if (stripped.changed) {
+        message.content = stripped.text;
+        changed = true;
+      }
+      if (!sessionId && stripped.sessionId) {
+        sessionId = stripped.sessionId;
+      }
+      continue;
+    }
+
+    if (!Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      if (!isRecord(part) || typeof part.text !== 'string') continue;
+      const stripped = stripCoworkSessionMarker(part.text);
+      if (stripped.changed) {
+        part.text = stripped.text;
+        changed = true;
+      }
+      if (!sessionId && stripped.sessionId) {
+        sessionId = stripped.sessionId;
+      }
+    }
+  }
+
+  return { sessionId, changed };
+}
+
+function rewriteCoworkSessionBody(body: Buffer): Buffer {
+  if (body.length === 0) return body;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body.toString('utf8'));
+  } catch {
+    return body;
+  }
+
+  if (!isRecord(parsed) || !Array.isArray(parsed.messages)) {
+    return body;
+  }
+
+  const rewritten = rewriteMessagesForCoworkSession(parsed.messages);
+  if (!rewritten.changed) {
+    return body;
+  }
+
+  if (rewritten.sessionId && typeof parsed.session_id !== 'string') {
+    parsed.session_id = rewritten.sessionId;
+  }
+
+  return Buffer.from(JSON.stringify(parsed), 'utf8');
+}
+
+export const __openClawTokenProxyTestUtils = {
+  rewriteCoworkSessionBody,
+};
 
 type UpstreamResult = {
   status: number;


### PR DESCRIPTION
 ## 背景

  当前 OpenClaw runtime 支持多个 cowork session 并发运行，但在默认的 OpenClaw + `lobsterai-server` 请求链路中，请求会经过 `openclawTokenProxy` 转发到 LobsterAI 服务端。

  此前这条链路没有把当前 cowork session id 写入请求体，导致转发到 `/api/proxy/v1/chat/completions` 的请求缺少顶层 `session_id` 字段，服务端无法稳定识别请求来源于哪个 cowork 会话。

  ## 修复内容

  - 在 OpenClaw runtime 发起 turn 时，为 LobsterAI 服务端模型的 outbound message 添加隐藏的 cowork session 标记。
  - 在 `openclawTokenProxy` 转发请求前：
    - 从 OpenAI-compatible 请求体的 `messages` 中提取 cowork session id；
    - 注入为顶层 `session_id`；
    - 移除隐藏标记，避免该标记继续传给服务端模型。
  - 新增单测覆盖两种请求体形态：
    - `messages[].content` 为字符串；
    - `messages[].content` 为 OpenAI array text content。
