### PR TITLE
fix(update): separate manual update flow from auto predownload

### DIFF
--- a/src/main/libs/appUpdateCoordinator.ts
+++ b/src/main/libs/appUpdateCoordinator.ts
@@ -1,11 +1,13 @@
 import crypto from 'crypto';
 import { app, BrowserWindow, session } from 'electron';
 import fs from 'fs';
+import path from 'path';
 
 import {
   type AppUpdateCheckResult,
   type AppUpdateInfo,
   AppUpdateIpc,
+  AppUpdateSource,
   type AppUpdateRuntimeState,
   AppUpdateStatus,
 } from '../../shared/appUpdate/constants';
@@ -41,16 +43,18 @@ type UpdateApiResponse = {
 
 const INSTALLATION_UUID_KEY = 'installation_uuid';
 const APP_UPDATE_TEST_CURRENT_VERSION_ENV = 'LOBSTERAI_UPDATE_CURRENT_VERSION';
-const APP_UPDATE_READY_FILE_KEY = 'app_update_ready_file';
+const APP_UPDATE_READY_FILE_KEY_PREFIX = 'app_update_ready_file';
 
 type StoredReadyFile = {
   version: string;
   filePath: string;
   fileHash: string;
+  info?: AppUpdateInfo;
 };
 
 const initialState = (): AppUpdateRuntimeState => ({
   status: AppUpdateStatus.Idle,
+  source: null,
   info: null,
   progress: null,
   readyFilePath: null,
@@ -62,9 +66,13 @@ export class AppUpdateCoordinator {
   private state: AppUpdateRuntimeState = initialState();
   private readonly store: SqliteStore;
   private autoOpenReadyModal = false;
+  private flowSequence = 0;
+  private activeFlowId = 0;
+  private activeFlowSource: AppUpdateSource | null = null;
 
   constructor(store: SqliteStore) {
     this.store = store;
+    this.restoreStoredReadyState();
   }
 
   getState(): AppUpdateRuntimeState {
@@ -80,45 +88,105 @@ export class AppUpdateCoordinator {
   }
 
   async checkNow(options?: { manual?: boolean }): Promise<AppUpdateCheckResult> {
+    const targetSource = options?.manual === true ? AppUpdateSource.Manual : AppUpdateSource.Auto;
+    console.log(
+      `[AppUpdate] checkNow started, manual=${options?.manual === true}, status=${this.state.status}, source=${this.state.source ?? 'none'}, readyFilePath=${this.state.readyFilePath ?? 'none'}`,
+    );
     if (this.isUpdateDisabled()) {
       console.log('[AppUpdate] updates are disabled by enterprise config');
       const state = this.resetToIdle();
       return { success: true, state, updateFound: false };
     }
 
+    if (options?.manual === true && this.state.source === AppUpdateSource.Auto) {
+      if (this.state.status === AppUpdateStatus.Downloading) {
+        console.log('[AppUpdate] manual check is preempting active auto download');
+        const cancelled = cancelActiveDownload();
+        console.log(`[AppUpdate] auto download cancel requested by manual check, cancelled=${cancelled}`);
+      } else if (this.state.status === AppUpdateStatus.Checking) {
+        console.log('[AppUpdate] manual check is preempting active auto check before download');
+      } else if (this.state.status === AppUpdateStatus.Installing) {
+        console.log('[AppUpdate] manual check cannot preempt auto install already in progress');
+        return { success: true, state: this.getState(), updateFound: this.state.info !== null };
+      }
+    }
+
     if (
-      this.state.status === AppUpdateStatus.Downloading ||
-      this.state.status === AppUpdateStatus.Installing
+      (this.state.status === AppUpdateStatus.Downloading || this.state.status === AppUpdateStatus.Installing) &&
+      this.state.source === targetSource
     ) {
+      console.log(`[AppUpdate] returning existing active ${targetSource} flow without starting a new check`);
       return { success: true, state: this.getState(), updateFound: this.state.info !== null };
     }
 
     const previousState = this.getState();
+    const flowId = this.beginFlow(
+      targetSource,
+      options?.manual === true ? 'manual-check' : 'auto-check',
+    );
     this.setState({
       ...this.state,
       status: AppUpdateStatus.Checking,
+      source: targetSource,
       errorMessage: null,
     });
 
     try {
       const currentVersion = this.resolveCurrentVersion();
       const info = await this.fetchUpdateInfo(currentVersion, options?.manual === true);
+      if (!this.isFlowActive(flowId, targetSource)) {
+        console.log(
+          `[AppUpdate] ignoring stale check result after fetch, flowId=${flowId}, source=${targetSource}, activeFlowId=${this.activeFlowId}, activeSource=${this.activeFlowSource ?? 'none'}`,
+        );
+        return { success: true, state: this.getState(), updateFound: this.getState().info !== null };
+      }
       if (!info) {
-        const state = this.resetToIdle();
+        if (
+          previousState.source === targetSource &&
+          previousState.status === AppUpdateStatus.Ready &&
+          previousState.readyFilePath != null &&
+          previousState.readyFileHash != null &&
+          previousState.info != null &&
+          this.compareVersions(previousState.info.latestVersion, currentVersion) > 0
+        ) {
+          console.log(
+            `[AppUpdate] no update from server, preserving existing ready update ${previousState.info.latestVersion}`,
+          );
+          const state = this.setState({
+            ...previousState,
+            errorMessage: null,
+          });
+          return { success: true, state, updateFound: true };
+        }
+        const state = this.setState({
+          ...initialState(),
+          source: targetSource,
+        });
         return { success: true, state, updateFound: false };
       }
 
       const updateFound = true;
       const matchingReadyFile = await this.resolveMatchingReadyFile(
         previousState,
+        targetSource,
         info.latestVersion,
       );
+      if (!this.isFlowActive(flowId, targetSource)) {
+        console.log(
+          `[AppUpdate] ignoring stale check result after ready-file resolution, flowId=${flowId}, source=${targetSource}, activeFlowId=${this.activeFlowId}, activeSource=${this.activeFlowSource ?? 'none'}`,
+        );
+        return { success: true, state: this.getState(), updateFound: this.getState().info !== null };
+      }
 
       if (matchingReadyFile) {
+        console.log(
+          `[AppUpdate] reusing ready file for version ${info.latestVersion}: ${matchingReadyFile.filePath}`,
+        );
         const state = this.setState({
           ...previousState,
           info,
           status: AppUpdateStatus.Ready,
+          source: targetSource,
           readyFilePath: matchingReadyFile.filePath,
           readyFileHash: matchingReadyFile.fileHash,
           errorMessage: null,
@@ -126,12 +194,20 @@ export class AppUpdateCoordinator {
         return { success: true, state, updateFound };
       }
 
-      await this.cleanupReadyFile(previousState.readyFilePath);
-      this.clearStoredReadyFile();
+      console.log(
+        `[AppUpdate] no reusable ready file found for version ${info.latestVersion}, previousReadyFilePath=${previousState.readyFilePath ?? 'none'}`,
+      );
+      const existingReadyFile = this.getStoredReadyFile(targetSource);
+      if (existingReadyFile?.filePath) {
+        await this.cleanupReadyFile(existingReadyFile.filePath);
+      }
+      this.clearStoredReadyFile(targetSource);
+      await this.pruneCachedInstallerFiles(targetSource);
 
       if (!this.canPredownload(info.url)) {
         const state = this.setState({
           status: AppUpdateStatus.Available,
+          source: targetSource,
           info,
           progress: null,
           readyFilePath: null,
@@ -141,9 +217,28 @@ export class AppUpdateCoordinator {
         return { success: true, state, updateFound };
       }
 
-      const state = await this.startDownload(info);
+      if (options?.manual === true) {
+        const state = this.setState({
+          status: AppUpdateStatus.Available,
+          source: targetSource,
+          info,
+          progress: null,
+          readyFilePath: null,
+          readyFileHash: null,
+          errorMessage: null,
+        });
+        return { success: true, state, updateFound };
+      }
+
+      const state = await this.startDownload(info, flowId, targetSource);
       return { success: true, state, updateFound };
     } catch (error) {
+      if (!this.isFlowActive(flowId, targetSource)) {
+        console.log(
+          `[AppUpdate] ignoring stale check failure, flowId=${flowId}, source=${targetSource}, activeFlowId=${this.activeFlowId}, activeSource=${this.activeFlowSource ?? 'none'}`,
+        );
+        return { success: true, state: this.getState(), updateFound: this.getState().info !== null };
+      }
       console.error('[AppUpdate] check failed:', error);
       const state = this.setState({
         ...previousState,
@@ -166,7 +261,13 @@ export class AppUpdateCoordinator {
     if (!this.canPredownload(this.state.info.url)) {
       return this.getState();
     }
-    return this.startDownload(this.state.info);
+    if (this.state.status === AppUpdateStatus.Downloading || this.state.status === AppUpdateStatus.Installing) {
+      return this.getState();
+    }
+    const source = this.state.source ?? AppUpdateSource.Auto;
+    const flowId = this.beginFlow(source, 'retry-download');
+    void this.startDownload(this.state.info, flowId, source);
+    return this.getState();
   }
 
   cancelDownload(): AppUpdateRuntimeState {
@@ -174,9 +275,10 @@ export class AppUpdateCoordinator {
     if (!cancelled) {
       return this.getState();
     }
-    this.clearStoredReadyFile();
+    this.clearStoredReadyFile(this.state.source);
     return this.setState({
       status: AppUpdateStatus.Available,
+      source: this.state.source,
       info: this.state.info,
       progress: null,
       readyFilePath: null,
@@ -225,17 +327,26 @@ export class AppUpdateCoordinator {
 
   private resetToIdle(): AppUpdateRuntimeState {
     const previousReadyFilePath = this.state.readyFilePath;
+    const previousSource = this.state.source;
     const state = this.setState(initialState());
     if (previousReadyFilePath) {
       void this.cleanupReadyFile(previousReadyFilePath);
     }
-    this.clearStoredReadyFile();
+    this.clearStoredReadyFile(previousSource);
     return state;
   }
 
-  private async startDownload(info: AppUpdateInfo): Promise<AppUpdateRuntimeState> {
+  private async startDownload(
+    info: AppUpdateInfo,
+    flowId: number,
+    source: AppUpdateSource,
+  ): Promise<AppUpdateRuntimeState> {
+    console.log(
+      `[AppUpdate] startDownload requested, flowId=${flowId}, source=${source}, version=${info.latestVersion}, url=${info.url}`,
+    );
     this.setState({
       status: AppUpdateStatus.Downloading,
+      source,
       info,
       progress: null,
       readyFilePath: null,
@@ -244,25 +355,44 @@ export class AppUpdateCoordinator {
     });
 
     try {
-      const filePath = await downloadUpdate(info.url, progress => {
+      const filePath = await downloadUpdate(info.url, source, progress => {
+        if (!this.isFlowActive(flowId, source)) {
+          console.log(
+            `[AppUpdate] ignoring stale download progress, flowId=${flowId}, source=${source}, activeFlowId=${this.activeFlowId}, activeSource=${this.activeFlowSource ?? 'none'}`,
+          );
+          return;
+        }
         this.setState({
           ...this.state,
           status: AppUpdateStatus.Downloading,
+          source,
           info,
           progress,
           errorMessage: null,
         });
       });
+      if (!this.isFlowActive(flowId, source)) {
+        console.log(
+          `[AppUpdate] ignoring stale download completion, flowId=${flowId}, source=${source}, filePath=${filePath}`,
+        );
+        return this.getState();
+      }
 
       const fileHash = await this.computeFileHash(filePath);
+      console.log(
+        `[AppUpdate] download completed, flowId=${flowId}, source=${source}, version=${info.latestVersion}, filePath=${filePath}, fileHash=${fileHash}`,
+      );
       this.setStoredReadyFile({
         version: info.latestVersion,
         filePath,
         fileHash,
+        info,
       });
+      await this.pruneCachedInstallerFiles(source, [filePath]);
       this.autoOpenReadyModal = true;
       return this.setState({
         status: AppUpdateStatus.Ready,
+        source,
         info,
         progress: null,
         readyFilePath: filePath,
@@ -270,11 +400,19 @@ export class AppUpdateCoordinator {
         errorMessage: null,
       });
     } catch (error) {
+      if (!this.isFlowActive(flowId, source)) {
+        console.log(
+          `[AppUpdate] ignoring stale download failure, flowId=${flowId}, source=${source}, error=${error instanceof Error ? error.message : String(error)}`,
+        );
+        return this.getState();
+      }
       const cancelled = error instanceof Error && error.message === 'Download cancelled';
       if (cancelled) {
-        this.clearStoredReadyFile();
+        console.log(`[AppUpdate] download cancelled for active flow, flowId=${flowId}, source=${source}`);
+        this.clearStoredReadyFile(source);
         return this.setState({
           status: AppUpdateStatus.Available,
+          source,
           info,
           progress: null,
           readyFilePath: null,
@@ -284,9 +422,10 @@ export class AppUpdateCoordinator {
       }
 
       console.error('[AppUpdate] background download failed:', error);
-      this.clearStoredReadyFile();
+      this.clearStoredReadyFile(source);
       return this.setState({
         status: AppUpdateStatus.Error,
+        source,
         info,
         progress: null,
         readyFilePath: null,
@@ -464,6 +603,18 @@ export class AppUpdateCoordinator {
     return snapshot;
   }
 
+  private beginFlow(source: AppUpdateSource, reason: string): number {
+    const flowId = ++this.flowSequence;
+    this.activeFlowId = flowId;
+    this.activeFlowSource = source;
+    console.log(`[AppUpdate] begin flow, flowId=${flowId}, source=${source}, reason=${reason}`);
+    return flowId;
+  }
+
+  private isFlowActive(flowId: number, source: AppUpdateSource): boolean {
+    return this.activeFlowId === flowId && this.activeFlowSource === source;
+  }
+
   private async cleanupReadyFile(filePath: string): Promise<void> {
     if (!filePath) {
       return;
@@ -475,11 +626,64 @@ export class AppUpdateCoordinator {
     }
   }
 
+  private getUpdateCacheDir(): string {
+    return path.join(app.getPath('userData'), 'updates');
+  }
+
+  private isCachedInstallerForSource(filename: string, source: AppUpdateSource | null): boolean {
+    if (!filename.startsWith('lobsterai-update-')) {
+      return false;
+    }
+    if (source == null) {
+      return true;
+    }
+    if (filename.startsWith(`lobsterai-update-${source}-`)) {
+      return true;
+    }
+    return /^lobsterai-update-\d+/.test(filename);
+  }
+
+  private async pruneCachedInstallerFiles(
+    source: AppUpdateSource | null,
+    keepFilePaths: string[] = [],
+  ): Promise<void> {
+    const keepSet = new Set(keepFilePaths.filter(Boolean).map(filePath => path.resolve(filePath)));
+    const cacheDir = this.getUpdateCacheDir();
+
+    try {
+      const entries = await fs.promises.readdir(cacheDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) {
+          continue;
+        }
+        if (!this.isCachedInstallerForSource(entry.name, source)) {
+          continue;
+        }
+        const entryPath = path.resolve(cacheDir, entry.name);
+        if (keepSet.has(entryPath)) {
+          continue;
+        }
+        await fs.promises.unlink(entryPath).catch(() => {});
+        console.log(`[AppUpdate] pruned cached installer file: ${entryPath}`);
+      }
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code !== 'ENOENT') {
+        console.warn('[AppUpdate] failed to prune cached installer files:', error);
+      }
+    }
+  }
+
   private async resolveMatchingReadyFile(
     previousState: AppUpdateRuntimeState,
+    targetSource: AppUpdateSource,
     latestVersion: string,
   ): Promise<StoredReadyFile | null> {
+    console.log(
+      `[AppUpdate] resolveMatchingReadyFile started, targetSource=${targetSource}, previousStatus=${previousState.status}, previousSource=${previousState.source ?? 'none'}, previousVersion=${previousState.info?.latestVersion ?? 'none'}, latestVersion=${latestVersion}`,
+    );
     const inMemoryReadyFile =
+      previousState.source === targetSource &&
       previousState.status === AppUpdateStatus.Ready &&
       previousState.info?.latestVersion === latestVersion &&
       previousState.readyFilePath != null &&
@@ -492,30 +696,45 @@ export class AppUpdateCoordinator {
         : null;
 
     if (inMemoryReadyFile) {
+      console.log(
+        `[AppUpdate] checking in-memory ready file: ${inMemoryReadyFile.filePath}`,
+      );
       const isValid = await this.isReadyFileValid(
         inMemoryReadyFile.filePath,
         inMemoryReadyFile.fileHash,
       );
       if (isValid) {
+        console.log('[AppUpdate] in-memory ready file is valid');
         return inMemoryReadyFile;
       }
+      console.warn('[AppUpdate] in-memory ready file is invalid');
     }
 
-    const storedReadyFile = this.getStoredReadyFile();
+    const storedReadyFile = this.getStoredReadyFile(targetSource);
     if (!storedReadyFile || storedReadyFile.version !== latestVersion) {
+      console.log(
+        `[AppUpdate] stored ready file mismatch, targetSource=${targetSource}, storedVersion=${storedReadyFile?.version ?? 'none'}, latestVersion=${latestVersion}`,
+      );
       return null;
     }
 
+    console.log(
+      `[AppUpdate] checking persisted ready file: ${storedReadyFile.filePath}`,
+    );
     const isValid = await this.isReadyFileValid(
       storedReadyFile.filePath,
       storedReadyFile.fileHash,
     );
     if (isValid) {
+      console.log('[AppUpdate] persisted ready file is valid');
       return storedReadyFile;
     }
 
+    console.warn(
+      `[AppUpdate] persisted ready file is invalid, deleting: ${storedReadyFile.filePath}`,
+    );
     await this.cleanupReadyFile(storedReadyFile.filePath);
-    this.clearStoredReadyFile();
+    this.clearStoredReadyFile(targetSource);
     return null;
   }
 
@@ -523,11 +742,22 @@ export class AppUpdateCoordinator {
     try {
       const stat = await fs.promises.stat(filePath);
       if (!stat.isFile() || stat.size <= 0) {
+        console.warn(
+          `[AppUpdate] ready file validation failed: file missing or empty, path=${filePath}`,
+        );
         return false;
       }
       const actualHash = await this.computeFileHash(filePath);
+      if (actualHash !== expectedHash) {
+        console.warn(
+          `[AppUpdate] ready file validation failed: hash mismatch, path=${filePath}, expectedHash=${expectedHash}, actualHash=${actualHash}`,
+        );
+      }
       return actualHash === expectedHash;
     } catch {
+      console.warn(
+        `[AppUpdate] ready file validation failed: stat/hash threw, path=${filePath}`,
+      );
       return false;
     }
   }
@@ -547,12 +777,99 @@ export class AppUpdateCoordinator {
     });
   }
 
-  private getStoredReadyFile(): StoredReadyFile | null {
+  private restoreStoredReadyState(): void {
+    const sources: AppUpdateSource[] = [AppUpdateSource.Manual, AppUpdateSource.Auto];
+    let restored = false;
+
+    for (const source of sources) {
+      const storedReadyFile = this.getStoredReadyFile(source);
+      if (!storedReadyFile) {
+        continue;
+      }
+
+      console.log(
+        `[AppUpdate] restoring persisted ready file, source=${source}, version=${storedReadyFile.version}, filePath=${storedReadyFile.filePath}`,
+      );
+
+      if (this.compareVersions(storedReadyFile.version, this.resolveCurrentVersion()) <= 0) {
+        console.log(
+          `[AppUpdate] persisted ready file is not newer than current version, clearing it: source=${source}, storedVersion=${storedReadyFile.version}, currentVersion=${this.resolveCurrentVersion()}`,
+        );
+        this.clearStoredReadyFile(source);
+        void this.pruneCachedInstallerFiles(source);
+        continue;
+      }
+
+      try {
+        const stat = fs.statSync(storedReadyFile.filePath);
+        if (!stat.isFile() || stat.size <= 0) {
+          console.warn(
+            `[AppUpdate] persisted ready file is missing or empty during startup restore: ${storedReadyFile.filePath}`,
+          );
+          this.clearStoredReadyFile(source);
+          void this.pruneCachedInstallerFiles(source);
+          continue;
+        }
+      } catch {
+        console.warn(
+          `[AppUpdate] persisted ready file stat failed during startup restore: ${storedReadyFile.filePath}`,
+        );
+        this.clearStoredReadyFile(source);
+        void this.pruneCachedInstallerFiles(source);
+        continue;
+      }
+
+      this.state = {
+        status: AppUpdateStatus.Ready,
+        source,
+        info: storedReadyFile.info ?? this.createStoredReadyInfo(storedReadyFile.version),
+        progress: null,
+        readyFilePath: storedReadyFile.filePath,
+        readyFileHash: storedReadyFile.fileHash,
+        errorMessage: null,
+      };
+      void this.pruneCachedInstallerFiles(source, [storedReadyFile.filePath]);
+      console.log(
+        `[AppUpdate] restored ready update into runtime state, source=${source}, version=${this.state.info?.latestVersion ?? 'none'}, filePath=${this.state.readyFilePath ?? 'none'}`,
+      );
+      restored = true;
+      break;
+    }
+
+    if (!restored) {
+      console.log('[AppUpdate] no persisted ready file found during startup restore');
+      void this.pruneCachedInstallerFiles(AppUpdateSource.Manual);
+      void this.pruneCachedInstallerFiles(AppUpdateSource.Auto);
+    }
+  }
+
+  private createStoredReadyInfo(version: string): AppUpdateInfo {
+    return {
+      latestVersion: version,
+      date: '',
+      changeLog: {
+        zh: { title: '', content: [] },
+        en: { title: '', content: [] },
+      },
+      url: '',
+    };
+  }
+
+  private getReadyFileStoreKey(source: AppUpdateSource | null): string {
+    return `${APP_UPDATE_READY_FILE_KEY_PREFIX}:${source ?? 'unknown'}`;
+  }
+
+  private getStoredReadyFile(source: AppUpdateSource | null): StoredReadyFile | null {
     try {
-      const value = this.store.get<StoredReadyFile>(APP_UPDATE_READY_FILE_KEY);
+      const key = this.getReadyFileStoreKey(source);
+      const value = this.store.get<StoredReadyFile>(key);
       if (!value?.version || !value.filePath || !value.fileHash) {
+        console.log('[AppUpdate] persisted ready file record is missing required fields');
         return null;
       }
+      console.log(
+        `[AppUpdate] loaded persisted ready file record, source=${source ?? 'unknown'}, version=${value.version}, filePath=${value.filePath}`,
+      );
       return value;
     } catch (error) {
       console.warn('[AppUpdate] failed to read stored ready file:', error);
@@ -562,15 +879,23 @@ export class AppUpdateCoordinator {
 
   private setStoredReadyFile(value: StoredReadyFile): void {
     try {
-      this.store.set(APP_UPDATE_READY_FILE_KEY, value);
+      const source = this.state.source ?? AppUpdateSource.Auto;
+      this.store.set(this.getReadyFileStoreKey(source), value);
+      console.log(
+        `[AppUpdate] persisted ready file record, source=${source}, version=${value.version}, filePath=${value.filePath}`,
+      );
     } catch (error) {
       console.warn('[AppUpdate] failed to persist ready file:', error);
     }
   }
 
-  private clearStoredReadyFile(): void {
+  private clearStoredReadyFile(source: AppUpdateSource | null): void {
+    if (source == null) {
+      return;
+    }
     try {
-      this.store.delete(APP_UPDATE_READY_FILE_KEY);
+      this.store.delete(this.getReadyFileStoreKey(source));
+      console.log(`[AppUpdate] cleared persisted ready file record for source=${source}`);
     } catch (error) {
       console.warn('[AppUpdate] failed to clear stored ready file:', error);
     }

--- a/src/main/libs/appUpdateInstaller.ts
+++ b/src/main/libs/appUpdateInstaller.ts
@@ -5,6 +5,8 @@ import path from 'path';
 import { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
 
+import { type AppUpdateSource } from '../../shared/appUpdate/constants';
+
 export interface AppUpdateDownloadProgress {
   received: number;
   total: number | undefined;
@@ -49,6 +51,7 @@ const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 60_000;
 
 export async function downloadUpdate(
   url: string,
+  source: AppUpdateSource,
   onProgress: (progress: AppUpdateDownloadProgress) => void,
 ): Promise<string> {
   if (activeDownloadController) {
@@ -66,10 +69,10 @@ export async function downloadUpdate(
   }
 
   const ext = path.extname(parsedUrl.pathname) || (process.platform === 'darwin' ? '.dmg' : '.exe');
-  const tempDir = app.getPath('temp');
+  const updateDir = path.join(app.getPath('userData'), 'updates');
   const ts = Date.now();
-  const downloadPath = path.join(tempDir, `lobsterai-update-${ts}${ext}.download`);
-  const finalPath = path.join(tempDir, `lobsterai-update-${ts}${ext}`);
+  const downloadPath = path.join(updateDir, `lobsterai-update-${source}-${ts}${ext}.download`);
+  const finalPath = path.join(updateDir, `lobsterai-update-${source}-${ts}${ext}`);
 
   console.log(`[AppUpdate] Temp path: ${downloadPath}`);
   console.log(`[AppUpdate] Final path: ${finalPath}`);
@@ -132,7 +135,7 @@ export async function downloadUpdate(
     // Emit initial progress
     emitProgress();
 
-    await fs.promises.mkdir(path.dirname(downloadPath), { recursive: true });
+    await fs.promises.mkdir(updateDir, { recursive: true });
     writeStream = fs.createWriteStream(downloadPath);
 
     const nodeStream = Readable.fromWeb(response.body as any);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -56,6 +56,7 @@ const App: React.FC = () => {
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [appUpdateState, setAppUpdateState] = useState<AppUpdateRuntimeState>({
     status: AppUpdateStatus.Idle,
+    source: null,
     info: null,
     progress: null,
     readyFilePath: null,
@@ -72,6 +73,7 @@ const App: React.FC = () => {
   const toastTimerRef = useRef<number | null>(null);
   const hasInitialized = useRef(false);
   const previousUpdateStatusRef = useRef<AppUpdateRuntimeState['status']>(AppUpdateStatus.Idle);
+  const shouldInstallReadyUpdateRef = useRef(false);
   const dispatch = useDispatch();
   const selectedModel = useSelector((state: RootState) => state.model.selectedModel);
   const currentSessionId = useSelector(selectCurrentSessionId);
@@ -356,6 +358,14 @@ const App: React.FC = () => {
 
       if (state.status === AppUpdateStatus.Ready && previousStatus !== AppUpdateStatus.Ready) {
         setShowUpdateModal(true);
+        if (shouldInstallReadyUpdateRef.current && state.readyFilePath) {
+          shouldInstallReadyUpdateRef.current = false;
+          void window.electron.appUpdate.installReady().then((installResult) => {
+            if (!installResult.success) {
+              showToast(installResult.error || i18nService.t('updateInstallFailed'));
+            }
+          });
+        }
       }
     });
 
@@ -396,6 +406,7 @@ const App: React.FC = () => {
     if (!updateInfo) return;
 
     if (appUpdateState.readyFilePath) {
+      shouldInstallReadyUpdateRef.current = false;
       const installResult = await window.electron.appUpdate.installReady();
       if (!installResult.success) {
         showToast(installResult.error || i18nService.t('updateInstallFailed'));
@@ -406,8 +417,10 @@ const App: React.FC = () => {
     if (appUpdateState.status === AppUpdateStatus.Error || appUpdateState.status === AppUpdateStatus.Available) {
       const isManualUrl = updateInfo.url.includes('#') || updateInfo.url.endsWith('/download-list');
       if (!isManualUrl) {
+        shouldInstallReadyUpdateRef.current = appUpdateState.status === AppUpdateStatus.Available;
         const retryResult = await window.electron.appUpdate.retryDownload();
         if (!retryResult.success) {
+          shouldInstallReadyUpdateRef.current = false;
           showToast(i18nService.t('updateDownloadFailed'));
         }
         return;
@@ -415,6 +428,7 @@ const App: React.FC = () => {
     }
 
     if (updateInfo.url.includes('#') || updateInfo.url.endsWith('/download-list')) {
+      shouldInstallReadyUpdateRef.current = false;
       setShowUpdateModal(false);
       try {
         const result = await window.electron.shell.openExternal(updateInfo.url);
@@ -430,16 +444,19 @@ const App: React.FC = () => {
   }, [appUpdateState.readyFilePath, appUpdateState.status, showToast, updateInfo]);
 
   const handleCancelDownload = useCallback(async () => {
+    shouldInstallReadyUpdateRef.current = false;
     await window.electron.appUpdate.cancelDownload();
   }, []);
 
   const handleRetryUpdate = useCallback(async () => {
     if (!updateInfo) return;
     if (updateInfo.url.includes('#') || updateInfo.url.endsWith('/download-list')) {
+      shouldInstallReadyUpdateRef.current = false;
       setShowUpdateModal(false);
       await window.electron.shell.openExternal(updateInfo.url);
       return;
     }
+    shouldInstallReadyUpdateRef.current = false;
     await window.electron.appUpdate.retryDownload();
   }, [updateInfo]);
 
@@ -579,26 +596,27 @@ const App: React.FC = () => {
     let cancelled = false;
     let lastCheckTime = 0;
 
-    const maybeCheck = async () => {
+    const maybeCheck = async (reason: 'startup' | 'heartbeat' | 'visibility') => {
       if (cancelled) return;
       const now = Date.now();
       if (lastCheckTime > 0 && now - lastCheckTime < APP_UPDATE_POLL_INTERVAL_MS) return;
       lastCheckTime = now;
+      console.log(`[App] auto update check triggered, reason=${reason}, at=${new Date(now).toISOString()}`);
       await runUpdateCheck();
     };
 
     // 启动时立即检查
-    void maybeCheck();
+    void maybeCheck('startup');
 
     // 心跳：每 30 分钟检测是否距上次检查已超过 12 小时
     const timer = window.setInterval(() => {
-      void maybeCheck();
+      void maybeCheck('heartbeat');
     }, APP_UPDATE_HEARTBEAT_INTERVAL_MS);
 
     // 窗口恢复可见时检测（覆盖休眠唤醒场景）
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
-        void maybeCheck();
+        void maybeCheck('visibility');
       }
     };
     document.addEventListener('visibilitychange', handleVisibilityChange);

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -3,7 +3,7 @@ import { ArrowTopRightOnSquareIcon, ChatBubbleLeftIcon, CheckCircleIcon, Cog6Too
 import React, { useCallback,useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { type AppUpdateInfo,AppUpdateStatus } from '../../shared/appUpdate/constants';
+import { AppUpdateSource,type AppUpdateInfo,type AppUpdateRuntimeState,AppUpdateStatus } from '../../shared/appUpdate/constants';
 import { ProviderName, ProviderRegistry, resolveCodingPlanBaseUrl } from '../../shared/providers';
 import { type AppConfig, defaultConfig, getCustomProviderDefaultName, getProviderDisplayName, getVisibleProviders, isCustomProvider } from '../config';
 import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
@@ -241,6 +241,25 @@ const getEffectiveApiFormat = (provider: string, value: unknown): 'anthropic' | 
 const shouldShowApiFormatSelector = (provider: string): boolean => (
   getFixedApiFormatForProvider(provider) === null
 );
+const getUpdateCheckStatusFromRuntimeStatus = (
+  state: AppUpdateRuntimeState,
+): 'idle' | 'checking' | 'upToDate' | 'error' | 'downloading' | 'ready' => {
+  if (state.source !== AppUpdateSource.Manual) {
+    return 'idle';
+  }
+  switch (state.status) {
+    case AppUpdateStatus.Checking:
+      return 'checking';
+    case AppUpdateStatus.Downloading:
+      return 'downloading';
+    case AppUpdateStatus.Ready:
+      return 'ready';
+    case AppUpdateStatus.Error:
+      return 'error';
+    default:
+      return 'idle';
+  }
+};
 const getProviderDefaultBaseUrl = (
   provider: ProviderType,
   apiFormat: 'anthropic' | 'openai' | 'gemini'
@@ -609,6 +628,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [logoClickCount, setLogoClickCount] = useState(0);
   const [testModeUnlocked, setTestModeUnlocked] = useState(false);
   const [updateCheckStatus, setUpdateCheckStatus] = useState<'idle' | 'checking' | 'upToDate' | 'error' | 'downloading' | 'ready'>('idle');
+  const [appUpdateState, setAppUpdateState] = useState<AppUpdateRuntimeState | null>(null);
 
   useEffect(() => {
     window.electron.appInfo.getVersion().then(setAppVersion);
@@ -617,6 +637,43 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   useEffect(() => {
     setShowApiKey(false);
   }, [activeProvider]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const syncUpdateStatus = async () => {
+      try {
+        const state = await window.electron.appUpdate.getState();
+        if (!mounted) {
+          return;
+        }
+        setAppUpdateState(state);
+        setUpdateCheckStatus(getUpdateCheckStatusFromRuntimeStatus(state));
+      } catch (error) {
+        console.error('Failed to load app update state in settings:', error);
+      }
+    };
+
+    void syncUpdateStatus();
+
+    const unsubscribe = window.electron.appUpdate.onStateChanged((state) => {
+      if (
+        updateCheckTimerRef.current != null &&
+        state.source === AppUpdateSource.Manual &&
+        state.status !== AppUpdateStatus.Idle
+      ) {
+        window.clearTimeout(updateCheckTimerRef.current);
+        updateCheckTimerRef.current = null;
+      }
+      setAppUpdateState(state);
+      setUpdateCheckStatus(getUpdateCheckStatusFromRuntimeStatus(state));
+    });
+
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
+  }, []);
 
   const handleCopyContactEmail = useCallback(async () => {
     const copied = await copyTextToClipboard(ABOUT_CONTACT_EMAIL);
@@ -675,6 +732,22 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       }, 3000);
     }
   }, [appVersion, updateCheckStatus, onUpdateFound]);
+
+  const updateButtonLabel = useMemo(() => {
+    if (
+      updateCheckStatus === 'downloading' &&
+      appUpdateState?.progress?.percent != null &&
+      Number.isFinite(appUpdateState.progress.percent)
+    ) {
+      return `${i18nService.t('updateDownloadingBackground')} ${Math.round(appUpdateState.progress.percent * 100)}%`;
+    }
+    if (updateCheckStatus === 'checking') return i18nService.t('updateChecking');
+    if (updateCheckStatus === 'downloading') return i18nService.t('updateDownloadingBackground');
+    if (updateCheckStatus === 'ready') return i18nService.t('updateReadyTitle');
+    if (updateCheckStatus === 'upToDate') return i18nService.t('updateUpToDate');
+    if (updateCheckStatus === 'error') return i18nService.t('updateCheckFailed');
+    return i18nService.t('checkForUpdate');
+  }, [appUpdateState?.progress?.percent, updateCheckStatus]);
 
   const handleOpenUserManual = useCallback(() => {
     void window.electron.shell.openExternal(ABOUT_USER_MANUAL_URL);
@@ -4038,19 +4111,14 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                   {!enterpriseConfig?.disableUpdate && (
                   <button
                     type="button"
-                    disabled={updateCheckStatus === 'checking'}
+                    disabled={updateCheckStatus === 'checking' || updateCheckStatus === 'downloading'}
                     onClick={(e) => {
                       e.stopPropagation();
                       void handleCheckUpdate();
                     }}
                     className="text-xs px-2 py-0.5 rounded-md border border-border text-secondary hover:text-primary dark:hover:text-primary hover:border-primary dark:hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    {updateCheckStatus === 'checking' && i18nService.t('updateChecking')}
-                    {updateCheckStatus === 'downloading' && i18nService.t('updateDownloadingBackground')}
-                    {updateCheckStatus === 'ready' && i18nService.t('updateReadyTitle')}
-                    {updateCheckStatus === 'upToDate' && i18nService.t('updateUpToDate')}
-                    {updateCheckStatus === 'error' && i18nService.t('updateCheckFailed')}
-                    {updateCheckStatus === 'idle' && i18nService.t('checkForUpdate')}
+                    {updateButtonLabel}
                   </button>
                   )}
                   {enterpriseConfig?.disableUpdate && (

--- a/src/renderer/components/update/AppUpdateModal.tsx
+++ b/src/renderer/components/update/AppUpdateModal.tsx
@@ -37,11 +37,13 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
   const lang = i18nService.getLanguage();
   const currentLog = changeLog?.[lang] ?? { title: '', content: [] };
   const isManualUrl = url.includes('#') || url.endsWith('/download-list');
-  const canDismiss = updateState.status !== AppUpdateStatus.Downloading && updateState.status !== AppUpdateStatus.Installing;
-  const canInstall = updateState.readyFilePath != null;
+  const isInstalling = updateState.status === AppUpdateStatus.Installing;
+  const canDismiss = updateState.status !== AppUpdateStatus.Downloading && !isInstalling;
+  const canInstall = updateState.status === AppUpdateStatus.Ready && updateState.readyFilePath != null;
   const isError = updateState.status === AppUpdateStatus.Error;
   const isDownloading = updateState.status === AppUpdateStatus.Downloading || updateState.status === AppUpdateStatus.Checking;
   const showInfoFooter = updateState.status === AppUpdateStatus.Available;
+  const isRetryState = updateState.status === AppUpdateStatus.Error;
 
   const title = isError
     ? (canInstall ? i18nService.t('updateInstallFailed') : i18nService.t('updateDownloadFailed'))
@@ -55,7 +57,9 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
     ? i18nService.t('updateReadyConfirm')
     : isManualUrl
       ? i18nService.t('updateAvailableConfirm')
-      : i18nService.t('updateRetry');
+      : isRetryState
+        ? i18nService.t('updateRetry')
+        : i18nService.t('updateAvailableConfirm');
 
   return (
     <Modal onClose={canDismiss ? onCancel : () => {}} overlayClassName="fixed inset-0 z-50 flex items-center justify-center modal-backdrop" className="modal-content w-full max-w-md mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden">
@@ -117,7 +121,7 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
           </div>
         )}
 
-        {updateState.status === AppUpdateStatus.Installing && (
+        {isInstalling && (
           <p className="mt-4 text-sm text-secondary">
             {i18nService.t('updateInstallingHint')}
           </p>
@@ -144,7 +148,7 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
             onClick={onConfirm}
             className="px-3 py-1.5 text-sm rounded-lg bg-primary text-white hover:bg-primary-hover transition-colors"
           >
-            {isManualUrl ? i18nService.t('updateAvailableConfirm') : i18nService.t('updateRetry')}
+            {confirmLabel}
           </button>
         </div>
       )}
@@ -180,7 +184,7 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
         </div>
       )}
 
-      {updateState.status === AppUpdateStatus.Installing && (
+      {isInstalling && (
         <div className="px-5 pb-5 flex justify-center">
           <svg
             className="animate-spin h-8 w-8 text-primary"
@@ -208,7 +212,7 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
             onClick={onRetry}
             className="px-3 py-1.5 text-sm rounded-lg bg-primary text-white hover:bg-primary-hover transition-colors"
           >
-            {isManualUrl ? i18nService.t('updateAvailableConfirm') : i18nService.t('updateRetry')}
+            {confirmLabel}
           </button>
         </div>
       )}

--- a/src/shared/appUpdate/constants.ts
+++ b/src/shared/appUpdate/constants.ts
@@ -10,6 +10,13 @@ export const AppUpdateStatus = {
 
 export type AppUpdateStatus = typeof AppUpdateStatus[keyof typeof AppUpdateStatus];
 
+export const AppUpdateSource = {
+  Auto: 'auto',
+  Manual: 'manual',
+} as const;
+
+export type AppUpdateSource = typeof AppUpdateSource[keyof typeof AppUpdateSource];
+
 export const AppUpdateIpc = {
   GetState: 'appUpdate:getState',
   CheckNow: 'appUpdate:checkNow',
@@ -40,6 +47,7 @@ export interface AppUpdateInfo {
 
 export interface AppUpdateRuntimeState {
   status: AppUpdateStatus;
+  source: AppUpdateSource | null;
   info: AppUpdateInfo | null;
   progress: AppUpdateDownloadProgress | null;
   readyFilePath: string | null;


### PR DESCRIPTION
Keep automatic update checks on the background predownload path. Stop manual update checks from downloading immediately after they find a new version. Manual checks now surface the update info first and let the user explicitly start the download.

Persist and restore ready installer metadata across restarts. Keep an already-downloaded ready build when the normal update endpoint temporarily reports no newer version.
Prune the update cache directory so only the current installer file is retained.

Align the renderer update UI with the new state model. Sync the About page button to runtime progress and fix modal action labels and button visibility.
Auto-continue from a manual download into install when the user has already chosen update now, and log when automatic update checks run.