### PR TITLE
fix: disable built-in mcporter skill to avoid MCP confusion

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -171,6 +171,13 @@ const MANAGED_SKILL_ENTRY_OVERRIDES: Record<string, { enabled: boolean }> = {
   'feishu-cron-reminder': {
     enabled: false,
   },
+  // LobsterAI implements its own MCP integration. The bundled mcporter skill
+  // tries to discover MCP servers via its own CLI, finds none, and produces
+  // confusing "no MCP servers" output. Disable it so users are routed through
+  // LobsterAI's MCP layer instead.
+  'mcporter': {
+    enabled: false,
+  },
 };
 
 const DISABLED_MANAGED_SKILL_NAMES = Object.entries(MANAGED_SKILL_ENTRY_OVERRIDES)


### PR DESCRIPTION
## Summary

- Disable OpenClaw's built-in `mcporter` skill via `MANAGED_SKILL_ENTRY_OVERRIDES`
- LobsterAI has its own MCP integration; the bundled mcporter finds no MCP servers and outputs confusing "scanning MCP servers..." messages, misleading users

## Note

This is a **transitional measure**. The long-term plan is to deprecate LobsterAI's custom MCP implementation and adopt OpenClaw's native MCP / built-in mcporter skill once the upstream integration matures. At that point this override should be removed.

## Test plan

- [ ] Launch LobsterAI, trigger an MCP-related query in chat
- [ ] Verify `mcporter` skill no longer activates (no "scanning MCP servers" output)
- [ ] Verify LobsterAI's own MCP tools still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)