### PR TITLE
fix(cowork): 修复停止会话后爬虫任务仍继续执行的问题

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -3046,6 +3046,23 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     const command = typeof request.command === 'string' ? request.command : '';
     const isChannelSession = parseChannelSessionKey(sessionKey) !== null;
 
+    // Suppress ALL approvals (including auto-approvals) for sessions that the
+    // user has already stopped.  Without this early return, non-delete commands
+    // would be auto-approved below before the cooldown check, allowing the
+    // gateway-side run to keep executing new tool calls after the user clicked
+    // Stop (e.g. a crawler task continuing to fetch pages).
+    // The Gateway-side run will time out on its own.
+    if (this.isSessionInStopCooldown(sessionId)) {
+      console.log('[OpenClawRuntime] suppressed approval for stopped session, requestId:', requestId, 'sessionId:', sessionId);
+      return;
+    }
+    // Also suppress for desktop sessions that were manually stopped (persists
+    // beyond the 10s cooldown window until the next runTurn or session deletion).
+    if (this.manuallyStoppedSessions.has(sessionId) && isManagedSessionKey(sessionKey)) {
+      console.log('[OpenClawRuntime] suppressed approval for manually stopped desktop session, requestId:', requestId, 'sessionId:', sessionId);
+      return;
+    }
+
     // Auto-approve: channel sessions always, local sessions for non-delete commands.
     // Intentionally allows non-delete dangerous commands (git push, kill, chmod) without
     // prompting — this is a deliberate trade-off to avoid the approval-pending timing
@@ -3055,12 +3072,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (isChannelSession || !isDeleteCommand(command)) {
       this.pendingApprovals.set(requestId, { requestId, sessionId, allowAlways: true });
       this.respondToPermission(requestId, { behavior: 'allow', updatedInput: {} });
-    }
-    // Suppress approval popups for sessions in stop cooldown — the user
-    // already stopped the session, so showing a new permission dialog
-    // would be confusing.  The Gateway-side run will time out on its own.
-    if (this.isSessionInStopCooldown(sessionId)) {
-      return;
     }
 
     this.pendingApprovals.set(requestId, { requestId, sessionId });


### PR DESCRIPTION
## 问题描述

用户在对话框中停止一个爬虫任务（如影视搜索、音乐搜索），但爬虫仍然不断执行，没有真正停止。

## 根因分析

**Bug 位于** `src/main/libs/agentEngine/openclawRuntimeAdapter.ts` 的 `handleApprovalRequested()` 方法中。

当用户点击「停止」后，完整的停止流程是：

1. `stopSession()` 向 OpenClaw 网关发送 `chat.abort`（fire-and-forget，异步不等待结果）
2. 本地 `ActiveTurn` 被清理，session 进入 10 秒停止冷却期（`stoppedSessions`），并加入 `manuallyStoppedSessions`
3. **但** 网关侧的 run 仍在继续（abort 信号传播需要时间）
4. 在这个时间窗口内，OpenClaw 可能为下一个工具调用发送 `exec.approvalRequested` 事件
5. **Bug：** `handleApprovalRequested` 中，对非删除命令（爬虫 bash 命令属于此类）的自动审批（auto-approve）逻辑在停止冷却检查 **之前** 执行
6. 因此审批响应已经发给网关了，之后的冷却检查为时已晚
7. 网关收到审批后继续执行新的工具调用，爬虫继续运行
8. 这个循环不断重复：每一次新的工具调用都被自动审批

**修复前的代码顺序：**
```
auto-approve (非删除命令) → 发送审批响应给网关  ← 问题在这里
stop cooldown 检查 → return                     ← 太晚了
```

**其他事件处理器不受影响的原因：**
- `handleChatEvent` 检查 `activeTurns.get(sessionId)` → turn 已清理，事件被正确丢弃
- `handleAgentEvent` 检查 `manuallyStoppedSessions` + `isManagedSessionKey` → 桌面会话被正确拦截
- 只有 `handleApprovalRequested` 不依赖 `ActiveTurn` 存在，它通过 `sessionIdBySessionKey`（停止时不清理）解析 sessionId，直接进入自动审批逻辑

## 修复方案

将停止冷却检查和手动停止检查移到自动审批逻辑 **之前**：

1. `isSessionInStopCooldown()` —— 覆盖停止后 10 秒窗口期（桌面和频道会话均适用）
2. `manuallyStoppedSessions` + `isManagedSessionKey()` —— 覆盖桌面会话在 10 秒冷却期过后的场景（此标记持续到下次 `runTurn` 或会话删除）

**修复后的代码顺序：**
```
stop cooldown 检查 → return（拦截）
manuallyStoppedSessions 检查 → return（拦截）
auto-approve (非删除命令) → 发送审批响应      ← 只有非停止的会话才走到这里
```

被拦截的审批不向网关发送响应，网关的 pending approval 会自行超时。这与原代码的设计意图一致（原注释：「The Gateway-side run will time out on its own」）。

## 场景验证

| 场景 | 行为 | 是否正确 |
|------|------|----------|
| 桌面会话，停止后 <10s | `isSessionInStopCooldown` → 拦截 | ✅ |
| 桌面会话，停止后 >10s | `manuallyStoppedSessions` + `isManagedSessionKey` → 拦截 | ✅ |
| 频道会话，停止后 <10s | `isSessionInStopCooldown` → 拦截 | ✅ |
| 频道会话，停止后 >10s | 两个检查都通过 → 允许新消息重新激活 | ✅ |
| 正常运行的会话 | 两个检查都通过 → 正常 auto-approve | ✅ |
| 停止后用户发送新消息 | `runTurn()` 清除标记 → 恢复正常审批 | ✅ |

## 影响范围

- 仅修改 `handleApprovalRequested()` 一个方法中的逻辑顺序
- 不影响正常运行中会话的 auto-approve 行为
- 不影响频道会话超时后的重新激活能力
- 所有 13 个 adapter 单元测试通过