### PR TITLE
fix(openclaw): align OPENCLAW_HOME to fix exec-approvals path mismatch

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -1938,12 +1938,14 @@ export class OpenClawConfigSync {
   }
 
   /**
-   * Ensures ~/.openclaw/exec-approvals.json has security=full + ask=off
-   * so the gateway never triggers approval-pending for any command.
+   * Ensures exec-approvals.json under the LobsterAI-managed openclaw home has
+   * security=full + ask=off so the gateway never triggers approval-pending
+   * for any command. The path must match the OPENCLAW_HOME env var passed to
+   * the gateway process so both sides read/write the same file.
    * Delete-command protection is handled via the system prompt instead.
    */
   private ensureExecApprovalDefaults(): void {
-    const filePath = path.join(app.getPath('home'), '.openclaw', 'exec-approvals.json');
+    const filePath = path.join(this.engineManager.getBaseDir(), '.openclaw', 'exec-approvals.json');
 
     type AgentEntry = { security?: string; ask?: string; [key: string]: unknown };
     type ApprovalsFile = {

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -415,7 +415,7 @@ export class OpenClawEngineManager extends EventEmitter {
       ...process.env,
       SKILLS_ROOT: skillsRoot,
       LOBSTERAI_SKILLS_ROOT: skillsRoot,
-      OPENCLAW_HOME: runtime.root,
+      OPENCLAW_HOME: this.baseDir,
       OPENCLAW_STATE_DIR: this.stateDir,
       OPENCLAW_CONFIG_PATH: this.configPath,
       OPENCLAW_GATEWAY_TOKEN: token,


### PR DESCRIPTION
## Summary

- `OPENCLAW_HOME` was incorrectly set to `runtime.root` (the vendor binary directory). In openclaw, this env var redefines `~` (user home), causing the gateway to resolve `~/.openclaw/exec-approvals.json` under the vendor dir (nonexistent) while LobsterAI's `ensureExecApprovalDefaults()` wrote to the real user home — a **path mismatch** that made the safety net (`security=full`) ineffective.
- Change `OPENCLAW_HOME` to `this.baseDir` (`%APPDATA%/LobsterAI/openclaw/`) and update `ensureExecApprovalDefaults()` to write to the matching path. This also isolates LobsterAI from a user's native openclaw installation.
- Other state/config paths (`OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`) are already set explicitly and unaffected.

## Test plan

- [ ] Start LobsterAI, verify `%APPDATA%/LobsterAI/openclaw/.openclaw/exec-approvals.json` is created with `security=full, ask=off`
- [ ] Verify exec tool works normally (send "帮我执行 ls -la" via Web panel or IM channel)
- [ ] Verify `C:\Users\<user>\.openclaw\exec-approvals.json` is no longer written by LobsterAI (no conflict with native openclaw)
- [ ] Check gateway.log for no exec-related errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)