### PR TITLE
feat(dingtalk): add QR code scanning for bot configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       {
         "id": "dingtalk-connector",
         "npm": "@dingtalk-real-ai/dingtalk-connector",
-        "version": "0.8.13"
+        "version": "0.8.17"
       },
       {
         "id": "openclaw-lark",

--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -2605,6 +2605,124 @@ export class IMGatewayManager extends EventEmitter {
     }
   }
 
+  // ==================== DingTalk Bot Install Helpers ====================
+
+  private static readonly DINGTALK_REGISTRATION_BASE_URL = 'https://oapi.dingtalk.com';
+  private static readonly DINGTALK_REGISTRATION_SOURCE = 'DING_DWS_CLAW';
+
+  /**
+   * Start the DingTalk Device Flow onboarding: init + begin.
+   * Returns data needed to render a QR code in the UI.
+   */
+  async startDingTalkInstallQrcode(): Promise<{
+    url: string;
+    deviceCode: string;
+    interval: number;
+    expireIn: number;
+  }> {
+    const baseUrl = IMGatewayManager.DINGTALK_REGISTRATION_BASE_URL;
+    const source = IMGatewayManager.DINGTALK_REGISTRATION_SOURCE;
+
+    // Step 1: init — obtain nonce
+    const initResp = await fetch(`${baseUrl}/app/registration/init`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source }),
+    });
+    const initData = await initResp.json() as { errcode: number; errmsg?: string; nonce?: string };
+    if (initData.errcode !== 0 || !initData.nonce) {
+      throw new Error(initData.errmsg || 'DingTalk registration init failed');
+    }
+
+    // Step 2: begin — obtain device_code + QR url
+    const beginResp = await fetch(`${baseUrl}/app/registration/begin`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nonce: initData.nonce }),
+    });
+    const beginData = await beginResp.json() as {
+      errcode: number;
+      errmsg?: string;
+      device_code?: string;
+      verification_uri_complete?: string;
+      interval?: number;
+      expires_in?: number;
+    };
+    if (beginData.errcode !== 0 || !beginData.device_code || !beginData.verification_uri_complete) {
+      throw new Error(beginData.errmsg || 'DingTalk registration begin failed');
+    }
+
+    return {
+      url: beginData.verification_uri_complete,
+      deviceCode: beginData.device_code,
+      interval: beginData.interval ?? 5,
+      expireIn: beginData.expires_in ?? 600,
+    };
+  }
+
+  /**
+   * Poll DingTalk Device Flow for the result of a QR code scan.
+   */
+  async pollDingTalkInstall(deviceCode: string): Promise<{
+    done: boolean;
+    clientId?: string;
+    clientSecret?: string;
+    error?: string;
+  }> {
+    const baseUrl = IMGatewayManager.DINGTALK_REGISTRATION_BASE_URL;
+    const pollResp = await fetch(`${baseUrl}/app/registration/poll`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ device_code: deviceCode }),
+    });
+    const pollData = await pollResp.json() as {
+      errcode: number;
+      errmsg?: string;
+      status?: string;
+      client_id?: string;
+      client_secret?: string;
+      fail_reason?: string;
+    };
+    if (pollData.errcode !== 0) {
+      return { done: false, error: pollData.errmsg || 'poll error' };
+    }
+    const status = (pollData.status ?? '').toUpperCase();
+    if (status === 'SUCCESS' && pollData.client_id && pollData.client_secret) {
+      return { done: true, clientId: pollData.client_id, clientSecret: pollData.client_secret };
+    }
+    if (status === 'FAIL') {
+      return { done: false, error: pollData.fail_reason || 'authorization failed' };
+    }
+    if (status === 'EXPIRED') {
+      return { done: false, error: 'authorization expired' };
+    }
+    // WAITING or other — keep polling
+    return { done: false };
+  }
+
+  /**
+   * Validate existing DingTalk app credentials (Client ID + Client Secret).
+   */
+  async verifyDingTalkCredentials(clientId: string, clientSecret: string): Promise<{
+    success: boolean;
+    error?: string;
+  }> {
+    try {
+      const resp = await fetch('https://api.dingtalk.com/v1.0/oauth2/accessToken', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ appKey: clientId, appSecret: clientSecret }),
+      });
+      const data = await resp.json() as { accessToken?: string; code?: string; message?: string };
+      if (data.accessToken) {
+        return { success: true };
+      }
+      return { success: false, error: data.message || t('dingtalkVerifyCredentialsFailed') };
+    } catch (err: any) {
+      return { success: false, error: err?.message || t('dingtalkVerifyFailed') };
+    }
+  }
+
   private calculateVerdict(checks: IMConnectivityCheck[]): IMConnectivityVerdict {
     if (checks.some((check) => check.level === 'fail')) {
       return 'fail';

--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -2718,8 +2718,8 @@ export class IMGatewayManager extends EventEmitter {
         return { success: true };
       }
       return { success: false, error: data.message || t('dingtalkVerifyCredentialsFailed') };
-    } catch (err: any) {
-      return { success: false, error: err?.message || t('dingtalkVerifyFailed') };
+    } catch (err: unknown) {
+      return { success: false, error: (err instanceof Error ? err.message : undefined) || t('dingtalkVerifyFailed') };
     }
   }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4305,6 +4305,31 @@ if (!gotTheLock) {
     }
   });
 
+  // DingTalk bot install helpers
+  ipcMain.handle('dingtalk:install:qrcode', async () => {
+    try {
+      return await getIMGatewayManager().startDingTalkInstallQrcode();
+    } catch (error) {
+      throw new Error(error instanceof Error ? error.message : '获取二维码失败');
+    }
+  });
+
+  ipcMain.handle('dingtalk:install:poll', async (_event, { deviceCode }: { deviceCode: string }) => {
+    try {
+      return await getIMGatewayManager().pollDingTalkInstall(deviceCode);
+    } catch (error) {
+      return { done: false, error: error instanceof Error ? error.message : '轮询失败' };
+    }
+  });
+
+  ipcMain.handle('dingtalk:install:verify', async (_event, { clientId, clientSecret }: { clientId: string; clientSecret: string }) => {
+    try {
+      return await getIMGatewayManager().verifyDingTalkCredentials(clientId, clientSecret);
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : '验证失败' };
+    }
+  });
+
   // GitHub Copilot device code authentication handlers
   ipcMain.handle('github-copilot:request-device-code', async () => {
     const { requestDeviceCode } = await import('./libs/githubCopilotAuth');

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -547,6 +547,29 @@ contextBridge.exposeInMainWorld('electron', {
         }>,
     },
   },
+  dingtalk: {
+    install: {
+      qrcode: () =>
+        ipcRenderer.invoke('dingtalk:install:qrcode') as Promise<{
+          url: string;
+          deviceCode: string;
+          interval: number;
+          expireIn: number;
+        }>,
+      poll: (deviceCode: string) =>
+        ipcRenderer.invoke('dingtalk:install:poll', { deviceCode }) as Promise<{
+          done: boolean;
+          clientId?: string;
+          clientSecret?: string;
+          error?: string;
+        }>,
+      verify: (clientId: string, clientSecret: string) =>
+        ipcRenderer.invoke('dingtalk:install:verify', { clientId, clientSecret }) as Promise<{
+          success: boolean;
+          error?: string;
+        }>,
+    },
+  },
   githubCopilot: {
     requestDeviceCode: () =>
       ipcRenderer.invoke('github-copilot:request-device-code') as Promise<{

--- a/src/renderer/components/im/DingTalkInstanceSettings.tsx
+++ b/src/renderer/components/im/DingTalkInstanceSettings.tsx
@@ -3,10 +3,11 @@
  * Configuration form for a single DingTalk bot instance in multi-instance mode
  */
 
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
-import { SignalIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { ArrowPathIcon, CheckCircleIcon, SignalIcon, XCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import TrashIcon from '../icons/TrashIcon';
+import { QRCodeSVG } from 'qrcode.react';
 import type { DingTalkInstanceConfig, DingTalkInstanceStatus, DingTalkOpenClawConfig, IMConnectivityTestResult } from '../../types/im';
 import { i18nService } from '../../services/i18n';
 import { PlatformRegistry } from '@shared/platform';
@@ -143,6 +144,79 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
   const [editingName, setEditingName] = useState(false);
   const [nameValue, setNameValue] = useState(instance.instanceName);
 
+  // QR code scanning state
+  const [qrStatus, setQrStatus] = useState<'idle' | 'loading' | 'showing' | 'success' | 'error'>('idle');
+  const [qrUrl, setQrUrl] = useState('');
+  const [qrTimeLeft, setQrTimeLeft] = useState(0);
+  const [qrError, setQrError] = useState('');
+  const qrDeviceCodeRef = useRef('');
+  const qrPollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const qrCountdownTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      if (qrPollTimerRef.current) clearInterval(qrPollTimerRef.current);
+      if (qrCountdownTimerRef.current) clearInterval(qrCountdownTimerRef.current);
+    };
+  }, []);
+
+  const handleStartQr = async () => {
+    if (qrPollTimerRef.current) clearInterval(qrPollTimerRef.current);
+    if (qrCountdownTimerRef.current) clearInterval(qrCountdownTimerRef.current);
+    setQrStatus('loading');
+    setQrError('');
+    try {
+      const result = await window.electron.dingtalk.install.qrcode();
+      if (!isMountedRef.current) return;
+      setQrUrl(result.url);
+      qrDeviceCodeRef.current = result.deviceCode;
+      const expireIn = result.expireIn ?? 600;
+      setQrTimeLeft(expireIn);
+      setQrStatus('showing');
+
+      qrCountdownTimerRef.current = setInterval(() => {
+        setQrTimeLeft((prev) => {
+          if (prev <= 1) {
+            clearInterval(qrCountdownTimerRef.current!);
+            qrCountdownTimerRef.current = null;
+            if (qrPollTimerRef.current) { clearInterval(qrPollTimerRef.current); qrPollTimerRef.current = null; }
+            setQrStatus('error');
+            setQrError(i18nService.t('dingtalkBotCreateWizardQrcodeExpired'));
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+
+      const intervalMs = Math.max(result.interval ?? 5, 3) * 1000;
+      qrPollTimerRef.current = setInterval(async () => {
+        try {
+          const pollResult = await window.electron.dingtalk.install.poll(qrDeviceCodeRef.current);
+          if (!isMountedRef.current) return;
+          if (pollResult.done && pollResult.clientId && pollResult.clientSecret) {
+            clearInterval(qrPollTimerRef.current!); qrPollTimerRef.current = null;
+            clearInterval(qrCountdownTimerRef.current!); qrCountdownTimerRef.current = null;
+            onConfigChange({ clientId: pollResult.clientId, clientSecret: pollResult.clientSecret, enabled: true });
+            await onSave({ clientId: pollResult.clientId, clientSecret: pollResult.clientSecret, enabled: true });
+            setQrStatus('success');
+          } else if (pollResult.error) {
+            clearInterval(qrPollTimerRef.current!); qrPollTimerRef.current = null;
+            clearInterval(qrCountdownTimerRef.current!); qrCountdownTimerRef.current = null;
+            setQrStatus('error');
+            setQrError(pollResult.error);
+          }
+        } catch { /* keep retrying */ }
+      }, intervalMs);
+    } catch (err: any) {
+      if (!isMountedRef.current) return;
+      setQrStatus('error');
+      setQrError(err?.message || '获取二维码失败');
+    }
+  };
+
   // Sync nameValue when instance changes
   React.useEffect(() => {
     setNameValue(instance.instanceName);
@@ -237,6 +311,64 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
           <TrashIcon className="h-4 w-4" />
           {language === 'zh' ? '删除' : 'Delete'}
         </button>
+      </div>
+
+      {/* Scan QR code section */}
+      <div className="rounded-lg border border-dashed border-border-subtle p-4 text-center space-y-3">
+        {(qrStatus === 'idle' || qrStatus === 'error') && (
+          <>
+            <button
+              type="button"
+              onClick={() => void handleStartQr()}
+              className="px-4 py-2.5 rounded-lg text-sm font-medium bg-primary text-white hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {i18nService.t('dingtalkBotCreateWizardScanBtn')}
+            </button>
+            <p className="text-xs text-secondary">
+              {i18nService.t('dingtalkBotCreateWizardScanHint')}
+            </p>
+            {qrStatus === 'error' && qrError && (
+              <div className="flex items-center justify-center gap-1.5 text-xs text-red-500 bg-red-500/10 px-3 py-2 rounded-lg">
+                <XCircleIcon className="h-4 w-4 flex-shrink-0" />
+                {qrError}
+              </div>
+            )}
+          </>
+        )}
+        {qrStatus === 'loading' && (
+          <div className="flex flex-col items-center gap-2 py-2">
+            <ArrowPathIcon className="h-7 w-7 text-primary animate-spin" />
+            <span className="text-xs text-secondary">{i18nService.t('dingtalkBotCreateWizardGenerating')}</span>
+          </div>
+        )}
+        {qrStatus === 'showing' && qrUrl && (
+          <div className="flex flex-col items-center gap-2">
+            <div className="p-2 bg-white rounded-lg inline-block">
+              <QRCodeSVG value={qrUrl} size={160} />
+            </div>
+            <p className="text-xs text-secondary max-w-[240px]">
+              {i18nService.t('dingtalkBotCreateWizardQrcodeDesc')}
+            </p>
+            <p className="text-xs text-secondary">
+              {qrTimeLeft}s
+            </p>
+          </div>
+        )}
+        {qrStatus === 'success' && (
+          <div className="flex items-center justify-center gap-1.5 text-xs text-green-600 dark:text-green-400 bg-green-500/10 px-3 py-2 rounded-lg">
+            <CheckCircleIcon className="h-4 w-4 flex-shrink-0" />
+            {i18nService.t('dingtalkBotCreateWizardSuccessTitle')}
+          </div>
+        )}
+      </div>
+
+      {/* Divider */}
+      <div className="relative flex items-center">
+        <div className="flex-1 border-t border-border-subtle" />
+        <span className="px-3 text-xs text-secondary whitespace-nowrap">
+          {i18nService.t('dingtalkBotCreateWizardOrManual')}
+        </span>
+        <div className="flex-1 border-t border-border-subtle" />
       </div>
 
       {/* Guide */}

--- a/src/renderer/components/im/DingTalkInstanceSettings.tsx
+++ b/src/renderer/components/im/DingTalkInstanceSettings.tsx
@@ -3,14 +3,15 @@
  * Configuration form for a single DingTalk bot instance in multi-instance mode
  */
 
-import React, { useState, useRef, useEffect } from 'react';
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
 import { ArrowPathIcon, CheckCircleIcon, SignalIcon, XCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
-import TrashIcon from '../icons/TrashIcon';
-import { QRCodeSVG } from 'qrcode.react';
-import type { DingTalkInstanceConfig, DingTalkInstanceStatus, DingTalkOpenClawConfig, IMConnectivityTestResult } from '../../types/im';
-import { i18nService } from '../../services/i18n';
 import { PlatformRegistry } from '@shared/platform';
+import { QRCodeSVG } from 'qrcode.react';
+import React, { useEffect,useRef, useState } from 'react';
+
+import { i18nService } from '../../services/i18n';
+import type { DingTalkInstanceConfig, DingTalkInstanceStatus, DingTalkOpenClawConfig, IMConnectivityTestResult } from '../../types/im';
+import TrashIcon from '../icons/TrashIcon';
 
 interface DingTalkInstanceSettingsProps {
   instance: DingTalkInstanceConfig;
@@ -210,10 +211,10 @@ const DingTalkInstanceSettings: React.FC<DingTalkInstanceSettingsProps> = ({
           }
         } catch { /* keep retrying */ }
       }, intervalMs);
-    } catch (err: any) {
+    } catch (err: unknown) {
       if (!isMountedRef.current) return;
       setQrStatus('error');
-      setQrError(err?.message || '获取二维码失败');
+      setQrError((err instanceof Error ? err.message : undefined) || '获取二维码失败');
     }
   };
 

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1079,6 +1079,14 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imDingtalkGuideStep2: '从应用凭证页获取 Client ID（AppKey）与 Client Secret（AppSecret）',
     imDingtalkGuideStep3: '启用"机器人"能力，并将 Client ID 和 Client Secret 填入下方',
     imDingtalkGuideStep4: '保存后机器人将自动通过 Stream 模式建立长连接',
+    dingtalkBotCreateWizardScanBtn: '扫码配置机器人',
+    dingtalkBotCreateWizardScanHint: '使用钉钉客户端扫描二维码，一键创建并配置机器人',
+    dingtalkBotCreateWizardOrManual: '或 手动填写机器人凭证',
+    dingtalkBotCreateWizardQrcodeDesc:
+      '使用钉钉客户端扫描二维码，完成机器人创建与授权。',
+    dingtalkBotCreateWizardQrcodeExpired: '二维码已过期，请点击重新扫码',
+    dingtalkBotCreateWizardSuccessTitle: '机器人配置成功',
+    dingtalkBotCreateWizardGenerating: '正在生成二维码…',
     imFeishuGuideStep1: '在下方填写飞书机器人的 App ID 和 App Secret 即可完成配置',
     imFeishuGuideStep2: '可在飞书开放平台查看应用凭证，详情参考配置手册。',
     feishuBotCreateWizardTitle: '创建机器人',
@@ -2621,6 +2629,15 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imDingtalkGuideStep3:
       'Turn on the "Bot" capability and enter Client ID and Client Secret below',
     imDingtalkGuideStep4: 'Once saved, the bot will auto-connect via Stream mode',
+    dingtalkBotCreateWizardScanBtn: 'Scan QR Code to Configure Bot',
+    dingtalkBotCreateWizardScanHint:
+      'Scan the QR code with DingTalk mobile app to create and configure a bot in one step',
+    dingtalkBotCreateWizardOrManual: 'or manually enter bot credentials',
+    dingtalkBotCreateWizardQrcodeDesc:
+      'Scan the QR code with DingTalk mobile app to complete bot creation and authorization.',
+    dingtalkBotCreateWizardQrcodeExpired: 'QR code expired, please scan again',
+    dingtalkBotCreateWizardSuccessTitle: 'Bot configured successfully',
+    dingtalkBotCreateWizardGenerating: 'Generating QR code...',
     imFeishuGuideStep1: 'Enter the Feishu bot App ID and App Secret below to complete setup',
     imFeishuGuideStep2:
       'App credentials are available on the Feishu Open Platform. See the setup manual for details.',

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -592,6 +592,26 @@ interface IElectronAPI {
       }>;
     };
   };
+  dingtalk: {
+    install: {
+      qrcode: () => Promise<{
+        url: string;
+        deviceCode: string;
+        interval: number;
+        expireIn: number;
+      }>;
+      poll: (deviceCode: string) => Promise<{
+        done: boolean;
+        clientId?: string;
+        clientSecret?: string;
+        error?: string;
+      }>;
+      verify: (clientId: string, clientSecret: string) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+    };
+  };
   githubCopilot: {
     requestDeviceCode: () => Promise<{
       userCode: string;


### PR DESCRIPTION
## Summary
- Upgrade dingtalk-connector plugin from 0.8.13 to 0.8.17
- Add DingTalk Device Authorization Flow (init → begin → poll) so users can scan a QR code with the DingTalk mobile app to create and configure a bot in one step
- Mirror the existing Feishu QR scan experience: QR code display, countdown timer, auto-fill credentials on success, manual fallback

## Test plan
- [ ] Build the project and verify no compile errors
- [ ] Launch app → DingTalk settings → click "扫码配置机器人" → QR code should appear
- [ ] Scan with DingTalk mobile app → credentials auto-filled, instance enabled
- [ ] Verify QR code expiration shows error and allows retry
- [ ] Verify manual credential entry still works as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)