### PR TITLE
feat(ui): add skeleton loading screen for cowork initialization

### DIFF
--- a/src/renderer/components/SkeletonLoader.tsx
+++ b/src/renderer/components/SkeletonLoader.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export function ChatSkeleton() {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="flex items-start gap-3">
+          <div className="w-8 h-8 rounded-full skeleton" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 skeleton w-3/4" />
+            <div className="h-4 skeleton w-1/2" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -24,6 +24,7 @@ import SidebarToggleIcon from '../icons/SidebarToggleIcon';
 import ModelSelector from '../ModelSelector';
 import { PromptPanel,QuickActionBar } from '../quick-actions';
 import type { SettingsOpenOptions } from '../Settings';
+import { ChatSkeleton } from '../SkeletonLoader';
 import WindowTitleBar from '../window/WindowTitleBar';
 import { resolveAgentModelSelection } from './agentModelSelection';
 import CoworkPromptInput, { type CoworkPromptInputRef } from './CoworkPromptInput';
@@ -467,10 +468,15 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         <div className="draggable flex h-12 items-center justify-end px-4 border-b border-border shrink-0">
           <WindowTitleBar inline />
         </div>
+<<<<<<< HEAD
         <div className="flex-1 flex items-center justify-center">
           <div className="text-secondary">
             {i18nService.t('loading')}
           </div>
+=======
+        <div className="flex-1 overflow-hidden">
+          <ChatSkeleton />
+>>>>>>> 50ed9ad (feat(ui): add skeleton loading screen for cowork initialization)
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
Add animated shimmer skeleton loading placeholders to replace the plain static loading text during app Cowork initialization. Optimizes user waiting experience, eliminates blank loading state, and keeps consistent with the project's existing skeleton design system.

## Related Issue
Closes #1920

## Changes Made
- Added reusable skeleton loading component for app initialization page
- Replaced original static `Loading...` prompt with adaptive skeleton placeholder
- Fully adapted project light/dark mode theme
- No changes to original business logic, non-breaking incremental optimization

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other (please describe):