### PR TITLE
fix(im): NIM agent channel config and QR code expiry refresh button

### DIFF
--- a/src/main/im/types.ts
+++ b/src/main/im/types.ts
@@ -256,6 +256,8 @@ export interface NimGatewayStatus {
   lastOutboundAt: number | null;
 }
 
+// NIM supports max 3 instances (enabled or not), may use different accounts or AppKeys.
+// See: https://doc.yunxin.163.com/messaging2/ai-guide/TMwNzk4MzU?platform=client#多实例配置
 export const MAX_NIM_INSTANCES = 3;
 
 export interface NimInstanceStatus extends NimGatewayStatus {

--- a/src/renderer/components/agent/AgentSettingsPanel.tsx
+++ b/src/renderer/components/agent/AgentSettingsPanel.tsx
@@ -10,7 +10,7 @@ import { imService } from '../../services/im';
 import { RootState } from '../../store';
 import type { Model } from '../../store/slices/modelSlice';
 import type { Agent } from '../../types/agent';
-import type { DingTalkInstanceConfig, DingTalkInstanceStatus, FeishuInstanceConfig, FeishuInstanceStatus, IMGatewayConfig, IMGatewayStatus, QQInstanceConfig, QQInstanceStatus, WecomInstanceConfig, WecomInstanceStatus } from '../../types/im';
+import type { DingTalkInstanceConfig, DingTalkInstanceStatus, FeishuInstanceConfig, FeishuInstanceStatus, IMGatewayConfig, IMGatewayStatus, NimInstanceConfig, NimInstanceStatus, QQInstanceConfig, QQInstanceStatus, WecomInstanceConfig, WecomInstanceStatus } from '../../types/im';
 import { resolveOpenClawModelRef, toOpenClawModelRef } from '../../utils/openclawModelRef';
 import { getVisibleIMPlatforms } from '../../utils/regionFilter';
 import Modal from '../common/Modal';
@@ -20,11 +20,11 @@ import AgentSkillSelector from './AgentSkillSelector';
 import EmojiPicker from './EmojiPicker';
 
 type SettingsTab = 'basic' | 'skills' | 'im';
-type MultiInstancePlatform = 'dingtalk' | 'feishu' | 'qq' | 'wecom';
-type MultiInstanceConfig = DingTalkInstanceConfig | FeishuInstanceConfig | QQInstanceConfig | WecomInstanceConfig;
-type MultiInstanceStatus = DingTalkInstanceStatus | FeishuInstanceStatus | QQInstanceStatus | WecomInstanceStatus;
+type MultiInstancePlatform = 'dingtalk' | 'feishu' | 'qq' | 'wecom' | 'nim';
+type MultiInstanceConfig = DingTalkInstanceConfig | FeishuInstanceConfig | QQInstanceConfig | WecomInstanceConfig | NimInstanceConfig;
+type MultiInstanceStatus = DingTalkInstanceStatus | FeishuInstanceStatus | QQInstanceStatus | WecomInstanceStatus | NimInstanceStatus;
 
-const MULTI_INSTANCE_PLATFORMS: MultiInstancePlatform[] = ['dingtalk', 'feishu', 'qq', 'wecom'];
+const MULTI_INSTANCE_PLATFORMS: MultiInstancePlatform[] = ['dingtalk', 'feishu', 'qq', 'wecom', 'nim'];
 
 const isMultiInstancePlatform = (platform: Platform): platform is MultiInstancePlatform =>
   MULTI_INSTANCE_PLATFORMS.includes(platform as MultiInstancePlatform);

--- a/src/renderer/components/im/NimInstanceSettings.tsx
+++ b/src/renderer/components/im/NimInstanceSettings.tsx
@@ -344,9 +344,18 @@ const NimInstanceSettings: React.FC<NimInstanceSettingsProps> = ({
                 {i18nService.t('imNimQrLoginHintSuffix')}
               </p>
               {qrStatus === 'error' && qrError && (
-                <div className="flex items-center justify-center gap-1.5 text-xs text-red-500 bg-red-500/10 px-3 py-2 rounded-lg">
-                  <XCircleIcon className="h-4 w-4 flex-shrink-0" />
-                  {qrError}
+                <div className="flex flex-col items-center gap-2">
+                  <div className="flex items-center justify-center gap-1.5 text-xs text-red-500 bg-red-500/10 px-3 py-2 rounded-lg">
+                    <XCircleIcon className="h-4 w-4 flex-shrink-0" />
+                    {qrError}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void handleStartQr()}
+                    className="px-3 py-1.5 rounded-lg text-xs font-medium bg-surface-raised text-foreground hover:bg-surface transition-colors"
+                  >
+                    {i18nService.t('imNimQrRefresh')}
+                  </button>
                 </div>
               )}
             </>

--- a/src/renderer/types/im.ts
+++ b/src/renderer/types/im.ts
@@ -258,6 +258,8 @@ export interface NimGatewayStatus {
   lastOutboundAt: number | null;
 }
 
+// NIM supports max 3 instances (enabled or not), may use different accounts or AppKeys.
+// See: https://doc.yunxin.163.com/messaging2/ai-guide/TMwNzk4MzU?platform=client#多实例配置
 export const MAX_NIM_INSTANCES = 3;
 
 export interface NimInstanceStatus extends NimGatewayStatus {


### PR DESCRIPTION
## Summary
- **Agent IM Channels**: NIM was missing from `MULTI_INSTANCE_PLATFORMS` in `AgentSettingsPanel.tsx`, causing the Agent IM Channels tab to always show "Not configured" for NIM even after a bot was set up. Added `'nim'` to the multi-instance platform type, array, and config/status type unions.
- **QR code expiry**: When the NIM QR code expired, the status transitioned to `error` but only an error message was rendered — the refresh button disappeared because it was only shown in the `showing` state. Added a refresh button to the `error` state so users can regenerate the QR code after expiration.
- **Docs**: Added comment on `MAX_NIM_INSTANCES = 3` clarifying this is a [platform-side limit](https://doc.yunxin.163.com/messaging2/ai-guide/TMwNzk4MzU?platform=client#多实例配置).

## Test plan
- [ ] Configure a NIM bot in Settings > IM Bot and verify it shows "Connected"
- [ ] Open My Agents > select an agent > IM Channels tab — verify NIM shows connected instance(s) with toggle switches
- [ ] Verify other multi-instance platforms (DingTalk, Feishu, QQ, WeCom) still work correctly
- [ ] Open NIM QR code scan, wait for expiration — verify the refresh button remains visible
- [ ] Click the refresh button — verify a new QR code is generated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)