### PR TITLE
fix(test): add missing getBaseDir mock in openclawConfigSync runtime tests

### DIFF
--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -67,6 +67,7 @@ describe('OpenClawConfigSync runtime config output', () => {
         getConfigPath: () => configPath,
         getGatewayToken: () => 'gateway-token',
         getStateDir: () => stateDir,
+        getBaseDir: () => tmpDir,
       } as never,
       getCoworkConfig: () => ({
         workingDirectory: tmpDir,
@@ -129,6 +130,7 @@ describe('OpenClawConfigSync runtime config output', () => {
         getConfigPath: () => configPath,
         getGatewayToken: () => 'gateway-token',
         getStateDir: () => stateDir,
+        getBaseDir: () => tmpDir,
       } as never,
       getCoworkConfig: () => ({
         workingDirectory: tmpDir,
@@ -221,6 +223,7 @@ describe('OpenClawConfigSync runtime config output', () => {
         getConfigPath: () => configPath,
         getGatewayToken: () => 'gateway-token',
         getStateDir: () => stateDir,
+        getBaseDir: () => tmpDir,
       } as never,
       getCoworkConfig: () => ({
         workingDirectory: tmpDir,
@@ -295,6 +298,7 @@ describe('OpenClawConfigSync runtime config output', () => {
         getConfigPath: () => configPath,
         getGatewayToken: () => 'gateway-token',
         getStateDir: () => stateDir,
+        getBaseDir: () => tmpDir,
       } as never,
       getCoworkConfig: () => ({
         workingDirectory: tmpDir,


### PR DESCRIPTION
## Summary
- `openclawConfigSync.runtime.test.ts` 的 4 个用例全部因 `TypeError: this.engineManager.getBaseDir is not a function` 而失败。原因是产品代码新增了 `ensureExecApprovalDefaults()` 调用了 `getBaseDir()`，但测试的 engineManager mock 缺少该方法。补上 `getBaseDir: () => tmpDir` 即可。

## 未修复
- `openclawRuntimeAdapter.test.ts` 有 2 个用例失败（"duplicate messages locally" 和 "gateway has fewer entries"），由 0715f03（PR #1768 `fix:修复im同步问题`）引入的 reconcile 阈值逻辑变更导致。该变更将保护条件从 `authoritativeEntries.length < localEntries.length` 改为 `rawGatewayCount < localEntries.length / 2`，测试断言未同步更新。此处暂不修改，待与原作者确认预期行为后再处理。

## Test plan
- [x] CI test job 中 `openclawConfigSync.runtime.test.ts` 的 4 个用例应全部通过
- [ ] `openclawRuntimeAdapter.test.ts` 的 2 个用例仍会失败（已知，待后续处理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)