### PR TITLE
fix(installer): 改用 AppData 备份方案保留 Windows 升级时的用户 skill

### DIFF
--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -20,8 +20,7 @@
   ; Stop-Process -Force is equivalent to taskkill /F — the processes have no
   ; chance to run before-quit cleanup, so file handles may linger briefly as
   ; "ghost handles" in the Windows kernel. We poll until no matching process
-  ; remains, then force-remove the old install directory so that the old
-  ; uninstaller (which may lack our customUnInit fix) is never invoked.
+  ; remains before proceeding.
 
   nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "\
     Stop-Process -Name LobsterAI -Force -ErrorAction SilentlyContinue;\
@@ -37,8 +36,8 @@
 
   ; ── Backup user-created skills to AppData before extraction overwrites them ──
   ; Copy non-bundled skills to %APPDATA%\LobsterAI\skills-backup\ so they are
-  ; preserved regardless of whether the rename below succeeds or the old
-  ; uninstaller deletes $INSTDIR. The backup is restored in customInstall.
+  ; preserved when NSIS extracts the new version over the existing install.
+  ; The backup is restored in customInstall after extraction completes.
   nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "\
     $$src    = [IO.Path]::Combine($\"$INSTDIR$\",  $\"resources$\", $\"SKILLs$\");\
     $$backup = [IO.Path]::Combine($\"$APPDATA$\", $\"LobsterAI$\", $\"skills-backup$\");\
@@ -59,30 +58,6 @@
       }\
     }"'
   Pop $0
-
-  ; ── Remove old installation directory ──
-  ; After all processes are gone, ghost file handles may still linger for a
-  ; few seconds. We must remove the old install directory — including the old
-  ; uninstaller exe — to prevent electron-builder from invoking it (which
-  ; lacks our customUnInit and would show an undismissable dialog).
-  ;
-  ; Strategy: rename $INSTDIR to a temp name (instant, even for thousands of
-  ; files). The actual deletion is deferred to customInstall.
-  ; User skills are already safe in the AppData backup above, so this rename
-  ; is best-effort: if it fails, skills are still restored from the backup.
-  IfFileExists "$INSTDIR.old\*.*" 0 SkipStaleOldDirCleanup
-    nsExec::ExecToLog 'cmd /c rd /s /q "$INSTDIR.old"'
-    Pop $0
-  SkipStaleOldDirCleanup:
-
-  IfFileExists "$INSTDIR\*.*" 0 SkipOldDirRemoval
-    Rename "$INSTDIR" "$INSTDIR.old"
-    IfErrors 0 RenameOK
-      Goto SkipOldDirRemoval
-    RenameOK:
-      ; Deletion is deferred to customInstall, after user-created skills are
-      ; copied back from $INSTDIR.old to the new $INSTDIR.
-  SkipOldDirRemoval:
 !macroend
 
 !macro customInstall
@@ -144,11 +119,6 @@
     ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
     FileWrite $2 "skill-restore-done: $5-$4-$3 $6:$7:$8 exit=$0$\r$\n"
   SkipSkillRestore:
-
-  ; ── Delete the old install directory if rename had succeeded ──
-  IfFileExists "$INSTDIR.old\*.*" 0 SkipOldDirCleanup
-    nsExec::Exec 'cmd /c rd /s /q "$INSTDIR.old"'
-  SkipOldDirCleanup:
 
   System::Call 'Kernel32::SetEnvironmentVariable(t "ELECTRON_RUN_AS_NODE", t "")i'
 

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -38,26 +38,61 @@
   ; Copy non-bundled skills to %APPDATA%\LobsterAI\skills-backup\ so they are
   ; preserved when NSIS extracts the new version over the existing install.
   ; The backup is restored in customInstall after extraction completes.
-  nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "\
-    $$src    = [IO.Path]::Combine($\"$INSTDIR$\",  $\"resources$\", $\"SKILLs$\");\
-    $$backup = [IO.Path]::Combine($\"$APPDATA$\", $\"LobsterAI$\", $\"skills-backup$\");\
-    $$config = [IO.Path]::Combine($$src, $\"skills.config.json$\");\
+  ;
+  ; Quoting note: paths use \"..\" (backslash-escaped quote) — NOT $\"..$\" —
+  ; because $\"..$\" produces raw quotes that Windows CRT argv parsing consumes,
+  ; leaving the path unquoted and causing PowerShell method calls to fail.
+  CreateDirectory "$APPDATA\LobsterAI"
+  ClearErrors
+  FileOpen $R0 "$APPDATA\LobsterAI\skill-migrate.log" w
+  IfErrors BackupLogOpenFailed
+    FileWrite $R0 "backup-start INSTDIR=$INSTDIR APPDATA=$APPDATA$\r$\n"
+    Goto BackupDoExec
+  BackupLogOpenFailed:
+    StrCpy $R0 ""
+  BackupDoExec:
+
+  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "\
+    $$src    = \"$INSTDIR\resources\SKILLs\";\
+    $$backup = \"$APPDATA\LobsterAI\skills-backup\";\
+    $$config = \"$$src\skills.config.json\";\
+    if (Test-Path $$backup) { Remove-Item -Path $$backup -Recurse -Force -ErrorAction SilentlyContinue };\
     if (Test-Path $$src) {\
       $$bundled = @(try {\
         if (Test-Path $$config) {\
           (Get-Content $$config -Raw | ConvertFrom-Json).defaults.PSObject.Properties.Name\
         }\
       } catch { });\
-      Remove-Item -Path $$backup -Recurse -Force -ErrorAction SilentlyContinue;\
-      New-Item -ItemType Directory -Path $$backup -Force | Out-Null;\
-      Get-ChildItem -Path $$src -Directory | ForEach-Object {\
-        if ($$bundled -notcontains $$_.Name) {\
-          Copy-Item -Path $$_.FullName -Destination (Join-Path $$backup $$_.Name)\
-            -Recurse -Force -ErrorAction SilentlyContinue\
+      $$userSkills = @(Get-ChildItem -Path $$src -Directory | Where-Object { $$bundled -notcontains $$_.Name });\
+      if ($$userSkills.Count -gt 0) {\
+        New-Item -ItemType Directory -Path $$backup -Force | Out-Null;\
+        $$userSkills | ForEach-Object {\
+          Copy-Item -Path $$_.FullName -Destination (Join-Path $$backup $$_.Name) -Recurse -Force\
         }\
       }\
     }"'
   Pop $0
+  Pop $1
+
+  StrCmp $R0 "" BackupSkipCloseLog
+    FileWrite $R0 "backup-end exit=$0$\r$\n"
+    FileWrite $R0 "output: $1$\r$\n"
+    FileClose $R0
+  BackupSkipCloseLog:
+
+  ; ── Remove old installation directory ──
+  ; Rename $INSTDIR so the old uninstaller exe disappears from its registered
+  ; path — electron-builder cannot invoke it and the "app cannot be closed"
+  ; dialog (present in old uninstallers that lack customUnInit) is never shown.
+  ; User skills are already safe in the AppData backup above, so skill
+  ; preservation does not depend on this rename succeeding.
+  IfFileExists "$INSTDIR\*.*" 0 SkipOldDirRemoval
+    Rename "$INSTDIR" "$INSTDIR.old"
+    IfErrors 0 RenameOK
+      Goto SkipOldDirRemoval
+    RenameOK:
+      nsExec::Exec 'cmd /c rd /s /q "$INSTDIR.old"'
+  SkipOldDirRemoval:
 !macroend
 
 !macro customInstall
@@ -103,21 +138,22 @@
     ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
     FileWrite $2 "skill-restore-start: $5-$4-$3 $6:$7:$8$\r$\n"
 
-    nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "\
-      $$backup    = [IO.Path]::Combine($\"$APPDATA$\", $\"LobsterAI$\", $\"skills-backup$\");\
-      $$newSkills = [IO.Path]::Combine($\"$INSTDIR$\",  $\"resources$\", $\"SKILLs$\");\
+    nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "\
+      $$backup    = \"$APPDATA\LobsterAI\skills-backup\";\
+      $$newSkills = \"$INSTDIR\resources\SKILLs\";\
       Get-ChildItem -Path $$backup -Directory | ForEach-Object {\
-        $$target = [IO.Path]::Combine($$newSkills, $$_.Name);\
+        $$target = Join-Path $$newSkills $$_.Name;\
         if (-not (Test-Path $$target)) {\
           Copy-Item -Path $$_.FullName -Destination $$target -Recurse -Force\
-            -ErrorAction SilentlyContinue\
         }\
       };\
       Remove-Item -Path $$backup -Recurse -Force -ErrorAction SilentlyContinue"'
     Pop $0
+    Pop $1
 
     ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
     FileWrite $2 "skill-restore-done: $5-$4-$3 $6:$7:$8 exit=$0$\r$\n"
+    FileWrite $2 "skill-restore-output: $1$\r$\n"
   SkipSkillRestore:
 
   System::Call 'Kernel32::SetEnvironmentVariable(t "ELECTRON_RUN_AS_NODE", t "")i'

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -47,6 +47,14 @@
   ; into the new install before the old directory is removed.
   ; If rename fails (ghost file handles), skip — the installer's built-in
   ; uninstall step will handle the old directory.
+  ; Remove any stale .old directory left by a previous interrupted install.
+  ; NSIS Rename silently fails when the destination already exists, which
+  ; would cause the skill-restore logic in customInstall to be skipped.
+  IfFileExists "$INSTDIR.old\*.*" 0 SkipStaleOldDirCleanup
+    nsExec::ExecToLog 'cmd /c rd /s /q "$INSTDIR.old"'
+    Pop $0
+  SkipStaleOldDirCleanup:
+
   IfFileExists "$INSTDIR\*.*" 0 SkipOldDirRemoval
     Rename "$INSTDIR" "$INSTDIR.old"
     IfErrors 0 RenameOK
@@ -99,7 +107,13 @@
   ; are user-created and copied back into the new install.
   ; Falls back to "copy anything not already in the new dir" if the config is absent.
   ; This runs synchronously so the app never launches before skills are ready.
-  IfFileExists "$INSTDIR.old\resources\SKILLs\*.*" 0 SkipSkillRestore
+  IfFileExists "$INSTDIR.old\*.*" 0 OldDirMissing
+    FileWrite $2 "old-dir-status: present$\r$\n"
+    Goto SkillRestoreBegin
+  OldDirMissing:
+    FileWrite $2 "old-dir-status: missing (rename failed or clean install)$\r$\n"
+    Goto SkipSkillRestore
+  SkillRestoreBegin:
     ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
     FileWrite $2 "skill-restore-start: $5-$4-$3 $6:$7:$8$\r$\n"
 

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -35,6 +35,31 @@
     }"'
   Pop $0
 
+  ; ── Backup user-created skills to AppData before extraction overwrites them ──
+  ; Copy non-bundled skills to %APPDATA%\LobsterAI\skills-backup\ so they are
+  ; preserved regardless of whether the rename below succeeds or the old
+  ; uninstaller deletes $INSTDIR. The backup is restored in customInstall.
+  nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "\
+    $$src    = [IO.Path]::Combine($\"$INSTDIR$\",  $\"resources$\", $\"SKILLs$\");\
+    $$backup = [IO.Path]::Combine($\"$APPDATA$\", $\"LobsterAI$\", $\"skills-backup$\");\
+    $$config = [IO.Path]::Combine($$src, $\"skills.config.json$\");\
+    if (Test-Path $$src) {\
+      $$bundled = @(try {\
+        if (Test-Path $$config) {\
+          (Get-Content $$config -Raw | ConvertFrom-Json).defaults.PSObject.Properties.Name\
+        }\
+      } catch { });\
+      Remove-Item -Path $$backup -Recurse -Force -ErrorAction SilentlyContinue;\
+      New-Item -ItemType Directory -Path $$backup -Force | Out-Null;\
+      Get-ChildItem -Path $$src -Directory | ForEach-Object {\
+        if ($$bundled -notcontains $$_.Name) {\
+          Copy-Item -Path $$_.FullName -Destination (Join-Path $$backup $$_.Name)\
+            -Recurse -Force -ErrorAction SilentlyContinue\
+        }\
+      }\
+    }"'
+  Pop $0
+
   ; ── Remove old installation directory ──
   ; After all processes are gone, ghost file handles may still linger for a
   ; few seconds. We must remove the old install directory — including the old
@@ -42,14 +67,9 @@
   ; lacks our customUnInit and would show an undismissable dialog).
   ;
   ; Strategy: rename $INSTDIR to a temp name (instant, even for thousands of
-  ; files). The actual deletion is deferred to customInstall so that
-  ; user-created skills in $INSTDIR.old\resources\SKILLs can be copied back
-  ; into the new install before the old directory is removed.
-  ; If rename fails (ghost file handles), skip — the installer's built-in
-  ; uninstall step will handle the old directory.
-  ; Remove any stale .old directory left by a previous interrupted install.
-  ; NSIS Rename silently fails when the destination already exists, which
-  ; would cause the skill-restore logic in customInstall to be skipped.
+  ; files). The actual deletion is deferred to customInstall.
+  ; User skills are already safe in the AppData backup above, so this rename
+  ; is best-effort: if it fails, skills are still restored from the backup.
   IfFileExists "$INSTDIR.old\*.*" 0 SkipStaleOldDirCleanup
     nsExec::ExecToLog 'cmd /c rd /s /q "$INSTDIR.old"'
     Pop $0
@@ -101,47 +121,31 @@
   FileWrite $2 "tar-extract-done: $5-$4-$3 $6:$7:$8 exit=$0$\r$\n"
   Delete "$INSTDIR\resources\win-resources.tar"
 
-  ; ── Restore user-created skills from old install dir ──
-  ; Read skills.config.json from the old install to identify bundled skill IDs.
-  ; Skills in $INSTDIR.old that are NOT listed in skills.config.json defaults
-  ; are user-created and copied back into the new install.
-  ; Falls back to "copy anything not already in the new dir" if the config is absent.
-  ; This runs synchronously so the app never launches before skills are ready.
-  IfFileExists "$INSTDIR.old\*.*" 0 OldDirMissing
-    FileWrite $2 "old-dir-status: present$\r$\n"
-    Goto SkillRestoreBegin
-  OldDirMissing:
-    FileWrite $2 "old-dir-status: missing (rename failed or clean install)$\r$\n"
-    Goto SkipSkillRestore
-  SkillRestoreBegin:
+  ; ── Restore user-created skills from AppData backup ──
+  ; The backup was created in customInit before extraction began. Restore any
+  ; skills not already present in the new install, then clean up the backup.
+  IfFileExists "$APPDATA\LobsterAI\skills-backup\*.*" 0 SkipSkillRestore
     ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
     FileWrite $2 "skill-restore-start: $5-$4-$3 $6:$7:$8$\r$\n"
 
     nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "\
-      $$oldSkills = [IO.Path]::Combine($\"$INSTDIR.old$\", $\"resources$\", $\"SKILLs$\");\
-      $$newSkills = [IO.Path]::Combine($\"$INSTDIR$\",     $\"resources$\", $\"SKILLs$\");\
-      $$config    = [IO.Path]::Combine($$oldSkills, $\"skills.config.json$\");\
-      $$bundled   = @(try {\
-        if (Test-Path $$config) {\
-          (Get-Content $$config -Raw | ConvertFrom-Json).defaults.PSObject.Properties.Name\
+      $$backup    = [IO.Path]::Combine($\"$APPDATA$\", $\"LobsterAI$\", $\"skills-backup$\");\
+      $$newSkills = [IO.Path]::Combine($\"$INSTDIR$\",  $\"resources$\", $\"SKILLs$\");\
+      Get-ChildItem -Path $$backup -Directory | ForEach-Object {\
+        $$target = [IO.Path]::Combine($$newSkills, $$_.Name);\
+        if (-not (Test-Path $$target)) {\
+          Copy-Item -Path $$_.FullName -Destination $$target -Recurse -Force\
+            -ErrorAction SilentlyContinue\
         }\
-      } catch { });\
-      Get-ChildItem -Path $$oldSkills -Directory | ForEach-Object {\
-        if ($$bundled -notcontains $$_.Name) {\
-          $$target = [IO.Path]::Combine($$newSkills, $$_.Name);\
-          if (-not (Test-Path $$target)) {\
-            Copy-Item -Path $$_.FullName -Destination $$target -Recurse -Force\
-              -ErrorAction SilentlyContinue\
-          }\
-        }\
-      }"'
+      };\
+      Remove-Item -Path $$backup -Recurse -Force -ErrorAction SilentlyContinue"'
     Pop $0
 
     ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
     FileWrite $2 "skill-restore-done: $5-$4-$3 $6:$7:$8 exit=$0$\r$\n"
   SkipSkillRestore:
 
-  ; ── Delete the old install directory now that user skills are restored ──
+  ; ── Delete the old install directory if rename had succeeded ──
   IfFileExists "$INSTDIR.old\*.*" 0 SkipOldDirCleanup
     nsExec::Exec 'cmd /c rd /s /q "$INSTDIR.old"'
   SkipOldDirCleanup:

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -1546,9 +1546,19 @@ export class SkillManager {
       throw new Error('Built-in skills cannot be deleted');
     }
 
-    const targetDir = resolveWithin(root, id);
+    let targetDir = resolveWithin(root, id);
     if (!fs.existsSync(targetDir)) {
-      throw new Error('Skill not found');
+      const bundledRoot = this.getBundledSkillsRoot();
+      if (bundledRoot && bundledRoot !== root) {
+        const bundledTarget = resolveWithin(bundledRoot, id);
+        if (fs.existsSync(bundledTarget)) {
+          targetDir = bundledTarget;
+        } else {
+          throw new Error('Skill not found');
+        }
+      } else {
+        throw new Error('Skill not found');
+      }
     }
 
     fs.rmSync(targetDir, { recursive: true, force: true });
@@ -2142,6 +2152,17 @@ export class SkillManager {
     const builtInRoot = this.getBundledSkillsRoot();
     if (!builtInRoot || !fs.existsSync(builtInRoot)) {
       return new Set();
+    }
+    try {
+      const configPath = path.join(builtInRoot, SKILLS_CONFIG_FILE);
+      if (fs.existsSync(configPath)) {
+        const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        if (parsed?.defaults && typeof parsed.defaults === 'object') {
+          return new Set(Object.keys(parsed.defaults));
+        }
+      }
+    } catch (error) {
+      console.warn('[skills] Failed to parse skills.config.json for built-in skill list:', error);
     }
     return new Set(listSkillDirs(builtInRoot).map(dir => path.basename(dir)));
   }

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -1309,10 +1309,32 @@ export class SkillManager {
     }
 
     try {
+      // Build allowlist of bundled skill IDs from skills.config.json so
+      // user-added skill folders that happen to sit in the bundled root
+      // (e.g. restored by the installer's AppData backup) are not synced
+      // to user data. Falls back to the legacy "sync everything" behavior
+      // if the config is missing or malformed.
+      let bundledIds: Set<string> | null = null;
+      try {
+        const configPath = path.join(bundledRoot, SKILLS_CONFIG_FILE);
+        if (fs.existsSync(configPath)) {
+          const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+          if (parsed?.defaults && typeof parsed.defaults === 'object') {
+            bundledIds = new Set(Object.keys(parsed.defaults));
+          }
+        }
+      } catch (error) {
+        console.warn('[skills] Failed to parse skills.config.json for sync filter:', error);
+      }
+
       const bundledSkillDirs = listSkillDirs(bundledRoot);
       console.log('[skills] syncBundledSkillsToUserData: found', bundledSkillDirs.length, 'bundled skills');
       bundledSkillDirs.forEach((dir) => {
         const id = path.basename(dir);
+        if (bundledIds && !bundledIds.has(id)) {
+          console.log(`[skills] syncBundledSkillsToUserData: skipping non-bundled "${id}"`);
+          return;
+        }
         const targetDir = path.join(userRoot, id);
         const targetExists = fs.existsSync(targetDir);
 


### PR DESCRIPTION
- fix(skills): 支持删除安装目录下的用户自定义 skill

listBuiltInSkillIds 改为读取 skills.config.json defaults 白名单，
安装目录中用户自建的 skill 不再被标记为内置，删除按钮正常显示；
deleteSkill 在 AppData 中找不到时回退到安装目录查找并删除。

- fix(skills): 同步内置 skill 到 AppData 时跳过用户自定义 skill