### PR TITLE
feat(log-export): include OpenClaw logs in exported ZIP

### DIFF
--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -4,6 +4,7 @@ import { app, type UtilityProcess,utilityProcess } from 'electron';
 import { EventEmitter } from 'events';
 import fs from 'fs';
 import net from 'net';
+import os from 'os';
 import path from 'path';
 
 import { ensureElectronNodeShim, getElectronNodeRuntimePath, getSkillsRoot } from './coworkUtil';
@@ -250,6 +251,38 @@ export class OpenClawEngineManager extends EventEmitter {
 
   getConfigPath(): string {
     return this.configPath;
+  }
+
+  getGatewayLogPath(): string {
+    return this.gatewayLogPath;
+  }
+
+  /**
+   * Resolve the directory where the OpenClaw gateway writes its daily rolling
+   * logs (openclaw-YYYY-MM-DD.log).  Returns null when no candidate exists.
+   */
+  getOpenClawDailyLogDir(): string | null {
+    if (process.platform === 'win32') {
+      const runtime = this.resolveRuntimeMetadata();
+      if (runtime.root) {
+        const drive = path.parse(runtime.root).root;
+        const preferred = path.join(drive, 'tmp', 'openclaw');
+        if (fs.existsSync(preferred)) return preferred;
+      }
+      const fallback = path.join(os.tmpdir(), 'openclaw');
+      return fs.existsSync(fallback) ? fallback : null;
+    }
+
+    // macOS / Linux
+    if (fs.existsSync('/tmp/openclaw')) return '/tmp/openclaw';
+    try {
+      const uid = process.getuid?.();
+      if (uid != null) {
+        const fallback = path.join(os.tmpdir(), `openclaw-${uid}`);
+        if (fs.existsSync(fallback)) return fallback;
+      }
+    } catch { /* getuid unavailable */ }
+    return null;
   }
 
   getGatewayConnectionInfo(): OpenClawGatewayConnectionInfo {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -332,6 +332,29 @@ const buildLogExportFileName = (): string => {
   return `lobsterai-logs-${datePart}-${timePart}.zip`;
 };
 
+const OPENCLAW_DAILY_LOG_RETENTION_DAYS = 7;
+const OPENCLAW_DAILY_LOG_RE = /^openclaw-\d{4}-\d{2}-\d{2}\.log$/;
+
+function getRecentOpenClawDailyLogEntries(
+  logDir: string | null,
+): Array<{ archiveName: string; filePath: string }> {
+  if (!logDir || !fs.existsSync(logDir)) return [];
+
+  const cutoffMs = Date.now() - OPENCLAW_DAILY_LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+
+  return fs.readdirSync(logDir)
+    .filter((f) => OPENCLAW_DAILY_LOG_RE.test(f))
+    .map((f) => ({ archiveName: f, filePath: path.join(logDir, f) }))
+    .filter(({ filePath }) => {
+      try {
+        return fs.statSync(filePath).mtimeMs >= cutoffMs;
+      } catch {
+        return false;
+      }
+    })
+    .sort((a, b) => a.archiveName.localeCompare(b.archiveName));
+}
+
 const truncateIpcString = (value: string, maxChars: number): string => {
   if (value.length <= maxChars) return value;
   return `${value.slice(0, maxChars)}\n...[truncated in main IPC forwarding]`;
@@ -2022,11 +2045,14 @@ if (!gotTheLock) {
       }
 
       const outputPath = ensureZipFileName(saveResult.filePath);
+      const manager = getOpenClawEngineManager();
       const archiveResult = await exportLogsZip({
         outputPath,
         entries: [
           ...getRecentMainLogEntries(),
           { archiveName: 'cowork.log', filePath: getCoworkLogPath() },
+          { archiveName: 'gateway.log', filePath: manager.getGatewayLogPath() },
+          ...getRecentOpenClawDailyLogEntries(manager.getOpenClawDailyLogDir()),
         ],
       });
 


### PR DESCRIPTION
## Summary
- Include OpenClaw **gateway.log** and **daily rolling logs** (`openclaw-YYYY-MM-DD.log`) in the "Export Logs" ZIP archive
- Add `getGatewayLogPath()` and `getOpenClawDailyLogDir()` public getters to `OpenClawEngineManager`, resolving platform-specific paths (Windows drive-letter logic, macOS `/tmp/openclaw`, fallback to `os.tmpdir()`)
- Add `getRecentOpenClawDailyLogEntries()` helper that scans for recent daily logs (last 7 days), mirroring the existing `getRecentMainLogEntries()` pattern

## Test plan
- [ ] Launch app, ensure OpenClaw gateway starts
- [ ] Click "Export Logs" in Settings → About
- [ ] Open the ZIP and verify `gateway.log` and `openclaw-YYYY-MM-DD.log` files are present alongside existing `main-*.log` and `cowork.log`
- [ ] Test export when gateway has never started (gateway.log missing) — should show partial success message
- [ ] Verify on both Windows and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)