### PR TITLE
fix(image): exclude image paths from prompt when base64 is available

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2748,6 +2748,14 @@ if (!gotTheLock) {
         messageMetadata.skillIds = options.activeSkillIds;
       }
       if (options.imageAttachments?.length) {
+        console.log('[Cowork:StartSession] imageAttachments received via IPC:', {
+          count: options.imageAttachments.length,
+          details: options.imageAttachments.map(img => ({
+            name: img.name,
+            mimeType: img.mimeType,
+            base64Length: img.base64Data?.length ?? 0,
+          })),
+        });
         messageMetadata.imageAttachments = options.imageAttachments;
       }
       coworkStoreInstance.addMessage(session.id, {
@@ -2820,6 +2828,17 @@ if (!gotTheLock) {
 
       const runtime = getCoworkEngineRouter();
       const existingSession = getCoworkStore().getSession(options.sessionId);
+      if (options.imageAttachments?.length) {
+        console.log('[Cowork:ContinueSession] imageAttachments received via IPC:', {
+          sessionId: options.sessionId,
+          count: options.imageAttachments.length,
+          details: options.imageAttachments.map(img => ({
+            name: img.name,
+            mimeType: img.mimeType,
+            base64Length: img.base64Data?.length ?? 0,
+          })),
+        });
+      }
       runtime.continueSession(options.sessionId, options.prompt, {
         systemPrompt: mergeCoworkSystemPrompt(
           activeEngine,

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -335,8 +335,12 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     // Image attachments also need their file paths in the prompt so the model knows
     // where the original files are located (e.g., for skills like seedream that need --image <path>).
     // Note: inline/clipboard images have pseudo-paths starting with 'inline:' and are excluded.
+    // Note: image attachments that already carry base64 data are excluded — their content
+    // is delivered via the attachments parameter of chat.send. Including the file path
+    // would trigger OpenClaw's Native-image detection, which rejects paths outside allowed
+    // directories and can drop the base64 image during sanitization (macOS-only bug).
     const attachmentLines = attachments
-      .filter((a) => !a.path.startsWith('inline:'))
+      .filter((a) => !a.path.startsWith('inline:') && !(a.isImage && a.dataUrl))
       .map((attachment) => `${i18nService.t('inputFileLabel')}: ${attachment.path}`)
       .join('\n');
     const finalPrompt = trimmedValue


### PR DESCRIPTION
## Summary
- Fix macOS bug where pasted images are not visible to the model (model falls back to `read` tool)
- Root cause: image file paths in prompt text trigger OpenClaw's Native-image detection → sanitization drops base64 images
- Add main-process IPC logging for imageAttachments diagnostics

## Root Cause

When a user pastes an image, LobsterAI:
1. Sends the image as base64 via `chat.send` attachments parameter ✅
2. Also includes `Input Files: /Users/.../cowork-temp/attachments/manual/image-xxx.png` in the prompt text

On macOS, OpenClaw's `detectAndLoadPromptImages` matches the Unix path → tries to load it → rejected (not in allowed roots) → `sanitizeImageBlocks` drops the base64 image too → `promptImages=0`.

On Windows, `C:\...` paths don't match OpenClaw's Unix-only regex, so the issue doesn't occur.

## Fix

In `CoworkPromptInput.tsx` `handleSubmit`, exclude image attachments that already carry base64 data from the prompt text:

```diff
 const attachmentLines = attachments
-  .filter((a) => !a.path.startsWith('inline:'))
+  .filter((a) => !a.path.startsWith('inline:') && !(a.isImage && a.dataUrl))
   .map((attachment) => `${i18nService.t('inputFileLabel')}: ${attachment.path}`)
   .join('\n');
```

## Evidence from logs

| Session | base64 sent? | Path in prompt? | Native image detected? | Dropped? | promptImages |
|---------|-------------|----------------|----------------------|----------|-------------|
| macOS 18:08 | ✅ 26KB | ✅ | ✅ → path rejected | No | **1** ✅ |
| macOS 18:51 | ✅ 42KB | ✅ | ✅ → path rejected | **Yes** | **0** ❌ |
| Windows 18:11 | ✅ 263KB | ✅ | No (regex doesn't match) | No | **1** ✅ |

## Test plan
- [ ] macOS: paste image → send → verify `promptImages > 0` in logs, no `Native image: detected`
- [ ] macOS: file picker image → send → same verification
- [ ] Windows: paste image → send → behavior unchanged
- [ ] Non-image file attachment → verify path still appears in prompt
- [ ] Image without base64 (modelSupportsImage=false case) → verify path still in prompt as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)