### PR TITLE
fix(dingtalk): downgrade dingtalk-connector to 0.8.16 to fix startup crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       {
         "id": "dingtalk-connector",
         "npm": "@dingtalk-real-ai/dingtalk-connector",
-        "version": "0.8.17"
+        "version": "0.8.16"
       },
       {
         "id": "openclaw-lark",


### PR DESCRIPTION
## Summary

- Downgrade `@dingtalk-real-ai/dingtalk-connector` from 0.8.17 to 0.8.16 to fix DingTalk not responding to messages
- 0.8.17 introduced tsdown pre-compilation, which exposes an OpenClaw framework bug where the plugin module loader fails to resolve `openclaw/plugin-sdk/*` imports for third-party plugins
- All 5 DingTalk accounts crash on startup with `ERR_MODULE_NOT_FOUND: Cannot find package 'openclaw'`, auto-restart retries all fail
- Other channels (Feishu, WeCom, QQ, WeChat, POPO) are unaffected as they are built-in plugins

## Root Cause

OpenClaw's `resolveLoaderPluginSdkPackageRoot()` cannot find the `openclaw` package when resolving from third-party plugin paths. This is a known upstream bug:

- [DingTalk-Real-AI/dingtalk-openclaw-connector#503](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/503)
- [openclaw/openclaw#53685](https://github.com/openclaw/openclaw/issues/53685)

## Why downgrade works

0.8.16 uses jiti runtime compilation where `import type` statements are erased and the sole value import (`promptSingleChannelSecretInput`) is only triggered during onboarding — not during normal message handling. 0.8.17's tsdown pre-compiled `.mjs` files contain static ESM imports that must resolve at module load time, triggering the bug.

## Test plan

- [ ] Verify DingTalk bot responds to messages after downgrade
- [ ] Verify other channels (Feishu, WeCom, QQ, WeChat, POPO) still work
- [ ] Check no `Cannot find package 'openclaw'` errors in openclaw logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)