### PR TITLE
Fix/windows installer observability

### DIFF
--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -1,16 +1,30 @@
 !include "FileFunc.nsh"
 
+!macro GetTimestamp OUTVAR
+  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "[DateTime]::Now.ToString(\"yyyy-MM-dd HH:mm:ss.fff\")"'
+  Pop $0
+  Pop ${OUTVAR}
+  StrCmp $0 "0" +2
+    StrCpy ${OUTVAR} "unknown-time"
+!macroend
+
 !macro customHeader
   ; Request admin privileges for script execution (tar extract, etc.)
   ; This does NOT change the default install path — just ensures UAC elevation.
   RequestExecutionLevel admin
 
-  ; Hide the (empty) details list — electron-builder uses 7z solid extraction
-  ; which produces no per-file output, so the box would just be blank.
+  ; Keep only the progress bar visible. The details box stays hidden and
+  ; NSIS/electron-builder retains the default status text behavior.
   ShowInstDetails nevershow
 !macroend
 
 !macro customInit
+  CreateDirectory "$APPDATA\LobsterAI"
+  FileOpen $9 "$APPDATA\LobsterAI\install-timing.log" w
+  !insertmacro GetTimestamp $8
+  FileWrite $9 "$8 phase=custom-init-start instdir=$INSTDIR appdata=$APPDATA$\r$\n"
+  FileClose $9
+
   ; ── Kill every process that might hold file handles in the install dir ──
   ;
   ; 1. LobsterAI.exe — the main app AND the OpenClaw gateway (ELECTRON_RUN_AS_NODE)
@@ -22,6 +36,8 @@
   ; "ghost handles" in the Windows kernel. We poll until no matching process
   ; remains before proceeding.
 
+  DetailPrint "[Installer] Stopping running LobsterAI processes"
+  System::Call 'kernel32::GetTickCount()i .r7'
   nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "\
     Stop-Process -Name LobsterAI -Force -ErrorAction SilentlyContinue;\
     Get-Process node -ErrorAction SilentlyContinue | Where-Object { $$_.Path -like \"*LobsterAI*\" } | Stop-Process -Force -ErrorAction SilentlyContinue;\
@@ -33,6 +49,12 @@
       Start-Sleep -Milliseconds 500;\
     }"'
   Pop $0
+  System::Call 'kernel32::GetTickCount()i .r6'
+  IntOp $5 $6 - $7
+  FileOpen $9 "$APPDATA\LobsterAI\install-timing.log" a
+  !insertmacro GetTimestamp $8
+  FileWrite $9 "$8 phase=process-stop-complete exit=$0 elapsed_ms=$5$\r$\n"
+  FileClose $9
 
   ; ── Backup user-created skills to AppData before extraction overwrites them ──
   ; Copy non-bundled skills to %APPDATA%\LobsterAI\skills-backup\ so they are
@@ -42,11 +64,13 @@
   ; Quoting note: paths use \"..\" (backslash-escaped quote) — NOT $\"..$\" —
   ; because $\"..$\" produces raw quotes that Windows CRT argv parsing consumes,
   ; leaving the path unquoted and causing PowerShell method calls to fail.
-  CreateDirectory "$APPDATA\LobsterAI"
+  DetailPrint "[Installer] Backing up user-created skills"
+  System::Call 'kernel32::GetTickCount()i .r7'
   ClearErrors
   FileOpen $R0 "$APPDATA\LobsterAI\skill-migrate.log" w
   IfErrors BackupLogOpenFailed
-    FileWrite $R0 "backup-start INSTDIR=$INSTDIR APPDATA=$APPDATA$\r$\n"
+    !insertmacro GetTimestamp $8
+    FileWrite $R0 "$8 phase=backup-start instdir=$INSTDIR appdata=$APPDATA$\r$\n"
     Goto BackupDoExec
   BackupLogOpenFailed:
     StrCpy $R0 ""
@@ -73,12 +97,19 @@
     }"'
   Pop $0
   Pop $1
+  System::Call 'kernel32::GetTickCount()i .r6'
+  IntOp $5 $6 - $7
 
   StrCmp $R0 "" BackupSkipCloseLog
-    FileWrite $R0 "backup-end exit=$0$\r$\n"
-    FileWrite $R0 "output: $1$\r$\n"
+    !insertmacro GetTimestamp $8
+    FileWrite $R0 "$8 phase=backup-end exit=$0 elapsed_ms=$5$\r$\n"
+    FileWrite $R0 "$8 phase=backup-output text=$1$\r$\n"
     FileClose $R0
   BackupSkipCloseLog:
+  FileOpen $9 "$APPDATA\LobsterAI\install-timing.log" a
+  !insertmacro GetTimestamp $8
+  FileWrite $9 "$8 phase=skill-backup-complete exit=$0 elapsed_ms=$5$\r$\n"
+  FileClose $9
 
   ; ── Remove old installation directory ──
   ; Rename $INSTDIR so the old uninstaller exe disappears from its registered
@@ -86,13 +117,33 @@
   ; dialog (present in old uninstallers that lack customUnInit) is never shown.
   ; User skills are already safe in the AppData backup above, so skill
   ; preservation does not depend on this rename succeeding.
+  ;
+  ; Important: never reuse a fixed "$INSTDIR.old" path. If a previous async
+  ; delete leaves that directory behind, Rename fails immediately and the old
+  ; uninstaller remains in place. Instead, schedule cleanup of any stale
+  ; *.old* dirs, then rename to a unique per-run suffix and schedule deletion
+  ; of that unique directory in the background so the installer UI can appear
+  ; immediately after the rename succeeds.
+  DetailPrint "[Installer] Removing previous installation directory"
+  System::Call 'kernel32::GetTickCount()i .r7'
   IfFileExists "$INSTDIR\*.*" 0 SkipOldDirRemoval
-    Rename "$INSTDIR" "$INSTDIR.old"
+    nsExec::ExecToLog 'cmd /c for /d %D in ("$INSTDIR.old*") do @start "" /b cmd /c rd /s /q "%~fD"'
+    Pop $0
+    System::Call 'kernel32::GetTickCount()i .r4'
+    StrCpy $3 "$INSTDIR.old.$4"
+    Rename "$INSTDIR" "$3"
     IfErrors 0 RenameOK
       Goto SkipOldDirRemoval
     RenameOK:
-      nsExec::Exec 'cmd /c rd /s /q "$INSTDIR.old"'
+      nsExec::ExecToLog 'cmd /c start "" /b cmd /c rd /s /q "$3"'
+      Pop $0
   SkipOldDirRemoval:
+  System::Call 'kernel32::GetTickCount()i .r6'
+  IntOp $5 $6 - $7
+  FileOpen $9 "$APPDATA\LobsterAI\install-timing.log" a
+  !insertmacro GetTimestamp $8
+  FileWrite $9 "$8 phase=old-install-cleanup-complete elapsed_ms=$5 renamed_path=$3 cleanup_mode=async$\r$\n"
+  FileClose $9
 !macroend
 
 !macro customInstall
@@ -101,42 +152,79 @@
   ; Log file: %APPDATA%\LobsterAI\install-timing.log
 
   CreateDirectory "$APPDATA\LobsterAI"
-  FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" w
-
-  ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
-  FileWrite $2 "extract-done: $5-$4-$3 $6:$7:$8$\r$\n"
+  FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  !insertmacro GetTimestamp $8
+  FileWrite $2 "$8 phase=nsis-extract-complete$\r$\n"
+  FileClose $2
+  DetailPrint "[Installer] Preparing installation steps"
 
   ; ─── Extract combined resource archive (win-resources.tar) ───
   ; All large resource directories (cfmind/, SKILLs/, python-win/) are packed
   ; into a single tar file. NSIS 7z extracts one large file almost instantly;
   ; we then unpack the tar here using Electron's Node runtime.
 
-  SetDetailsPrint none
+  ; ─── Windows Defender Exclusion (optional, best-effort) ───
+  ; Add exclusions before tar extraction so Defender does not slow down the
+  ; expansion of large resource trees.
+  CreateDirectory "$INSTDIR\resources\cfmind"
+  CreateDirectory "$INSTDIR\resources\python-win"
+  CreateDirectory "$INSTDIR\resources\SKILLs"
+  DetailPrint "[Installer] Preparing resource directories"
+  DetailPrint "[Installer] Adding Windows Defender exclusions before extraction"
+  FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  !insertmacro GetTimestamp $8
+  FileWrite $2 "$8 phase=defender-exclusion-start$\r$\n"
+  FileClose $2
+  System::Call 'kernel32::GetTickCount()i .r7'
+  nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "try { Add-MpPreference -ExclusionPath $\"$INSTDIR\resources\cfmind$\",$\"$INSTDIR\resources\python-win$\",$\"$INSTDIR\resources\SKILLs$\",$\"$INSTDIR\resources\app.asar.unpacked$\" -ErrorAction Stop; Write-Output \"[Installer] Windows Defender exclusions added\" } catch { Write-Output (\"[Installer] Windows Defender exclusions skipped: \" + $$_.Exception.Message) }"'
+  Pop $0
+  System::Call 'kernel32::GetTickCount()i .r6'
+  IntOp $5 $6 - $7
+  FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  !insertmacro GetTimestamp $8
+  FileWrite $2 "$8 phase=defender-exclusion-complete exit=$0 elapsed_ms=$5$\r$\n"
+  FileClose $2
 
   System::Call 'Kernel32::SetEnvironmentVariable(t "ELECTRON_RUN_AS_NODE", t "1")i'
 
-  ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
-  FileWrite $2 "tar-extract-start: $5-$4-$3 $6:$7:$8$\r$\n"
+  DetailPrint "[Installer] Launching bundled extractor"
+  DetailPrint "[Installer] Extracting bundled resources"
+  FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  !insertmacro GetTimestamp $8
+  FileWrite $2 "$8 phase=tar-extract-start tar=$INSTDIR\resources\win-resources.tar dest=$INSTDIR\resources$\r$\n"
+  FileClose $2
+  System::Call 'kernel32::GetTickCount()i .r7'
 
-  nsExec::ExecToStack '"$INSTDIR\${APP_EXECUTABLE_FILENAME}" "$INSTDIR\resources\unpack-cfmind.cjs" "$INSTDIR\resources\win-resources.tar" "$INSTDIR\resources"'
+  nsExec::ExecToLog '"$INSTDIR\${APP_EXECUTABLE_FILENAME}" "$INSTDIR\resources\unpack-cfmind.cjs" "$INSTDIR\resources\win-resources.tar" "$INSTDIR\resources" "$APPDATA\LobsterAI\install-timing.log"'
   Pop $0
-  Pop $1
+  System::Call 'kernel32::GetTickCount()i .r6'
+  IntOp $5 $6 - $7
 
   StrCmp $0 "0" TarExtractOK
-    FileWrite $2 "tar-extract-error: exit=$0 output=$1$\r$\n"
-    MessageBox MB_OK|MB_ICONEXCLAMATION "Resource extraction failed (exit code $0):$\r$\n$\r$\n$1"
+    FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+    !insertmacro GetTimestamp $8
+    FileWrite $2 "$8 phase=tar-extract-error exit=$0 elapsed_ms=$5$\r$\n"
+    FileClose $2
+    MessageBox MB_OK|MB_ICONEXCLAMATION "Resource extraction failed (exit code $0). See %APPDATA%\LobsterAI\install-timing.log for details."
   TarExtractOK:
 
-  ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
-  FileWrite $2 "tar-extract-done: $5-$4-$3 $6:$7:$8 exit=$0$\r$\n"
+  FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  !insertmacro GetTimestamp $8
+  FileWrite $2 "$8 phase=tar-extract-complete exit=$0 elapsed_ms=$5$\r$\n"
+  FileClose $2
+  DetailPrint "[Installer] Bundled resources extraction complete"
   Delete "$INSTDIR\resources\win-resources.tar"
 
   ; ── Restore user-created skills from AppData backup ──
   ; The backup was created in customInit before extraction began. Restore any
   ; skills not already present in the new install, then clean up the backup.
   IfFileExists "$APPDATA\LobsterAI\skills-backup\*.*" 0 SkipSkillRestore
-    ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
-    FileWrite $2 "skill-restore-start: $5-$4-$3 $6:$7:$8$\r$\n"
+    DetailPrint "[Installer] Restoring user-created skills"
+    FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+    !insertmacro GetTimestamp $8
+    FileWrite $2 "$8 phase=skill-restore-start$\r$\n"
+    FileClose $2
+    System::Call 'kernel32::GetTickCount()i .r7'
 
     nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "\
       $$backup    = \"$APPDATA\LobsterAI\skills-backup\";\
@@ -150,40 +238,26 @@
       Remove-Item -Path $$backup -Recurse -Force -ErrorAction SilentlyContinue"'
     Pop $0
     Pop $1
-
-    ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
-    FileWrite $2 "skill-restore-done: $5-$4-$3 $6:$7:$8 exit=$0$\r$\n"
-    FileWrite $2 "skill-restore-output: $1$\r$\n"
+    System::Call 'kernel32::GetTickCount()i .r6'
+    IntOp $5 $6 - $7
+    FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+    !insertmacro GetTimestamp $8
+    FileWrite $2 "$8 phase=skill-restore-complete exit=$0 elapsed_ms=$5$\r$\n"
+    FileWrite $2 "$8 phase=skill-restore-output text=$1$\r$\n"
+    FileClose $2
   SkipSkillRestore:
 
   System::Call 'Kernel32::SetEnvironmentVariable(t "ELECTRON_RUN_AS_NODE", t "")i'
 
-  ; ─── Windows Defender Exclusion (optional, best-effort) ───
-  ; Only specific resource subdirectories are excluded (not the full
-  ; $INSTDIR root or $APPDATA) to keep the exclusion scope minimal:
-  ;   cfmind\              — ~3000 JS/native files, primary startup bottleneck
-  ;   python-win\          — bundled Python interpreter
-  ;   SKILLs\              — skill scripts
-  ;   app.asar.unpacked\   — native modules loaded at startup (better-sqlite3, node-nim, npm)
-  ;
-  ; This is a best-effort optimization:
-  ; - Requires admin privileges (already elevated for installation)
-  ; - Silently skipped if Defender is not running or policy disallows it
-  ; - Common practice for developer tools (VS Code, Docker Desktop, etc.)
-
-  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "try { Add-MpPreference -ExclusionPath $\"$INSTDIR\resources\cfmind$\",$\"$INSTDIR\resources\python-win$\",$\"$INSTDIR\resources\SKILLs$\",$\"$INSTDIR\resources\app.asar.unpacked$\" -ErrorAction Stop; Write-Output ok } catch { Write-Output skip }"'
-  Pop $0
-  Pop $1
-  FileWrite $2 "defender-exclusion: exit=$0 result=$1$\r$\n"
-
   ; Clean up the unpack script — no longer needed after installation
+  DetailPrint "[Installer] Cleaning up temporary installer files"
   Delete "$INSTDIR\resources\unpack-cfmind.cjs"
 
-  ${GetTime} "" "L" $3 $4 $5 $6 $7 $8 $9
-  FileWrite $2 "install-done: $5-$4-$3 $6:$7:$8$\r$\n"
+  FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  !insertmacro GetTimestamp $8
+  FileWrite $2 "$8 phase=install-complete$\r$\n"
   FileClose $2
-
-  SetDetailsPrint both
+  DetailPrint "[Installer] Installation complete"
 !macroend
 
 !macro customUnInit

--- a/scripts/unpack-cfmind.cjs
+++ b/scripts/unpack-cfmind.cjs
@@ -25,6 +25,7 @@ const path = require('path');
 
 const tarPath = process.argv[2];
 const destDir = process.argv[3];
+const installLogPath = process.argv[4];
 
 if (!tarPath || !destDir) {
   console.error('[unpack-cfmind] Usage: LobsterAI.exe unpack-cfmind.cjs <tarPath> <destDir>');
@@ -34,6 +35,60 @@ if (!tarPath || !destDir) {
 if (!fs.existsSync(tarPath)) {
   console.error(`[unpack-cfmind] tar file not found: ${tarPath}`);
   process.exit(1);
+}
+
+function formatTimestamp(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  const milliseconds = String(date.getMilliseconds()).padStart(3, '0');
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${milliseconds}`;
+}
+
+function stringifyError(error) {
+  if (!error) return 'unknown error';
+  if (error instanceof Error) return error.stack || error.message;
+  return String(error);
+}
+
+let logFd = null;
+if (installLogPath) {
+  try {
+    fs.mkdirSync(path.dirname(installLogPath), { recursive: true });
+    logFd = fs.openSync(installLogPath, 'a');
+  } catch (error) {
+    console.error(`[unpack-cfmind] Failed to open install log: ${stringifyError(error)}`);
+  }
+}
+
+function logLine(message) {
+  const line = `${formatTimestamp()} ${message}`;
+  console.log(line);
+  if (logFd !== null) {
+    try {
+      fs.writeSync(logFd, `${line}\n`);
+    } catch (error) {
+      console.error(`${formatTimestamp()} [unpack-cfmind] Failed to write install log: ${stringifyError(error)}`);
+      logFd = null;
+    }
+  }
+}
+
+function closeLogFile() {
+  if (logFd === null) return;
+  try {
+    fs.closeSync(logFd);
+  } catch {
+    // Ignore cleanup errors.
+  }
+  logFd = null;
+}
+
+function formatMegabytes(bytes) {
+  return (bytes / (1024 * 1024)).toFixed(1);
 }
 
 // ============================================================
@@ -48,7 +103,7 @@ function loadTarModule() {
   try {
     return require(asarTarPath);
   } catch (e) {
-    console.error(`[unpack-cfmind] Failed to load tar from asar: ${e.message}`);
+    logLine(`[unpack-cfmind] phase=load-tar-from-asar-failed error=${stringifyError(e)}`);
   }
 
   // Strategy 2: Direct require (may be in NODE_PATH)
@@ -58,8 +113,8 @@ function loadTarModule() {
     // Also failed
   }
 
-  console.error('[unpack-cfmind] Error: cannot load tar module');
-  console.error(`[unpack-cfmind] Tried: ${asarTarPath}`);
+  logLine('[unpack-cfmind] phase=load-tar-failed');
+  logLine(`[unpack-cfmind] phase=load-tar-tried path=${asarTarPath}`);
   process.exit(1);
 }
 
@@ -68,11 +123,17 @@ function loadTarModule() {
 // ============================================================
 
 try {
-  console.log(`[unpack-cfmind] Extracting: ${tarPath}`);
-  console.log(`[unpack-cfmind] Destination: ${destDir}`);
+  logLine(`[unpack-cfmind] phase=extract-open tar=${tarPath}`);
+  logLine(`[unpack-cfmind] phase=extract-destination dir=${destDir}`);
 
   const tar = loadTarModule();
   const t0 = Date.now();
+  let extractedEntries = 0;
+  let extractedBytes = 0;
+  let currentRoot = '';
+  let nextGlobalProgressBytes = 25 * 1024 * 1024;
+  let nextRootProgressBytes = 25 * 1024 * 1024;
+  const rootStats = new Map();
 
   // Ensure destination directory exists
   fs.mkdirSync(destDir, { recursive: true });
@@ -82,25 +143,76 @@ try {
     file: tarPath,
     cwd: destDir,
     sync: true,
+    onentry: (entry) => {
+      const entryPath = String(entry?.path || '');
+      const root = entryPath.split(/[\\/]/)[0] || '(root)';
+      const size = Number(entry?.size || 0);
+      extractedEntries += 1;
+      extractedBytes += size;
+
+      const stats = rootStats.get(root) || {
+        entries: 0,
+        bytes: 0,
+        startedAtMs: Date.now(),
+      };
+      stats.entries += 1;
+      stats.bytes += size;
+      rootStats.set(root, stats);
+
+      if (root !== currentRoot) {
+        currentRoot = root;
+        nextRootProgressBytes = stats.bytes + (25 * 1024 * 1024);
+        logLine(`[unpack-cfmind] phase=root-start root=${root} entry=${entryPath}`);
+      }
+
+      if (extractedEntries <= 20 || extractedBytes >= nextGlobalProgressBytes) {
+        const elapsedMs = Date.now() - t0;
+        logLine(
+          `[unpack-cfmind] phase=extract-progress entries=${extractedEntries} bytes=${extractedBytes} mb=${formatMegabytes(extractedBytes)} elapsed_ms=${elapsedMs} current=${entryPath}`,
+        );
+        while (extractedBytes >= nextGlobalProgressBytes) {
+          nextGlobalProgressBytes += 25 * 1024 * 1024;
+        }
+      }
+
+      if (stats.bytes >= nextRootProgressBytes) {
+        const elapsedMs = Date.now() - stats.startedAtMs;
+        logLine(
+          `[unpack-cfmind] phase=root-progress root=${root} entries=${stats.entries} bytes=${stats.bytes} mb=${formatMegabytes(stats.bytes)} elapsed_ms=${elapsedMs} current=${entryPath}`,
+        );
+        while (stats.bytes >= nextRootProgressBytes) {
+          nextRootProgressBytes += 25 * 1024 * 1024;
+        }
+      }
+    },
   });
 
-  const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
-  console.log(`[unpack-cfmind] Done in ${elapsed}s`);
+  const elapsedMs = Date.now() - t0;
+  logLine(`[unpack-cfmind] phase=extract-complete entries=${extractedEntries} bytes=${extractedBytes} elapsed_ms=${elapsedMs}`);
+
+  for (const [root, stats] of rootStats.entries()) {
+    const elapsedMs = Date.now() - stats.startedAtMs;
+    logLine(
+      `[unpack-cfmind] phase=root-summary root=${root} entries=${stats.entries} bytes=${stats.bytes} mb=${formatMegabytes(stats.bytes)} elapsed_ms=${elapsedMs}`,
+    );
+  }
 
   // Verify key directories exist
-  const expectedDirs = ['cfmind'];
+  const expectedDirs = ['cfmind', 'SKILLs', 'python-win'];
   for (const dir of expectedDirs) {
     const dirPath = path.join(destDir, dir);
     if (fs.existsSync(dirPath)) {
-      console.log(`[unpack-cfmind] Verified: ${dir}/`);
+      logLine(`[unpack-cfmind] phase=verify-ok dir=${dir}`);
     } else {
-      console.error(`[unpack-cfmind] Warning: expected directory missing: ${dir}/`);
+      logLine(`[unpack-cfmind] phase=verify-missing dir=${dir}`);
     }
   }
 
-  console.log('[unpack-cfmind] OK');
+  logLine('[unpack-cfmind] phase=extract-ok');
+  closeLogFile();
   process.exit(0);
 } catch (err) {
-  console.error(`[unpack-cfmind] Extraction failed: ${err.message}`);
+  logLine(`[unpack-cfmind] phase=extract-failed error=${stringifyError(err)}`);
+  closeLogFile();
   process.exit(1);
 }

--- a/src/renderer/services/skill.ts
+++ b/src/renderer/services/skill.ts
@@ -226,7 +226,7 @@ class SkillService {
   async fetchMarketplaceSkills(): Promise<{ skills: MarketplaceSkill[]; tags: MarketTag[] }> {
     try {
       const result = await window.electron.skills.fetchMarketplace();
-      if (!result.success) {
+      if (!result.success || !result.data) {
         throw new Error(result.error || 'Failed to fetch');
       }
       const json = JSON.parse(result.data);

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -263,6 +263,7 @@ interface IElectronAPI {
       skillId: string,
       config: Record<string, string>
     ) => Promise<{ success: boolean; result?: EmailConnectivityTestResult; error?: string }>;
+    fetchMarketplace: () => Promise<{ success: boolean; data?: string; error?: string }>;
     onChanged: (callback: () => void) => () => void;
   };
   mcp: {


### PR DESCRIPTION
## Summary
Improve Windows NSIS installer observability and upgrade behavior.

This PR makes the Windows installer easier to diagnose by adding more precise timing and progress logs, improving the visible status messaging during installation, and fixing stale old-
directory rename conflicts that could prevent async cleanup from working during upgrades.

It also fixes a renderer type mismatch for `skills.fetchMarketplace` that caused a TypeScript build failure.

## Related Issue
N/A

## Changes Made
- Added millisecond-level timing and phase logging for Windows NSIS installation flow, including custom init, resource extraction, skill backup/restore, and Defender exclusion steps.
- Improved installer UI messaging by keeping early default NSIS status text, then switching to custom status messages when bundled resource extraction begins.
- Fixed stale `$INSTDIR.old*` rename conflicts by using unique old-directory suffixes and async cleanup scheduling so upgrades do not block on recursive deletion.
- Moved Windows Defender exclusion setup before bundled tar extraction to reduce extraction overhead.
- Added structured unpack progress logging for `win-resources.tar` extraction, including per-root summaries and cumulative progress.
- Fixed renderer typings for `window.electron.skills.fetchMarketplace` and guarded against missing marketplace payloads before parsing.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other (please describe):

## Testing
- [x] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [x] Manual testing performed

## Screenshots (if applicable)
- Windows NSIS installer screenshots were used during manual verification of status text and details-pane behavior.
- No renderer UI screenshots included.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes
- [ ] Changes to main process (src/main/)
- [x] Changes to preload script (src/main/preload.ts)
- [x] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes
- Main installer changes are in `scripts/nsis-installer.nsh` and `scripts/unpack-cfmind.cjs`.
- Renderer typing/build fix touches `src/renderer/types/electron.d.ts` and `src/renderer/services/skill.ts`.
- TypeScript verification completed with `npx tsc --noEmit --project tsconfig.json`.
- Windows installer behavior was validated through manual install runs and log inspection (`install-timing.log`, `skill-migrate.log`).
- The NSIS status line now intentionally preserves default early extraction text and only takes over with custom messaging once bundled resource extraction starts.