### PR TITLE
fix(cowork): restart gateway when model image-support config changes

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1981,7 +1981,7 @@ if (!gotTheLock) {
       refreshEndpointsTestMode(getStore());
       const syncResult = await syncOpenClawConfig({
         reason: 'app-config-change',
-        restartGatewayIfRunning: false,
+        restartGatewayIfRunning: true,
       });
       if (!syncResult.success) {
         console.error('[OpenClaw] Failed to sync config after app_config update:', syncResult.error);
@@ -2404,6 +2404,11 @@ if (!gotTheLock) {
       if (data.code !== 0) return { success: false };
       // Cache server model metadata for use in OpenClaw config sync (supportsImage, etc.)
       updateServerModelMetadata(data.data);
+      // Re-sync so the gateway picks up the correct supportsImage values for server models.
+      // The startup sync runs before this IPC call, so the cache was empty then.
+      // restartGatewayIfRunning:true ensures the gateway restarts only when the config
+      // actually changed; the deferred-restart mechanism keeps active sessions safe.
+      syncOpenClawConfig({ reason: 'server-models-updated', restartGatewayIfRunning: true }).catch(() => {});
       return { success: true, models: data.data };
     } catch (e) {
       console.error('[Auth:getModels] Error:', e);


### PR DESCRIPTION
OpenClaw pins its model-capability snapshot at startup; hot-reload does not update it. Two timing gaps caused images to be silently dropped for affected models:

1. Startup sync runs before auth:getModels populates the server-model cache, so subscription models had no supportsImage in the gateway config. Fixed by triggering a re-sync after the cache is filled.

2. Saving custom model settings wrote the correct config file but did not restart the gateway (restartGatewayIfRunning was false), so the new supportsImage value was never picked up. Fixed by setting restartGatewayIfRunning to true; the deferred-restart mechanism keeps active sessions safe.