### PR TITLE
Liuzhq/UI responsive

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1182,11 +1182,11 @@ export const UserMessageItem: React.FC<{
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <div className="max-w-3xl mx-auto">
+      <div className="max-w-4xl min-w-[320px] mx-auto">
         <div className="pl-4 sm:pl-8 md:pl-12">
           <div className="flex items-start gap-3 flex-row-reverse">
             <div className="w-full min-w-0 flex flex-col items-end">
-              <div className="w-fit max-w-[42rem] rounded-2xl px-4 py-2.5 bg-surface text-foreground shadow-subtle">
+              <div className="w-fit max-w-[48rem] rounded-2xl px-4 py-2.5 bg-surface text-foreground shadow-subtle">
                 {message.content?.trim() && (
                   <MarkdownContent
                     content={message.content}
@@ -1334,7 +1334,7 @@ const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ message
 
   return (
     <div className="shrink-0 animate-fade-in px-4">
-      <div className="max-w-3xl mx-auto">
+      <div className="max-w-4xl min-w-[320px] mx-auto">
         <div className="streaming-bar" />
         <div className="py-1">
           <span className="text-xs text-secondary">
@@ -1493,7 +1493,7 @@ export const AssistantTurnBlock: React.FC<{
 
   return (
     <div className="px-4 py-2">
-      <div className="max-w-3xl mx-auto">
+      <div className="max-w-4xl min-w-[320px] mx-auto">
         <div className="flex items-start gap-3">
           <div className="flex-1 min-w-0 px-4 py-3 space-y-3">
             {visibleAssistantItems.map((item, index) => {
@@ -2792,7 +2792,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
       {/* Input Area */}
       <div className="p-4 shrink-0">
-        <div className="max-w-3xl mx-auto">
+        <div className="max-w-4xl min-w-[320px] mx-auto">
           <CoworkPromptInput
             ref={promptInputRef}
             onSubmit={onContinue}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -923,7 +923,7 @@ const ToolCallGroup: React.FC<{
               {toolName}
             </span>
             {toolInputSummary && (
-              <code className="text-xs text-muted font-mono truncate max-w-[400px]">
+              <code className="text-xs text-muted font-mono truncate max-w-full">
                 {toolInputSummary}
               </code>
             )}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1182,11 +1182,11 @@ export const UserMessageItem: React.FC<{
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <div className="max-w-4xl min-w-[320px] mx-auto">
+      <div className="max-w-5xl min-w-[320px] mx-auto">
         <div className="pl-4 sm:pl-8 md:pl-12">
           <div className="flex items-start gap-3 flex-row-reverse">
             <div className="w-full min-w-0 flex flex-col items-end">
-              <div className="w-fit max-w-[48rem] rounded-2xl px-4 py-2.5 bg-surface text-foreground shadow-subtle">
+              <div className="w-fit max-w-[54rem] rounded-2xl px-4 py-2.5 bg-surface text-foreground shadow-subtle">
                 {message.content?.trim() && (
                   <MarkdownContent
                     content={message.content}
@@ -1334,7 +1334,7 @@ const StreamingActivityBar: React.FC<{ messages: CoworkMessage[] }> = ({ message
 
   return (
     <div className="shrink-0 animate-fade-in px-4">
-      <div className="max-w-4xl min-w-[320px] mx-auto">
+      <div className="max-w-5xl min-w-[320px] mx-auto">
         <div className="streaming-bar" />
         <div className="py-1">
           <span className="text-xs text-secondary">
@@ -1493,7 +1493,7 @@ export const AssistantTurnBlock: React.FC<{
 
   return (
     <div className="px-4 py-2">
-      <div className="max-w-4xl min-w-[320px] mx-auto">
+      <div className="max-w-5xl min-w-[320px] mx-auto">
         <div className="flex items-start gap-3">
           <div className="flex-1 min-w-0 px-4 py-3 space-y-3">
             {visibleAssistantItems.map((item, index) => {
@@ -2792,7 +2792,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
       {/* Input Area */}
       <div className="p-4 shrink-0">
-        <div className="max-w-4xl min-w-[320px] mx-auto">
+        <div className="max-w-5xl min-w-[320px] mx-auto">
           <CoworkPromptInput
             ref={promptInputRef}
             onSubmit={onContinue}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -588,7 +588,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
 
       {/* Main Content */}
       <div className="flex-1 overflow-y-auto min-h-0">
-        <div className="max-w-3xl w-full mx-auto px-4 pt-[15vh] pb-8 space-y-10">
+        <div className="max-w-4xl w-full min-w-[320px] mx-auto px-4 pt-[15vh] pb-8 space-y-10">
           {/* Welcome Section */}
           <div className="text-center space-y-5">
             <img src="logo.png" alt="logo" className="w-16 h-16 mx-auto" />

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -588,7 +588,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
 
       {/* Main Content */}
       <div className="flex-1 overflow-y-auto min-h-0">
-        <div className="max-w-3xl mx-auto px-4 py-16 space-y-12">
+        <div className="max-w-3xl w-full mx-auto px-4 pt-[15vh] pb-8 space-y-10">
           {/* Welcome Section */}
           <div className="text-center space-y-5">
             <img src="logo.png" alt="logo" className="w-16 h-16 mx-auto" />

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -588,7 +588,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
 
       {/* Main Content */}
       <div className="flex-1 overflow-y-auto min-h-0">
-        <div className="max-w-4xl w-full min-w-[320px] mx-auto px-4 pt-[15vh] pb-8 space-y-10">
+        <div className="max-w-5xl w-full min-w-[320px] mx-auto px-4 pt-[15vh] pb-8 space-y-10">
           {/* Welcome Section */}
           <div className="text-center space-y-5">
             <img src="logo.png" alt="logo" className="w-16 h-16 mx-auto" />


### PR DESCRIPTION
+ style(cowork): expand tool call summary display width

Remove hardcoded max-w-[400px] on tool input summary; use max-w-full
so the summary fills available container width before truncating.

+ style(cowork): increase content max-width from 896px to 1024px

Replace max-w-4xl with max-w-5xl across homepage and session detail;
scale user message bubble from max-w-[48rem] to max-w-[54rem] proportionally.

+ style(cowork): widen content area and improve homepage layout

- Increase max content width from max-w-3xl (768px) to max-w-4xl (896px)
  across homepage and session detail for better large-screen utilization
- Scale user message bubble from max-w-[42rem] to max-w-[48rem] proportionally
- Add min-w-[320px] safety constraint on all content wrappers
- Replace fixed py-16 with pt-[15vh] pb-8 on homepage to anchor content
  top-edge and prevent jumping when input/action area height changes

+ fix(cowork): anchor home content to fixed top position to prevent layout shift

Replace justify-center with a fixed pt-[15vh] so the content block stays
stable when the prompt input grows or the quick-action panel expands.