### PR TITLE
fix(chat/mcp): prevent stale reply loop and MCP tool abort signal misfire

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -3559,24 +3559,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           return;
         }
 
-        if (isChannel) {
-          canonicalText = extractCurrentTurnAssistantText(history.messages);
-        } else {
-          for (let index = history.messages.length - 1; index >= 0; index -= 1) {
-            const message = history.messages[index];
-            if (!isRecord(message)) continue;
-            const role = typeof message.role === 'string' ? message.role.trim().toLowerCase() : '';
-            if (role !== 'assistant') continue;
-            canonicalText = extractMessageText(message).trim();
-            if (canonicalText && shouldSuppressHeartbeatText('assistant', canonicalText)) {
-              canonicalText = '';
-              continue;
-            }
-            if (canonicalText) {
-              break;
-            }
-          }
-        }
+        // Use turn-aware extraction for ALL session types.
+        // The previous non-channel backward scan could return stale assistant text
+        // from a prior turn when the gateway rejected the current run (empty final).
+        canonicalText = extractCurrentTurnAssistantText(history.messages);
 
         if (canonicalText) {
           break;

--- a/src/main/libs/mcpBridgeServer.ts
+++ b/src/main/libs/mcpBridgeServer.ts
@@ -239,6 +239,13 @@ export class McpBridgeServer {
   }
 
   private async handleMcpExecute(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    // Abort in-flight MCP tool calls when the gateway drops the HTTP connection
+    // (e.g. after chat.abort).  This prevents zombie 60-second MCP timeouts from
+    // keeping the gateway run active and blocking new user messages.
+    const abortController = new AbortController();
+    const onClose = () => abortController.abort();
+    req.on('close', onClose);
+
     try {
       const body = await this.readBody(req);
       const { server, tool, args } = JSON.parse(body) as {
@@ -256,7 +263,7 @@ export class McpBridgeServer {
       }
 
       const t0 = Date.now();
-      const result = await this.mcpManager.callTool(server, tool, args || {});
+      const result = await this.mcpManager.callTool(server, tool, args || {}, { signal: abortController.signal });
       const contentPreview = serializeToolContentForLog(result.content);
       const textPreview = getToolTextPreview(result.content);
       log('INFO', `Execute completed for server="${server}" tool="${tool}" in ${Date.now() - t0}ms with isError=${result.isError}. Result=${contentPreview}`);
@@ -264,16 +271,22 @@ export class McpBridgeServer {
         log('WARN', `Execute completed for server="${server}" tool="${tool}" with transport-style error text but isError=false. Result text="${textPreview}"`);
       }
 
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify(result));
+      if (!res.writableEnded) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(result));
+      }
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
       log('ERROR', `Request handling error: ${errMsg}`);
-      res.writeHead(500, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({
-        content: [{ type: 'text', text: `Bridge error: ${errMsg}` }],
-        isError: true,
-      }));
+      if (!res.writableEnded) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          content: [{ type: 'text', text: `Bridge error: ${errMsg}` }],
+          isError: true,
+        }));
+      }
+    } finally {
+      req.removeListener('close', onClose);
     }
   }
 

--- a/src/main/libs/mcpBridgeServer.ts
+++ b/src/main/libs/mcpBridgeServer.ts
@@ -242,9 +242,20 @@ export class McpBridgeServer {
     // Abort in-flight MCP tool calls when the gateway drops the HTTP connection
     // (e.g. after chat.abort).  This prevents zombie 60-second MCP timeouts from
     // keeping the gateway run active and blocking new user messages.
+    //
+    // Listen on `res` (ServerResponse), NOT `req` (IncomingMessage).
+    // `req` is a Readable stream that emits `close` after the body is consumed
+    // (auto-destroy via nextTick, which runs before the Promise microtask from
+    // readBody), causing the signal to be aborted before callTool even starts.
+    // `res.close` fires when the underlying socket disconnects; we only abort
+    // if the response hasn't been fully sent yet (i.e. a premature disconnect).
     const abortController = new AbortController();
-    const onClose = () => abortController.abort();
-    req.on('close', onClose);
+    const onClose = () => {
+      if (!res.writableFinished) {
+        abortController.abort();
+      }
+    };
+    res.on('close', onClose);
 
     try {
       const body = await this.readBody(req);
@@ -286,7 +297,7 @@ export class McpBridgeServer {
         }));
       }
     } finally {
-      req.removeListener('close', onClose);
+      res.removeListener('close', onClose);
     }
   }
 

--- a/src/main/libs/mcpServerManager.ts
+++ b/src/main/libs/mcpServerManager.ts
@@ -36,6 +36,24 @@ interface ManagedMcpServer {
 
 const MAX_RECENT_STDERR_LINES = 20;
 
+/**
+ * Race a promise against an AbortSignal.  When the signal fires first the
+ * returned promise rejects with an Error whose message is `reason`.
+ * The original promise is NOT cancelled — it keeps running in the background
+ * but its result is discarded.
+ */
+function raceAbortSignal<T>(promise: Promise<T>, signal: AbortSignal, reason: string): Promise<T> {
+  if (signal.aborted) return Promise.reject(new Error(reason));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new Error(reason));
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => { signal.removeEventListener('abort', onAbort); resolve(value); },
+      (err) => { signal.removeEventListener('abort', onAbort); reject(err); },
+    );
+  });
+}
+
 const log = (level: string, msg: string) => {
   const formatted = `[McpBridge:SDK][${level}] ${msg}`;
   if (level === 'ERROR') {
@@ -457,6 +475,7 @@ export class McpServerManager {
     serverName: string,
     toolName: string,
     args: Record<string, unknown>,
+    options?: { signal?: AbortSignal },
   ): Promise<{ content: Array<{ type: string; text?: string }>; isError: boolean }> {
     const server = this.servers.get(serverName);
     if (!server) {
@@ -466,11 +485,28 @@ export class McpServerManager {
       };
     }
 
+    if (options?.signal?.aborted) {
+      return {
+        content: [{ type: 'text', text: 'Tool execution aborted: request cancelled before start' }],
+        isError: true,
+      };
+    }
+
     try {
       const startedAt = Date.now();
       const argsPreview = serializeForLog(args);
       log('INFO', `Calling tool "${toolName}" on server "${serverName}" with arguments ${argsPreview}`);
-      const result = await server.client.callTool({ name: toolName, arguments: args });
+
+      // Race the tool call against the abort signal so that in-flight MCP calls
+      // return immediately when the gateway drops the HTTP connection (e.g. after chat.abort).
+      const toolPromise = server.client.callTool({ name: toolName, arguments: args });
+      let result: Awaited<typeof toolPromise>;
+      if (options?.signal) {
+        result = await raceAbortSignal(toolPromise, options.signal, `Tool "${toolName}" aborted`);
+      } else {
+        result = await toolPromise;
+      }
+
       const content = Array.isArray(result.content)
         ? (result.content as Array<{ type: string; text?: string }>)
         : [{ type: 'text', text: String(result.content) }];


### PR DESCRIPTION
## Summary
- **Stale reply loop**: When a user stops a session while an MCP tool is executing (e.g. 60s timeout), then sends a new message, the gateway rejects the new run and returns an empty final event. `syncFinalAssistantWithHistory` scanned backwards and returned the *previous* turn's stale text. Fixed by unifying all session types to use `extractCurrentTurnAssistantText`, which uses the last user message as a turn boundary.
- **MCP tool abort signal misfire**: The abort signal listened on `req.on('close')` (IncomingMessage/Readable), which fires after the request body is consumed due to auto-destroy. Node.js nextTick-before-microtask ordering caused the signal to be aborted before `callTool` even started, making **every MCP tool call fail with "request cancelled before start" in 0ms**. Fixed by listening on `res.on('close')` with a `!res.writableFinished` guard.

## Test plan
- [ ] Send a message that triggers an MCP tool call (e.g. minimax web_search) — verify the tool executes normally instead of returning 0ms abort
- [ ] While an MCP tool is running, click stop — verify the tool call is aborted promptly (not waiting 60s)
- [ ] After stopping a session mid-MCP-call, send a new message — verify the new response is fresh, not a repeat of the previous turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)