### PR TITLE
fix(test): update stale tests for LmStudio, Telegram multi-instance, and backup manager

### DIFF
--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -82,9 +82,11 @@ describe('OpenClawConfigSync runtime config output', () => {
         skipMissedJobs: false,
       }),
       isEnterprise: () => false,
-      getTelegramOpenClawConfig: () => ({
+      getTelegramInstances: () => [{
         enabled: true,
         botToken: 'tg-token',
+        instanceId: 'tg-inst-001',
+        instanceName: 'Test Telegram',
         dmPolicy: 'open',
         allowFrom: ['*'],
         groupPolicy: 'allowlist',
@@ -99,7 +101,7 @@ describe('OpenClawConfigSync runtime config output', () => {
         webhookUrl: '',
         webhookSecret: '',
         debug: false,
-      }),
+      }],
       getDiscordOpenClawConfig: () => null,
       getDingTalkInstances: () => [],
       getFeishuInstances: () => [],
@@ -119,7 +121,9 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(result.ok).toBe(true);
 
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-    expect(config.channels.telegram.streaming).toEqual({ mode: 'off' });
+    const accounts = config.channels.telegram.accounts;
+    const accountKey = Object.keys(accounts)[0];
+    expect(accounts[accountKey].streaming).toEqual({ mode: 'off' });
   });
 
   test('does not inject unsupported _agentBinding channel metadata and requests restart when bindings change', async () => {

--- a/src/main/libs/sqliteBackup/sqliteBackupManager.test.ts
+++ b/src/main/libs/sqliteBackup/sqliteBackupManager.test.ts
@@ -72,10 +72,10 @@ test('retainLatestSnapshots keeps only the newest successful snapshot', () => {
 test('buildBackupPaths creates manifest snapshots and quarantine locations under userData', () => {
   const userDataPath = '/tmp/lobsterai-user-data';
   const paths = buildSqliteBackupPaths(userDataPath);
-  expect(paths.backupDir).toContain('backups/sqlite');
-  expect(paths.snapshotsDir).toContain('backups/sqlite/snapshots');
-  expect(paths.quarantineDir).toContain('backups/sqlite/quarantine');
-  expect(paths.manifestPath).toContain('backups/sqlite/manifest.json');
+  expect(paths.backupDir).toContain(path.join('backups', 'sqlite'));
+  expect(paths.snapshotsDir).toContain(path.join('backups', 'sqlite', 'snapshots'));
+  expect(paths.quarantineDir).toContain(path.join('backups', 'sqlite', 'quarantine'));
+  expect(paths.manifestPath).toContain(path.join('backups', 'sqlite', 'manifest.json'));
 });
 
 test('createBackup writes a snapshot and a manifest record', async () => {
@@ -161,6 +161,8 @@ test('shouldCreatePeriodicBackup returns true only when the latest snapshot is o
 
   const paths = manager.getPaths();
   fs.mkdirSync(paths.backupDir, { recursive: true });
+  fs.mkdirSync(paths.snapshotsDir, { recursive: true });
+  fs.writeFileSync(path.join(paths.snapshotsDir, SQLITE_BACKUP_FILE_NAME), '');
   fs.writeFileSync(
     paths.manifestPath,
     JSON.stringify({

--- a/src/renderer/config.test.ts
+++ b/src/renderer/config.test.ts
@@ -1,8 +1,9 @@
-import { test, expect } from 'vitest';
+import { expect, test } from 'vitest';
+
 import {
-  isCustomProvider,
   getCustomProviderDefaultName,
   getProviderDisplayName,
+  isCustomProvider,
 } from './config';
 
 test('isCustomProvider: custom_0 is custom', () => {

--- a/src/renderer/config.test.ts
+++ b/src/renderer/config.test.ts
@@ -46,11 +46,11 @@ test('getCustomProviderDefaultName: custom_42 -> Custom42', () => {
 });
 
 test('getProviderDisplayName: built-in provider capitalizes first letter', () => {
-  expect(getProviderDisplayName('openai')).toBe('Openai');
+  expect(getProviderDisplayName('openai')).toBe('OpenAI');
 });
 
 test('getProviderDisplayName: built-in provider with no config', () => {
-  expect(getProviderDisplayName('deepseek')).toBe('Deepseek');
+  expect(getProviderDisplayName('deepseek')).toBe('DeepSeek');
 });
 
 test('getProviderDisplayName: custom provider without config uses default name', () => {

--- a/src/shared/providers/constants.test.ts
+++ b/src/shared/providers/constants.test.ts
@@ -16,9 +16,9 @@ describe('ProviderName constants', () => {
 });
 
 describe('ProviderRegistry', () => {
-  test('providerIds returns 16 providers (no custom)', () => {
+  test('providerIds returns 17 providers (no custom)', () => {
     const ids = ProviderRegistry.providerIds;
-    expect(ids.length).toBe(16);
+    expect(ids.length).toBe(17);
     expect(ids).not.toContain(ProviderName.Custom);
     expect(ids).not.toContain(ProviderName.LobsteraiServer);
   });
@@ -49,9 +49,9 @@ describe('ProviderRegistry', () => {
     expect(ProviderRegistry.supportsCodingPlan('unknown')).toBe(false);
   });
 
-  test('idsByRegion china returns 11 providers', () => {
+  test('idsByRegion china returns 12 providers', () => {
     const china = ProviderRegistry.idsByRegion('china');
-    expect(china.length).toBe(11);
+    expect(china.length).toBe(12);
     expect(china).toContain(ProviderName.DeepSeek);
     expect(china).toContain(ProviderName.Qianfan);
     expect(china).toContain(ProviderName.Ollama);
@@ -75,9 +75,9 @@ describe('ProviderRegistry', () => {
     expect(en[2]).toBe(ProviderName.Gemini);
   });
 
-  test('idsForEnLocale puts ollama at end', () => {
+  test('idsForEnLocale puts lm-studio at end', () => {
     const en = ProviderRegistry.idsForEnLocale();
-    expect(en[en.length - 1]).toBe(ProviderName.Ollama);
+    expect(en[en.length - 1]).toBe(ProviderName.LmStudio);
     expect(en).not.toContain(ProviderName.Custom);
   });
 


### PR DESCRIPTION
## Summary
- **config.test**: `getProviderDisplayName` now returns `def.label` from registry (e.g. `OpenAI`, `DeepSeek`) — update expectations to match
- **constants.test**: bump provider counts for new LM Studio provider (16→17 total, 11→12 china), last locale item is now `LmStudio`
- **sqliteBackupManager.test**: use `path.join` for cross-platform path assertions; create actual snapshot file so `shouldCreatePeriodicBackup` file-existence check passes
- **openclawConfigSync.runtime.test**: migrate from deprecated `getTelegramOpenClawConfig` to `getTelegramInstances` multi-instance API, access streaming via `accounts[key]`

All 8 failures are stale/incomplete tests — no source code bugs found.

## Test plan
- [x] `npm test` passes (52 files, 655 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)