### PR TITLE
fix(cowork): restore sharp native binding and add cfmind node_modules to NODE_PATH

### DIFF
--- a/scripts/prune-openclaw-runtime.cjs
+++ b/scripts/prune-openclaw-runtime.cjs
@@ -97,7 +97,9 @@ const PACKAGES_TO_STUB = [
   '@napi-rs',
   'pdfjs-dist',
   '@matrix-org',
-  '@img'
+  // NOTE: @img is intentionally NOT stubbed — it contains platform-specific sharp
+  // native bindings (e.g. @img/sharp-win32-x64) required by openclaw's image-ops
+  // module and by exec-tool scripts that use require('sharp').
 ];
 
 const GENERIC_STUB_INDEX_CJS = `// Stub (CJS): this package is not needed for headless gateway operation.

--- a/src/main/libs/coworkUtil.ts
+++ b/src/main/libs/coworkUtil.ts
@@ -1,12 +1,10 @@
-import { app } from 'electron';
 import { execSync, spawnSync } from 'child_process';
-import { existsSync, mkdirSync, writeFileSync, chmodSync, statSync, readdirSync } from 'fs';
+import { app } from 'electron';
+import { chmodSync, existsSync, mkdirSync, readdirSync, realpathSync, statSync, writeFileSync } from 'fs';
 import { delimiter, dirname, join } from 'path';
+
 import { buildEnvForConfig, getCurrentApiConfig, resolveCurrentApiConfig, resolveRawApiConfig } from './claudeSettings';
-import type { OpenAICompatProxyTarget } from './coworkOpenAICompatProxy';
 import { coworkLog } from './coworkLogger';
-import { appendPythonRuntimeToEnv } from './pythonRuntime';
-import { isSystemProxyEnabled, resolveSystemProxyUrl } from './systemProxy';
 import {
   buildAnthropicMessagesUrl,
   buildGeminiGenerateContentUrl,
@@ -15,6 +13,9 @@ import {
   extractTextFromAnthropicResponse,
   extractTextFromGeminiResponse,
 } from './coworkModelApi';
+import type { OpenAICompatProxyTarget } from './coworkOpenAICompatProxy';
+import { appendPythonRuntimeToEnv } from './pythonRuntime';
+import { isSystemProxyEnabled, resolveSystemProxyUrl } from './systemProxy';
 
 function appendEnvPath(current: string | undefined, additions: string[]): string | undefined {
   const items = new Set<string>();
@@ -1112,6 +1113,26 @@ function applyPackagedEnvOverrides(env: Record<string, string | undefined>): voi
       env.PATH = [devBinDir, env.PATH].filter(Boolean).join(delimiter);
       coworkLog('INFO', 'applyPackagedEnvOverrides', `Dev mode: prepended node_modules/.bin to PATH: ${devBinDir}`);
     }
+
+    // In dev mode, add openclaw runtime's node_modules to NODE_PATH so exec tool
+    // can access shared packages like sharp.
+    const devRuntimeNodeModules = (() => {
+      const candidates = [
+        join(app.getAppPath(), 'vendor', 'openclaw-runtime', 'current', 'node_modules'),
+        join(process.cwd(), 'vendor', 'openclaw-runtime', 'current', 'node_modules'),
+      ];
+      for (const c of candidates) {
+        try {
+          const resolved = realpathSync(c);
+          if (existsSync(resolved)) return resolved;
+        } catch { /* symlink target missing — skip */ }
+      }
+      return null;
+    })();
+    if (devRuntimeNodeModules) {
+      env.NODE_PATH = appendEnvPath(env.NODE_PATH, [devRuntimeNodeModules]);
+      coworkLog('INFO', 'applyPackagedEnvOverrides', `Dev mode: added openclaw runtime node_modules to NODE_PATH: ${devRuntimeNodeModules}`);
+    }
     return;
   }
 
@@ -1186,6 +1207,7 @@ function applyPackagedEnvOverrides(env: Record<string, string | undefined>): voi
   const nodePaths = [
     join(resourcesPath, 'app.asar', 'node_modules'),
     join(resourcesPath, 'app.asar.unpacked', 'node_modules'),
+    join(resourcesPath, 'cfmind', 'node_modules'),
   ].filter((nodePath) => existsSync(nodePath));
 
   if (nodePaths.length > 0) {


### PR DESCRIPTION
## Summary
- Remove `@img` from `PACKAGES_TO_STUB` in openclaw runtime pruning script, restoring the real `@img/sharp-win32-x64` native binding that was stubbed in #1685
- Add `cfmind/node_modules` to `NODE_PATH` in packaged mode so exec-tool scripts can `require('sharp')`
- Add openclaw-runtime `node_modules` to `NODE_PATH` in dev mode (with symlink resolution)

## Background
PR #1685 stubbed `@img` to reduce package size, but this broke two paths:
1. **exec tool**: AI agent writes Node scripts that `require('sharp')` for image processing → `Cannot find module` because NODE_PATH didn't include cfmind's node_modules
2. **openclaw image-ops**: internal `resizeToJpeg()`, `resizeToPng()`, `convertHeicToJpeg()` call `await import("sharp")` → sharp finds the `@img` stub instead of the real native binding → throws on Windows (no sips fallback)

## Test plan
- [x] `npx vitest run tests/pruneOpenClawRuntime.test.ts` — passed
- [x] `npx vitest run tests/openclawRuntimePackaging.test.ts` — passed
- [x] `npx eslint src/main/libs/coworkUtil.ts` — passed
- [ ] Dev mode: run LobsterAI, chat `通过 exec 工具调用 node -e "require('sharp')"` → should succeed
- [ ] Packaged build: verify sharp loads in exec environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)