### PR TITLE
fix(cowork): preserve draft input and attachments when switching sessions

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -305,7 +305,8 @@ const App: React.FC = () => {
   }, []);
 
   const handleNewChat = useCallback(() => {
-    const shouldClearInput = mainView === 'cowork' || !!currentSessionId;
+    // Only clear when already on home (no session) — preserve __home__ draft when returning from a session
+    const shouldClearInput = mainView === 'cowork' && !currentSessionId;
     coworkService.clearSession();
     dispatch(clearSelection());
     setMainView('cowork');

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -236,6 +236,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       if (shouldClear) {
         setValue('');
         dispatch(clearDraftAttachments(draftKey));
+        setImageVisionHint(false);
       }
       requestAnimationFrame(() => {
         textareaRef.current?.focus();
@@ -257,8 +258,11 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   // Sync value from draft when sessionId changes
   useEffect(() => {
     setValue(draftPrompt);
+    // Re-derive imageVisionHint from the new session's draft attachments
+    const hasImageWithoutVision = !modelSupportsImage && attachments.some(a => a.isImage || isImagePath(a.path));
+    setImageVisionHint(hasImageWithoutVision);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [draftKey]); // intentionally omit draftPrompt to only trigger on session switch
+  }, [draftKey]); // intentionally omit other deps to only trigger on session switch
 
   useEffect(() => {
     if (value !== draftPrompt) {

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -439,17 +439,19 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
 
   useEffect(() => {
     const handleNewSession = () => {
+      // Only clear when already on home (no session) — preserve __home__ draft when returning from a session
+      const shouldClear = !currentSession;
       dispatch(clearCurrentSession());
       dispatch(clearSelection());
       window.dispatchEvent(new CustomEvent('cowork:focus-input', {
-        detail: { clear: true },
+        detail: { clear: shouldClear },
       }));
     };
     window.addEventListener('cowork:shortcut:new-session', handleNewSession);
     return () => {
       window.removeEventListener('cowork:shortcut:new-session', handleNewSession);
     };
-  }, [dispatch]);
+  }, [dispatch, currentSession]);
 
   useEffect(() => {
     if (!isOpenClawEngine) return;


### PR DESCRIPTION
## Summary
- Fix draft text and attachments being cleared when returning to home screen from a session via "New Chat" button or keyboard shortcut
- Change `shouldClearInput` logic: only clear when already on home screen (user explicitly wants a fresh start), not when navigating back from a session
- Sync `imageVisionHint` state per session on switch, consistent with draft text and attachments behavior

## Test plan
- [ ] 主页输入内容 + 添加附件 → 切换到其他对话 → 点"新建对话"回来 → 输入内容、附件、image 警告应全部保留
- [ ] 已在主页时再点"新建对话" → 应清除所有草稿
- [ ] 快捷键新建会话时，同样验证上述两种场景
- [ ] 添加图片附件（模型不支持 vision）→ 切换会话再切回 → image 警告应正确显示/隐藏

🤖 Generated with [Claude Code](https://claude.com/claude-code)