### PR TITLE
style(cowork): constrain homepage input width to 768px

### DIFF
--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -603,7 +603,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
           </div>
 
           {/* Prompt Input Area - Large version with folder selector */}
-          <div className="space-y-3">
+          <div className="max-w-3xl mx-auto w-full space-y-3">
             <div className="shadow-glow-accent rounded-2xl">
               <CoworkPromptInput
                 ref={promptInputRef}


### PR DESCRIPTION
Wrap the homepage prompt input in max-w-3xl so it stays narrower
than the 1024px content area on large screens.
