### PR TITLE
fix(skills): remove ~/.claude/skills from discovery roots to match runtime path

### DIFF
--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -253,8 +253,6 @@ const SKILL_FILE_NAME = 'SKILL.md';
 const SKILLS_CONFIG_FILE = 'skills.config.json';
 const SKILL_STATE_KEY = 'skills_state';
 const WATCH_DEBOUNCE_MS = 250;
-const CLAUDE_SKILLS_DIR_NAME = '.claude';
-const CLAUDE_SKILLS_SUBDIR = 'skills';
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
@@ -2218,21 +2216,11 @@ export class SkillManager {
     const resolvedPrimary = primaryRoot ?? this.getSkillsRoot();
     const roots: string[] = [resolvedPrimary];
 
-    const claudeSkillsRoot = this.getClaudeSkillsRoot();
-    if (claudeSkillsRoot && fs.existsSync(claudeSkillsRoot)) {
-      roots.push(claudeSkillsRoot);
-    }
-
     const appRoot = this.getBundledSkillsRoot();
     if (appRoot !== resolvedPrimary && fs.existsSync(appRoot)) {
       roots.push(appRoot);
     }
     return roots;
-  }
-
-  private getClaudeSkillsRoot(): string | null {
-    const homeDir = app.getPath('home');
-    return path.join(homeDir, CLAUDE_SKILLS_DIR_NAME, CLAUDE_SKILLS_SUBDIR);
   }
 
   private getBundledSkillsRoot(): string {

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -10,7 +10,7 @@ import { cpRecursiveSync } from './fsCompat';
 import { t } from './i18n';
 import { getElectronNodeRuntimePath } from './libs/coworkUtil';
 import { appendPythonRuntimeToEnv } from './libs/pythonRuntime';
-import { mergeReports,scanMultipleSkillDirs, scanSkillSecurity } from './libs/skillSecurity/skillSecurityScanner';
+import { mergeReports,scanMultipleSkillDirs } from './libs/skillSecurity/skillSecurityScanner';
 import type { SecurityReportAction,SkillSecurityReport } from './libs/skillSecurity/skillSecurityTypes';
 import { SqliteStore } from './sqliteStore';
 
@@ -1042,12 +1042,7 @@ const downloadNpmPackage = async (spec: string, tempRoot: string): Promise<strin
 
   // Use tar to extract (Node.js built-in zlib + tar via npm's own bundled tar)
   const tarExtract = await new Promise<{ code: number; stderr: string }>((resolve) => {
-    const tarCommand = npmCliJs ? electronPath : (process.platform === 'win32' ? 'npm.cmd' : 'npm');
-    const tarArgs = npmCliJs
-      ? [npmCliJs, 'exec', '--', 'tar', 'xzf', tgzPath, '-C', extractDir]
-      : ['exec', '--', 'tar', 'xzf', tgzPath, '-C', extractDir];
-
-    // Try system tar first (available on all platforms including Windows 10+)
+    // Use system tar (available on all platforms including Windows 10+)
     const child = spawn('tar', ['xzf', tgzPath, '-C', extractDir], {
       windowsHide: true,
       stdio: ['ignore', 'ignore', 'pipe'],


### PR DESCRIPTION
## Summary
- Remove `~/.claude/skills` from skill discovery roots in `skillManager.ts`
- Skills from that path were shown in Agent config UI but unavailable at OpenClaw runtime (which only uses `userData/SKILLs`), causing "skill not found" errors
- Now UI discovery and runtime resolution use the same paths, eliminating the mismatch

## Test plan
- [ ] Install a skill into `~/.claude/skills` only — verify it does **not** appear in Agent config UI
- [ ] Install a skill into `AppData/Roaming/LobsterAI/SKILLs` — verify it appears in UI and works at runtime
- [ ] Verify bundled skills still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)