### PR TITLE
style(cowork): align quick actions width with homepage input box

### DIFF
--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -624,7 +624,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
           </div>
 
           {/* Quick Actions */}
-          <div className="space-y-4">
+          <div className="max-w-3xl mx-auto w-full space-y-4">
             {selectedAction ? (
               <PromptPanel
                 action={selectedAction}


### PR DESCRIPTION
Add max-w-3xl mx-auto to the quick actions container so the action buttons and expanded prompt panel stay within the same 768px bound as the input box.