### PR TITLE
fix(cowork): sync session model so agent reports current model correctly

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -704,6 +704,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private readonly confirmationModeBySession = new Map<string, 'modal' | 'text'>();
   private readonly bridgedSessions = new Set<string>();
   private readonly lastSystemPromptBySession = new Map<string, string>();
+  private readonly lastPatchedModelBySession = new Map<string, string>();
   private readonly gatewayHistoryCountBySession = new Map<string, number>();
   private readonly latestTurnTokenBySession = new Map<string, number>();
 
@@ -1347,6 +1348,19 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     const runId = randomUUID();
     const turnToken = this.nextTurnToken(sessionId);
+
+    const agent = this.store.getAgent(agentId);
+    const currentModel = session.modelOverride || agent?.model || '';
+    if (currentModel && currentModel !== this.lastPatchedModelBySession.get(sessionId)) {
+      try {
+        const client = this.requireGatewayClient();
+        await client.request('sessions.patch', { key: sessionKey, model: currentModel });
+        this.lastPatchedModelBySession.set(sessionId, currentModel);
+      } catch (error) {
+        console.warn('[OpenClawRuntime] Failed to patch session model, will retry on next turn:', error);
+      }
+    }
+
     const outboundMessage = await this.buildOutboundPrompt(
       sessionId,
       prompt,
@@ -1458,11 +1472,18 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       this.lastSystemPromptBySession.delete(sessionId);
     }
 
+    const session = this.store.getSession(sessionId);
+    const agent = agentId ? this.store.getAgent(agentId) : null;
+    const currentModel = session?.modelOverride || agent?.model || '';
+
     const sections: string[] = [];
     if (shouldInjectSystemPrompt) {
       sections.push(this.buildSystemPromptPrefix(normalizedSystemPrompt));
     }
     sections.push(buildOpenClawLocalTimeContextPrompt());
+    if (currentModel) {
+      sections.push(`[Session info]\nCurrent model: ${currentModel}`);
+    }
 
     if (this.bridgedSessions.has(sessionId)) {
       if (prompt.trim()) {
@@ -1487,7 +1508,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     this.bridgedSessions.add(sessionId);
 
     if (!hasHistory) {
-      const session = this.store.getSession(sessionId);
       if (session) {
         const bridgePrefix = this.buildBridgePrefix(session.messages, prompt);
         if (bridgePrefix) {
@@ -4097,6 +4117,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     this.bridgedSessions.delete(sessionId);
     this.confirmationModeBySession.delete(sessionId);
     this.manuallyStoppedSessions.delete(sessionId);
+    this.lastPatchedModelBySession.delete(sessionId);
 
     // Propagate to channel session sync
     if (this.channelSessionSync) {


### PR DESCRIPTION
OpenClaw bakes the model name into the session's Runtime system prompt at
creation time. When the user switches models mid-session, the agent was still
reading the stale name from there.

Two-layer fix in openclawRuntimeAdapter.ts:
- Call sessions.patch RPC before each chat.send to set the session-level model
  override; a lastPatchedModelBySession map skips the RPC when the model is
  unchanged.
- Inject "[Session info]\nCurrent model: X" per turn in buildOutboundPrompt,
  matching the existing time-context pattern, so the agent always has an
  authoritative in-context fact that overrides the stale Runtime section.
