### PR TITLE
fix(security): 脱敏主进程与 IM 模块的敏感日志

### DIFF
--- a/src/main/im/dingtalkMediaParser.ts
+++ b/src/main/im/dingtalkMediaParser.ts
@@ -74,15 +74,11 @@ export function parseMediaMarkers(text: string): MediaMarker[] {
   const markers: MediaMarker[] = [];
   const processedPaths = new Set<string>();
 
-  console.log(`[DingTalk MediaParser] 开始解析媒体标记, 文本长度: ${text.length}`);
-
   // 1. 解析 Markdown 图片 ![alt](path)
   for (const match of text.matchAll(MARKDOWN_IMAGE_RE)) {
     const [fullMatch, altText, rawPath] = match;
     const path = cleanPath(rawPath);
-    // 使用 alt 文本作为文件名（如果有的话），否则从路径提取
     const name = altText?.trim() || undefined;
-    console.log(`[DingTalk MediaParser] 发现 Markdown 图片:`, JSON.stringify({ rawPath, cleanedPath: path, name, fullMatch }));
     if (!processedPaths.has(path)) {
       processedPaths.add(path);
       markers.push({
@@ -99,9 +95,7 @@ export function parseMediaMarkers(text: string): MediaMarker[] {
     const [fullMatch, linkText, rawPath] = match;
     const path = cleanPath(rawPath);
     const mediaType = getMediaTypeByExtension(path);
-    // 使用链接文本作为文件名（如果有的话）
     const name = linkText?.trim() || undefined;
-    console.log(`[DingTalk MediaParser] 发现 Markdown 链接:`, JSON.stringify({ rawPath, cleanedPath: path, mediaType, name, fullMatch }));
     if (mediaType && !processedPaths.has(path)) {
       processedPaths.add(path);
       markers.push({
@@ -117,7 +111,6 @@ export function parseMediaMarkers(text: string): MediaMarker[] {
   for (const match of text.matchAll(BARE_IMAGE_PATH_RE)) {
     const [fullMatch, rawPath] = match;
     const path = cleanPath(rawPath.trim());
-    console.log(`[DingTalk MediaParser] 发现裸图片路径:`, JSON.stringify({ rawPath, cleanedPath: path, fullMatch: fullMatch.trim() }));
     if (!processedPaths.has(path)) {
       processedPaths.add(path);
       markers.push({
@@ -133,7 +126,6 @@ export function parseMediaMarkers(text: string): MediaMarker[] {
     const [fullMatch, rawPath] = match;
     const path = cleanPath(rawPath.trim());
     const mediaType = getMediaTypeByExtension(path);
-    console.log(`[DingTalk MediaParser] 发现裸音视频路径:`, JSON.stringify({ rawPath, cleanedPath: path, mediaType, fullMatch: fullMatch.trim() }));
     if (mediaType && !processedPaths.has(path)) {
       processedPaths.add(path);
       markers.push({
@@ -148,7 +140,6 @@ export function parseMediaMarkers(text: string): MediaMarker[] {
   for (const match of text.matchAll(BARE_FILE_PATH_RE)) {
     const [fullMatch, rawPath] = match;
     const path = cleanPath(rawPath.trim());
-    console.log(`[DingTalk MediaParser] 发现裸文件路径:`, JSON.stringify({ rawPath, cleanedPath: path, fullMatch: fullMatch.trim() }));
     if (!processedPaths.has(path)) {
       processedPaths.add(path);
       markers.push({
@@ -163,7 +154,6 @@ export function parseMediaMarkers(text: string): MediaMarker[] {
   for (const match of text.matchAll(VIDEO_MARKER_RE)) {
     try {
       const info = JSON.parse(match[1]);
-      console.log(`[DingTalk MediaParser] 发现视频标记:`, JSON.stringify({ info, fullMatch: match[0] }));
       if (info.path && !processedPaths.has(info.path)) {
         processedPaths.add(info.path);
         markers.push({
@@ -174,7 +164,7 @@ export function parseMediaMarkers(text: string): MediaMarker[] {
         });
       }
     } catch (e) {
-      console.warn(`[DingTalk MediaParser] 解析视频标记失败:`, match[0], e);
+      console.warn('[DingTalkMediaParser] failed to parse video marker:', e);
     }
   }
 
@@ -182,7 +172,6 @@ export function parseMediaMarkers(text: string): MediaMarker[] {
   for (const match of text.matchAll(AUDIO_MARKER_RE)) {
     try {
       const info = JSON.parse(match[1]);
-      console.log(`[DingTalk MediaParser] 发现音频标记:`, JSON.stringify({ info, fullMatch: match[0] }));
       if (info.path && !processedPaths.has(info.path)) {
         processedPaths.add(info.path);
         markers.push({
@@ -192,7 +181,7 @@ export function parseMediaMarkers(text: string): MediaMarker[] {
         });
       }
     } catch (e) {
-      console.warn(`[DingTalk MediaParser] 解析音频标记失败:`, match[0], e);
+      console.warn('[DingTalkMediaParser] failed to parse audio marker:', e);
     }
   }
 
@@ -200,7 +189,6 @@ export function parseMediaMarkers(text: string): MediaMarker[] {
   for (const match of text.matchAll(FILE_MARKER_RE)) {
     try {
       const info = JSON.parse(match[1]);
-      console.log(`[DingTalk MediaParser] 发现文件标记:`, JSON.stringify({ info, fullMatch: match[0] }));
       if (info.path && !processedPaths.has(info.path)) {
         processedPaths.add(info.path);
         markers.push({
@@ -211,11 +199,13 @@ export function parseMediaMarkers(text: string): MediaMarker[] {
         });
       }
     } catch (e) {
-      console.warn(`[DingTalk MediaParser] 解析文件标记失败:`, match[0], e);
+      console.warn('[DingTalkMediaParser] failed to parse file marker:', e);
     }
   }
 
-  console.log(`[DingTalk MediaParser] 解析完成, 共发现 ${markers.length} 个媒体标记:`, JSON.stringify(markers, null, 2));
+  if (markers.length > 0) {
+    console.debug(`[DingTalkMediaParser] parsed ${markers.length} media marker(s) from ${text.length} chars`);
+  }
 
   return markers;
 }

--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -227,17 +227,12 @@ export class IMCoworkHandler extends EventEmitter {
       console.warn('[IMCoworkHandler] Skills auto-routing prompt missing for current IM turn');
     }
 
-    // 打印完整的输入消息日志
-    console.log(`[IMCoworkHandler] 处理消息:`, JSON.stringify({
-      platform: message.platform,
-      conversationId: message.conversationId,
-      coworkSessionId,
-      isActive,
-      originalContent: message.content,
-      formattedContent,
-      attachments: message.attachments,
-      hasAvailableSkills,
-    }, null, 2));
+    console.log(
+      `[IMCoworkHandler] dispatching ${message.platform} message to cowork session ${coworkSessionId} ` +
+      `(active=${isActive}, contentChars=${message.content?.length ?? 0}, ` +
+      `formattedChars=${formattedContent.length}, attachments=${message.attachments?.length ?? 0}, ` +
+      `hasSkills=${hasAvailableSkills})`,
+    );
 
     const onSessionStartError = (error: unknown) => {
       this.rejectAccumulator(
@@ -857,14 +852,12 @@ export class IMCoworkHandler extends EventEmitter {
       ? this.formatReplyRaw(messages)
       : this.formatReply(sessionId, messages);
 
-    console.log(`[IMCoworkHandler] 会话完成:`, JSON.stringify({
-      sessionId,
-      messageCount: messages.length,
-      replyLength: replyText.length,
-      reply: replyText,
-      backgroundDelivery: accumulator.backgroundDelivery ?? null,
-      usedStoreMessages: storeMessages.length > 0,
-    }, null, 2));
+    console.log(
+      `[IMCoworkHandler] session ${sessionId} completed ` +
+      `(messages=${messages.length}, replyChars=${replyText.length}, ` +
+      `background=${Boolean(accumulator.backgroundDelivery)}, ` +
+      `usedStoreMessages=${storeMessages.length > 0})`,
+    );
 
     this.cleanupAccumulator(sessionId);
 

--- a/src/main/im/qqMediaDownload.ts
+++ b/src/main/im/qqMediaDownload.ts
@@ -2,9 +2,10 @@
  * QQ Media Download Utilities
  * QQ 媒体下载工具函数（接收端）
  */
+import { app } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
-import { app } from 'electron';
+
 import { fetchWithSystemProxy } from './http';
 import type { IMMediaType } from './types';
 
@@ -119,22 +120,18 @@ export async function downloadQQAttachment(
 ): Promise<{ localPath: string; fileSize: number; mimeType: string } | null> {
   try {
     const mimeType = inferMimeType(type, fileName);
-    console.log(`[QQ Media] 下载附件:`, JSON.stringify({
-      type,
-      mimeType,
-      fileName,
-    }));
+    console.debug(`[QQMedia] downloading ${type} attachment (mime=${mimeType})`);
 
     const response = await fetchWithSystemProxy(url);
     if (!response.ok) {
-      console.error(`[QQ Media] 下载失败: HTTP ${response.status}`);
+      console.error(`[QQMedia] download failed with status ${response.status}`);
       return null;
     }
 
     const buffer = Buffer.from(await response.arrayBuffer());
 
     if (buffer.length > MAX_FILE_SIZE) {
-      console.warn(`[QQ Media] 文件过大: ${(buffer.length / 1024 / 1024).toFixed(1)}MB (限制: 25MB)`);
+      console.warn(`[QQMedia] attachment too large: ${(buffer.length / 1024 / 1024).toFixed(1)}MB (limit 25MB)`);
       return null;
     }
 
@@ -151,7 +148,7 @@ export async function downloadQQAttachment(
 
     fs.writeFileSync(localPath, buffer);
 
-    console.log(`[QQ Media] 下载成功: ${localFileName} (${(buffer.length / 1024).toFixed(1)} KB)`);
+    console.log(`[QQMedia] saved attachment ${localFileName} (${(buffer.length / 1024).toFixed(1)} KB)`);
 
     return {
       localPath,
@@ -159,7 +156,7 @@ export async function downloadQQAttachment(
       mimeType,
     };
   } catch (error: any) {
-    console.error(`[QQ Media] 下载失败: ${error.message}`);
+    console.error('[QQMedia] download failed:', error?.message ?? error);
     return null;
   }
 }
@@ -190,14 +187,14 @@ export function cleanupOldQQMediaFiles(maxAgeDays: number = 7): void {
           cleanedCount++;
         }
       } catch (err: any) {
-        console.warn(`[QQ Media] 清理文件失败 ${file}: ${err.message}`);
+        console.warn(`[QQMedia] failed to clean file ${file}:`, err?.message ?? err);
       }
     }
 
     if (cleanedCount > 0) {
-      console.log(`[QQ Media] 清理了 ${cleanedCount} 个过期文件`);
+      console.log(`[QQMedia] cleaned up ${cleanedCount} expired file(s)`);
     }
   } catch (error: any) {
-    console.warn(`[QQ Media] 清理错误: ${error.message}`);
+    console.warn('[QQMedia] cleanup failed:', error?.message ?? error);
   }
 }

--- a/src/main/logSanitize.test.ts
+++ b/src/main/logSanitize.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest';
+
+import { redactHeadersForLog, sanitizeUrlForLog } from './logSanitize';
+
+describe('sanitizeUrlForLog', () => {
+  test('strips query string from valid URL', () => {
+    expect(sanitizeUrlForLog('https://api.example.com/v1/foo?token=secret')).toBe(
+      'https://api.example.com/v1/foo',
+    );
+  });
+
+  test('strips fragment from valid URL', () => {
+    expect(sanitizeUrlForLog('https://api.example.com/v1/foo#section')).toBe(
+      'https://api.example.com/v1/foo',
+    );
+  });
+
+  test('preserves origin and pathname', () => {
+    expect(sanitizeUrlForLog('https://api.example.com:8443/v1/foo/bar')).toBe(
+      'https://api.example.com:8443/v1/foo/bar',
+    );
+  });
+
+  test('handles deep-link style URLs without losing scheme', () => {
+    expect(sanitizeUrlForLog('lobsterai://auth/callback?code=abc')).toBe(
+      'lobsterai://auth/callback',
+    );
+  });
+
+  test('returns sentinel for empty input', () => {
+    expect(sanitizeUrlForLog('')).toBe('<empty-url>');
+    expect(sanitizeUrlForLog(undefined as unknown as string)).toBe('<empty-url>');
+  });
+
+  test('falls back gracefully for malformed URLs', () => {
+    expect(sanitizeUrlForLog('not a url?token=x')).toBe('not a url');
+  });
+
+  test('keeps non-special schemes intact', () => {
+    expect(sanitizeUrlForLog('mailto:foo@example.com?subject=hi')).toBe('mailto:foo@example.com');
+    expect(sanitizeUrlForLog('ws://srv.example.com:8080/path?token=secret')).toBe(
+      'ws://srv.example.com:8080/path',
+    );
+  });
+});
+
+describe('redactHeadersForLog', () => {
+  test('redacts Authorization header regardless of case', () => {
+    const out = redactHeadersForLog({
+      Authorization: 'Bearer abc',
+      'content-type': 'application/json',
+    });
+    expect(out.Authorization).toBe('***');
+    expect(out['content-type']).toBe('application/json');
+  });
+
+  test('redacts API key style headers', () => {
+    const out = redactHeadersForLog({
+      'x-api-key': 'sk-123',
+      'X-Anthropic-Api-Key': 'sk-anthropic',
+      'x-openai-api-key': 'sk-openai',
+      'X-Goog-Api-Key': 'sk-goog',
+      cookie: 'session=foo',
+      'set-cookie': 'token=bar',
+    });
+    expect(out['x-api-key']).toBe('***');
+    expect(out['X-Anthropic-Api-Key']).toBe('***');
+    expect(out['x-openai-api-key']).toBe('***');
+    expect(out['X-Goog-Api-Key']).toBe('***');
+    expect(out.cookie).toBe('***');
+    expect(out['set-cookie']).toBe('***');
+  });
+
+  test('returns empty object for null or undefined input', () => {
+    expect(redactHeadersForLog(null)).toEqual({});
+    expect(redactHeadersForLog(undefined)).toEqual({});
+  });
+
+  test('keeps non-sensitive headers untouched', () => {
+    const out = redactHeadersForLog({
+      'user-agent': 'lobsterai/1.0',
+      accept: 'application/json',
+    });
+    expect(out['user-agent']).toBe('lobsterai/1.0');
+    expect(out.accept).toBe('application/json');
+  });
+});

--- a/src/main/logSanitize.ts
+++ b/src/main/logSanitize.ts
@@ -1,0 +1,52 @@
+/**
+ * Helpers for redacting sensitive values from log messages emitted by the main
+ * process. These helpers exist because URLs, request headers, IM payloads and
+ * auth responses routinely contain bearer tokens, API keys and PII that must
+ * not land in `electron-log` files or stdout.
+ *
+ * Use `sanitizeUrlForLog` whenever a fully-qualified URL is logged at INFO
+ * level — query strings can contain access tokens (e.g. `?access_token=...`)
+ * or single-use auth codes (e.g. `lobsterai://auth/callback?code=...`). When a
+ * deeper trace is needed, log the raw value at DEBUG level only.
+ */
+
+const SENSITIVE_HEADER_RE =
+  /(authori[sz]ation|cookie|api[-_]?key|secret|token|password|set-cookie|x-anthropic|x-openai|x-goog|x-novita)/i;
+
+const REDACTED = '***';
+
+/**
+ * Drops query string and fragment from a URL so we never log access tokens /
+ * one-time codes / refresh tokens that some upstream servers smuggle in URLs.
+ *
+ * We deliberately use string-based stripping rather than `new URL()`-based
+ * reconstruction because the WHATWG URL parser reports `origin === 'null'`
+ * for custom schemes (e.g. `lobsterai://auth/callback`) and that would mangle
+ * our deep-link logs.
+ */
+export function sanitizeUrlForLog(rawUrl: string): string {
+  if (typeof rawUrl !== 'string' || rawUrl.length === 0) return '<empty-url>';
+  const queryIdx = rawUrl.indexOf('?');
+  const hashIdx = rawUrl.indexOf('#');
+  let cut = rawUrl.length;
+  if (queryIdx !== -1) cut = Math.min(cut, queryIdx);
+  if (hashIdx !== -1) cut = Math.min(cut, hashIdx);
+  const trimmed = rawUrl.slice(0, cut);
+  return trimmed.length > 0 ? trimmed : '<invalid-url>';
+}
+
+/**
+ * Returns a shallow copy of the headers map with sensitive values replaced by
+ * a placeholder. Header names matched case-insensitively against a single
+ * regex so adding new providers does not require code changes elsewhere.
+ */
+export function redactHeadersForLog(
+  headers: Record<string, string> | null | undefined,
+): Record<string, string> {
+  if (!headers || typeof headers !== 'object') return {};
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    out[name] = SENSITIVE_HEADER_RE.test(name) ? REDACTED : String(value);
+  }
+  return out;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -85,6 +85,7 @@ import {
   setSystemProxyEnabled,
 } from './libs/systemProxy';
 import { getLogFilePath, getRecentMainLogEntries, initLogger } from './logger';
+import { redactHeadersForLog, sanitizeUrlForLog } from './logSanitize';
 import type { McpServerFormData } from './mcpStore';
 import { McpStore } from './mcpStore';
 import { OpenClawSessionIpc } from './openclawSession/constants';
@@ -1953,11 +1954,10 @@ if (!gotTheLock) {
     handleDeepLink(url);
   });
 
-  app.on('second-instance', (_event, commandLine, workingDirectory) => {
-    console.debug('[Main] second-instance event', { commandLine, workingDirectory });
-
+  app.on('second-instance', (_event, commandLine, _workingDirectory) => {
     // Check for deep link in command line args (Windows/Linux)
     const deepLink = commandLine.find(arg => arg.startsWith('lobsterai://'));
+    console.debug(`[Main] second-instance event received hasDeepLink=${Boolean(deepLink)}`);
     if (deepLink) {
       handleDeepLink(deepLink);
     }
@@ -2279,7 +2279,10 @@ if (!gotTheLock) {
         return { success: false, error: body.message || 'Exchange failed' };
       }
       saveAuthTokens(body.data.accessToken, body.data.refreshToken);
-      console.log('[Auth] exchange user data:', JSON.stringify(body.data.user));
+      const exchangedUserId = (body.data.user && typeof body.data.user === 'object'
+        ? (body.data.user as Record<string, unknown>).id ?? (body.data.user as Record<string, unknown>).userId
+        : undefined);
+      console.log(`[Auth] auth code exchanged successfully for user ${exchangedUserId ?? '<unknown>'}`);
       return { success: true, user: body.data.user, quota: normalizeQuota(body.data.quota) };
     } catch (error) {
       console.error('[Auth] exchange failed:', error);
@@ -2306,7 +2309,10 @@ if (!gotTheLock) {
           quota = normalizeQuota(quotaBody.data);
         }
       }
-      console.log('[Auth] getUser profile data:', JSON.stringify(profileBody.data));
+      const profileUserId = (profileBody.data && typeof profileBody.data === 'object'
+        ? (profileBody.data as Record<string, unknown>).id ?? (profileBody.data as Record<string, unknown>).userId
+        : undefined);
+      console.debug(`[Auth] fetched profile for user ${profileUserId ?? '<unknown>'}`);
       return { success: true, user: profileBody.data, quota };
     } catch {
       return { success: false };
@@ -4882,7 +4888,10 @@ if (!gotTheLock) {
     headers: Record<string, string>;
     body?: string;
   }) => {
-    console.log(`[api:fetch] ${options.method} ${options.url}, headers: ${JSON.stringify(options.headers)}, body: ${options.body}`);
+    const sanitizedUrl = sanitizeUrlForLog(options.url);
+    console.debug(
+      `[api:fetch] ${options.method} ${sanitizedUrl} headers=${JSON.stringify(redactHeadersForLog(options.headers))}`,
+    );
 
     const doFetch = async (headers: Record<string, string>) => {
       const response = await session.defaultSession.fetch(options.url, {
@@ -4913,7 +4922,8 @@ if (!gotTheLock) {
 
     try {
       let result = await doFetch(options.headers);
-      console.log(`[api:fetch] ${options.method} ${options.url} -> ${result.status} ${result.statusText}`, typeof result.data === 'object' ? JSON.stringify(result.data) : result.data);
+      const logFn = result.ok ? console.debug : console.warn;
+      logFn(`[api:fetch] ${options.method} ${sanitizedUrl} -> ${result.status} ${result.statusText}`);
 
       // Auto-retry once for Copilot 401/403
       if (!result.ok && (result.status === 401 || result.status === 403) && isCopilotUrl(options.url)) {
@@ -4927,7 +4937,7 @@ if (!gotTheLock) {
 
       return result;
     } catch (error) {
-      console.error(`[api:fetch] ${options.method} ${options.url} -> ERROR:`, error instanceof Error ? error.message : error);
+      console.error(`[api:fetch] ${options.method} ${sanitizedUrl} request failed:`, error instanceof Error ? error.message : error);
       return {
         ok: false,
         status: 0,


### PR DESCRIPTION
## 背景

`api:fetch` IPC 处理器在每次调用时都会以 INFO 级别打印完整的请求 URL、headers 和 body，并在成功时再打印整段响应体。Bearer token、第三方 API key、SSE 内容都会落盘到任意用户的 `electron-log` 日志文件。除此之外：

- 两处 `[Auth]` 路径会序列化用户 profile JSON。
- `second-instance` 调试日志会把整段命令行（含 `lobsterai://auth/callback?code=...` 一次性 authCode）写进日志。
- IM cowork 调度器在每个对话回合都会把入站消息原文 + 全部附件以 INFO 级别整包 `JSON.stringify` 入日志。
- DingTalk media parser 对每个匹配项都会打印 fullMatch + JSON 配对（含完整文件路径）。
- QQ media downloader 的日志为中文，违反 AGENTS 规范。

## 改动

引入新的 `logSanitize` 工具并改写所有受影响的日志点，统一为英文 `[Module]` tag + 计数化摘要：

- **新增 `src/main/logSanitize.ts`**
  - `sanitizeUrlForLog()` 用纯字符串切片去除 `?query` 与 `#fragment`，避免使用 WHATWG URL 解析（自定义协议 `lobsterai://` 在该解析器下 `origin === 'null'` 会损坏深链日志）。
  - `redactHeadersForLog()` 用单个正则匹配敏感 header 名（`authorization` / `cookie` / `*api-key` / `token` / `secret` / `x-anthropic-*` / `x-openai-*` / `x-goog-*` / `x-novita-*` 等），命中即替换为 `***`。
- **`src/main/main.ts`**
  - `api:fetch` 入参日志降级为 DEBUG，仅记录 sanitized URL + 脱敏 headers。
  - `api:fetch` 响应日志根据 `ok` 走 DEBUG / WARN，不再打印响应体。
  - `api:fetch` 错误日志使用 sanitized URL。
  - `[Auth] auth:exchange` 改为只打 user id。
  - `[Auth] auth:getUser` 改为 DEBUG 级别 + 只打 user id。
  - `second-instance` 改为只记录 `hasDeepLink` 布尔值。
- **`src/main/im/imCoworkHandler.ts`**：入站派发与会话完成两条 `JSON.stringify` 全量日志改为英文 + 计数摘要（`contentChars` / `attachments` / `messages` 等）。
- **`src/main/im/dingtalkMediaParser.ts`**：删除每个匹配项的 INFO 全量日志，保留一条可选 DEBUG 总结，其余 warning 翻译为英文。
- **`src/main/im/qqMediaDownload.ts`**：所有中文日志翻译为英文 `[QQMedia]` tag；下载日志移除 URL；顺手修了原仓库 pre-existing 的 `simple-import-sort/imports` lint 错误。

## 验证

| 检查项 | 结果 |
|---|---|
| `npx vitest run src/main/logSanitize.test.ts` | 11 / 11 通过 |
| `npx vitest run`（全量） | 668 通过 / 1 跳过 |
| `npx tsc --project electron-tsconfig.json --noEmit` | 无错 |
| `npm run lint` | errors 130 → 129（顺手修了 1 个 pre-existing），无新增错误 |

## 影响面

- 不改任何 IPC / HTTP 协议，不改用户可见行为。
- 新增的单测覆盖：HTTP / 自定义协议 / 空输入 / 畸形 URL / 各类敏感 header。
- 这是一系列安全 / 质量清理 PR 中的第 1 个；后续 PR 还会处理 store IPC 越权、`shell.openExternal` 白名单、CI 跳过测试、ESLint 配置、提交 lockfile 等。

## 备注

- 本 PR 把 QQMedia 模块的日志 tag 从 `[QQ Media]` 改为 `[QQMedia]`，更贴近 AGENTS 中 `[ModuleName]` PascalCase 的写法。其他 IM 模块的 tag 风格不一致问题留到后续清理 PR 一并处理。
