### PR TITLE
fix(security): 限制 store:* IPC 越权访问 + 收窄通用 ipcRenderer 桥

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -94,6 +94,7 @@ import { SkillManager } from './skillManager';
 import { getSkillServiceManager } from './skillServices';
 import { SqliteStore } from './sqliteStore';
 import { StartupProfiler } from './startupProfiler';
+import { describeSensitiveKeyDenial, isSensitiveStoreKey } from './storeAccessControl';
 import { createTray, destroyTray, updateTrayMenu } from './trayManager';
 
 // 设置应用程序名称
@@ -1972,10 +1973,18 @@ if (!gotTheLock) {
 
   // IPC 处理程序
   ipcMain.handle('store:get', (_event, key) => {
+    if (isSensitiveStoreKey(key)) {
+      console.warn('[Store] denied store:get for reserved key from renderer');
+      throw new Error(describeSensitiveKeyDenial('store:get'));
+    }
     return getStore().get(key);
   });
 
   ipcMain.handle('store:set', async (_event, key, value) => {
+    if (isSensitiveStoreKey(key)) {
+      console.warn('[Store] denied store:set for reserved key from renderer');
+      throw new Error(describeSensitiveKeyDenial('store:set'));
+    }
     getStore().set(key, value);
     if (key === 'app_config') {
       refreshEndpointsTestMode(getStore());
@@ -1990,6 +1999,10 @@ if (!gotTheLock) {
   });
 
   ipcMain.handle('store:remove', (_event, key) => {
+    if (isSensitiveStoreKey(key)) {
+      console.warn('[Store] denied store:remove for reserved key from renderer');
+      throw new Error(describeSensitiveKeyDenial('store:remove'));
+    }
     getStore().delete(key);
   });
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -113,16 +113,36 @@ contextBridge.exposeInMainWorld('electron', {
       return () => ipcRenderer.removeListener(`api:stream:${requestId}:abort`, handler);
     },
   },
-  ipcRenderer: {
-    send: (channel: string, ...args: any[]) => {
-      ipcRenderer.send(channel, ...args);
-    },
-    on: (channel: string, func: (...args: any[]) => void) => {
-      const handler = (_event: any, ...args: any[]) => func(...args);
-      ipcRenderer.on(channel, handler);
-      return () => ipcRenderer.removeListener(channel, handler);
-    },
-  },
+  ipcRenderer: (() => {
+    // Generic ipcRenderer bridge is intentionally narrow. Anything not in this
+    // allowlist must go through a dedicated, typed entry on `window.electron`.
+    const ALLOWED_INBOUND_CHANNELS: ReadonlySet<string> = new Set([
+      'app:openSettings',
+      'app:newTask',
+    ]);
+    const ALLOWED_OUTBOUND_CHANNELS: ReadonlySet<string> = new Set<string>();
+
+    return {
+      send: (channel: string, ...args: any[]) => {
+        if (!ALLOWED_OUTBOUND_CHANNELS.has(channel)) {
+          console.warn(`[Preload] blocked ipcRenderer.send on unsupported channel: ${channel}`);
+          return;
+        }
+        ipcRenderer.send(channel, ...args);
+      },
+      on: (channel: string, func: (...args: any[]) => void) => {
+        if (!ALLOWED_INBOUND_CHANNELS.has(channel)) {
+          console.warn(`[Preload] blocked ipcRenderer.on for unsupported channel: ${channel}`);
+          return () => {
+            // No-op unsubscribe so renderer code never has to special-case this.
+          };
+        }
+        const handler = (_event: any, ...args: any[]) => func(...args);
+        ipcRenderer.on(channel, handler);
+        return () => ipcRenderer.removeListener(channel, handler);
+      },
+    };
+  })(),
   window: {
     minimize: () => ipcRenderer.send('window-minimize'),
     toggleMaximize: () => ipcRenderer.send('window-maximize'),

--- a/src/main/storeAccessControl.test.ts
+++ b/src/main/storeAccessControl.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeSensitiveKeyDenial, isSensitiveStoreKey } from './storeAccessControl';
+
+describe('isSensitiveStoreKey', () => {
+  it('flags the auth_tokens kv entry', () => {
+    expect(isSensitiveStoreKey('auth_tokens')).toBe(true);
+  });
+
+  it('flags the github_copilot_github_token kv entry', () => {
+    expect(isSensitiveStoreKey('github_copilot_github_token')).toBe(true);
+  });
+
+  it('flags any key under the copilot: prefix', () => {
+    expect(isSensitiveStoreKey('copilot:access_token')).toBe(true);
+    expect(isSensitiveStoreKey('copilot:refresh_token')).toBe(true);
+  });
+
+  it('flags any key under the github_copilot: prefix', () => {
+    expect(isSensitiveStoreKey('github_copilot:device_token')).toBe(true);
+  });
+
+  it('treats key matching as case-sensitive', () => {
+    expect(isSensitiveStoreKey('AUTH_TOKENS')).toBe(false);
+    expect(isSensitiveStoreKey('Copilot:foo')).toBe(false);
+  });
+
+  it('allows benign renderer-managed keys', () => {
+    expect(isSensitiveStoreKey('app_config')).toBe(false);
+    expect(isSensitiveStoreKey('privacy_agreed')).toBe(false);
+    expect(isSensitiveStoreKey('installation_uuid')).toBe(false);
+    expect(isSensitiveStoreKey('providers_export_key')).toBe(false);
+    expect(isSensitiveStoreKey('skills')).toBe(false);
+    expect(isSensitiveStoreKey('skills_state')).toBe(false);
+  });
+
+  it('rejects non-string keys without throwing', () => {
+    expect(isSensitiveStoreKey(undefined)).toBe(false);
+    expect(isSensitiveStoreKey(null)).toBe(false);
+    expect(isSensitiveStoreKey(123)).toBe(false);
+    expect(isSensitiveStoreKey({})).toBe(false);
+    expect(isSensitiveStoreKey('')).toBe(false);
+  });
+
+  it('does not match keys that merely contain a sensitive substring', () => {
+    expect(isSensitiveStoreKey('auth_tokens_legacy_log')).toBe(false);
+    expect(isSensitiveStoreKey('legacy:auth_tokens')).toBe(false);
+  });
+});
+
+describe('describeSensitiveKeyDenial', () => {
+  it('returns a stable message that includes the channel name', () => {
+    expect(describeSensitiveKeyDenial('store:get')).toBe(
+      'store:get blocked: key is reserved for the main process',
+    );
+    expect(describeSensitiveKeyDenial('store:set')).toBe(
+      'store:set blocked: key is reserved for the main process',
+    );
+  });
+
+  it('does not echo the key value back to the renderer', () => {
+    const message = describeSensitiveKeyDenial('store:remove');
+    expect(message).not.toContain('auth_tokens');
+    expect(message).not.toContain('copilot');
+  });
+});

--- a/src/main/storeAccessControl.ts
+++ b/src/main/storeAccessControl.ts
@@ -1,0 +1,44 @@
+/**
+ * Renderer-facing access control for the generic SQLite KV store.
+ *
+ * Renderer processes can read/write arbitrary keys via the `store:*` IPC bridge
+ * that lives in `preload.ts`. A handful of keys store secrets that must only
+ * ever be touched by the main process (Bearer tokens, OAuth refresh tokens,
+ * GitHub Copilot tokens, etc.). This module centralises the deny-list so the
+ * IPC handler in `main.ts` can reject any renderer call that targets those
+ * keys, even if a compromised renderer is convinced to issue the call.
+ *
+ * Exact-match keys cover individual sensitive entries; prefix matches cover
+ * key namespaces (e.g. `copilot:` reserved for Copilot-related secrets).
+ *
+ * Internal main-process code keeps using `getStore().set/get/delete` directly,
+ * which bypasses these checks because it never crosses the IPC boundary.
+ */
+
+const SENSITIVE_KEY_EXACT = new Set<string>([
+  'auth_tokens',
+  'github_copilot_github_token',
+]);
+
+const SENSITIVE_KEY_PREFIXES: readonly string[] = [
+  'copilot:',
+  'github_copilot:',
+];
+
+export function isSensitiveStoreKey(key: unknown): boolean {
+  if (typeof key !== 'string' || key.length === 0) return false;
+  if (SENSITIVE_KEY_EXACT.has(key)) return true;
+  for (const prefix of SENSITIVE_KEY_PREFIXES) {
+    if (key.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns the user-visible reason for blocking a renderer-side store access.
+ * Used in `Error.message` so renderer code can surface a stable diagnostic
+ * without leaking internal detail about which keys are sensitive.
+ */
+export function describeSensitiveKeyDenial(channel: string): string {
+  return `${channel} blocked: key is reserved for the main process`;
+}


### PR DESCRIPTION
## 背景

渲染进程通过 `store:get` / `store:set` / `store:remove` 三个 IPC 通道直接读写主进程 SQLite KV，**没有任何 key 级别的访问控制**。这意味着：

- 任何被 XSS / 模型输出 / 第三方组件污染的渲染端代码都可以读出 `auth_tokens`（access/refresh token 明文）。
- 同样可以读出 `github_copilot_github_token`（GitHub Copilot session token）。
- 还可以**覆盖**这些 key，把 token 替换成攻击者控制的值，配合 401 自动续期把整个会话劫持过去。

同一份 `preload.ts` 还暴露了一个完全无限制的 `ipcRenderer.send / on(channel, ...args)` 通用桥，渲染进程理论上可以订阅或触发主进程上的任意 IPC 通道。

## 改动

### 1. 新增 `src/main/storeAccessControl.ts`

集中维护一份"渲染进程不可访问"的 KV key 黑名单：

- 精确匹配：`auth_tokens`、`github_copilot_github_token`
- 前缀匹配：`copilot:`、`github_copilot:`

提供两个纯函数：

- `isSensitiveStoreKey(key)`：判定是否命中黑名单；非字符串输入返回 `false` 不抛错。
- `describeSensitiveKeyDenial(channel)`：返回稳定的拒绝消息（**不会把 key 值回显给渲染端**），交给 IPC 抛错时使用。

**注意**：主进程内部的 `getStore().get/set/delete` 直接调用 SQLite，**不经过 IPC**，因此完全不受影响。这只是渲染端的访问限制。

### 2. `src/main/main.ts`：在三个 `store:*` IPC handler 入口收口

```ts
ipcMain.handle('store:get', (_event, key) => {
  if (isSensitiveStoreKey(key)) {
    console.warn('[Store] denied store:get for reserved key from renderer');
    throw new Error(describeSensitiveKeyDenial('store:get'));
  }
  return getStore().get(key);
});
```

`store:set` / `store:remove` 同样处理。命中黑名单时：日志只打 `[Store]` warning（不打 key 名），抛错让渲染端按正常 IPC 错误处理。

### 3. `src/main/preload.ts`：把通用 `ipcRenderer` 桥收窄为两个白名单

- inbound（`on`）允许：`app:openSettings`、`app:newTask`（目前渲染端 `App.tsx` 只订阅了这两个，由 `trayManager` 通过 `webContents.send` 推送）
- outbound（`send`）允许集合为空（现有渲染端代码均走 `window.electron.*` 上的具名入口）

非白名单 channel：

- `on()` 返回一个**空 unsubscribe 函数**，避免 hook cleanup 在未来添加新 channel 但忘记加白名单时崩溃。
- `send()` 直接 no-op。
- 二者均打 `[Preload] blocked …` warning。

## 验证

| 检查项 | 结果 |
|---|---|
| `npx vitest run src/main/storeAccessControl.test.ts` | 10 / 10 通过 |
| `npx vitest run`（全量） | 667 通过 / 1 跳过 |
| `npx tsc --project electron-tsconfig.json --noEmit` | 无错 |
| `npx tsc --project tsconfig.json --noEmit` | 无错 |
| `npx eslint src/main/storeAccessControl.ts src/main/storeAccessControl.test.ts src/main/main.ts src/main/preload.ts` | 无错 |

新增单测 10 个用例覆盖：精确匹配、前缀匹配、大小写敏感、子串误报、非字符串输入、拒绝消息不回显敏感字段。

## 影响面

**渲染端**：

- 现有渲染端代码（`localStore.get/set` 调用 `app_config` / `installation_uuid` / `providers_export_key` / `privacy_agreed` / `skills`）全部不在黑名单里，行为完全不变。
- 新增的两个白名单 channel 与渲染端 `App.tsx` 现有用法完全一致。

**主进程内部**：

- 所有内部对 `auth_tokens` / `github_copilot_github_token` 的读写继续走 `getStore().set/get/delete`，不经 IPC，完全不受新黑名单影响。

## 后续

- 后续 PR #3 会处理 `shell.openExternal` 的 scheme/host 白名单。
- 进一步硬化（如把 `auth_tokens` 移到 OS Keychain / `safeStorage`）放到独立 PR，避免和本次改动耦合。
