### PR TITLE
fix(security): shell.openExternal 增加 scheme 白名单（拒绝 file:/javascript:/data:）

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -90,6 +90,7 @@ import { McpStore } from './mcpStore';
 import { OpenClawSessionIpc } from './openclawSession/constants';
 import { OpenClawSessionPolicyIpc } from './openclawSessionPolicy/constants';
 import { loadOpenClawSessionPolicyConfig, saveOpenClawSessionPolicyConfig } from './openclawSessionPolicy/store';
+import { safeOpenExternal } from './openExternalGuard';
 import { SkillManager } from './skillManager';
 import { getSkillServiceManager } from './skillServices';
 import { SqliteStore } from './sqliteStore';
@@ -2246,7 +2247,11 @@ if (!gotTheLock) {
     try {
       const baseUrl = loginUrl || `${getServerApiBaseUrl()}/login`;
       const finalUrl = `${baseUrl}?source=electron`;
-      await shell.openExternal(finalUrl);
+      const openResult = await safeOpenExternal(finalUrl, 'auth:login');
+      if (!openResult.ok) {
+        console.error('[Auth] login failed:', openResult.error);
+        return { success: false, error: openResult.error };
+      }
       return { success: true };
     } catch (error) {
       console.error('[Auth] login failed:', error);
@@ -4828,12 +4833,11 @@ if (!gotTheLock) {
   });
 
   ipcMain.handle('shell:openExternal', async (_event, url: string) => {
-    try {
-      await shell.openExternal(url);
+    const openResult = await safeOpenExternal(url, 'shell:openExternal');
+    if (openResult.ok) {
       return { success: true };
-    } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
     }
+    return { success: false, error: openResult.error, reason: openResult.reason };
   });
 
   ipcMain.handle(AppUpdateIpc.GetState, async () => {
@@ -5180,7 +5184,7 @@ if (!gotTheLock) {
           },
         };
       }
-      shell.openExternal(url);
+      void safeOpenExternal(url, 'windowOpenHandler');
       return { action: 'deny' };
     });
 

--- a/src/main/openExternalGuard.test.ts
+++ b/src/main/openExternalGuard.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateExternalUrl } from './openExternalGuard';
+
+describe('validateExternalUrl', () => {
+  it('accepts https URLs', () => {
+    const result = validateExternalUrl('https://example.com/path?foo=bar#frag');
+    expect(result).toMatchObject({ ok: true, scheme: 'https:' });
+    if (result.ok) {
+      expect(result.sanitizedUrl).toBe('https://example.com/path?foo=bar#frag');
+    }
+  });
+
+  it('accepts http URLs (intranet docs / dev links)', () => {
+    const result = validateExternalUrl('http://lobsterai-server.inner.youdao.com/login');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.scheme).toBe('http:');
+    }
+  });
+
+  it('accepts mailto and preserves the original string verbatim', () => {
+    const original = 'mailto:foo@bar.com?subject=Hello%20World&body=Hi%20there';
+    const result = validateExternalUrl(original);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.scheme).toBe('mailto:');
+      expect(result.sanitizedUrl).toBe(original);
+    }
+  });
+
+  it('trims surrounding whitespace before parsing', () => {
+    const result = validateExternalUrl('  https://example.com/  ');
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects file: URLs (local file probing risk)', () => {
+    const result = validateExternalUrl('file:///etc/passwd');
+    expect(result).toEqual({ ok: false, reason: 'scheme-not-allowed', scheme: 'file:' });
+  });
+
+  it('rejects javascript: URLs', () => {
+    expect(validateExternalUrl('javascript:alert(1)')).toEqual({
+      ok: false,
+      reason: 'scheme-not-allowed',
+      scheme: 'javascript:',
+    });
+  });
+
+  it('rejects data: URLs', () => {
+    expect(validateExternalUrl('data:text/html,<script>alert(1)</script>')).toEqual({
+      ok: false,
+      reason: 'scheme-not-allowed',
+      scheme: 'data:',
+    });
+  });
+
+  it('rejects vbscript and other exotic schemes', () => {
+    for (const url of ['vbscript:msgbox(1)', 'chrome://settings', 'cmd:/c calc.exe', 'intent://x']) {
+      const result = validateExternalUrl(url);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe('scheme-not-allowed');
+    }
+  });
+
+  it('treats scheme matching as case-insensitive', () => {
+    const result = validateExternalUrl('HTTPS://example.com');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.scheme).toBe('https:');
+  });
+
+  it('rejects malformed URLs without throwing', () => {
+    expect(validateExternalUrl('not a url')).toEqual({
+      ok: false,
+      reason: 'malformed-url',
+    });
+    expect(validateExternalUrl('http://')).toEqual({
+      ok: false,
+      reason: 'malformed-url',
+    });
+  });
+
+  it('rejects empty / non-string input', () => {
+    expect(validateExternalUrl('')).toEqual({ ok: false, reason: 'empty-url' });
+    expect(validateExternalUrl('   ')).toEqual({ ok: false, reason: 'empty-url' });
+    expect(validateExternalUrl(undefined)).toEqual({ ok: false, reason: 'invalid-input' });
+    expect(validateExternalUrl(null)).toEqual({ ok: false, reason: 'invalid-input' });
+    expect(validateExternalUrl(123)).toEqual({ ok: false, reason: 'invalid-input' });
+    expect(validateExternalUrl({})).toEqual({ ok: false, reason: 'invalid-input' });
+  });
+});

--- a/src/main/openExternalGuard.ts
+++ b/src/main/openExternalGuard.ts
@@ -1,0 +1,109 @@
+import { shell } from 'electron';
+
+/**
+ * URL validation guard for `shell.openExternal()`.
+ *
+ * `shell.openExternal()` hands a URL to the OS, which may resolve schemes
+ * the desktop user did not opt into:
+ *   - `file:`  → opens local files in the default viewer (data exfiltration
+ *                / sensitive-file probing via model-generated markdown).
+ *   - `javascript:` / `data:` / `vbscript:` → may execute in the default
+ *                browser depending on platform/version.
+ *   - `cmd:` / `ms-*:` / `intent:` / `chrome:` etc → trigger system actions.
+ *
+ * The renderer surface that flows into this is wide: tray menu links,
+ * settings buttons, IM guide URLs, model-generated markdown links opened
+ * from chat output, MiniMax/GitHub Copilot device-flow verification URLs,
+ * update download URLs. All legitimate callers use http(s) or mailto, so
+ * we deliberately allow only those three schemes and reject everything
+ * else with a `[Shell]` warning. The reject path returns a stable, opaque
+ * reason so renderer UIs can surface a single "unsafe link" toast without
+ * caring about the exact scheme.
+ */
+
+const ALLOWED_SCHEMES: ReadonlySet<string> = new Set([
+  'http:',
+  'https:',
+  'mailto:',
+]);
+
+/**
+ * Validation result. Uses a flat shape (rather than a discriminated union)
+ * because `electron-tsconfig.json` does not enable `strictNullChecks`, so
+ * union narrowing on `ok` would not work for callers in the main process.
+ */
+export interface ExternalUrlValidation {
+  ok: boolean;
+  sanitizedUrl?: string;
+  scheme?: string;
+  reason?: string;
+}
+
+export function validateExternalUrl(rawUrl: unknown): ExternalUrlValidation {
+  if (typeof rawUrl !== 'string') {
+    return { ok: false, reason: 'invalid-input' };
+  }
+  const trimmed = rawUrl.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, reason: 'empty-url' };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { ok: false, reason: 'malformed-url' };
+  }
+
+  const scheme = parsed.protocol.toLowerCase();
+  if (!ALLOWED_SCHEMES.has(scheme)) {
+    return { ok: false, reason: 'scheme-not-allowed', scheme };
+  }
+
+  // For mailto we keep the original string (URL re-encoding can lose
+  // intentional formatting in subject/body parts); for http(s) we use the
+  // normalized URL which strips trailing whitespace and resolves edge cases.
+  const sanitizedUrl = scheme === 'mailto:' ? trimmed : parsed.toString();
+  return { ok: true, sanitizedUrl, scheme };
+}
+
+export interface SafeOpenExternalResult {
+  ok: boolean;
+  error?: string;
+  reason?: string;
+  scheme?: string;
+}
+
+/**
+ * Wraps `shell.openExternal()` with the guard above. The `caller` tag is
+ * included in the warning log only, so we can attribute blocked attempts
+ * to a specific main-process site (e.g. `auth:login`, `windowOpenHandler`,
+ * `shell:openExternal`).
+ */
+export async function safeOpenExternal(
+  rawUrl: unknown,
+  caller: string,
+): Promise<SafeOpenExternalResult> {
+  const validation = validateExternalUrl(rawUrl);
+  if (!validation.ok) {
+    const reason = validation.reason ?? 'unknown';
+    const schemeTag = validation.scheme ? ` scheme=${validation.scheme}` : '';
+    console.warn(`[Shell] blocked openExternal from ${caller} reason=${reason}${schemeTag}`);
+    return {
+      ok: false,
+      error: 'Refused to open URL: unsupported scheme',
+      reason,
+      scheme: validation.scheme,
+    };
+  }
+
+  const sanitizedUrl = validation.sanitizedUrl ?? '';
+  try {
+    await shell.openExternal(sanitizedUrl);
+    return { ok: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.warn(`[Shell] openExternal failed from ${caller}: ${message}`);
+    return { ok: false, error: message, reason: 'openExternal-threw' };
+  }
+}


### PR DESCRIPTION
## 背景

`shell.openExternal(url)` 把 URL 直接交给操作系统解析，scheme 由 OS 决定行为：

- `file://` → 在默认查看器打开本地文件（可被模型输出的恶意 markdown 引导探测/泄漏本地文件）
- `javascript:` / `data:` / `vbscript:` → 视平台/浏览器版本可能被执行
- `cmd:` / `ms-*:` / `intent:` / `chrome:` 等 → 触发 OS 级动作

渲染端流入 `shell.openExternal` 的入口非常广：托盘菜单链接、设置页按钮、各 IM 指引 URL、聊天 markdown 中的模型生成链接、MiniMax / GitHub Copilot 设备授权 verification URL、更新下载 URL。**目前的 `shell:openExternal` IPC handler 与 `windowOpenHandler` 回调对入参 0 校验**，因此模型在任意一次回复里写一段 `[click here](file:///Users/xxx/.ssh/id_rsa)` 就能让宿主机打开本地敏感文件。

## 改动

### 1. 新增 `src/main/openExternalGuard.ts`

- `validateExternalUrl(rawUrl: unknown): ExternalUrlValidation`
  - **允许 scheme**：`http:` / `https:` / `mailto:`（覆盖所有现有合法 caller）
  - 拒绝：非字符串 / 空串 / 无法解析 / 其他 scheme
  - 命中 `mailto:` 时**保留原串**，避免 `URL.toString()` 重新编码 `subject` / `body` 损坏内容
  - scheme 比较忽略大小写

- `safeOpenExternal(rawUrl, caller): Promise<SafeOpenExternalResult>`
  - 调用 validator；不通过则打 `[Shell] blocked openExternal from <caller> reason=<code> [scheme=<scheme>]` warning，返回 `{ ok: false, error, reason, scheme? }`
  - 通过则调用 `shell.openExternal(sanitizedUrl)`；如果 `openExternal` 自己抛错也包装成 `{ ok: false, reason: 'openExternal-threw', error }`

**注意**：`ExternalUrlValidation` / `SafeOpenExternalResult` 都是**扁平结构**而不是 discriminated union——因为 `electron-tsconfig.json` 没开 `strictNullChecks`，main 进程里的 caller 没法对 `ok` 做窄化。

### 2. `src/main/main.ts`：三处 `shell.openExternal` 全部走 wrapper

- `auth:login` IPC handler（line 2247）
- `shell:openExternal` IPC handler（line 4833）— 把 `reason` 透出给渲染端，前端可以区分「scheme 被拦」vs「openExternal 自己 throw」
- `webContents.setWindowOpenHandler` 回调（line 5184）— 子窗口请求转 `safeOpenExternal`

## 验证

| 检查项 | 结果 |
|---|---|
| `npx vitest run src/main/openExternalGuard.test.ts` | 11 / 11 通过 |
| `npx vitest run`（全量） | 678 通过 / 1 跳过 |
| `npx tsc --project electron-tsconfig.json --noEmit` | 无错 |
| `npx tsc --project tsconfig.json --noEmit` | 无错 |
| `npx eslint src/main/openExternalGuard.ts src/main/openExternalGuard.test.ts src/main/main.ts` | 无错 |

新增 11 个用例覆盖：

- `https://...` 接受 + 保留 fragment / query
- `http://intranet/...` 接受
- `mailto:...` 接受 + 原串透传
- 前后空格修剪
- `file:` / `javascript:` / `data:` / `vbscript:` / `chrome:` / `cmd:` / `intent:` 拒绝
- scheme 大小写不敏感
- 畸形 URL / 空串 / 非字符串拒绝且不抛错

## 影响面

**渲染端用户行为变化**：

- 所有现有 caller（设置页帮助链接、Auth 登录、IM 指引、Copilot device flow、MiniMax OAuth、更新下载、tray 菜单）都是 `https://`，零行为变化。
- markdown 中模型生成的 `https://...` 链接继续可点。
- markdown 中模型生成的 `file:///`、`javascript:` 等链接被拒绝，IPC 返回 `{ success: false, error: 'Refused to open URL: unsupported scheme' }`，前端表现为「点了没反应」+ 主进程日志 `[Shell] blocked …`。

**主进程**：

- 已有的 try/catch 行为保持一致（wrapper 内部已捕获）。
- 仅新增一行 import 和三处 1~3 行替换，回滚成本极低。

## 后续

- 后续可在渲染端给 `{ success: false, reason: 'scheme-not-allowed' }` 做 i18n toast 提示；本 PR 暂不耦合渲染端 i18n 改动。
- 进一步收窄白名单（如把 `http:` 限制为内网域名）放到独立 PR，避免和本次拦截动作耦合。
