### PR TITLE
fix: upgrade openclaw-weixin to 2.1.10 and add openclaw patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       {
         "id": "openclaw-weixin",
         "npm": "@tencent-weixin/openclaw-weixin",
-        "version": "2.1.7"
+        "version": "2.1.10"
       },
       {
         "id": "moltbot-popo",

--- a/scripts/patches/v2026.4.14/openclaw-skip-derive-prompt-segments-deadloop.patch
+++ b/scripts/patches/v2026.4.14/openclaw-skip-derive-prompt-segments-deadloop.patch
@@ -1,0 +1,20 @@
+diff --git a/src/auto-reply/reply/agent-runner.ts b/src/auto-reply/reply/agent-runner.ts
+index b8dc87cab2..78fa2a44b7 100644
+--- a/src/auto-reply/reply/agent-runner.ts
++++ b/src/auto-reply/reply/agent-runner.ts
+@@ -1605,9 +1605,13 @@ export async function runReplyAgent(params: {
+         runResult.meta?.requestShaping?.blockStreaming ??
+         normalizeOptionalString(resolvedBlockStreamingBreak),
+     };
++    // LobsterAI patch: skip derivePromptSegments fallback — it enters a dead
++    // loop on inputs containing image attachment markers (e.g. "[media attached:
++    // …jpg (image/*)]").  The function is only used for trace/diagnostics prompt
++    // segmentation and is not required for reply delivery.  Use only the
++    // pre-computed value from the agent run result.
+     const promptSegments =
+-      (runResult.meta?.promptSegments as TracePromptSegmentView[] | undefined) ??
+-      derivePromptSegments(rawUserText);
++      runResult.meta?.promptSegments as TracePromptSegmentView[] | undefined;
+     const toolSummary = runResult.meta?.toolSummary as TraceToolSummaryView | undefined;
+     const completion =
+       (runResult.meta?.completion as TraceCompletionView | undefined) ??

--- a/scripts/patches/v2026.4.14/openclaw-widen-incomplete-turn-retry-guard.patch
+++ b/scripts/patches/v2026.4.14/openclaw-widen-incomplete-turn-retry-guard.patch
@@ -1,0 +1,40 @@
+diff --git a/src/agents/pi-embedded-runner/run/incomplete-turn.ts b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+index 9341af3610..711764781c 100644
+--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
++++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+@@ -294,14 +294,10 @@ export function resolveReasoningOnlyRetryInstruction(params: {
+     return null;
+   }
+ 
+-  if (
+-    !shouldApplyPlanningOnlyRetryGuard({
+-      provider: params.provider,
+-      modelId: params.modelId,
+-    })
+-  ) {
+-    return null;
+-  }
++  // LobsterAI patch: remove provider gate so reasoning-only retry applies to
++  // all providers, not just GPT-5 family.  Non-frontier models (Volcengine,
++  // Ollama, etc.) can return reasoning/thinking content without visible text,
++  // triggering "payloads=0" errors.  Upstream widens this in v2026.4.23+.
+ 
+   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
+   if (params.attempt.assistantTexts.join("\n\n").trim().length > 0) {
+@@ -337,14 +333,8 @@ export function resolveEmptyResponseRetryInstruction(params: {
+     return null;
+   }
+ 
+-  if (
+-    !shouldApplyPlanningOnlyRetryGuard({
+-      provider: params.provider,
+-      modelId: params.modelId,
+-    })
+-  ) {
+-    return null;
+-  }
++  // LobsterAI patch: remove provider gate — same rationale as reasoning-only
++  // retry above.  See resolveReasoningOnlyRetryInstruction patch comment.
+ 
+   if (
+     !isEmptyResponseAssistantTurn({


### PR DESCRIPTION
## Summary
- Bump `@tencent-weixin/openclaw-weixin` from 2.1.7 to 2.1.10
- Add patch to skip derive prompt segments deadloop
- Add patch to widen incomplete turn retry guard

## Test plan
- [ ] Verify openclaw-weixin 2.1.10 loads correctly
- [ ] Verify patches apply cleanly during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)