### PR TITLE
fix(cowork): 去除 continueSession 失败时重复推送的系统错误消息

### DIFF
--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -314,19 +314,11 @@ class CoworkService {
       }
       if (result.code !== 'ENGINE_NOT_READY') {
         store.dispatch(updateSessionStatus({ sessionId: options.sessionId, status: 'error' }));
-        if (result.error) {
-          store.dispatch(addMessage({
-            sessionId: options.sessionId,
-            message: {
-              id: `error-${Date.now()}`,
-              type: 'system',
-              content: i18nService.t('coworkErrorSessionContinueFailed').replace('{error}', result.error),
-              timestamp: Date.now(),
-            },
-          }));
-        }
       }
-      // Show a user-visible error message in the session
+      // Surface a single user-visible system message: engine-not-ready
+      // gets a dedicated copy, every other error goes through classifyError
+      // which already produces a more diagnostic, user-friendly string than
+      // the bare `coworkErrorSessionContinueFailed` template would.
       if (result.error) {
         const errorContent = result.code === 'ENGINE_NOT_READY'
           ? i18nService.t('coworkErrorEngineNotReady')


### PR DESCRIPTION
## 背景

`CoworkService.continueSession()` 在非 `ENGINE_NOT_READY` 失败时，会**连续 dispatch 两条**系统错误消息：

1. **第一条**（line 318–326）：`coworkErrorSessionContinueFailed` 模板  
   渲染为 `发送消息失败：<error>` / `Failed to send message: <error>`
2. **第二条**（line 330–343）：`classifyError(result.error)` 的诊断消息

用户在对话流里会看到两条连续的"发送消息失败"，看起来像 bug，并且诊断信息和模板信息相互冗余 —— `classifyError` 本来就是为了把原始错误转成对用户友好的文案，比直接拼模板更准确（区分网络错误、token 不足、模型不可用等）。

## 改动

`src/renderer/services/cowork.ts`：删除第一条 dispatch，只保留 `classifyError` / `coworkErrorEngineNotReady` 那条。其余行为完全保持：

- `setStreaming(false)` 保留  
- `notifyOpenClawStatus(result.engineStatus)` 保留  
- 非 `ENGINE_NOT_READY` 时 `updateSessionStatus({ status: 'error' })` 保留  
- 用户仍能看到一条系统错误消息（更精准）  
- `console.error('Failed to continue session:', result.error)` 保留

未使用的 i18n key `coworkErrorSessionContinueFailed`（zh + en）**暂未删除**，因为：

- 删除会扩大 PR 范围（涉及 i18n.ts 这种噪声较大的文件）
- 后续如果要复用模板，留着零成本

## 验证

| 检查项 | 结果 |
|---|---|
| `npx vitest run`（全量） | 668 通过 / 1 跳过 |
| `npx tsc --project tsconfig.json --noEmit` | 无错 |
| `npx eslint src/renderer/services/cowork.ts` | 无错 |

## 影响面

- 纯渲染端改动；不动 IPC、不动主进程、不动 i18n key 集合。
- 行为差异：失败时系统消息从 2 条降为 1 条，文案更精准。无 API 变化、无回滚风险。
