### PR TITLE
fix(config): prevent updateConfig from overwriting stored providers with stale defaults

### DIFF
--- a/src/renderer/services/config.ts
+++ b/src/renderer/services/config.ts
@@ -143,6 +143,9 @@ class ConfigService {
   async init() {
     try {
       const storedConfig = await localStore.getItem<AppConfig>(CONFIG_KEYS.APP_CONFIG);
+      if (!storedConfig) {
+        console.warn('[ConfigService] init: no stored config found, using defaults');
+      }
       if (storedConfig) {
         const mergedProviders = storedConfig.providers
           ? Object.fromEntries(
@@ -216,7 +219,7 @@ class ConfigService {
         });
       }
     } catch (error) {
-      console.error('Failed to load config:', error);
+      console.error('[ConfigService] init failed:', error);
     }
   }
 
@@ -226,8 +229,15 @@ class ConfigService {
 
   async updateConfig(newConfig: Partial<AppConfig>) {
     const normalizedProviders = normalizeProvidersConfig(newConfig.providers as AppConfig['providers'] | undefined);
+
+    // Read-modify-write: use the latest stored value as the base to avoid
+    // overwriting fields (e.g. providers) with stale in-memory defaults when
+    // only a subset of config is being updated.
+    const stored = await localStore.getItem<AppConfig>(CONFIG_KEYS.APP_CONFIG);
+    const base = stored ?? this.config;
+
     this.config = {
-      ...this.config,
+      ...base,
       ...newConfig,
       ...(normalizedProviders ? { providers: normalizedProviders } : {}),
     };


### PR DESCRIPTION
Use read-modify-write in configService.updateConfig() so partial updates
(e.g. model selection) read the latest stored config as base instead of
the in-memory this.config, which may still hold defaultConfig if init()
failed to load from store.
