### PR TITLE
fix(cowork): persist model override when creating new sessions

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -547,7 +547,8 @@ export class CoworkStore {
     systemPrompt: string = '',
     executionMode: CoworkExecutionMode = 'local',
     activeSkillIds: string[] = [],
-    agentId: string = 'main'
+    agentId: string = 'main',
+    modelOverride: string = ''
   ): CoworkSession {
     const id = uuidv4();
     const now = Date.now();
@@ -556,7 +557,7 @@ export class CoworkStore {
       .prepare(
         `
       INSERT INTO cowork_sessions (id, title, claude_session_id, status, cwd, system_prompt, model_override, execution_mode, active_skill_ids, agent_id, pinned, created_at, updated_at)
-      VALUES (?, ?, NULL, 'idle', ?, ?, '', ?, ?, ?, 0, ?, ?)
+      VALUES (?, ?, NULL, 'idle', ?, ?, ?, ?, ?, ?, 0, ?, ?)
     `,
       )
       .run(
@@ -564,6 +565,7 @@ export class CoworkStore {
         title,
         cwd,
         systemPrompt,
+        modelOverride,
         executionMode,
         JSON.stringify(activeSkillIds),
         agentId,
@@ -579,7 +581,7 @@ export class CoworkStore {
       pinned: false,
       cwd,
       systemPrompt,
-      modelOverride: '',
+      modelOverride,
       executionMode,
       activeSkillIds,
       agentId,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2750,6 +2750,7 @@ if (!gotTheLock) {
     activeSkillIds?: string[];
     imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
     agentId?: string;
+    modelOverride?: string;
   }) => {
     try {
       const activeEngine = resolveCoworkAgentEngine();
@@ -2786,8 +2787,13 @@ if (!gotTheLock) {
         systemPrompt,
         config.executionMode || 'local',
         options.activeSkillIds || [],
-        options.agentId || 'main'
+        options.agentId || 'main',
+        options.modelOverride || ''
       );
+
+      if (options.modelOverride) {
+        console.log('[Cowork:StartSession] session created with modelOverride:', session.id, options.modelOverride);
+      }
 
       // Update session status to 'running' before starting async task
       // This ensures the frontend receives the correct status immediately

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -241,7 +241,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         updatedAt: now,
         cwd: config.workingDirectory || '',
         systemPrompt: '',
-        modelOverride: '',
+        modelOverride: headerSelectedModel ? toOpenClawModelRef(headerSelectedModel) : '',
         executionMode: config.executionMode || 'local',
         activeSkillIds: sessionSkillIds,
         agentId: currentAgentId,
@@ -284,6 +284,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         .join('\n\n') || undefined;
 
       // Start the actual session immediately with fallback title
+      const sessionModelOverride = headerSelectedModel ? toOpenClawModelRef(headerSelectedModel) : '';
       const { session: startedSession, error: startError } = await coworkService.startSession({
         prompt,
         title: fallbackTitle,
@@ -291,6 +292,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         systemPrompt: combinedSystemPrompt,
         activeSkillIds: sessionSkillIds,
         agentId: currentAgentId,
+        modelOverride: sessionModelOverride,
         imageAttachments,
       });
 

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -540,7 +540,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     agentIdentityPlaceholder: '身份描述（IDENTITY.md）...',
     agentDefaultModel: 'Agent 默认模型',
     agentModelOpenClawOnly: '仅 OpenClaw 引擎使用此设置',
-    agentModelInvalidHint: '当前对话的模型已不可用，请重新选择模型',
+    agentModelInvalidHint: '当前模型已不可用，请重新选择',
     agentSkills: '技能',
     agentSkillsHint: '选择该 Agent 可使用的技能。不选则使用所有已启用技能。',
     agentSkillsSearch: '搜索技能...',
@@ -2098,8 +2098,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     agentIdentityPlaceholder: 'Identity description (IDENTITY.md)...',
     agentDefaultModel: 'Agent Default Model',
     agentModelOpenClawOnly: 'This setting only applies to the OpenClaw engine',
-    agentModelInvalidHint:
-      'The model used in this conversation is no longer available. Please select a different model',
+    agentModelInvalidHint: 'Model unavailable. Please select another',
     agentSkills: 'Skills',
     agentSkillsHint:
       'Select skills available to this Agent. Leave empty to use all enabled skills.',

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -198,6 +198,7 @@ export interface CoworkStartOptions {
   title?: string;
   activeSkillIds?: string[];
   agentId?: string;
+  modelOverride?: string;
   imageAttachments?: CoworkImageAttachment[];
 }
 


### PR DESCRIPTION
Previously new sessions had an empty modelOverride and relied on
Agent.model at runtime, causing parallel sessions to share the same
model. Now the resolved model is written to the backend SQLite row
at creation time, ensuring each session retains its own model.

Also shortened the invalid-model hint copy.