### PR TITLE
fix(cowork): prevent session modelOverride from being rewritten by model normalization

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1374,13 +1374,13 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     const agent = this.store.getAgent(agentId);
     const rawCurrentModel = session.modelOverride || agent?.model || '';
-    const currentModel = rawCurrentModel ? this.normalizeModelRef(rawCurrentModel) : '';
-    if (currentModel && currentModel !== rawCurrentModel) {
-      if (session.modelOverride) {
-        this.store.updateSession(sessionId, { modelOverride: currentModel });
-      } else if (agent?.id) {
-        this.store.updateAgent(agent.id, { model: currentModel });
-      }
+    // Normalize only agent-level model refs (may need provider migration).
+    // Session modelOverride is user-selected and must not be rewritten.
+    const currentModel = session.modelOverride
+      ? rawCurrentModel
+      : (rawCurrentModel ? this.normalizeModelRef(rawCurrentModel) : '');
+    if (!session.modelOverride && currentModel && currentModel !== rawCurrentModel && agent?.id) {
+      this.store.updateAgent(agent.id, { model: currentModel });
     }
     if (currentModel && currentModel !== this.lastPatchedModelBySession.get(sessionId)) {
       try {

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -198,6 +198,10 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     engine: coworkAgentEngine,
   });
 
+  if (sessionId && currentSession) {
+    console.log('[CoworkPromptInput] model resolve:', { sessionId, currentSessionId: currentSession.id, modelOverride: currentSession.modelOverride, resolvedName: agentSelectedModel?.name, resolvedProvider: agentSelectedModel?.providerKey, resolvedIsServer: agentSelectedModel?.isServerModel });
+  }
+
   const isLarge = size === 'large';
   const minHeight = isLarge ? 60 : 24;
   const maxHeight = isLarge ? 200 : 200;
@@ -925,6 +929,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                         ? async (nextModel) => {
                             if (!nextModel) return;
                             const modelRef = toOpenClawModelRef(nextModel);
+                            console.log('[CoworkPromptInput] model selected:', { id: nextModel.id, providerKey: nextModel.providerKey, isServerModel: nextModel.isServerModel, modelRef });
                             if (sessionId) {
                               await coworkService.patchSession(sessionId, { model: modelRef });
                               if (currentAgent && agentModelIsInvalid) {

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -285,6 +285,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
 
       // Start the actual session immediately with fallback title
       const sessionModelOverride = headerSelectedModel ? toOpenClawModelRef(headerSelectedModel) : '';
+      console.log('[CoworkView] creating session:', { modelId: headerSelectedModel?.id, providerKey: headerSelectedModel?.providerKey, isServerModel: headerSelectedModel?.isServerModel, sessionModelOverride, agentModel: currentAgent?.model });
       const { session: startedSession, error: startError } = await coworkService.startSession({
         prompt,
         title: fallbackTitle,

--- a/src/renderer/utils/openclawModelRef.ts
+++ b/src/renderer/utils/openclawModelRef.ts
@@ -38,6 +38,8 @@ export function resolveOpenClawModelRef<T extends ModelRefInput>(
     const exact = availableModels.find((model) => toOpenClawModelRef(model) === normalizedRef) ?? null;
     if (exact) return exact;
 
+    console.log('[openclawModelRef] exact match failed for', normalizedRef, 'available refs:', availableModels.map(m => toOpenClawModelRef(m)));
+
     const slashIndex = normalizedRef.indexOf('/');
     const providerId = normalizedRef.slice(0, slashIndex);
     const modelId = normalizedRef.slice(slashIndex + 1);


### PR DESCRIPTION
The normalizeModelRef in openclawRuntimeAdapter was requalifying
lobsterai-server model refs to custom provider refs (e.g.
lobsterai-server/qwen3.5-plus → qwen-portal/qwen3.5-plus) because
buildAvailableOpenClawProviders excludes the server provider.

Now normalization only applies to agent-level model refs which may
need provider migration. Session modelOverride is user-selected and
preserved as-is.
