### PR TITLE
fix(dingtalk): patch file:// URL for Windows image inbound

### DIFF
--- a/scripts/ensure-openclaw-plugins.cjs
+++ b/scripts/ensure-openclaw-plugins.cjs
@@ -691,6 +691,37 @@ exports.plugin = {
   } else {
     log('openclaw-lark not found, skipping deferred loading patch');
   }
+
+  // --- Post-install patch: dingtalk-connector file:// URL fix (Windows only) ---
+  // On Windows, downloadImageToFile returns paths with backslashes (e.g.
+  // D:\data\media\inbound\image.jpg).  The original code constructs
+  // `file://${path}` which produces `file://D:\...` — an invalid file URL
+  // where the drive letter is parsed as the hostname, causing
+  // safeFileURLToPath to reject it.  Images silently fail to reach the model.
+  // On macOS/Linux paths start with `/`, so `file://${path}` already produces
+  // a valid three-slash URL — no patching needed there.
+  //
+  // Fix: on Windows, normalise backslashes to forward slashes and use three
+  // slashes after `file:` so the hostname is always empty.
+  const dingtalkMsgHandlerPath = path.join(
+    runtimeExtensionsDir, 'dingtalk-connector', 'src', 'core', 'message-handler.ts'
+  );
+  if (fs.existsSync(dingtalkMsgHandlerPath)) {
+    let dtSrc = fs.readFileSync(dingtalkMsgHandlerPath, 'utf8');
+    const brokenPattern = "imageLocalPaths.map(p => `![image](file://${p})`)";
+    if (dtSrc.includes(brokenPattern)) {
+      dtSrc = dtSrc.replace(
+        brokenPattern,
+        "imageLocalPaths.map(p => { if (process.platform !== 'win32') return `![image](file://${p})`; const n = p.replace(/\\\\/g, '/'); return `![image](file:///${n})`; })"
+      );
+      fs.writeFileSync(dingtalkMsgHandlerPath, dtSrc);
+      log('Patched dingtalk-connector/message-handler.ts: fixed file:// URL format for Windows');
+    } else {
+      log('dingtalk-connector/message-handler.ts: file:// pattern not found or already patched, skipping');
+    }
+  } else {
+    log('dingtalk-connector not found, skipping file:// URL patch');
+  }
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- DingTalk 渠道在 Windows 上发送图片给 AI 时，`file://` URL 格式错误导致图片无法传递给模型
- 根因：`file://${localPath}` 在 Windows 上生成 `file://D:\...`，URL parser 将盘符 `D` 解析为 hostname，被 SDK 的 `safeFileURLToPath` 拒绝
- 修复：在 `ensure-openclaw-plugins.cjs` 添加 post-install patch，仅 Windows 上将反斜杠转正斜杠并使用三斜杠格式 `file:///D:/...`；macOS/Linux 保持原行为不变

## Test plan
- [ ] Windows 环境下通过钉钉发送图片消息，确认模型能正确接收并描述图片内容
- [ ] 验证飞书、微信渠道图片功能不受影响
- [ ] 运行 `node scripts/ensure-openclaw-plugins.cjs` 确认 patch 正常应用

🤖 Generated with [Claude Code](https://claude.com/claude-code)