### PR TITLE
docs: update spec and plan to reflect final implementation

### DIFF
--- a/spec/refactor/fix-agent-model-invalid/plan.md
+++ b/spec/refactor/fix-agent-model-invalid/plan.md
@@ -1,211 +1,175 @@
-# 修复 "Agent 绑定模型已不可用" 报错 — 实施计划
+# 修复 "Agent 绑定模型已不可用" 报错 — 实施记录（最终版）
 
 **前置文档:** [audit.md](./audit.md)（排查报告） | [spec.md](./spec.md)（验收规格）
 
 ---
 
-## 安全审查结论
+## 实施总结
 
-| Step | 原方案 | 审查结论 | 调整 |
-|------|--------|----------|------|
-| 1 | onChange 修正 Agent.model | ✓ 可行，需加异常处理 | 小幅调整 |
-| 2 | Settings 保存时遍历清理 Agent | ✗ 风险较高，需重新设计 | 改为更安全的方案 |
-| 3 | 裸 ID 歧义优先 server | ✗ 不实施 | 当前行为是有意的防御性设计 |
-| 4 | UI 显示失效模型名 | ✓ 无风险 | 保持 |
-
-### Step 2 原方案的问题
-
-1. **Settings.tsx 未导入 agentService** — 需新增导入，增加模块耦合
-2. **Agent 列表可能未加载** — 用户可能未进入过 Agent 页面，`store.getState().agent.agents` 可能为空或不完整
-3. **多次 dispatch 造成渲染抖动** — 每次 `updateAgent` 都会触发 Redux dispatch + re-render
-4. **时序问题** — `setAvailableModels` 保留了 server 模型，但此时 `store.getState().model.availableModels` 已包含 server 模型，不会误清 server 模型引用。但如果 `loadServerModels()` 恰好在 Settings 保存前后被触发（如窗口 focus），可能出现竞态。
-
-### Step 3 不实施的原因
-
-- 现有测试 `agentModelSelection.test.ts:80-91` 明确验证"歧义裸 ID 应判定为 invalid"
-- 这是**防御性设计决策**：宁可报错也不猜测用户意图
-- `matchesOpenClawModelRef` 函数没有歧义处理，若修改 `resolveOpenClawModelRef` 行为会造成两个函数语义不一致
-- 裸 ID 在正常流程中不应出现（`toOpenClawModelRef` 总是生成带 provider 前缀的引用）
+共 6 个 commit，修改 9 个核心文件。从初始方案（B1 onChange 修正 + B4 UI 优化）演变为更全面的重构，核心思路从"修复死循环"变为"每个 session 有自己独立的模型"。
 
 ---
 
-## Step 1: 修复 B1 — Agent.model invalid 时，session 内选模型可修正 Agent (P0)
+## Step 1: 核心模型选择逻辑重构
 
-**文件:** `src/renderer/components/cowork/CoworkPromptInput.tsx`
+**commit**: `7153cd2`
 
-**修改位置:** onChange handler (line 920-928)
+### 1.1 agentModelSelection.ts — Agent.model 失效改为静默 fallback
 
-**修改为:**
+**变更**: Agent.model 解析失败时，`hasInvalidExplicitModel` 从 `true` 改为 `false`。
+
 ```typescript
-onChange={coworkAgentEngine === 'openclaw'
-  ? async (nextModel) => {
-      if (!nextModel) return;
-      const modelRef = toOpenClawModelRef(nextModel);
-      if (sessionId) {
-        await coworkService.patchSession(sessionId, { model: modelRef });
-        // Agent.model 无效时同步修正，解除全局报错
-        if (currentAgent && agentModelIsInvalid) {
-          agentService.updateAgent(currentAgent.id, { model: modelRef });
-        }
-        return;
-      }
-      if (!currentAgent) return;
-      agentService.updateAgent(currentAgent.id, { model: modelRef });
-    }
-  : undefined}
+// agent model 失效 → 静默 fallback（不阻塞用户）
+return { selectedModel: fallbackModel, usesFallback: true, hasInvalidExplicitModel: false };
 ```
 
-**设计要点:**
-- `agentService.updateAgent` 不 await — 它本身已经是 fire-and-forget 模式（内部 catch error + console.error），不阻塞 UI
-- 条件守卫 `agentModelIsInvalid` 确保 Agent.model 有效时不被 session 级操作覆盖
-- `agentModelIsInvalid` 是 render 时从 Redux state 同步计算的，onChange 执行时值稳定
-- IM 渠道不受影响：IM session 走同样的 patchSession 路径，只有 invalid 时才额外修正 Agent
+**设计决策**: 原方案（plan.md v1）保持报错，通过 Step 1 的 onChange 修正解除死循环。在讨论中改为静默 fallback，原因：
+- Agent.model 是全局共享的，一个对话的操作可能导致所有对话报错
+- 报错对用户来说不直观（"我什么都没做，怎么就不可用了？"）
+- Session.modelOverride 是用户显式选择的，失效时报错合理；Agent.model 不是
 
-**不影响的场景:**
-- 多 Agent 隔离：`currentAgent` 是当前选中的 Agent，不影响其他 Agent
-- Session 模型独立性：Agent.model 有效时，session 切换仍只改 modelOverride
-- IM 渠道：与普通 session 走同一条代码路径，行为一致
+### 1.2 agentModelSelection.test.ts — 更新测试
 
-**验证:**
-1. `npx tsc --noEmit`
-2. `npm test` — 现有测试不应受影响（测试不涉及 onChange 行为）
-3. 手动验证：Agent invalid → session 内选模型 → 新建对话不报错
-4. 手动验证：Agent valid → session 内选模型 → Agent.model 不变
+- `silently falls back when agent model is invalid` — 验证 agent 级别 `hasInvalidExplicitModel: false`
+- `silently falls back when agent model is an ambiguous bare id` — 同上
+- `marks invalid session model override as error` — 新增：验证 session 级别仍报错
 
----
+### 1.3 openclawModelRef.ts — Provider ID fallback
 
-## Step 2: 修复 B2 — Provider 禁用时清理 Agent.model (P1)
-
-**重新设计**: 不在 Settings.tsx 中处理，改为在 **modelSlice reducer 中通过 listener/middleware** 或在 **App.tsx 的模型加载逻辑中** 处理。
-
-### 方案 A（推荐）: 在 agentModelSelection 判定层做容错
-
-**思路**: 不主动清理 Agent.model，而是在判定函数中增加"自动清空无效 agent model"的副作用。
-
-**否决原因**: 判定函数是纯函数，不应有副作用。违反架构原则。
-
-### 方案 B（推荐）: 在 App.tsx 启动时做一次性校验
-
-**文件:** `src/renderer/App.tsx`
-
-**位置:** 在 `dispatch(setAvailableModels(resolvedModels))` 之后（约 line 172-180）
-
-**逻辑:**
 ```typescript
-// 启动时校验所有 Agent 的 model，清理无效引用
-const finalAvailableModels = store.getState().model.availableModels;
-const loadedAgents = store.getState().agent.agents;
-for (const agent of loadedAgents) {
-  if (agent.model && !resolveOpenClawModelRef(agent.model, finalAvailableModels)) {
-    agentService.updateAgent(agent.id, { model: '' });
-  }
+// 精确匹配失败后，按 modelId 在所有 availableModels 中查找唯一匹配
+const idMatches = availableModels.filter((model) => model.id === modelId);
+if (idMatches.length === 1) {
+  return idMatches[0];
 }
 ```
 
-**前提**: 需确认 agents 在此时已加载。检查 App.tsx 中 agent 加载时机。
+**设计决策**: 原 plan.md 中 B3 标记为"不实施"（歧义是防御性设计）。实施时增加了有条件的 fallback——仅在 modelId **唯一**时才 fallback，歧义时仍返回 null。这保留了防御性同时兼容 provider 迁移。
 
-### 方案 C（最安全）: 在 Settings 保存后发事件，由 agentService 响应
-
-**思路**: Settings 保存后通过 Redux action 或 event 通知系统"模型列表变更"，由订阅方（如 App 层 useEffect）负责清理。
-
-**文件:** `src/renderer/App.tsx` 或新建 hook `useAgentModelCleanup`
+### 1.4 CoworkPromptInput.tsx — onChange 修正 Agent.model + UI 改进
 
 ```typescript
-// 在 App.tsx 或 CoworkView.tsx 中
-useEffect(() => {
-  const agents = store.getState().agent.agents;
-  for (const agent of agents) {
-    if (agent.model && !resolveOpenClawModelRef(agent.model, availableModels)) {
-      agentService.updateAgent(agent.id, { model: '' });
-    }
+if (sessionId) {
+  await coworkService.patchSession(sessionId, { model: modelRef });
+  // Agent.model 无效时同步修正
+  if (currentAgent && agentModelIsInvalid) {
+    agentService.updateAgent(currentAgent.id, { model: modelRef });
   }
-}, [availableModels]);
+  return;
+}
 ```
 
-**风险**: useEffect 依赖 `availableModels` 可能导致首次加载时误触发（此时 server 模型可能还没到）。
+ModelSelector value：invalid 时显示失效模型名（从 session.modelOverride 提取）。
 
-### 方案 D（最简）: 仅依赖 Step 1 的修复
+### 1.5 i18n — 文案精简
 
-**思路**: 不做主动清理。Agent.model 无效时报错，但用户可以通过选模型解除（Step 1 已保证）。下次新建对话时也不报错（因为 Step 1 已修正了 Agent.model）。
-
-**优点**: 零额外代码，零风险。报错是合理的，Step 1 已解除死循环。
-**缺点**: 重启后首次进入仍会报错一次，需用户手动选模型。
+- `'当前模型已不可用，请重新选择'` / `'Model unavailable. Please select another'`
+- 原方案是在红字中附加失效模型名，最终改为在 ModelSelector 本身显示失效模型名
 
 ---
 
-### Step 2 结论
+## Step 2: 合并冲突解决
 
-**推荐方案 D（仅依赖 Step 1）**，理由：
-1. 报错本身合理（模型确实不可用）
-2. Step 1 已解除死循环（用户可通过 UI 修复）
-3. 无额外代码 = 无额外风险
-4. 如果未来需要"静默修复"，可以单独迭代方案 B 或 C
+**commit**: `6144ff1`
 
-如果一定要做主动清理，推荐**方案 B**（启动时校验），但需要先确认 App.tsx 中 agents 的加载时机。
+release 分支合并了 OpenAI → OpenAI Codex provider 迁移兼容逻辑（与 Step 1.3 的 provider fallback 冲突），两者保留。
 
 ---
 
-## Step 3: 不实施
+## Step 3: 新建 session 时持久化 modelOverride
 
-裸 ID 歧义判定为 invalid 是正确的防御性行为，且有测试覆盖。不修改。
+**commit**: `18a33b5`
+
+**新增需求**（不在原 plan 中）：用户反馈"每个会话应该有自己固定的模型"。
+
+### 改动链路
+
+1. **`src/renderer/types/cowork.ts`** — `CoworkStartOptions` 增加 `modelOverride?: string`
+2. **`src/main/coworkStore.ts`** — `createSession()` 接受 `modelOverride` 参数，写入 SQL
+3. **`src/main/main.ts`** — IPC handler 传递 `options.modelOverride` 到 `createSession()`
+4. **`src/renderer/components/cowork/CoworkView.tsx`** — `startSession()` 调用时传入 `globalSelectedModel` 生成的 modelOverride
+
+**设计决策**: 之前 session 创建时 modelOverride 始终为空（`''`），用户的模型选择实际来自 Agent.model 继承。改为创建时即固化到 session，实现真正的 per-session 模型隔离。
 
 ---
 
-## Step 4: UI 显示失效模型名称 (P2)
+## Step 4: 阻止 session.modelOverride 被 normalization 改写
 
-**文件:** `src/renderer/components/cowork/CoworkPromptInput.tsx`
+**commit**: `2500d89`
 
-**修改:** 在红字提示中附加失效的模型引用。
+**新增需求**（不在原 plan 中）：发现 `openclawRuntimeAdapter.ts` 的 `startTurn` 会对 modelOverride 做 normalization，导致 `lobsterai-server/qwen3.5-plus` 被改写为 `qwen-portal/qwen3.5-plus`（因为 `buildAvailableOpenClawProviders()` 跳过 lobsterai-server provider）。
 
 ```typescript
-{coworkAgentEngine === 'openclaw' && agentModelIsInvalid && (
-  <span className="max-w-60 text-[11px] leading-4 text-red-500">
-    {i18nService.t('agentModelInvalidHint')}
-    {currentAgent?.model && (
-      <span className="opacity-70"> ({currentAgent.model.split('/').pop()})</span>
-    )}
-  </span>
-)}
+const currentModel = session.modelOverride
+  ? rawCurrentModel  // 用户选的，不动
+  : (rawCurrentModel ? this.normalizeModelRef(rawCurrentModel) : '');  // agent 的，可能需要迁移
 ```
 
-**要点:**
-- `split('/').pop()` 取模型 ID 部分（去掉 provider 前缀），用户友好
-- `opacity-70` 降低视觉权重，主信息仍是报错文案
-- `max-w-60` 已有，长模型名会自然换行
-- 无性能/内存问题：纯渲染逻辑，无副作用
+**影响**: 仅 agent-level model ref 做 normalization（处理 provider 迁移），session.modelOverride 原样发送给 gateway。
 
 ---
 
-## 最终提交计划
+## Step 5: Home 页模型选择解耦
 
-| Step | commit message | 文件 |
-|------|----------------|------|
-| 1 | `fix(cowork): allow session model change to fix invalid agent model` | CoworkPromptInput.tsx |
-| 4 | `fix(cowork): show invalid model name in error hint` | CoworkPromptInput.tsx, i18n.ts |
+**commit**: `0cb02d6`
 
-**总修改量**: ~10 行有效代码变更，集中在 1 个文件。
+**新增需求**（不在原 plan 中）：home 页选模型调用 `agentService.updateAgent` → 触发 `syncOpenClawConfig` → 影响 gateway primaryModel → 影响其他 session。
+
+### 改动
+
+1. **`CoworkView.tsx` header ModelSelector**: `agentService.updateAgent()` → `dispatch(setSelectedModel(nextModel))`
+2. **`CoworkPromptInput.tsx` home page ModelSelector** (无 sessionId 时): 同上
+3. 清理相关未使用的 import
+
+**设计决策**: Home 页选模型只影响 Redux 内存态，创建 session 时才写入 modelOverride。不持久化 home 页的模型选择（重启后回到默认），这是可接受的 tradeoff。
 
 ---
 
-## 验证清单
+## Step 6: 清理
 
-| 项目 | 方法 |
-|------|------|
-| TypeScript 编译 | `npx tsc --noEmit` |
-| 单元测试 | `npm test` |
-| 生产构建 | `npm run build` |
-| Agent.model invalid → session 选模型 → 修正 | 手动 |
-| Agent.model valid → session 选模型 → 不动 Agent | 手动 |
-| 新建对话不报错 | 手动 |
-| IM 渠道对话不受影响 | 手动 |
-| 多 Agent 切换不互相影响 | 手动 |
-| Mac + Windows 构建 | CI |
+**commit**: `0d96884`
 
-## 不涉及的内容
+移除 CoworkView.tsx 中未使用的 `headerSelectedModel`、`availableModels` selector、`resolveAgentModelSelection` import。
 
-- 无数据库 schema 变更（使用已有 API）
-- 无新增文件
-- 无新增依赖
-- 无跨平台差异代码
-- 无分辨率相关改动
-- 老用户覆盖安装无兼容问题（Agent.model 清空后 fallback 到 globalSelectedModel 是已有行为）
+---
+
+## 方案演变过程
+
+| 阶段 | 核心思路 | 触发变化的原因 |
+|------|----------|----------------|
+| v1 (plan.md 初版) | B1 onChange 修正 + B4 UI | 初始分析 |
+| v2 | + Agent.model 失效改为静默 fallback | 用户反馈：Agent.model 失效不应该阻塞 |
+| v3 | + 新建时持久化 modelOverride | 用户要求：每个 session 应有自己的模型 |
+| v4 | + 阻止 normalize 改写 session model | 调试发现：server 模型被错误改写 |
+| v5 (最终) | + Home 页选模型解耦 | 发现：home 选模型触发 sync 影响运行中 session |
+
+## 废弃的方案
+
+### B2 Settings 禁用时主动清理 Agent.model
+
+plan.md v1 列举了 4 个方案（A-D），最终选择了方案 D（不做主动清理）。后来 Agent.model 失效改为静默 fallback 后，这个问题完全消失——不需要清理，因为失效不再报错。
+
+### B3 裸 ID 歧义优先 server
+
+plan.md v1 标记为"不实施"。实际通过 Step 1.3 的有条件 provider ID fallback 部分解决（唯一匹配时 fallback，歧义时仍 null）。
+
+---
+
+## 涉及的文件
+
+| 文件 | 改动内容 |
+|------|----------|
+| `src/renderer/components/cowork/agentModelSelection.ts` | Agent.model 失效改为静默 fallback |
+| `src/renderer/components/cowork/agentModelSelection.test.ts` | 更新 2 个测试 + 新增 1 个测试 |
+| `src/renderer/components/cowork/CoworkPromptInput.tsx` | onChange 修正 Agent.model + home 页解耦 + UI 显示失效模型名 |
+| `src/renderer/components/cowork/CoworkView.tsx` | header 解耦 + 新建 session 传 modelOverride + 清理 |
+| `src/renderer/utils/openclawModelRef.ts` | Provider ID fallback + OpenAI Codex 兼容 |
+| `src/renderer/services/i18n.ts` | 文案精简 |
+| `src/renderer/types/cowork.ts` | CoworkStartOptions 增加 modelOverride |
+| `src/main/coworkStore.ts` | createSession 接受 modelOverride |
+| `src/main/main.ts` | IPC handler 传递 modelOverride |
+| `src/main/libs/agentEngine/openclawRuntimeAdapter.ts` | 跳过 session.modelOverride 的 normalization |
+
+## 待清理
+
+- 多个文件中有调试用的 `console.log` 语句（标记为 `[CoworkPromptInput]`、`[CoworkView]`、`[openclawModelRef]`），应在功能稳定后清理

--- a/spec/refactor/fix-agent-model-invalid/spec.md
+++ b/spec/refactor/fix-agent-model-invalid/spec.md
@@ -1,64 +1,110 @@
-# 修复 "Agent 绑定模型已不可用" 报错 — 验收规格
+# 修复 "Agent 绑定模型已不可用" 报错 — 验收规格（最终版）
 
 ## Overview
 
-修复 Agent 模型绑定失效后的系列问题：报错无法通过 UI 解除（死循环）、禁用 provider 后大面积 session 报错、重启不恢复。
+修复 Agent 模型绑定失效后的系列问题：报错无法通过 UI 解除（死循环）、禁用 provider 后大面积 session 报错、重启不恢复、home 页选模型影响正在运行的 session。
 
 ## 设计原则
 
-1. **报错本身合理** — 模型确实不可用时，阻止发送并提示用户是正确行为
-2. **session.modelOverride 必须保持** — 每个对话的模型选定后要保持住（多 agent、IM 渠道依赖此机制）
-3. **修复"不可达"问题** — 确保用户总能通过合理的 UI 操作解除报错状态
-4. **不引入新的副作用** — 不能因为修复而破坏多 Agent 隔离或 session 模型独立性
+1. **每个 session 有自己的模型** — 创建时即固定，不被其他 session 的操作修改
+2. **Agent.model 失效时静默 fallback** — 不阻塞发送，使用全局 fallback 模型
+3. **Session.modelOverride 失效时报错** — 要求用户手动选择（这是用户显式选择的模型，值得告知）
+4. **Home 页选模型不触发 gateway 配置变更** — 避免影响其他正在运行的 session
+5. **Session modelOverride 不被 normalization 改写** — 用户选定的模型引用原样发送给 gateway
 
 ---
 
-## 终态要求
+## 终态行为
 
-### B1 (P0): 用户在 session 中选模型时应能修正 Agent.model
+### 1. Agent.model 失效时静默 fallback（原 B1 + B2）
 
-**问题**: 有 sessionId 时 onChange 只 patch session，Agent.model 永远不被修正。
+**修改文件**: `agentModelSelection.ts`
 
-**修复行为**:
-- 当 Agent.model 处于 invalid 状态，用户在任何 session 中选择新模型时，**除了 patch session，还应修正 Agent.model**
-- 当 Agent.model 有效时，session 中切换模型仅 patch session（保持 session 级模型独立性）
+**行为**:
+- Agent.model 解析失败 → `hasInvalidExplicitModel: false`，使用 `fallbackModel`（globalSelectedModel）
+- 不阻塞发送，不显示红字
+- 用户在 session 中切换模型时，若 Agent.model 处于无效状态，**同时修正 Agent.model**
 
-**验证方法**:
-1. Agent 绑定 deepseek-v4 → 禁用 deepseek → 进入对话 → 选 qwen → 确认 Agent.model 被更新为 qwen
-2. Agent 绑定 qwen（有效）→ 进入对话 → 切到 kimi → 确认 Agent.model 不变（仍为 qwen），仅 session.modelOverride 变为 kimi
-3. 修正后新建对话 → 不报错
+**验证**:
+1. Agent 绑定 deepseek-v4 → 禁用 deepseek → 进入对话 → 不报错，使用全局模型
+2. 在对话中选 qwen → Agent.model 被更新为 qwen → 新建对话不报错
+3. Agent.model 有效时，session 中切换模型 → Agent.model 不变，仅 session.modelOverride 变化
 
-### B2 (P1): provider 禁用时校验/清理受影响的 Agent.model
+### 2. Session.modelOverride 失效时报错
 
-**问题**: Settings 中禁用 provider 后，引用该 provider 模型的 Agent.model 变成脏数据，无清理机制。
+**修改文件**: `agentModelSelection.ts`
 
-**修复行为**:
-- Settings 保存触发 `setAvailableModels()` 后，检查所有 Agent 的 model 字段
-- 若 Agent.model 在新的 availableModels 中不可解析，**自动清空该 Agent 的 model**（让其 fallback 到 globalSelectedModel）
-- 可选：通知用户"Agent X 的模型已被重置"
+**行为**:
+- session.modelOverride 非空但解析失败 → `hasInvalidExplicitModel: true`
+- 显示红字："当前模型已不可用，请重新选择"
+- 发送按钮禁用
+- ModelSelector 显示失效模型名称（从 modelOverride 中提取 modelId 部分）
 
-**验证方法**:
-1. Agent 绑定 deepseek → Settings 禁用 deepseek provider → 保存 → Agent.model 被自动清空
-2. 回到对话 → 不报错，使用 global fallback 模型
-3. 多 Agent: Agent A 绑定 deepseek，Agent B 绑定 qwen → 禁用 deepseek → Agent A model 被清空，Agent B 不受影响
+**验证**:
+1. 手动 patch session.modelOverride 为无效值 → 红字提示 + 发送禁用
+2. 在模型选择器中选新模型 → 红字消失 → 可正常发送
 
-### B3 (P2): 裸 ID 歧义优化
+### 3. 新建 session 时持久化 modelOverride
 
-**问题**: 裸 ID 匹配到多个模型时判定为无效。
+**修改文件**: `CoworkView.tsx`, `cowork.ts (types)`, `coworkStore.ts`, `main.ts`
 
-**修复行为**:
-- 歧义时优先选择 server 模型，而非返回 null
+**行为**:
+- 新建 session 时，使用 `globalSelectedModel` 生成 `modelOverride` 写入 SQLite
+- 后续该 session 的模型独立于 Agent.model 和其他 session
+- 创建链路：`CoworkView → IPC(cowork:session:start) → coworkStore.createSession(modelOverride)`
 
-**验证方法**:
-1. 同时存在 server/kimi-k2.6 和 custom/kimi-k2.6 → 裸 ID `kimi-k2.6` → 解析到 server 模型
+**验证**:
+1. 选模型 X → 新建 session A → 切换到模型 Y → 新建 session B → session A 保持模型 X
+2. 重启后 session A 仍使用模型 X
 
-### B4 (P2): UI 状态优化
+### 4. Home 页模型选择解耦（不触发 syncOpenClawConfig）
 
-**问题**: invalid 时 ModelSelector 显示的是 fallback 模型名（而非失效模型名），用户困惑。
+**修改文件**: `CoworkView.tsx` (header), `CoworkPromptInput.tsx` (home page)
 
-**修复行为**:
-- 红字提示中包含失效的模型名称，帮助用户理解是哪个模型出了问题
-- 或：ModelSelector 在 invalid 时显示一个"模型已失效"的占位状态
+**行为**:
+- Header 和 Input 的模型选择器都改为 `dispatch(setSelectedModel(nextModel))`
+- **不再** 调用 `agentService.updateAgent()` → 不写 SQLite → 不触发 `syncOpenClawConfig`
+- Gateway 的 `primaryModel` 不受 home 页操作影响
+- 模型选择仅存在于 Redux 内存态（`globalSelectedModel`），创建 session 时写入 `modelOverride`
+
+**验证**:
+1. Home 页选模型 → 不触发 `[reason=agent-updated] syncOpenClawConfig`
+2. 正在运行的 session 不受影响
+3. 重启后 home 页显示默认模型（不持久化 home 页选择）
+
+### 5. Session modelOverride 不被 normalization 改写
+
+**修改文件**: `openclawRuntimeAdapter.ts`
+
+**行为**:
+- `startTurn` 时，若 session 有 modelOverride，**跳过 normalization**，原样发送给 gateway
+- 仅对 agent-level model ref 做 normalization（处理 provider 迁移）
+- 解决：`lobsterai-server/qwen3.5-plus` 被错误改写为 `qwen-portal/qwen3.5-plus` 的问题
+
+**验证**:
+1. 使用 server 模型创建对话 → startTurn 日志显示 `source: 'sessionOverride'` + 原始模型引用
+2. 使用 custom 模型创建对话 → 同样不被改写
+
+### 6. Provider ID fallback（openclawModelRef）
+
+**修改文件**: `openclawModelRef.ts`
+
+**行为**:
+- `provider/modelId` 精确匹配失败时，提取 modelId 部分在所有 availableModels 中查找
+- 若 modelId 唯一匹配到一个模型 → 返回该模型（兼容 provider 迁移）
+- 若匹配到 0 个或多个 → 返回 null（保持原有行为）
+- OpenAI → OpenAI Codex provider 迁移的特殊兼容逻辑保留
+
+**验证**:
+1. 模型引用为旧 provider 格式（如 `old-provider/model-x`）但 model-x 在新 provider 下唯一存在 → 正常解析
+2. model-x 在多个 provider 下存在 → 返回 null（不猜测）
+
+### 7. i18n 文案
+
+**修改文件**: `i18n.ts`
+
+- 中文：`'当前模型已不可用，请重新选择'`
+- 英文：`'Model unavailable. Please select another'`
 
 ---
 
@@ -67,23 +113,36 @@
 | 验收项 | 命令 |
 |--------|------|
 | TypeScript 编译通过 | `npx tsc --noEmit` |
-| 测试通过 | `npm test` |
-| 现有测试更新 | `agentModelSelection.test.ts` 覆盖新行为 |
+| 单元测试通过 | `npm test` |
 | 生产构建成功 | `npm run build` |
 
 ## 功能验证
 
 | 验收项 | 验证方法 |
 |--------|----------|
-| 正常模型绑定 | Agent 绑定有效模型 → 对话正常 → 新建对话正常 |
-| Provider 禁用后自动清理 | 禁用 provider → Agent.model 被清空 → 使用 fallback → 不报错 |
-| Session 模型独立性 | 在 session A 切到 kimi → session B 仍用 Agent 默认模型 |
-| 多 Agent 隔离 | Agent A 被清理 → Agent B 不受影响 |
-| 重启一致性 | 任何操作后重启 → 无报错（脏数据已被清理） |
+| Agent.model 失效 → 静默 fallback | 禁用 provider → 对话正常 → 使用 fallback 模型 |
+| Session.modelOverride 失效 → 报错 | 手动构造无效 override → 红字 + 禁用发送 |
+| Session 模型独立性 | session A 用 X，session B 用 Y → 互不影响 |
+| Home 页选模型不触发 sync | 选模型后日志无 `syncOpenClawConfig` |
+| Server 模型不被 normalize 改写 | 使用 lobsterai-server 模型 → sessions.patch 发送原始引用 |
+| 多 Agent/IM 不受影响 | IM 渠道对话正常使用 Agent 设置中的模型 |
+| 重启一致性 | 重启后各 session 保持自己的 modelOverride |
 
 ## 不在范围内
 
+- ~~B2 Settings 禁用 provider 时主动清理 Agent.model~~ → Agent.model 失效已改为静默 fallback，无需主动清理
+- ~~B3 裸 ID 歧义优先 server~~ → 通过 provider ID fallback 部分解决，歧义仍返回 null
 - 运行时 LLM 调用错误的 UI 展示改进（网络错误、auth 错误等）
 - 模型列表服务端接口的可靠性
-- Provider 配置 UI 的重构
-- session.modelOverride 的自动清理（session 级失效模型暂保留报错行为，用户可手动切换解除）
+- `isSameModelIdentity` 的 providerKey 缺失时 fallback 行为
+
+## 提交记录
+
+| commit | 说明 |
+|--------|------|
+| `7153cd2` | 核心修复：agent fallback + session error + provider ID fallback + i18n + 测试 |
+| `6144ff1` | 合并冲突解决（openclawModelRef OpenAI Codex 兼容） |
+| `18a33b5` | 新建 session 时持久化 modelOverride（types → IPC → SQLite 全链路） |
+| `2500d89` | 阻止 normalizeModelRef 改写 session.modelOverride |
+| `0cb02d6` | home 页模型选择解耦（不触发 agent update / syncOpenClawConfig） |
+| `0d96884` | 清理未使用的代码 |


### PR DESCRIPTION
The original spec was written for the initial approach (B1 onChange fix +
B4 UI hint). The implementation evolved significantly through five
iterations, adding session modelOverride persistence, normalization
bypass, and home-page model selection decoupling. Update both documents
to match the shipped behavior.
