### PR TITLE
fix: strip IM media metadata from user message display

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1668,6 +1668,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     setHoveredRailIndex(null);
   }, [currentSession?.id]);
 
+  const closeMenu = useCallback(() => {
+    setMenuPosition(null);
+    setShowConfirmDelete(false);
+  }, []);
+
   // Close menu on outside click
   useEffect(() => {
     if (!menuPosition) return;
@@ -1729,11 +1734,6 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     }
     setShowConfirmDelete(false);
   };
-
-  const closeMenu = useCallback(() => {
-    setMenuPosition(null);
-    setShowConfirmDelete(false);
-  }, []);
 
   // Open folder in Finder/Explorer
   const handleOpenFolder = useCallback(async () => {

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1634,6 +1634,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       setRenameValue(currentSession.title);
       ignoreNextBlurRef.current = false;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRenaming, currentSession?.title]);
 
   useEffect(() => {
@@ -1692,7 +1693,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       window.removeEventListener('scroll', handleScroll, true);
       window.removeEventListener('resize', handleScroll);
     };
-  }, [menuPosition]);
+  }, [menuPosition, closeMenu]);
 
   // Helper: truncate path for display
   const truncatePath = (path: string, maxLength = 20): string => {
@@ -1729,10 +1730,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     setShowConfirmDelete(false);
   };
 
-  const closeMenu = () => {
+  const closeMenu = useCallback(() => {
     setMenuPosition(null);
     setShowConfirmDelete(false);
-  };
+  }, []);
 
   // Open folder in Finder/Explorer
   const handleOpenFolder = useCallback(async () => {

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -25,6 +25,7 @@ import { setActiveSkillIds } from '../../store/slices/skillSlice';
 import type { CoworkImageAttachment,CoworkMessage, CoworkMessageMetadata } from '../../types/cowork';
 import type { Skill } from '../../types/skill';
 import { getCompactFolderName } from '../../utils/path';
+import { parseUserMessageForDisplay } from '../../utils/userMessageDisplay';
 import Modal from '../common/Modal';
 import ComposeIcon from '../icons/ComposeIcon';
 import EllipsisHorizontalIcon from '../icons/EllipsisHorizontalIcon';
@@ -1167,6 +1168,12 @@ export const UserMessageItem: React.FC<{
   const [isHovered, setIsHovered] = useState(false);
   const [expandedImage, setExpandedImage] = useState<string | null>(null);
 
+  // Transform content for display: strip IM media metadata, render images inline
+  const displayContent = useMemo(
+    () => parseUserMessageForDisplay(message.content || ''),
+    [message.content]
+  );
+
   // Get skills used for this message
   const messageSkillIds = (message.metadata as CoworkMessageMetadata)?.skillIds || [];
   const messageSkills = messageSkillIds
@@ -1187,14 +1194,14 @@ export const UserMessageItem: React.FC<{
           <div className="flex items-start gap-3 flex-row-reverse">
             <div className="w-full min-w-0 flex flex-col items-end">
               <div className="w-fit max-w-[54rem] rounded-2xl px-4 py-2.5 bg-surface text-foreground shadow-subtle">
-                {message.content?.trim() && (
+                {displayContent?.trim() && (
                   <MarkdownContent
-                    content={message.content}
+                    content={displayContent}
                     className="max-w-none whitespace-pre-wrap break-words"
                   />
                 )}
                 {imageAttachments.length > 0 && (
-                  <div className={`flex flex-wrap gap-2 ${message.content?.trim() ? 'mt-2' : ''}`}>
+                  <div className={`flex flex-wrap gap-2 ${displayContent?.trim() ? 'mt-2' : ''}`}>
                     {imageAttachments.map((img, idx) => (
                       <div key={idx} className="relative group">
                         <img

--- a/src/renderer/utils/userMessageDisplay.test.ts
+++ b/src/renderer/utils/userMessageDisplay.test.ts
@@ -47,7 +47,7 @@ describe('passthrough (no transformation)', () => {
 // ─── Pattern A: NIM/DingTalk ────────────────────────────────
 
 describe('Pattern A: NIM/DingTalk', () => {
-  test('[图片] with URL and [附件信息] → strip metadata, render image', () => {
+  test('[图片] with URL and [附件信息] → strip metadata, preserve URL as text', () => {
     const imgPath = fileImg(WIN_INBOUND, 'abc123.jpg');
     const input = [
       '[图片] https://nos.netease.com/xxx.jpg',
@@ -57,37 +57,35 @@ describe('Pattern A: NIM/DingTalk', () => {
     ].join('\n');
 
     const result = parseUserMessageForDisplay(input);
-    expect(result).toBe(toFileUrl(imgPath));
+    expect(result).toBe('https://nos.netease.com/xxx.jpg');
     expect(result).not.toContain('[图片]');
     expect(result).not.toContain('[附件信息]');
   });
 
   test('[图片] without URL → strip placeholder', () => {
-    const imgPath = fileImg(WIN_INBOUND, 'abc123.jpg');
     const input = [
       '[图片]',
       '',
       '[附件信息]',
-      `- 类型: image, 路径: ${imgPath}, MIME: image/jpeg`,
+      `- 类型: image, 路径: ${fileImg(WIN_INBOUND, 'abc123.jpg')}, MIME: image/jpeg`,
     ].join('\n');
 
     const result = parseUserMessageForDisplay(input);
-    expect(result).toBe(toFileUrl(imgPath));
+    expect(result).toBe('');
   });
 
-  test('user text + [图片] → preserve user text, strip metadata', () => {
-    const imgPath = fileImg(WIN_INBOUND, 'abc123.jpg');
+  test('user text + [图片] → preserve user text and URL', () => {
     const input = [
       '看看这张图',
       '[图片] https://nos.netease.com/xxx.jpg',
       '',
       '[附件信息]',
-      `- 类型: image, 路径: ${imgPath}, MIME: image/jpeg`,
+      `- 类型: image, 路径: ${fileImg(WIN_INBOUND, 'abc123.jpg')}, MIME: image/jpeg`,
     ].join('\n');
 
     const result = parseUserMessageForDisplay(input);
     expect(result).toContain('看看这张图');
-    expect(result).toContain(toFileUrl(imgPath));
+    expect(result).toContain('https://nos.netease.com/xxx.jpg');
     expect(result).not.toContain('[图片]');
   });
 
@@ -104,26 +102,30 @@ describe('Pattern A: NIM/DingTalk', () => {
     expect(result).not.toContain('[附件信息]');
   });
 
-  test('[文件] placeholder stripped', () => {
+  test('[文件] with URL → preserve URL', () => {
     const input = '[文件] https://nos.netease.com/file.pdf';
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe('https://nos.netease.com/file.pdf');
+  });
+
+  test('[文件] without URL → strip', () => {
+    const input = '[文件]';
     const result = parseUserMessageForDisplay(input);
     expect(result).toBe('');
   });
 
-  test('multiple images in [附件信息]', () => {
-    const img1 = fileImg(WIN_INBOUND, 'img1.jpg');
-    const img2 = fileImg(WIN_INBOUND, 'img2.png');
+  test('multiple images in [附件信息] → strip block', () => {
     const input = [
       '[图片]',
       '',
       '[附件信息]',
-      `- 类型: image, 路径: ${img1}, MIME: image/jpeg`,
-      `- 类型: image, 路径: ${img2}, MIME: image/png`,
+      `- 类型: image, 路径: ${fileImg(WIN_INBOUND, 'img1.jpg')}, MIME: image/jpeg`,
+      `- 类型: image, 路径: ${fileImg(WIN_INBOUND, 'img2.png')}, MIME: image/png`,
     ].join('\n');
 
     const result = parseUserMessageForDisplay(input);
-    expect(result).toContain(toFileUrl(img1));
-    expect(result).toContain(toFileUrl(img2));
+    expect(result).not.toContain('[附件信息]');
+    expect(result).not.toContain('[图片]');
   });
 });
 
@@ -293,16 +295,15 @@ describe('\\r\\n handling', () => {
   });
 
   test('NIM format with \\r\\n line endings', () => {
-    const imgPath = fileImg(WIN_INBOUND, 'abc123.jpg');
     const input = [
       '[图片] https://nos.netease.com/xxx.jpg',
       '',
       '[附件信息]',
-      `- 类型: image, 路径: ${imgPath}, MIME: image/jpeg`,
+      `- 类型: image, 路径: ${fileImg(WIN_INBOUND, 'abc123.jpg')}, MIME: image/jpeg`,
     ].join('\r\n');
 
     const result = parseUserMessageForDisplay(input);
-    expect(result).toBe(toFileUrl(imgPath));
+    expect(result).toBe('https://nos.netease.com/xxx.jpg');
   });
 });
 

--- a/src/renderer/utils/userMessageDisplay.test.ts
+++ b/src/renderer/utils/userMessageDisplay.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import { parseUserMessageForDisplay } from './userMessageDisplay';
 

--- a/src/renderer/utils/userMessageDisplay.test.ts
+++ b/src/renderer/utils/userMessageDisplay.test.ts
@@ -1,0 +1,324 @@
+import { expect, test, describe } from 'vitest';
+
+import { parseUserMessageForDisplay } from './userMessageDisplay';
+
+// ─── Helpers ────────────────────────────────────────────────
+
+const WIN_INBOUND = String.raw`C:\Users\yangwn\AppData\Roaming\LobsterAI\openclaw\state\media\inbound`;
+const MAC_INBOUND = '/Users/yangwn/Library/Application Support/LobsterAI/openclaw/state/media/inbound';
+
+const fileImg = (dir: string, name: string) => `${dir}${dir.includes('\\') ? '\\' : '/'}${name}`;
+
+const toFileUrl = (p: string) => {
+  const normalized = p.replace(/\\/g, '/');
+  const urlPath = normalized.startsWith('/') ? normalized : `/${normalized}`;
+  return `![](file://${encodeURI(urlPath)})`;
+};
+
+// ─── Passthrough ────────────────────────────────────────────
+
+describe('passthrough (no transformation)', () => {
+  test('empty string', () => {
+    expect(parseUserMessageForDisplay('')).toBe('');
+  });
+
+  test('null/undefined returns as-is', () => {
+    // @ts-expect-error test null input
+    expect(parseUserMessageForDisplay(null)).toBe(null);
+    // @ts-expect-error test undefined input
+    expect(parseUserMessageForDisplay(undefined)).toBe(undefined);
+  });
+
+  test('plain text message unchanged', () => {
+    expect(parseUserMessageForDisplay('你好，今天天气不错')).toBe('你好，今天天气不错');
+  });
+
+  test('message with markdown unchanged', () => {
+    const md = '## Hello\n\n- item 1\n- item 2\n\n```js\nconsole.log("hi")\n```';
+    expect(parseUserMessageForDisplay(md)).toBe(md);
+  });
+
+  test('file path NOT in inbound directory unchanged', () => {
+    const msg = String.raw`C:\Users\yangwn\Desktop\screenshot.jpg`;
+    expect(parseUserMessageForDisplay(msg)).toBe(msg);
+  });
+});
+
+// ─── Pattern A: NIM/DingTalk ────────────────────────────────
+
+describe('Pattern A: NIM/DingTalk', () => {
+  test('[图片] with URL and [附件信息] → strip metadata, render image', () => {
+    const imgPath = fileImg(WIN_INBOUND, 'abc123.jpg');
+    const input = [
+      '[图片] https://nos.netease.com/xxx.jpg',
+      '',
+      '[附件信息]',
+      `- 类型: image, 路径: ${imgPath}, MIME: image/jpeg, 尺寸: 1920x1080`,
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe(toFileUrl(imgPath));
+    expect(result).not.toContain('[图片]');
+    expect(result).not.toContain('[附件信息]');
+  });
+
+  test('[图片] without URL → strip placeholder', () => {
+    const imgPath = fileImg(WIN_INBOUND, 'abc123.jpg');
+    const input = [
+      '[图片]',
+      '',
+      '[附件信息]',
+      `- 类型: image, 路径: ${imgPath}, MIME: image/jpeg`,
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe(toFileUrl(imgPath));
+  });
+
+  test('user text + [图片] → preserve user text, strip metadata', () => {
+    const imgPath = fileImg(WIN_INBOUND, 'abc123.jpg');
+    const input = [
+      '看看这张图',
+      '[图片] https://nos.netease.com/xxx.jpg',
+      '',
+      '[附件信息]',
+      `- 类型: image, 路径: ${imgPath}, MIME: image/jpeg`,
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toContain('看看这张图');
+    expect(result).toContain(toFileUrl(imgPath));
+    expect(result).not.toContain('[图片]');
+  });
+
+  test('[语音消息] placeholder stripped', () => {
+    const input = [
+      '[语音消息]',
+      '',
+      '[附件信息]',
+      `- 类型: audio, 路径: ${WIN_INBOUND}\\voice.mp3, MIME: audio/mp3`,
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).not.toContain('[语音消息]');
+    expect(result).not.toContain('[附件信息]');
+  });
+
+  test('[文件] placeholder stripped', () => {
+    const input = '[文件] https://nos.netease.com/file.pdf';
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe('');
+  });
+
+  test('multiple images in [附件信息]', () => {
+    const img1 = fileImg(WIN_INBOUND, 'img1.jpg');
+    const img2 = fileImg(WIN_INBOUND, 'img2.png');
+    const input = [
+      '[图片]',
+      '',
+      '[附件信息]',
+      `- 类型: image, 路径: ${img1}, MIME: image/jpeg`,
+      `- 类型: image, 路径: ${img2}, MIME: image/png`,
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toContain(toFileUrl(img1));
+    expect(result).toContain(toFileUrl(img2));
+  });
+});
+
+// ─── Pattern B: OpenClaw gateway ────────────────────────────
+
+describe('Pattern B: 企微 (WeCom)', () => {
+  test('full format with pipe → strip all, render image', () => {
+    const imgPath = fileImg(WIN_INBOUND, 'b02db622.jpg');
+    const input = [
+      `[media attached: ${imgPath} (image/jpeg) | ${imgPath}]`,
+      'To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Avoid absolute paths (MEDIA:/...) and ~ paths - they are blocked for security. Keep caption in the text body.',
+      '',
+      'media:image',
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe(toFileUrl(imgPath));
+    expect(result).not.toContain('[media attached');
+    expect(result).not.toContain('To send an image back');
+    expect(result).not.toContain('media:image');
+  });
+});
+
+describe('Pattern B: 微信 (WeChat)', () => {
+  test('format without pipe → strip all, render image', () => {
+    const imgPath = fileImg(WIN_INBOUND, '154ba6cf.jpg');
+    const input = [
+      `[media attached: ${imgPath} (image/*)]`,
+      'To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Avoid absolute paths (MEDIA:/...) and ~ paths - they are blocked for security. Keep caption in the text body.',
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe(toFileUrl(imgPath));
+  });
+});
+
+describe('Pattern B: 飞书 (Feishu) — full content', () => {
+  test('full format with System: line and bare path → strip all, render image', () => {
+    const imgPath = fileImg(WIN_INBOUND, '0f209ea9.jpg');
+    const input = [
+      `[media attached: ${imgPath} (image/jpeg) | ${imgPath}]`,
+      'To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Avoid absolute paths (MEDIA:/...) and ~ paths - they are blocked for security. Keep caption in the text body.',
+      'System: [2026-04-27 15:54:25 GMT+8] Feishu[41f9d3b5] DM | ou_a17d2d2850e3d7a4cb4db0eeaf9cebd3 [msg:om_x100, image, 1 attachment(s)]',
+      '',
+      imgPath,
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe(toFileUrl(imgPath));
+    expect(result).not.toContain('System:');
+    expect(result).not.toContain('[media attached');
+  });
+});
+
+describe('Pattern B: 飞书 — after server-side stripFeishuSystemHeader', () => {
+  test('bare inbound path only (post-strip) → render image', () => {
+    const imgPath = fileImg(WIN_INBOUND, '58c6a4bb.jpg');
+    // After stripFeishuSystemHeader, only the bare path remains
+    const result = parseUserMessageForDisplay(imgPath);
+    expect(result).toBe(toFileUrl(imgPath));
+  });
+
+  test('bare inbound path with \\r\\n → render image', () => {
+    const imgPath = fileImg(WIN_INBOUND, '58c6a4bb.jpg');
+    const result = parseUserMessageForDisplay(`${imgPath}\r\n`);
+    expect(result).toBe(toFileUrl(imgPath));
+  });
+});
+
+// ─── System: timestamp lines ────────────────────────────────
+
+describe('System: timestamp lines', () => {
+  test('NIM system header stripped from text message', () => {
+    const input = [
+      'System: [2026-04-28 11:53:11 GMT+8] From user889589',
+      '',
+      '123',
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe('123');
+  });
+
+  test('multiple system lines stripped', () => {
+    const input = [
+      'System: [2026-04-28 11:53:11 GMT+8] From user889589',
+      'System: [2026-04-28 11:53:12 GMT+8] NIM[abc123] DM',
+      '',
+      'hello',
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe('hello');
+  });
+
+  test('does NOT strip user text that looks vaguely like System:', () => {
+    const msg = 'System: this is not a timestamp line';
+    expect(parseUserMessageForDisplay(msg)).toBe(msg);
+  });
+
+  test('does NOT strip System: without valid timestamp', () => {
+    const msg = 'System: [invalid] something';
+    expect(parseUserMessageForDisplay(msg)).toBe(msg);
+  });
+});
+
+// ─── Mac compatibility ──────────────────────────────────────
+
+describe('Mac compatibility', () => {
+  test('Mac inbound path → render image', () => {
+    const imgPath = fileImg(MAC_INBOUND, 'abc123.jpg');
+    const result = parseUserMessageForDisplay(imgPath);
+    expect(result).toBe(toFileUrl(imgPath));
+  });
+
+  test('Mac path in [media attached:] → render image', () => {
+    const imgPath = fileImg(MAC_INBOUND, 'abc123.jpg');
+    const input = [
+      `[media attached: ${imgPath} (image/jpeg) | ${imgPath}]`,
+      'To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg.',
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe(toFileUrl(imgPath));
+  });
+});
+
+// ─── False positive safety ──────────────────────────────────
+
+describe('false positive safety', () => {
+  test('user discussing a file path (not inbound) is NOT stripped', () => {
+    const msg = String.raw`文件在 C:\Users\test\Documents\photo.jpg`;
+    expect(parseUserMessageForDisplay(msg)).toBe(msg);
+  });
+
+  test('user typing "media:video" in a sentence is NOT stripped', () => {
+    const msg = '格式是 media:video 这样的';
+    expect(parseUserMessageForDisplay(msg)).toBe(msg);
+  });
+
+  test('user mentioning "To send an image back" without [media attached:] is NOT stripped', () => {
+    const msg = 'To send an image back, prefer the message tool — 这是说明文档的内容';
+    expect(parseUserMessageForDisplay(msg)).toBe(msg);
+  });
+
+  test('user typing [图片] in a sentence is NOT stripped (not on its own line)', () => {
+    const msg = '他发了一个[图片]标记在消息里';
+    // [图片] is not on its own line, NIM_PLACEHOLDER_RE requires ^...$
+    expect(parseUserMessageForDisplay(msg)).toBe(msg);
+  });
+});
+
+// ─── \\r\\n handling ─────────────────────────────────────────
+
+describe('\\r\\n handling', () => {
+  test('企微 format with \\r\\n line endings', () => {
+    const imgPath = fileImg(WIN_INBOUND, 'b02db622.jpg');
+    const input = [
+      `[media attached: ${imgPath} (image/jpeg) | ${imgPath}]`,
+      'To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg.',
+      '',
+      'media:image',
+    ].join('\r\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe(toFileUrl(imgPath));
+  });
+
+  test('NIM format with \\r\\n line endings', () => {
+    const imgPath = fileImg(WIN_INBOUND, 'abc123.jpg');
+    const input = [
+      '[图片] https://nos.netease.com/xxx.jpg',
+      '',
+      '[附件信息]',
+      `- 类型: image, 路径: ${imgPath}, MIME: image/jpeg`,
+    ].join('\r\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).toBe(toFileUrl(imgPath));
+  });
+});
+
+// ─── Non-image media ────────────────────────────────────────
+
+describe('non-image media', () => {
+  test('[media attached:] with application/pdf → strip markers but no image rendered', () => {
+    const pdfPath = fileImg(WIN_INBOUND, 'doc.pdf');
+    const input = [
+      `[media attached: ${pdfPath} (application/pdf) | ${pdfPath}]`,
+      'To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg.',
+    ].join('\n');
+
+    const result = parseUserMessageForDisplay(input);
+    expect(result).not.toContain('[media attached');
+    // PDF should not be rendered as an image
+    expect(result).not.toContain('![](');
+  });
+});

--- a/src/renderer/utils/userMessageDisplay.ts
+++ b/src/renderer/utils/userMessageDisplay.ts
@@ -11,13 +11,11 @@
 // --------------- Pattern A: NIM/DingTalk ---------------
 
 // Placeholder line — e.g. "[图片] https://nos.netease.com/..."
-const NIM_PLACEHOLDER_RE = /^\[(图片|语音消息|视频|文件|多媒体消息)\](?:\s+https?:\/\/\S+)?\s*$/m;
+// Capture the URL (group 2) so we can preserve it as plain text instead of stripping it.
+const NIM_PLACEHOLDER_RE = /^\[(图片|语音消息|视频|文件|多媒体消息)\](?:\s+(https?:\/\/\S+))?\s*$/m;
 
 // [附件信息] block — header line followed by "- ..." lines
 const ATTACHMENT_INFO_BLOCK_RE = /\n?\[附件信息\]\n(?:- .+(?:\n|$))+/;
-
-// Extract image paths from [附件信息] entries where 类型 is image
-const NIM_IMAGE_PATH_RE = /- 类型:\s*image[^]*?路径:\s*([^,\n]+)/g;
 
 // --------------- Pattern B: OpenClaw gateway ---------------
 
@@ -63,19 +61,8 @@ export function parseUserMessageForDisplay(content: string): string {
   if (result.includes('[图片]') || result.includes('[语音消息]') || result.includes('[视频]')
     || result.includes('[文件]') || result.includes('[多媒体消息]') || result.includes('[附件信息]')) {
 
-    // Extract image paths from [附件信息] block before stripping
-    const attachBlock = result.match(ATTACHMENT_INFO_BLOCK_RE);
-    if (attachBlock) {
-      const block = attachBlock[0];
-      let m: RegExpExecArray | null;
-      const re = new RegExp(NIM_IMAGE_PATH_RE.source, NIM_IMAGE_PATH_RE.flags);
-      while ((m = re.exec(block)) !== null) {
-        const p = m[1].trim();
-        if (p) imagePaths.push(p);
-      }
-    }
-
-    result = result.replace(NIM_PLACEHOLDER_RE, '');
+    // Strip [图片] etc. but preserve the URL as plain text
+    result = result.replace(NIM_PLACEHOLDER_RE, (_match, _type, url) => url || '');
     result = result.replace(ATTACHMENT_INFO_BLOCK_RE, '');
   }
 

--- a/src/renderer/utils/userMessageDisplay.ts
+++ b/src/renderer/utils/userMessageDisplay.ts
@@ -1,0 +1,137 @@
+/**
+ * Display-side transformation for user messages from IM channels.
+ * Strips IM-specific media metadata and replaces it with renderable markdown image syntax.
+ * DISPLAY ONLY — does not affect what is sent to the AI model.
+ *
+ * NOTE: Some stripping (e.g. stripFeishuSystemHeader) already happens server-side
+ * in openclawRuntimeAdapter.ts before the message is stored. This means some messages
+ * arrive here already partially stripped (e.g. Feishu messages may be just a bare path).
+ */
+
+// --------------- Pattern A: NIM/DingTalk ---------------
+
+// Placeholder line — e.g. "[图片] https://nos.netease.com/..."
+const NIM_PLACEHOLDER_RE = /^\[(图片|语音消息|视频|文件|多媒体消息)\](?:\s+https?:\/\/\S+)?\s*$/m;
+
+// [附件信息] block — header line followed by "- ..." lines
+const ATTACHMENT_INFO_BLOCK_RE = /\n?\[附件信息\]\n(?:- .+(?:\n|$))+/;
+
+// Extract image paths from [附件信息] entries where 类型 is image
+const NIM_IMAGE_PATH_RE = /- 类型:\s*image[^]*?路径:\s*([^,\n]+)/g;
+
+// --------------- Pattern B: OpenClaw gateway ---------------
+
+// [media attached: <path> (<mime>)] or [media attached: <path> (<mime>) | <path>]
+const OPENCLAW_MEDIA_RE = /\[media attached:\s*(.+?)\s*\(([^)]+)\)(?:\s*\|\s*(.+?))?\s*\]/g;
+
+// Instructional text from openclaw plugins (spans to next blank line or end)
+const OPENCLAW_INSTRUCTION_RE = /To send an image back, prefer the message tool[^\n]*(?:\n(?!\n)[^\n]*)*/gi;
+
+// "media:image" or "media:<type>" on its own line
+const MEDIA_TAG_RE = /^\s*media:\w+\s*$/gm;
+
+// --------------- Shared patterns ---------------
+
+// System: [timestamp ...] metadata lines — injected by various openclaw plugins
+// (feishu, nim, popo, etc.) Matches timestamps like [2026-04-28 11:53:25 GMT+8]
+const SYSTEM_TIMESTAMP_LINE_RE = /^System:\s*\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\s+[^\]]*\].*$/gm;
+
+// Bare path in the openclaw inbound media directory — highly specific, safe to match
+const OPENCLAW_INBOUND_IMAGE_RE = /^((?:[A-Za-z]:\\|\/)[^\n]*[/\\]openclaw[/\\]state[/\\]media[/\\]inbound[/\\][^\n]+\.(?:jpg|jpeg|png|gif|bmp|webp))\s*$/gm;
+
+const IMAGE_EXTENSIONS = /\.(?:jpg|jpeg|png|gif|bmp|webp)$/i;
+
+function encodeFilePathAsMarkdownImage(filePath: string): string {
+  const trimmed = filePath.trim();
+  const normalized = trimmed.replace(/\\/g, '/');
+  // Ensure correct file:// URL: file:///C:/... or file:///Users/...
+  const urlPath = normalized.startsWith('/') ? normalized : `/${normalized}`;
+  const encoded = encodeURI(urlPath);
+  return `![](file://${encoded})`;
+}
+
+export function parseUserMessageForDisplay(content: string): string {
+  if (!content) return content;
+
+  // Normalize \r\n to \n so all line-anchored regexes work correctly
+  let result = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  const imagePaths: string[] = [];
+
+  // --- Pattern A: NIM/DingTalk ---
+
+  if (result.includes('[图片]') || result.includes('[语音消息]') || result.includes('[视频]')
+    || result.includes('[文件]') || result.includes('[多媒体消息]') || result.includes('[附件信息]')) {
+
+    // Extract image paths from [附件信息] block before stripping
+    const attachBlock = result.match(ATTACHMENT_INFO_BLOCK_RE);
+    if (attachBlock) {
+      const block = attachBlock[0];
+      let m: RegExpExecArray | null;
+      const re = new RegExp(NIM_IMAGE_PATH_RE.source, NIM_IMAGE_PATH_RE.flags);
+      while ((m = re.exec(block)) !== null) {
+        const p = m[1].trim();
+        if (p) imagePaths.push(p);
+      }
+    }
+
+    result = result.replace(NIM_PLACEHOLDER_RE, '');
+    result = result.replace(ATTACHMENT_INFO_BLOCK_RE, '');
+  }
+
+  // --- Pattern B: OpenClaw gateway (微信/飞书/企微) ---
+
+  if (result.includes('[media attached:')) {
+    // Extract image paths
+    let om: RegExpExecArray | null;
+    const openclawRe = new RegExp(OPENCLAW_MEDIA_RE.source, OPENCLAW_MEDIA_RE.flags);
+    while ((om = openclawRe.exec(result)) !== null) {
+      const firstPath = om[1].trim();
+      const mime = om[2].trim();
+      const secondPath = om[3]?.trim();
+      const filePath = secondPath || firstPath;
+      if ((mime.startsWith('image/') || mime === 'image/*') && filePath) {
+        imagePaths.push(filePath);
+      }
+    }
+
+    // Strip markers
+    result = result.replace(new RegExp(OPENCLAW_MEDIA_RE.source, OPENCLAW_MEDIA_RE.flags), '');
+    result = result.replace(OPENCLAW_INSTRUCTION_RE, '');
+    result = result.replace(MEDIA_TAG_RE, '');
+  }
+
+  // --- Always: strip System: [timestamp] metadata lines ---
+  // These are injected by openclaw plugins (feishu, nim, popo, etc.)
+  // and are never user-typed content. The timestamp format is specific enough
+  // to avoid false positives.
+  result = result.replace(SYSTEM_TIMESTAMP_LINE_RE, '');
+
+  // --- Always: detect bare inbound image paths ---
+  // After server-side stripping (e.g. stripFeishuSystemHeader), the message may
+  // be reduced to just a bare path like "C:\...\openclaw\state\media\inbound\xxx.jpg".
+  // Only match paths in the openclaw inbound directory to avoid false positives.
+  result = result.replace(OPENCLAW_INBOUND_IMAGE_RE, (_match, path) => {
+    const p = path.trim();
+    if (IMAGE_EXTENSIONS.test(p)) {
+      const alreadyExtracted = imagePaths.some(
+        existing => existing.toLowerCase() === p.toLowerCase()
+      );
+      if (!alreadyExtracted) {
+        imagePaths.push(p);
+      }
+    }
+    return '';
+  });
+
+  // Collapse excessive blank lines and trim
+  result = result.replace(/\n{3,}/g, '\n\n').trim();
+
+  // Append extracted images as markdown
+  if (imagePaths.length > 0) {
+    const imageMarkdown = imagePaths.map(encodeFilePathAsMarkdownImage).join('\n');
+    result = result ? `${result}\n\n${imageMarkdown}` : imageMarkdown;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- Strip IM-specific media metadata (DingTalk `[图片]`, openclaw `[media attached:]`, instruction text, `System:` timestamp lines, bare inbound paths) from user message display in the desktop client
- Extracted image paths are rendered inline via `file://` markdown, leveraging existing `localfile://` protocol
- Display-only — model input is unchanged

## Changes

- **New**: `src/renderer/utils/userMessageDisplay.ts` — `parseUserMessageForDisplay()` utility
- **New**: `src/renderer/utils/userMessageDisplay.test.ts` — 29 unit tests
- **Modified**: `src/renderer/components/cowork/CoworkSessionDetail.tsx` — `UserMessageItem` uses `displayContent` for rendering

## Platforms covered

| Platform | Format | Handling |
|----------|--------|----------|
| DingTalk (钉钉) | `[图片] URL` + `[附件信息]` block | Strip metadata, extract image path |
| WeCom (企微) | `[media attached: path (mime) \| path]` + `media:image` | Strip all, render image |
| WeChat (微信) | `[media attached: path (mime)]` (no pipe) | Strip all, render image |
| Feishu (飞书) | Full or post-`stripFeishuSystemHeader` bare path | Strip all, render image |
| NIM (云信) | `System: [timestamp] From userXXX` prefix | Strip System: line |

## Test plan

- [x] 29 vitest unit tests passing (`npx vitest run src/renderer/utils/userMessageDisplay.test.ts`)
- [ ] Manual: send image from DingTalk → no `[图片]` prefix, image renders
- [ ] Manual: send image from WeCom → no raw `[media attached:]` text, image renders
- [ ] Manual: send image from Feishu → no bare path text, image renders
- [ ] Manual: plain text messages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)