### PR TITLE
fix: raise EngineStartupOverlay z-index above Settings modal

### DIFF
--- a/src/renderer/components/cowork/EngineStartupOverlay.tsx
+++ b/src/renderer/components/cowork/EngineStartupOverlay.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
+import React, { useEffect,useState } from 'react';
 import { useSelector } from 'react-redux';
-import { selectIsOpenClawEngine } from '../../store/selectors/coworkSelectors';
+
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
-import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
+import { selectIsOpenClawEngine } from '../../store/selectors/coworkSelectors';
 import type { OpenClawEngineStatus } from '../../types/cowork';
 
 const resolveEngineStatusText = (status: OpenClawEngineStatus): string => {
@@ -55,7 +56,7 @@ const EngineStartupOverlay: React.FC = () => {
     : null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/90 backdrop-blur-sm">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/90 backdrop-blur-sm">
       <div className="w-full max-w-lg rounded-2xl border border-border bg-surface p-6 shadow-card">
         <div className="flex flex-col items-center text-center gap-3">
           <div className="h-10 w-10 rounded-full bg-primary/15 text-primary flex items-center justify-center animate-pulse">


### PR DESCRIPTION
## Summary
- IM bot toggle triggers gateway restart while Settings dialog is open, but the startup overlay (`z-50`) was hidden behind Settings modal (also `z-50`)
- Bump `EngineStartupOverlay` z-index to `z-[100]` so it always renders above Settings
- Fix pre-existing `simple-import-sort/imports` lint error in the same file

## Test plan
- [ ] Open Settings → IM 机器人, toggle a bot's enable switch
- [ ] Verify the "AI 引擎正在启动网关..." overlay covers the Settings dialog
- [ ] Verify Toast notifications (z-[10000]) still appear above the overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)