### PR TITLE
fix(cowork): use header-selected model for supportsImage on home page

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -207,6 +207,13 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   const minHeight = isLarge ? 60 : 24;
   const maxHeight = isLarge ? 200 : 200;
 
+  const effectiveSelectedModel = resolveEffectiveModel({
+    sessionId,
+    agentSelectedModel,
+    globalSelectedModel,
+  });
+  const modelSupportsImage = !!effectiveSelectedModel?.supportsImage;
+
   // Load skills on mount
   useEffect(() => {
     const loadSkills = async () => {
@@ -378,7 +385,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     dispatch(setDraftPrompt({ sessionId: draftKey, draft: '' }));
     dispatch(clearDraftAttachments(draftKey));
     setImageVisionHint(false);
-  }, [value, isStreaming, disabled, onSubmit, activeSkillIds, skills, attachments, showFolderSelector, workingDirectory, dispatch, draftKey]);
+  }, [value, isStreaming, disabled, onSubmit, activeSkillIds, skills, attachments, showFolderSelector, workingDirectory, dispatch, draftKey, effectiveSelectedModel?.id, modelSupportsImage]);
 
   const handleSelectSkill = useCallback((skill: Skill) => {
     dispatch(toggleActiveSkill(skill.id));
@@ -458,13 +465,6 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       onWorkingDirectoryChange(path);
     }
   };
-
-  const effectiveSelectedModel = resolveEffectiveModel({
-    sessionId,
-    agentSelectedModel,
-    globalSelectedModel,
-  });
-  const modelSupportsImage = !!effectiveSelectedModel?.supportsImage;
 
   const addAttachment = useCallback((filePath: string, imageInfo?: { isImage: boolean; dataUrl?: string }) => {
     if (!filePath) return;

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -12,9 +12,9 @@ import { skillService } from '../../services/skill';
 import { RootState } from '../../store';
 import { selectDraftPrompts } from '../../store/selectors/coworkSelectors';
 import { addDraftAttachment, clearDraftAttachments, type DraftAttachment, setDraftAttachments, setDraftPrompt } from '../../store/slices/coworkSlice';
-import { setSkills, toggleActiveSkill } from '../../store/slices/skillSlice';
 import type { Model } from '../../store/slices/modelSlice';
 import { setSelectedModel } from '../../store/slices/modelSlice';
+import { setSkills, toggleActiveSkill } from '../../store/slices/skillSlice';
 import { CoworkImageAttachment } from '../../types/cowork';
 import { Skill } from '../../types/skill';
 import { toOpenClawModelRef } from '../../utils/openclawModelRef';
@@ -23,7 +23,7 @@ import PaperClipIcon from '../icons/PaperClipIcon';
 import XMarkIcon from '../icons/XMarkIcon';
 import ModelSelector from '../ModelSelector';
 import { ActiveSkillBadge,SkillsButton } from '../skills';
-import { resolveAgentModelSelection } from './agentModelSelection';
+import { resolveAgentModelSelection, resolveEffectiveModel } from './agentModelSelection';
 import AttachmentCard from './AttachmentCard';
 import FolderSelectorPopover from './FolderSelectorPopover';
 
@@ -459,7 +459,11 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     }
   };
 
-  const effectiveSelectedModel = coworkAgentEngine === 'openclaw' ? agentSelectedModel : globalSelectedModel;
+  const effectiveSelectedModel = resolveEffectiveModel({
+    sessionId,
+    agentSelectedModel,
+    globalSelectedModel,
+  });
   const modelSupportsImage = !!effectiveSelectedModel?.supportsImage;
 
   const addAttachment = useCallback((filePath: string, imageInfo?: { isImage: boolean; dataUrl?: string }) => {

--- a/src/renderer/components/cowork/agentModelSelection.test.ts
+++ b/src/renderer/components/cowork/agentModelSelection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import type { Model } from '../../store/slices/modelSlice';
-import { resolveAgentModelSelection } from './agentModelSelection';
+import { resolveAgentModelSelection, resolveEffectiveModel } from './agentModelSelection';
 
 const models: Model[] = [
   { id: 'gpt-4o', name: 'GPT-4o', providerKey: 'openai' },
@@ -9,6 +9,9 @@ const models: Model[] = [
   { id: 'deepseek-v3.2', name: 'DeepSeek', providerKey: 'anthropic' },
   { id: 'deepseek-v3.2', name: 'DeepSeek Server', providerKey: 'openai', isServerModel: true },
 ];
+
+const visionModel: Model = { id: 'qwen3.5-plus', name: 'Qwen3.5 Plus', providerKey: 'qwen', supportsImage: true };
+const nonVisionModel: Model = { id: 'glm-5.1', name: 'GLM 5.1', providerKey: 'zhipu', supportsImage: false };
 
 describe('resolveAgentModelSelection', () => {
   test('uses explicit agent model when present', () => {
@@ -102,5 +105,41 @@ describe('resolveAgentModelSelection', () => {
     expect(result.selectedModel?.id).toBe('gpt-4o');
     expect(result.usesFallback).toBe(true);
     expect(result.hasInvalidExplicitModel).toBe(true);
+  });
+});
+
+describe('resolveEffectiveModel', () => {
+  test('home page (no sessionId) uses globalSelectedModel even when agent model differs', () => {
+    // Bug scenario: agent default model supports images, user picked a non-vision model in header
+    const result = resolveEffectiveModel({
+      sessionId: undefined,
+      agentSelectedModel: visionModel,
+      globalSelectedModel: nonVisionModel,
+    });
+
+    expect(result?.id).toBe('glm-5.1');
+    expect(result?.supportsImage).toBe(false);
+  });
+
+  test('home page uses globalSelectedModel supportsImage=true when user picks vision model', () => {
+    const result = resolveEffectiveModel({
+      sessionId: undefined,
+      agentSelectedModel: nonVisionModel,
+      globalSelectedModel: visionModel,
+    });
+
+    expect(result?.id).toBe('qwen3.5-plus');
+    expect(result?.supportsImage).toBe(true);
+  });
+
+  test('inside session (has sessionId) uses agentSelectedModel from session override', () => {
+    const result = resolveEffectiveModel({
+      sessionId: 'session-123',
+      agentSelectedModel: nonVisionModel,
+      globalSelectedModel: visionModel,
+    });
+
+    expect(result?.id).toBe('glm-5.1');
+    expect(result?.supportsImage).toBe(false);
   });
 });

--- a/src/renderer/components/cowork/agentModelSelection.ts
+++ b/src/renderer/components/cowork/agentModelSelection.ts
@@ -16,6 +16,30 @@ type ResolveAgentModelSelectionResult = {
   hasInvalidExplicitModel: boolean;
 };
 
+/**
+ * Determine which Model object the prompt input should use for capability
+ * checks (e.g. supportsImage).
+ *
+ * On the **home page** (no sessionId) the header ModelSelector writes
+ * directly to globalSelectedModel (Redux), so we must honour that value —
+ * otherwise the agent's default model may shadow the user's choice and
+ * produce a wrong supportsImage flag (see PR #1850 / #1856 regression).
+ *
+ * Inside a **session** (has sessionId) the agent-level resolution
+ * (session override → agent model → fallback) is authoritative.
+ */
+export function resolveEffectiveModel({
+  sessionId,
+  agentSelectedModel,
+  globalSelectedModel,
+}: {
+  sessionId: string | undefined;
+  agentSelectedModel: Model | null;
+  globalSelectedModel: Model | null;
+}): Model | null {
+  return sessionId ? agentSelectedModel : globalSelectedModel;
+}
+
 export function resolveAgentModelSelection({
   sessionModel,
   agentModel,


### PR DESCRIPTION
## Summary

- On the home page, `CoworkPromptInput` was checking `supportsImage` from the agent-level model instead of the header ModelSelector's `globalSelectedModel`. When the agent had a vision-capable default model but the user picked a non-vision model (e.g. glm-5.1) in the header, images were sent as base64 instead of file-path text — causing the first-turn image to be invisible to the model.
- Extract `resolveEffectiveModel()` into `agentModelSelection.ts`: home page (no `sessionId`) → `globalSelectedModel`; inside session → `agentSelectedModel` (unchanged).
- Add 3 test cases covering the mismatch scenario.
- Fix pre-existing eslint `react-hooks/exhaustive-deps` warning on `handleSubmit`: move `effectiveSelectedModel` / `modelSupportsImage` declarations before the callback so they can be listed as dependencies (both only used in diagnostic logs — no behavioral change).

Regression introduced by #1850.

## Test plan

- [ ] New conversation with a non-vision model (e.g. glm-5.1), attach an image, send — model should receive file path as text and acknowledge the image
- [ ] Same conversation, second turn with image — should still work (regression check)
- [ ] New conversation with a vision model (e.g. qwen3.5-plus), attach an image — should send base64 as before
- [ ] `npx vitest run src/renderer/components/cowork/agentModelSelection.test.ts` — 10 tests pass
- [ ] `npx eslint src/renderer/components/cowork/CoworkPromptInput.tsx` — 0 errors, 0 warnings