### PR TITLE
fix(cowork): per-agent model selection in header ModelSelector

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -42,7 +42,7 @@ import {
   selectFirstPendingPermission,
 } from './store/selectors/coworkSelectors';
 import { setDraftPrompt } from './store/slices/coworkSlice';
-import { setAvailableModels, setSelectedModel } from './store/slices/modelSlice';
+import { setAvailableModels, setDefaultSelectedModel } from './store/slices/modelSlice';
 import { clearSelection } from './store/slices/quickActionSlice';
 import type { CoworkPermissionResult } from './types/cowork';
 
@@ -86,7 +86,7 @@ const App: React.FC = () => {
   const previousUpdateStatusRef = useRef<AppUpdateRuntimeState['status']>(AppUpdateStatus.Idle);
   const shouldInstallReadyUpdateRef = useRef(false);
   const dispatch = useDispatch();
-  const selectedModel = useSelector((state: RootState) => state.model.selectedModel);
+  const defaultSelectedModel = useSelector((state: RootState) => state.model.defaultSelectedModel);
   const currentSessionId = useSelector(selectCurrentSessionId);
   const pendingPermission = useSelector(selectFirstPendingPermission);
   const authUser = useSelector((state: RootState) => state.auth.user);
@@ -193,7 +193,7 @@ const App: React.FC = () => {
             model => model.id === config.model.defaultModel
               && (!config.model.defaultModelProvider || model.providerKey === config.model.defaultModelProvider)
           ) ?? allModels[0];
-          dispatch(setSelectedModel(preferredModel));
+          dispatch(setDefaultSelectedModel(preferredModel));
         }
         mark('model resolution done');
 
@@ -275,22 +275,22 @@ const App: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (!isInitialized || !selectedModel?.id) return;
+    if (!isInitialized || !defaultSelectedModel?.id) return;
     const config = configService.getConfig();
     if (
-      config.model.defaultModel === selectedModel.id
-      && (config.model.defaultModelProvider ?? '') === (selectedModel.providerKey ?? '')
+      config.model.defaultModel === defaultSelectedModel.id
+      && (config.model.defaultModelProvider ?? '') === (defaultSelectedModel.providerKey ?? '')
     ) {
       return;
     }
     void configService.updateConfig({
       model: {
         ...config.model,
-        defaultModel: selectedModel.id,
-        defaultModelProvider: selectedModel.providerKey,
+        defaultModel: defaultSelectedModel.id,
+        defaultModelProvider: defaultSelectedModel.providerKey,
       },
     });
-  }, [isInitialized, selectedModel?.id, selectedModel?.providerKey]);
+  }, [isInitialized, defaultSelectedModel?.id, defaultSelectedModel?.providerKey]);
 
   const handleShowSettings = useCallback((options?: SettingsOpenOptions) => {
     setSettingsOptions({

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -393,7 +393,7 @@ const App: React.FC = () => {
       mounted = false;
       unsubscribe();
     };
-  }, []);
+  }, [showToast]);
 
   const handleShowLogin = useCallback(() => {
     showToast(i18nService.t('featureInDevelopment'));

--- a/src/renderer/components/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector.tsx
@@ -34,7 +34,8 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
   const containerRef = React.useRef<HTMLDivElement>(null);
 
   const controlled = onChange !== undefined;
-  const globalSelectedModel = useSelector((state: RootState) => state.model.selectedModel);
+  const globalSelectedModel = useSelector((state: RootState) => state.model.defaultSelectedModel);
+  const currentAgentId = useSelector((state: RootState) => state.agent.currentAgentId);
   const selectedModel = controlled ? value ?? null : globalSelectedModel;
   const availableModels = useSelector((state: RootState) => state.model.availableModels);
 
@@ -74,7 +75,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
     if (controlled) {
       onChange(model);
     } else if (model) {
-      dispatch(setSelectedModel(model));
+      dispatch(setSelectedModel({ agentId: currentAgentId, model }));
     }
     setIsOpen(false);
   };

--- a/src/renderer/components/agent/AgentCreateModal.tsx
+++ b/src/renderer/components/agent/AgentCreateModal.tsx
@@ -41,7 +41,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({ isOpen, onClose }) 
   const [skillIds, setSkillIds] = useState<string[]>([]);
   const [creating, setCreating] = useState(false);
   const [activeTab, setActiveTab] = useState<CreateTab>('basic');
-  const globalSelectedModel = useSelector((state: RootState) => state.model.selectedModel);
+  const globalSelectedModel = useSelector((state: RootState) => state.model.defaultSelectedModel);
   const agents = useSelector((state: RootState) => state.agent.agents);
   const [showUnsavedConfirm, setShowUnsavedConfirm] = useState(false);
 

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -23,7 +23,7 @@ import PaperClipIcon from '../icons/PaperClipIcon';
 import XMarkIcon from '../icons/XMarkIcon';
 import ModelSelector from '../ModelSelector';
 import { ActiveSkillBadge,SkillsButton } from '../skills';
-import { resolveAgentModelSelection, resolveEffectiveModel } from './agentModelSelection';
+import { resolveAgentModelSelection, resolveEffectiveModel, useAgentSelectedModel } from './agentModelSelection';
 import AttachmentCard from './AttachmentCard';
 import FolderSelectorPopover from './FolderSelectorPopover';
 
@@ -144,7 +144,6 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const agents = useSelector((state: RootState) => state.agent.agents);
     const coworkAgentEngine = useSelector((state: RootState) => state.cowork.config.agentEngine);
     const availableModels = useSelector((state: RootState) => state.model.availableModels);
-    const globalSelectedModel = useSelector((state: RootState) => state.model.selectedModel);
     const currentSession = useSelector((state: RootState) => state.cowork.currentSession);
     const [value, setValue] = useState(draftPrompt);
     const [showFolderMenu, setShowFolderMenu] = useState(false);
@@ -188,6 +187,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
   const skills = useSelector((state: RootState) => state.skill.skills);
   const currentAgent = agents.find((agent) => agent.id === currentAgentId);
+  const currentAgentSelectedModel = useAgentSelectedModel(currentAgentId, currentAgent?.model ?? '');
   const {
     selectedModel: agentSelectedModel,
     hasInvalidExplicitModel: agentModelIsInvalid,
@@ -195,7 +195,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     sessionModel: currentSession && currentSession.id === sessionId ? currentSession.modelOverride : '',
     agentModel: currentAgent?.model ?? '',
     availableModels,
-    fallbackModel: globalSelectedModel,
+    fallbackModel: currentAgentSelectedModel,
     engine: coworkAgentEngine,
   });
 
@@ -210,7 +210,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   const effectiveSelectedModel = resolveEffectiveModel({
     sessionId,
     agentSelectedModel,
-    globalSelectedModel,
+    globalSelectedModel: currentAgentSelectedModel,
   });
   const modelSupportsImage = !!effectiveSelectedModel?.supportsImage;
 
@@ -945,7 +945,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                             }
                             if (!currentAgent) return;
                             console.log('[CoworkPromptInput] home page model change (Redux only, no agent update):', { modelRef, modelName: nextModel.name, providerKey: nextModel.providerKey });
-                            dispatch(setSelectedModel(nextModel));
+                            dispatch(setSelectedModel({ agentId: currentAgentId, model: nextModel }));
                           }
                         : undefined}
                     />

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -2,7 +2,6 @@ import { ShieldCheckIcon } from '@heroicons/react/24/outline';
 import React, { useEffect, useRef,useState } from 'react';
 import { useDispatch,useSelector } from 'react-redux';
 
-
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { quickActionService } from '../../services/quickAction';
@@ -15,9 +14,9 @@ import {
   selectIsStreaming,
 } from '../../store/selectors/coworkSelectors';
 import { addMessage, clearCurrentSession, setCurrentSession, setStreaming, updateSessionStatus } from '../../store/slices/coworkSlice';
+import { setSelectedModel } from '../../store/slices/modelSlice';
 import { clearSelection,selectAction, setActions } from '../../store/slices/quickActionSlice';
 import { clearActiveSkills, setActiveSkillIds } from '../../store/slices/skillSlice';
-import { setSelectedModel } from '../../store/slices/modelSlice';
 import type { CoworkImageAttachment, CoworkSession, OpenClawEngineStatus } from '../../types/cowork';
 import { toOpenClawModelRef } from '../../utils/openclawModelRef';
 import ComposeIcon from '../icons/ComposeIcon';
@@ -26,6 +25,7 @@ import ModelSelector from '../ModelSelector';
 import { PromptPanel,QuickActionBar } from '../quick-actions';
 import type { SettingsOpenOptions } from '../Settings';
 import WindowTitleBar from '../window/WindowTitleBar';
+import { useAgentSelectedModel } from './agentModelSelection';
 import CoworkPromptInput, { type CoworkPromptInputRef } from './CoworkPromptInput';
 import CoworkSessionDetail from './CoworkSessionDetail';
 
@@ -68,8 +68,8 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   const selectedActionId = useSelector((state: RootState) => state.quickAction.selectedActionId);
   const currentAgentId = useSelector((state: RootState) => state.agent.currentAgentId);
   const agents = useSelector((state: RootState) => state.agent.agents);
-  const globalSelectedModel = useSelector((state: RootState) => state.model.selectedModel);
   const currentAgent = agents.find((agent) => agent.id === currentAgentId);
+  const currentAgentSelectedModel = useAgentSelectedModel(currentAgentId, currentAgent?.model ?? '');
 
   const buildApiConfigNotice = (error?: string): { noticeI18nKey: string; noticeExtra?: string } => {
     const key = 'coworkModelSettingsRequired';
@@ -232,7 +232,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         updatedAt: now,
         cwd: config.workingDirectory || '',
         systemPrompt: '',
-        modelOverride: globalSelectedModel ? toOpenClawModelRef(globalSelectedModel) : '',
+        modelOverride: currentAgentSelectedModel ? toOpenClawModelRef(currentAgentSelectedModel) : '',
         executionMode: config.executionMode || 'local',
         activeSkillIds: sessionSkillIds,
         agentId: currentAgentId,
@@ -275,8 +275,8 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         .join('\n\n') || undefined;
 
       // Start the actual session immediately with fallback title
-      const sessionModelOverride = globalSelectedModel ? toOpenClawModelRef(globalSelectedModel) : '';
-      console.log('[CoworkView] creating session:', { modelId: globalSelectedModel?.id, providerKey: globalSelectedModel?.providerKey, isServerModel: globalSelectedModel?.isServerModel, sessionModelOverride, agentModel: currentAgent?.model });
+      const sessionModelOverride = currentAgentSelectedModel ? toOpenClawModelRef(currentAgentSelectedModel) : '';
+      console.log('[CoworkView] creating session:', { modelId: currentAgentSelectedModel?.id, providerKey: currentAgentSelectedModel?.providerKey, isServerModel: currentAgentSelectedModel?.isServerModel, sessionModelOverride, agentModel: currentAgent?.model });
       const { session: startedSession, error: startError } = await coworkService.startSession({
         prompt,
         title: fallbackTitle,
@@ -506,11 +506,11 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
           </div>
         )}
         <ModelSelector
-          value={isOpenClawEngine ? globalSelectedModel : undefined}
+          value={isOpenClawEngine ? currentAgentSelectedModel : undefined}
           onChange={isOpenClawEngine
             ? async (nextModel) => {
                 if (!nextModel) return;
-                dispatch(setSelectedModel(nextModel));
+                dispatch(setSelectedModel({ agentId: currentAgentId, model: nextModel }));
               }
             : undefined}
         />

--- a/src/renderer/components/cowork/agentModelSelection.ts
+++ b/src/renderer/components/cowork/agentModelSelection.ts
@@ -1,4 +1,8 @@
-import type { Model } from '../../store/slices/modelSlice';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import type { RootState } from '../../store';
+import { type Model,selectAgentSelectedModel } from '../../store/slices/modelSlice';
 import type { CoworkAgentEngine } from '../../types/cowork';
 import { resolveOpenClawModelRef } from '../../utils/openclawModelRef';
 
@@ -67,4 +71,18 @@ export function resolveAgentModelSelection({
   }
 
   return { selectedModel: fallbackModel, usesFallback: true, hasInvalidExplicitModel: false };
+}
+
+/**
+ * Hook: resolve the effective selected model for a given agent.
+ *
+ * Shared by CoworkView (header) and CoworkPromptInput (prompt area) to avoid
+ * duplicating the per-agent model resolution logic.
+ */
+export function useAgentSelectedModel(agentId: string, agentModelRef: string): Model {
+  const modelState = useSelector((state: RootState) => state.model);
+  return useMemo(
+    () => selectAgentSelectedModel(modelState, agentId, agentModelRef),
+    [modelState, agentId, agentModelRef],
+  );
 }

--- a/src/renderer/services/agent.ts
+++ b/src/renderer/services/agent.ts
@@ -8,6 +8,7 @@ import {
   updateAgent as updateAgentAction,
 } from '../store/slices/agentSlice';
 import { clearCurrentSession } from '../store/slices/coworkSlice';
+import { clearAgentSelectedModel } from '../store/slices/modelSlice';
 import { clearActiveSkills,setActiveSkillIds } from '../store/slices/skillSlice';
 import type { Agent, PresetAgent } from '../types/agent';
 
@@ -107,6 +108,7 @@ class AgentService {
       const wasCurrentAgent = store.getState().agent.currentAgentId === id;
       await window.electron?.agents?.delete(id);
       store.dispatch(removeAgent(id));
+      store.dispatch(clearAgentSelectedModel(id));
       if (wasCurrentAgent) {
         this.switchAgent('main');
         const { coworkService } = await import('./cowork');

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -1,7 +1,7 @@
-import { store } from '../store';
-import { configService } from './config';
-import { ChatMessagePayload, ChatUserMessageInput, ImageAttachment } from '../types/chat';
 import { resolveCodingPlanBaseUrl } from '../../shared/providers';
+import { store } from '../store';
+import { ChatMessagePayload, ChatUserMessageInput, ImageAttachment } from '../types/chat';
+import { configService } from './config';
 
 export interface ApiConfig {
   apiKey: string;

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -321,7 +321,7 @@ class ApiService {
       throw new ApiError('API configuration not set. Please configure your API settings in the settings menu.');
     }
 
-    const selectedModel = store.getState().model.selectedModel;
+    const selectedModel = store.getState().model.defaultSelectedModel;
     const provider = this.detectProvider(
       selectedModel.id,
       selectedModel.providerKey ?? selectedModel.provider

--- a/src/renderer/store/slices/modelSlice.test.ts
+++ b/src/renderer/store/slices/modelSlice.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'vitest';
+
+import type { Model } from './modelSlice';
+import modelReducer, {
+  clearAgentSelectedModel,
+  clearServerModels,
+  selectAgentSelectedModel,
+  setAvailableModels,
+  setDefaultSelectedModel,
+  setSelectedModel,
+  setServerModels,
+} from './modelSlice';
+
+const modelA: Model = { id: 'gpt-4o', name: 'GPT-4o', providerKey: 'openai' };
+const modelB: Model = { id: 'glm-5.1', name: 'GLM 5.1', providerKey: 'zhipu' };
+const modelC: Model = { id: 'claude-3-sonnet', name: 'Claude 3 Sonnet', providerKey: 'anthropic' };
+const serverModel: Model = { id: 'server-model', name: 'Server Model', providerKey: 'lobsterai-server', isServerModel: true };
+
+function makeState(overrides?: Partial<ReturnType<typeof modelReducer>>) {
+  const base = modelReducer(undefined, { type: 'init' });
+  return { ...base, ...overrides };
+}
+
+describe('setSelectedModel', () => {
+  test('writes per-agent model to map', () => {
+    const state = modelReducer(undefined, setSelectedModel({ agentId: 'agent-1', model: modelA }));
+    expect(state.selectedModelByAgent['agent-1']).toEqual(modelA);
+  });
+
+  test('overwrites existing per-agent model', () => {
+    let state = modelReducer(undefined, setSelectedModel({ agentId: 'agent-1', model: modelA }));
+    state = modelReducer(state, setSelectedModel({ agentId: 'agent-1', model: modelB }));
+    expect(state.selectedModelByAgent['agent-1']).toEqual(modelB);
+  });
+
+  test('independent per-agent entries', () => {
+    let state = modelReducer(undefined, setSelectedModel({ agentId: 'agent-1', model: modelA }));
+    state = modelReducer(state, setSelectedModel({ agentId: 'agent-2', model: modelB }));
+    expect(state.selectedModelByAgent['agent-1']).toEqual(modelA);
+    expect(state.selectedModelByAgent['agent-2']).toEqual(modelB);
+  });
+});
+
+describe('setDefaultSelectedModel', () => {
+  test('sets app-level default model', () => {
+    const state = modelReducer(undefined, setDefaultSelectedModel(modelB));
+    expect(state.defaultSelectedModel).toEqual(modelB);
+  });
+});
+
+describe('clearAgentSelectedModel', () => {
+  test('removes agent entry from map', () => {
+    let state = modelReducer(undefined, setSelectedModel({ agentId: 'agent-1', model: modelA }));
+    state = modelReducer(state, clearAgentSelectedModel('agent-1'));
+    expect(state.selectedModelByAgent['agent-1']).toBeUndefined();
+  });
+
+  test('no-op for non-existent agent', () => {
+    const state = modelReducer(undefined, clearAgentSelectedModel('non-existent'));
+    expect(Object.keys(state.selectedModelByAgent)).toHaveLength(0);
+  });
+});
+
+describe('setAvailableModels', () => {
+  test('re-matches per-agent models when available models change', () => {
+    // Set up: agent has modelA selected
+    let state = modelReducer(undefined, setSelectedModel({ agentId: 'agent-1', model: modelA }));
+
+    // Update available models — modelA still present but with updated name
+    const updatedModelA: Model = { ...modelA, name: 'GPT-4o (Updated)' };
+    state = modelReducer(state, setAvailableModels([updatedModelA, modelB]));
+
+    expect(state.selectedModelByAgent['agent-1'].name).toBe('GPT-4o (Updated)');
+  });
+
+  test('removes per-agent model when it is no longer available', () => {
+    let state = modelReducer(undefined, setSelectedModel({ agentId: 'agent-1', model: modelA }));
+
+    // Update available models — modelA removed
+    state = modelReducer(state, setAvailableModels([modelB, modelC]));
+
+    expect(state.selectedModelByAgent['agent-1']).toBeUndefined();
+  });
+
+  test('re-matches defaultSelectedModel', () => {
+    let state = modelReducer(undefined, setDefaultSelectedModel(modelA));
+    const updatedModelA: Model = { ...modelA, supportsImage: true };
+    state = modelReducer(state, setAvailableModels([updatedModelA, modelB]));
+
+    expect(state.defaultSelectedModel.supportsImage).toBe(true);
+  });
+});
+
+describe('setServerModels / clearServerModels', () => {
+  test('setServerModels syncs per-agent models', () => {
+    let state = modelReducer(undefined, setSelectedModel({ agentId: 'agent-1', model: serverModel }));
+    const updatedServerModel: Model = { ...serverModel, supportsImage: true };
+    state = modelReducer(state, setServerModels([updatedServerModel]));
+
+    expect(state.selectedModelByAgent['agent-1'].supportsImage).toBe(true);
+  });
+
+  test('clearServerModels removes server model entries from per-agent map', () => {
+    let state = modelReducer(undefined, setSelectedModel({ agentId: 'agent-1', model: serverModel }));
+    // Ensure there's at least one non-server model available
+    state = modelReducer(state, setAvailableModels([modelA]));
+    state = modelReducer(state, setServerModels([serverModel]));
+    state = modelReducer(state, clearServerModels());
+
+    // serverModel no longer available → per-agent entry removed
+    expect(state.selectedModelByAgent['agent-1']).toBeUndefined();
+  });
+});
+
+describe('selectAgentSelectedModel', () => {
+  test('returns per-agent override when present', () => {
+    const state = makeState({
+      selectedModelByAgent: { 'agent-1': modelA },
+      availableModels: [modelA, modelB],
+      defaultSelectedModel: modelB,
+    });
+
+    const result = selectAgentSelectedModel(state, 'agent-1', '');
+    expect(result).toEqual(modelA);
+  });
+
+  test('resolves from agent model ref when no override', () => {
+    const state = makeState({
+      selectedModelByAgent: {},
+      availableModels: [modelA, modelB],
+      defaultSelectedModel: modelB,
+    });
+
+    const result = selectAgentSelectedModel(state, 'agent-1', 'openai/gpt-4o');
+    expect(result.id).toBe('gpt-4o');
+  });
+
+  test('falls back to defaultSelectedModel when agent model is empty', () => {
+    const state = makeState({
+      selectedModelByAgent: {},
+      availableModels: [modelA, modelB],
+      defaultSelectedModel: modelB,
+    });
+
+    const result = selectAgentSelectedModel(state, 'agent-1', '');
+    expect(result).toEqual(modelB);
+  });
+
+  test('falls back to defaultSelectedModel when agent model ref is invalid', () => {
+    const state = makeState({
+      selectedModelByAgent: {},
+      availableModels: [modelA, modelB],
+      defaultSelectedModel: modelB,
+    });
+
+    const result = selectAgentSelectedModel(state, 'agent-1', 'nonexistent/model');
+    expect(result).toEqual(modelB);
+  });
+});

--- a/src/renderer/store/slices/modelSlice.ts
+++ b/src/renderer/store/slices/modelSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { defaultConfig, getProviderDisplayName } from '../../config';
+import { resolveOpenClawModelRef } from '../../utils/openclawModelRef';
 
 export interface Model {
   id: string;
@@ -57,16 +58,60 @@ export let availableModels: Model[] = buildInitialModels();
 const defaultModelProvider = defaultConfig.model.defaultModelProvider;
 
 interface ModelState {
-  selectedModel: Model;
+  defaultSelectedModel: Model;
+  selectedModelByAgent: Record<string, Model>;
   availableModels: Model[];
+}
+
+/**
+ * Resolve the effective selected model for a given agent.
+ *
+ * Resolution chain:
+ *   1. Per-agent user override from selectedModelByAgent map
+ *   2. Agent's configured model string (resolved via resolveOpenClawModelRef)
+ *   3. App-level defaultSelectedModel
+ */
+export function selectAgentSelectedModel(
+  modelState: ModelState,
+  agentId: string,
+  agentModelRef: string,
+): Model {
+  const override = modelState.selectedModelByAgent[agentId];
+  if (override) return override;
+  const trimmed = agentModelRef.trim();
+  if (trimmed) {
+    const resolved = resolveOpenClawModelRef(trimmed, modelState.availableModels);
+    if (resolved) return resolved;
+  }
+  return modelState.defaultSelectedModel;
+}
+
+/**
+ * Re-match each per-agent selected model against the current available models.
+ * Removes entries that no longer match any available model.
+ */
+function syncSelectedModelByAgent(
+  selectedModelByAgent: Record<string, Model>,
+  allAvailableModels: Model[],
+): void {
+  for (const agentId of Object.keys(selectedModelByAgent)) {
+    const agentModel = selectedModelByAgent[agentId];
+    const matched = allAvailableModels.find(m => isSameModelIdentity(m, agentModel));
+    if (matched) {
+      selectedModelByAgent[agentId] = matched;
+    } else {
+      delete selectedModelByAgent[agentId];
+    }
+  }
 }
 
 const initialState: ModelState = {
   // 使用 config 中的默认模型
-  selectedModel: availableModels.find(
+  defaultSelectedModel: availableModels.find(
     model => model.id === defaultConfig.model.defaultModel
       && (!defaultModelProvider || model.providerKey === defaultModelProvider)
   ) || availableModels[0],
+  selectedModelByAgent: {},
   availableModels: availableModels,
 };
 
@@ -74,8 +119,14 @@ const modelSlice = createSlice({
   name: 'model',
   initialState,
   reducers: {
-    setSelectedModel: (state, action: PayloadAction<Model>) => {
-      state.selectedModel = action.payload;
+    setSelectedModel: (state, action: PayloadAction<{ agentId: string; model: Model }>) => {
+      state.selectedModelByAgent[action.payload.agentId] = action.payload.model;
+    },
+    setDefaultSelectedModel: (state, action: PayloadAction<Model>) => {
+      state.defaultSelectedModel = action.payload;
+    },
+    clearAgentSelectedModel: (state, action: PayloadAction<string>) => {
+      delete state.selectedModelByAgent[action.payload];
     },
     setAvailableModels: (state, action: PayloadAction<Model[]>) => {
       // 保留已有的服务端模型，只更新用户自配模型（与 setServerModels 对称）
@@ -83,42 +134,54 @@ const modelSlice = createSlice({
       state.availableModels = [...serverModels, ...action.payload];
       // 更新导出的 availableModels
       availableModels = state.availableModels;
-      // 同步选中模型信息，确保名称与最新配置一致
+      // 同步 defaultSelectedModel
       if (state.availableModels.length > 0) {
-        const matchedModel = state.availableModels.find(m => isSameModelIdentity(m, state.selectedModel));
+        const matchedModel = state.availableModels.find(m => isSameModelIdentity(m, state.defaultSelectedModel));
         if (matchedModel) {
-          state.selectedModel = matchedModel;
+          state.defaultSelectedModel = matchedModel;
         } else {
-          // 如果当前选中的模型不在新的可用模型列表中，选择第一个可用模型
-          state.selectedModel = state.availableModels[0];
+          state.defaultSelectedModel = state.availableModels[0];
         }
       }
+      // 同步 per-agent 选中模型
+      syncSelectedModelByAgent(state.selectedModelByAgent, state.availableModels);
     },
     setServerModels: (state, action: PayloadAction<Model[]>) => {
       // 服务端模型放前面，自配模型保留在后面
       const userModels = state.availableModels.filter(m => !m.isServerModel);
       state.availableModels = [...action.payload, ...userModels];
       availableModels = state.availableModels;
-      // 同步选中模型信息（如 supportsImage 等属性可能随服务端更新）
+      // 同步 defaultSelectedModel
       if (state.availableModels.length > 0) {
-        const matchedModel = state.availableModels.find(m => isSameModelIdentity(m, state.selectedModel));
+        const matchedModel = state.availableModels.find(m => isSameModelIdentity(m, state.defaultSelectedModel));
         if (matchedModel) {
-          state.selectedModel = matchedModel;
+          state.defaultSelectedModel = matchedModel;
         } else {
-          state.selectedModel = state.availableModels[0];
+          state.defaultSelectedModel = state.availableModels[0];
         }
       }
+      // 同步 per-agent 选中模型
+      syncSelectedModelByAgent(state.selectedModelByAgent, state.availableModels);
     },
     clearServerModels: (state) => {
       state.availableModels = state.availableModels.filter(m => !m.isServerModel);
       availableModels = state.availableModels;
-      // 如果当前选中的是服务端模型，切换到第一个可用模型
-      if (state.selectedModel.isServerModel && state.availableModels.length > 0) {
-        state.selectedModel = state.availableModels[0];
+      // 如果 defaultSelectedModel 是服务端模型，切换到第一个可用模型
+      if (state.defaultSelectedModel.isServerModel && state.availableModels.length > 0) {
+        state.defaultSelectedModel = state.availableModels[0];
       }
+      // 同步 per-agent 选中模型
+      syncSelectedModelByAgent(state.selectedModelByAgent, state.availableModels);
     },
   },
 });
 
-export const { setSelectedModel, setAvailableModels, setServerModels, clearServerModels } = modelSlice.actions;
-export default modelSlice.reducer; 
+export const {
+  setSelectedModel,
+  setDefaultSelectedModel,
+  clearAgentSelectedModel,
+  setAvailableModels,
+  setServerModels,
+  clearServerModels,
+} = modelSlice.actions;
+export default modelSlice.reducer;


### PR DESCRIPTION
## Summary
- Header ModelSelector 使用全局单值 `selectedModel`，切换 agent 时不更新，导致非 main agent 始终显示 app 默认模型（如 glm-5.1）
- 将 `modelSlice.selectedModel` 拆分为 `defaultSelectedModel`（app 级默认）+ `selectedModelByAgent`（per-agent 用户覆盖 map）
- 新增 `useAgentSelectedModel` hook，懒解析链：`selectedModelByAgent[agentId]` → `resolveOpenClawModelRef(agent.model)` → `defaultSelectedModel`
- 回归来源：commit 0cb02d6（decouple home-page model selection from agent config sync）

## Changed files
| File | Change |
|------|--------|
| `modelSlice.ts` | 核心状态改造：`selectedModel` → `defaultSelectedModel` + `selectedModelByAgent` map |
| `agentModelSelection.ts` | 新增 `useAgentSelectedModel` shared hook |
| `CoworkView.tsx` | Header 展示 + session 创建改用 per-agent model |
| `CoworkPromptInput.tsx` | fallback + supportsImage 改用 per-agent model |
| `App.tsx` | 初始化 + 持久化改用 `defaultSelectedModel`；补充 `showToast` 缺失依赖 |
| `ModelSelector.tsx` | 非受控模式读 `defaultSelectedModel`，dispatch 带 agentId |
| `AgentCreateModal.tsx` | 读 `defaultSelectedModel` |
| `agent.ts` | 删除 agent 时 `clearAgentSelectedModel` 清理 map |
| `api.ts` | 旧版 chat 路径改用 `defaultSelectedModel`；修复 import sort |
| `modelSlice.test.ts` | **新建** 15 个测试用例 |

## Known warnings (pre-existing, not in scope)
`src/renderer/services/api.ts` 有 5 处 `@typescript-eslint/no-explicit-any` warning，为旧代码遗留问题（Gemini response 解析和 OpenAI-compatible request body 缺少类型定义），需单独 PR 补充接口类型。

## Test plan
- [ ] 切换到 model="" (Auto) 的 agent → header 显示 app 默认模型
- [ ] 切换到有显式 model 的 agent → header 显示该模型
- [ ] agent A 手动选模型 X → 切到 B → 切回 A → 仍显示 X
- [ ] Auto agent 下新建 session → modelOverride 正确
- [ ] agent 有 vision 模型，header 选 non-vision → supportsImage=false
- [ ] 删除 agent 后 map 条目被清理
- [ ] App 重启后 defaultSelectedModel 正确恢复