### PR TITLE
fix(cowork): constrain markdown image size and add click-to-preview for IM channel images

### DIFF
--- a/src/renderer/components/MarkdownContent.tsx
+++ b/src/renderer/components/MarkdownContent.tsx
@@ -509,7 +509,7 @@ const createMarkdownComponents = (
     if (typeof src === 'string') {
       if (src.startsWith('file://')) {
         resolvedSrc = src.replace(/^file:\/\//, 'localfile://');
-      } else if (src.startsWith('/')) {
+      } else if (src.startsWith('/') && !src.startsWith('//')) {
         resolvedSrc = `localfile://${src}`;
       }
     }
@@ -518,7 +518,7 @@ const createMarkdownComponents = (
         className={`max-w-full max-h-96 object-contain rounded-xl my-4${onImageClick ? ' cursor-pointer hover:opacity-90 transition-opacity' : ''}`}
         src={resolvedSrc}
         alt={alt}
-        onClick={onImageClick ? () => onImageClick(resolvedSrc) : undefined}
+        onClick={onImageClick && resolvedSrc ? () => onImageClick(resolvedSrc) : undefined}
         {...props}
       />
     );

--- a/src/renderer/components/MarkdownContent.tsx
+++ b/src/renderer/components/MarkdownContent.tsx
@@ -424,6 +424,7 @@ const findFallbackPathFromContext = (
 const createMarkdownComponents = (
   resolveLocalFilePath?: (href: string, text: string) => string | null,
   showRevealInFolderAction = false,
+  onImageClick?: (src: string) => void,
 ) => ({
   p: ({ node, className, children, ...props }: any) => (
     <p className="my-1 first:mt-0 last:mb-0 leading-6 text-foreground" {...props}>
@@ -504,10 +505,23 @@ const createMarkdownComponents = (
     </td>
   ),
   img: ({ node, className, src, alt, ...props }: any) => {
-    const resolvedSrc = typeof src === 'string' && src.startsWith('file://')
-      ? src.replace(/^file:\/\//, 'localfile://')
-      : src;
-    return <img className="max-w-full h-auto rounded-xl my-4" src={resolvedSrc} alt={alt} {...props} />;
+    let resolvedSrc = src;
+    if (typeof src === 'string') {
+      if (src.startsWith('file://')) {
+        resolvedSrc = src.replace(/^file:\/\//, 'localfile://');
+      } else if (src.startsWith('/')) {
+        resolvedSrc = `localfile://${src}`;
+      }
+    }
+    return (
+      <img
+        className={`max-w-full max-h-96 object-contain rounded-xl my-4${onImageClick ? ' cursor-pointer hover:opacity-90 transition-opacity' : ''}`}
+        src={resolvedSrc}
+        alt={alt}
+        onClick={onImageClick ? () => onImageClick(resolvedSrc) : undefined}
+        {...props}
+      />
+    );
   },
   hr: ({ node, ...props }: any) => (
     <hr className="my-5 border-border" {...props} />
@@ -674,6 +688,7 @@ interface MarkdownContentProps {
   className?: string;
   resolveLocalFilePath?: (href: string, text: string) => string | null;
   showRevealInFolderAction?: boolean;
+  onImageClick?: (src: string) => void;
 }
 
 const MarkdownContent: React.FC<MarkdownContentProps> = ({
@@ -681,10 +696,11 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
   className = '',
   resolveLocalFilePath,
   showRevealInFolderAction = false,
+  onImageClick,
 }) => {
   const components = useMemo(
-    () => createMarkdownComponents(resolveLocalFilePath, showRevealInFolderAction),
-    [resolveLocalFilePath, showRevealInFolderAction]
+    () => createMarkdownComponents(resolveLocalFilePath, showRevealInFolderAction, onImageClick),
+    [resolveLocalFilePath, showRevealInFolderAction, onImageClick]
   );
   const normalizedContent = useMemo(() => normalizeDisplayMath(encodeFileUrlsInMarkdown(content)), [content]);
   return (

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1168,6 +1168,13 @@ export const UserMessageItem: React.FC<{
   const [isHovered, setIsHovered] = useState(false);
   const [expandedImage, setExpandedImage] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (!expandedImage) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') setExpandedImage(null); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [expandedImage]);
+
   // Transform content for display: strip IM media metadata, render images inline
   const displayContent = useMemo(
     () => parseUserMessageForDisplay(message.content || ''),
@@ -1285,6 +1292,13 @@ const AssistantMessageItem: React.FC<{
   const [isHovered, setIsHovered] = useState(false);
   const [expandedImage, setExpandedImage] = useState<string | null>(null);
   const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content;
+
+  useEffect(() => {
+    if (!expandedImage) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') setExpandedImage(null); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [expandedImage]);
 
   return (
     <div

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1198,6 +1198,7 @@ export const UserMessageItem: React.FC<{
                   <MarkdownContent
                     content={displayContent}
                     className="max-w-none whitespace-pre-wrap break-words"
+                    onImageClick={setExpandedImage}
                   />
                 )}
                 {imageAttachments.length > 0 && (
@@ -1282,6 +1283,7 @@ const AssistantMessageItem: React.FC<{
   showCopyButton = false,
 }) => {
   const [isHovered, setIsHovered] = useState(false);
+  const [expandedImage, setExpandedImage] = useState<string | null>(null);
   const displayContent = mapDisplayText ? mapDisplayText(message.content) : message.content;
 
   return (
@@ -1296,6 +1298,7 @@ const AssistantMessageItem: React.FC<{
           className="prose dark:prose-invert max-w-none"
           resolveLocalFilePath={resolveLocalFilePath}
           showRevealInFolderAction
+          onImageClick={setExpandedImage}
         />
       </div>
       {showCopyButton && (
@@ -1303,6 +1306,19 @@ const AssistantMessageItem: React.FC<{
           <CopyButton
             content={displayContent}
             visible={isHovered}
+          />
+        </div>
+      )}
+      {expandedImage && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 cursor-pointer"
+          onClick={() => setExpandedImage(null)}
+        >
+          <img
+            src={expandedImage}
+            alt="Preview"
+            className="max-h-[90vh] max-w-[90vw] object-contain rounded-lg shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
           />
         </div>
       )}


### PR DESCRIPTION
修复：微信渠道发送的图片展示过大，并且没有预览