### PR TITLE
refactor: remove dead engine-branching code

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -336,11 +336,6 @@ export interface UpdateAgentRequest {
   enabled?: boolean;
 }
 
-const COWORK_AGENT_ENGINE = 'openclaw';
-
-function normalizeCoworkAgentEngineValue(_value?: string | null): CoworkAgentEngine {
-  return COWORK_AGENT_ENGINE;
-}
 
 export interface CoworkMessageMetadata {
   toolName?: string;
@@ -1072,7 +1067,7 @@ export class CoworkStore {
       workingDirectory: cfg.get('workingDirectory') || getDefaultWorkingDirectory(),
       systemPrompt: getDefaultSystemPrompt(),
       executionMode: 'local' as CoworkExecutionMode,
-      agentEngine: normalizeCoworkAgentEngineValue(cfg.get('agentEngine')),
+      agentEngine: 'openclaw' as CoworkAgentEngine,
       memoryEnabled: parseBooleanConfig(cfg.get('memoryEnabled'), DEFAULT_MEMORY_ENABLED),
       memoryImplicitUpdateEnabled: parseBooleanConfig(
         cfg.get('memoryImplicitUpdateEnabled'),
@@ -1107,7 +1102,7 @@ export class CoworkStore {
       this.upsertConfig('executionMode', config.executionMode, now);
     }
     if (config.agentEngine !== undefined) {
-      this.upsertConfig('agentEngine', normalizeCoworkAgentEngineValue(config.agentEngine), now);
+      this.upsertConfig('agentEngine', 'openclaw', now);
     }
     if (config.memoryEnabled !== undefined) {
       this.upsertConfig('memoryEnabled', config.memoryEnabled ? '1' : '0', now);

--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -382,7 +382,7 @@ export class IMCoworkHandler extends EventEmitter {
     const config = this.coworkStore.getConfig();
     const imSettings = this.imStore.getIMSettings();
     const systemPrompt = config.systemPrompt || '';
-    const scheduledTaskPrompt = buildScheduledTaskEnginePrompt(config.agentEngine);
+    const scheduledTaskPrompt = buildScheduledTaskEnginePrompt();
 
     // Build media instruction for IM media sending capability
     const mediaInstruction = buildIMMediaInstruction(imSettings);

--- a/src/main/im/imGatewayManager.ts
+++ b/src/main/im/imGatewayManager.ts
@@ -74,7 +74,6 @@ export interface IMGatewayManagerOptions {
   coworkRuntime?: CoworkRuntime;
   coworkStore?: CoworkStore;
   ensureCoworkReady?: () => Promise<void>;
-  isOpenClawEngine?: () => boolean;
   syncOpenClawConfig?: (reason?: string) => Promise<void>;
   ensureOpenClawGatewayConnected?: () => Promise<void>;
   getOpenClawGatewayClient?: () => GatewayClientLike | null;
@@ -95,7 +94,6 @@ export class IMGatewayManager extends EventEmitter {
   private getLLMConfig: (() => Promise<any>) | null = null;
   private getSkillsPrompt: (() => Promise<string | null>) | null = null;
   private ensureCoworkReady: (() => Promise<void>) | null = null;
-  private isOpenClawEngine: (() => boolean) | null = null;
   private syncOpenClawConfig: ((reason?: string) => Promise<void>) | null = null;
   private ensureOpenClawGatewayConnected: (() => Promise<void>) | null = null;
   private getOpenClawGatewayClient: (() => GatewayClientLike | null) | null = null;
@@ -130,7 +128,6 @@ export class IMGatewayManager extends EventEmitter {
       this.coworkStore = options.coworkStore;
     }
     this.ensureCoworkReady = options?.ensureCoworkReady ?? null;
-    this.isOpenClawEngine = options?.isOpenClawEngine ?? null;
     this.syncOpenClawConfig = options?.syncOpenClawConfig ?? null;
     this.ensureOpenClawGatewayConnected = options?.ensureOpenClawGatewayConnected ?? null;
     this.getOpenClawGatewayClient = options?.getOpenClawGatewayClient ?? null;

--- a/src/main/libs/agentEngine/coworkEngineRouter.ts
+++ b/src/main/libs/agentEngine/coworkEngineRouter.ts
@@ -180,12 +180,7 @@ export class CoworkEngineRouter extends EventEmitter implements CoworkRuntime {
   }
 
   private safeResolveEngine(): CoworkAgentEngine {
-    const nextEngine = this.getCurrentEngine();
-    if (nextEngine === 'openclaw') {
-      this.currentEngine = nextEngine;
-      return nextEngine;
-    }
-    this.currentEngine = 'openclaw';
-    return 'openclaw';
+    this.currentEngine = this.getCurrentEngine();
+    return this.currentEngine;
   }
 }

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -2539,7 +2539,7 @@ export class OpenClawConfigSync {
 
       // Keep scheduled-task policy after skills so native channel sessions
       // treat it as the final app-managed override for reminder handling.
-      const scheduledTaskPrompt = buildScheduledTaskEnginePrompt('openclaw').replaceAll(MARKER, '');
+      const scheduledTaskPrompt = buildScheduledTaskEnginePrompt().replaceAll(MARKER, '');
       if (scheduledTaskPrompt) {
         sections.push(scheduledTaskPrompt);
       }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1037,7 +1037,7 @@ const shouldRefreshServerQuotaForSession = (sessionId: string): boolean => {
 };
 
 const resolveCoworkAgentEngine = (): CoworkAgentEngine => {
-  return getCoworkStore().getConfig().agentEngine;
+  return 'openclaw';
 };
 
 const getOpenClawConfigSync = (): OpenClawConfigSync => {
@@ -1644,15 +1644,11 @@ const getIMGatewayManager = () => {
         coworkRuntime: runtime,
         coworkStore: store,
         ensureCoworkReady: async () => {
-          if (resolveCoworkAgentEngine() !== 'openclaw') {
-            return;
-          }
           const status = await ensureOpenClawRunningForCowork();
           if (status.phase !== 'running') {
             throw new Error(status.message || 'AI engine is initializing. Please try again in a moment.');
           }
         },
-        isOpenClawEngine: () => resolveCoworkAgentEngine() === 'openclaw',
         syncOpenClawConfig: async (reason?: string) => {
           await syncOpenClawConfig({
             reason: reason || 'im-gateway-sync',
@@ -1803,11 +1799,10 @@ const getIMGatewayManager = () => {
 };
 
 function mergeCoworkSystemPrompt(
-  engine: CoworkAgentEngine,
   systemPrompt?: string,
 ): string | undefined {
   const sections = [
-    buildScheduledTaskEnginePrompt(engine),
+    buildScheduledTaskEnginePrompt(),
     systemPrompt?.trim() || '',
   ].filter(Boolean);
   return sections.length > 0 ? sections.join('\n\n') : undefined;
@@ -2805,18 +2800,14 @@ if (!gotTheLock) {
     modelOverride?: string;
   }) => {
     try {
-      const activeEngine = resolveCoworkAgentEngine();
-      if (activeEngine === 'openclaw') {
-        const engineStatus = await ensureOpenClawRunningForCowork();
-        if (engineStatus.phase !== 'running') {
-          return getEngineNotReadyResponse(engineStatus);
-        }
+      const engineStatus = await ensureOpenClawRunningForCowork();
+      if (engineStatus.phase !== 'running') {
+        return getEngineNotReadyResponse(engineStatus);
       }
 
       const coworkStoreInstance = getCoworkStore();
       const config = coworkStoreInstance.getConfig();
       const systemPrompt = mergeCoworkSystemPrompt(
-        activeEngine,
         options.systemPrompt ?? config.systemPrompt,
       );
       const selectedWorkspaceRoot = (options.cwd || config.workingDirectory || '').trim();
@@ -2927,12 +2918,9 @@ if (!gotTheLock) {
     imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
   }) => {
     try {
-      const activeEngine = resolveCoworkAgentEngine();
-      if (activeEngine === 'openclaw') {
-        const engineStatus = await ensureOpenClawRunningForCowork();
-        if (engineStatus.phase !== 'running') {
-          return getEngineNotReadyResponse(engineStatus);
-        }
+      const engineStatus = await ensureOpenClawRunningForCowork();
+      if (engineStatus.phase !== 'running') {
+        return getEngineNotReadyResponse(engineStatus);
       }
 
       const runtime = getCoworkEngineRouter();
@@ -2950,7 +2938,6 @@ if (!gotTheLock) {
       }
       runtime.continueSession(options.sessionId, options.prompt, {
         systemPrompt: mergeCoworkSystemPrompt(
-          activeEngine,
           options.systemPrompt ?? existingSession?.systemPrompt,
         ),
         skillIds: options.activeSkillIds,
@@ -3729,11 +3716,6 @@ if (!gotTheLock) {
       }
 
       const nextConfig = getCoworkStore().getConfig();
-      if (normalizedAgentEngine !== undefined && normalizedAgentEngine !== previousConfig.agentEngine) {
-        getCoworkEngineRouter().handleEngineConfigChanged(normalizedAgentEngine);
-      }
-      const switchedToOpenClaw = normalizedAgentEngine === 'openclaw'
-        && previousConfig.agentEngine !== 'openclaw';
 
       const shouldSyncOpenClawConfig = normalizedExecutionMode !== undefined
         || normalizedAgentEngine !== undefined
@@ -3753,11 +3735,6 @@ if (!gotTheLock) {
         }
       }
 
-      if (switchedToOpenClaw) {
-        void ensureOpenClawRunningForCowork().catch((error) => {
-          console.error('[OpenClaw] Failed to auto-start gateway after engine switch:', error);
-        });
-      }
       return { success: true };
     } catch (error) {
       return {
@@ -5914,18 +5891,16 @@ if (!gotTheLock) {
       console.error('[OpenClaw] Startup config sync failed:', startupSync.error);
     }
     profiler.measure('syncOpenClawConfig');
-    if (resolveCoworkAgentEngine() === 'openclaw') {
-      void ensureOpenClawRunningForCowork().then(() => {
-        // Start cron polling once the gateway is confirmed running.
-        try {
-          getCronJobService().startPolling();
-        } catch (err) {
-          console.warn('[Main] CronJobService not available after OpenClaw startup:', err);
-        }
-      }).catch((error) => {
-        console.error('[OpenClaw] Failed to auto-start gateway on app startup:', error);
-      });
-    }
+    void ensureOpenClawRunningForCowork().then(() => {
+      // Start cron polling once the gateway is confirmed running.
+      try {
+        getCronJobService().startPolling();
+      } catch (err) {
+        console.warn('[Main] CronJobService not available after OpenClaw startup:', err);
+      }
+    }).catch((error) => {
+      console.error('[OpenClaw] Failed to auto-start gateway on app startup:', error);
+    });
 
     // ── Step 1: Show window ASAP ──────────────────────────────────────
     // CSP + createWindow moved before skill initialisation so the user

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -925,31 +925,27 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                   <div className="flex flex-col items-start gap-1">
                     <ModelSelector
                       dropdownDirection="up"
-                      value={coworkAgentEngine === 'openclaw'
-                        ? (agentModelIsInvalid && currentSession?.modelOverride
-                          ? { id: '__invalid__', name: currentSession.modelOverride.split('/').pop() || currentSession.modelOverride } as Model
-                          : agentSelectedModel)
-                        : null}
-                      onChange={coworkAgentEngine === 'openclaw'
-                        ? async (nextModel) => {
-                            if (!nextModel) return;
-                            const modelRef = toOpenClawModelRef(nextModel);
-                            console.log('[CoworkPromptInput] model selected:', { id: nextModel.id, providerKey: nextModel.providerKey, isServerModel: nextModel.isServerModel, modelRef });
-                            if (sessionId) {
-                              await coworkService.patchSession(sessionId, { model: modelRef });
-                              if (currentAgent && agentModelIsInvalid) {
-                                console.log('[CoworkPromptInput] auto-fixing invalid agent model:', currentAgent.id, currentAgent.model, '->', modelRef);
-                                agentService.updateAgent(currentAgent.id, { model: modelRef });
-                              }
-                              return;
-                            }
-                            if (!currentAgent) return;
-                            console.log('[CoworkPromptInput] home page model change (Redux only, no agent update):', { modelRef, modelName: nextModel.name, providerKey: nextModel.providerKey });
-                            dispatch(setSelectedModel({ agentId: currentAgentId, model: nextModel }));
+                      value={agentModelIsInvalid && currentSession?.modelOverride
+                        ? { id: '__invalid__', name: currentSession.modelOverride.split('/').pop() || currentSession.modelOverride } as Model
+                        : agentSelectedModel}
+                      onChange={async (nextModel) => {
+                        if (!nextModel) return;
+                        const modelRef = toOpenClawModelRef(nextModel);
+                        console.log('[CoworkPromptInput] model selected:', { id: nextModel.id, providerKey: nextModel.providerKey, isServerModel: nextModel.isServerModel, modelRef });
+                        if (sessionId) {
+                          await coworkService.patchSession(sessionId, { model: modelRef });
+                          if (currentAgent && agentModelIsInvalid) {
+                            console.log('[CoworkPromptInput] auto-fixing invalid agent model:', currentAgent.id, currentAgent.model, '->', modelRef);
+                            agentService.updateAgent(currentAgent.id, { model: modelRef });
                           }
-                        : undefined}
+                          return;
+                        }
+                        if (!currentAgent) return;
+                        console.log('[CoworkPromptInput] home page model change (Redux only, no agent update):', { modelRef, modelName: nextModel.name, providerKey: nextModel.providerKey });
+                        dispatch(setSelectedModel({ agentId: currentAgentId, model: nextModel }));
+                      }}
                     />
-                    {coworkAgentEngine === 'openclaw' && agentModelIsInvalid && (
+                    {agentModelIsInvalid && (
                       <span className="max-w-60 text-[11px] leading-4 text-red-500">
                         {i18nService.t('agentModelInvalidHint')}
                       </span>

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -5,12 +5,10 @@ import { useDispatch,useSelector } from 'react-redux';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { quickActionService } from '../../services/quickAction';
-import { skillService } from '../../services/skill';
 import { RootState } from '../../store';
 import {
   selectCoworkConfig,
   selectCurrentSession,
-  selectIsOpenClawEngine,
   selectIsStreaming,
 } from '../../store/selectors/coworkSelectors';
 import { addMessage, clearCurrentSession, setCurrentSession, setStreaming, updateSessionStatus } from '../../store/slices/coworkSlice';
@@ -60,7 +58,6 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   const currentSession = useSelector(selectCurrentSession);
   const isStreaming = useSelector(selectIsStreaming);
   const config = useSelector(selectCoworkConfig);
-  const isOpenClawEngine = useSelector(selectIsOpenClawEngine);
 
   const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
   const skills = useSelector((state: RootState) => state.skill.skills);
@@ -178,7 +175,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       count: imageAttachments?.length ?? 0,
       details: imageAttachments?.map(a => ({ name: a.name, mimeType: a.mimeType, base64Length: a.base64Data?.length ?? 0 })) ?? [],
     });
-    if (isOpenClawEngine && openClawStatus && !isOpenClawReadyForSession(openClawStatus)) {
+    if (openClawStatus && !isOpenClawReadyForSession(openClawStatus)) {
       window.dispatchEvent(new CustomEvent('app:showToast', { detail: i18nService.t('coworkErrorEngineNotReady') }));
       return false;
     }
@@ -266,11 +263,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       // auto-routing prompt to avoid injecting Claude SDK tool-calling instructions
       // that confuse non-Claude models (e.g. kimi-k2.5 falls back to text-based
       // tool calls, producing empty tool names and err=true failures).
-      let effectiveSkillPrompt = skillPrompt;
-      if (!skillPrompt && !isOpenClawEngine) {
-        effectiveSkillPrompt = await skillService.getAutoRoutingPrompt() || undefined;
-      }
-      const combinedSystemPrompt = [effectiveSkillPrompt, config.systemPrompt]
+      const combinedSystemPrompt = [skillPrompt, config.systemPrompt]
         .filter(p => p?.trim())
         .join('\n\n') || undefined;
 
@@ -334,7 +327,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     if (!currentSession) return;
     // Prevent duplicate submissions
     if (isContinuingRef.current) return;
-    if (isOpenClawEngine && openClawStatus && !isOpenClawReadyForSession(openClawStatus)) {
+    if (openClawStatus && !isOpenClawReadyForSession(openClawStatus)) {
       window.dispatchEvent(new CustomEvent('app:showToast', { detail: i18nService.t('coworkErrorEngineNotReady') }));
       return false;
     }
@@ -358,11 +351,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
 
       // Combine skill prompt with system prompt for continuation.
       // Skip auto-routing prompt for OpenClaw — skills are loaded natively.
-      let effectiveSkillPrompt = skillPrompt;
-      if (!skillPrompt && !isOpenClawEngine) {
-        effectiveSkillPrompt = await skillService.getAutoRoutingPrompt() || undefined;
-      }
-      const combinedSystemPrompt = [effectiveSkillPrompt, config.systemPrompt]
+      const combinedSystemPrompt = [skillPrompt, config.systemPrompt]
         .filter(p => p?.trim())
         .join('\n\n') || undefined;
 
@@ -448,7 +437,6 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   }, [dispatch, currentSession]);
 
   useEffect(() => {
-    if (!isOpenClawEngine) return;
     if (!currentSession || currentSession.status !== 'running') return;
 
     const runningSessionId = currentSession.id;
@@ -460,7 +448,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     return () => {
       window.removeEventListener('focus', handleWindowFocus);
     };
-  }, [currentSession, isOpenClawEngine]);
+  }, [currentSession]);
 
   if (!isInitialized) {
     return (
@@ -477,11 +465,9 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
     );
   }
 
-  const shouldShowEngineStatus = Boolean(isOpenClawEngine && openClawStatus && openClawStatus.phase !== 'running');
+  const shouldShowEngineStatus = Boolean(openClawStatus && openClawStatus.phase !== 'running');
   const isEngineError = openClawStatus?.phase === 'error';
-  const isEngineReady = isOpenClawEngine
-    ? isOpenClawReadyForSession(openClawStatus)
-    : true;
+  const isEngineReady = isOpenClawReadyForSession(openClawStatus);
 
   const homeHeader = (
     <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border shrink-0">
@@ -506,13 +492,11 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
           </div>
         )}
         <ModelSelector
-          value={isOpenClawEngine ? currentAgentSelectedModel : undefined}
-          onChange={isOpenClawEngine
-            ? async (nextModel) => {
-                if (!nextModel) return;
-                dispatch(setSelectedModel({ agentId: currentAgentId, model: nextModel }));
-              }
-            : undefined}
+          value={currentAgentSelectedModel}
+          onChange={async (nextModel) => {
+            if (!nextModel) return;
+            dispatch(setSelectedModel({ agentId: currentAgentId, model: nextModel }));
+          }}
         />
       </div>
       <div className="non-draggable flex items-center">

--- a/src/renderer/components/cowork/EngineStartupOverlay.tsx
+++ b/src/renderer/components/cowork/EngineStartupOverlay.tsx
@@ -1,10 +1,8 @@
 import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
 import React, { useEffect,useState } from 'react';
-import { useSelector } from 'react-redux';
 
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
-import { selectIsOpenClawEngine } from '../../store/selectors/coworkSelectors';
 import type { OpenClawEngineStatus } from '../../types/cowork';
 
 const resolveEngineStatusText = (status: OpenClawEngineStatus): string => {
@@ -30,12 +28,9 @@ const resolveEngineStatusText = (status: OpenClawEngineStatus): string => {
  * Renders on top of all views (cowork, skills, scheduled tasks, mcp).
  */
 const EngineStartupOverlay: React.FC = () => {
-  const isOpenClawEngine = useSelector(selectIsOpenClawEngine);
   const [status, setStatus] = useState<OpenClawEngineStatus | null>(null);
 
   useEffect(() => {
-    if (!isOpenClawEngine) return;
-
     coworkService.getOpenClawEngineStatus().then((s) => {
       if (s) setStatus(s);
     });
@@ -45,9 +40,9 @@ const EngineStartupOverlay: React.FC = () => {
     });
 
     return unsubscribe;
-  }, [isOpenClawEngine]);
+  }, []);
 
-  if (!isOpenClawEngine || !status || status.phase !== 'starting') {
+  if (!status || status.phase !== 'starting') {
     return null;
   }
 

--- a/src/scheduledTask/enginePrompt.test.ts
+++ b/src/scheduledTask/enginePrompt.test.ts
@@ -3,7 +3,7 @@ import { expect,test } from 'vitest';
 import { buildScheduledTaskEnginePrompt } from './enginePrompt';
 
 test('openclaw prompt points scheduled task requests to the native cron tool', () => {
-  const prompt = buildScheduledTaskEnginePrompt('openclaw');
+  const prompt = buildScheduledTaskEnginePrompt();
 
   expect(prompt).toMatch(/native `cron` tool/i);
   expect(prompt).toMatch(/action: "add".*cron\.add/i);
@@ -25,7 +25,7 @@ test('openclaw prompt points scheduled task requests to the native cron tool', (
 });
 
 test('scheduled task prompt always uses the openclaw instructions', () => {
-  const prompt = buildScheduledTaskEnginePrompt('openclaw');
+  const prompt = buildScheduledTaskEnginePrompt();
 
   expect(prompt).not.toMatch(/switch the agent engine/i);
   expect(prompt).not.toMatch(/do not attempt to create, update, list, enable, disable, or delete scheduled tasks/i);

--- a/src/scheduledTask/enginePrompt.ts
+++ b/src/scheduledTask/enginePrompt.ts
@@ -1,6 +1,4 @@
-import type { CoworkAgentEngine } from '../main/libs/agentEngine/types';
-
-export function buildScheduledTaskEnginePrompt(_engine: CoworkAgentEngine): string {
+export function buildScheduledTaskEnginePrompt(): string {
   return [
     '## Scheduled Tasks',
     '- Use the native `cron` tool for any scheduled task creation or management request.',


### PR DESCRIPTION
## Summary

- 移除已废弃的 `yd_cowork` 引擎分支逻辑，统一为 `openclaw` 单引擎路径
- 清理 `CoworkAgentEngine` 联合类型为单值，删除所有对已移除引擎的条件分支
- 涉及 11 个文件，净减少 65 行代码

## 变更范围

- `src/main/main.ts` — 移除引擎切换逻辑
- `src/main/libs/agentEngine/coworkEngineRouter.ts` — 简化路由
- `src/main/coworkStore.ts` — 移除引擎选择持久化
- `src/renderer/components/cowork/` — 移除前端引擎分支 UI
- `src/scheduledTask/enginePrompt.ts` — 简化引擎参数

## Test plan

- [ ] 确认应用正常启动，openclaw 引擎正常加载
- [ ] 确认对话功能正常工作
- [ ] 确认无 yd_cowork 相关残留引用