### PR TITLE
feat: decouple main agent workspace from working directory

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -2,6 +2,7 @@ import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
+import { getMainAgentWorkspacePath } from './openclawMemoryFile';
 import { buildScheduledTaskEnginePrompt } from '../../scheduledTask/enginePrompt';
 import {
   AuthType,
@@ -1056,11 +1057,9 @@ export class OpenClawConfigSync {
         const result = this.writeMinimalConfig(configPath, reason);
         // Still sync AGENTS.md even when API is not configured — skills/systemPrompt
         // may already be set and should be available when the user configures a model.
-        const workspaceDir = (coworkConfig.workingDirectory || '').trim();
-        const resolvedWorkspaceDir =
-          workspaceDir || path.join(app.getPath('home'), '.openclaw', 'workspace');
-        const agentsMdWarning = this.syncAgentsMd(resolvedWorkspaceDir, coworkConfig);
-        this.syncPerAgentWorkspaces(resolvedWorkspaceDir, coworkConfig);
+        const mainWorkspacePath = getMainAgentWorkspacePath(this.engineManager.getStateDir());
+        const agentsMdWarning = this.syncAgentsMd(mainWorkspacePath, coworkConfig);
+        this.syncPerAgentWorkspaces(mainWorkspacePath, coworkConfig);
         if (agentsMdWarning) result.agentsMdWarning = agentsMdWarning;
         return result;
       }
@@ -1182,7 +1181,8 @@ export class OpenClawConfigSync {
       `[OpenClawConfigSync] sandbox mode: ${sandboxMode} (executionMode: ${coworkConfig.executionMode || 'local'}, enterprise: ${this.isEnterprise()})`,
     );
 
-    const workspaceDir = (coworkConfig.workingDirectory || '').trim();
+    const mainWorkspacePath = getMainAgentWorkspacePath(this.engineManager.getStateDir());
+    ensureDir(mainWorkspacePath);
 
     const preinstalledPlugins = readPreinstalledPlugins();
     const hasPreinstalledPlugin = (...ids: string[]) => (
@@ -1287,7 +1287,7 @@ export class OpenClawConfigSync {
           sandbox: {
             mode: sandboxMode,
           },
-          ...(workspaceDir ? { workspace: path.resolve(workspaceDir) } : {}),
+          workspace: path.resolve(mainWorkspacePath),
           ...(coworkConfig.embeddingEnabled ? {
             memorySearch: {
               enabled: true,
@@ -2059,12 +2059,10 @@ export class OpenClawConfigSync {
     // Sync AGENTS.md with skills routing prompt to the OpenClaw workspace directory.
     // This runs on every sync regardless of openclaw.json changes, because skills
     // may have been installed/enabled/disabled independently.
-    const resolvedWorkspaceDir =
-      workspaceDir || path.join(app.getPath('home'), '.openclaw', 'workspace');
-    const agentsMdWarning = this.syncAgentsMd(resolvedWorkspaceDir, coworkConfig);
+    const agentsMdWarning = this.syncAgentsMd(mainWorkspacePath, coworkConfig);
 
     // Sync per-agent workspace files (SOUL.md, IDENTITY.md, AGENTS.md) for non-main agents
-    this.syncPerAgentWorkspaces(resolvedWorkspaceDir, coworkConfig);
+    this.syncPerAgentWorkspaces(mainWorkspacePath, coworkConfig);
 
     return {
       ok: true,

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -2,7 +2,6 @@ import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
-import { getMainAgentWorkspacePath } from './openclawMemoryFile';
 import { buildScheduledTaskEnginePrompt } from '../../scheduledTask/enginePrompt';
 import {
   AuthType,
@@ -37,6 +36,7 @@ import {
 } from './openclawAgentModels';
 import { parseChannelSessionKey } from './openclawChannelSessionSync';
 import type { OpenClawEngineManager } from './openclawEngineManager';
+import { getMainAgentWorkspacePath } from './openclawMemoryFile';
 
 const gwDiagTs = (): string => {
   const d = new Date();

--- a/src/main/libs/openclawMemoryFile.ts
+++ b/src/main/libs/openclawMemoryFile.ts
@@ -39,8 +39,20 @@ export interface OpenClawMemoryStats {
 const DEFAULT_OPENCLAW_WORKSPACE = path.join(os.homedir(), '.openclaw', 'workspace');
 
 /**
- * Resolve the MEMORY.md path from the user-configured working directory.
+ * Return the fixed workspace path for the main agent.
+ * All main-agent state files (MEMORY.md, IDENTITY.md, AGENTS.md, etc.) live here,
+ * decoupled from the user-visible "working directory" (which is only used as session cwd).
+ */
+export function getMainAgentWorkspacePath(stateDir: string): string {
+  return path.join(stateDir, 'workspace-main');
+}
+
+/**
+ * Resolve the MEMORY.md path from an agent workspace directory.
  * Falls back to `~/.openclaw/workspace/MEMORY.md` when unset.
+ *
+ * NOTE: The parameter represents the agent's workspace path (e.g. from
+ * `getMainAgentWorkspacePath()`), not the user-visible working directory.
  */
 export function resolveMemoryFilePath(workingDirectory: string | undefined): string {
   const dir = (workingDirectory || '').trim();
@@ -438,7 +450,10 @@ function validateBootstrapFilename(filename: string): void {
 }
 
 /**
- * Resolve the path to a bootstrap file in the workspace directory.
+ * Resolve the path to a bootstrap file in the agent workspace directory.
+ *
+ * NOTE: The parameter represents the agent's workspace path (e.g. from
+ * `getMainAgentWorkspacePath()`), not the user-visible working directory.
  */
 export function resolveBootstrapFilePath(workingDirectory: string | undefined, filename: string): string {
   validateBootstrapFilename(filename);
@@ -485,6 +500,9 @@ export function ensureDefaultIdentity(workingDirectory: string | undefined): voi
 /**
  * Sync MEMORY.md when workspace directory changes.
  * Copies entries from old path to new path (merge-dedup, keeps old file as backup).
+ *
+ * Primarily used by the one-time migration from user working directory to
+ * the fixed `{STATE_DIR}/workspace-main/` path.
  */
 export function syncMemoryFileOnWorkspaceChange(
   oldWorkingDirectory: string | undefined,

--- a/src/main/libs/openclawWorkspaceMigration.ts
+++ b/src/main/libs/openclawWorkspaceMigration.ts
@@ -1,0 +1,127 @@
+/**
+ * One-time migration: move main agent workspace files from the user's
+ * configured working directory to the fixed `{STATE_DIR}/workspace-main/`
+ * path, so the main agent workspace is decoupled from the working directory.
+ *
+ * Safe to call multiple times — uses a kv flag for idempotency.
+ * Never deletes source files.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import type { SqliteStore } from '../sqliteStore';
+import {
+  getMainAgentWorkspacePath,
+  syncMemoryFileOnWorkspaceChange,
+} from './openclawMemoryFile';
+
+const TAG = '[OpenClaw Migration]';
+const MIGRATION_KEY = 'migration.mainAgentWorkspace.v1.completed';
+
+const BOOTSTRAP_FILES = ['IDENTITY.md', 'USER.md', 'SOUL.md'];
+
+/**
+ * Copy a file from `src` to `dest` only if `src` exists and `dest` is
+ * missing or empty.  Returns true if a copy was made.
+ */
+function copyIfNeeded(src: string, dest: string): boolean {
+  try {
+    if (!fs.existsSync(src) || !fs.statSync(src).isFile()) return false;
+    const srcContent = fs.readFileSync(src, 'utf8');
+    if (!srcContent.trim()) return false; // nothing worth copying
+
+    // Don't overwrite non-empty destination
+    try {
+      const destContent = fs.readFileSync(dest, 'utf8');
+      if (destContent.trim()) return false;
+    } catch {
+      // dest doesn't exist — proceed with copy
+    }
+
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, srcContent, 'utf8');
+    return true;
+  } catch (err) {
+    console.warn(`${TAG} copyIfNeeded failed: ${src} → ${dest}:`, err instanceof Error ? err.message : err);
+    return false;
+  }
+}
+
+/**
+ * Recursively copy a directory if the destination does not exist.
+ */
+function copyDirIfNeeded(src: string, dest: string): boolean {
+  try {
+    if (!fs.existsSync(src) || !fs.statSync(src).isDirectory()) return false;
+    if (fs.existsSync(dest)) return false; // don't overwrite existing dir
+
+    fs.cpSync(src, dest, { recursive: true });
+    return true;
+  } catch (err) {
+    console.warn(`${TAG} copyDirIfNeeded failed: ${src} → ${dest}:`, err instanceof Error ? err.message : err);
+    return false;
+  }
+}
+
+/**
+ * Migrate main agent workspace files from the old working directory to
+ * `{STATE_DIR}/workspace-main/`.
+ */
+export function migrateMainAgentWorkspace(
+  stateDir: string,
+  oldWorkingDirectory: string | undefined,
+  store: SqliteStore,
+): void {
+  // Already completed — skip
+  if (store.get<string>(MIGRATION_KEY) === '1') return;
+
+  const oldDir = (oldWorkingDirectory || '').trim();
+  const newDir = getMainAgentWorkspacePath(stateDir);
+
+  console.log(`${TAG} Starting main agent workspace migration: ${oldDir || '(empty)'} → ${newDir}`);
+
+  // Ensure destination exists
+  fs.mkdirSync(newDir, { recursive: true });
+
+  // Skip if source and destination are the same path
+  if (oldDir && path.resolve(oldDir) === path.resolve(newDir)) {
+    console.log(`${TAG} Source and destination are identical, marking done`);
+    store.set(MIGRATION_KEY, '1');
+    return;
+  }
+
+  if (!oldDir) {
+    console.log(`${TAG} No previous working directory configured, marking done`);
+    store.set(MIGRATION_KEY, '1');
+    return;
+  }
+
+  // 1. Migrate MEMORY.md via merge-dedup
+  try {
+    const result = syncMemoryFileOnWorkspaceChange(oldDir, newDir);
+    console.log(`${TAG} MEMORY.md migration: synced=${result.synced}${result.error ? `, error=${result.error}` : ''}`);
+  } catch (err) {
+    console.warn(`${TAG} MEMORY.md migration failed:`, err instanceof Error ? err.message : err);
+  }
+
+  // 2. Migrate bootstrap files (IDENTITY.md, USER.md, SOUL.md)
+  for (const filename of BOOTSTRAP_FILES) {
+    const src = path.join(oldDir, filename);
+    const dest = path.join(newDir, filename);
+    if (copyIfNeeded(src, dest)) {
+      console.log(`${TAG} Migrated ${filename}`);
+    }
+  }
+
+  // 3. Migrate memory/ directory (daily logs)
+  const oldMemoryDir = path.join(oldDir, 'memory');
+  const newMemoryDir = path.join(newDir, 'memory');
+  if (copyDirIfNeeded(oldMemoryDir, newMemoryDir)) {
+    console.log(`${TAG} Migrated memory/ directory`);
+  }
+
+  // Mark as completed
+  store.set(MIGRATION_KEY, '1');
+  console.log(`${TAG} Main agent workspace migration completed`);
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -46,6 +46,7 @@ import {
   setCopilotTokenState,
 } from './libs/copilotTokenManager';
 import { saveCoworkApiConfig } from './libs/coworkConfigStore';
+import { migrateMainAgentWorkspace } from './libs/openclawWorkspaceMigration';
 import { getCoworkLogPath } from './libs/coworkLogger';
 import { registerProxyTokenRefresher, startCoworkOpenAICompatProxy, stopCoworkOpenAICompatProxy } from './libs/coworkOpenAICompatProxy';
 import { generateSessionTitle, probeCoworkModelReadiness } from './libs/coworkUtil';
@@ -67,12 +68,12 @@ import {
   addMemoryEntry,
   deleteMemoryEntry,
   ensureDefaultIdentity,
+  getMainAgentWorkspacePath,
   migrateSqliteToMemoryMd,
   readBootstrapFile,
   readMemoryEntries,
   resolveMemoryFilePath,
   searchMemoryEntries,
-  syncMemoryFileOnWorkspaceChange,
   updateMemoryEntry,
   writeBootstrapFile,
 } from './libs/openclawMemoryFile';
@@ -901,9 +902,9 @@ const bootstrapOpenClawEngine = async (options: { forceReinstall?: boolean; reas
       console.log(`[OpenClaw] bootstrap: MCP bridge setup done (${elapsed()}), result=${bridgeResult ? `${bridgeResult.tools.length} tools` : 'null'}`);
       console.log(`[OpenClaw] bootstrap: mcpBridgeServer=${mcpBridgeServer?.callbackUrl || 'null'}, mcpServerManager.tools=${mcpServerManager?.toolManifest?.length ?? 'null'}, secret=${mcpBridgeSecret ? 'set' : 'null'}`);
 
-      // Ensure IDENTITY.md has default content in the current workspace
+      // Ensure IDENTITY.md has default content in the main agent workspace
       try {
-        ensureDefaultIdentity(getCoworkStore().getConfig().workingDirectory);
+        ensureDefaultIdentity(getMainAgentWorkspacePath(manager.getStateDir()));
       } catch (err) {
         console.warn('[OpenClaw] bootstrap: ensureDefaultIdentity failed (non-fatal):', err);
       }
@@ -3463,8 +3464,7 @@ if (!gotTheLock) {
     offset?: number;
   }) => {
     try {
-      const config = getCoworkStore().getConfig();
-      const filePath = resolveMemoryFilePath(config.workingDirectory);
+      const filePath = resolveMemoryFilePath(getMainAgentWorkspacePath(getOpenClawEngineManager().getStateDir()));
 
       // Lazy migration: SQLite → MEMORY.md (one-time, cached in memory)
       if (!memoryMigrationDone) {
@@ -3501,8 +3501,7 @@ if (!gotTheLock) {
     isExplicit?: boolean;
   }) => {
     try {
-      const config = getCoworkStore().getConfig();
-      const filePath = resolveMemoryFilePath(config.workingDirectory);
+      const filePath = resolveMemoryFilePath(getMainAgentWorkspacePath(getOpenClawEngineManager().getStateDir()));
       const entry = addMemoryEntry(filePath, input.text);
       return { success: true, entry };
     } catch (error) {
@@ -3520,8 +3519,7 @@ if (!gotTheLock) {
     isExplicit?: boolean;
   }) => {
     try {
-      const config = getCoworkStore().getConfig();
-      const filePath = resolveMemoryFilePath(config.workingDirectory);
+      const filePath = resolveMemoryFilePath(getMainAgentWorkspacePath(getOpenClawEngineManager().getStateDir()));
       if (!input.text) {
         return { success: false, error: 'Memory text is required' };
       }
@@ -3541,8 +3539,7 @@ if (!gotTheLock) {
     id: string;
   }) => {
     try {
-      const config = getCoworkStore().getConfig();
-      const filePath = resolveMemoryFilePath(config.workingDirectory);
+      const filePath = resolveMemoryFilePath(getMainAgentWorkspacePath(getOpenClawEngineManager().getStateDir()));
       const success = deleteMemoryEntry(filePath, input.id);
       return success
         ? { success: true }
@@ -3556,8 +3553,7 @@ if (!gotTheLock) {
   });
   ipcMain.handle('cowork:memory:getStats', async () => {
     try {
-      const config = getCoworkStore().getConfig();
-      const filePath = resolveMemoryFilePath(config.workingDirectory);
+      const filePath = resolveMemoryFilePath(getMainAgentWorkspacePath(getOpenClawEngineManager().getStateDir()));
       const entries = readMemoryEntries(filePath);
       return {
         success: true,
@@ -3579,8 +3575,8 @@ if (!gotTheLock) {
   });
   ipcMain.handle('cowork:bootstrap:read', async (_event, filename: string) => {
     try {
-      const config = getCoworkStore().getConfig();
-      const content = readBootstrapFile(config.workingDirectory, filename);
+      const mainWorkspace = getMainAgentWorkspacePath(getOpenClawEngineManager().getStateDir());
+      const content = readBootstrapFile(mainWorkspace, filename);
       return { success: true, content };
     } catch (error) {
       return {
@@ -3592,8 +3588,8 @@ if (!gotTheLock) {
   });
   ipcMain.handle('cowork:bootstrap:write', async (_event, filename: string, content: string) => {
     try {
-      const config = getCoworkStore().getConfig();
-      writeBootstrapFile(config.workingDirectory, filename, content);
+      const mainWorkspace = getMainAgentWorkspacePath(getOpenClawEngineManager().getStateDir());
+      writeBootstrapFile(mainWorkspace, filename, content);
       return { success: true };
     } catch (error) {
       return {
@@ -3702,25 +3698,16 @@ if (!gotTheLock) {
       getCoworkStore().setConfig(normalizedConfig);
       if (normalizedConfig.workingDirectory !== undefined && normalizedConfig.workingDirectory !== previousWorkingDir) {
         getSkillManager().handleWorkingDirectoryChange();
-        // Sync MEMORY.md to new workspace directory
-        const syncResult = syncMemoryFileOnWorkspaceChange(previousWorkingDir, normalizedConfig.workingDirectory);
-        if (syncResult.error) {
-          console.warn('[OpenClaw Memory] Workspace sync failed:', syncResult.error);
-        }
-        // Ensure IDENTITY.md has default content in the new workspace
-        try {
-          ensureDefaultIdentity(normalizedConfig.workingDirectory);
-        } catch (err) {
-          console.warn('[OpenClaw] ensureDefaultIdentity failed (non-fatal):', err);
-        }
+        // Main agent workspace is decoupled from workingDirectory — no MEMORY.md
+        // or IDENTITY.md sync needed here. The workspace is always at
+        // {STATE_DIR}/workspace-main/ regardless of the user's working directory.
       }
 
       const nextConfig = getCoworkStore().getConfig();
 
       const shouldSyncOpenClawConfig = normalizedExecutionMode !== undefined
         || normalizedAgentEngine !== undefined
-        || Object.values(normalizedEmbedding).some(v => v !== undefined)
-        || (normalizedConfig.workingDirectory !== undefined && normalizedConfig.workingDirectory !== previousWorkingDir);
+        || Object.values(normalizedEmbedding).some(v => v !== undefined);
       if (shouldSyncOpenClawConfig) {
         const syncResult = await syncOpenClawConfig({
           reason: 'cowork-config-change',
@@ -5866,6 +5853,19 @@ if (!gotTheLock) {
       console.log(
         `[Main] migrated agent model bindings: backfilled=${backfilledAgentModels}, qualified=${qualifiedAgentModels}`,
       );
+    }
+
+    // One-time migration: move main agent workspace files from the user's
+    // working directory to the fixed {STATE_DIR}/workspace-main/ path.
+    try {
+      const engineManager = getOpenClawEngineManager();
+      migrateMainAgentWorkspace(
+        engineManager.getStateDir(),
+        getCoworkStore().getConfig().workingDirectory,
+        getStore(),
+      );
+    } catch (err) {
+      console.warn('[OpenClaw] main agent workspace migration failed (non-fatal):', err);
     }
 
     // Start proxy BEFORE config sync so proxy-dependent providers (e.g. copilot)

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -46,7 +46,6 @@ import {
   setCopilotTokenState,
 } from './libs/copilotTokenManager';
 import { saveCoworkApiConfig } from './libs/coworkConfigStore';
-import { migrateMainAgentWorkspace } from './libs/openclawWorkspaceMigration';
 import { getCoworkLogPath } from './libs/coworkLogger';
 import { registerProxyTokenRefresher, startCoworkOpenAICompatProxy, stopCoworkOpenAICompatProxy } from './libs/coworkOpenAICompatProxy';
 import { generateSessionTitle, probeCoworkModelReadiness } from './libs/coworkUtil';
@@ -78,6 +77,7 @@ import {
   writeBootstrapFile,
 } from './libs/openclawMemoryFile';
 import { startOpenClawTokenProxy, stopOpenClawTokenProxy } from './libs/openclawTokenProxy';
+import { migrateMainAgentWorkspace } from './libs/openclawWorkspaceMigration';
 import { ensurePythonRuntimeReady } from './libs/pythonRuntime';
 import { serializeForLog } from './libs/sanitizeForLog';
 import { SqliteBackupManager } from './libs/sqliteBackup/sqliteBackupManager';
@@ -4092,7 +4092,7 @@ if (!gotTheLock) {
 
       if (instance.transport === 'imap') {
         // Test IMAP connection using node-imap
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic require with no type definitions
+         
         let Imap: new (config: Record<string, unknown>) => any;
         try {
           Imap = require('imap');

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -3108,12 +3108,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 {i18nService.t('coworkMemoryTitle')}
               </div>
               {/* Memory toggle hidden – always enabled by default */}
-              <div className="mt-2 text-xs text-secondary">
-                <span className="font-medium">{i18nService.t('coworkMemoryFilePath')}:</span>{' '}
-                <span className="break-all font-mono opacity-80">
-                  {joinWorkspacePath(coworkConfig.workingDirectory, 'MEMORY.md')}
-                </span>
-              </div>
             </div>
 
             <div className="space-y-4 rounded-xl border px-4 py-4 border-border">

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -3102,14 +3102,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       case 'coworkMemory':
         return (
           <div className="space-y-6">
-            {/* Section 1: Long-term Memory (MEMORY.md) */}
-            <div className="space-y-3 rounded-xl border px-4 py-4 border-border">
-              <div className="text-sm font-medium text-foreground">
-                {i18nService.t('coworkMemoryTitle')}
-              </div>
-              {/* Memory toggle hidden – always enabled by default */}
-            </div>
-
             <div className="space-y-4 rounded-xl border px-4 py-4 border-border">
               <div className="flex items-center justify-between">
                 <div className="space-y-1">

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -409,16 +409,6 @@ const getDefaultActiveProvider = (): ProviderType => {
   return firstEnabledProvider ?? providerKeys[0];
 };
 
-/** Join workspace directory with a filename using platform-aware separator. */
-const joinWorkspacePath = (dir: string | undefined, filename: string): string => {
-  const base = dir?.trim() || '~/.openclaw/workspace';
-  const sep = window.electron.platform === 'win32' ? '\\' : '/';
-  // Normalize: if base already ends with a separator, don't double it
-  return base.endsWith(sep) || base.endsWith('/') || base.endsWith('\\')
-    ? `${base}${filename}`
-    : `${base}${sep}${filename}`;
-};
-
 // System shortcuts that should not be captured (clipboard, undo, select-all, quit, etc.)
 const isSystemShortcut = (e: KeyboardEvent): boolean => {
   const key = e.key.toLowerCase();
@@ -4426,9 +4416,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             </div>
             <div className="flex flex-col flex-1 min-h-0 space-y-2">
               <p className="text-xs text-secondary shrink-0">{i18nService.t(activeItem.hintKey)}</p>
-              <div className="text-xs text-secondary opacity-60 shrink-0">
-                {i18nService.t('coworkBootstrapStoragePath')}：<span className="font-mono">{joinWorkspacePath(coworkConfig.workingDirectory, activeItem.key)}</span>
-              </div>
               <textarea
                 key={activeItem.key}
                 value={activeItem.value}

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -386,7 +386,6 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkBootstrapSoulTitle: '助手性格',
     coworkBootstrapSoulHint: '助手的性格、语气和行为准则。会强制助手遵循此设定。',
     coworkBootstrapPlaceholder: '支持 Markdown 格式，可用中文或英文书写',
-    coworkBootstrapStoragePath: '存储路径',
     coworkBootstrapSaveFailed: 'Agent 设定保存失败',
     coworkMemoryEnabled: '启用用户记忆',
     coworkMemoryEnabledHint: 'OpenClaw 会自动索引 MEMORY.md 文件，为 Agent 提供长期记忆检索。',
@@ -1944,7 +1943,6 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkBootstrapSoulHint:
       'Assistant personality, tone, and behavior guidelines. The assistant will be instructed to follow this.',
     coworkBootstrapPlaceholder: 'Supports Markdown. Write in any language.',
-    coworkBootstrapStoragePath: 'Storage path',
     coworkBootstrapSaveFailed: 'Failed to save agent settings',
     coworkMemoryEnabled: 'Enable user memories',
     coworkMemoryEnabledHint:


### PR DESCRIPTION
## Summary
- Decouple the main agent's workspace (MEMORY.md, IDENTITY.md, SOUL.md, AGENTS.md, etc.) from the user-configurable "working directory" setting. The main agent workspace is now always at `{stateDir}/workspace-main/`, so changing the working directory no longer moves or loses agent state files.
- Add a one-time migration (`openclawWorkspaceMigration.ts`) that copies existing workspace files from the old working directory to the new fixed path on first launch.
- Remove the stale "storage path" display from the Personalization settings page, which was showing the old working directory path instead of the actual storage location.

## Changes
- `openclawConfigSync.ts`: Replace `workingDirectory`-based workspace resolution with `getMainAgentWorkspacePath()`
- `openclawMemoryFile.ts`: Add `getMainAgentWorkspacePath()` helper
- `openclawWorkspaceMigration.ts`: New file — idempotent migration logic (MEMORY.md merge-dedup, bootstrap file copy, memory/ dir copy)
- `main.ts`: Update all memory/bootstrap IPC handlers to use `getMainAgentWorkspacePath()`; remove `syncMemoryFileOnWorkspaceChange` on working directory change; add migration call at startup
- `Settings.tsx`: Remove empty memory section header and stale bootstrap storage path display; clean up dead `joinWorkspacePath` utility
- `i18n.ts`: Remove unused `coworkBootstrapStoragePath` key

## Test plan
- [ ] Verify IDENTITY.md / SOUL.md / MEMORY.md are read from and written to `{stateDir}/workspace-main/`
- [ ] Change working directory in settings — confirm agent state files are NOT affected
- [ ] Fresh install: confirm workspace-main directory is created and default IDENTITY.md is written
- [ ] Existing install with custom working directory: confirm one-time migration copies files to workspace-main
- [ ] Personalization settings page: confirm storage path label is removed
- [ ] Memory settings page: confirm empty section header is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)