### PR TITLE
fix: patch openclaw-weixin to read dmPolicy/allowFrom from config

### DIFF
--- a/scripts/ensure-openclaw-plugins.cjs
+++ b/scripts/ensure-openclaw-plugins.cjs
@@ -621,6 +621,38 @@ function main() {
     }
   }
 
+  // --- Post-install patch: openclaw-weixin dmPolicy from config ---
+  // The plugin hardcodes dmPolicy:"pairing" and configuredAllowFrom:[] in
+  // process-message.ts, ignoring the channel config from openclaw.json.
+  // This causes all inbound messages from non-bot senders to be silently
+  // dropped as "unauthorized" even when the config specifies dmPolicy:"open"
+  // with allowFrom:["*"].  Patch it to read from deps.config.channels.
+  const weixinProcessMsgPath = path.join(runtimeExtensionsDir, 'openclaw-weixin', 'src', 'messaging', 'process-message.ts');
+  if (fs.existsSync(weixinProcessMsgPath)) {
+    let pmSrc = fs.readFileSync(weixinProcessMsgPath, 'utf8');
+    const dmPolicyPatchMarker = 'chanCfg_dmPolicy_patch';
+    if (!pmSrc.includes(dmPolicyPatchMarker)) {
+      const oldAllowFrom = 'configuredAllowFrom: [],';
+      // There are two occurrences of dmPolicy: "pairing" — one in
+      // resolveSenderCommandAuthorizationWithRuntime and one in
+      // resolveDirectDmAuthorizationOutcome.  Both must use the config value.
+      // We use replaceAll to patch both at once.
+      const oldDmPolicy = 'dmPolicy: "pairing",';
+      const patchedDmPolicy = `dmPolicy: (() => { /* ${dmPolicyPatchMarker} */ const _cc = (deps.config.channels)?.['openclaw-weixin'] ?? {}; return _cc.dmPolicy || 'pairing'; })(),`;
+      if (pmSrc.includes(oldDmPolicy) && pmSrc.includes(oldAllowFrom)) {
+        pmSrc = pmSrc.replaceAll(oldDmPolicy, patchedDmPolicy);
+        pmSrc = pmSrc.replace(
+          oldAllowFrom,
+          `configuredAllowFrom: (() => { const _cc = (deps.config.channels)?.['openclaw-weixin'] ?? {}; return Array.isArray(_cc.allowFrom) ? _cc.allowFrom.map(String) : []; })(),`
+        );
+        fs.writeFileSync(weixinProcessMsgPath, pmSrc);
+        log('Patched openclaw-weixin/src/messaging/process-message.ts: dmPolicy/allowFrom now read from config');
+      }
+    } else {
+      log('openclaw-weixin/src/messaging/process-message.ts dmPolicy patch already applied, skipping');
+    }
+  }
+
   // --- Post-install patch: openclaw-lark deferred startup loading ---
   // The openclaw-lark plugin eagerly loads the 86K-line @larksuiteoapi/node-sdk and
   // 186 source files at startup, adding ~8s to the 30s plugin loading phase.

--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -17,7 +17,7 @@ import { i18nService } from '../../services/i18n';
 import { imService } from '../../services/im';
 import { RootState } from '../../store';
 import { clearError,setDingTalkConfig, setDingTalkInstanceConfig, setDiscordConfig, setDiscordInstanceConfig, setEmailInstanceConfig, setFeishuConfig, setFeishuInstanceConfig, setNeteaseBeeChanConfig, setNimConfig, setNimInstanceConfig, setPopoInstanceConfig, setQQConfig, setQQInstanceConfig, setTelegramInstanceConfig, setTelegramOpenClawConfig, setWecomConfig, setWecomInstanceConfig, setWeixinConfig } from '../../store/slices/imSlice';
-import type { EmailInstanceConfig, IMConnectivityCheck, IMConnectivityTestResult, IMGatewayConfig } from '../../types/im';
+import type { EmailInstanceConfig, IMConnectivityCheck, IMConnectivityTestResult, IMGatewayConfig, WeixinOpenClawConfig } from '../../types/im';
 import { MAX_DINGTALK_INSTANCES, MAX_DISCORD_INSTANCES, MAX_EMAIL_INSTANCES, MAX_FEISHU_INSTANCES, MAX_NIM_INSTANCES, MAX_POPO_INSTANCES, MAX_QQ_INSTANCES, MAX_TELEGRAM_INSTANCES, MAX_WECOM_INSTANCES } from '../../types/im';
 import { getVisibleIMPlatforms } from '../../utils/regionFilter';
 import Modal from '../common/Modal';
@@ -136,6 +136,7 @@ const IMSettings: React.FC = () => {
   const [weixinQrStatus, setWeixinQrStatus] = useState<'idle' | 'loading' | 'showing' | 'waiting' | 'success' | 'error'>('idle');
   const [weixinQrUrl, setWeixinQrUrl] = useState<string>('');
   const [weixinQrError, setWeixinQrError] = useState<string>('');
+  const [weixinAllowFromInput, setWeixinAllowFromInput] = useState<string>('');
   const weixinTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [_localIp, setLocalIp] = useState<string>('');
   const isMountedRef = useRef(true);
@@ -2582,6 +2583,97 @@ const IMSettings: React.FC = () => {
                 {status.weixin.lastError}
               </div>
             )}
+
+            {/* Advanced Settings (collapsible) */}
+            <details className="group">
+              <summary className="cursor-pointer text-xs font-medium text-secondary hover:text-primary transition-colors">
+                {i18nService.t('imAdvancedSettings')}
+              </summary>
+              <div className="mt-2 space-y-3 pl-2 border-l-2 border-border-subtle">
+                {/* DM Policy */}
+                <div className="space-y-1.5">
+                  <label className="block text-xs font-medium text-secondary">
+                    DM Policy
+                  </label>
+                  <select
+                    value={weixinOpenClawConfig.dmPolicy}
+                    onChange={(e) => {
+                      const update = { dmPolicy: e.target.value as WeixinOpenClawConfig['dmPolicy'] };
+                      void imService.updateConfig({ weixin: { ...weixinOpenClawConfig, ...update } });
+                    }}
+                    className="block w-full rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
+                  >
+                    <option value="open">{i18nService.t('imDmPolicyOpen')}</option>
+                    <option value="pairing">{i18nService.t('imDmPolicyPairing')}</option>
+                    <option value="allowlist">{i18nService.t('imDmPolicyAllowlist')}</option>
+                    <option value="disabled">{i18nService.t('imDmPolicyDisabled')}</option>
+                  </select>
+                </div>
+
+                {/* Allow From */}
+                <div className="space-y-1.5">
+                  <label className="block text-xs font-medium text-secondary">
+                    Allow From (User IDs)
+                  </label>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={weixinAllowFromInput}
+                      onChange={(e) => setWeixinAllowFromInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          const id = weixinAllowFromInput.trim();
+                          if (id && !weixinOpenClawConfig.allowFrom.includes(id)) {
+                            const newIds = [...weixinOpenClawConfig.allowFrom, id];
+                            setWeixinAllowFromInput('');
+                            void imService.updateConfig({ weixin: { ...weixinOpenClawConfig, allowFrom: newIds } });
+                          }
+                        }
+                      }}
+                      className="block flex-1 rounded-lg bg-surface border-border-subtle border focus:border-primary focus:ring-1 focus:ring-primary/30 text-foreground px-3 py-2 text-sm transition-colors"
+                      placeholder="wxid_xxx@im.wechat"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const id = weixinAllowFromInput.trim();
+                        if (id && !weixinOpenClawConfig.allowFrom.includes(id)) {
+                          const newIds = [...weixinOpenClawConfig.allowFrom, id];
+                          setWeixinAllowFromInput('');
+                          void imService.updateConfig({ weixin: { ...weixinOpenClawConfig, allowFrom: newIds } });
+                        }
+                      }}
+                      className="px-3 py-2 rounded-lg text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+                    >
+                      {i18nService.t('add') || '添加'}
+                    </button>
+                  </div>
+                  {weixinOpenClawConfig.allowFrom.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5 mt-1.5">
+                      {weixinOpenClawConfig.allowFrom.map((id) => (
+                        <span
+                          key={id}
+                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-surface border-border-subtle border text-foreground"
+                        >
+                          {id}
+                          <button
+                            type="button"
+                            onClick={() => {
+                              const newIds = weixinOpenClawConfig.allowFrom.filter((uid) => uid !== id);
+                              void imService.updateConfig({ weixin: { ...weixinOpenClawConfig, allowFrom: newIds } });
+                            }}
+                            className="text-secondary hover:text-red-500 dark:hover:text-red-400 transition-colors"
+                          >
+                            <XMarkIcon className="w-3 h-3" />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </details>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

- Patch `openclaw-weixin` plugin's `process-message.ts` via `ensure-openclaw-plugins.cjs` to read `dmPolicy` and `allowFrom` from `openclaw.json` channel config instead of hardcoding `"pairing"` / `[]`
- Add Advanced Settings section to WeChat settings panel (DM Policy dropdown + Allow From tag input)
- Fixes silent message dropping for non-bot WeChat senders when dmPolicy is configured as "open"

## Root Cause

The openclaw-weixin plugin hardcodes `dmPolicy: "pairing"` and `configuredAllowFrom: []` in two authorization calls within `process-message.ts`. Combined with `readAllowFromStore` returning only the bot's own wxid, this makes `isSenderAllowed` return false for all real senders — silently dropping their messages as "unauthorized".

LobsterAI correctly generates `{ dmPolicy: "open", allowFrom: ["*"] }` in `openclaw.json` via `openclawConfigSync.ts`, but the plugin never reads it.

## Test plan

- [ ] Run `node scripts/ensure-openclaw-plugins.cjs` and verify the patch marker `chanCfg_dmPolicy_patch` appears in `vendor/openclaw-runtime/win-x64/third-party-extensions/openclaw-weixin/src/messaging/process-message.ts`
- [ ] Verify both `dmPolicy` occurrences and `configuredAllowFrom` are patched
- [ ] Run the app and confirm the Advanced Settings section appears under WeChat settings
- [ ] Change DM Policy in UI → verify `openclaw.json` updates via config sync
- [ ] Test that messages from non-bot senders are no longer dropped when dmPolicy=open

🤖 Generated with [Claude Code](https://claude.com/claude-code)