### PR TITLE
[fix(cowork): harden assistant segment persistence for markdown table 

### DIFF
--- a/specs/bugfixes/markdown-table-render/2026-05-06-markdown-table-render-fix-design.md
+++ b/specs/bugfixes/markdown-table-render/2026-05-06-markdown-table-render-fix-design.md
@@ -1,0 +1,114 @@
+# Markdown 表格流式结束后渲染失败修复 Spec
+
+## 问题描述
+
+用户在 Cowork 对话中，AI 回复包含 GFM 表格时，**流式输出期间表格渲染正常，但消息结束后表格变为 markdown 原始字符串**（管道符 `|` 以纯文本形式显示）。该问题概率性出现，历史记录中同样显示为损坏状态。
+
+### 现象
+
+- 流式期间：表格正确渲染为 HTML `<table>`
+- 消息结束后：表格退化为 `<p>| 维度 | 优点 | 缺点 |...</p>`
+- 重新加载会话（历史记录）：表格仍然损坏
+- 概率性触发，多并发会话时更易复现
+
+---
+
+## 根因分析
+
+系统中存在两条文本提取路径：
+
+| 路径 | 函数 | 数据源 | 格式保真度 |
+|------|------|--------|-----------|
+| Agent 流 | `extractOpenClawAssistantStreamText` | agent event 的 `text` 字段（单一完整字符串） | ✅ 完整保留原始格式 |
+| Chat 事件 | `extractGatewayMessageText` → `collectTextChunks` | chat message 的 `content` 数组（可能多个 text block） | ❌ 每个 block 做 `.trim()` 后用 `\n` join |
+
+当 OpenClaw gateway 将响应内容拆分为多个 text block，且拆分点恰好落在 GFM 表格对齐行内部时：
+
+```
+原始（agent 流）:  |------|------|------|    （3列，有效 GFM）
+拆分后（chat 事件）: |------|------\n------|  （对齐行被断行，无效 GFM）
+```
+
+`remark-gfm` 解析器因对齐行列数与表头不匹配而拒绝将其识别为表格，回退为段落渲染。
+
+### 破坏路径
+
+1. **`handleChatDelta`**：使用 `extractGatewayMessageText` 提取文本，覆写 `turn.currentAssistantSegmentText`，将 agent 流设置的正确值替换为损坏值
+2. **`handleChatFinal`**：`finalSegmentText || previousSegmentText` 优先使用 `finalSegmentText`（同样来自 `extractGatewayMessageText`），将损坏内容写入 SQLite 并发送给渲染器
+
+### 为什么流式期间正常
+
+流式期间渲染器接收的内容来自 `processAgentAssistantText` → `throttledEmitMessageUpdate`，使用的是 agent 流的原始 `text` 字段，格式完好。`handleChatDelta` 虽然在内存中破坏了 segment text，但不执行 IPC emit，因此渲染器不受影响——直到 `handleChatFinal` 读取被破坏的值并发送给渲染器。
+
+---
+
+## 解决方案
+
+### 修复 1：`handleChatDelta` — 防止覆写
+
+当 agent 事件路径已激活时（`agentAssistantTextLength > 0`），不再允许 chat delta 覆写 `turn.currentAssistantSegmentText`：
+
+```typescript
+if (turn.assistantMessageId && segmentText !== previousSegmentText) {
+  if (turn.agentAssistantTextLength === 0) {
+    turn.currentAssistantSegmentText = segmentText;
+  }
+}
+```
+
+- agent 事件存在时：跳过覆写，保留格式正确的值
+- 无 agent 事件时（纯 chat 模型）：仍允许更新，保持兼容
+
+### 修复 2：`handleChatFinal` — 优先使用 agent 流文本
+
+```typescript
+const persistedSegmentText = previousSegmentText || finalSegmentText;
+```
+
+- `previousSegmentText`：来自 agent 流（`processAgentAssistantText` 设置），格式保真
+- `finalSegmentText`：来自 chat.final 消息（`extractGatewayMessageText`），可能损坏
+- 仅当 `previousSegmentText` 为空时 fallback 到 `finalSegmentText`
+
+同时移除冗余的 store 读取和条件 emit：
+- `flushPendingStoreUpdate` 后 store 内容即为最新，无需再 `getSession` + `find`
+- 无条件 `emit('messageUpdate')` 确保渲染器收到最终版本
+
+---
+
+## 涉及文件
+
+| 文件 | 变更 |
+|------|------|
+| `src/main/libs/agentEngine/openclawRuntimeAdapter.ts` | `handleChatDelta` 添加 guard；`handleChatFinal` 调整文本优先级 |
+
+---
+
+## 验证方法
+
+### 功能验证
+
+1. 启动开发服务，创建 Cowork 会话
+2. 发送提示词引导 AI 生成包含表格的回复（如"总结 OpenClaw 优缺点，用表格"）
+3. 验证：
+   - 流式期间表格正确渲染 ✓
+   - 消息结束后表格仍然正确 ✓
+   - 退出会话后重新进入，历史记录中表格正确 ✓
+4. 并发 6 个会话同时测试，确认高并发下表格不损坏
+
+### 回归验证
+
+| 场景 | 预期 |
+|------|------|
+| 无 tool call 的纯文本表格回复 | 正常渲染 |
+| 有 tool call 后生成表格（多 segment） | 正常渲染 |
+| 纯 chat 模型（无 agent event） | 仍能正常显示流式内容 |
+| 长表格（10+ 行） | 正常渲染，无截断 |
+| 包含 emoji/粗体/链接的表格 | 格式正确 |
+
+---
+
+## 已知边界
+
+1. 若模型通过 chat 事件返回的文本与 agent 流文本**语义不同**（非格式差异），当前方案优先使用 agent 流版本。在实际场景中两者内容一致，仅格式（whitespace）可能不同。
+2. 对于完全没有 agent 事件的模型，`handleChatDelta` 仍允许更新 segment text，此时若 gateway 拆分 block 导致损坏，该路径无法修复。但当前 OpenClaw 架构下所有模型均同时发送 agent 和 chat 事件。
+3. `extractGatewayMessageText` 的 `collectTextChunks` trim+join 行为本身未修改，其他使用该函数的场景（如 `extractGatewayHistoryEntries` 历史摘要）不受影响——这些场景不需要保真 GFM 格式。

--- a/specs/bugfixes/markdown-table-render/2026-05-06-markdown-table-render-fix-design.md
+++ b/specs/bugfixes/markdown-table-render/2026-05-06-markdown-table-render-fix-design.md
@@ -44,34 +44,43 @@
 
 ## 解决方案
 
-### 修复 1：`handleChatDelta` — 防止覆写
+### 修复 1：`handleChatDelta` — 防止覆写（升级版）
 
-当 agent 事件路径已激活时（`agentAssistantTextLength > 0`），不再允许 chat delta 覆写 `turn.currentAssistantSegmentText`：
+引入不可逆标记 `hasSeenAgentAssistantStream`。一旦当前 assistant segment 收到过 agent stream 正文，后续 `chat.delta` 不再允许覆写 `turn.currentAssistantSegmentText`（即使 `agentAssistantTextLength` 因 split 流程被重置）：
 
 ```typescript
 if (turn.assistantMessageId && segmentText !== previousSegmentText) {
-  if (turn.agentAssistantTextLength === 0) {
+  if (!turn.hasSeenAgentAssistantStream) {
     turn.currentAssistantSegmentText = segmentText;
+  } else if (!turn.chatDeltaOverwriteSkipLogged) {
+    turn.chatDeltaOverwriteSkipLogged = true;
+    console.debug('skipping further chat.delta segment overwrite ...');
   }
 }
 ```
 
 - agent 事件存在时：跳过覆写，保留格式正确的值
-- 无 agent 事件时（纯 chat 模型）：仍允许更新，保持兼容
+- 避免了 `agentAssistantTextLength === 0` 的竞态窗口
+- split 新 segment 时会显式重置标记，不影响后续新段落写入
 
-### 修复 2：`handleChatFinal` — 优先使用 agent 流文本
+### 修复 2：`handleChatFinal` — 带长度保护的最终文本选择
 
 ```typescript
-const persistedSegmentText = previousSegmentText || finalSegmentText;
+const { content: persistedSegmentText, reason } = pickPersistedAssistantSegment(
+  previousSegmentText,
+  finalSegmentText,
+  turn.hasSeenAgentAssistantStream,
+);
 ```
 
-- `previousSegmentText`：来自 agent 流（`processAgentAssistantText` 设置），格式保真
-- `finalSegmentText`：来自 chat.final 消息（`extractGatewayMessageText`），可能损坏
-- 仅当 `previousSegmentText` 为空时 fallback 到 `finalSegmentText`
+- 当 `hasSeenAgentAssistantStream=true` 且 `previous.length >= final.length`：优先 `previous`
+- 当 `hasSeenAgentAssistantStream=true` 但 `previous` 更短：优先 `final`，避免流式尾包丢失造成截断
+- 当无 agent stream 权威（纯 chat 路径）：优先 `final`
 
 同时移除冗余的 store 读取和条件 emit：
 - `flushPendingStoreUpdate` 后 store 内容即为最新，无需再 `getSession` + `find`
 - 无条件 `emit('messageUpdate')` 确保渲染器收到最终版本
+- 追加关键诊断日志：记录 `reason/previousLen/finalLen/persistedLen/hadAgentStreamAuthority`
 
 ---
 
@@ -79,7 +88,8 @@ const persistedSegmentText = previousSegmentText || finalSegmentText;
 
 | 文件 | 变更 |
 |------|------|
-| `src/main/libs/agentEngine/openclawRuntimeAdapter.ts` | `handleChatDelta` 添加 guard；`handleChatFinal` 调整文本优先级 |
+| `src/main/libs/agentEngine/openclawRuntimeAdapter.ts` | 新增 `hasSeenAgentAssistantStream`、`pickPersistedAssistantSegment`；`handleChatDelta`/`handleChatFinal` 逻辑升级；新增关键 debug 日志 |
+| `src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts` | 新增 `pickPersistedAssistantSegment` 分支测试（空值、chat-only、stream 权威、stream 短于 final） |
 
 ---
 
@@ -94,6 +104,9 @@ const persistedSegmentText = previousSegmentText || finalSegmentText;
    - 消息结束后表格仍然正确 ✓
    - 退出会话后重新进入，历史记录中表格正确 ✓
 4. 并发 6 个会话同时测试，确认高并发下表格不损坏
+5. 检查日志关键字段：
+   - `persisting assistant segment at chat.final ... reason=...`
+   - `skipping further chat.delta segment overwrite ...`（最多一次）
 
 ### 回归验证
 
@@ -109,6 +122,6 @@ const persistedSegmentText = previousSegmentText || finalSegmentText;
 
 ## 已知边界
 
-1. 若模型通过 chat 事件返回的文本与 agent 流文本**语义不同**（非格式差异），当前方案优先使用 agent 流版本。在实际场景中两者内容一致，仅格式（whitespace）可能不同。
+1. 若模型通过 chat 事件返回的文本与 agent 流文本**语义不同**（非格式差异），当前方案在 `hasSeenAgentAssistantStream=true` 时采用“长度保护优先”：仅当 `previous.length >= final.length` 才优先 agent 流。
 2. 对于完全没有 agent 事件的模型，`handleChatDelta` 仍允许更新 segment text，此时若 gateway 拆分 block 导致损坏，该路径无法修复。但当前 OpenClaw 架构下所有模型均同时发送 agent 和 chat 事件。
 3. `extractGatewayMessageText` 的 `collectTextChunks` trim+join 行为本身未修改，其他使用该函数的场景（如 `extractGatewayHistoryEntries` 历史摘要）不受影响——这些场景不需要保真 GFM 格式。

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -10,7 +10,47 @@ vi.mock('electron', () => ({
   },
 }));
 
-import { OpenClawRuntimeAdapter } from './openclawRuntimeAdapter';
+import { OpenClawRuntimeAdapter, pickPersistedAssistantSegment } from './openclawRuntimeAdapter';
+
+test('pickPersistedAssistantSegment: stream authority keeps previous when same length or longer', () => {
+  expect(pickPersistedAssistantSegment('aa', 'a', true)).toEqual({
+    content: 'aa',
+    reason: 'stream_authority_same_or_longer',
+  });
+  expect(pickPersistedAssistantSegment('same', 'same', true)).toEqual({
+    content: 'same',
+    reason: 'stream_authority_same_or_longer',
+  });
+});
+
+test('pickPersistedAssistantSegment: stream shorter prefers chat.final payload', () => {
+  expect(pickPersistedAssistantSegment('a', 'final-longer', true)).toEqual({
+    content: 'final-longer',
+    reason: 'stream_shorter_prefer_chat_final',
+  });
+});
+
+test('pickPersistedAssistantSegment: chat-only path prefers chat.final extraction', () => {
+  expect(pickPersistedAssistantSegment('fromDelta', 'fromFinal', false)).toEqual({
+    content: 'fromFinal',
+    reason: 'chat_path_prefer_final',
+  });
+});
+
+test('pickPersistedAssistantSegment: empty branches', () => {
+  expect(pickPersistedAssistantSegment('', '', false)).toEqual({
+    content: '',
+    reason: 'both_empty',
+  });
+  expect(pickPersistedAssistantSegment('', 'fin', false)).toEqual({
+    content: 'fin',
+    reason: 'final_only',
+  });
+  expect(pickPersistedAssistantSegment('prev', '', false)).toEqual({
+    content: 'prev',
+    reason: 'previous_only',
+  });
+});
 
 // ==================== Reconcile tests ====================
 

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -3093,13 +3093,11 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       // Flush any pending throttled updates so store content is current.
       this.flushPendingStoreUpdate(sessionId, turn.assistantMessageId);
       this.clearPendingMessageUpdate(turn.assistantMessageId);
-      const storeSession = this.store.getSession(sessionId);
-      const storeMsg = storeSession?.messages.find((m) => m.id === turn.assistantMessageId);
-      if (storeMsg?.content) {
-        this.emit('messageUpdate', sessionId, turn.assistantMessageId, storeMsg.content);
-      }
 
-      const persistedSegmentText = finalSegmentText || previousSegmentText;
+      // Prefer previousSegmentText (from agent stream, preserves formatting) over
+      // finalSegmentText (from extractGatewayMessageText which may corrupt tables).
+      // Fall back to finalSegmentText only when agent stream text is unavailable.
+      const persistedSegmentText = previousSegmentText || finalSegmentText;
       if (persistedSegmentText) {
         this.store.updateMessage(sessionId, turn.assistantMessageId, {
           content: persistedSegmentText,
@@ -3108,9 +3106,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
             isFinal: true,
           },
         });
-        if (persistedSegmentText !== previousSegmentText) {
-          this.emit('messageUpdate', sessionId, turn.assistantMessageId, persistedSegmentText);
-        }
+        this.emit('messageUpdate', sessionId, turn.assistantMessageId, persistedSegmentText);
       }
     } else if (finalSegmentText) {
       const reusedMessageId = this.reuseFinalAssistantMessage(sessionId, finalSegmentText);

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -51,6 +51,44 @@ const GATEWAY_READY_TIMEOUT_MS = 60_000;
 const FINAL_HISTORY_SYNC_LIMIT = 50;
 const CHANNEL_SESSION_DISCOVERY_LIMIT = 200;
 
+/** How we chose assistant text to persist at chat.final (for tests and logs). */
+export type PersistedSegmentPickReason =
+  | 'both_empty'
+  | 'previous_only'
+  | 'final_only'
+  | 'stream_authority_same_or_longer'
+  | 'stream_shorter_prefer_chat_final'
+  | 'chat_path_prefer_final';
+
+/**
+ * Prefer agent-stream segment text when it is authoritative (longer or equal vs chat.final).
+ * When only the chat path updated the UI, prefer chat.final extraction.
+ */
+export function pickPersistedAssistantSegment(
+  previousSegmentText: string,
+  finalSegmentText: string,
+  hasSeenAgentAssistantStream: boolean,
+): { content: string; reason: PersistedSegmentPickReason } {
+  const prev = previousSegmentText;
+  const fin = finalSegmentText;
+  if (!prev.trim() && !fin.trim()) {
+    return { content: '', reason: 'both_empty' };
+  }
+  if (!prev.trim()) {
+    return { content: fin, reason: 'final_only' };
+  }
+  if (!fin.trim()) {
+    return { content: prev, reason: 'previous_only' };
+  }
+  if (hasSeenAgentAssistantStream) {
+    if (prev.length >= fin.length) {
+      return { content: prev, reason: 'stream_authority_same_or_longer' };
+    }
+    return { content: fin, reason: 'stream_shorter_prefer_chat_final' };
+  }
+  return { content: fin, reason: 'chat_path_prefer_final' };
+}
+
 type GatewayEventFrame = {
   event: string;
   seq?: number;
@@ -126,6 +164,13 @@ type ActiveTurn = {
   currentText: string;
   /** Highest text length from agent assistant events (immune to chat delta noise). */
   agentAssistantTextLength: number;
+  /**
+   * Once true for the current assistant segment, chat.delta must not overwrite
+   * `currentAssistantSegmentText` (even if agentAssistantTextLength is reset).
+   */
+  hasSeenAgentAssistantStream: boolean;
+  /** Dedup debug log when chat.delta tries to overwrite an agent-owned segment. */
+  chatDeltaOverwriteSkipLogged?: boolean;
   currentContentText: string;
   currentContentBlocks: string[];
   sawNonTextContentBlocks: boolean;
@@ -1449,6 +1494,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       currentAssistantSegmentText: '',
       currentText: '',
       agentAssistantTextLength: 0,
+      hasSeenAgentAssistantStream: false,
       currentContentText: '',
       currentContentBlocks: [],
       sawNonTextContentBlocks: false,
@@ -2936,6 +2982,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     // Track high-water mark.
     turn.agentAssistantTextLength = Math.max(turn.agentAssistantTextLength, text.length);
 
+    if (text.trim().length > 0) {
+      turn.hasSeenAgentAssistantStream = true;
+    }
+
     // Update turn text state and push to store.
     turn.currentText = text;
     turn.currentAssistantSegmentText = this.resolveAssistantSegmentText(turn, text);
@@ -2984,6 +3034,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     turn.assistantMessageId = null;
     turn.currentAssistantSegmentText = '';
+    turn.hasSeenAgentAssistantStream = false;
+    turn.chatDeltaOverwriteSkipLogged = false;
   }
 
   private handleChatDelta(sessionId: string, turn: ActiveTurn, payload: ChatEventPayload): void {
@@ -3043,14 +3095,16 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
 
     if (turn.assistantMessageId && segmentText !== previousSegmentText) {
-      // Only update segment text from chat delta if the agent stream path has NOT
-      // been active. When agent events are present, processAgentAssistantText is the
-      // authority — it uses the raw text field which preserves formatting faithfully.
-      // The chat delta path uses extractGatewayMessageText which trims each content
-      // block and joins with \n. When the gateway splits content at a boundary inside
-      // a GFM table row, the join corrupts the table structure.
-      if (turn.agentAssistantTextLength === 0) {
+      // Only update segment text from chat delta if this segment has NOT yet received
+      // agent assistant stream text. Agent stream preserves formatting; chat delta uses
+      // extractGatewayMessageText (multi-block trim/join), which can break GFM tables.
+      // hasSeenAgentAssistantStream stays true across agentAssistantTextLength resets
+      // (e.g. split before tool) until a new assistant segment begins.
+      if (!turn.hasSeenAgentAssistantStream) {
         turn.currentAssistantSegmentText = segmentText;
+      } else if (!turn.chatDeltaOverwriteSkipLogged) {
+        turn.chatDeltaOverwriteSkipLogged = true;
+        console.debug('[OpenClawRuntime] skipping further chat.delta segment overwrite; agent stream owns this assistant segment until split');
       }
     }
   }
@@ -3094,11 +3148,22 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       this.flushPendingStoreUpdate(sessionId, turn.assistantMessageId);
       this.clearPendingMessageUpdate(turn.assistantMessageId);
 
-      // Prefer previousSegmentText (from agent stream, preserves formatting) over
-      // finalSegmentText (from extractGatewayMessageText which may corrupt tables).
-      // Fall back to finalSegmentText only when agent stream text is unavailable.
-      const persistedSegmentText = previousSegmentText || finalSegmentText;
+      const { content: persistedSegmentText, reason: persistPickReason } = pickPersistedAssistantSegment(
+        previousSegmentText,
+        finalSegmentText,
+        turn.hasSeenAgentAssistantStream,
+      );
       if (persistedSegmentText) {
+        console.debug(
+          '[OpenClawRuntime] persisting assistant segment at chat.final',
+          `sessionId=${sessionId}`,
+          `messageId=${turn.assistantMessageId}`,
+          `reason=${persistPickReason}`,
+          `previousLen=${previousSegmentText.length}`,
+          `finalLen=${finalSegmentText.length}`,
+          `persistedLen=${persistedSegmentText.length}`,
+          `hadAgentStreamAuthority=${turn.hasSeenAgentAssistantStream}`,
+        );
         this.store.updateMessage(sessionId, turn.assistantMessageId, {
           content: persistedSegmentText,
           metadata: {
@@ -4293,6 +4358,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       currentAssistantSegmentText: '',
       currentText: '',
       agentAssistantTextLength: 0,
+      hasSeenAgentAssistantStream: false,
       currentContentText: '',
       currentContentBlocks: [],
       sawNonTextContentBlocks: false,

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -3043,9 +3043,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
 
     if (turn.assistantMessageId && segmentText !== previousSegmentText) {
-      // Only update in-memory state; SQLite write and IPC emit are handled
-      // by processAgentAssistantText on the agent event path.
-      turn.currentAssistantSegmentText = segmentText;
+      // Only update segment text from chat delta if the agent stream path has NOT
+      // been active. When agent events are present, processAgentAssistantText is the
+      // authority — it uses the raw text field which preserves formatting faithfully.
+      // The chat delta path uses extractGatewayMessageText which trims each content
+      // block and joins with \n. When the gateway splits content at a boundary inside
+      // a GFM table row, the join corrupts the table structure.
+      if (turn.agentAssistantTextLength === 0) {
+        turn.currentAssistantSegmentText = segmentText;
+      }
     }
   }
 


### PR DESCRIPTION
Prevent chat.delta from overwriting agent-owned assistant segments and add a guarded final-text picker to avoid truncated persistence when stream text is shorter than chat.final. This reduces intermittent post-stream markdown table degradation under concurrent sessions.