### PR TITLE
fix: 修复 POPO 设置页面标题栏展示和 i18n 问题

### DIFF
--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -1615,8 +1615,8 @@ const IMSettings: React.FC = () => {
 
       {/* Platform Settings - Right Side */}
       <div className="flex-1 min-w-0 pl-4 pr-2 space-y-4 overflow-y-auto [scrollbar-gutter:stable]">
-        {/* Header with status (hidden for multi-instance platforms that render per-instance headers) */}
-        {activePlatform !== 'qq' && activePlatform !== 'feishu' && activePlatform !== 'dingtalk' && activePlatform !== 'email' && activePlatform !== 'wecom' && activePlatform !== 'nim' && activePlatform !== 'telegram' && activePlatform !== 'discord' && (
+        {/* Header with status (only for single-instance platforms without per-instance headers) */}
+        {(activePlatform === 'weixin' || activePlatform === 'netease-bee') && (
         <div className="flex items-center gap-3 pb-3 border-b border-border-subtle">
           <div className="flex items-center gap-2">
              <div className="flex h-7 w-7 items-center justify-center rounded-md bg-surface border border-border-subtle p-1">

--- a/src/renderer/components/im/PopoInstanceSettings.tsx
+++ b/src/renderer/components/im/PopoInstanceSettings.tsx
@@ -323,7 +323,7 @@ const PopoInstanceSettings: React.FC<PopoInstanceSettingsProps> = ({
           ) : (
             <SignalIcon className="h-3.5 w-3.5" />
           )}
-          {i18nService.t('imTestConnectivity')}
+          {i18nService.t('imConnectivityTest')}
         </button>
         {connectivityResult && (
           <div className="mt-2 space-y-1">


### PR DESCRIPTION
## Summary
- 隐藏 POPO 平台级别的设置标题栏（"POPO设置 已连接"），与其他多实例 IM 保持一致
- 将 header 展示条件从黑名单改为白名单（仅 weixin/netease-bee 展示），简化逻辑
- 修复测试连通性按钮 i18n key 错误（`imTestConnectivity` → `imConnectivityTest`），中文下正确显示"测试连通性"

## Test plan
- [ ] 打开 IM 机器人设置，选择 POPO，确认不再展示"POPO设置 已连接"标题栏
- [ ] 确认中文语言下测试连通性按钮显示为"测试连通性"
- [ ] 确认微信、小蜜蜂仍正常展示设置标题栏