### PR TITLE
fix: 修复流式文本合并时重复字符被误吞的问题

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -705,18 +705,6 @@ const toToolInputRecord = (value: unknown): Record<string, unknown> => {
   return { value };
 };
 
-const computeSuffixPrefixOverlap = (left: string, right: string): number => {
-  const leftProbe = left.slice(-256);
-  const rightProbe = right.slice(0, 256);
-  const maxOverlap = Math.min(leftProbe.length, rightProbe.length);
-  for (let size = maxOverlap; size > 0; size -= 1) {
-    if (leftProbe.slice(-size) === rightProbe.slice(0, size)) {
-      return size;
-    }
-  }
-  return 0;
-};
-
 const mergeStreamingText = (
   previousText: string,
   incomingText: string,
@@ -743,8 +731,7 @@ const mergeStreamingText = (
     if (incomingText.startsWith(previousText)) {
       return { text: incomingText, mode: 'snapshot' };
     }
-    const overlap = computeSuffixPrefixOverlap(previousText, incomingText);
-    return { text: previousText + incomingText.slice(overlap), mode };
+    return { text: previousText + incomingText, mode };
   }
 
   if (incomingText.startsWith(previousText)) {
@@ -757,11 +744,9 @@ const mergeStreamingText = (
     return { text: incomingText, mode: 'snapshot' };
   }
 
-  const overlap = computeSuffixPrefixOverlap(previousText, incomingText);
-  if (overlap > 0) {
-    return { text: previousText + incomingText.slice(overlap), mode: 'delta' };
-  }
-
+  // Overlap detection removed: coincidental suffix-prefix matches (e.g. "...p" + "ptx")
+  // would incorrectly strip characters. Once snapshot detection above has failed,
+  // treat the incoming text as a pure delta append.
   return { text: previousText + incomingText, mode: 'delta' };
 };
 


### PR DESCRIPTION
## Summary

- 移除 `computeSuffixPrefixOverlap` 函数及其在 `mergeStreamingText` 中的调用
- 当 token 分块边界恰好落在重复字符中间（如 `.pptx` 切为 `.p` + `ptx`），overlap 检测会将末尾与开头的偶然字符匹配误判为重叠并去掉，导致渲染结果丢失字符（如 `.pptx` → `.ptx`）
- snapshot 模式的 `startsWith`/`includes` 检测已覆盖合法的重叠场景，overlap 函数不再需要

## Test plan

- [ ] 验证流式输出包含 `.pptx`、`.ppt` 等重复字符的文件名时不再丢字符
- [ ] 验证正常的 snapshot 模式流式输出仍然正确合并
- [ ] 验证正常的 delta 模式流式输出仍然正确拼接