### PR TITLE
fix: resolve Windows file preview duplicate cards and path errors

### DIFF
--- a/src/renderer/components/artifacts/ArtifactPanel.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanel.tsx
@@ -157,6 +157,10 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({ artifacts }) => {
       } else if (filePath.startsWith('file:/')) {
         filePath = filePath.slice(5);
       }
+      // Strip leading / before Windows drive letter
+      if (/^\/[A-Za-z]:/.test(filePath)) {
+        filePath = filePath.slice(1);
+      }
       window.electron?.shell?.openPath(filePath);
     }
   }, [selectedArtifact]);

--- a/src/renderer/components/artifacts/renderers/DocumentRenderer.tsx
+++ b/src/renderer/components/artifacts/renderers/DocumentRenderer.tsx
@@ -49,6 +49,10 @@ function useFileContent(artifact: Artifact): { data: ArrayBuffer | null; loading
         } else if (filePath.startsWith('file:/')) {
           filePath = filePath.slice(5);
         }
+        // Strip leading / before Windows drive letter
+        if (/^\/[A-Za-z]:/.test(filePath)) {
+          filePath = filePath.slice(1);
+        }
         try {
           const result = await window.electron.dialog.readFileAsDataUrl(filePath);
           if (cancelled) return;
@@ -787,6 +791,8 @@ const PptxHtmlFallback: React.FC<{ artifact: Artifact; data: ArrayBuffer }> = ({
       if (filePath.startsWith('file:///')) filePath = filePath.slice(7);
       else if (filePath.startsWith('file://')) filePath = filePath.slice(7);
       else if (filePath.startsWith('file:/')) filePath = filePath.slice(5);
+      // Strip leading / before Windows drive letter
+      if (/^\/[A-Za-z]:/.test(filePath)) filePath = filePath.slice(1);
 
       const dir = filePath.substring(0, filePath.lastIndexOf('/'));
       const slidesDir = `${dir}/slides`;

--- a/src/renderer/components/artifacts/renderers/DocumentRenderer.tsx
+++ b/src/renderer/components/artifacts/renderers/DocumentRenderer.tsx
@@ -453,7 +453,6 @@ const PdfSubRenderer: React.FC<{ artifact: Artifact }> = ({ artifact }) => {
   const { data, loading, error: loadError } = useFileContent(artifact);
   const [pageCount, setPageCount] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [pdfDoc, setPdfDoc] = useState<any>(null);
   const [renderWidth, setRenderWidth] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -565,7 +564,6 @@ const PdfPageCanvas: React.FC<{
 
     const renderPage = async () => {
       try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const page = await (pdfDoc as any).getPage(pageNumber);
         if (cancelled) return;
 

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -11,7 +11,7 @@ import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { getScheduledReminderDisplayText } from '../../../scheduledTask/reminderText';
-import { getArtifactTypeFromExtension, parseCodeBlockArtifacts, parseFileLinksFromMessage, parseFilePathsFromText, parseToolArtifact } from '../../services/artifactParser';
+import { getArtifactTypeFromExtension, normalizeFilePathForDedup, parseCodeBlockArtifacts, parseFileLinksFromMessage, parseFilePathsFromText, parseToolArtifact } from '../../services/artifactParser';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { RootState } from '../../store';
@@ -1780,16 +1780,18 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
           const fileLinks = parseFileLinksFromMessage(msg.content, msg.id, sessionId);
           for (const fl of fileLinks) {
-            if (fl.filePath && !seenFilePaths.has(fl.filePath)) {
-              seenFilePaths.add(fl.filePath);
+            const normalized = fl.filePath ? normalizeFilePathForDedup(fl.filePath) : '';
+            if (fl.filePath && !seenFilePaths.has(normalized)) {
+              seenFilePaths.add(normalized);
               detected.push(fl);
             }
           }
 
           const pathArtifacts = parseFilePathsFromText(msg.content, msg.id, sessionId);
           for (const pa of pathArtifacts) {
-            if (pa.filePath && !seenFilePaths.has(pa.filePath)) {
-              seenFilePaths.add(pa.filePath);
+            const normalized = pa.filePath ? normalizeFilePathForDedup(pa.filePath) : '';
+            if (pa.filePath && !seenFilePaths.has(normalized)) {
+              seenFilePaths.add(normalized);
               detected.push(pa);
             }
           }
@@ -1798,8 +1800,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         if (msg.type === 'tool_result' && msg.content) {
           const pathArtifacts = parseFilePathsFromText(msg.content, msg.id, sessionId, 'artifact-toolresult');
           for (const pa of pathArtifacts) {
-            if (pa.filePath && !seenFilePaths.has(pa.filePath)) {
-              seenFilePaths.add(pa.filePath);
+            const normalized = pa.filePath ? normalizeFilePathForDedup(pa.filePath) : '';
+            if (pa.filePath && !seenFilePaths.has(normalized)) {
+              seenFilePaths.add(normalized);
               detected.push(pa);
             }
           }
@@ -1814,9 +1817,12 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             ? messages.find(m => m.type === 'tool_result' && m.metadata?.toolUseId === toolUseId)
             : messages[i + 1]?.type === 'tool_result' ? messages[i + 1] : undefined;
           const toolArtifact = parseToolArtifact(msg, toolResult, sessionId);
-          if (toolArtifact && toolArtifact.filePath && !seenFilePaths.has(toolArtifact.filePath)) {
-            seenFilePaths.add(toolArtifact.filePath);
-            detected.push(toolArtifact);
+          if (toolArtifact && toolArtifact.filePath) {
+            const normalized = normalizeFilePathForDedup(toolArtifact.filePath);
+            if (!seenFilePaths.has(normalized)) {
+              seenFilePaths.add(normalized);
+              detected.push(toolArtifact);
+            }
           } else if (toolArtifact && !toolArtifact.filePath) {
             detected.push(toolArtifact);
           }
@@ -1841,9 +1847,13 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
           } else if (rawPath.startsWith('file:/')) {
             rawPath = rawPath.slice(5);
           }
+          // Strip leading / before Windows drive letter
+          if (/^\/[A-Za-z]:/.test(rawPath)) {
+            rawPath = rawPath.slice(1);
+          }
           const absPath = rawPath.startsWith('/')
             ? rawPath
-            : `${cwd}/${rawPath}`;
+            : (/^[A-Za-z]:/.test(rawPath) ? rawPath : `${cwd}/${rawPath}`);
           try {
             const result = await window.electron.dialog.readFileAsDataUrl(absPath);
             if (result?.success && result.dataUrl) {
@@ -1893,6 +1903,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       } catch {
         filePath = href.replace(/^file:\/\//, '');
       }
+      // Strip leading / before Windows drive letter
+      if (/^\/[A-Za-z]:/.test(filePath)) {
+        filePath = filePath.slice(1);
+      }
 
       const lastDot = filePath.lastIndexOf('.');
       if (lastDot === -1) return;
@@ -1902,7 +1916,8 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       e.preventDefault();
       e.stopPropagation();
 
-      const existing = sessionArtifacts.find(a => a.filePath === filePath);
+      const normalizedClick = normalizeFilePathForDedup(filePath);
+      const existing = sessionArtifacts.find(a => a.filePath && normalizeFilePathForDedup(a.filePath) === normalizedClick);
       if (existing) {
         dispatch(selectArtifact(existing.id));
       } else {

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1883,6 +1883,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     } catch (err) {
       console.error('[ArtifactDetection] failed:', err);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- uses messagesLength as stable proxy for currentSession.messages
   }, [sessionId, messagesLength, isStreaming, dispatch]);
 
   // Intercept clicks on artifact-compatible file links → open in panel

--- a/src/renderer/services/artifactParser.test.ts
+++ b/src/renderer/services/artifactParser.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest';
+
+import { normalizeFilePathForDedup, parseFileLinksFromMessage, parseFilePathsFromText, parseToolArtifact } from './artifactParser';
+
+describe('normalizeFilePathForDedup', () => {
+  test('strips leading / before Windows drive letter', () => {
+    expect(normalizeFilePathForDedup('/D:/path/file.html')).toBe('d:/path/file.html');
+  });
+
+  test('normalizes backslashes to forward slashes', () => {
+    expect(normalizeFilePathForDedup('D:\\path\\file.html')).toBe('d:/path/file.html');
+  });
+
+  test('lowercases for case-insensitive comparison', () => {
+    expect(normalizeFilePathForDedup('D:/Path/File.HTML')).toBe('d:/path/file.html');
+  });
+
+  test('handles Unix absolute paths unchanged (except lowercase)', () => {
+    expect(normalizeFilePathForDedup('/home/user/file.html')).toBe('/home/user/file.html');
+  });
+
+  test('dedup matches: file:// derived path vs tool path', () => {
+    const fromFileUrl = '/D:/new_ws_test_2/hello-slide.html';
+    const fromTool = 'D:\\new_ws_test_2\\hello-slide.html';
+    expect(normalizeFilePathForDedup(fromFileUrl)).toBe(normalizeFilePathForDedup(fromTool));
+  });
+});
+
+describe('parseFileLinksFromMessage', () => {
+  test('strips leading / from Windows file:// link path', () => {
+    const content = '文件：[hello.pptx](file:///D:/workspace/hello.pptx)';
+    const artifacts = parseFileLinksFromMessage(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].filePath).toBe('D:/workspace/hello.pptx');
+  });
+
+  test('preserves Unix file:// link path', () => {
+    const content = '[report.pdf](file:///home/user/report.pdf)';
+    const artifacts = parseFileLinksFromMessage(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].filePath).toBe('/home/user/report.pdf');
+  });
+
+  test('handles URI-encoded paths', () => {
+    const content = '[文件.pptx](file:///D:/my%20folder/%E6%96%87%E4%BB%B6.pptx)';
+    const artifacts = parseFileLinksFromMessage(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].filePath).toBe('D:/my folder/文件.pptx');
+  });
+});
+
+describe('parseFilePathsFromText', () => {
+  test('strips leading / after file:/// protocol removal on Windows', () => {
+    const content = 'output at file:///D:/project/output.pdf done';
+    const artifacts = parseFilePathsFromText(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].filePath).toBe('D:/project/output.pdf');
+  });
+});
+
+describe('parseToolArtifact', () => {
+  test('extracts file path from Write tool input', () => {
+    const toolUseMsg = {
+      id: 'tool1',
+      type: 'tool_use' as const,
+      content: '',
+      timestamp: Date.now(),
+      metadata: {
+        toolName: 'Write',
+        toolUseId: 'tu1',
+        toolInput: { file_path: 'D:\\workspace\\hello.html', content: '<html></html>' },
+      },
+    };
+    const toolResultMsg = {
+      id: 'result1',
+      type: 'tool_result' as const,
+      content: 'OK',
+      timestamp: Date.now(),
+      metadata: { toolUseId: 'tu1' },
+    };
+    const artifact = parseToolArtifact(toolUseMsg, toolResultMsg, 'sess1');
+    expect(artifact).not.toBeNull();
+    expect(artifact!.filePath).toBe('D:\\workspace\\hello.html');
+  });
+
+  test('dedup: tool path and file link path normalize to same value', () => {
+    const toolPath = 'D:\\new_ws_test_2\\hello-slide.pptx';
+    const linkContent = '[hello-slide.pptx](file:///D:/new_ws_test_2/hello-slide.pptx)';
+    const linkArtifacts = parseFileLinksFromMessage(linkContent, 'msg1', 'sess1');
+    expect(linkArtifacts).toHaveLength(1);
+
+    expect(normalizeFilePathForDedup(toolPath))
+      .toBe(normalizeFilePathForDedup(linkArtifacts[0].filePath!));
+  });
+});

--- a/src/renderer/services/artifactParser.ts
+++ b/src/renderer/services/artifactParser.ts
@@ -1,6 +1,17 @@
 import type { Artifact, ArtifactType } from '../types/artifact';
 import type { CoworkMessage } from '../types/cowork';
 
+/**
+ * Normalize file path for deduplication comparison.
+ * Handles Windows file:// URL leading slash and backslash differences.
+ */
+export function normalizeFilePathForDedup(p: string): string {
+  // Strip leading / before drive letter (e.g. /D:/path from file:///D:/path)
+  if (/^\/[A-Za-z]:/.test(p)) p = p.slice(1);
+  // Unify separators and case for comparison
+  return p.replace(/\\/g, '/').toLowerCase();
+}
+
 const LANGUAGE_TO_ARTIFACT_TYPE: Record<string, ArtifactType> = {
   html: 'html',
   svg: 'svg',
@@ -132,6 +143,11 @@ export function parseFilePathsFromText(
       filePath = filePath.slice(5);
     }
 
+    // Strip leading / before Windows drive letter (e.g. /D:/path from file:///D:/path)
+    if (/^\/[A-Za-z]:/.test(filePath)) {
+      filePath = filePath.slice(1);
+    }
+
     const ext = getFileExtension(filePath);
     const artifactType = getArtifactTypeFromExtension(ext);
     if (!artifactType) continue;
@@ -176,6 +192,10 @@ export function parseFileLinksFromMessage(
       filePath = decodeURIComponent(match[2]);
     } catch {
       filePath = match[2];
+    }
+    // Strip leading / before Windows drive letter (e.g. /D:/path from file:///D:/path)
+    if (/^\/[A-Za-z]:/.test(filePath)) {
+      filePath = filePath.slice(1);
     }
     const ext = getFileExtension(filePath);
     const artifactType = getArtifactTypeFromExtension(ext);


### PR DESCRIPTION
## Summary
- Fix duplicate file preview cards caused by dedup failure between `file:///D:/path` (yields `/D:/path`) and tool-derived `D:\path`
- Fix ENOENT `D:\D:\path` error when loading document preview (path.resolve on `/D:/path` prepends drive letter again)
- Fix clicking inline file links adding duplicate entries to artifact panel
- Add `normalizeFilePathForDedup` utility for consistent path comparison
- Add unit tests covering the normalization and dedup logic

## Test plan
- [x] Unit tests pass (11 new tests in `artifactParser.test.ts`)
- [ ] Manual: generate a file via Write tool on Windows, verify single preview card appears
- [ ] Manual: click inline `file://` link, verify no duplicate in right panel and preview loads correctly
- [ ] Manual: click "打开" button, verify file opens in external app
- [ ] Verify Mac builds are unaffected (regex only matches `/[A-Z]:` pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)