### PR TITLE
fix(test): cross-platform cwd test assertions

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { expect, test, vi } from 'vitest';
 
 vi.mock('electron', () => ({
@@ -355,7 +357,7 @@ test('continueSession sends the session cwd to OpenClaw chat.send', async () => 
 
   const chatSend = requests.find((request) => request.method === 'chat.send');
   expect(chatSend?.params).toMatchObject({
-    cwd: '/tmp/lobsterai-selected-project',
+    cwd: path.resolve('/tmp/lobsterai-selected-project'),
   });
 });
 

--- a/src/main/libs/openclawAgentModels.test.ts
+++ b/src/main/libs/openclawAgentModels.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { describe, expect, test } from 'vitest';
 
 import {
@@ -110,7 +112,7 @@ describe('buildAgentEntry', () => {
 
     expect(result).toMatchObject({
       id: 'docs',
-      cwd: '/tmp/docs-project',
+      cwd: path.resolve('/tmp/docs-project'),
     });
   });
 });


### PR DESCRIPTION
## Summary
- Agent cwd tests hardcoded Unix paths (`/tmp/...`) in assertions, causing failures on Windows where `path.resolve()` produces `D:\tmp\...`
- Use `path.resolve()` in test expectations to match source code behavior across platforms

## Test plan
- [x] `npm test` passes on Windows (852 passed)
- [ ] Verify CI passes on Linux