### PR TITLE
feat(ui): add entrance animations and theme-aware styling (from #1554)

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -2726,12 +2726,12 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       return (
         <LazyRenderTurn key={turn.id} turnId={turn.id} alwaysRender={alwaysRender} data-turn-index={index}>
           {turn.userMessage && (
-            <div data-export-role="user-message" {...(userRailIdx >= 0 ? { 'data-rail-index': userRailIdx } : undefined)}>
+            <div data-export-role="user-message" className={isLastTurn ? 'animate-message-in' : undefined} {...(userRailIdx >= 0 ? { 'data-rail-index': userRailIdx } : undefined)}>
               <UserMessageItem message={turn.userMessage} skills={skills} onReEdit={remoteManaged ? undefined : handleReEdit} />
             </div>
           )}
           {showAssistantBlock && (
-            <div data-export-role="assistant-block" {...(asstRailIdx >= 0 ? { 'data-rail-index': asstRailIdx } : undefined)}>
+            <div data-export-role="assistant-block" className={isLastTurn ? 'animate-message-in' : undefined} {...(asstRailIdx >= 0 ? { 'data-rail-index': asstRailIdx } : undefined)}>
               <AssistantTurnBlock
                 turn={turn}
                 artifacts={turnArtifacts}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -571,21 +571,38 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       {homeHeader}
 
       {/* Main Content */}
-      <div className="flex-1 overflow-y-auto min-h-0">
-        <div className="max-w-5xl w-full min-w-[320px] mx-auto px-4 pt-[15vh] pb-8 space-y-10">
-          {/* Welcome Section */}
+      <div className="flex-1 overflow-y-auto min-h-0 relative">
+        {/* Gradient mesh background using theme gradient tokens */}
+        <div
+          className="pointer-events-none absolute inset-0"
+          style={{
+            background:
+              'radial-gradient(ellipse 60% 50% at 25% 20%, var(--lobster-gradient-1), transparent), radial-gradient(ellipse 50% 40% at 75% 70%, var(--lobster-gradient-2), transparent)',
+          }}
+        />
+        <div className="relative max-w-5xl w-full min-w-[320px] mx-auto px-4 pt-[15vh] pb-8 space-y-10">
+          {/* Welcome Section - staggered entrance animation */}
           <div className="text-center space-y-5">
-            <img src="logo.png" alt="logo" className="w-16 h-16 mx-auto" />
-            <h2 className="text-3xl font-bold tracking-tight text-foreground">
+            <img src="logo.png" alt="logo" className="w-16 h-16 mx-auto animate-fade-in-up" />
+            <h2
+              className="text-3xl font-bold tracking-tight text-foreground animate-fade-in-up"
+              style={{ animationDelay: '60ms', animationFillMode: 'both' }}
+            >
               {i18nService.t('coworkWelcome')}
             </h2>
-            <p className="text-sm text-secondary max-w-md mx-auto">
+            <p
+              className="text-sm text-secondary max-w-md mx-auto animate-fade-in-up"
+              style={{ animationDelay: '120ms', animationFillMode: 'both' }}
+            >
               {i18nService.t('coworkDescription')}
             </p>
           </div>
 
           {/* Prompt Input Area - Large version with folder selector */}
-          <div className="max-w-3xl mx-auto w-full space-y-3">
+          <div
+            className="max-w-3xl mx-auto w-full space-y-3 animate-fade-in-up"
+            style={{ animationDelay: '200ms', animationFillMode: 'both' }}
+          >
             <div className="shadow-glow-accent rounded-2xl">
               <CoworkPromptInput
                 ref={promptInputRef}
@@ -606,7 +623,10 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
           </div>
 
           {/* Quick Actions */}
-          <div className="max-w-3xl mx-auto w-full space-y-4">
+          <div
+            className="max-w-3xl mx-auto w-full space-y-4 animate-fade-in-up"
+            style={{ animationDelay: '300ms', animationFillMode: 'both' }}
+          >
             {selectedAction ? (
               <PromptPanel
                 action={selectedAction}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -220,7 +220,7 @@ select::-ms-expand {
   height: 2px;
   overflow: hidden;
   border-radius: 1px;
-  background: rgba(59,130,246,0.1);
+  background: var(--lobster-primary-muted);
 }
 .streaming-bar::before {
   content: '';
@@ -230,7 +230,8 @@ select::-ms-expand {
   height: 100%;
   width: 40%;
   border-radius: 1px;
-  background: linear-gradient(90deg, rgba(59,130,246,0.3) 0%, rgba(59,130,246,0.8) 50%, rgba(59,130,246,0.3) 100%);
+  background: linear-gradient(90deg, transparent 0%, var(--lobster-primary) 50%, transparent 100%);
+  opacity: 0.7;
   animation: streaming-slide 1.5s ease-in-out infinite;
 }
 /* Streaming bar glow uses primary color */
@@ -240,4 +241,15 @@ select::-ms-expand {
 @keyframes streaming-slide {
   0% { left: -40%; }
   100% { left: 100%; }
+}
+
+/* Respect reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,7 +13,7 @@ export default {
         elevated: '0 4px 12px rgba(0,0,0,0.1), 0 1px 3px rgba(0,0,0,0.04)',
         modal: '0 8px 30px rgba(0,0,0,0.16), 0 2px 8px rgba(0,0,0,0.08)',
         popover: '0 4px 20px rgba(0,0,0,0.12), 0 1px 4px rgba(0,0,0,0.05)',
-        'glow-accent': '0 0 20px rgba(59,130,246,0.15)',
+        'glow-accent': '0 0 20px var(--lobster-primary-muted)',
       },
       keyframes: {
         'fade-in': {
@@ -43,6 +43,10 @@ export default {
           '60%': { transform: 'translateX(-2px)' },
           '80%': { transform: 'translateX(2px)' },
         },
+        'message-in': {
+          '0%': { opacity: '0', transform: 'translateY(6px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
       },
       animation: {
         'fade-in': 'fade-in 0.2s ease-out',
@@ -51,6 +55,7 @@ export default {
         'scale-in': 'scale-in 0.2s ease-out',
         shimmer: 'shimmer 1.5s infinite',
         shake: 'shake 0.4s ease-in-out',
+        'message-in': 'message-in 0.25s ease-out both',
       },
       transitionTimingFunction: {
         smooth: 'cubic-bezier(0.4, 0, 0.2, 1)',
@@ -58,16 +63,16 @@ export default {
       typography: {
         DEFAULT: {
           css: {
-            color: 'var(--yde-text-primary)',
+            color: 'var(--lobster-text-primary)',
             a: {
-              color: 'var(--yde-primary)',
+              color: 'var(--lobster-primary)',
               '&:hover': {
-                color: 'var(--yde-primary-hover)',
+                color: 'var(--lobster-primary-hover)',
               },
             },
             code: {
-              color: 'var(--yde-text-primary)',
-              backgroundColor: 'var(--yde-surface-raised)',
+              color: 'var(--lobster-text-primary)',
+              backgroundColor: 'var(--lobster-surface-raised)',
               padding: '0.2em 0.4em',
               borderRadius: '0.25rem',
               fontWeight: '400',
@@ -79,21 +84,21 @@ export default {
               content: '""',
             },
             pre: {
-              backgroundColor: 'var(--yde-surface-raised)',
-              color: 'var(--yde-text-primary)',
+              backgroundColor: 'var(--lobster-surface-raised)',
+              color: 'var(--lobster-text-primary)',
               padding: '1em',
               borderRadius: '0.75rem',
               overflowX: 'auto',
             },
             blockquote: {
-              borderLeftColor: 'var(--yde-primary)',
-              color: 'var(--yde-text-secondary)',
+              borderLeftColor: 'var(--lobster-primary)',
+              color: 'var(--lobster-text-secondary)',
             },
-            h1: { color: 'var(--yde-text-primary)' },
-            h2: { color: 'var(--yde-text-primary)' },
-            h3: { color: 'var(--yde-text-primary)' },
-            h4: { color: 'var(--yde-text-primary)' },
-            strong: { color: 'var(--yde-text-primary)' },
+            h1: { color: 'var(--lobster-text-primary)' },
+            h2: { color: 'var(--lobster-text-primary)' },
+            h3: { color: 'var(--lobster-text-primary)' },
+            h4: { color: 'var(--lobster-text-primary)' },
+            strong: { color: 'var(--lobster-text-primary)' },
             table: { marginTop: '0', marginBottom: '0' },
           },
         },


### PR DESCRIPTION
## Summary

Cherry-pick animation-related changes from #1554 onto `release/2026.05.08`:

- Staggered entrance animation on home screen (Logo 0ms → Title 60ms → Description 120ms → Input 200ms → Quick Actions 300ms)
- `animate-message-in` on latest conversation turn (user + assistant)
- Gradient mesh background using existing `--lobster-gradient-1/2` theme tokens
- `glow-accent` shadow and streaming progress bar now use theme CSS vars instead of hardcoded `rgba(59,130,246,...)`
- Typography plugin migrated from undefined `--yde-*` to `--lobster-*` variables
- `prefers-reduced-motion` media query for accessibility

Original PR #1554 by @swuzjb had 79 merge conflicts with release branch due to large-scale refactoring since April. This PR extracts only the animation and theme-fix subset, applied cleanly to the current release code.

## Test plan

- [ ] `npm run build` passes
- [ ] Home screen shows staggered fade-in-up entrance on load
- [ ] Sending a message shows slide-up animation on the latest turn
- [ ] Gradient background visible on home screen (subtle, varies by theme)
- [ ] Switch to non-blue theme (e.g. sakura/emerald) — streaming bar and glow should follow theme color
- [ ] Verify `prefers-reduced-motion: reduce` disables all animations