### PR TITLE
fix(cowork): improve message metadata hover behavior and sidebar icon clarity

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Cog6ToothIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { AgentId } from '@shared/agent';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -17,6 +17,7 @@ import MyAgentSidebarTree from './agentSidebar/MyAgentSidebarTree';
 import Modal from './common/Modal';
 import CoworkSearchModal from './cowork/CoworkSearchModal';
 import ClockIcon from './icons/ClockIcon';
+import Cog6ToothIcon from './icons/Cog6ToothIcon';
 import ComposeIcon from './icons/ComposeIcon';
 import ConnectorIcon from './icons/ConnectorIcon';
 import PuzzleIcon from './icons/PuzzleIcon';

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1177,7 +1177,7 @@ const ReEditButton: React.FC<{
         e.stopPropagation();
         onClick();
       }}
-      className={`p-1.5 rounded-md dark:hover:bg-claude-darkSurfaceHover hover:bg-claude-surfaceHover transition-all duration-200 ${
+      className={`p-1.5 rounded-md hover:bg-surface-raised transition-all duration-200 ${
         visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
       }`}
       tabIndex={visible ? 0 : -1}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1217,7 +1217,9 @@ export const UserMessageItem: React.FC<{
     setIsHovered(false);
   }, []);
   const handleMouseLeave = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    if (hasFocusWithin(event.currentTarget)) return;
+    if (document.activeElement instanceof HTMLElement && event.currentTarget.contains(document.activeElement)) {
+      document.activeElement.blur();
+    }
     setIsHovered(false);
   }, []);
 
@@ -1343,7 +1345,9 @@ const AssistantMessageItem: React.FC<{
     setIsHovered(false);
   }, []);
   const handleMouseLeave = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    if (hasFocusWithin(event.currentTarget)) return;
+    if (document.activeElement instanceof HTMLElement && event.currentTarget.contains(document.activeElement)) {
+      document.activeElement.blur();
+    }
     setIsHovered(false);
   }, []);
 


### PR DESCRIPTION
## Summary

- Fix message metadata row (timestamp, copy button, edit button) staying visible after clicking — now properly hides when mouse leaves
- Unify CopyButton and ReEditButton hover background to use the same `bg-surface-raised` token
- Fix settings icon appearing blurry on low-DPI displays by switching from @heroicons (strokeWidth 1.5) to custom icon (strokeWidth 2) matching other sidebar icons

## Test plan

- [ ] Hover over user/assistant message → metadata row appears
- [ ] Click copy button → text copied, mouse leave → metadata row disappears
- [ ] Hover ReEditButton and CopyButton → same hover background color
- [ ] Check settings icon on low-DPI display → no longer blurry, same weight as adjacent icons
- [ ] Verify keyboard Tab navigation still shows/hides metadata row correctly

