### PR TITLE
fix: code block background not extending on horizontal scroll

### DIFF
--- a/src/renderer/components/CodeBlock.tsx
+++ b/src/renderer/components/CodeBlock.tsx
@@ -1391,7 +1391,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ node, className, children, ...pro
               )}
             </button>
           </CodeBlockTooltip>
-          <code className="block px-4 py-3 font-mono dark:text-gray-100 text-gray-800 whitespace-pre">
+          <code className="block px-4 py-3 font-mono dark:text-gray-100 text-gray-800 whitespace-pre dark:bg-[#282c34] bg-[#f0f2f5] w-max min-w-full">
             {trimmedCodeText}
           </code>
         </div>
@@ -1514,7 +1514,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ node, className, children, ...pro
           )
         ) : (
           <div className="m-0 overflow-x-auto dark:bg-[#282c34] bg-[#f0f2f5] text-[13px] leading-6">
-            <code className="block px-4 py-3 font-mono dark:text-gray-100 text-gray-800 whitespace-pre">
+            <code className="block px-4 py-3 font-mono dark:text-gray-100 text-gray-800 whitespace-pre dark:bg-[#282c34] bg-[#f0f2f5] w-max min-w-full">
               {trimmedCodeText}
             </code>
           </div>

--- a/src/renderer/components/MarkdownContent.tsx
+++ b/src/renderer/components/MarkdownContent.tsx
@@ -319,7 +319,7 @@ const createMarkdownComponents = (
     </li>
   ),
   blockquote: ({ node: _node, className: _className, children, ...props }: any) => (
-    <blockquote className="border-l-4 border-primary pl-4 py-1 my-2 bg-surface-raised/30 rounded-r-lg text-foreground/90" {...props}>
+    <blockquote className="border-l-4 border-primary pl-4 py-1 my-2 bg-surface-raised/30 rounded-r-lg text-foreground/90 overflow-x-auto" {...props}>
       {children}
     </blockquote>
   ),


### PR DESCRIPTION
## Summary
- 修复代码块（无语言标记的纯文本块和长代码回退块）在水平滚动时背景色不完整的问题
- 将背景色同时应用到内部 `code` 元素，并使用 `w-max min-w-full` 使其随内容宽度扩展
- 为 blockquote 添加 `overflow-x-auto`，防止内容溢出传播到父级滚动容器

## Test plan
- [ ] 在对话中让 AI 生成一段较长的无语言代码块（三个反引号包裹的纯文本），验证水平滚动时背景色完整覆盖
- [ ] 验证带语言标记的代码块在长代码回退模式下背景色表现正常
- [ ] 验证 blockquote 内含长内容时不会导致聊天区域出现水平滚动条
- [ ] 在 daylight 等浅色主题和 dark 主题下分别验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)