### PR TITLE
fix(cowork): polish chat message layout and code block controls

### DIFF
--- a/src/renderer/components/CodeBlock.tsx
+++ b/src/renderer/components/CodeBlock.tsx
@@ -1257,7 +1257,6 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ node, className, children, ...pro
 
   const shouldUseCodeMirror =
     !isInline &&
-    match &&
     trimmedCodeText.length <= CODE_BLOCK_CHAR_LIMIT &&
     trimmedCodeText.split('\n').length <= CODE_BLOCK_LINE_LIMIT;
 
@@ -1368,41 +1367,11 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ node, className, children, ...pro
   }
 
   // -------------------------------------------------------------------------
-  // No-language plain block
-  // -------------------------------------------------------------------------
-  if (!match) {
-    return (
-      <div className="my-2 relative group">
-        <div className="overflow-x-auto rounded-lg border border-border-subtle dark:bg-[#282c34] bg-[#f0f2f5] text-[13px] leading-6">
-          <CodeBlockTooltip
-            content={i18nService.t('copyToClipboard')}
-            className="absolute top-2 right-2 z-10 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-all duration-200"
-          >
-            <button
-              type="button"
-              onClick={handleCopy}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-secondary hover:bg-surface-raised hover:text-foreground transition-colors transform-gpu"
-              aria-label={i18nService.t('copyToClipboard')}
-            >
-              {isCopied ? (
-                <CheckIcon className="h-4 w-4 text-green-500" />
-              ) : (
-                <CopyIcon className="h-4 w-4" />
-              )}
-            </button>
-          </CodeBlockTooltip>
-          <code className="block px-4 py-3 font-mono dark:text-gray-100 text-gray-800 whitespace-pre dark:bg-[#282c34] bg-[#f0f2f5] w-max min-w-full">
-            {trimmedCodeText}
-          </code>
-        </div>
-      </div>
-    );
-  }
-
-  // -------------------------------------------------------------------------
   // Language code block header
   // -------------------------------------------------------------------------
-  const displayLang = isDiffBlock
+  const displayLang = !match
+    ? 'text'
+    : isDiffBlock
     ? diffInnerLang
       ? `diff · ${diffInnerLang}`
       : 'diff'

--- a/src/renderer/components/MarkdownContent.tsx
+++ b/src/renderer/components/MarkdownContent.tsx
@@ -15,6 +15,7 @@ import { i18nService } from '../services/i18n';
 import CodeBlock from './CodeBlock';
 
 const SAFE_URL_PROTOCOLS = new Set(['http', 'https', 'mailto', 'tel', 'file']);
+const LINK_CLASS_NAME = 'text-primary hover:text-primary-hover underline decoration-primary/50 hover:decoration-primary transition-colors break-words [overflow-wrap:anywhere]';
 
 const encodeFileUrl = (url: string): string => {
   const encoded = encodeURI(url);
@@ -470,11 +471,11 @@ const createMarkdownComponents = (
           <a
             href={toFileHref(filePath)}
             onClick={handleClick}
-            className="text-primary hover:text-primary-hover underline decoration-primary/50 hover:decoration-primary transition-colors cursor-pointer inline-flex items-center gap-1"
+            className={`${LINK_CLASS_NAME} cursor-pointer inline-flex max-w-full flex-wrap items-center gap-1`}
             title={filePath}
             {...props}
           >
-            {children}
+            <span className="min-w-0 break-words [overflow-wrap:anywhere]">{children}</span>
             {isDirectoryLink ? (
               <FolderIcon className="h-3.5 w-3.5 inline" />
             ) : (
@@ -516,7 +517,7 @@ const createMarkdownComponents = (
           target="_blank"
           rel="noopener noreferrer"
           onClick={handleExternalClick}
-          className="text-primary hover:text-primary-hover underline decoration-primary/50 hover:decoration-primary transition-colors"
+          className={LINK_CLASS_NAME}
           {...props}
         >
           {children}
@@ -529,7 +530,7 @@ const createMarkdownComponents = (
         href={hrefValue}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-primary hover:text-primary-hover underline decoration-primary/50 hover:decoration-primary transition-colors"
+        className={LINK_CLASS_NAME}
         {...props}
       >
         {children}
@@ -559,7 +560,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
   );
   const normalizedContent = useMemo(() => normalizeDisplayMath(encodeFileUrlsInMarkdown(content)), [content]);
   return (
-    <div className={`markdown-content text-[15px] leading-[23px] ${className}`}>
+    <div className={`markdown-content min-w-0 max-w-full text-[15px] leading-[23px] ${className}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex]}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -2957,7 +2957,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       {isStreaming && <StreamingActivityBar messages={currentSession.messages} />}
 
       {/* Input Area */}
-      <div className={`py-4 shrink-0 ${COWORK_DETAIL_GUTTER_CLASS}`}>
+      <div className={`pt-0 pb-4 shrink-0 ${COWORK_DETAIL_GUTTER_CLASS}`}>
         <div className={COWORK_DETAIL_CONTENT_CLASS}>
           <CoworkPromptInput
             ref={promptInputRef}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -2734,7 +2734,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         <div
           ref={scrollContainerRef}
           onScroll={handleMessagesScroll}
-          className={`h-full min-h-0 overflow-y-auto pt-3 ${turns.length > 1 && isScrollable ? 'pr-8' : 'pr-3'}`}
+          className="h-full min-h-0 overflow-y-auto pt-3"
         >
           {isLoadingMoreMessages && (
             <div className="py-2 text-center text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">


### PR DESCRIPTION
## Summary

- Align the cowork message list and bottom composer to the same content column
- Remove extra top spacing above the bottom composer while preserving bottom and horizontal spacing
- Unify plain code block rendering with language-tagged code blocks so toolbar controls stay consistent
