### PR TITLE
fix(cowork): stabilize chat scroll gutter

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -2549,6 +2549,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const artifactPanelFrameWidth = isArtifactPanelVisible
     ? Math.max(artifactPanelMinWidth, Math.min(panelWidth, artifactPanelMaxWidth)) + ARTIFACT_PANEL_RESIZE_HANDLE_WIDTH
     : 0;
+  const shouldShowTurnNavigationRail = turns.length > 1 && isScrollable;
 
   const renderConversationTurns = () => {
     let railCounter = 0;
@@ -2735,6 +2736,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
           ref={scrollContainerRef}
           onScroll={handleMessagesScroll}
           className="h-full min-h-0 overflow-y-auto pt-3"
+          style={{ scrollbarGutter: 'stable both-edges' }}
         >
           {isLoadingMoreMessages && (
             <div className="py-2 text-center text-xs dark:text-claude-darkTextSecondary text-claude-textSecondary">
@@ -2746,7 +2748,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         </div>
 
         {/* Turn Navigation Rail — to the left of scrollbar */}
-        {turns.length > 1 && isScrollable && (
+        {shouldShowTurnNavigationRail && (
           <div
             className="absolute right-[18px] top-1/2 -translate-y-1/2 w-5 flex flex-col items-end z-10"
             style={{ maxHeight: 'calc(100% - 40px)' }}


### PR DESCRIPTION
Use stable scroll gutters in the message list so scrollbar space does not shift the conversation column away from the composer.