### PR TITLE
fix(artifact): 修复中文路径下点击在浏览器中打开无反应

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5168,7 +5168,7 @@ if (!gotTheLock) {
       fs.mkdirSync(tmpDir, { recursive: true });
       const tmpFile = path.join(tmpDir, `preview-${Date.now()}.html`);
       fs.writeFileSync(tmpFile, htmlContent, 'utf-8');
-      await shell.openExternal(`file://${tmpFile}`);
+      await shell.openPath(tmpFile);
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };

--- a/src/renderer/components/artifacts/ArtifactPanel.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanel.tsx
@@ -187,10 +187,12 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
       return;
     }
 
-    // Has file on disk: open directly
+    // Has file on disk: open directly via native path
+    // NOTE: shell.openExternal with file:// URLs fails on Windows when path contains
+    // non-ASCII characters (e.g. Chinese) — ERROR_FILE_NOT_FOUND (0x2).
+    // Use shell.openPath which handles native Unicode paths correctly.
     if (selectedArtifact.filePath) {
-      const fileUrl = `file://${selectedArtifact.filePath}`;
-      window.electron?.shell?.openExternal(fileUrl);
+      window.electron?.shell?.openPath(selectedArtifact.filePath);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Windows 上项目存储目录含中文时，artifact 预览页点击"在浏览器中打开"无反应
- 根因：`shell.openExternal('file:///C:/Users/.../向日葵.svg')` 在 Windows 上返回 ERROR_FILE_NOT_FOUND (0x2)，ShellExecuteW 无法解析 file:// URL 中的非 ASCII 字符
- 修复：改用 `shell.openPath(filePath)`，走原生文件系统 API，正确处理 Unicode 路径

## Test plan
- [ ] 在包含中文的项目目录下生成 .html/.svg artifact，点击"在浏览器中打开"验证可正常打开
- [ ] 纯 ASCII 路径下验证功能不受影响
- [ ] macOS 上验证功能正常