### PR TITLE
fix(im): improve POPO channel session title display

### DIFF
--- a/src/main/libs/openclawChannelSessionSync.test.ts
+++ b/src/main/libs/openclawChannelSessionSync.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest';
 
 import {
+  buildChannelDisplayName,
   buildManagedSessionKey,
   DEFAULT_MANAGED_AGENT_ID,
   isManagedSessionKey,
@@ -209,4 +210,47 @@ test('channel sync backfills the real OpenClaw session key for existing mappings
 
   expect(sync.resolveOrCreateSession(sessionKey)).toBe('cowork-1');
   expect(updateSessionOpenClawSessionKey).toHaveBeenCalledWith('dm:ou_123', 'feishu', sessionKey);
+});
+
+// --- buildChannelDisplayName ---
+
+test('buildChannelDisplayName strips email domain and removes direct prefix', () => {
+  expect(buildChannelDisplayName('direct:alice@corp.example.com')).toBe('alice');
+});
+
+test('buildChannelDisplayName keeps group prefix', () => {
+  expect(buildChannelDisplayName('group:3911967@popo.netease.com')).toBe('group:3911967');
+});
+
+test('buildChannelDisplayName handles account:direct:peer format', () => {
+  expect(buildChannelDisplayName('bot1:direct:zhangsan@corp.netease.com')).toBe('zhangsan');
+});
+
+test('buildChannelDisplayName handles account:group:peer format', () => {
+  expect(buildChannelDisplayName('bot1:group:12345@popo.netease.com')).toBe('group:12345');
+});
+
+test('buildChannelDisplayName handles channel peerKind', () => {
+  expect(buildChannelDisplayName('channel:room-abc')).toBe('ch:room-abc');
+});
+
+test('buildChannelDisplayName passes through plain ids', () => {
+  expect(buildChannelDisplayName('123456789')).toBe('123456789');
+});
+
+test('buildChannelDisplayName passes through non-email conversationId without peerKind', () => {
+  expect(buildChannelDisplayName('dm:ou_123')).toBe('dm:ou_123');
+});
+
+test('buildChannelDisplayName truncates long results to 20 chars', () => {
+  const result = buildChannelDisplayName('direct:a_very_long_username_that_exceeds_limit@example.com');
+  expect(result.length).toBeLessThanOrEqual(20);
+  expect(result).toBe('a_very_long_username');
+});
+
+test('buildChannelDisplayName truncates long fallback ids to 20 chars', () => {
+  const result = buildChannelDisplayName('abcdefghijklmnopqrstuvwxyz1234567890');
+  expect(result.length).toBeLessThanOrEqual(20);
+  // fallback uses slice(-20)
+  expect(result).toBe('qrstuvwxyz1234567890');
 });

--- a/src/main/libs/openclawChannelSessionSync.ts
+++ b/src/main/libs/openclawChannelSessionSync.ts
@@ -270,6 +270,48 @@ function getChannelTitlePrefix(platform: string): string {
   return `[${label}]`;
 }
 
+const PEER_KIND_LABELS: Record<string, string> = {
+  direct: '',
+  group: 'group:',
+  channel: 'ch:',
+};
+
+/**
+ * Build a human-readable display name from a structured conversationId.
+ *
+ * conversationId formats (from parseChannelSessionKey):
+ *   - "{peerKind}:{peerId}"                  e.g. "direct:alice@corp.example.com"
+ *   - "{accountId}:{peerKind}:{peerId}"      e.g. "bot1:group:12345@popo.netease.com"
+ *   - plain id                               e.g. "123456789"
+ *
+ * Steps:
+ *   1. Strip email domain (@...) from the raw conversationId.
+ *   2. Extract peerKind (direct/group/channel) and the trailing peerId.
+ *   3. For "direct", show just the peerId; for "group"/"channel", add a short prefix.
+ *   4. Truncate the final result to 20 characters if needed.
+ *
+ * @see https://docs.openclaw.ai/reference/session-management-compaction#session-keys-sessionkey
+ */
+export function buildChannelDisplayName(conversationId: string): string {
+  // 1. Strip email domain
+  const stripped = conversationId.replace(/@[^:]+/g, '');
+
+  // 2. Try to extract peerKind from the segments
+  const segments = stripped.split(':');
+  for (let i = 0; i < segments.length; i++) {
+    const kind = segments[i];
+    if (kind in PEER_KIND_LABELS) {
+      const peerId = segments.slice(i + 1).join(':') || stripped;
+      const prefix = PEER_KIND_LABELS[kind];
+      const display = `${prefix}${peerId}`;
+      return display.length > 20 ? display.slice(0, 20) : display;
+    }
+  }
+
+  // 3. Fallback: no recognized peerKind, use the stripped value as-is
+  return stripped.length > 20 ? stripped.slice(-20) : stripped;
+}
+
 export interface ChannelSessionSyncDeps {
   coworkStore: CoworkStore;
   imStore: IMStore;
@@ -399,11 +441,7 @@ export class OpenClawChannelSessionSync {
             '— creating new session',
           );
           const titlePrefix = getChannelTitlePrefix(parsed.platform);
-          const displayId = parsed.conversationId.includes('@')
-            ? parsed.conversationId.split('@')[0]
-            : parsed.conversationId;
-          const shortId = displayId.length > 12 ? displayId.slice(-12) : displayId;
-          const title = `${titlePrefix} ${shortId}`;
+          const title = `${titlePrefix} ${buildChannelDisplayName(parsed.conversationId)}`;
           const cwd = this.getDefaultCwd(currentAgentId);
           const newSession = this.coworkStore.createSession(
             title,
@@ -445,13 +483,7 @@ export class OpenClawChannelSessionSync {
 
     // 5. Create new Cowork session
     const titlePrefix = getChannelTitlePrefix(parsed.platform);
-    // For conversationIds that look like email addresses (e.g. POPO),
-    // use the local part before '@' as the display name.
-    const displayId = parsed.conversationId.includes('@')
-      ? parsed.conversationId.split('@')[0]
-      : parsed.conversationId;
-    const shortId = displayId.length > 12 ? displayId.slice(-12) : displayId;
-    const title = `${titlePrefix} ${shortId}`;
+    const title = `${titlePrefix} ${buildChannelDisplayName(parsed.conversationId)}`;
     // Look up the per-platform agent binding so the session is filed under the correct agent.
     const imSettings = this.imStore.getIMSettings();
     const accountId = extractAccountIdFromKey(sessionKey);


### PR DESCRIPTION
## Summary
- POPO 渠道会话标题因 12 字符硬截断导致显示异常，替换为基于 OpenClaw session key 结构的智能解析
- 新增 `buildChannelDisplayName()` 函数，识别 `direct/group/channel` peerKind 段，剥离邮箱域名，生成可读标题（如 `[POPO] alice`、`[POPO] group:3911967`）
- 补充 9 个单元测试覆盖各种 conversationId 格式

## Test plan
- [ ] POPO 私聊会话标题显示完整用户名，无截断
- [ ] POPO 群聊会话标题显示 `group:` 前缀 + 群 ID
- [ ] 其它 IM 渠道（飞书/钉钉/TG 等）标题不受影响
- [ ] 单元测试全部通过 (`npx vitest run src/main/libs/openclawChannelSessionSync.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)