### PR TITLE
fix(artifacts): resolve garbled app names in open-with dropdown on Chinese Windows

### DIFF
--- a/src/main/shellApps.ts
+++ b/src/main/shellApps.ts
@@ -320,7 +320,7 @@ foreach ($entry in $apps.Keys) {
     $displayName = [System.IO.Path]::GetFileNameWithoutExtension($exePath)
   }
 
-  if ($exePath) {
+  if ($exePath -and (Test-Path $exePath)) {
     $result += @{ name = $displayName; path = $exePath; isDefault = ($progId -eq $defaultProgId -or $entry -eq $defaultProgId) }
   }
 }

--- a/src/main/shellApps.ts
+++ b/src/main/shellApps.ts
@@ -238,6 +238,8 @@ async function getApps_windows(ext: string): Promise<AppInfo[]> {
   if (!ext.startsWith('.')) ext = '.' + ext;
 
   const psScript = `
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
 $ext = "${ext}"
 $apps = @{}
 


### PR DESCRIPTION
## Summary
- Fix garbled text (e.g. "Microsoft Word �j�") in artifact open-with dropdown on Chinese Windows
- Root cause: PowerShell defaults to GBK (CP936) output encoding, but Node.js `execFile` decodes as UTF-8
- Fix: force `[Console]::OutputEncoding` and `$OutputEncoding` to UTF-8 in the PowerShell script

## Test plan
- [ ] On Chinese Windows, create a `.docx` artifact and verify the open-with dropdown shows correct app names (e.g. "Microsoft Word" without garbled characters)
- [ ] Verify other file types (.xlsx, .pptx, .pdf) also display correctly