### PR TITLE
fix(plugins): 插件管理图标调整及用户插件持久化

### DIFF
--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -50,6 +50,7 @@ vi.mock('./claudeSettings', () => ({
 }));
 
 vi.mock('./openclawLocalExtensions', () => ({
+  findBundledExtensionsDir: () => null,
   findThirdPartyExtensionsDir: () => null,
   hasBundledOpenClawExtension: (id: string) => id !== 'qwen-portal-auth',
   resolveOpenClawExtensionPluginId: (id: string) => {

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -47,7 +47,7 @@ const gwDiagTs = (): string => {
   const abs = Math.abs(tz);
   return `[GW-RESTART-DIAG] ${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}${sign}${p(Math.floor(abs / 60))}:${p(abs % 60)}`;
 };
-import { findThirdPartyExtensionsDir, hasBundledOpenClawExtension, resolveOpenClawExtensionPluginId } from './openclawLocalExtensions';
+import { findBundledExtensionsDir, findThirdPartyExtensionsDir, hasBundledOpenClawExtension, resolveOpenClawExtensionPluginId } from './openclawLocalExtensions';
 import { getOpenClawTokenProxyPort } from './openclawTokenProxy';
 import { isSystemProxyEnabled } from './systemProxy';
 
@@ -1454,8 +1454,11 @@ export class OpenClawConfigSync {
                 // them with origin="config", bypassing the bundled-channel-entry
                 // contract check.  See openclaw/openclaw#60196.
                 ...((() => {
-                  const thirdPartyDir = findThirdPartyExtensionsDir();
-                  return thirdPartyDir ? { load: { paths: [thirdPartyDir] } } : {};
+                  const paths = [
+                    findBundledExtensionsDir(),
+                    findThirdPartyExtensionsDir(),
+                  ].filter((p): p is string => p !== null);
+                  return paths.length > 0 ? { load: { paths } } : {};
                 })()),
                 // Deny list cleared — unused bundled plugins are physically removed
                 // from dist/extensions/ at build time (see prune-openclaw-runtime.cjs).

--- a/src/main/libs/openclawLocalExtensions.ts
+++ b/src/main/libs/openclawLocalExtensions.ts
@@ -79,7 +79,7 @@ const findLocalExtensionsSourceDir = (): string | null => {
   return null;
 };
 
-const findBundledExtensionsDir = (): string | null => {
+export const findBundledExtensionsDir = (): string | null => {
   const candidates = app.isPackaged
     ? [path.join(process.resourcesPath, 'cfmind', THIRD_PARTY_EXTENSIONS_DIR)]
     : [
@@ -200,17 +200,18 @@ export const hasBundledOpenClawExtension = (extensionId: string): boolean => {
  * in a separate `extensions/` directory — NOT in `dist/extensions/` which is
  * reserved for runtime-bundled plugins that satisfy the bundled-channel-entry
  * contract.  The gateway discovers these via `plugins.load.paths`.
+ *
+ * The directory is located under userData so that user-installed plugins
+ * persist across application upgrades / reinstalls.
  */
 export const findThirdPartyExtensionsDir = (): string | null => {
-  const dir = findBundledExtensionsDir();
-  if (!dir) return null;
-  // Resolve symlinks so the path matches what the gateway sees after
-  // resolving the `current` → `win-x64` (or other platform) junction.
+  const dir = path.join(app.getPath('userData'), THIRD_PARTY_EXTENSIONS_DIR);
   try {
-    return fs.realpathSync(dir);
+    fs.mkdirSync(dir, { recursive: true });
   } catch {
-    return dir;
+    return null;
   }
+  return dir;
 };
 
 /**

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1,5 +1,5 @@
 import { EyeIcon, EyeSlashIcon, XCircleIcon as XCircleIconSolid } from '@heroicons/react/20/solid';
-import { ArrowTopRightOnSquareIcon, ChatBubbleLeftIcon, CheckCircleIcon, CpuChipIcon, CubeIcon, EnvelopeIcon, InformationCircleIcon, KeyIcon, PuzzlePieceIcon, ShieldCheckIcon, SignalIcon, SunIcon, UserCircleIcon, XCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { ArrowTopRightOnSquareIcon, ChatBubbleLeftIcon, CheckCircleIcon, CpuChipIcon, CubeIcon, EnvelopeIcon, InformationCircleIcon, KeyIcon, ShieldCheckIcon, SignalIcon, SunIcon, UserCircleIcon, XCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import React, { useCallback,useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -32,6 +32,7 @@ import EmbeddingSettingsSection from './cowork/EmbeddingSettingsSection';
 import ErrorMessage from './ErrorMessage';
 import BrainIcon from './icons/BrainIcon';
 import PencilIcon from './icons/PencilIcon';
+import PlugIcon from './icons/PlugIcon';
 import PlusCircleIcon from './icons/PlusCircleIcon';
 import { GitHubCopilotIcon } from './icons/providers';
 import TrashIcon from './icons/TrashIcon';
@@ -2674,8 +2675,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       { key: 'email' as TabType,          label: i18nService.t('emailTab'),       icon: <EnvelopeIcon className="h-5 w-5" /> },
       { key: 'coworkMemory' as TabType,   label: i18nService.t('coworkMemoryTitle'), icon: <BrainIcon className="h-5 w-5" /> },
       { key: 'coworkAgent' as TabType,    label: i18nService.t('coworkAgentTab'),    icon: <UserCircleIcon className="h-5 w-5" /> },
+      { key: 'plugins' as TabType,        label: i18nService.t('pluginsTab'),     icon: <PlugIcon className="h-5 w-5" /> },
       { key: 'shortcuts' as TabType,      label: i18nService.t('shortcuts'),      icon: <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-5 w-5"><rect x="2" y="4" width="20" height="14" rx="2" /><line x1="6" y1="8" x2="8" y2="8" /><line x1="10" y1="8" x2="12" y2="8" /><line x1="14" y1="8" x2="16" y2="8" /><line x1="6" y1="12" x2="8" y2="12" /><line x1="10" y1="12" x2="14" y2="12" /><line x1="16" y1="12" x2="18" y2="12" /><line x1="8" y1="15.5" x2="16" y2="15.5" /></svg> },
-      { key: 'plugins' as TabType,        label: i18nService.t('pluginsTab'),     icon: <PuzzlePieceIcon className="h-5 w-5" /> },
       { key: 'about' as TabType,          label: i18nService.t('about'),          icon: <InformationCircleIcon className="h-5 w-5" /> },
     ];
     // Filter out tabs hidden by enterprise config

--- a/src/renderer/components/icons/PlugIcon.tsx
+++ b/src/renderer/components/icons/PlugIcon.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const PlugIcon: React.FC<{ className?: string }> = ({ className }) => {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 22v-5" />
+      <path d="M15 8V2" />
+      <path d="M17 8a1 1 0 0 1 1 1v4a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V9a1 1 0 0 1 1-1z" />
+      <path d="M9 8V2" />
+    </svg>
+  );
+};
+
+export default PlugIcon;


### PR DESCRIPTION
## Summary
- 将插件管理 tab 图标从 PuzzlePiece 更换为 Plug（小插头）
- 将插件 tab 位置从快捷键之后调整到个性化与快捷键之间
- 将用户安装插件目录从应用安装目录迁移到 userData，避免升级/覆盖安装时丢失

## Details
用户通过插件管理安装的第三方插件原来存放在 `vendor/openclaw-runtime/current/third-party-extensions/`（生产环境为 `resources/cfmind/third-party-extensions/`），该目录在应用升级时会被覆盖导致插件丢失。

现将用户安装插件目录改为 `%APPDATA%/LobsterAI/third-party-extensions`（userData），升级时不受影响。同时在 `openclaw.json` 的 `plugins.load.paths` 中保留 bundled 目录，确保预装插件正常加载。

## Test plan
- [ ] 验证设置面板插件 tab 图标为插头样式，位置在个性化和快捷键之间
- [ ] 安装一个第三方插件，确认插件文件位于 userData 目录
- [ ] 重启应用后插件仍正常加载
- [ ] 预装插件（mcp-bridge、email 等）正常工作