### PR TITLE
fix(plugin): 修复 macOS 插件 npm 安装失败

### DIFF
--- a/src/main/libs/pluginManager.ts
+++ b/src/main/libs/pluginManager.ts
@@ -5,6 +5,7 @@ import os from 'os';
 import path from 'path';
 
 import type { CoworkStore, PluginSource } from '../coworkStore';
+import { getElectronNodeRuntimePath } from './coworkUtil';
 import { findThirdPartyExtensionsDir } from './openclawLocalExtensions';
 
 export interface PluginInstallParams {
@@ -126,6 +127,42 @@ function runAsync(
       reject(err);
     });
   });
+}
+
+/**
+ * Resolve the bundled npm-cli.js path so we don't depend on npm being in PATH.
+ * On macOS, Electron apps launched from Dock/Launchpad have a minimal PATH that
+ * typically doesn't include nvm/homebrew/volta-managed npm installations.
+ */
+function resolveNpmCliJs(): string | null {
+  const candidates = app.isPackaged
+    ? [path.join(process.resourcesPath, 'app.asar.unpacked', 'node_modules', 'npm', 'bin', 'npm-cli.js')]
+    : [
+        path.join(app.getAppPath(), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+        path.join(process.cwd(), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+      ];
+  return candidates.find(c => fs.existsSync(c)) || null;
+}
+
+/** Resolve npm command and base args, preferring the bundled npm-cli.js. */
+function resolveNpmCommand(): { command: string; baseArgs: string[]; env: NodeJS.ProcessEnv; shell: boolean } {
+  const npmCliJs = resolveNpmCliJs();
+  if (npmCliJs) {
+    return {
+      command: getElectronNodeRuntimePath(),
+      baseArgs: [npmCliJs],
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+      shell: false,
+    };
+  }
+  // Fallback: rely on system npm in PATH
+  const isWin = process.platform === 'win32';
+  return {
+    command: isWin ? 'npm.cmd' : 'npm',
+    baseArgs: [],
+    env: { ...process.env },
+    shell: isWin,
+  };
 }
 
 /** Humanize a camelCase/snake_case key into a label */
@@ -399,24 +436,23 @@ export class PluginManager {
 
   private async packNpmPlugin(params: PluginInstallParams, onLog?: PluginInstallLogCallback): Promise<string> {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lobsterai-plugin-'));
-    const isWin = process.platform === 'win32';
-    const npmBin = isWin ? 'npm.cmd' : 'npm';
     const spec = params.version ? `${params.spec}@${params.version}` : params.spec;
-    const args = ['pack', spec, '--pack-destination', tmpDir];
+    const npm = resolveNpmCommand();
+    const args = [...npm.baseArgs, 'pack', spec, '--pack-destination', tmpDir];
 
     if (params.registry) {
       args.push(`--registry=${params.registry}`);
     }
 
-    const result = await runAsync(npmBin, args, {
+    const result = await runAsync(npm.command, args, {
       cwd: tmpDir,
       env: {
-        ...process.env,
+        ...npm.env,
         npm_config_prefer_offline: '',
         npm_config_prefer_online: '',
       },
       timeout: 3 * 60 * 1000,
-      shell: isWin,
+      shell: npm.shell,
       onLog,
     });
 
@@ -456,12 +492,12 @@ export class PluginManager {
     }
 
     // Pack the cloned source
-    const isWin = process.platform === 'win32';
-    const npmBin = isWin ? 'npm.cmd' : 'npm';
-    const packResult = await runAsync(npmBin, ['pack', sourceDir, '--pack-destination', tmpDir], {
+    const npm = resolveNpmCommand();
+    const packResult = await runAsync(npm.command, [...npm.baseArgs, 'pack', sourceDir, '--pack-destination', tmpDir], {
       cwd: tmpDir,
+      env: npm.env,
       timeout: 3 * 60 * 1000,
-      shell: isWin,
+      shell: npm.shell,
       onLog,
     });
 


### PR DESCRIPTION
## Summary
- macOS 从 Dock/Launchpad 启动时，Electron 进程的 PATH 仅包含 `/usr/bin:/bin:/usr/sbin:/sbin`，不含 nvm/homebrew/volta 安装的 npm 路径
- 插件安装 `packNpmPlugin` / `packGitPlugin` 直接 `spawn('npm', ...)` 且 Mac 上 `shell: false`，导致 `ENOENT` 错误
- 参照 `skillManager.ts` 的 `resolveNpmCliJs` 模式，优先使用内置 `npm-cli.js`（打包在 `app.asar.unpacked` 中）通过 `ELECTRON_RUN_AS_NODE=1` 执行，完全不依赖系统 PATH

## Test plan
- [ ] macOS 从 Dock 启动 LobsterAI，安装 npm 源插件（如 nsp-clawguard），验证安装成功
- [ ] macOS 从终端启动 LobsterAI，安装 npm 源插件，验证安装成功
- [ ] Windows 安装 npm 源插件，验证无回归
- [ ] 安装 git 源插件，验证 packGitPlugin 路径正常