### PR TITLE
fix(cowork): 收窄 mid-turn artifact 检测，避免工具输出裸路径误识别

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -2058,21 +2058,14 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         if (msg.type !== 'tool_result' || !msg.content || !msg.metadata?.isFinal) continue;
         if (loadedFileIdsRef.current.has(msg.id)) continue;
 
+        // Only detect explicit MEDIA: tokens in tool results — do NOT parse bare file paths
+        // here, because tool output (e.g. `ls`) may contain many irrelevant file paths.
         const mediaArtifacts = parseMediaTokensFromText(msg.content, msg.id, sessionId);
         for (const ma of mediaArtifacts) {
           const normalized = ma.filePath ? normalizeFilePathForDedup(ma.filePath) : '';
           if (ma.filePath && !seenFilePaths.has(normalized) && !loadedFileIdsRef.current.has(ma.id)) {
             seenFilePaths.add(normalized);
             toLoad.push(ma);
-          }
-        }
-
-        const pathArtifacts = parseFilePathsFromText(msg.content, msg.id, sessionId);
-        for (const pa of pathArtifacts) {
-          const normalized = pa.filePath ? normalizeFilePathForDedup(pa.filePath) : '';
-          if (pa.filePath && !seenFilePaths.has(normalized) && !loadedFileIdsRef.current.has(pa.id)) {
-            seenFilePaths.add(normalized);
-            toLoad.push(pa);
           }
         }
       }

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -415,7 +415,7 @@ const getToolInputString = (
 const truncatePreview = (value: string, maxLength = 120): string =>
   value.length <= maxLength ? value : `${value.slice(0, maxLength - 3)}...`;
 
-const MEDIA_TOKEN_DISPLAY_RE = /\n?MEDIA:\s*`?[^\s`\n]+`?/gi;
+const MEDIA_TOKEN_DISPLAY_RE = /\n?MEDIA:\s*`?[^`\n]+?`?\s*$/gim;
 
 const normalizeToolResultText = (value: string): string => {
   const withoutAnsi = value.replace(ANSI_ESCAPE_PATTERN, '');

--- a/src/renderer/services/artifactParser.test.ts
+++ b/src/renderer/services/artifactParser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { normalizeFilePathForDedup, parseFileLinksFromMessage, parseFilePathsFromText, parseToolArtifact } from './artifactParser';
+import { normalizeFilePathForDedup, parseFileLinksFromMessage, parseFilePathsFromText, parseMediaTokensFromText, parseToolArtifact } from './artifactParser';
 
 describe('normalizeFilePathForDedup', () => {
   test('strips leading / before Windows drive letter', () => {
@@ -55,6 +55,66 @@ describe('parseFilePathsFromText', () => {
     const artifacts = parseFilePathsFromText(content, 'msg1', 'sess1');
     expect(artifacts).toHaveLength(1);
     expect(artifacts[0].filePath).toBe('D:/project/output.pdf');
+  });
+});
+
+describe('parseMediaTokensFromText', () => {
+  test('parses MEDIA token with Windows path (no space)', () => {
+    const content = 'MEDIA:C:\\Users\\test\\images\\output.png';
+    const artifacts = parseMediaTokensFromText(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].filePath).toBe('C:\\Users\\test\\images\\output.png');
+    expect(artifacts[0].type).toBe('image');
+  });
+
+  test('parses MEDIA token with space after colon', () => {
+    const content = 'MEDIA: /tmp/output.png';
+    const artifacts = parseMediaTokensFromText(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].filePath).toBe('/tmp/output.png');
+  });
+
+  test('parses macOS path with spaces (Application Support)', () => {
+    const content = 'MEDIA: /Users/test/Library/Application Support/com.lobsterai/images/output.png';
+    const artifacts = parseMediaTokensFromText(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].filePath).toBe('/Users/test/Library/Application Support/com.lobsterai/images/output.png');
+    expect(artifacts[0].type).toBe('image');
+  });
+
+  test('parses backtick-wrapped path with spaces', () => {
+    const content = 'MEDIA: `/Users/test/Library/Application Support/output.png`';
+    const artifacts = parseMediaTokensFromText(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].filePath).toBe('/Users/test/Library/Application Support/output.png');
+  });
+
+  test('parses file:// prefixed MEDIA path', () => {
+    const content = 'MEDIA: file:///D:/workspace/image.jpg';
+    const artifacts = parseMediaTokensFromText(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].filePath).toBe('D:/workspace/image.jpg');
+  });
+
+  test('parses multiple MEDIA tokens on separate lines', () => {
+    const content = 'MEDIA: /tmp/img1.png\nMEDIA: /tmp/img2.jpg';
+    const artifacts = parseMediaTokensFromText(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts[0].filePath).toBe('/tmp/img1.png');
+    expect(artifacts[1].filePath).toBe('/tmp/img2.jpg');
+  });
+
+  test('ignores MEDIA token with unknown extension', () => {
+    const content = 'MEDIA: /tmp/data.xyz';
+    const artifacts = parseMediaTokensFromText(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(0);
+  });
+
+  test('trims trailing whitespace from path', () => {
+    const content = 'MEDIA: /tmp/output.png   ';
+    const artifacts = parseMediaTokensFromText(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].filePath).toBe('/tmp/output.png');
   });
 });
 

--- a/src/renderer/services/artifactParser.ts
+++ b/src/renderer/services/artifactParser.ts
@@ -53,7 +53,7 @@ export function isBinaryDocumentExtension(ext: string): boolean {
   return BINARY_DOCUMENT_EXTENSIONS.has(ext.toLowerCase());
 }
 
-export const MEDIA_TOKEN_RE = /\bMEDIA:\s*`?([^\s`\n]+)`?/gi;
+export const MEDIA_TOKEN_RE = /\bMEDIA:\s*`?([^`\n]+?)`?\s*$/gim;
 
 export function parseMediaTokensFromText(
   messageContent: string,
@@ -63,7 +63,7 @@ export function parseMediaTokensFromText(
   if (!messageContent) return [];
 
   const artifacts: Artifact[] = [];
-  const re = new RegExp(MEDIA_TOKEN_RE.source, 'gi');
+  const re = new RegExp(MEDIA_TOKEN_RE.source, 'gim');
   let match: RegExpExecArray | null;
   let index = 0;
 


### PR DESCRIPTION
## Summary
- 移除 mid-turn artifact detection effect 中对 `tool_result` 内容调用 `parseFilePathsFromText` 的逻辑，避免 `ls` 等工具输出中裸路径被误识别为 artifact
- 修复 `MEDIA_TOKEN_RE` 正则在路径含空格时截断的问题（macOS `Application Support` 等路径），改用行尾锚定匹配
- 同步修复 `MEDIA_TOKEN_DISPLAY_RE` 和 `parseMediaTokensFromText` 的 RegExp flags
- 新增 8 个 `parseMediaTokensFromText` 单元测试

## Background
PR #1972 引入了 tool result 回填 + artifact 检测，用于处理 `image_generate` 的 `MEDIA:` 标识。存在两个问题：

1. **误检**：mid-turn effect 额外调用了 `parseFilePathsFromText`，导致 `ls` 等工具输出中不相关的文件路径也被当作 artifact 展示
2. **漏检**：`MEDIA_TOKEN_RE` 的捕获组 `[^\s\x60\n]+` 遇空格即截断，macOS 上 `Application Support` 等含空格路径无法正确识别图片

## Changes
- `CoworkSessionDetail.tsx`：移除 mid-turn effect 中对 tool_result 的 `parseFilePathsFromText` 调用；更新 `MEDIA_TOKEN_DISPLAY_RE` 正则
- `artifactParser.ts`：`MEDIA_TOKEN_RE` 改用 `[^\x60\n]+?` + `$` 行尾锚定 (multiline)，支持含空格路径
- `artifactParser.test.ts`：新增 macOS 空格路径、反引号包裹、file:// 前缀、多行、未知扩展名等测试用例

## Test plan
- [ ] 执行 `ls` 等工具调用，确认输出中的文件路径不再被误识别为 artifact
- [ ] 在 macOS 上执行 `image_generate`，确认含空格路径的图片正常展示
- [ ] 执行 `write` 工具写文件，确认 `parseToolArtifact` 路径仍正常工作
- [ ] `npx vitest run src/renderer/services/artifactParser.test.ts` 全部通过