### PR TITLE
feat: add thinking level control for chat sessions

### DIFF
--- a/src/main/coworkPagination.test.ts
+++ b/src/main/coworkPagination.test.ts
@@ -87,6 +87,8 @@ const SESSION_SCHEMA = `
     pin_order INTEGER,
     cwd TEXT NOT NULL,
     system_prompt TEXT NOT NULL DEFAULT '',
+    model_override TEXT NOT NULL DEFAULT '',
+    thinking_level TEXT NOT NULL DEFAULT '',
     execution_mode TEXT,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL

--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -45,6 +45,7 @@ function setupDb(): void {
       cwd TEXT NOT NULL,
       system_prompt TEXT NOT NULL DEFAULT '',
       model_override TEXT NOT NULL DEFAULT '',
+      thinking_level TEXT NOT NULL DEFAULT '',
       execution_mode TEXT NOT NULL DEFAULT 'local',
       active_skill_ids TEXT,
       agent_id TEXT NOT NULL DEFAULT 'main',

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -415,6 +415,7 @@ export interface CoworkSession {
   cwd: string;
   systemPrompt: string;
   modelOverride: string;
+  thinkingLevel: string;
   executionMode: CoworkExecutionMode;
   activeSkillIds: string[];
   agentId: string;
@@ -617,7 +618,8 @@ export class CoworkStore {
     executionMode: CoworkExecutionMode = 'local',
     activeSkillIds: string[] = [],
     agentId: string = 'main',
-    modelOverride: string = ''
+    modelOverride: string = '',
+    thinkingLevel: string = ''
   ): CoworkSession {
     const id = uuidv4();
     const now = Date.now();
@@ -625,8 +627,8 @@ export class CoworkStore {
     this.db
       .prepare(
         `
-      INSERT INTO cowork_sessions (id, title, claude_session_id, status, cwd, system_prompt, model_override, execution_mode, active_skill_ids, agent_id, pinned, created_at, updated_at)
-      VALUES (?, ?, NULL, 'idle', ?, ?, ?, ?, ?, ?, 0, ?, ?)
+      INSERT INTO cowork_sessions (id, title, claude_session_id, status, cwd, system_prompt, model_override, thinking_level, execution_mode, active_skill_ids, agent_id, pinned, created_at, updated_at)
+      VALUES (?, ?, NULL, 'idle', ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
     `,
       )
       .run(
@@ -635,6 +637,7 @@ export class CoworkStore {
         cwd,
         systemPrompt,
         modelOverride,
+        thinkingLevel,
         executionMode,
         JSON.stringify(activeSkillIds),
         agentId,
@@ -652,6 +655,7 @@ export class CoworkStore {
       cwd,
       systemPrompt,
       modelOverride,
+      thinkingLevel,
       executionMode,
       activeSkillIds,
       agentId,
@@ -674,6 +678,7 @@ export class CoworkStore {
       cwd: string;
       system_prompt: string;
       model_override?: string | null;
+      thinking_level?: string | null;
       execution_mode?: string | null;
       active_skill_ids?: string | null;
       agent_id?: string | null;
@@ -683,7 +688,7 @@ export class CoworkStore {
 
     const row = this.getOne<SessionRow>(
       `
-      SELECT id, title, claude_session_id, status, pinned, pin_order, cwd, system_prompt, model_override, execution_mode, active_skill_ids, agent_id, created_at, updated_at
+      SELECT id, title, claude_session_id, status, pinned, pin_order, cwd, system_prompt, model_override, thinking_level, execution_mode, active_skill_ids, agent_id, created_at, updated_at
       FROM cowork_sessions
       WHERE id = ?
     `,
@@ -719,6 +724,7 @@ export class CoworkStore {
       cwd: row.cwd,
       systemPrompt: row.system_prompt,
       modelOverride: row.model_override || '',
+      thinkingLevel: row.thinking_level || '',
       executionMode: (row.execution_mode as CoworkExecutionMode) || 'local',
       activeSkillIds,
       agentId: row.agent_id || 'main',
@@ -735,7 +741,7 @@ export class CoworkStore {
     updates: Partial<
       Pick<
         CoworkSession,
-        'title' | 'claudeSessionId' | 'status' | 'cwd' | 'systemPrompt' | 'modelOverride' | 'executionMode'
+        'title' | 'claudeSessionId' | 'status' | 'cwd' | 'systemPrompt' | 'modelOverride' | 'thinkingLevel' | 'executionMode'
       >
     >,
     options: { touchUpdatedAt?: boolean } = {},
@@ -771,6 +777,10 @@ export class CoworkStore {
     if (updates.modelOverride !== undefined) {
       setClauses.push('model_override = ?');
       values.push(updates.modelOverride);
+    }
+    if (updates.thinkingLevel !== undefined) {
+      setClauses.push('thinking_level = ?');
+      values.push(updates.thinkingLevel);
     }
     if (updates.executionMode !== undefined) {
       setClauses.push('execution_mode = ?');

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1338,6 +1338,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         cwd: '',
         systemPrompt: '',
         modelOverride: '',
+        thinkingLevel: '',
         executionMode: 'local' as CoworkExecutionMode,
         activeSkillIds: [],
         messages,
@@ -1439,6 +1440,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         cwd: '',
         systemPrompt: '',
         modelOverride: '',
+        thinkingLevel: '',
         executionMode: 'local' as CoworkExecutionMode,
         activeSkillIds: [],
         messages,
@@ -1953,6 +1955,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       const message = error instanceof Error ? error.message : String(error);
       this.emit('error', sessionId, message);
       throw error;
+    }
+
+    if (session.thinkingLevel) {
+      try {
+        const client = this.requireGatewayClient();
+        await client.request('sessions.patch', { key: sessionKey, thinkingLevel: session.thinkingLevel });
+      } catch (error) {
+        console.warn('[OpenClawRuntime] failed to patch session thinkingLevel before chat.send:', error);
+      }
     }
 
     const outboundMessage = await this.buildOutboundPrompt(

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2859,6 +2859,7 @@ if (!gotTheLock) {
     imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
     agentId?: string;
     modelOverride?: string;
+    thinkingLevel?: string;
   }) => {
     try {
       const engineStatus = await ensureOpenClawRunningForCowork();
@@ -2897,7 +2898,8 @@ if (!gotTheLock) {
         config.executionMode || 'local',
         options.activeSkillIds || [],
         options.agentId || 'main',
-        options.modelOverride || ''
+        options.modelOverride || '',
+        options.thinkingLevel || ''
       );
 
       if (options.modelOverride) {
@@ -3592,6 +3594,12 @@ if (!gotTheLock) {
       if (patch.model !== undefined) {
         getCoworkStore().updateSession(sessionId, {
           modelOverride: patch.model ?? '',
+        }, { touchUpdatedAt: false });
+      }
+
+      if (patch.thinkingLevel !== undefined) {
+        getCoworkStore().updateSession(sessionId, {
+          thinkingLevel: patch.thinkingLevel ?? '',
         }, { touchUpdatedAt: false });
       }
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -218,7 +218,7 @@ contextBridge.exposeInMainWorld('electron', {
   },
   cowork: {
     // Session management
-    startSession: (options: { prompt: string; cwd?: string; systemPrompt?: string; title?: string; activeSkillIds?: string[]; agentId?: string; modelOverride?: string; imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }> }) =>
+    startSession: (options: { prompt: string; cwd?: string; systemPrompt?: string; title?: string; activeSkillIds?: string[]; agentId?: string; modelOverride?: string; thinkingLevel?: string; imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }> }) =>
       ipcRenderer.invoke('cowork:session:start', options),
     continueSession: (options: { sessionId: string; prompt: string; systemPrompt?: string; activeSkillIds?: string[]; imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }> }) =>
       ipcRenderer.invoke('cowork:session:continue', options),

--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -251,6 +251,11 @@ export class SqliteStore {
         this.didRunMigration = true;
       }
 
+      if (!colNames.includes('thinking_level')) {
+        this.db.exec("ALTER TABLE cowork_sessions ADD COLUMN thinking_level TEXT NOT NULL DEFAULT '';");
+        this.didRunMigration = true;
+      }
+
       // Migration: Add sequence column to cowork_messages
       const msgColumns = this.db.pragma('table_info(cowork_messages)') as Array<{ name: string }>;
       const msgColNames = msgColumns.map(c => c.name);

--- a/src/renderer/components/ThinkingLevelSelector.tsx
+++ b/src/renderer/components/ThinkingLevelSelector.tsx
@@ -1,0 +1,114 @@
+import { CheckIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
+import React from 'react';
+
+import { i18nService } from '../services/i18n';
+
+interface ThinkingLevelOption {
+  value: string;
+  labelKey: string;
+  fallbackLabel: string;
+}
+
+const THINKING_LEVEL_OPTIONS: ThinkingLevelOption[] = [
+  { value: '', labelKey: 'coworkThinkingDefault', fallbackLabel: 'Default' },
+  { value: 'off', labelKey: '', fallbackLabel: 'Off' },
+  { value: 'minimal', labelKey: '', fallbackLabel: 'Minimal' },
+  { value: 'low', labelKey: '', fallbackLabel: 'Low' },
+  { value: 'medium', labelKey: '', fallbackLabel: 'Medium' },
+  { value: 'high', labelKey: '', fallbackLabel: 'High' },
+  { value: 'adaptive', labelKey: '', fallbackLabel: 'Adaptive' },
+];
+
+interface ThinkingLevelSelectorProps {
+  value: string;
+  onChange: (level: string) => void;
+  disabled?: boolean;
+  compact?: boolean;
+  dropdownDirection?: 'up' | 'down';
+}
+
+const ThinkingLevelSelector: React.FC<ThinkingLevelSelectorProps> = ({
+  value,
+  onChange,
+  disabled = false,
+  compact = false,
+  dropdownDirection = 'up',
+}) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  const getOptionLabel = (opt: ThinkingLevelOption): string => {
+    if (opt.labelKey) {
+      return i18nService.t(opt.labelKey) || opt.fallbackLabel;
+    }
+    return opt.fallbackLabel;
+  };
+
+  const currentOption = THINKING_LEVEL_OPTIONS.find(o => o.value === value) ?? THINKING_LEVEL_OPTIONS[0];
+  const displayLabel = getOptionLabel(currentOption);
+
+  const triggerClassName = compact
+    ? 'space-x-1.5 px-2 py-1 rounded-lg max-w-[160px]'
+    : 'space-x-2 px-3 py-1.5 rounded-xl max-w-[200px]';
+  const triggerTextClassName = compact ? 'text-xs' : 'text-sm';
+  const triggerIconClassName = compact ? 'h-3 w-3' : 'h-3.5 w-3.5';
+
+  const dropdownPositionClass = dropdownDirection === 'up'
+    ? 'bottom-full mb-1'
+    : 'top-full mt-1';
+
+  const handleSelect = (optValue: string) => {
+    onChange(optValue);
+    setIsOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className={`relative ${disabled ? 'cursor-wait' : 'cursor-pointer'}`}>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => !disabled && setIsOpen(!isOpen)}
+        className={`flex items-center hover:bg-surface-raised text-foreground transition-colors disabled:opacity-70 disabled:cursor-wait ${triggerClassName} ${isOpen ? 'bg-surface-raised' : ''}`}
+        aria-label={i18nService.t('coworkThinkingLevel') || 'Thinking Level'}
+      >
+        <span className={`${triggerTextClassName} truncate`}>{displayLabel}</span>
+        <ChevronDownIcon className={`${triggerIconClassName} shrink-0 dark:text-claude-darkTextSecondary text-claude-textSecondary`} />
+      </button>
+
+      {isOpen && (
+        <div
+          className={`absolute right-0 ${dropdownPositionClass} w-44 bg-surface rounded-xl shadow-popover z-50 border-border border overflow-hidden`}
+        >
+          <div className="py-1 max-h-72 overflow-y-auto">
+            {THINKING_LEVEL_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => handleSelect(opt.value)}
+                className={`w-full px-3 py-2 text-left flex items-center justify-between gap-2 transition-colors hover:bg-surface-raised ${
+                  value === opt.value ? 'text-foreground' : 'text-secondary'
+                }`}
+              >
+                <span className="truncate text-[13px] font-normal leading-5">{getOptionLabel(opt)}</span>
+                {value === opt.value && <CheckIcon className="h-4 w-4 shrink-0 text-emerald-500" />}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ThinkingLevelSelector;

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -8,6 +8,7 @@ import { configService } from '../../services/config';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { skillService } from '../../services/skill';
+import { localStore } from '../../services/store';
 import { RootState } from '../../store';
 import { selectDraftPrompts } from '../../store/selectors/coworkSelectors';
 import {
@@ -17,6 +18,7 @@ import {
   setDraftAttachments,
   setDraftPrompt,
   updateCurrentSessionModelOverride,
+  updateCurrentSessionThinkingLevel,
 } from '../../store/slices/coworkSlice';
 import type { Model } from '../../store/slices/modelSlice';
 import { setSkills, toggleActiveSkill } from '../../store/slices/skillSlice';
@@ -31,6 +33,7 @@ import PaperClipIcon from '../icons/PaperClipIcon';
 import XMarkIcon from '../icons/XMarkIcon';
 import ModelSelector from '../ModelSelector';
 import { ActiveSkillBadge, SkillsButton } from '../skills';
+import ThinkingLevelSelector from '../ThinkingLevelSelector';
 import { resolveAgentModelSelection, resolveEffectiveModel, useAgentSelectedModel } from './agentModelSelection';
 import AttachmentCard from './AttachmentCard';
 import FolderSelectorPopover from './FolderSelectorPopover';
@@ -211,6 +214,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const [isAddingFile, setIsAddingFile] = useState(false);
     const [imageVisionHint, setImageVisionHint] = useState(false);
     const [isPatchingModel, setIsPatchingModel] = useState(false);
+    const [pendingThinkingLevel, setPendingThinkingLevel] = useState('');
     const [showAgentMenu, setShowAgentMenu] = useState(false);
     const [isReadOnlyContextCompact, setIsReadOnlyContextCompact] = useState(false);
 
@@ -970,6 +974,12 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     return () => window.removeEventListener('config-updated', syncFromConfig);
   }, []);
 
+  useEffect(() => {
+    localStore.getItem<string>('lastThinkingLevel').then((level) => {
+      if (level) setPendingThinkingLevel(level);
+    });
+  }, []);
+
   const largeModelSelector = showModelSelector ? (
     <div className="flex flex-col items-start gap-1">
       <ModelSelector
@@ -1040,6 +1050,52 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       )}
     </div>
   ) : null;
+
+  const thinkingLevelSelector = (
+    <ThinkingLevelSelector
+      compact={useHomeContextLayout}
+      dropdownDirection="up"
+      disabled={disabled}
+      value={sessionId ? (currentSession?.thinkingLevel ?? '') : pendingThinkingLevel}
+      onChange={async (level) => {
+        if (!sessionId) {
+          void localStore.setItem('lastThinkingLevel', level);
+          setPendingThinkingLevel(level);
+          return;
+        }
+
+        const previousThinkingLevel = currentSession?.id === sessionId
+          ? (currentSession.thinkingLevel ?? '')
+          : '';
+
+        dispatch(updateCurrentSessionThinkingLevel({ sessionId, thinkingLevel: level }));
+
+        try {
+          const patchedSession = await coworkService.patchSession(sessionId, {
+            thinkingLevel: level || null,
+          });
+
+          if (!patchedSession) {
+            dispatch(updateCurrentSessionThinkingLevel({
+              sessionId,
+              thinkingLevel: previousThinkingLevel,
+            }));
+            window.dispatchEvent(new CustomEvent('app:showToast', {
+              detail: i18nService.t('coworkThinkingSwitchFailed'),
+            }));
+          }
+        } catch {
+          dispatch(updateCurrentSessionThinkingLevel({
+            sessionId,
+            thinkingLevel: previousThinkingLevel,
+          }));
+          window.dispatchEvent(new CustomEvent('app:showToast', {
+            detail: i18nService.t('coworkThinkingSwitchFailed'),
+          }));
+        }
+      }}
+    />
+  );
 
   const largeInputActions = !remoteManaged ? (
     <>
@@ -1210,6 +1266,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
                     {contextUsageControl}
+                    {thinkingLevelSelector}
                     {largeModelSelector}
                     {largeSendButton}
                   </div>
@@ -1358,6 +1415,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
                   {contextUsageControl}
+                  {thinkingLevelSelector}
                   {largeModelSelector}
                   {largeSendButton}
                 </div>

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -1,5 +1,5 @@
 import { ShieldCheckIcon } from '@heroicons/react/24/outline';
-import React, { useEffect, useRef,useState } from 'react';
+import React, { useCallback, useEffect, useRef,useState } from 'react';
 import { useDispatch,useSelector } from 'react-redux';
 
 import { buildSessionTitleFromInput } from '../../../common/sessionTitle';
@@ -7,6 +7,7 @@ import { agentService } from '../../services/agent';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { quickActionService } from '../../services/quickAction';
+import { localStore } from '../../services/store';
 import { RootState } from '../../store';
 import {
   selectCoworkConfig,
@@ -69,6 +70,11 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   const currentAgent = agents.find((agent) => agent.id === currentAgentId);
   const currentAgentWorkingDirectory = currentAgent?.workingDirectory?.trim() || config.workingDirectory || '';
   const currentAgentSelectedModel = useAgentSelectedModel(currentAgentId, currentAgent?.model ?? '');
+
+  const refreshLastThinkingLevel = useCallback(async () => {
+    const level = await localStore.getItem<string>('lastThinkingLevel');
+    return level || '';
+  }, []);
 
   const buildApiConfigNotice = (error?: string): { noticeI18nKey: string; noticeExtra?: string } => {
     const key = 'coworkModelSettingsRequired';
@@ -224,6 +230,9 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
       // Capture active skill IDs before clearing them
       const sessionSkillIds = [...activeSkillIds];
 
+      // Read fresh thinking level from persistent store
+      const inheritedThinkingLevel = await refreshLastThinkingLevel();
+
       const tempSession: CoworkSession = {
         id: tempSessionId,
         title: fallbackTitle,
@@ -235,6 +244,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         cwd: currentAgentWorkingDirectory,
         systemPrompt: '',
         modelOverride: currentAgentSelectedModel ? toOpenClawModelRef(currentAgentSelectedModel) : '',
+        thinkingLevel: inheritedThinkingLevel,
         executionMode: config.executionMode || 'local',
         activeSkillIds: sessionSkillIds,
         agentId: currentAgentId,
@@ -283,6 +293,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         activeSkillIds: sessionSkillIds,
         agentId: currentAgentId,
         modelOverride: sessionModelOverride,
+        thinkingLevel: inheritedThinkingLevel,
         imageAttachments,
       });
 

--- a/src/renderer/services/coworkClearSession.test.ts
+++ b/src/renderer/services/coworkClearSession.test.ts
@@ -17,6 +17,7 @@ const makeSession = (): CoworkSession => ({
   cwd: '/tmp',
   systemPrompt: '',
   modelOverride: '',
+  thinkingLevel: '',
   executionMode: 'local',
   activeSkillIds: [],
   agentId: 'agent-1',

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -909,6 +909,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionStartFailed: '会话启动失败：{error}',
     coworkErrorSessionContinueFailed: '发送消息失败：{error}',
     coworkModelSwitchFailed: '模型切换失败，请稍后重试。',
+    coworkThinkingLevel: '思考深度',
+    coworkThinkingDefault: '默认',
+    coworkThinkingSwitchFailed: '切换思考深度失败，请稍后重试。',
     coworkErrorEngineNotReady: 'AI 引擎正在启动中，请稍等几秒后重试。',
     coworkErrorUnknown: '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
 
@@ -2818,6 +2821,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorSessionStartFailed: 'Failed to start session: {error}',
     coworkErrorSessionContinueFailed: 'Failed to send message: {error}',
     coworkModelSwitchFailed: 'Failed to switch model. Please try again later.',
+    coworkThinkingLevel: 'Thinking',
+    coworkThinkingDefault: 'Default',
+    coworkThinkingSwitchFailed: 'Failed to switch thinking level. Please try again later.',
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
     coworkErrorUnknown:
       'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -21,6 +21,7 @@ const makeSession = (overrides: Partial<Parameters<typeof addSession>[0]> = {}) 
   cwd: '/tmp',
   systemPrompt: '',
   modelOverride: '',
+  thinkingLevel: '',
   executionMode: 'local' as const,
   activeSkillIds: [],
   agentId: 'main',

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -345,6 +345,12 @@ const coworkSlice = createSlice({
       state.currentSession.modelOverride = modelOverride;
     },
 
+    updateCurrentSessionThinkingLevel(state, action: PayloadAction<{ sessionId: string; thinkingLevel: string }>) {
+      const { sessionId, thinkingLevel } = action.payload;
+      if (state.currentSession?.id !== sessionId) return;
+      state.currentSession.thinkingLevel = thinkingLevel;
+    },
+
     enqueuePendingPermission(state, action: PayloadAction<CoworkPermissionRequest>) {
       const alreadyQueued = state.pendingPermissions.some(
         (permission) => permission.requestId === action.payload.requestId
@@ -432,6 +438,7 @@ export const {
   updateSessionPinned,
   updateSessionTitle,
   updateCurrentSessionModelOverride,
+  updateCurrentSessionThinkingLevel,
   enqueuePendingPermission,
   dequeuePendingPermission,
   clearPendingPermissions,

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -96,6 +96,7 @@ export interface CoworkSession {
   cwd: string;
   systemPrompt: string;
   modelOverride: string;
+  thinkingLevel: string;
   executionMode: CoworkExecutionMode;
   activeSkillIds: string[];
   agentId: string;
@@ -245,6 +246,7 @@ export interface CoworkStartOptions {
   activeSkillIds?: string[];
   agentId?: string;
   modelOverride?: string;
+  thinkingLevel?: string;
   imageAttachments?: CoworkImageAttachment[];
 }
 

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -27,6 +27,7 @@ interface CoworkSession {
   cwd: string;
   systemPrompt: string;
   modelOverride: string;
+  thinkingLevel: string;
   executionMode: 'auto' | 'local' | 'sandbox';
   activeSkillIds: string[];
   agentId: string;
@@ -434,6 +435,8 @@ interface IElectronAPI {
       title?: string;
       activeSkillIds?: string[];
       agentId?: string;
+      modelOverride?: string;
+      thinkingLevel?: string;
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
     }) => Promise<{
       success: boolean;


### PR DESCRIPTION
## Summary
- Add ThinkingLevelSelector dropdown next to model selector, supporting Off/Minimal/Low/Medium/High/Adaptive levels
- Full end-to-end integration: type definitions, DB migration, Redux, IPC, preload, runtime adapter, i18n
- Session-scoped changes in active sessions; global default on new-task page inherited by future sessions
- Patches thinkingLevel to OpenClaw gateway via sessions.patch

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] New-task page shows thinking level selector next to model selector
- [ ] Active session page shows thinking level selector with current session value
- [ ] Changing level in active session patches to OpenClaw (verify in gateway logs)
- [ ] Changing level in active session does NOT affect global default
- [ ] Changing level on new-task page persists as global default
- [ ] New session inherits global default thinking level
- [ ] Selecting "Default" sends null to OpenClaw, clearing the override
- [ ] App restart preserves global default thinking level