### PR TITLE
chore: upgrade moltbot-popo plugin from 2.1.1 to 2.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       {
         "id": "moltbot-popo",
         "npm": "moltbot-popo",
-        "version": "2.1.1",
+        "version": "2.1.8",
         "registry": "https://npm.nie.netease.com",
         "optional": true
       },


### PR DESCRIPTION
## Summary
- 升级泡泡插件 moltbot-popo 从 2.1.1 到 2.1.8

## Test plan
- [x] 验证 POPO IM 通道消息收发正常