### PR TITLE
fix: hash non-ASCII MCP server names for OpenClaw compatibility

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -1,5 +1,4 @@
 import { createHash } from 'crypto';
-
 import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'crypto';
+
 import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
@@ -924,6 +926,22 @@ function lowercaseHeaderKeys(headers: Record<string, string>): Record<string, st
   return result;
 }
 
+/**
+ * Generates a deterministic ASCII-safe key for MCP server names.
+ * OpenClaw sanitizes non-ASCII characters in server names to hyphens,
+ * which makes Chinese/CJK names unrecognizable. This function transparently
+ * converts unsafe names to a stable `mcp-<hash>` form before passing to OpenClaw.
+ * ASCII-only names (even with spaces/special chars) are left as-is for OpenClaw
+ * to handle natively (e.g., "My Server" → "My-Server" by OpenClaw).
+ */
+const MCP_NAME_NON_ASCII_RE = /[^\x00-\x7F]/;
+
+function safeServerKey(name: string): string {
+  if (!MCP_NAME_NON_ASCII_RE.test(name)) return name;
+  const hash = createHash('md5').update(name).digest('hex').slice(0, 8);
+  return `mcp-${hash}`;
+}
+
 function buildOpenClawMcpServers(
   servers: ResolvedMcpServer[],
 ): Record<string, Record<string, unknown>> {
@@ -948,7 +966,7 @@ function buildOpenClawMcpServers(
         entry.transport = 'streamable-http';
         break;
     }
-    result[server.name] = entry;
+    result[safeServerKey(server.name)] = entry;
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- OpenClaw internally sanitizes non-ASCII characters in MCP server names to hyphens, making Chinese/CJK names unrecognizable (e.g. `"天眼查-中文"` → `"------"`)
- Adds a deterministic md5-based key generation in `buildOpenClawMcpServers()` so non-ASCII names get a stable ASCII alias (e.g. `"mcp-b5c265da"`)
- ASCII-only names pass through unchanged, preserving OpenClaw's native sanitization (e.g. `"My Server"` → `"My-Server"`)
- Fully transparent to users — UI still displays original Chinese names

## Test plan
- [ ] Configure an MCP server with a Chinese name (e.g. `"天眼查-中文"`)
- [ ] Verify OpenClaw logs show `mcp-<hash>` instead of `"------"`
- [ ] Verify tools from the server are registered and callable
- [ ] Verify ASCII-named servers still work unchanged
- [ ] Restart app and confirm hash is stable (same name → same key)