### PR TITLE
fix(ui): restore new-task page background to theme color

### DIFF
--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -532,7 +532,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
 
   // Home view - no current session
   return (
-    <div className="flex-1 flex flex-col bg-surface h-full">
+    <div className="flex-1 flex flex-col bg-background h-full">
       {/* Engine status banner for error states */}
       {engineStatusBanner}
 


### PR DESCRIPTION
## Summary
- Commit 822d0596 mistakenly changed the home view (新建任务页面) container class from `bg-background` to `bg-surface`, making it white instead of the theme-aware warm/beige color
- Reverts that single class change so the new-task page background matches the conversation page again

## Test plan
- [ ] Open a themed skin (e.g. Daylight) and verify the new-task page background is the same warm color as the conversation page
- [ ] Switch themes and confirm both pages stay consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)