### PR TITLE
feat: support contextWindow for package models

### DIFF
--- a/src/main/libs/claudeSettings.ts
+++ b/src/main/libs/claudeSettings.ts
@@ -81,26 +81,28 @@ export function setServerBaseUrlGetter(getter: () => string): void {
 }
 
 // Cached server model metadata (populated when auth:getModels is called)
-// Keyed by modelId → { supportsImage }
-let serverModelMetadataCache: Map<string, { supportsImage?: boolean }> = new Map();
+// Keyed by modelId → { supportsImage, contextWindow }
+let serverModelMetadataCache: Map<string, { supportsImage?: boolean; contextWindow?: number }> = new Map();
 
 const serializeServerModelMetadata = (
-  models: Array<{ modelId: string; supportsImage?: boolean }>,
+  models: Array<{ modelId: string; supportsImage?: boolean; contextWindow?: number }>,
 ): string => JSON.stringify(
   models
     .map((model) => ({
       modelId: model.modelId,
       supportsImage: model.supportsImage,
+      contextWindow: model.contextWindow,
     }))
     .sort((a, b) => a.modelId.localeCompare(b.modelId)),
 );
 
-export function updateServerModelMetadata(models: Array<{ modelId: string; supportsImage?: boolean }>): boolean {
+export function updateServerModelMetadata(models: Array<{ modelId: string; supportsImage?: boolean; contextWindow?: number }>): boolean {
   const previous = serializeServerModelMetadata(getAllServerModelMetadata());
-  const nextCache = new Map(models.map(m => [m.modelId, { supportsImage: m.supportsImage }]));
+  const nextCache = new Map(models.map(m => [m.modelId, { supportsImage: m.supportsImage, contextWindow: m.contextWindow }]));
   const next = serializeServerModelMetadata(Array.from(nextCache.entries()).map(([modelId, meta]) => ({
     modelId,
     supportsImage: meta.supportsImage,
+    contextWindow: meta.contextWindow,
   })));
   serverModelMetadataCache = nextCache;
   return previous !== next;
@@ -110,10 +112,11 @@ export function clearServerModelMetadata(): void {
   serverModelMetadataCache.clear();
 }
 
-export function getAllServerModelMetadata(): Array<{ modelId: string; supportsImage?: boolean }> {
+export function getAllServerModelMetadata(): Array<{ modelId: string; supportsImage?: boolean; contextWindow?: number }> {
   return Array.from(serverModelMetadataCache.entries()).map(([modelId, meta]) => ({
     modelId,
     supportsImage: meta.supportsImage,
+    contextWindow: meta.contextWindow,
   }));
 }
 

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -1235,6 +1235,7 @@ export class OpenClawConfigSync {
                 providerName: ProviderName.LobsteraiServer,
                 supportsImage: sm.supportsImage,
                 modelName: sm.modelId,
+                contextWindow: sm.contextWindow,
               });
               upsertProviderModel(lobsteraiProviderConfig, serverSel.providerConfig.models[0]);
             }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2679,7 +2679,7 @@ if (!gotTheLock) {
         console.log('[Auth:getModels] Response not ok:', resp.status, resp.statusText);
         return { success: false };
       }
-      const data = await resp.json() as { code: number; data: Array<{ modelId: string; modelName: string; provider: string; apiFormat: string; supportsImage?: boolean }> };
+      const data = await resp.json() as { code: number; data: Array<{ modelId: string; modelName: string; provider: string; apiFormat: string; supportsImage?: boolean; contextWindow?: number }> };
       console.log('[Auth:getModels] Response data:', JSON.stringify(data).slice(0, 500));
       if (data.code !== 0) return { success: false };
       // Cache server model metadata for use in OpenClaw config sync (supportsImage, etc.)


### PR DESCRIPTION
## Summary
- 套餐模型（server models）支持 contextWindow 配置
- 当后端 `/api/models/available` 接口返回 `contextWindow` 字段时，客户端将其透传写入 `openclaw.json`，引擎据此控制上下文截断长度
- 该字段为可选，不传时行为不变，向后兼容

## Changes
- `src/main/main.ts` — API 响应类型声明加上 `contextWindow?: number`
- `src/main/libs/claudeSettings.ts` — 缓存结构扩展，序列化/getter 带上 contextWindow
- `src/main/libs/openclawConfigSync.ts` — 构建 provider 配置时传入 contextWindow

## 依赖
- 需后端 `/api/models/available` 接口配合下发 `contextWindow` 字段（单位 tokens）

## Test plan
- [ ] 后端接口返回 contextWindow 时，验证 openclaw.json 中对应模型写入了 contextWindow
- [ ] 后端接口不返回 contextWindow 时，验证行为与之前一致（无 contextWindow 字段写入）