### PR TITLE
fix: subagent session bugs

### DIFF
--- a/src/main/libs/agentEngine/subagentTracker.ts
+++ b/src/main/libs/agentEngine/subagentTracker.ts
@@ -174,18 +174,27 @@ export class SubagentTracker {
 
   /**
    * Called when backfill retrieves a sessions_spawn tool result text.
-   * Extracts childSessionKey if not already known.
+   * Extracts childSessionKey if not already known and detects error status.
    */
   onBackfillResult(toolCallId: string, text: string): void {
     if (!this.subagentToolCallIdToAgentId.has(toolCallId)) return;
-    if (this.subagentSessionKeys.has(toolCallId)) return;
+    const alreadyHasKey = this.subagentSessionKeys.has(toolCallId);
     try {
       const parsed = JSON.parse(text);
-      const childSessionKey = typeof parsed?.childSessionKey === 'string' ? parsed.childSessionKey : '';
-      if (childSessionKey) {
-        this.subagentSessionKeys.set(toolCallId, childSessionKey);
-        this.store.updateSubagentRunSessionKey(toolCallId, childSessionKey);
-        console.log('[SubagentTracker] session key from backfill:', toolCallId, childSessionKey);
+      // Extract session key if not yet known
+      if (!alreadyHasKey) {
+        const childSessionKey = typeof parsed?.childSessionKey === 'string' ? parsed.childSessionKey : '';
+        if (childSessionKey) {
+          this.subagentSessionKeys.set(toolCallId, childSessionKey);
+          this.store.updateSubagentRunSessionKey(toolCallId, childSessionKey);
+          console.log('[SubagentTracker] session key from backfill:', toolCallId, childSessionKey);
+        }
+      }
+      // Detect error status (spawn may have failed with a timeout)
+      if (parsed?.status === 'error' && this.subagentStatus.get(toolCallId) !== 'error') {
+        this.subagentStatus.set(toolCallId, 'error');
+        this.store.updateSubagentRunStatus(toolCallId, 'error', Date.now());
+        console.log('[SubagentTracker] subagent spawn failed (from backfill):', toolCallId, parsed.error);
       }
     } catch { /* not JSON */ }
   }

--- a/src/main/libs/agentEngine/subagentTracker.ts
+++ b/src/main/libs/agentEngine/subagentTracker.ts
@@ -10,6 +10,33 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 };
 
+/**
+ * Resolve tool input from a tool_use block, handling multiple field names and formats.
+ * The gateway can return tool arguments as:
+ *  - `input` (Anthropic format, object)
+ *  - `args` (OpenClaw format, object)
+ *  - `arguments` (OpenAI format, may be a JSON string)
+ */
+const resolveToolInput = (block: Record<string, unknown>): Record<string, unknown> => {
+  if (isRecord(block.input)) return block.input;
+  if (isRecord(block.args)) return block.args;
+  if (isRecord(block.arguments)) return block.arguments;
+  // arguments may be a JSON string (OpenAI format)
+  if (typeof block.arguments === 'string') {
+    try {
+      const parsed = JSON.parse(block.arguments);
+      if (isRecord(parsed)) return parsed;
+    } catch { /* ignore parse errors */ }
+  }
+  if (typeof block.input === 'string') {
+    try {
+      const parsed = JSON.parse(block.input);
+      if (isRecord(parsed)) return parsed;
+    } catch { /* ignore parse errors */ }
+  }
+  return {};
+};
+
 /** Message format compatible with renderer CoworkMessage interface */
 export interface SubagentCoworkMessage {
   id: string;
@@ -353,7 +380,7 @@ export class SubagentTracker {
               const blockType = typeof block.type === 'string' ? block.type : '';
               if (blockType === 'tool_use' || blockType === 'tool_call' || blockType === 'toolCall') {
                 const toolName = typeof block.name === 'string' ? block.name : 'tool';
-                const toolInput = isRecord(block.input) ? block.input as Record<string, unknown> : {};
+                const toolInput = resolveToolInput(block);
                 const toolUseId = typeof block.id === 'string' ? block.id : null;
                 messages.push({
                   id: crypto.randomUUID(),
@@ -363,6 +390,42 @@ export class SubagentTracker {
                   metadata: { toolName, toolInput, toolUseId },
                 });
               }
+            }
+          } else if (role === 'user' && Array.isArray(raw.content)) {
+            // User messages may contain tool_result blocks (Anthropic API format)
+            let hasToolResult = false;
+            for (const block of raw.content as unknown[]) {
+              if (!isRecord(block)) continue;
+              const blockType = typeof block.type === 'string' ? block.type : '';
+              if (blockType === 'tool_result') {
+                hasToolResult = true;
+                const resultText = typeof block.content === 'string'
+                  ? block.content
+                  : extractGatewayMessageText(block).trim();
+                const toolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : null;
+                const isError = block.is_error === true;
+                if (resultText) {
+                  messages.push({
+                    id: crypto.randomUUID(),
+                    type: 'tool_result',
+                    content: resultText,
+                    timestamp: ts++,
+                    metadata: { toolResult: resultText, toolUseId, isError: isError || undefined },
+                  });
+                }
+              }
+            }
+            // If there was also text content alongside tool results, emit it
+            if (text && !shouldSuppressHeartbeatText('user', text)) {
+              messages.push({
+                id: crypto.randomUUID(),
+                type: 'user',
+                content: text,
+                timestamp: ts++,
+              });
+            }
+            if (!hasToolResult && !text) {
+              console.log('[SubagentTracker] dropped user message with empty text, keys:', Object.keys(raw).join(','));
             }
           } else if (text && !shouldSuppressHeartbeatText(role as 'user' | 'assistant' | 'system', text)) {
             const type = role === 'system' ? 'system' : role as 'user' | 'assistant';
@@ -407,7 +470,7 @@ export class SubagentTracker {
             const blockType = typeof block.type === 'string' ? block.type : '';
             if (blockType === 'tool_use' || blockType === 'tool_call' || blockType === 'toolCall') {
               const toolName = typeof block.name === 'string' ? block.name : 'tool';
-              const toolInput = isRecord(block.input) ? block.input as Record<string, unknown> : {};
+              const toolInput = resolveToolInput(block);
               const toolUseId = typeof block.id === 'string' ? block.id : null;
               messages.push({
                 id: crypto.randomUUID(),

--- a/src/main/libs/agentEngine/subagentTracker.ts
+++ b/src/main/libs/agentEngine/subagentTracker.ts
@@ -79,6 +79,14 @@ export class SubagentTracker {
   private readonly subagentStatus = new Map<string, 'running' | 'done' | 'error'>();
   /** Reverse map: agentId → Set of toolCallIds (for lookups from sessions_resume args) */
   private readonly agentIdToToolCallIds = new Map<string, Set<string>>();
+  /** Pending spawn info stored at tool start, used for DB insertion when result arrives */
+  private readonly pendingSpawnInfo = new Map<string, {
+    agentId: string;
+    task: string | null;
+    label: string | null;
+    parentSessionId: string;
+    createdAt: number;
+  }>();
 
   constructor(
     private readonly store: SubagentRunStore,
@@ -89,9 +97,8 @@ export class SubagentTracker {
 
   /**
    * Called when a sessions_spawn tool call starts.
-   * Tracks the subagent and persists the initial run record.
-   * Uses toolCallId as the unique run identifier to avoid collisions
-   * when multiple subagents share the same agentId.
+   * Stores spawn info in memory only — DB insertion is deferred until the result arrives
+   * so we can determine the correct initial status (running vs error).
    */
   onToolStart(
     toolCallId: string,
@@ -108,7 +115,6 @@ export class SubagentTracker {
     const task = typeof args?.task === 'string' ? args.task : '';
     const label = typeof args?.label === 'string' ? args.label : undefined;
     if (agentId) {
-      this.subagentStatus.set(toolCallId, 'running');
       if (!this.subagentMessages.has(toolCallId)) {
         this.subagentMessages.set(toolCallId, []);
       }
@@ -120,39 +126,40 @@ export class SubagentTracker {
         this.agentIdToToolCallIds.set(agentId, toolCallIds);
       }
       toolCallIds.add(toolCallId);
-      this.store.insertSubagentRun({
-        id: toolCallId,
-        parentSessionId: sessionId,
-        sessionKey: null,
+      // Store info for deferred DB insertion
+      this.pendingSpawnInfo.set(toolCallId, {
         agentId,
         task: task || null,
         label: label ?? null,
-        status: 'running',
+        parentSessionId: sessionId,
         createdAt: Date.now(),
       });
     }
   }
 
   /**
-   * Called when a sessions_spawn tool result arrives.
-   * Extracts childSessionKey and persists it.
+   * Called when a sessions_spawn tool result arrives (non-empty).
+   * Creates the DB record with the correct status based on the result.
    */
   onSpawnResult(toolCallId: string, resultText: string, _args: Record<string, unknown>): void {
     if (!resultText) return;
+    if (!this.subagentToolCallIdToAgentId.has(toolCallId)) return;
     try {
       const parsed = JSON.parse(resultText);
-      const childSessionKey = typeof parsed?.childSessionKey === 'string' ? parsed.childSessionKey : '';
-      if (toolCallId && childSessionKey && this.subagentToolCallIdToAgentId.has(toolCallId)) {
-        this.subagentSessionKeys.set(toolCallId, childSessionKey);
-        this.store.updateSubagentRunSessionKey(toolCallId, childSessionKey);
-      }
-      // Mark as error if the spawn result indicates failure
-      if (toolCallId && parsed?.status === 'error' && this.subagentToolCallIdToAgentId.has(toolCallId)) {
-        this.subagentStatus.set(toolCallId, 'error');
-        this.store.updateSubagentRunStatus(toolCallId, 'error', Date.now());
-        console.log('[SubagentTracker] subagent spawn failed:', toolCallId, parsed.error);
-      }
+      this.commitSpawnResult(toolCallId, parsed);
     } catch { /* result may not be JSON */ }
+  }
+
+  /**
+   * Called when backfill retrieves a sessions_spawn tool result text.
+   * Creates the DB record if not already done.
+   */
+  onBackfillResult(toolCallId: string, text: string): void {
+    if (!this.subagentToolCallIdToAgentId.has(toolCallId)) return;
+    try {
+      const parsed = JSON.parse(text);
+      this.commitSpawnResult(toolCallId, parsed);
+    } catch { /* not JSON */ }
   }
 
   /**
@@ -170,33 +177,6 @@ export class SubagentTracker {
         this.store.updateSubagentRunStatus(tcId, 'done', Date.now());
       }
     }
-  }
-
-  /**
-   * Called when backfill retrieves a sessions_spawn tool result text.
-   * Extracts childSessionKey if not already known and detects error status.
-   */
-  onBackfillResult(toolCallId: string, text: string): void {
-    if (!this.subagentToolCallIdToAgentId.has(toolCallId)) return;
-    const alreadyHasKey = this.subagentSessionKeys.has(toolCallId);
-    try {
-      const parsed = JSON.parse(text);
-      // Extract session key if not yet known
-      if (!alreadyHasKey) {
-        const childSessionKey = typeof parsed?.childSessionKey === 'string' ? parsed.childSessionKey : '';
-        if (childSessionKey) {
-          this.subagentSessionKeys.set(toolCallId, childSessionKey);
-          this.store.updateSubagentRunSessionKey(toolCallId, childSessionKey);
-          console.log('[SubagentTracker] session key from backfill:', toolCallId, childSessionKey);
-        }
-      }
-      // Detect error status (spawn may have failed with a timeout)
-      if (parsed?.status === 'error' && this.subagentStatus.get(toolCallId) !== 'error') {
-        this.subagentStatus.set(toolCallId, 'error');
-        this.store.updateSubagentRunStatus(toolCallId, 'error', Date.now());
-        console.log('[SubagentTracker] subagent spawn failed (from backfill):', toolCallId, parsed.error);
-      }
-    } catch { /* not JSON */ }
   }
 
   /**
@@ -231,6 +211,7 @@ export class SubagentTracker {
     this.subagentStatus.clear();
     this.subagentToolCallIdToAgentId.clear();
     this.agentIdToToolCallIds.clear();
+    this.pendingSpawnInfo.clear();
   }
 
   // ── Public query API ───────────────────────────────────────────────────
@@ -238,6 +219,8 @@ export class SubagentTracker {
   /**
    * Returns persisted subagent runs for a parent session.
    * Merges in-memory status with database records for real-time accuracy.
+   * Records stuck in 'running' from a previous app session (no in-memory state)
+   * are automatically marked as 'error'.
    */
   listSubagentRuns(parentSessionId: string): Array<{
     id: string;
@@ -252,6 +235,22 @@ export class SubagentTracker {
     return runs.map((run) => {
       const memoryStatus = this.subagentStatus.get(run.id);
       const memorySessionKey = this.subagentSessionKeys.get(run.id);
+
+      // Stale 'running' record from a previous session: no in-memory tracking means
+      // it was never committed in this app lifecycle → mark as error and persist.
+      if (run.status === 'running' && !memoryStatus && !this.pendingSpawnInfo.has(run.id)) {
+        this.store.updateSubagentRunStatus(run.id, 'error', Date.now());
+        return {
+          id: run.id,
+          agentId: run.agentId,
+          task: run.task,
+          label: run.label,
+          sessionKey: memorySessionKey ?? run.sessionKey,
+          status: 'error' as const,
+          createdAt: run.createdAt,
+        };
+      }
+
       return {
         id: run.id,
         agentId: run.agentId,
@@ -274,15 +273,20 @@ export class SubagentTracker {
     runId: string,
     sessionKey?: string,
   ): Promise<SubagentCoworkMessage[]> {
-    // 1. Try locally collected messages (only serve cache if subagent is done)
+    // 1. Try locally collected messages (only serve cache if subagent is done/error)
     const status = this.subagentStatus.get(runId);
     const local = this.subagentMessages.get(runId);
-    if (local && local.length > 0 && status === 'done') {
+    if (local && local.length > 0 && (status === 'done' || status === 'error')) {
       return local;
     }
 
     // 2. Resolve session key from multiple sources
     let key = sessionKey || this.subagentSessionKeys.get(runId);
+
+    // Cache externally-provided session key in memory for later lookups
+    if (sessionKey && !this.subagentSessionKeys.has(runId)) {
+      this.subagentSessionKeys.set(runId, sessionKey);
+    }
 
     // 2b. Try reading from persistent store if not in memory
     if (!key) {
@@ -309,7 +313,7 @@ export class SubagentTracker {
       const discovered = await this.discoverSubagentSessionKey(runId);
       if (!discovered) return [];
       this.subagentSessionKeys.set(runId, discovered);
-      return this.fetchSubagentHistory(discovered, runId);
+      key = discovered;
     }
 
     console.log('[SubagentTracker] getSubTaskHistory: fetching history for runId:', runId, 'key:', key);
@@ -317,6 +321,49 @@ export class SubagentTracker {
   }
 
   // ── Private helpers ────────────────────────────────────────────────────
+
+  /**
+   * Shared logic for onSpawnResult and onBackfillResult.
+   * Inserts the DB record (if not already done) with the correct status.
+   */
+  private commitSpawnResult(toolCallId: string, parsed: Record<string, unknown>): void {
+    const childSessionKey = typeof parsed?.childSessionKey === 'string' ? parsed.childSessionKey : '';
+    const isError = parsed?.status === 'error';
+    const status = isError ? 'error' : 'running';
+
+    // Store session key in memory
+    if (childSessionKey) {
+      this.subagentSessionKeys.set(toolCallId, childSessionKey);
+    }
+
+    // If already committed (e.g., onSpawnResult fired then backfill also fires), just update
+    if (this.subagentStatus.has(toolCallId)) {
+      // Update session key in DB if newly discovered
+      if (childSessionKey && !this.subagentSessionKeys.has(toolCallId)) {
+        this.store.updateSubagentRunSessionKey(toolCallId, childSessionKey);
+      }
+      return;
+    }
+
+    // First time: insert the DB record
+    this.subagentStatus.set(toolCallId, status);
+    const pending = this.pendingSpawnInfo.get(toolCallId);
+    if (pending) {
+      this.store.insertSubagentRun({
+        id: toolCallId,
+        parentSessionId: pending.parentSessionId,
+        sessionKey: childSessionKey || null,
+        agentId: pending.agentId,
+        task: pending.task,
+        label: pending.label,
+        status,
+        createdAt: pending.createdAt,
+      });
+      this.pendingSpawnInfo.delete(toolCallId);
+      console.log('[SubagentTracker] committed spawn result:', toolCallId, status,
+        isError ? parsed.error : '');
+    }
+  }
 
   private async discoverSubagentSessionKey(runId: string): Promise<string | null> {
     const client = this.getGatewayClient();

--- a/src/main/libs/agentEngine/subagentTracker.ts
+++ b/src/main/libs/agentEngine/subagentTracker.ts
@@ -49,7 +49,7 @@ export class SubagentTracker {
   /** Maps toolCallId → agentId for correlating spawn start → result */
   private readonly subagentToolCallIdToAgentId = new Map<string, string>();
   /** Maps toolCallId → lifecycle status */
-  private readonly subagentStatus = new Map<string, 'running' | 'done'>();
+  private readonly subagentStatus = new Map<string, 'running' | 'done' | 'error'>();
   /** Reverse map: agentId → Set of toolCallIds (for lookups from sessions_resume args) */
   private readonly agentIdToToolCallIds = new Map<string, Set<string>>();
 
@@ -118,6 +118,12 @@ export class SubagentTracker {
       if (toolCallId && childSessionKey && this.subagentToolCallIdToAgentId.has(toolCallId)) {
         this.subagentSessionKeys.set(toolCallId, childSessionKey);
         this.store.updateSubagentRunSessionKey(toolCallId, childSessionKey);
+      }
+      // Mark as error if the spawn result indicates failure
+      if (toolCallId && parsed?.status === 'error' && this.subagentToolCallIdToAgentId.has(toolCallId)) {
+        this.subagentStatus.set(toolCallId, 'error');
+        this.store.updateSubagentRunStatus(toolCallId, 'error', Date.now());
+        console.log('[SubagentTracker] subagent spawn failed:', toolCallId, parsed.error);
       }
     } catch { /* result may not be JSON */ }
   }

--- a/src/renderer/components/agentSidebar/AgentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/AgentTaskRow.tsx
@@ -20,6 +20,7 @@ interface AgentTaskRowProps {
   isSelected: boolean;
   isSelectionDisabled?: boolean;
   showBatchOption?: boolean;
+  hasActiveSubagent?: boolean;
   onSelect: () => void;
   onDelete: () => Promise<void>;
   onShare: () => Promise<void>;
@@ -40,6 +41,7 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
   isSelected,
   isSelectionDisabled = false,
   showBatchOption = false,
+  hasActiveSubagent = false,
   onSelect,
   onDelete,
   onShare,
@@ -184,7 +186,7 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
       } pr-2.5 text-[14px] font-normal transition-colors ${
         isSelectionDisabled
           ? 'cursor-default text-foreground/30'
-          : task.isSelected
+          : task.isSelected && !hasActiveSubagent
           ? 'cursor-pointer bg-black/[0.06] text-foreground dark:bg-white/[0.07]'
           : 'cursor-pointer text-foreground/80 hover:bg-black/[0.03] hover:text-foreground dark:hover:bg-white/[0.04]'
       }`}

--- a/src/renderer/components/agentSidebar/AgentTreeNode.tsx
+++ b/src/renderer/components/agentSidebar/AgentTreeNode.tsx
@@ -24,6 +24,7 @@ interface AgentTreeNodeProps {
   selectedIds: Set<string>;
   showBatchOption?: boolean;
   subagentsBySessionId?: Record<string, SubagentSessionSummary[]>;
+  selectedSubagentId?: string | null;
   onSelectSubagent?: (subagent: SubagentSessionSummary) => void;
   onToggleExpanded: (agentId: string) => void;
   onEditAgent: (agent: AgentSidebarAgentNode) => void;
@@ -70,6 +71,7 @@ const AgentTreeNode: React.FC<AgentTreeNodeProps> = ({
   selectedIds,
   showBatchOption = false,
   subagentsBySessionId,
+  selectedSubagentId,
   onSelectSubagent,
   onToggleExpanded,
   onEditAgent,
@@ -406,6 +408,7 @@ const AgentTreeNode: React.FC<AgentTreeNodeProps> = ({
                     isSelected={selectedIds.has(task.id)}
                     isSelectionDisabled={isOutsideBatchAgent}
                     showBatchOption={showBatchOption && !isBatchMode}
+                    hasActiveSubagent={task.isSelected && selectedSubagentId != null}
                     onSelect={() => onSelectTask(task)}
                     onDelete={() => onDeleteTask(task)}
                     onShare={() => onShareTask(task)}
@@ -418,6 +421,7 @@ const AgentTreeNode: React.FC<AgentTreeNodeProps> = ({
                     <SubagentTaskRow
                       key={sub.id}
                       subagent={sub}
+                      isSelected={sub.id === selectedSubagentId}
                       onSelect={() => onSelectSubagent?.(sub)}
                     />
                   ))}

--- a/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
+++ b/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
@@ -47,6 +47,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
   );
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [settingsAgentId, setSettingsAgentId] = useState<string | null>(null);
+  const [selectedSubagentId, setSelectedSubagentId] = useState<string | null>(null);
   const { subagentsBySessionId } = useSubagentSessions(currentSessionId, currentSessionStatus);
   const {
     agentNodes,
@@ -62,6 +63,16 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
 
   useEffect(() => {
     void agentService.loadAgents();
+  }, []);
+
+  // Listen for subagent selection events to track active subagent in sidebar
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<SubagentSessionSummary | null>).detail;
+      setSelectedSubagentId(detail?.id ?? null);
+    };
+    window.addEventListener(CoworkUiEvent.SelectSubagent, handler);
+    return () => window.removeEventListener(CoworkUiEvent.SelectSubagent, handler);
   }, []);
 
   const handleSelectTask = async (task: AgentSidebarTaskNode) => {
@@ -160,6 +171,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
       selectedIds={selectedIds}
       showBatchOption
       subagentsBySessionId={subagentsBySessionId}
+      selectedSubagentId={selectedSubagentId}
       onSelectSubagent={(sub) => {
         onSelectSubagent?.(sub);
         onShowCowork();

--- a/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
+++ b/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
@@ -48,7 +48,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [settingsAgentId, setSettingsAgentId] = useState<string | null>(null);
   const [selectedSubagentId, setSelectedSubagentId] = useState<string | null>(null);
-  const { subagentsBySessionId } = useSubagentSessions(currentSessionId, currentSessionStatus);
+  const { subagentsBySessionId, refetchSubagents } = useSubagentSessions(currentSessionId, currentSessionStatus);
   const {
     agentNodes,
     patchTaskPreview,
@@ -70,10 +70,14 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<SubagentSessionSummary | null>).detail;
       setSelectedSubagentId(detail?.id ?? null);
+      // Refetch subagent data when navigating back from detail view
+      if (!detail && currentSessionId) {
+        void refetchSubagents(currentSessionId);
+      }
     };
     window.addEventListener(CoworkUiEvent.SelectSubagent, handler);
     return () => window.removeEventListener(CoworkUiEvent.SelectSubagent, handler);
-  }, []);
+  }, [currentSessionId, refetchSubagents]);
 
   const handleSelectTask = async (task: AgentSidebarTaskNode) => {
     if (task.agentId !== currentAgentId) {

--- a/src/renderer/components/agentSidebar/SubagentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/SubagentTaskRow.tsx
@@ -6,6 +6,7 @@ import LoadingIcon from '../icons/LoadingIcon';
 
 interface SubagentTaskRowProps {
   subagent: SubagentSessionSummary;
+  isSelected?: boolean;
   onSelect: () => void;
 }
 
@@ -21,16 +22,21 @@ const formatDuration = (createdAt: number): string => {
   return `${days}d`;
 };
 
-const SubagentTaskRow: React.FC<SubagentTaskRowProps> = ({ subagent, onSelect }) => {
+const SubagentTaskRow: React.FC<SubagentTaskRowProps> = ({ subagent, isSelected = false, onSelect }) => {
   const displayName = subagent.label ?? subagent.agentId ?? i18nService.t('subagentUnnamed');
   const duration = formatDuration(subagent.createdAt);
 
   return (
     <div
-      className="group relative -ml-[6px] flex h-[26px] w-[calc(100%+12px)] cursor-pointer items-center gap-1.5 rounded-md pl-[52px] pr-2.5 text-[13px] font-normal text-foreground/60 transition-colors hover:bg-black/[0.03] hover:text-foreground/80 dark:hover:bg-white/[0.04]"
+      className={`group relative -ml-[6px] flex h-[26px] w-[calc(100%+12px)] cursor-pointer items-center gap-1.5 rounded-md pl-[52px] pr-2.5 text-[13px] font-normal transition-colors ${
+        isSelected
+          ? 'bg-black/[0.06] text-foreground/80 dark:bg-white/[0.07]'
+          : 'text-foreground/60 hover:bg-black/[0.03] hover:text-foreground/80 dark:hover:bg-white/[0.04]'
+      }`}
       onClick={onSelect}
       role="treeitem"
       aria-level={3}
+      aria-selected={isSelected}
     >
       <span className="min-w-0 flex-1 truncate">
         {displayName}

--- a/src/renderer/components/agentSidebar/SubagentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/SubagentTaskRow.tsx
@@ -40,6 +40,10 @@ const SubagentTaskRow: React.FC<SubagentTaskRowProps> = ({ subagent, onSelect })
         <span className="inline-flex h-3 w-3 shrink-0 items-center justify-center">
           <LoadingIcon className="h-3 w-3 animate-spin text-secondary" aria-hidden="true" />
         </span>
+      ) : subagent.status === 'error' ? (
+        <span className="shrink-0 whitespace-nowrap text-[11px] font-normal text-red-500/60">
+          {i18nService.t('subagentError') || 'Error'}
+        </span>
       ) : (
         <span className="shrink-0 whitespace-nowrap text-[11px] font-normal text-foreground opacity-[0.28]">
           {duration}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -539,7 +539,10 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
         {engineStatusBanner}
         <SubagentSessionDetail
           subagent={viewingSubagent}
-          onBack={() => setViewingSubagent(null)}
+          onBack={() => {
+            setViewingSubagent(null);
+            window.dispatchEvent(new CustomEvent(CoworkUiEvent.SelectSubagent, { detail: null }));
+          }}
           isSidebarCollapsed={isSidebarCollapsed}
           onToggleSidebar={onToggleSidebar}
           onNewChat={onNewChat}

--- a/src/renderer/components/cowork/SubagentSessionDetail.tsx
+++ b/src/renderer/components/cowork/SubagentSessionDetail.tsx
@@ -64,20 +64,15 @@ const SubagentSessionDetail: React.FC<SubagentSessionDetailProps> = ({ subagent,
     void fetchHistory();
     void fetchStatus();
 
-    const timer = setInterval(() => {
-      void fetchHistory();
-      void fetchStatus();
-    }, 5000);
-
-    return () => clearInterval(timer);
-  }, [fetchHistory, fetchStatus]);
-
-  // Stop polling when done
-  useEffect(() => {
-    if (status === 'done') {
-      void fetchHistory();
+    // Only poll while subagent is still running
+    if (status === 'running') {
+      const timer = setInterval(() => {
+        void fetchHistory();
+        void fetchStatus();
+      }, 5000);
+      return () => clearInterval(timer);
     }
-  }, [status, fetchHistory]);
+  }, [fetchHistory, fetchStatus, status]);
 
   // Use agent name as title to avoid duplicating the task content shown in conversation
   const displayTitle = subagent.agentId ?? subagent.label ?? 'Subagent';

--- a/src/renderer/components/cowork/SubagentSessionDetail.tsx
+++ b/src/renderer/components/cowork/SubagentSessionDetail.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeftIcon } from '@heroicons/react/20/solid';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
 import type { CoworkMessage, SubagentSessionSummary } from '../../types/cowork';
@@ -79,9 +79,21 @@ const SubagentSessionDetail: React.FC<SubagentSessionDetailProps> = ({ subagent,
     }
   }, [status, fetchHistory]);
 
-  const displayTitle = subagent.task
-    ? subagent.task.length > 60 ? subagent.task.slice(0, 60) + '...' : subagent.task
-    : subagent.agentId ?? 'Subagent';
+  // Use agent name as title to avoid duplicating the task content shown in conversation
+  const displayTitle = subagent.agentId ?? subagent.label ?? 'Subagent';
+
+  // When messages are empty but task exists, synthesize a user message so
+  // the view shows the initial prompt instead of "暂无对话记录"
+  const effectiveMessages = useMemo(() => {
+    if (messages.length > 0) return messages;
+    if (!subagent.task) return messages;
+    return [{
+      id: 'synthetic-task',
+      type: 'user' as const,
+      content: subagent.task,
+      timestamp: subagent.createdAt,
+    }] as CoworkMessage[];
+  }, [messages, subagent.task, subagent.createdAt]);
 
   return (
     <div className="flex h-full flex-col">
@@ -154,17 +166,9 @@ const SubagentSessionDetail: React.FC<SubagentSessionDetailProps> = ({ subagent,
           </div>
         )}
 
-        {!loading && messages.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-12">
-            <p className="text-sm text-secondary">
-              {i18nService.t('subTaskNoHistory') || 'No messages yet'}
-            </p>
-          </div>
-        )}
-
-        {!loading && messages.length > 0 && (
+        {!loading && (
           <ConversationTurnsView
-            messages={messages}
+            messages={effectiveMessages}
             isStreaming={status === 'running'}
             readOnly={true}
           />


### PR DESCRIPTION
## Summary
- Fix subagent session sync missing tool results and tool input display
- Fix sidebar highlight state when navigating back from subagent detail
- Fix subagent session empty state and error status handling
- Detect subagent spawn errors in backfill path
- Defer subagent DB record creation until spawn result arrives

## Changed files
- `subagentTracker.ts` — deferred DB record creation, spawn error detection
- `SubagentSessionDetail.tsx` — fix empty state & tool result rendering
- `MyAgentSidebarTree.tsx` / `SubagentTaskRow.tsx` / `AgentTreeNode.tsx` — sidebar highlight fixes
- `CoworkView.tsx` — clear highlight on back navigation

## Test plan
- [ ] Spawn subagent, verify session detail shows tool inputs and results
- [ ] Click back from subagent detail, confirm sidebar highlight clears
- [ ] Trigger subagent spawn error, verify error status shown correctly
- [ ] Verify no orphan DB records when spawn fails before result arrives