### PR TITLE
feat: persist subagent session messages to local DB

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -12,6 +12,7 @@ import {
 import type { OpenClawSessionPatch } from '../../../common/openclawSession';
 import type { CoworkExecutionMode, CoworkMessage, CoworkMessageMetadata, CoworkSession, CoworkSessionStatus, CoworkStore } from '../../coworkStore';
 import { t } from '../../i18n';
+import type { SubagentMessageStore } from '../../subagentMessageStore';
 import type { SubagentRunStore } from '../../subagentRunStore';
 import { getCommandDangerLevel,isDeleteCommand } from '../commandSafety';
 import { setCoworkProxySessionId } from '../coworkOpenAICompatProxy';
@@ -1583,16 +1584,17 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     engineManager: OpenClawEngineManager,
     options: OpenClawRuntimeAdapterOptions = {},
     subagentRunStore?: SubagentRunStore,
+    subagentMessageStore?: SubagentMessageStore,
   ) {
     super();
     this.store = store;
     this.engineManager = engineManager;
     this.options = options;
     if (subagentRunStore) {
-      this.subagentTracker = new SubagentTracker(subagentRunStore, () => this.gatewayClient);
+      this.subagentTracker = new SubagentTracker(subagentRunStore, subagentMessageStore ?? null, () => this.gatewayClient);
     } else {
       // Fallback: create a no-op tracker (should not happen in production)
-      this.subagentTracker = new SubagentTracker(null as unknown as SubagentRunStore, () => this.gatewayClient);
+      this.subagentTracker = new SubagentTracker(null as unknown as SubagentRunStore, null, () => this.gatewayClient);
     }
   }
 
@@ -6466,8 +6468,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       this.channelSessionSync.onSessionDeleted(sessionId);
     }
 
-    // Clean up subagent tracking state
-    this.subagentTracker.onSessionDeleted();
+    // Clean up subagent tracking state and persisted messages
+    this.subagentTracker.onSessionDeleted(sessionId);
   }
 
   /**

--- a/src/main/libs/agentEngine/subagentTracker.ts
+++ b/src/main/libs/agentEngine/subagentTracker.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
 
+import type { SubagentMessageStore } from '../../subagentMessageStore';
 import type { SubagentRunStore } from '../../subagentRunStore';
 import {
   extractGatewayMessageText,
@@ -90,6 +91,7 @@ export class SubagentTracker {
 
   constructor(
     private readonly store: SubagentRunStore,
+    private readonly messageStore: SubagentMessageStore | null,
     private readonly getGatewayClient: () => GatewayClientLike | null,
   ) {}
 
@@ -203,9 +205,13 @@ export class SubagentTracker {
   }
 
   /**
-   * Clears all in-memory subagent tracking state.
+   * Clears all in-memory subagent tracking state and removes persisted messages.
    */
-  onSessionDeleted(): void {
+  onSessionDeleted(parentSessionId?: string): void {
+    // Clean up persisted messages for this parent session
+    if (parentSessionId && this.messageStore) {
+      this.messageStore.deleteByParentSession(parentSessionId);
+    }
     this.subagentSessionKeys.clear();
     this.subagentMessages.clear();
     this.subagentStatus.clear();
@@ -280,7 +286,11 @@ export class SubagentTracker {
       return local;
     }
 
-    // 2. Resolve session key from multiple sources
+    // 2. Try persisted messages from local database
+    const persisted = this.loadPersistedMessages(runId);
+    if (persisted) return persisted;
+
+    // 3. Resolve session key from multiple sources
     let key = sessionKey || this.subagentSessionKeys.get(runId);
 
     // Cache externally-provided session key in memory for later lookups
@@ -288,7 +298,7 @@ export class SubagentTracker {
       this.subagentSessionKeys.set(runId, sessionKey);
     }
 
-    // 2b. Try reading from persistent store if not in memory
+    // 3b. Try reading from persistent store if not in memory
     if (!key) {
       const runs = this.store.listSubagentRuns(parentSessionId);
       const matchingRun = runs.find((r) => r.id === runId || r.agentId === runId);
@@ -296,7 +306,7 @@ export class SubagentTracker {
         key = matchingRun.sessionKey;
         this.subagentSessionKeys.set(runId, key);
       }
-      // 2c. If runId didn't match directly, check if it's a UUID that appears in any session key
+      // 3c. If runId didn't match directly, check if it's a UUID that appears in any session key
       if (!key) {
         const runWithKeyMatch = runs.find((r) =>
           r.sessionKey && r.sessionKey.includes(runId),
@@ -554,6 +564,9 @@ export class SubagentTracker {
       // Cache locally
       this.subagentMessages.set(runId, messages);
 
+      // Persist to database for future instant loads
+      this.persistMessages(runId, messages);
+
       // Update status if we got messages and the session appears done
       if (messages.length > 0 && this.subagentStatus.get(runId) !== 'done') {
         this.subagentStatus.set(runId, 'done');
@@ -566,6 +579,54 @@ export class SubagentTracker {
     } catch (error) {
       console.warn('[SubagentTracker] Failed to fetch subagent history:', error);
       return [];
+    }
+  }
+
+  /**
+   * Load messages from the persisted subagent_messages table.
+   * Returns null if no persisted messages are found.
+   */
+  private loadPersistedMessages(runId: string): SubagentCoworkMessage[] | null {
+    if (!this.messageStore) return null;
+    if (!this.store.isMessagesPersisted(runId)) return null;
+
+    const rows = this.messageStore.getMessages(runId);
+    if (rows.length === 0) return null;
+
+    const messages: SubagentCoworkMessage[] = rows.map((row) => ({
+      id: row.id,
+      type: row.type as SubagentCoworkMessage['type'],
+      content: row.content,
+      timestamp: row.createdAt,
+      metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
+    }));
+
+    // Populate in-memory cache so subsequent reads skip the DB
+    this.subagentMessages.set(runId, messages);
+    return messages;
+  }
+
+  /**
+   * Persist fetched messages to local database for instant future reads.
+   */
+  private persistMessages(runId: string, messages: SubagentCoworkMessage[]): void {
+    if (!this.messageStore) return;
+    if (messages.length === 0) return;
+    if (this.store.isMessagesPersisted(runId)) return;
+
+    try {
+      this.messageStore.insertMessages(runId, messages.map((msg, idx) => ({
+        id: msg.id,
+        type: msg.type,
+        content: msg.content,
+        metadata: msg.metadata ?? null,
+        timestamp: msg.timestamp,
+        sequence: idx + 1,
+      })));
+      this.store.markMessagesPersisted(runId);
+      console.log('[SubagentTracker] persisted', messages.length, 'messages for runId:', runId);
+    } catch (error) {
+      console.warn('[SubagentTracker] Failed to persist messages for runId:', runId, error);
     }
   }
 }

--- a/src/main/libs/agentEngine/subagentTracker.ts
+++ b/src/main/libs/agentEngine/subagentTracker.ts
@@ -177,6 +177,8 @@ export class SubagentTracker {
       if (this.subagentStatus.get(tcId) === 'running') {
         this.subagentStatus.set(tcId, 'done');
         this.store.updateSubagentRunStatus(tcId, 'done', Date.now());
+        // Persist cached messages now that completion is confirmed
+        this.tryPersistCachedMessages(tcId);
       }
     }
   }
@@ -196,6 +198,8 @@ export class SubagentTracker {
           this.subagentStatus.set(toolCallId, 'done');
           this.store.updateSubagentRunStatus(toolCallId, 'done', Date.now());
           console.log('[SubagentTracker] marked subagent as done via announce:', toolCallId);
+          // Persist cached messages now that completion is confirmed
+          this.tryPersistCachedMessages(toolCallId);
         }
         return true;
       }
@@ -564,14 +568,13 @@ export class SubagentTracker {
       // Cache locally
       this.subagentMessages.set(runId, messages);
 
-      // Persist to database for future instant loads
-      this.persistMessages(runId, messages);
-
-      // Update status if we got messages and the session appears done
-      if (messages.length > 0 && this.subagentStatus.get(runId) !== 'done') {
-        this.subagentStatus.set(runId, 'done');
-        this.store.updateSubagentRunStatus(runId, 'done', Date.now());
-        console.log('[SubagentTracker] marked subagent as done via history fallback:', runId);
+      // Only persist to database if the subagent is confirmed done/error.
+      // If still running, the history may be incomplete — persist later when
+      // done is confirmed via announce/resume/read events.
+      const currentStatus = this.subagentStatus.get(runId)
+        || this.store.getRunStatus(runId);
+      if (currentStatus === 'done' || currentStatus === 'error') {
+        this.persistMessages(runId, messages);
       }
 
       console.log('[SubagentTracker] fetchSubagentHistory: extracted', messages.length, 'display messages for runId:', runId);
@@ -628,5 +631,17 @@ export class SubagentTracker {
     } catch (error) {
       console.warn('[SubagentTracker] Failed to persist messages for runId:', runId, error);
     }
+  }
+
+  /**
+   * When a subagent is confirmed done, clear stale in-memory cache so that the
+   * next getSubTaskHistory call fetches fresh complete data from the gateway.
+   * We do NOT persist the cached messages here because they may have been fetched
+   * while the subagent was still running (incomplete). Persistence will happen
+   * on the next getSubTaskHistory call which will see status=done and persist.
+   */
+  private tryPersistCachedMessages(runId: string): void {
+    // Clear potentially stale/incomplete cached messages
+    this.subagentMessages.delete(runId);
   }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -127,6 +127,7 @@ import { SkillManager } from './skillManager';
 import { getSkillServiceManager } from './skillServices';
 import { SqliteStore } from './sqliteStore';
 import { StartupProfiler } from './startupProfiler';
+import { SubagentMessageStore } from './subagentMessageStore';
 import { SubagentRunStore } from './subagentRunStore';
 import { createTray, destroyTray, updateTrayMenu } from './trayManager';
 import {
@@ -1578,7 +1579,7 @@ const getCoworkEngineRouter = () => {
     if (!openClawRuntimeAdapter) {
       openClawRuntimeAdapter = new OpenClawRuntimeAdapter(getCoworkStore(), getOpenClawEngineManager(), {
         normalizeModelRef: normalizeOpenClawModelRef,
-      }, new SubagentRunStore(getStore().getDatabase()));
+      }, new SubagentRunStore(getStore().getDatabase()), new SubagentMessageStore(getStore().getDatabase()));
       // Wire up channel session sync for IM conversations via OpenClaw
       try {
         const imManager = getIMGatewayManager();

--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -227,6 +227,34 @@ export class SqliteStore {
       ON subagent_runs(parent_session_id);
     `);
 
+    // Subagent messages table — stores fetched conversation history locally
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS subagent_messages (
+        id TEXT PRIMARY KEY,
+        run_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        content TEXT NOT NULL DEFAULT '',
+        metadata TEXT,
+        created_at INTEGER NOT NULL,
+        sequence INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_subagent_messages_run_id
+      ON subagent_messages(run_id);
+    `);
+
+    // Migration: add messages_persisted column to subagent_runs
+    try {
+      const subagentCols = this.db.pragma('table_info(subagent_runs)') as Array<{ name: string }>;
+      if (!subagentCols.some(c => c.name === 'messages_persisted')) {
+        this.db.exec('ALTER TABLE subagent_runs ADD COLUMN messages_persisted INTEGER NOT NULL DEFAULT 0;');
+        this.didRunMigration = true;
+      }
+    } catch {
+      // Migration not needed
+    }
+
     // Migration: add config column to user_plugins
     try {
       const pluginCols = this.db.pragma('table_info(user_plugins)') as Array<{ name: string }>;

--- a/src/main/subagentMessageStore.ts
+++ b/src/main/subagentMessageStore.ts
@@ -1,0 +1,96 @@
+import Database from 'better-sqlite3';
+
+export interface SubagentMessage {
+  id: string;
+  runId: string;
+  type: string;
+  content: string;
+  metadata: string | null;
+  createdAt: number;
+  sequence: number;
+}
+
+export class SubagentMessageStore {
+  private db: Database.Database;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+  }
+
+  /**
+   * Batch-insert messages for a subagent run.
+   * Uses a transaction for performance on larger message lists.
+   */
+  insertMessages(runId: string, messages: Array<{
+    id: string;
+    type: string;
+    content: string;
+    metadata?: Record<string, unknown> | null;
+    timestamp: number;
+    sequence: number;
+  }>): void {
+    if (messages.length === 0) return;
+
+    const stmt = this.db.prepare(
+      `INSERT OR IGNORE INTO subagent_messages (id, run_id, type, content, metadata, created_at, sequence)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    const insertAll = this.db.transaction(() => {
+      for (const msg of messages) {
+        stmt.run(
+          msg.id,
+          runId,
+          msg.type,
+          msg.content,
+          msg.metadata ? JSON.stringify(msg.metadata) : null,
+          msg.timestamp,
+          msg.sequence,
+        );
+      }
+    });
+    insertAll();
+  }
+
+  /**
+   * Read all messages for a subagent run, ordered by sequence.
+   */
+  getMessages(runId: string): SubagentMessage[] {
+    return this.db
+      .prepare('SELECT * FROM subagent_messages WHERE run_id = ? ORDER BY sequence ASC')
+      .all(runId) as SubagentMessage[];
+  }
+
+  /**
+   * Check if messages exist for a given run.
+   */
+  hasMessages(runId: string): boolean {
+    const row = this.db
+      .prepare('SELECT 1 FROM subagent_messages WHERE run_id = ? LIMIT 1')
+      .get(runId);
+    return row !== undefined;
+  }
+
+  /**
+   * Delete messages for specific runs (used when parent session is deleted).
+   */
+  deleteByRunIds(runIds: string[]): void {
+    if (runIds.length === 0) return;
+    const placeholders = runIds.map(() => '?').join(',');
+    this.db
+      .prepare(`DELETE FROM subagent_messages WHERE run_id IN (${placeholders})`)
+      .run(...runIds);
+  }
+
+  /**
+   * Delete all messages belonging to subagent runs of a parent session.
+   */
+  deleteByParentSession(parentSessionId: string): void {
+    this.db
+      .prepare(
+        `DELETE FROM subagent_messages WHERE run_id IN
+         (SELECT id FROM subagent_runs WHERE parent_session_id = ?)`,
+      )
+      .run(parentSessionId);
+  }
+}

--- a/src/main/subagentRunStore.ts
+++ b/src/main/subagentRunStore.ts
@@ -84,6 +84,18 @@ export class SubagentRunStore {
     }));
   }
 
+  markMessagesPersisted(id: string): void {
+    this.db.prepare('UPDATE subagent_runs SET messages_persisted = 1 WHERE id = ?')
+      .run(id);
+  }
+
+  isMessagesPersisted(id: string): boolean {
+    const row = this.db
+      .prepare('SELECT messages_persisted FROM subagent_runs WHERE id = ?')
+      .get(id) as { messages_persisted: number } | undefined;
+    return row?.messages_persisted === 1;
+  }
+
   deleteSubagentRunsByParent(parentSessionId: string): void {
     this.db.prepare('DELETE FROM subagent_runs WHERE parent_session_id = ?')
       .run(parentSessionId);

--- a/src/main/subagentRunStore.ts
+++ b/src/main/subagentRunStore.ts
@@ -96,6 +96,13 @@ export class SubagentRunStore {
     return row?.messages_persisted === 1;
   }
 
+  getRunStatus(id: string): SubagentRunStatus | null {
+    const row = this.db
+      .prepare('SELECT status FROM subagent_runs WHERE id = ?')
+      .get(id) as { status: string } | undefined;
+    return (row?.status as SubagentRunStatus) ?? null;
+  }
+
   deleteSubagentRunsByParent(parentSessionId: string): void {
     this.db.prepare('DELETE FROM subagent_runs WHERE parent_session_id = ?')
       .run(parentSessionId);


### PR DESCRIPTION
## Summary
- Subagent session messages are now persisted to a dedicated `subagent_messages` SQLite table after first gateway fetch
- Subsequent views load instantly from local DB without network RPC
- Existing old subagent sessions get backfilled on first click (lazy persist)
- Independent table avoids impacting main session storage (safe for version rollback)

## Changes
- New `SubagentMessageStore` class with batch insert / read / cascade delete
- DB migration: `subagent_messages` table + `messages_persisted` column on `subagent_runs`
- `SubagentTracker.getSubTaskHistory()` now checks local DB before falling back to gateway RPC
- Cascade cleanup when parent session is deleted

## Test plan
- [ ] Open a completed subagent session detail — first load fetches from gateway, subsequent loads instant
- [ ] Restart app, re-open the same subagent detail — no loading spinner
- [ ] Delete a parent session — verify subagent messages are cleaned up
- [ ] Old subagent sessions (pre-patch) still viewable via lazy backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)