### PR TITLE
fix: preserve selected skills when switching model

### DIFF
--- a/src/renderer/services/agent.test.ts
+++ b/src/renderer/services/agent.test.ts
@@ -67,6 +67,38 @@ describe('agentService.updateAgent', () => {
     expect(store.getState().skill.activeSkillIds).toEqual(['docx', 'web-search']);
   });
 
+  test('does not clear active skills when only model is updated', async () => {
+    store.dispatch(setAgents([{
+      id: 'agent-1',
+      name: 'Agent 1',
+      description: '',
+      icon: '',
+      model: '',
+      workingDirectory: '',
+      enabled: true,
+      pinned: false,
+      pinOrder: null,
+      isDefault: false,
+      source: 'custom',
+      skillIds: [],
+    }]));
+    store.dispatch(setCurrentAgentId('agent-1'));
+    store.dispatch(setActiveSkillIds(['user-selected-skill']));
+
+    (globalThis as { window?: unknown }).window = {
+      electron: {
+        agents: {
+          update: vi.fn().mockResolvedValue(makeAgent({ model: 'new-model', skillIds: [] })),
+        },
+      },
+    };
+
+    await agentService.updateAgent('agent-1', { model: 'new-model' });
+
+    // Active skills should remain untouched since skillIds was not in the update
+    expect(store.getState().skill.activeSkillIds).toEqual(['user-selected-skill']);
+  });
+
   test('does not replace active skills when another agent is saved', async () => {
     store.dispatch(setAgents([{
       id: 'agent-1',

--- a/src/renderer/services/agent.ts
+++ b/src/renderer/services/agent.ts
@@ -121,7 +121,12 @@ class AgentService {
             skillIds,
           },
         }));
-        syncActiveSkillsForCurrentAgent(agent.id, skillIds);
+        // Only sync active skills when skillIds were explicitly updated,
+        // to avoid clearing user's temporary skill selection on unrelated
+        // updates (e.g. model change).
+        if ('skillIds' in updates) {
+          syncActiveSkillsForCurrentAgent(agent.id, skillIds);
+        }
         return agent;
       }
       return null;


### PR DESCRIPTION
## Summary
- 修复切换模型后用户临时选中的 skill 被清除的问题
- 根因：`agentService.updateAgent()` 无条件调用 `syncActiveSkillsForCurrentAgent()`，model-only 更新时会用 agent 配置的空 `skillIds` 覆盖用户选择
- 修复：仅当 `updates` 中显式包含 `skillIds` 字段时才同步 active skills

## Test plan
- [x] 新增单元测试：验证 model-only 更新不清除 active skills
- [x] 已有测试通过（skillIds 更新仍正常同步）
- [ ] 手动验证：选择 skill → 切换模型 → skill 仍选中

🤖 Generated with [Claude Code](https://claude.com/claude-code)