### PR TITLE
fix: hide provider and alias plugins from sync detection

### DIFF
--- a/src/main/libs/pluginManager.ts
+++ b/src/main/libs/pluginManager.ts
@@ -733,18 +733,50 @@ export class PluginManager {
 
 /** Plugins that should never appear in the user-managed plugin list. */
 const INTERNAL_PLUGIN_IDS = [
+  // Core internal plugins
   'ask-user-question',
   'memory-core',
   'qwen-portal-auth',
   'qqbot',
   'acpx',
-  'minimax',
   'browser',
-  'qwen',
-  'zai',
-  'qianfan',
-  'volcengine',
+
+  // Provider plugins auto-injected by OpenClaw runtime — not user-installable.
+  // Keep in sync with OpenClawProviderId in src/shared/providers/constants.ts.
+  'google',
+  'anthropic',
+  'openai',
+  'openai-codex',
   'deepseek',
+  'moonshot',
+  'minimax',
+  'volcengine',
+  'qianfan',
+  'qwen',
+  'qwen-portal',
+  'zai',
+  'youdaozhiyun',
+  'stepfun',
+  'xiaomi',
+  'openrouter',
+  'ollama',
+  'lm-studio',
+  'lobsterai-server',
+  'github-copilot',
+  'lobsterai-copilot',
+  'lobster',
+
+  // Aliases / legacy IDs for preinstalled channel plugins.
+  // The canonical IDs are in package.json openclaw.plugins and get hidden
+  // via readPreinstalledPluginIdsFromPackageJson(); these are alt names that
+  // may appear in openclaw.json entries on some installations.
+  'dingtalk',
+  'feishu',
+  'feishu-openclaw-plugin',
+  'openclaw-nim',
+  'nim',
+  'nimsuite-openclaw-nim-channel',
+  'email',
 ];
 
 /** Read preinstalled plugin IDs from package.json openclaw.plugins field. */


### PR DESCRIPTION
## Summary
- Expanded `INTERNAL_PLUGIN_IDS` in `pluginManager.ts` to include all OpenClaw provider plugin IDs (google, anthropic, openai, moonshot, openrouter, xiaomi, deepseek, volcengine, etc.) and preinstalled channel plugin aliases (feishu-openclaw-plugin, openclaw-nim, dingtalk, etc.)
- These entries are auto-injected into `openclaw.json` by the runtime but have no actual install directory — they were incorrectly surfaced as "syncable plugins" in the UI

## Test plan
- [ ] Verify that provider plugins (google, anthropic, openai, moonshot, openrouter, xiaomi) no longer appear in the sync dialog
- [ ] Verify that alias plugins (feishu-openclaw-plugin, openclaw-nim) no longer appear
- [ ] Verify that legitimately user-installed third-party plugins still sync correctly