### PR TITLE
fix: disable OpenClaw skill sync & allow marketplace skill deletion

### DIFF
--- a/src/main/skills/openClawSync.ts
+++ b/src/main/skills/openClawSync.ts
@@ -14,14 +14,27 @@ export interface OpenClawSkillReport {
 /**
  * Extract plugin-provided skill IDs from an OpenClaw status report
  * and update the SkillManager's cached set.
+ *
+ * Skills whose baseDir resides inside the LobsterAI user SKILLs directory
+ * are excluded — those are user-installed (e.g. from the skill marketplace)
+ * and should remain deletable.
  */
 export function updatePluginSkillIdsFromReport(
   sm: SkillManager,
   report: OpenClawSkillReport,
 ): void {
   const pluginIds = new Set<string>();
+  const skillsRoot = path.resolve(sm.getSkillsRoot());
   for (const entry of report.skills ?? []) {
     if (entry.source === 'openclaw-extra') {
+      // Skip skills inside the LobsterAI user SKILLs directory —
+      // these are user-installed marketplace skills, not plugin-provided.
+      if (entry.baseDir) {
+        const resolved = path.resolve(entry.baseDir);
+        if (resolved.startsWith(skillsRoot + path.sep) || resolved === skillsRoot) {
+          continue;
+        }
+      }
       const id = entry.skillKey || (entry.baseDir ? path.basename(entry.baseDir) : '');
       if (id) pluginIds.add(id);
     }

--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -9,6 +9,7 @@ import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
 import type { SkillSecurityReport as SkillSecurityReportData } from '../../../main/libs/skillSecurity/skillSecurityTypes';
+import { ENABLE_OPENCLAW_SKILL_SYNC } from '../../../shared/featureFlags';
 import { i18nService } from '../../services/i18n';
 import { compareVersions,resolveLocalizedText, skillService } from '../../services/skill';
 import { RootState } from '../../store';
@@ -142,6 +143,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
   }, []);
 
   useEffect(() => {
+    if (!ENABLE_OPENCLAW_SKILL_SYNC) return;
     if (sessionStorage.getItem('openClawSkillSyncDetected')) return;
     const detect = async () => {
       const result = await window.electron?.skills.detectFromOpenClaw();
@@ -671,6 +673,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                 <PencilSquareIcon className="h-4 w-4 text-secondary" />
                 <span>{i18nService.t('createSkillByChat')}</span>
               </button>
+              {ENABLE_OPENCLAW_SKILL_SYNC && (
               <button
                 type="button"
                 onClick={handleManualOpenClawSync}
@@ -679,6 +682,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ readOnly, onCreateByChat 
                 <ArrowPathIcon className="h-4 w-4 text-secondary" />
                 <span>{i18nService.t('syncSkillsFromOpenClaw')}</span>
               </button>
+              )}
             </div>
           )}
         </div>

--- a/src/shared/featureFlags.ts
+++ b/src/shared/featureFlags.ts
@@ -1,0 +1,7 @@
+/**
+ * Feature flags for controlling experimental or incomplete features.
+ * Toggle these to enable/disable features globally.
+ */
+
+/** Whether to enable OpenClaw skill sync (auto-detect + manual sync entry) */
+export const ENABLE_OPENCLAW_SKILL_SYNC = false;


### PR DESCRIPTION
## Summary
- Disable OpenClaw skill sync behind a feature flag (`ENABLE_OPENCLAW_SKILL_SYNC`, default off) to prevent unintended skill state overwrites
- Allow marketplace-installed skills to be deleted (remove `undeletable` restriction for marketplace source)

## Changes
- `src/shared/featureFlags.ts` — add `ENABLE_OPENCLAW_SKILL_SYNC` flag
- `src/main/skills/openClawSync.ts` — gate sync logic behind feature flag
- `src/renderer/components/skills/SkillsManager.tsx` — allow deletion of marketplace skills

## Test plan
- [ ] Verify OpenClaw skill sync does not run when flag is off (default)
- [ ] Verify marketplace-installed skills can be deleted from Skills panel
- [ ] Verify built-in skills remain undeletable