### PR TITLE
fix: dev mode OAuth protocol handler registration on Windows

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2650,7 +2650,15 @@ if (!gotTheLock) {
   app.quit();
 } else {
   // Register custom protocol for OAuth callback
-  app.setAsDefaultProtocolClient('lobsterai');
+  if (!app.isPackaged) {
+    // In dev mode, setAsDefaultProtocolClient needs the electron exe path
+    // and the app entry point as extra args so the OS can relaunch correctly
+    app.setAsDefaultProtocolClient('lobsterai', process.execPath, [
+      path.resolve(process.argv[1]),
+    ]);
+  } else {
+    app.setAsDefaultProtocolClient('lobsterai');
+  }
 
   // Buffer for deep link auth code received before renderer is ready
   let pendingAuthCode: string | null = null;


### PR DESCRIPTION
## Summary
- Fix OAuth login callback error in Windows dev mode where the callback URL was treated as a file path instead of a deep link
- Pass `process.execPath` and app entry script path to `setAsDefaultProtocolClient` when `!app.isPackaged`
- No impact on macOS or production builds

## Test plan
- [ ] Run app in dev mode on Windows, trigger OAuth login, verify callback is handled correctly
- [ ] Verify production build login flow is unaffected