### PR TITLE
fix(agent): 使用短 UUID 替代名称生成 Agent ID

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -1935,21 +1935,14 @@ export class CoworkStore {
   }
 
   createAgent(request: CreateAgentRequest): Agent {
-    const id =
-      request.id ||
-      request.name
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, '') ||
-      uuidv4();
-    const now = Date.now();
+    // Generate a short unique ID using first 8 chars of UUID v4
+    const generateShortId = (): string => {
+      const shortId = uuidv4().split('-')[0];
+      return this.getAgent(shortId) ? generateShortId() : shortId;
+    };
 
-    // Ensure no duplicate ID
-    const existing = this.getAgent(id);
-    if (existing) {
-      // Append timestamp to make unique
-      return this.createAgent({ ...request, id: `${id}-${Date.now()}` });
-    }
+    const id = request.id || generateShortId();
+    const now = Date.now();
 
     this.db
       .prepare(


### PR DESCRIPTION
## 问题背景
当前 Agent ID 基于名称生成（如 "My Assistant" → "my-assistant"），存在以下问题：
**数据复活问题**：删除 Agent 后，本地文件（workspace、sessions）未清理，重新创建同名 Agent 时会复用相同 ID，导致旧数据意外复活。

### 删除 Agent 时的遗漏问题（待后续修复）
当前删除 Agent 时存在以下数据未清理的问题：
| 数据 | 当前状态 | 影响 |
|------|---------|------|
| `cowork_sessions`（关联的会话） | ❌ 未清理 | 孤儿会话无法在 UI 显示 |
| `cowork_messages`（关联的消息） | ❌ 未清理 | 数据库空间浪费 |
| `im_session_mappings`（IM 映射） | ❌ 未清理 | 孤儿映射记录 |
| 定时任务（agentId 匹配的任务） | ❌ 未处理 | 任务继续执行但结果无处显示 |
| OpenClaw workspace 目录 | ❌ 未清理 | 磁盘空间浪费、数据复活风险 |
| OpenClaw sessions 目录 | ❌ 未清理 | 磁盘空间浪费 |

本次 PR 通过使用随机 ID 解决**数据复活**的核心问题，上述清理逻辑作为后续优化项。
## 解决方案
使用 UUID v4 前 8 位作为 Agent ID（如 `550e8400`）：

- 每次创建 Agent 生成唯一随机 ID
- 碰撞时自动重试（实际碰撞概率极低：43 亿种可能）
- 保持向后兼容：如果调用方显式传入 `request.id`，仍使用传入值

## 改动内容
- `src/main/coworkStore.ts`：修改 `createAgent` 方法的 ID 生成逻辑
- 
<img width="275" height="308" alt="image" src="https://github.com/user-attachments/assets/9eb154f6-fa32-4111-858c-7010733f0f94" />
