### PR TITLE
fix(mcp): kill stdio process trees and share runtime across sessions

### DIFF
--- a/scripts/patches/v2026.4.14/openclaw-mcp-shared-runtime.patch
+++ b/scripts/patches/v2026.4.14/openclaw-mcp-shared-runtime.patch
@@ -1,0 +1,218 @@
+diff --git a/src/agents/pi-bundle-mcp-runtime.ts b/src/agents/pi-bundle-mcp-runtime.ts
+index dcf116f7e4..745bce4643 100644
+--- a/src/agents/pi-bundle-mcp-runtime.ts
++++ b/src/agents/pi-bundle-mcp-runtime.ts
+@@ -289,17 +289,51 @@ export function createSessionMcpRuntime(params: {
+   };
+ }
+ 
++/**
++ * LobsterAI patch: shared MCP runtime keyed by config fingerprint.
++ *
++ * PROBLEM: The original manager creates one MCP runtime (= one set of stdio
++ * child processes) per sessionId.  LobsterAI desktop creates a unique gateway
++ * session key per conversation, so every new conversation spawns N new node
++ * processes that are never cleaned up.
++ *
++ * FIX: Key runtimes by config fingerprint instead of sessionId.  Sessions with
++ * identical MCP config share a single runtime instance.  Reference counting
++ * tracks which sessions use each runtime; processes are only disposed when the
++ * last reference is removed.
++ *
++ * REMOVABLE: once openclaw runtime >= v2026.4.22 with native idle eviction.
++ */
+ function createSessionMcpRuntimeManager(): SessionMcpRuntimeManager {
+-  const runtimesBySessionId = new Map<string, SessionMcpRuntime>();
++  const runtimesByFingerprint = new Map<string, SessionMcpRuntime>();
++  const refsByFingerprint = new Map<string, Set<string>>();
++  const fingerprintBySessionId = new Map<string, string>();
+   const sessionIdBySessionKey = new Map<string, string>();
+-  const createInFlight = new Map<
+-    string,
+-    {
+-      promise: Promise<SessionMcpRuntime>;
+-      workspaceDir: string;
+-      configFingerprint: string;
++  const createInFlight = new Map<string, Promise<SessionMcpRuntime>>();
++
++  function addRef(fingerprint: string, sessionId: string): void {
++    let refs = refsByFingerprint.get(fingerprint);
++    if (!refs) {
++      refs = new Set();
++      refsByFingerprint.set(fingerprint, refs);
+     }
+-  >();
++    refs.add(sessionId);
++    fingerprintBySessionId.set(sessionId, fingerprint);
++  }
++
++  function removeRef(fingerprint: string, sessionId: string): boolean {
++    const refs = refsByFingerprint.get(fingerprint);
++    if (refs) {
++      refs.delete(sessionId);
++      if (refs.size === 0) {
++        refsByFingerprint.delete(fingerprint);
++        fingerprintBySessionId.delete(sessionId);
++        return true;
++      }
++    }
++    fingerprintBySessionId.delete(sessionId);
++    return false;
++  }
+ 
+   return {
+     async getOrCreate(params) {
+@@ -311,53 +345,53 @@ function createSessionMcpRuntimeManager(): SessionMcpRuntimeManager {
+         cfg: params.cfg,
+         logDiagnostics: false,
+       });
+-      const existing = runtimesBySessionId.get(params.sessionId);
+-      if (existing) {
+-        if (
+-          existing.workspaceDir !== params.workspaceDir ||
+-          existing.configFingerprint !== nextFingerprint
+-        ) {
+-          runtimesBySessionId.delete(params.sessionId);
+-          await existing.dispose();
+-        } else {
+-          existing.markUsed();
+-          return existing;
++
++      // If this session previously used a different fingerprint, unref the old one.
++      const prevFingerprint = fingerprintBySessionId.get(params.sessionId);
++      if (prevFingerprint && prevFingerprint !== nextFingerprint) {
++        const isLast = removeRef(prevFingerprint, params.sessionId);
++        if (isLast) {
++          const stale = runtimesByFingerprint.get(prevFingerprint);
++          runtimesByFingerprint.delete(prevFingerprint);
++          await stale?.dispose();
+         }
+       }
+-      const inFlight = createInFlight.get(params.sessionId);
+-      if (inFlight) {
+-        if (
+-          inFlight.workspaceDir === params.workspaceDir &&
+-          inFlight.configFingerprint === nextFingerprint
+-        ) {
+-          return inFlight.promise;
+-        }
+-        createInFlight.delete(params.sessionId);
+-        const staleRuntime = await inFlight.promise.catch(() => undefined);
+-        runtimesBySessionId.delete(params.sessionId);
+-        await staleRuntime?.dispose();
++
++      // Return existing shared runtime if fingerprint matches.
++      const shared = runtimesByFingerprint.get(nextFingerprint);
++      if (shared) {
++        addRef(nextFingerprint, params.sessionId);
++        shared.markUsed();
++        return shared;
+       }
+-      const created = Promise.resolve(
+-        createSessionMcpRuntime({
+-          sessionId: params.sessionId,
+-          sessionKey: params.sessionKey,
+-          workspaceDir: params.workspaceDir,
+-          cfg: params.cfg,
+-        }),
+-      ).then((runtime) => {
++
++      // Deduplicate concurrent creation for the same fingerprint.
++      const inFlight = createInFlight.get(nextFingerprint);
++      if (inFlight) {
++        const runtime = await inFlight;
++        addRef(nextFingerprint, params.sessionId);
+         runtime.markUsed();
+-        runtimesBySessionId.set(params.sessionId, runtime);
+         return runtime;
+-      });
+-      createInFlight.set(params.sessionId, {
+-        promise: created,
++      }
++
++      // Create new shared runtime.
++      const created = Promise.resolve(createSessionMcpRuntime({
++        sessionId: params.sessionId,
++        sessionKey: params.sessionKey,
+         workspaceDir: params.workspaceDir,
+-        configFingerprint: nextFingerprint,
++        cfg: params.cfg,
++      })).then((runtime) => {
++        runtimesByFingerprint.set(nextFingerprint, runtime);
++        runtime.markUsed();
++        return runtime;
+       });
++      createInFlight.set(nextFingerprint, created);
+       try {
+-        return await created;
++        const runtime = await created;
++        addRef(nextFingerprint, params.sessionId);
++        return runtime;
+       } finally {
+-        createInFlight.delete(params.sessionId);
++        createInFlight.delete(nextFingerprint);
+       }
+     },
+     bindSessionKey(sessionKey, sessionId) {
+@@ -367,36 +401,32 @@ function createSessionMcpRuntimeManager(): SessionMcpRuntimeManager {
+       return sessionIdBySessionKey.get(sessionKey);
+     },
+     async disposeSession(sessionId) {
+-      const inFlight = createInFlight.get(sessionId);
+-      createInFlight.delete(sessionId);
+-      let runtime = runtimesBySessionId.get(sessionId);
+-      if (!runtime && inFlight) {
+-        runtime = await inFlight.promise.catch(() => undefined);
+-      }
+-      runtimesBySessionId.delete(sessionId);
+-      if (!runtime) {
+-        for (const [sessionKey, mappedSessionId] of sessionIdBySessionKey.entries()) {
+-          if (mappedSessionId === sessionId) {
+-            sessionIdBySessionKey.delete(sessionKey);
+-          }
+-        }
+-        return;
+-      }
++      const fingerprint = fingerprintBySessionId.get(sessionId);
+       for (const [sessionKey, mappedSessionId] of sessionIdBySessionKey.entries()) {
+         if (mappedSessionId === sessionId) {
+           sessionIdBySessionKey.delete(sessionKey);
+         }
+       }
+-      await runtime.dispose();
++      if (!fingerprint) {
++        return;
++      }
++      const isLast = removeRef(fingerprint, sessionId);
++      if (isLast) {
++        const runtime = runtimesByFingerprint.get(fingerprint);
++        runtimesByFingerprint.delete(fingerprint);
++        await runtime?.dispose();
++      }
+     },
+     async disposeAll() {
+-      const inFlightRuntimes = Array.from(createInFlight.values());
++      const inFlightPromises = Array.from(createInFlight.values());
+       createInFlight.clear();
+-      const runtimes = Array.from(runtimesBySessionId.values());
+-      runtimesBySessionId.clear();
++      const runtimes = Array.from(runtimesByFingerprint.values());
++      runtimesByFingerprint.clear();
++      refsByFingerprint.clear();
++      fingerprintBySessionId.clear();
+       sessionIdBySessionKey.clear();
+       const lateRuntimes = await Promise.all(
+-        inFlightRuntimes.map(async ({ promise }) => await promise.catch(() => undefined)),
++        inFlightPromises.map(async (promise) => await promise.catch(() => undefined)),
+       );
+       const allRuntimes = new Set<SessionMcpRuntime>(runtimes);
+       for (const runtime of lateRuntimes) {
+@@ -407,7 +437,7 @@ function createSessionMcpRuntimeManager(): SessionMcpRuntimeManager {
+       await Promise.allSettled(Array.from(allRuntimes, (runtime) => runtime.dispose()));
+     },
+     listSessionIds() {
+-      return Array.from(runtimesBySessionId.keys());
++      return Array.from(fingerprintBySessionId.keys());
+     },
+   };
+ }

--- a/scripts/patches/v2026.4.14/openclaw-mcp-stdio-process-tree-kill.patch
+++ b/scripts/patches/v2026.4.14/openclaw-mcp-stdio-process-tree-kill.patch
@@ -1,0 +1,195 @@
+diff --git a/src/agents/mcp-stdio-transport.ts b/src/agents/mcp-stdio-transport.ts
+new file mode 100644
+index 0000000000..00049eb73a
+--- /dev/null
++++ b/src/agents/mcp-stdio-transport.ts
+@@ -0,0 +1,153 @@
++/**
++ * LobsterAI patch: custom stdio MCP transport with process-tree cleanup.
++ *
++ * Backported from openclaw v2026.4.22 (commit 5f7b44045d).
++ * The MCP SDK's built-in StdioClientTransport.close() uses process.kill()
++ * which on Windows only terminates the direct child process, leaving
++ * grandchild processes (e.g. node.exe spawned via cmd.exe) as orphans.
++ *
++ * This custom transport uses killProcessTree() which calls taskkill /T /PID
++ * on Windows, correctly terminating the entire process tree.
++ *
++ * REMOVABLE: delete this file once openclaw runtime is upgraded to >= v2026.4.22.
++ */
++import { spawn, type ChildProcess } from "node:child_process";
++import process from "node:process";
++import { PassThrough } from "node:stream";
++import { getDefaultEnvironment } from "@modelcontextprotocol/sdk/client/stdio.js";
++import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
++import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
++import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
++import { killProcessTree } from "../process/kill-tree.js";
++
++export type OpenClawStdioServerParameters = {
++  command: string;
++  args?: string[];
++  env?: Record<string, string>;
++  cwd?: string;
++  stderr?: "pipe" | "overlapped" | "inherit" | "ignore";
++};
++
++const CLOSE_TIMEOUT_MS = 2000;
++
++function delay(ms: number) {
++  return new Promise<void>((resolve) => {
++    setTimeout(resolve, ms).unref();
++  });
++}
++
++export class OpenClawStdioClientTransport implements Transport {
++  onclose?: () => void;
++  onerror?: (error: Error) => void;
++  onmessage?: (message: JSONRPCMessage) => void;
++
++  private readonly readBuffer = new ReadBuffer();
++  private readonly stderrStream: PassThrough | null = null;
++  private process?: ChildProcess;
++
++  constructor(private readonly serverParams: OpenClawStdioServerParameters) {
++    if (serverParams.stderr === "pipe" || serverParams.stderr === "overlapped") {
++      this.stderrStream = new PassThrough();
++    }
++  }
++
++  async start(): Promise<void> {
++    if (this.process) {
++      throw new Error(
++        "OpenClawStdioClientTransport already started; Client.connect() starts transports automatically.",
++      );
++    }
++
++    await new Promise<void>((resolve, reject) => {
++      const child = spawn(this.serverParams.command, this.serverParams.args ?? [], {
++        cwd: this.serverParams.cwd,
++        detached: process.platform !== "win32",
++        env: {
++          ...getDefaultEnvironment(),
++          ...this.serverParams.env,
++        },
++        shell: false,
++        stdio: ["pipe", "pipe", this.serverParams.stderr ?? "inherit"],
++        windowsHide: process.platform === "win32",
++      });
++      this.process = child;
++
++      child.on("error", (error: Error) => {
++        reject(error);
++        this.onerror?.(error);
++      });
++      child.on("spawn", () => resolve());
++      child.on("close", () => {
++        this.process = undefined;
++        this.onclose?.();
++      });
++      child.stdin?.on("error", (error: Error) => this.onerror?.(error));
++      child.stdout?.on("data", (chunk: Buffer) => {
++        this.readBuffer.append(chunk);
++        this.processReadBuffer();
++      });
++      child.stdout?.on("error", (error: Error) => this.onerror?.(error));
++      if (this.stderrStream && child.stderr) {
++        child.stderr.pipe(this.stderrStream);
++      }
++    });
++  }
++
++  get stderr() {
++    return this.stderrStream ?? this.process?.stderr ?? null;
++  }
++
++  get pid() {
++    return this.process?.pid ?? null;
++  }
++
++  private processReadBuffer() {
++    while (true) {
++      try {
++        const message = this.readBuffer.readMessage();
++        if (message === null) {
++          break;
++        }
++        this.onmessage?.(message);
++      } catch (error) {
++        this.onerror?.(error instanceof Error ? error : new Error(String(error)));
++      }
++    }
++  }
++
++  async close(): Promise<void> {
++    const processToClose = this.process;
++    this.process = undefined;
++    if (processToClose) {
++      const closePromise = new Promise<void>((resolve) => {
++        processToClose.once("close", () => resolve());
++      });
++      try {
++        processToClose.stdin?.end();
++      } catch {
++        // best-effort
++      }
++      await Promise.race([closePromise, delay(CLOSE_TIMEOUT_MS)]);
++      if (processToClose.exitCode === null && processToClose.pid) {
++        killProcessTree(processToClose.pid);
++        await Promise.race([closePromise, delay(CLOSE_TIMEOUT_MS)]);
++      }
++    }
++    this.readBuffer.clear();
++  }
++
++  send(message: JSONRPCMessage): Promise<void> {
++    return new Promise((resolve) => {
++      const stdin = this.process?.stdin;
++      if (!stdin) {
++        throw new Error("Not connected");
++      }
++      const json = serializeMessage(message);
++      if (stdin.write(json)) {
++        resolve();
++      } else {
++        stdin.once("drain", resolve);
++      }
++    });
++  }
++}
+diff --git a/src/agents/mcp-transport.ts b/src/agents/mcp-transport.ts
+index 6c35f9710d..2429284d7f 100644
+--- a/src/agents/mcp-transport.ts
++++ b/src/agents/mcp-transport.ts
+@@ -2,12 +2,12 @@ import {
+   SSEClientTransport,
+   type SSEClientTransportOptions,
+ } from "@modelcontextprotocol/sdk/client/sse.js";
+-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+ import type { FetchLike, Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+ import { loadUndiciRuntimeDeps } from "../infra/net/undici-runtime.js";
+ import { logDebug } from "../logger.js";
+ import { normalizeOptionalString } from "../shared/string-coerce.js";
++import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
+ import { resolveMcpTransportConfig } from "./mcp-transport-config.js";
+ 
+ export type ResolvedMcpTransport = {
+@@ -18,7 +18,7 @@ export type ResolvedMcpTransport = {
+   detachStderr?: () => void;
+ };
+ 
+-function attachStderrLogging(serverName: string, transport: StdioClientTransport) {
++function attachStderrLogging(serverName: string, transport: OpenClawStdioClientTransport) {
+   const stderr = transport.stderr;
+   if (!stderr || typeof stderr.on !== "function") {
+     return undefined;
+@@ -84,7 +84,7 @@ export function resolveMcpTransport(
+     return null;
+   }
+   if (resolved.kind === "stdio") {
+-    const transport = new StdioClientTransport({
++    const transport = new OpenClawStdioClientTransport({
+       command: resolved.command,
+       args: resolved.args,
+       env: resolved.env,

--- a/specs/bugfixes/mcp-stdio-process-leak/2026-05-28-mcp-shared-runtime-design.md
+++ b/specs/bugfixes/mcp-stdio-process-leak/2026-05-28-mcp-shared-runtime-design.md
@@ -1,0 +1,134 @@
+# MCP stdio 进程泄漏修复设计文档
+
+## 1. 概述
+
+### 1.1 问题
+
+LobsterAI 桌面端运行期间，Node.js 进程不断增殖。每新建一个对话（无论是否用到 MCP 工具），都会额外产生 N 个 Node.js 子进程（N = 已配置的 stdio MCP server 数量）。这些进程永远不会被释放，直到用户退出应用。
+
+典型表现：配置 3 个 MCP server，开 5 个对话 → 任务管理器中出现 15 个 Node.js 进程。
+
+### 1.2 根因
+
+OpenClaw 的 `SessionMcpRuntimeManager` 以 **sessionId** 为 key 管理 MCP 连接。每个 session 拥有独立的 stdio 子进程组。
+
+LobsterAI 桌面端每个对话对应一个**独立的 gateway session key**（`agent:{agentId}:lobsterai:{uuid}`），新建对话 = 新 sessionId = 新 MCP 进程。
+
+释放路径的缺陷：
+
+| 路径 | 是否触发释放 | 原因 |
+|------|---|---|
+| Run 结束（`cleanupBundleMcpOnRunEnd`） | 否 | Gateway 模式下为 `false`，设计意图是同 session 内复用 |
+| `sessions.delete` / `sessions.reset` | 否 | `ensureSessionRuntimeCleanup` 未调用 `disposeSessionMcpRuntime` |
+| Session freshness 过期自动 rollover | 否 | 仅在 auto-reply 路径（IM 渠道）生效，desktop gateway RPC 路径不走此逻辑 |
+| 用户手动删除对话 | 否 | `onSessionDeleted` 只清理 LobsterAI 侧状态，不通知 gateway |
+
+结论：对于 LobsterAI 桌面端的 gateway 模式，**不存在任何有效的 MCP 进程释放路径**。
+
+### 1.3 上游关联
+
+openclaw/openclaw 仓库中的相关 issue：
+- #70364 — MCP child process leak: sessions_send via gateway never calls disposeSessionMcpRuntime
+- #70808 — Gateway never disposes stdio MCP runtimes on session end
+- #82830 — MCP stdio server processes leak on Windows (fix in v2026.4.22+)
+
+当前 runtime 版本 v2026.4.14 未包含修复。
+
+## 2. 用户场景
+
+### 场景 1: 正常多对话使用
+**Given** 用户配置了 3 个 MCP server（Context7, mcp-19a3c673, Playwright）
+**When** 用户在一次使用中依次新建 5 个对话（无论对话内容是否涉及 MCP）
+**Then** 只应有 3 个 MCP 相关 Node.js 进程存在（全局共享），而非 15 个
+
+### 场景 2: MCP 配置变更
+**Given** 用户在设置中新增了一个 MCP server
+**When** 下一个对话开始时
+**Then** 旧的 3 个进程被释放，新的 4 个进程启动（配置指纹变化触发重建）
+
+### 场景 3: 回到旧对话继续
+**Given** 用户 10 分钟前创建了对话 A，之后创建了对话 B
+**When** 用户切回对话 A 继续提问
+**Then** 直接复用全局共享的 MCP 连接，无任何延迟或进程增加
+
+## 3. 功能需求
+
+### FR-1: 按配置指纹共享 MCP runtime
+
+相同 MCP 配置（config fingerprint 相同）的所有 session 共享同一个 runtime 实例及其 stdio 子进程。
+
+### FR-2: 引用计数管理生命周期
+
+runtime 实例通过引用计数关联到使用它的 session。只有当最后一个 session 释放引用时，才真正 dispose runtime（关闭连接、杀进程）。
+
+### FR-3: 配置变更自动迁移
+
+当 session 检测到 fingerprint 变化时（MCP server 增删改），自动从旧 runtime 解引用，关联到新 runtime。旧 runtime 在引用归零后销毁。
+
+### FR-4: 保持接口兼容
+
+`SessionMcpRuntimeManager` 的对外接口（`getOrCreate`, `disposeSession`, `disposeAll`, `listSessionIds`）保持不变，外部调用者无需修改。
+
+## 4. 实现方案
+
+### 4.1 改动范围
+
+仅修改 `src/agents/pi-bundle-mcp-runtime.ts` 中的 `createSessionMcpRuntimeManager()` 函数内部实现。
+
+### 4.2 数据结构替换
+
+```
+// 旧
+runtimesBySessionId: Map<sessionId, SessionMcpRuntime>
+createInFlight: Map<sessionId, {promise, workspaceDir, configFingerprint}>
+
+// 新
+runtimesByFingerprint: Map<fingerprint, SessionMcpRuntime>
+refsByFingerprint: Map<fingerprint, Set<sessionId>>
+fingerprintBySessionId: Map<sessionId, fingerprint>
+createInFlight: Map<fingerprint, Promise<SessionMcpRuntime>>
+```
+
+### 4.3 核心逻辑
+
+**getOrCreate:**
+1. 计算当前 fingerprint
+2. 如果该 session 之前关联了不同 fingerprint → 解引用旧的（引用归零则 dispose）
+3. 查 `runtimesByFingerprint[fingerprint]` → 命中则 addRef + markUsed + return
+4. 查 `createInFlight[fingerprint]` → 命中则 await + addRef + return
+5. 创建新 runtime → 存入 `runtimesByFingerprint` → addRef → return
+
+**disposeSession:**
+1. 查 `fingerprintBySessionId[sessionId]` → 得到 fingerprint
+2. removeRef(fingerprint, sessionId)
+3. 如果是最后一个引用 → dispose runtime + 从 `runtimesByFingerprint` 删除
+
+### 4.4 交付形式
+
+以 git patch 文件形式交付，位于 `scripts/patches/v2026.4.14/openclaw-mcp-shared-runtime.patch`，通过 `npm run openclaw:patch` 应用。
+
+## 5. 边界情况
+
+| 场景 | 处理方式 |
+|------|---------|
+| 并发创建（多个 session 同时首次请求相同 fingerprint） | `createInFlight` 按 fingerprint 去重，第二个等待第一个完成后共享 |
+| disposeSession 被调用但还有其他 session 在用 | 仅移除引用，不 dispose runtime |
+| disposeAll 被调用 | 清空所有 map，dispose 所有 runtime（gateway 关闭时） |
+| 某个 MCP server 连接失败 | 与之前行为一致：跳过该 server，其余正常工作 |
+| CLI 本地模式 `cleanupBundleMcpOnRunEnd=true` | disposeSession 被调用，若是唯一使用者则正常销毁 |
+| 配置热更新导致 fingerprint 变化 | 下次 getOrCreate 时检测到变化，旧 runtime 在引用归零后清理 |
+
+## 6. 涉及文件
+
+| 文件 | 改动类型 |
+|------|---------|
+| `scripts/patches/v2026.4.14/openclaw-mcp-shared-runtime.patch` | 新增 patch |
+| `src/agents/pi-bundle-mcp-runtime.ts`（openclaw 源码） | patch 目标 |
+
+## 7. 验收标准
+
+1. 配置 3 个 stdio MCP server，连续新建 5 个对话 → 任务管理器中始终只有 3 个对应 Node.js 进程
+2. 在任意对话中发送涉及 MCP 的提问 → 工具正常调用
+3. 在设置中新增/删除 MCP server 后发起新对话 → 进程数正确反映新配置
+4. 退出应用 → 所有 MCP 子进程正常退出
+5. `npm run openclaw:patch` 可正常应用 patch，无冲突


### PR DESCRIPTION
## Summary

- **Kill stdio process trees on Windows**: MCP SDK's `StdioClientTransport.close()` only terminates the direct child on Windows, leaving grandchild node processes as orphans. Patch replaces SDK transport with `OpenClawStdioClientTransport` that uses `taskkill /T` for full process-tree cleanup.
- **Share MCP runtime across sessions**: Per-session MCP stdio processes accumulate because the gateway creates independent connections for each session key. Patch introduces fingerprint-based shared pool with reference counting — regardless of conversation count, only N processes exist (one per configured server).

Both patches target openclaw runtime v2026.4.14 and are removable once upgraded to >= v2026.4.22.

## Changes

- `scripts/patches/v2026.4.14/openclaw-mcp-stdio-process-tree-kill.patch`
- `scripts/patches/v2026.4.14/openclaw-mcp-shared-runtime.patch`
- `specs/2026-05-28-mcp-shared-runtime-design.md`

## Test plan

- [ ] Launch LobsterAI with MCP servers configured
- [ ] Open multiple conversations → verify only 1 process per MCP server (not N×conversations)
- [ ] Close a conversation → verify shared runtime stays alive (ref count > 0)
- [ ] Close all conversations → verify MCP processes terminate cleanly (no orphans in Task Manager)
- [ ] Kill an MCP connection mid-session → verify `taskkill /T` terminates the full process tree