### PR TITLE
fix: Kit try-asking 跳转后未转换为 skills

### DIFF
--- a/src/renderer/components/kits/KitsManager.tsx
+++ b/src/renderer/components/kits/KitsManager.tsx
@@ -1,9 +1,11 @@
 import { ArrowDownTrayIcon, ArrowLeftIcon, TrashIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { i18nService } from '../../services/i18n';
 import { kitService } from '../../services/kit';
 import { resolveLocalizedText } from '../../services/skill';
+import { setInstalledKits as setInstalledKitsAction, setMarketplaceKits } from '../../store/slices/kitSlice';
 import type { InstalledKit, MarketplaceKit } from '../../types/kit';
 import Modal from '../common/Modal';
 import SearchIcon from '../icons/SearchIcon';
@@ -15,6 +17,7 @@ interface KitsManagerProps {
 }
 
 const KitsManager: React.FC<KitsManagerProps> = ({ onTryAsking }) => {
+  const dispatch = useDispatch();
   const [kits, setKits] = useState<MarketplaceKit[]>([]);
   const [installedKits, setInstalledKits] = useState<Record<string, InstalledKit>>({});
   const [isLoading, setIsLoading] = useState(false);
@@ -32,8 +35,10 @@ const KitsManager: React.FC<KitsManagerProps> = ({ onTryAsking }) => {
     ]);
     setKits(marketKits);
     setInstalledKits(installed);
+    dispatch(setMarketplaceKits(marketKits));
+    dispatch(setInstalledKitsAction(installed));
     setIsLoading(false);
-  }, []);
+  }, [dispatch]);
 
   useEffect(() => {
     loadData();
@@ -61,6 +66,7 @@ const KitsManager: React.FC<KitsManagerProps> = ({ onTryAsking }) => {
       if (result.success) {
         const installed = await kitService.getInstalledKits();
         setInstalledKits(installed);
+        dispatch(setInstalledKitsAction(installed));
       } else {
         console.error('[KitsManager] Install failed:', result.error);
       }
@@ -78,6 +84,7 @@ const KitsManager: React.FC<KitsManagerProps> = ({ onTryAsking }) => {
       if (result.success) {
         const installed = await kitService.getInstalledKits();
         setInstalledKits(installed);
+        dispatch(setInstalledKitsAction(installed));
       } else {
         console.error('[KitsManager] Uninstall failed:', result.error);
       }


### PR DESCRIPTION
## Summary
- KitsManager 安装/卸载 Kit 后仅更新组件本地 state，未同步到 Redux store
- 导致从 Kit 详情页 try-asking 跳转到会话页后：
  1. 提交时 Kit 不会展开为 skills（Redux `installedKits` 缺失新安装的 Kit）
  2. 输入框 Kit badge 不显示（Redux `marketplaceKits` 为空）
- 修复：在 `loadData`、`handleInstall`、`handleUninstall` 中同步 dispatch 到 Redux store

## Test plan
- [ ] 从 Kit 详情页点击 try-asking，未安装时安装后跳转，确认 badge 正常显示
- [ ] 提交会话，确认 Kit 对应的 skills 被正确注入
- [ ] 已安装 Kit 直接点击 try-asking 跳转，确认 badge 和 skills 均正常

🤖 Generated with [Claude Code](https://claude.ai/claude-code)