### PR TITLE
fix: defer plugin settings save — batch write + dirty guard

### DIFF
--- a/src/main/ipcHandlers/plugins/handlers.ts
+++ b/src/main/ipcHandlers/plugins/handlers.ts
@@ -142,4 +142,30 @@ export function registerPluginHandlers(deps: PluginHandlerDeps): void {
       return { ok: false, error: error instanceof Error ? error.message : 'Failed to save plugin config' };
     }
   });
+
+  ipcMain.handle('plugins:batch-save', async (_event, changes: {
+    toggles?: Array<{ pluginId: string; enabled: boolean }>;
+    configs?: Array<{ pluginId: string; config: Record<string, unknown> }>;
+  }) => {
+    try {
+      const { PluginManager } = await import('../../libs/pluginManager');
+      const manager = new PluginManager(getCoworkStore());
+      for (const { pluginId, enabled } of changes.toggles ?? []) {
+        manager.setPluginEnabled(pluginId, enabled);
+      }
+      for (const { pluginId, config } of changes.configs ?? []) {
+        manager.savePluginConfig(pluginId, config);
+      }
+      const hasChanges = (changes.toggles?.length ?? 0) > 0 || (changes.configs?.length ?? 0) > 0;
+      if (hasChanges) {
+        await syncOpenClawConfig({
+          reason: 'plugin-batch-save',
+          restartGatewayIfRunning: true,
+        });
+      }
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : 'Failed to batch save plugin changes' };
+    }
+  });
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -619,6 +619,10 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.invoke('plugins:get-config-schema', pluginId),
     saveConfig: (pluginId: string, config: Record<string, unknown>) =>
       ipcRenderer.invoke('plugins:save-config', pluginId, config),
+    batchSave: (changes: {
+      toggles?: Array<{ pluginId: string; enabled: boolean }>;
+      configs?: Array<{ pluginId: string; config: Record<string, unknown> }>;
+    }) => ipcRenderer.invoke('plugins:batch-save', changes),
     onInstallLog: (callback: (line: string) => void) => {
       const handler = (_event: any, line: string) => callback(line);
       ipcRenderer.on('plugins:install-log', handler);

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -37,7 +37,7 @@ import BrainIcon from './icons/BrainIcon';
 import PlugIcon from './icons/PlugIcon';
 import PlusCircleIcon from './icons/PlusCircleIcon';
 import IMSettings from './im/IMSettings';
-import PluginsSettings from './plugins/PluginsSettings';
+import PluginsSettings, { type PluginsSettingsHandle } from './plugins/PluginsSettings';
 import BrowserWebAccessSettings from './settings/BrowserWebAccessSettings';
 import {
   buildOpenAICompatibleChatCompletionsUrl,
@@ -500,6 +500,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const initialThemeIdRef = useRef<string>(themeService.getThemeId());
   const initialLanguageRef = useRef<LanguageType>(i18nService.getLanguage());
   const didSaveRef = useRef(false);
+
+  // Plugin settings dirty tracking
+  const pluginsDirtyRef = useRef(false);
+  const pluginsSettingsRef = useRef<PluginsSettingsHandle>(null);
+  const [showPluginsUnsavedConfirm, setShowPluginsUnsavedConfirm] = useState(false);
+  const [pendingLeaveAction, setPendingLeaveAction] = useState<(() => void) | null>(null);
 
   // Add state for active provider
   const [activeProvider, setActiveProvider] = useState<ProviderType>(getDefaultActiveProvider());
@@ -1923,6 +1929,16 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         throw new Error(i18nService.t('settingsSavedButOpenClawSyncFailed'));
       }
 
+      // Batch save plugin changes (toggles + configs) if any pending
+      if (activeTab === 'plugins' && pluginsSettingsRef.current) {
+        const pendingChanges = pluginsSettingsRef.current.getPendingChanges();
+        if (pendingChanges) {
+          await window.electron?.plugins.batchSave(pendingChanges);
+          pluginsSettingsRef.current.resetDirty();
+          pluginsDirtyRef.current = false;
+        }
+      }
+
       didSaveRef.current = true;
       onClose();
     } catch (error) {
@@ -1933,7 +1949,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   };
 
   // 标签页切换处理
-  const handleTabChange = (tab: TabType) => {
+  const doTabChange = (tab: TabType) => {
     if (tab !== 'model') {
       setIsAddingModel(false);
       setIsEditingModel(false);
@@ -1945,6 +1961,25 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
     }
     setActiveTab(tab);
   };
+
+  const handleTabChange = (tab: TabType) => {
+    if (activeTab === 'plugins' && pluginsDirtyRef.current) {
+      setPendingLeaveAction(() => () => doTabChange(tab));
+      setShowPluginsUnsavedConfirm(true);
+      return;
+    }
+    doTabChange(tab);
+  };
+
+  // Guarded close: check plugin dirty state before closing
+  const guardedClose = useCallback(() => {
+    if (activeTab === 'plugins' && pluginsDirtyRef.current) {
+      setPendingLeaveAction(() => () => onClose());
+      setShowPluginsUnsavedConfirm(true);
+      return;
+    }
+    onClose();
+  }, [activeTab, onClose]);
 
   // Mapping from shortcut key to i18n label key for conflict messages
   const shortcutLabelMap: Record<string, string> = {
@@ -3213,7 +3248,12 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         return <IMSettings />;
 
       case 'plugins':
-        return <PluginsSettings />;
+        return (
+          <PluginsSettings
+            onDirtyChange={(dirty) => { pluginsDirtyRef.current = dirty; }}
+            handleRef={pluginsSettingsRef}
+          />
+        );
 
       case 'about':
         return (
@@ -3373,7 +3413,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   return (
     <Modal
-      onClose={onClose}
+      onClose={guardedClose}
       overlayClassName="fixed inset-0 z-50 modal-backdrop flex items-center justify-center p-3 sm:p-4"
       className="w-[calc(100vw-1.5rem)] max-w-[900px] min-w-0 sm:w-[calc(100vw-2rem)]"
     >
@@ -3410,7 +3450,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
           <div className="flex justify-between items-center gap-3 px-6 pt-5 pb-3 shrink-0">
             <h3 className="min-w-0 truncate text-lg font-semibold text-foreground">{activeTabLabel}</h3>
             <button
-              onClick={onClose}
+              onClick={guardedClose}
               className="text-secondary hover:text-foreground p-1.5 hover:bg-surface-raised rounded-lg transition-colors"
             >
               <XMarkIcon className="h-5 w-5" />
@@ -3449,7 +3489,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             <div className="flex justify-end space-x-4 p-4 border-border border-t bg-background shrink-0">
               <button
                 type="button"
-                onClick={onClose}
+                onClick={guardedClose}
                 className="px-4 py-2 rounded-xl transition-colors text-sm font-medium border border-border text-foreground hover:bg-surface-raised active:scale-[0.98]"
               >
                 {i18nService.t('cancel')}
@@ -3541,6 +3581,45 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
               </div>
             </div>
           )}
+
+      {/* Plugins unsaved changes confirmation dialog */}
+      {showPluginsUnsavedConfirm && (
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/35 px-4">
+          <div className="w-full max-w-sm rounded-2xl bg-background border border-border shadow-modal p-5">
+            <h4 className="text-sm font-semibold text-foreground mb-2">
+              {i18nService.t('pluginsUnsavedTitle')}
+            </h4>
+            <p className="text-sm text-secondary mb-4">
+              {i18nService.t('pluginsUnsavedMessage')}
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowPluginsUnsavedConfirm(false);
+                  setPendingLeaveAction(null);
+                }}
+                className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
+              >
+                {i18nService.t('pluginsUnsavedStay')}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowPluginsUnsavedConfirm(false);
+                  pluginsDirtyRef.current = false;
+                  const action = pendingLeaveAction;
+                  setPendingLeaveAction(null);
+                  action?.();
+                }}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity"
+              >
+                {i18nService.t('pluginsUnsavedDiscard')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       </div>
     </Modal>
   );

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -501,11 +501,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const initialLanguageRef = useRef<LanguageType>(i18nService.getLanguage());
   const didSaveRef = useRef(false);
 
-  // Plugin settings dirty tracking
-  const pluginsDirtyRef = useRef(false);
+  // Plugin settings handle (deferred save)
   const pluginsSettingsRef = useRef<PluginsSettingsHandle>(null);
-  const [showPluginsUnsavedConfirm, setShowPluginsUnsavedConfirm] = useState(false);
-  const [pendingLeaveAction, setPendingLeaveAction] = useState<(() => void) | null>(null);
 
   // Add state for active provider
   const [activeProvider, setActiveProvider] = useState<ProviderType>(getDefaultActiveProvider());
@@ -1935,7 +1932,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
         if (pendingChanges) {
           await window.electron?.plugins.batchSave(pendingChanges);
           pluginsSettingsRef.current.resetDirty();
-          pluginsDirtyRef.current = false;
         }
       }
 
@@ -1963,9 +1959,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   };
 
   const handleTabChange = (tab: TabType) => {
-    if (activeTab === 'plugins' && pluginsDirtyRef.current) {
-      setPendingLeaveAction(() => () => doTabChange(tab));
-      setShowPluginsUnsavedConfirm(true);
+    if (activeTab === 'plugins' && pluginsSettingsRef.current?.guardLeave(() => doTabChange(tab))) {
       return;
     }
     doTabChange(tab);
@@ -1973,9 +1967,7 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   // Guarded close: check plugin dirty state before closing
   const guardedClose = useCallback(() => {
-    if (activeTab === 'plugins' && pluginsDirtyRef.current) {
-      setPendingLeaveAction(() => () => onClose());
-      setShowPluginsUnsavedConfirm(true);
+    if (activeTab === 'plugins' && pluginsSettingsRef.current?.guardLeave(() => onClose())) {
       return;
     }
     onClose();
@@ -3250,7 +3242,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       case 'plugins':
         return (
           <PluginsSettings
-            onDirtyChange={(dirty) => { pluginsDirtyRef.current = dirty; }}
             handleRef={pluginsSettingsRef}
           />
         );
@@ -3582,44 +3573,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
             </div>
           )}
 
-      {/* Plugins unsaved changes confirmation dialog */}
-      {showPluginsUnsavedConfirm && (
-        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/35 px-4">
-          <div className="w-full max-w-sm rounded-2xl bg-background border border-border shadow-modal p-5">
-            <h4 className="text-sm font-semibold text-foreground mb-2">
-              {i18nService.t('pluginsUnsavedTitle')}
-            </h4>
-            <p className="text-sm text-secondary mb-4">
-              {i18nService.t('pluginsUnsavedMessage')}
-            </p>
-            <div className="flex justify-end gap-3">
-              <button
-                type="button"
-                onClick={() => {
-                  setShowPluginsUnsavedConfirm(false);
-                  setPendingLeaveAction(null);
-                }}
-                className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                {i18nService.t('pluginsUnsavedStay')}
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setShowPluginsUnsavedConfirm(false);
-                  pluginsDirtyRef.current = false;
-                  const action = pendingLeaveAction;
-                  setPendingLeaveAction(null);
-                  action?.();
-                }}
-                className="px-4 py-2 text-sm font-medium rounded-lg bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity"
-              >
-                {i18nService.t('pluginsUnsavedDiscard')}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
       </div>
     </Modal>
   );

--- a/src/renderer/components/plugins/PluginConfigPage.tsx
+++ b/src/renderer/components/plugins/PluginConfigPage.tsx
@@ -7,6 +7,9 @@ import { SchemaForm } from '../im/SchemaForm';
 interface PluginConfigPageProps {
   pluginId: string;
   onBack: () => void;
+  initialConfig?: Record<string, unknown>;
+  onConfigChange: (pluginId: string, config: Record<string, unknown>) => void;
+  onConfigLoaded: (pluginId: string, config: Record<string, unknown>) => void;
 }
 
 interface ConfigSchemaData {
@@ -46,13 +49,11 @@ function deepSet(obj: Record<string, unknown>, path: string, value: unknown): Re
   return result;
 }
 
-export default function PluginConfigPage({ pluginId, onBack }: PluginConfigPageProps) {
+export default function PluginConfigPage({ pluginId, onBack, initialConfig, onConfigChange, onConfigLoaded }: PluginConfigPageProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [schema, setSchema] = useState<ConfigSchemaData | null>(null);
-  const [configValue, setConfigValue] = useState<Record<string, unknown>>({});
-  const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
+  const [configValue, setConfigValue] = useState<Record<string, unknown>>(initialConfig ?? {});
   const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
 
   const loadSchema = useCallback(async () => {
@@ -62,7 +63,13 @@ export default function PluginConfigPage({ pluginId, onBack }: PluginConfigPageP
       const result = await window.electron?.plugins.getConfigSchema(pluginId);
       if (result?.success && result.schema) {
         setSchema(result.schema);
-        setConfigValue(result.config ?? {});
+        const loadedConfig = result.config ?? {};
+        // If parent already has a pending config for this plugin, use that instead
+        if (!initialConfig) {
+          setConfigValue(loadedConfig);
+        }
+        // Notify parent about the initial config from backend
+        onConfigLoaded(pluginId, loadedConfig);
       } else {
         setError(result?.error || i18nService.t('pluginsConfigLoadError'));
       }
@@ -70,35 +77,20 @@ export default function PluginConfigPage({ pluginId, onBack }: PluginConfigPageP
       setError(i18nService.t('pluginsConfigLoadError'));
     }
     setLoading(false);
-  }, [pluginId]);
+  }, [pluginId, initialConfig, onConfigLoaded]);
 
   useEffect(() => {
     loadSchema();
   }, [loadSchema]);
 
   const handleChange = (path: string, value: unknown) => {
-    setConfigValue(prev => deepSet(prev, path, value));
-    setSaved(false);
+    const next = deepSet(configValue, path, value);
+    setConfigValue(next);
+    onConfigChange(pluginId, next);
   };
 
   const handleToggleSecret = (path: string) => {
     setShowSecrets(prev => ({ ...prev, [path]: !prev[path] }));
-  };
-
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      const result = await window.electron?.plugins.saveConfig(pluginId, configValue);
-      if (result?.ok) {
-        setSaved(true);
-        setTimeout(() => setSaved(false), 2000);
-      } else {
-        setError(result?.error || 'Save failed');
-      }
-    } catch {
-      setError('Save failed');
-    }
-    setSaving(false);
   };
 
   return (
@@ -132,41 +124,16 @@ export default function PluginConfigPage({ pluginId, onBack }: PluginConfigPageP
           {i18nService.t('pluginsConfigNoSchema')}
         </div>
       ) : (
-        <>
-          <div className="rounded-lg border border-border p-4">
-            <SchemaForm
-              schema={schema.configSchema}
-              hints={schema.uiHints as Record<string, import('../im/SchemaForm').UiHint>}
-              value={configValue}
-              onChange={handleChange}
-              showSecrets={showSecrets}
-              onToggleSecret={handleToggleSecret}
-            />
-          </div>
-
-          {/* Actions */}
-          <div className="flex justify-end gap-2">
-            <button
-              type="button"
-              onClick={onBack}
-              className="px-4 py-2 text-sm rounded-md border border-border text-foreground hover:bg-surface-raised transition-colors"
-            >
-              {i18nService.t('pluginsConfigBack')}
-            </button>
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={saving}
-              className="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {saving
-                ? i18nService.t('pluginsConfigSaving')
-                : saved
-                  ? i18nService.t('pluginsConfigSaved')
-                  : i18nService.t('pluginsConfigSave')}
-            </button>
-          </div>
-        </>
+        <div className="rounded-lg border border-border p-4">
+          <SchemaForm
+            schema={schema.configSchema}
+            hints={schema.uiHints as Record<string, import('../im/SchemaForm').UiHint>}
+            value={configValue}
+            onChange={handleChange}
+            showSecrets={showSecrets}
+            onToggleSecret={handleToggleSecret}
+          />
+        </div>
       )}
     </div>
   );

--- a/src/renderer/components/plugins/PluginsSettings.tsx
+++ b/src/renderer/components/plugins/PluginsSettings.tsx
@@ -1,5 +1,5 @@
 import { ArrowPathIcon, Cog6ToothIcon,PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { useCallback, useEffect, useRef,useState } from 'react';
+import { useCallback, useEffect, useImperativeHandle, useRef,useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
 import PluginConfigPage from './PluginConfigPage';
@@ -23,7 +23,22 @@ interface InstallForm {
   version: string;
 }
 
-export default function PluginsSettings() {
+export interface PluginPendingChanges {
+  toggles: Array<{ pluginId: string; enabled: boolean }>;
+  configs: Array<{ pluginId: string; config: Record<string, unknown> }>;
+}
+
+export interface PluginsSettingsHandle {
+  getPendingChanges: () => PluginPendingChanges | null;
+  resetDirty: () => void;
+}
+
+interface PluginsSettingsProps {
+  onDirtyChange?: (dirty: boolean) => void;
+  handleRef?: React.Ref<PluginsSettingsHandle>;
+}
+
+export default function PluginsSettings({ onDirtyChange, handleRef }: PluginsSettingsProps) {
   const [plugins, setPlugins] = useState<PluginListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [showInstallModal, setShowInstallModal] = useState(false);
@@ -44,10 +59,81 @@ export default function PluginsSettings() {
     version: '',
   });
 
+  // --- Deferred save: track initial state and pending changes ---
+  const initialPluginsRef = useRef<Map<string, boolean>>(new Map());
+  const [pendingToggles, setPendingToggles] = useState<Map<string, boolean>>(new Map());
+  const [pendingConfigs, setPendingConfigs] = useState<Map<string, Record<string, unknown>>>(new Map());
+  // Store initial configs loaded from IPC for dirty comparison
+  const initialConfigsRef = useRef<Map<string, Record<string, unknown>>>(new Map());
+
+  // Compute dirty state
+  const isDirty = useCallback((): boolean => {
+    // Check toggles: compare current state against initial
+    for (const [pluginId, enabled] of pendingToggles) {
+      const initialEnabled = initialPluginsRef.current.get(pluginId);
+      if (initialEnabled !== enabled) return true;
+    }
+    // Check configs
+    for (const [pluginId, config] of pendingConfigs) {
+      const initialConfig = initialConfigsRef.current.get(pluginId);
+      if (JSON.stringify(config) !== JSON.stringify(initialConfig ?? {})) return true;
+    }
+    return false;
+  }, [pendingToggles, pendingConfigs]);
+
+  // Notify parent of dirty state changes
+  useEffect(() => {
+    onDirtyChange?.(isDirty());
+  }, [isDirty, onDirtyChange]);
+
+  // Expose handle to parent
+  useImperativeHandle(handleRef, () => ({
+    getPendingChanges: (): PluginPendingChanges | null => {
+      const dirty = isDirty();
+      if (!dirty) return null;
+
+      const toggles: PluginPendingChanges['toggles'] = [];
+      for (const [pluginId, enabled] of pendingToggles) {
+        const initialEnabled = initialPluginsRef.current.get(pluginId);
+        if (initialEnabled !== enabled) {
+          toggles.push({ pluginId, enabled });
+        }
+      }
+
+      const configs: PluginPendingChanges['configs'] = [];
+      for (const [pluginId, config] of pendingConfigs) {
+        const initialConfig = initialConfigsRef.current.get(pluginId);
+        if (JSON.stringify(config) !== JSON.stringify(initialConfig ?? {})) {
+          configs.push({ pluginId, config });
+        }
+      }
+
+      if (toggles.length === 0 && configs.length === 0) return null;
+      return { toggles, configs };
+    },
+    resetDirty: () => {
+      // Update initial refs to reflect current state after save
+      for (const [pluginId, enabled] of pendingToggles) {
+        initialPluginsRef.current.set(pluginId, enabled);
+      }
+      for (const [pluginId, config] of pendingConfigs) {
+        initialConfigsRef.current.set(pluginId, config);
+      }
+      setPendingToggles(new Map());
+      setPendingConfigs(new Map());
+    },
+  }), [isDirty, pendingToggles, pendingConfigs]);
+
   const loadPlugins = useCallback(async () => {
     const result = await window.electron?.plugins.list();
     if (result?.success && result.plugins) {
       setPlugins(result.plugins);
+      // Snapshot initial enabled state
+      const initial = new Map<string, boolean>();
+      for (const p of result.plugins) {
+        initial.set(p.pluginId, p.enabled);
+      }
+      initialPluginsRef.current = initial;
     }
     setLoading(false);
   }, []);
@@ -106,11 +192,16 @@ export default function PluginsSettings() {
     return cleanup;
   }, [installing]);
 
-  const handleToggle = async (pluginId: string, enabled: boolean) => {
-    await window.electron?.plugins.setEnabled(pluginId, enabled);
+  const handleToggle = (pluginId: string, enabled: boolean) => {
+    // Only update local state — do NOT call IPC
     setPlugins(prev =>
       prev.map(p => p.pluginId === pluginId ? { ...p, enabled } : p),
     );
+    setPendingToggles(prev => {
+      const next = new Map(prev);
+      next.set(pluginId, enabled);
+      return next;
+    });
   };
 
   const handleUninstall = async (pluginId: string) => {
@@ -119,6 +210,19 @@ export default function PluginsSettings() {
     setUninstalling(false);
     if (result?.ok) {
       setPlugins(prev => prev.filter(p => p.pluginId !== pluginId));
+      // Remove from pending state and initial ref
+      initialPluginsRef.current.delete(pluginId);
+      setPendingToggles(prev => {
+        const next = new Map(prev);
+        next.delete(pluginId);
+        return next;
+      });
+      setPendingConfigs(prev => {
+        const next = new Map(prev);
+        next.delete(pluginId);
+        return next;
+      });
+      initialConfigsRef.current.delete(pluginId);
     }
     setConfirmUninstall(null);
   };
@@ -158,6 +262,21 @@ export default function PluginsSettings() {
     }
   };
 
+  const handleConfigChange = useCallback((pluginId: string, config: Record<string, unknown>) => {
+    setPendingConfigs(prev => {
+      const next = new Map(prev);
+      next.set(pluginId, config);
+      return next;
+    });
+  }, []);
+
+  const handleConfigLoaded = useCallback((pluginId: string, config: Record<string, unknown>) => {
+    // Store initial config for dirty comparison (only if not already stored)
+    if (!initialConfigsRef.current.has(pluginId)) {
+      initialConfigsRef.current.set(pluginId, config);
+    }
+  }, []);
+
   const sourceLabel = (source: PluginSource | 'bundled') => {
     switch (source) {
       case 'npm': return i18nService.t('pluginsSourceNpm');
@@ -175,6 +294,9 @@ export default function PluginsSettings() {
       <PluginConfigPage
         pluginId={configPluginId}
         onBack={() => setConfigPluginId(null)}
+        initialConfig={pendingConfigs.get(configPluginId)}
+        onConfigChange={handleConfigChange}
+        onConfigLoaded={handleConfigLoaded}
       />
     );
   }

--- a/src/renderer/components/plugins/PluginsSettings.tsx
+++ b/src/renderer/components/plugins/PluginsSettings.tsx
@@ -31,16 +31,20 @@ export interface PluginPendingChanges {
 export interface PluginsSettingsHandle {
   getPendingChanges: () => PluginPendingChanges | null;
   resetDirty: () => void;
+  /** Returns true if leave is blocked (dialog shown). Caller should abort navigation. */
+  guardLeave: (proceedAction: () => void) => boolean;
 }
 
 interface PluginsSettingsProps {
-  onDirtyChange?: (dirty: boolean) => void;
   handleRef?: React.Ref<PluginsSettingsHandle>;
 }
 
-export default function PluginsSettings({ onDirtyChange, handleRef }: PluginsSettingsProps) {
+export default function PluginsSettings({ handleRef }: PluginsSettingsProps) {
   const [plugins, setPlugins] = useState<PluginListItem[]>([]);
   const [loading, setLoading] = useState(true);
+  // --- Unsaved-changes guard (internal dialog) ---
+  const [showUnsavedConfirm, setShowUnsavedConfirm] = useState(false);
+  const pendingLeaveActionRef = useRef<(() => void) | null>(null);
   const [showInstallModal, setShowInstallModal] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [installError, setInstallError] = useState<string | null>(null);
@@ -81,11 +85,6 @@ export default function PluginsSettings({ onDirtyChange, handleRef }: PluginsSet
     return false;
   }, [pendingToggles, pendingConfigs]);
 
-  // Notify parent of dirty state changes
-  useEffect(() => {
-    onDirtyChange?.(isDirty());
-  }, [isDirty, onDirtyChange]);
-
   // Expose handle to parent
   useImperativeHandle(handleRef, () => ({
     getPendingChanges: (): PluginPendingChanges | null => {
@@ -121,6 +120,12 @@ export default function PluginsSettings({ onDirtyChange, handleRef }: PluginsSet
       }
       setPendingToggles(new Map());
       setPendingConfigs(new Map());
+    },
+    guardLeave: (proceedAction: () => void): boolean => {
+      if (!isDirty()) return false;
+      pendingLeaveActionRef.current = proceedAction;
+      setShowUnsavedConfirm(true);
+      return true;
     },
   }), [isDirty, pendingToggles, pendingConfigs]);
 
@@ -715,6 +720,47 @@ export default function PluginsSettings({ onDirtyChange, handleRef }: PluginsSet
                 className="px-4 py-2 text-sm rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {uninstalling ? i18nService.t('pluginsUninstalling') : i18nService.t('pluginsUninstall')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Unsaved changes confirmation dialog */}
+      {showUnsavedConfirm && (
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/35 px-4">
+          <div className="w-full max-w-sm rounded-2xl bg-background border border-border shadow-modal p-5">
+            <h4 className="text-sm font-semibold text-foreground mb-2">
+              {i18nService.t('pluginsUnsavedTitle')}
+            </h4>
+            <p className="text-sm text-secondary mb-4">
+              {i18nService.t('pluginsUnsavedMessage')}
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowUnsavedConfirm(false);
+                  pendingLeaveActionRef.current = null;
+                }}
+                className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
+              >
+                {i18nService.t('pluginsUnsavedStay')}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowUnsavedConfirm(false);
+                  // Reset dirty state so subsequent navigation is not blocked
+                  setPendingToggles(new Map());
+                  setPendingConfigs(new Map());
+                  const action = pendingLeaveActionRef.current;
+                  pendingLeaveActionRef.current = null;
+                  action?.();
+                }}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity"
+              >
+                {i18nService.t('pluginsUnsavedDiscard')}
               </button>
             </div>
           </div>

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1409,6 +1409,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     pluginsSyncNow: '立即同步',
     pluginsSyncSkip: '暂不同步',
     pluginsSyncLater: '如果现在不同步，后续可以在「安装插件」页面的 OpenClaw 分类下手动操作。',
+    pluginsUnsavedTitle: '未保存的更改',
+    pluginsUnsavedMessage: '插件设置的修改将丢失，确认离开吗？',
+    pluginsUnsavedStay: '继续编辑',
+    pluginsUnsavedDiscard: '放弃更改',
 
     // IM Bot
     imBot: 'IM 机器人',
@@ -3696,6 +3700,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     pluginsSyncNow: 'Sync Now',
     pluginsSyncSkip: 'Not Now',
     pluginsSyncLater: 'You can always sync later from the "Install Plugin" dialog under the OpenClaw tab.',
+    pluginsUnsavedTitle: 'Unsaved Changes',
+    pluginsUnsavedMessage: 'Plugin setting changes will be lost. Leave anyway?',
+    pluginsUnsavedStay: 'Keep Editing',
+    pluginsUnsavedDiscard: 'Discard Changes',
 
     // IM Bot
     imBot: 'IM Bot',

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -899,6 +899,10 @@ interface IElectronAPI {
       pluginId: string,
       config: Record<string, unknown>,
     ) => Promise<{ ok: boolean; error?: string }>;
+    batchSave: (changes: {
+      toggles?: Array<{ pluginId: string; enabled: boolean }>;
+      configs?: Array<{ pluginId: string; config: Record<string, unknown> }>;
+    }) => Promise<{ ok: boolean; error?: string }>;
     detect: () => Promise<{ plugins: string[]; error?: string }>;
     sync: () => Promise<{ synced: string[]; error?: string }>;
     onInstallLog: (callback: (line: string) => void) => () => void;


### PR DESCRIPTION
## Summary
- Plugin toggle/config changes now stage in frontend local state instead of immediately triggering `syncOpenClawConfig` + gateway restart
- New `plugins:batch-save` IPC batches all pending toggles and config changes into a single write + one gateway restart on Save
- Leaving the plugins tab (tab switch / close / backdrop click) with unsaved changes shows a confirmation dialog
- `PluginConfigPage` no longer has independent Save/Back buttons — edits are staged in parent and committed together

## Test plan
- [ ] Open Settings → Plugins, toggle several switches → confirm gateway does **not** restart
- [ ] Click Save → confirm gateway restarts once
- [ ] Toggle switches then try switching to another tab → confirm unsaved dialog appears
- [ ] Toggle switches then click X / Cancel / backdrop → confirm unsaved dialog appears
- [ ] Enter plugin config sub-page, edit fields, go back → confirm changes persist in list view
- [ ] Click Save with both toggle + config changes → confirm single batch write
- [ ] Toggle back to original state → confirm Save does not trigger restart (not dirty)
- [ ] Install/uninstall a plugin → confirm still works immediately as before