### PR TITLE
feat: plugin update check for npm/clawhub sources

### DIFF
--- a/specs/features/plugin-management/2026-05-28-plugin-update-check-design.md
+++ b/specs/features/plugin-management/2026-05-28-plugin-update-check-design.md
@@ -1,0 +1,156 @@
+# 插件更新检测设计文档
+
+## 1. 概述
+
+### 1.1 问题/背景
+
+LobsterAI 支持从 npm 和 clawhub 安装第三方插件，但安装后没有任何版本更新检测机制。用户无法得知插件是否有新版本，也无法便捷地执行更新。
+
+### 1.2 目标
+
+- 支持用户手动检测已安装插件是否有新版本（npm 和 clawhub 来源）
+- 检测到新版本后，用户确认即可一键更新
+- 不做自动检测，避免不必要的网络请求和干扰
+
+## 2. 用户场景
+
+### 场景 1: 检测到可用更新
+
+**Given** 用户已安装来自 npm 的插件 `nsp-clawguard@2.1.5`，npm 上最新版为 `2.2.0`
+**When** 用户在插件设置页点击"检查更新"按钮
+**Then** 系统对所有 npm/clawhub 插件并行查询最新版本，`nsp-clawguard` 旁显示 `→ 2.2.0` 更新标记
+
+### 场景 2: 执行更新
+
+**Given** 插件 `nsp-clawguard` 显示有可用更新 `2.1.5 → 2.2.0`
+**When** 用户点击该插件的"更新"按钮并在确认弹窗中确认
+**Then** 系统执行更新（复用安装流程），完成后版本号更新，gateway 自动重启
+
+### 场景 3: 所有插件已是最新
+
+**Given** 用户已安装的所有插件均为最新版
+**When** 用户点击"检查更新"
+**Then** 提示"所有插件已是最新版本"
+
+### 场景 4: 检测失败（网络错误）
+
+**Given** 用户网络不可用或目标 registry 不可达
+**When** 用户点击"检查更新"
+**Then** 对检测失败的插件显示错误信息，不影响其他插件的检测结果
+
+## 3. 功能需求
+
+### FR-1: 版本检测
+
+- 支持 npm 和 clawhub 两种来源的版本检测
+- npm：通过 `npm view {spec} version --registry={registry}` 查询
+- clawhub：通过 HTTP GET `{clawhubBaseUrl}/api/v1/packages/{name}` 查询 `package.latestVersion`
+- 并行检测所有符合条件的插件
+- 单个插件检测超时 30 秒
+- 使用已记录的 registry 信息（SQLite `user_plugins.registry` 列）
+
+### FR-2: 版本对比
+
+- 比较本地已安装版本与远程最新版本
+- 字符串不等即视为有更新（不引入 semver 库）
+- 本地版本为空时视为有可用更新
+
+### FR-3: 更新执行
+
+- 复用现有 `installPlugin()` 流程，不指定 version（即安装最新）
+- 更新过程流式输出日志
+- 更新完成后触发 gateway 配置同步和重启
+- 更新 SQLite 中的版本记录
+
+### FR-4: UI 交互
+
+- 插件设置页 header 区域新增"检查更新"按钮
+- 检测期间按钮显示加载状态
+- 有更新的插件在列表中显示目标版本号和"更新"按钮
+- 点击"更新"弹出确认对话框
+- 确认后显示更新日志（复用现有 install-log 模式）
+
+## 4. 实现方案
+
+### 4.1 PluginManager 新增方法
+
+文件：`src/main/libs/pluginManager.ts`
+
+```typescript
+export interface PluginUpdateInfo {
+  pluginId: string;
+  currentVersion: string | null;
+  latestVersion: string | null;
+  hasUpdate: boolean;
+  error?: string;
+}
+```
+
+新增方法：
+- `checkPluginUpdates(pluginIds?: string[]): Promise<PluginUpdateInfo[]>` — 主入口
+- `private checkNpmLatestVersion(spec: string, registry?: string): Promise<string>` — npm 版本查询
+- `private checkClawHubLatestVersion(spec: string): Promise<string>` — clawhub 版本查询
+
+npm 版本查询复用 `resolveNpmCommand()` 和 `runAsync()`，执行 `npm view {spec} version --json`。
+
+clawhub 版本查询使用 Node.js `https` 模块，请求 `GET /api/v1/packages/{name}`，读取响应中 `package.latestVersion` 字段。base URL 默认 `https://clawhub.ai`，可被 `OPENCLAW_CLAWHUB_URL` 环境变量覆盖。
+
+### 4.2 IPC Handler
+
+文件：`src/main/ipcHandlers/plugins/handlers.ts`
+
+新增：
+- `plugins:check-updates` — 调用 `PluginManager.checkPluginUpdates()`
+- `plugins:update` — 调用 `PluginManager.installPlugin()` 复用安装流程，更新后同步配置
+
+### 4.3 Preload Bridge
+
+文件：`src/main/preload.ts`
+
+`window.electron.plugins` 新增：
+- `checkUpdates(pluginIds?: string[])` → `ipcRenderer.invoke('plugins:check-updates', pluginIds)`
+- `update(pluginId: string)` → `ipcRenderer.invoke('plugins:update', pluginId)`
+
+### 4.4 Renderer UI
+
+文件：`src/renderer/components/plugins/PluginsSettings.tsx`
+
+- Header 新增"检查更新"按钮（ArrowPathIcon，检测中旋转动画）
+- 新增 state：`checking`、`updateInfos`（Map<pluginId, PluginUpdateInfo>）、`updating`
+- 插件列表项：有更新时显示 `→ {latestVersion}` 绿色标记 + "更新"按钮
+- 更新确认弹窗：显示从哪个版本到哪个版本，确认后触发更新
+- 更新日志复用现有 `installLog` + `onInstallLog` 模式
+
+## 5. 边界情况
+
+| 场景 | 处理方式 |
+|------|---------|
+| 插件无 version 字段 | 跳过该插件，不报错 |
+| npm 自定义 registry 不可达 | 该插件返回 error，其他插件不受影响 |
+| clawhub API 返回 latestVersion 为 null | 视为无可用更新 |
+| 更新过程中 gateway 持有文件锁 | 已有 staging-dir 模式规避（Windows 安全） |
+| 更新后 configSchema 变更 | 保留用户旧 config 不动，可能出现 schema 不匹配但不致命 |
+| source 为 local/git/openclaw | 不参与检测，界面不显示更新按钮 |
+| 并发：用户连续点击检查按钮 | 检测进行中按钮 disabled |
+
+## 6. 涉及文件
+
+| 文件 | 改动 |
+|------|------|
+| `src/main/libs/pluginManager.ts` | 新增检测方法 |
+| `src/main/ipcHandlers/plugins/handlers.ts` | 新增 IPC handler |
+| `src/main/preload.ts` | bridge 扩展 |
+| `src/renderer/components/plugins/PluginsSettings.tsx` | UI 实现 |
+| i18n 文件 | 新增翻译 key |
+
+## 7. 验收标准
+
+- [ ] 点击"检查更新"，npm 来源插件能正确检测到最新版本
+- [ ] 点击"检查更新"，clawhub 来源插件能正确检测到最新版本
+- [ ] 使用自定义 registry 的 npm 插件能正确检测
+- [ ] 检测结果正确区分"有更新"和"已是最新"
+- [ ] 点击"更新"后弹出确认对话框
+- [ ] 确认更新后流程正常完成，版本号更新
+- [ ] 更新完成后 gateway 自动重启
+- [ ] 网络超时/失败时有明确错误提示
+- [ ] 检测期间 UI 有适当的加载状态反馈

--- a/src/main/ipcHandlers/plugins/handlers.ts
+++ b/src/main/ipcHandlers/plugins/handlers.ts
@@ -168,4 +168,63 @@ export function registerPluginHandlers(deps: PluginHandlerDeps): void {
       return { ok: false, error: error instanceof Error ? error.message : 'Failed to batch save plugin changes' };
     }
   });
+
+  ipcMain.handle('plugins:check-updates', async (_event, pluginIds?: string[]) => {
+    try {
+      const { PluginManager } = await import('../../libs/pluginManager');
+      const manager = new PluginManager(getCoworkStore());
+      const updates = await manager.checkPluginUpdates(pluginIds);
+      return { success: true, updates };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Failed to check plugin updates' };
+    }
+  });
+
+  ipcMain.handle('plugins:update', async (event, pluginId: string) => {
+    try {
+      const { PluginManager } = await import('../../libs/pluginManager');
+      const manager = new PluginManager(getCoworkStore());
+
+      // Find plugin info to determine source/spec/registry
+      const plugins = getCoworkStore().listUserPlugins();
+      const plugin = plugins.find(p => p.pluginId === pluginId);
+      if (!plugin) {
+        return { ok: false, error: `Plugin "${pluginId}" not found` };
+      }
+      if (plugin.source !== 'npm' && plugin.source !== 'clawhub') {
+        return { ok: false, error: `Update not supported for source "${plugin.source}"` };
+      }
+
+      const previousEnabled = plugin.enabled;
+
+      const sender = event.sender;
+      const sendLog = (line: string) => {
+        try { sender.send('plugins:install-log', line); } catch { /* window closed */ }
+      };
+
+      // Reinstall without version constraint to get latest
+      const result = await manager.installPlugin({
+        source: plugin.source,
+        spec: plugin.spec,
+        registry: plugin.registry,
+      }, sendLog);
+
+      if (result.ok) {
+        // Restore previous enabled state (installPlugin always sets enabled=true)
+        if (!previousEnabled) {
+          manager.setPluginEnabled(pluginId, false);
+        }
+        sendLog('Syncing gateway config...\n');
+        const impactDecision = classifyPluginConfigChange(OpenClawPluginChangeAction.Install);
+        await syncOpenClawConfig({
+          reason: 'plugin-update',
+          restartGatewayIfRunning: impactDecision.impact === OpenClawConfigImpact.Restart,
+        });
+        sendLog('Gateway config synced.\n');
+      }
+      return result;
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : 'Failed to update plugin' };
+    }
+  });
 }

--- a/src/main/libs/coworkOpenAICompatProxy.test.ts
+++ b/src/main/libs/coworkOpenAICompatProxy.test.ts
@@ -1,5 +1,9 @@
 import type http from 'http';
-import { describe,expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  session: { defaultSession: { webRequest: { onBeforeSendHeaders: vi.fn() } } },
+}));
 
 import { __openAICompatProxyTestUtils, isAllowedProxyHost } from './coworkOpenAICompatProxy';
 

--- a/src/main/libs/openclawMemoryFile.test.ts
+++ b/src/main/libs/openclawMemoryFile.test.ts
@@ -1,4 +1,9 @@
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => process.cwd(), getPath: () => '/tmp' },
+}));
+
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';

--- a/src/main/libs/openclawMemoryFile.test.ts
+++ b/src/main/libs/openclawMemoryFile.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 vi.mock('electron', () => ({
   app: { getAppPath: () => process.cwd(), getPath: () => '/tmp' },
@@ -7,15 +7,16 @@ vi.mock('electron', () => ({
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+
 import {
-  parseMemoryMd,
-  serializeMemoryMd,
-  resolveMemoryFilePath,
   addMemoryEntry,
-  updateMemoryEntry,
   deleteMemoryEntry,
-  searchMemoryEntries,
   migrateSqliteToMemoryMd,
+  parseMemoryMd,
+  resolveMemoryFilePath,
+  searchMemoryEntries,
+  serializeMemoryMd,
+  updateMemoryEntry,
 } from './openclawMemoryFile';
 
 // ---- helpers ----------------------------------------------------------------

--- a/src/main/libs/pluginManager.ts
+++ b/src/main/libs/pluginManager.ts
@@ -48,6 +48,14 @@ export interface PluginListItem {
   hasConfig: boolean;
 }
 
+export interface PluginUpdateInfo {
+  pluginId: string;
+  currentVersion: string | null;
+  latestVersion: string | null;
+  hasUpdate: boolean;
+  error?: string;
+}
+
 interface PluginManifest {
   id?: string;
   name?: string;
@@ -728,6 +736,118 @@ export class PluginManager {
     }
 
     return { synced };
+  }
+
+  /**
+   * Check for available updates for installed plugins (npm and clawhub sources).
+   */
+  async checkPluginUpdates(pluginIds?: string[]): Promise<PluginUpdateInfo[]> {
+    const userPlugins = this.store.listUserPlugins();
+    const candidates = userPlugins.filter(p => {
+      if (p.source !== 'npm' && p.source !== 'clawhub') return false;
+      if (pluginIds && pluginIds.length > 0 && !pluginIds.includes(p.pluginId)) return false;
+      return true;
+    });
+
+    if (candidates.length === 0) return [];
+
+    const results = await Promise.allSettled(
+      candidates.map(async (plugin): Promise<PluginUpdateInfo> => {
+        const currentVersion = plugin.version || null;
+        try {
+          let latestVersion: string | null = null;
+          if (plugin.source === 'npm') {
+            latestVersion = await this.checkNpmLatestVersion(plugin.spec, plugin.registry);
+          } else if (plugin.source === 'clawhub') {
+            latestVersion = await this.checkClawHubLatestVersion(plugin.spec);
+          }
+
+          const hasUpdate = latestVersion !== null
+            && (currentVersion === null || currentVersion !== latestVersion);
+
+          return {
+            pluginId: plugin.pluginId,
+            currentVersion,
+            latestVersion,
+            hasUpdate,
+          };
+        } catch (err) {
+          return {
+            pluginId: plugin.pluginId,
+            currentVersion,
+            latestVersion: null,
+            hasUpdate: false,
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }),
+    );
+
+    return results.map(r => r.status === 'fulfilled'
+      ? r.value
+      : { pluginId: '', currentVersion: null, latestVersion: null, hasUpdate: false, error: 'Unknown error' },
+    ).filter(r => r.pluginId !== '');
+  }
+
+  private async checkNpmLatestVersion(spec: string, registry?: string): Promise<string> {
+    const npm = resolveNpmCommand();
+    const args = [...npm.baseArgs, 'view', spec, 'version', '--json'];
+    if (registry) {
+      args.push(`--registry=${registry}`);
+    }
+
+    const result = await runAsync(npm.command, args, {
+      env: npm.env,
+      timeout: 30_000,
+      shell: npm.shell,
+    });
+
+    if (result.code !== 0) {
+      throw new Error(`npm view failed: ${result.stderr || `exit code ${result.code}`}`);
+    }
+
+    // npm view --json returns version as a JSON string (e.g. "2.2.0")
+    const output = result.stdout.trim();
+    try {
+      const parsed = JSON.parse(output);
+      if (typeof parsed === 'string') return parsed;
+      // In case of multiple versions (dist-tags), take the first
+      if (Array.isArray(parsed)) return parsed[0];
+      return output.replace(/"/g, '');
+    } catch {
+      // Fallback: raw output without quotes
+      return output.replace(/"/g, '');
+    }
+  }
+
+  private async checkClawHubLatestVersion(spec: string): Promise<string> {
+    const baseUrl = process.env.OPENCLAW_CLAWHUB_URL || 'https://clawhub.ai';
+    const url = `${baseUrl}/api/v1/packages/${encodeURIComponent(spec)}`;
+
+    const data = await new Promise<string>((resolve, reject) => {
+      const protocol = url.startsWith('https') ? require('https') : require('http');
+      const req = protocol.get(url, { timeout: 30_000 }, (res: any) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`ClawHub API returned HTTP ${res.statusCode}`));
+          return;
+        }
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk: string) => { body += chunk; });
+        res.on('end', () => resolve(body));
+        res.on('error', reject);
+      });
+      req.on('error', reject);
+      req.on('timeout', () => { req.destroy(); reject(new Error('ClawHub request timeout')); });
+    });
+
+    const detail = JSON.parse(data);
+    const latestVersion = detail?.package?.latestVersion ?? detail?.package?.tags?.latest ?? null;
+    if (!latestVersion) {
+      throw new Error(`No latest version found for ClawHub package "${spec}"`);
+    }
+    return latestVersion;
   }
 }
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -623,6 +623,8 @@ contextBridge.exposeInMainWorld('electron', {
       toggles?: Array<{ pluginId: string; enabled: boolean }>;
       configs?: Array<{ pluginId: string; config: Record<string, unknown> }>;
     }) => ipcRenderer.invoke('plugins:batch-save', changes),
+    checkUpdates: (pluginIds?: string[]) => ipcRenderer.invoke('plugins:check-updates', pluginIds),
+    update: (pluginId: string) => ipcRenderer.invoke('plugins:update', pluginId),
     onInstallLog: (callback: (line: string) => void) => {
       const handler = (_event: any, line: string) => callback(line);
       ipcRenderer.on('plugins:install-log', handler);

--- a/src/main/skillManager.test.ts
+++ b/src/main/skillManager.test.ts
@@ -1,4 +1,11 @@
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => process.cwd(), getPath: () => '/tmp' },
+  BrowserWindow: { getAllWindows: () => [] },
+  session: { defaultSession: { webRequest: { onBeforeSendHeaders: vi.fn() } } },
+}));
+
 import { __skillManagerTestUtils } from './skillManager';
 
 const { parseFrontmatter, isTruthy, extractDescription } = __skillManagerTestUtils;

--- a/src/main/skillManager.test.ts
+++ b/src/main/skillManager.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 vi.mock('electron', () => ({
   app: { getAppPath: () => process.cwd(), getPath: () => '/tmp' },

--- a/src/renderer/components/plugins/PluginsSettings.tsx
+++ b/src/renderer/components/plugins/PluginsSettings.tsx
@@ -1,4 +1,4 @@
-import { ArrowPathIcon, Cog6ToothIcon,PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { ArrowPathIcon, ArrowUpCircleIcon, Cog6ToothIcon,PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { useCallback, useEffect, useImperativeHandle, useRef,useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
@@ -14,6 +14,14 @@ interface PluginListItem {
   enabled: boolean;
   canUninstall: boolean;
   hasConfig: boolean;
+}
+
+interface PluginUpdateInfo {
+  pluginId: string;
+  currentVersion: string | null;
+  latestVersion: string | null;
+  hasUpdate: boolean;
+  error?: string;
 }
 
 interface InstallForm {
@@ -62,6 +70,14 @@ export default function PluginsSettings({ handleRef }: PluginsSettingsProps) {
     registry: '',
     version: '',
   });
+
+  // --- Update checking state ---
+  const [checking, setChecking] = useState(false);
+  const [updateInfos, setUpdateInfos] = useState<Map<string, PluginUpdateInfo>>(new Map());
+  const [confirmUpdate, setConfirmUpdate] = useState<PluginUpdateInfo | null>(null);
+  const [updating, setUpdating] = useState(false);
+  const [updateLog, setUpdateLog] = useState<string>('');
+  const updateLogRef = useRef<HTMLPreElement>(null);
 
   // --- Deferred save: track initial state and pending changes ---
   const initialPluginsRef = useRef<Map<string, boolean>>(new Map());
@@ -197,6 +213,18 @@ export default function PluginsSettings({ handleRef }: PluginsSettingsProps) {
     return cleanup;
   }, [installing]);
 
+  // Listen for update log events (reuses the same install-log channel)
+  useEffect(() => {
+    if (!updating) return;
+    const cleanup = window.electron?.plugins.onInstallLog((line: string) => {
+      setUpdateLog(prev => prev + line);
+      if (updateLogRef.current) {
+        updateLogRef.current.scrollTop = updateLogRef.current.scrollHeight;
+      }
+    });
+    return cleanup;
+  }, [updating]);
+
   const handleToggle = (pluginId: string, enabled: boolean) => {
     // Only update local state — do NOT call IPC
     setPlugins(prev =>
@@ -282,6 +310,38 @@ export default function PluginsSettings({ handleRef }: PluginsSettingsProps) {
     }
   }, []);
 
+  const handleCheckUpdates = useCallback(async () => {
+    setChecking(true);
+    try {
+      const result = await window.electron?.plugins.checkUpdates();
+      if (result?.success && result.updates) {
+        const map = new Map<string, PluginUpdateInfo>();
+        for (const info of result.updates) {
+          map.set(info.pluginId, info);
+        }
+        setUpdateInfos(map);
+      }
+    } finally {
+      setChecking(false);
+    }
+  }, []);
+
+  const handleUpdate = useCallback(async (pluginId: string) => {
+    setUpdating(true);
+    setUpdateLog('');
+    const result = await window.electron?.plugins.update(pluginId);
+    setUpdating(false);
+    if (result?.ok) {
+      setConfirmUpdate(null);
+      setUpdateInfos(prev => {
+        const next = new Map(prev);
+        next.delete(pluginId);
+        return next;
+      });
+      loadPlugins();
+    }
+  }, [loadPlugins]);
+
   const sourceLabel = (source: PluginSource | 'bundled') => {
     switch (source) {
       case 'npm': return i18nService.t('pluginsSourceNpm');
@@ -366,14 +426,25 @@ export default function PluginsSettings({ handleRef }: PluginsSettingsProps) {
             {i18nService.t('pluginsDesc')}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => { setShowInstallModal(true); setInstallLog(''); setInstallError(null); setDiscoverResult(null); }}
-          className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-        >
-          <PlusIcon className="h-4 w-4" />
-          {i18nService.t('pluginsInstall')}
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleCheckUpdates}
+            disabled={checking}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-foreground hover:bg-surface-raised transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <ArrowPathIcon className={`h-4 w-4 ${checking ? 'animate-spin' : ''}`} />
+            {checking ? i18nService.t('pluginsChecking') : i18nService.t('pluginsCheckUpdates')}
+          </button>
+          <button
+            type="button"
+            onClick={() => { setShowInstallModal(true); setInstallLog(''); setInstallError(null); setDiscoverResult(null); }}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            <PlusIcon className="h-4 w-4" />
+            {i18nService.t('pluginsInstall')}
+          </button>
+        </div>
       </div>
 
       {/* Plugin List */}
@@ -404,6 +475,11 @@ export default function PluginsSettings({ handleRef }: PluginsSettingsProps) {
                   {plugin.version && (
                     <span className="text-xs text-muted-foreground">v{plugin.version}</span>
                   )}
+                  {updateInfos.get(plugin.pluginId)?.hasUpdate && (
+                    <span className="text-xs text-primary font-medium">
+                      → v{updateInfos.get(plugin.pluginId)!.latestVersion}
+                    </span>
+                  )}
                   <span className="text-xs px-1.5 py-0.5 rounded bg-surface-raised text-muted-foreground">
                     {sourceLabel(plugin.source)}
                   </span>
@@ -415,6 +491,16 @@ export default function PluginsSettings({ handleRef }: PluginsSettingsProps) {
                 )}
               </div>
               <div className="flex items-center gap-2 ml-4">
+                {updateInfos.get(plugin.pluginId)?.hasUpdate && (
+                  <button
+                    type="button"
+                    onClick={() => setConfirmUpdate(updateInfos.get(plugin.pluginId)!)}
+                    className="p-1 rounded text-primary hover:text-primary hover:bg-primary/10 transition-colors"
+                    title={i18nService.t('pluginsUpdate')}
+                  >
+                    <ArrowUpCircleIcon className="h-4 w-4" />
+                  </button>
+                )}
                 {plugin.hasConfig && (
                   <button
                     type="button"
@@ -720,6 +806,46 @@ export default function PluginsSettings({ handleRef }: PluginsSettingsProps) {
                 className="px-4 py-2 text-sm rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {uninstalling ? i18nService.t('pluginsUninstalling') : i18nService.t('pluginsUninstall')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Update Confirmation Modal */}
+      {confirmUpdate && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-background border border-border rounded-xl shadow-lg w-full max-w-md p-6">
+            <h3 className="text-base font-semibold text-foreground mb-2">
+              {i18nService.t('pluginsUpdateConfirm')}
+            </h3>
+            <p className="text-sm text-muted-foreground mb-4">
+              {confirmUpdate.pluginId}: v{confirmUpdate.currentVersion || '?'} → v{confirmUpdate.latestVersion}
+            </p>
+            {updateLog && (
+              <pre
+                ref={updateLogRef}
+                className="text-xs font-mono bg-surface-raised border border-border rounded-md p-2 max-h-40 overflow-y-auto mb-4 whitespace-pre-wrap"
+              >
+                {updateLog}
+              </pre>
+            )}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => { setConfirmUpdate(null); setUpdateLog(''); }}
+                disabled={updating}
+                className="px-4 py-2 text-sm rounded-md border border-border text-foreground hover:bg-surface-raised transition-colors disabled:opacity-50"
+              >
+                {i18nService.t('cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleUpdate(confirmUpdate.pluginId)}
+                disabled={updating}
+                className="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {updating ? i18nService.t('pluginsUpdating') : i18nService.t('pluginsUpdate')}
               </button>
             </div>
           </div>

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1413,6 +1413,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
     pluginsUnsavedMessage: '插件设置的修改将丢失，确认离开吗？',
     pluginsUnsavedStay: '继续编辑',
     pluginsUnsavedDiscard: '放弃更改',
+    pluginsCheckUpdates: '检查更新',
+    pluginsChecking: '检查中...',
+    pluginsUpdate: '更新',
+    pluginsUpdating: '更新中...',
+    pluginsUpdateConfirm: '确认更新插件',
 
     // IM Bot
     imBot: 'IM 机器人',
@@ -3704,6 +3709,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
     pluginsUnsavedMessage: 'Plugin setting changes will be lost. Leave anyway?',
     pluginsUnsavedStay: 'Keep Editing',
     pluginsUnsavedDiscard: 'Discard Changes',
+    pluginsCheckUpdates: 'Check Updates',
+    pluginsChecking: 'Checking...',
+    pluginsUpdate: 'Update',
+    pluginsUpdating: 'Updating...',
+    pluginsUpdateConfirm: 'Confirm Plugin Update',
 
     // IM Bot
     imBot: 'IM Bot',

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -905,6 +905,18 @@ interface IElectronAPI {
     }) => Promise<{ ok: boolean; error?: string }>;
     detect: () => Promise<{ plugins: string[]; error?: string }>;
     sync: () => Promise<{ synced: string[]; error?: string }>;
+    checkUpdates: (pluginIds?: string[]) => Promise<{
+      success: boolean;
+      updates?: Array<{
+        pluginId: string;
+        currentVersion: string | null;
+        latestVersion: string | null;
+        hasUpdate: boolean;
+        error?: string;
+      }>;
+      error?: string;
+    }>;
+    update: (pluginId: string) => Promise<{ ok: boolean; version?: string; error?: string }>;
     onInstallLog: (callback: (line: string) => void) => () => void;
   };
   im: {

--- a/src/scheduledTask/cronJobService.test.ts
+++ b/src/scheduledTask/cronJobService.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
 
 import {
   DeliveryMode,


### PR DESCRIPTION
## Summary

- Add manual "Check Updates" button in plugin settings page
- Support version detection for **npm** (via `npm view`) and **clawhub** (via ClawHub REST API) sources
- Show update availability inline with target version, confirm dialog before updating
- Preserve plugin enabled/disabled state after update
- Reuse existing `installPlugin()` flow for the actual update execution

## Implementation

- `PluginManager.checkPluginUpdates()` — parallel version queries for all npm/clawhub plugins
- `plugins:check-updates` / `plugins:update` IPC handlers
- Preload bridge + renderer type declarations
- UI: check button (header), version indicator (per-plugin), update confirmation modal with log streaming

## Test plan

- [ ] Install an npm plugin, click "Check Updates", verify correct latest version is shown
- [ ] Install a clawhub plugin, click "Check Updates", verify correct latest version is shown
- [ ] Confirm update, verify plugin files are replaced and version updates in UI
- [ ] Verify a disabled plugin remains disabled after update
- [ ] Test with custom npm registry (e.g. `https://npm.nie.netease.com/`)
- [ ] Test network timeout/failure shows error without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)