### PR TITLE
fix: scope tool_result artifact detection to image gen tools only

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo,useRef, useStat
 import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { normalizeFilePathForDedup, normalizeLocalServiceUrlForDedup, parseFileLinksFromMessage, parseFilePathsFromText, parseLocalServiceUrlsFromText, parseMediaTokensFromText, parseRemoteImageArtifactsFromText, parseToolArtifact, parseToolResultMediaArtifacts, stripFileLinksFromText } from '../../services/artifactParser';
+import { normalizeFilePathForDedup, normalizeLocalServiceUrlForDedup, parseFileLinksFromMessage, parseFilePathsFromText, parseLocalServiceUrlsFromText, parseMediaTokensFromText, parseRemoteImageArtifactsFromText, parseToolArtifact, parseToolResultMediaArtifacts, shouldParseFilePathsFromToolResult, stripFileLinksFromText } from '../../services/artifactParser';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { RootState } from '../../store';
@@ -1166,12 +1166,25 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               detected.push(ma);
             }
           }
-          const pathArtifacts = parseFilePathsFromText(msg.content, msg.id, sessionId, 'artifact-toolresult');
-          for (const pa of pathArtifacts) {
-            const normalized = pa.filePath ? normalizeFilePathForDedup(pa.filePath) : '';
-            if (pa.filePath && !seenFilePaths.has(normalized)) {
-              seenFilePaths.add(normalized);
-              detected.push(pa);
+
+          // Only parse bare file paths from tool results of image generation tools.
+          // Other tools (e.g. Bash running `find`) may output many file paths in their
+          // results that should NOT become artifacts.
+          const toolUseId = msg.metadata?.toolUseId;
+          const pairedToolUse = toolUseId
+            ? messages.find(m => m.type === 'tool_use' && m.metadata?.toolUseId === toolUseId)
+            : undefined;
+          const toolName = pairedToolUse?.metadata?.toolName
+            ? String(pairedToolUse.metadata.toolName)
+            : '';
+          if (shouldParseFilePathsFromToolResult(toolName)) {
+            const pathArtifacts = parseFilePathsFromText(msg.content, msg.id, sessionId, 'artifact-toolresult');
+            for (const pa of pathArtifacts) {
+              const normalized = pa.filePath ? normalizeFilePathForDedup(pa.filePath) : '';
+              if (pa.filePath && !seenFilePaths.has(normalized)) {
+                seenFilePaths.add(normalized);
+                detected.push(pa);
+              }
             }
           }
           detected.push(...parseRemoteImageArtifactsFromText(msg.content, msg.id, sessionId, 'artifact-remote-toolresult'));

--- a/src/renderer/services/artifactParser.test.ts
+++ b/src/renderer/services/artifactParser.test.ts
@@ -8,6 +8,7 @@ import {
   parseFilePathsFromText, parseLocalServiceUrlsFromText, parseMediaTokensFromText,
   parseToolArtifact,
   parseToolResultMediaArtifacts,
+  shouldParseFilePathsFromToolResult,
 } from './artifactParser';
 
 describe('normalizeFilePathForDedup', () => {
@@ -485,5 +486,65 @@ describe('parseToolArtifact', () => {
 
     expect(normalizeFilePathForDedup(toolPath))
       .toBe(normalizeFilePathForDedup(linkArtifacts[0].filePath!));
+  });
+});
+
+describe('shouldParseFilePathsFromToolResult', () => {
+  test('returns true for image_generate tool', () => {
+    expect(shouldParseFilePathsFromToolResult('image_generate')).toBe(true);
+  });
+
+  test('returns true for lobsterai_image_generate tool', () => {
+    expect(shouldParseFilePathsFromToolResult('lobsterai_image_generate')).toBe(true);
+  });
+
+  test('is case-insensitive', () => {
+    expect(shouldParseFilePathsFromToolResult('Image_Generate')).toBe(true);
+    expect(shouldParseFilePathsFromToolResult('LOBSTERAI_IMAGE_GENERATE')).toBe(true);
+  });
+
+  test('returns false for Bash tool (find/ls output should not become artifacts)', () => {
+    expect(shouldParseFilePathsFromToolResult('Bash')).toBe(false);
+  });
+
+  test('returns false for other command execution tools', () => {
+    expect(shouldParseFilePathsFromToolResult('execute_command')).toBe(false);
+    expect(shouldParseFilePathsFromToolResult('run_terminal_command')).toBe(false);
+    expect(shouldParseFilePathsFromToolResult('shell')).toBe(false);
+  });
+
+  test('returns false for null/undefined/empty', () => {
+    expect(shouldParseFilePathsFromToolResult(null)).toBe(false);
+    expect(shouldParseFilePathsFromToolResult(undefined)).toBe(false);
+    expect(shouldParseFilePathsFromToolResult('')).toBe(false);
+  });
+
+  test('returns false for file tools (Read, Write, Edit)', () => {
+    expect(shouldParseFilePathsFromToolResult('Read')).toBe(false);
+    expect(shouldParseFilePathsFromToolResult('Write')).toBe(false);
+    expect(shouldParseFilePathsFromToolResult('Edit')).toBe(false);
+  });
+});
+
+describe('parseFilePathsFromText — find command output scenario', () => {
+  test('regex matches paths from find output (demonstrating the bug vector)', () => {
+    // Simulates `find . -name "*.png"` output on macOS
+    const findOutput = [
+      './B-01-seedream.png',
+      './B-02-chart.png',
+      './subfolder/凡人修仙传女性角色群像全身照.png',
+      './black_huaqiang_bao_shu_reference.png',
+    ].join('\n');
+
+    const artifacts = parseFilePathsFromText(findOutput, 'msg1', 'sess1');
+    // These paths all have a `/` so they match BARE_FILE_PATH_RE
+    expect(artifacts.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('bare filenames without directory separator do NOT match', () => {
+    // Simulates output from `ls *.png` (no path prefix)
+    const content = 'B-01-seedream.png\nB-02-chart.png';
+    const artifacts = parseFilePathsFromText(content, 'msg1', 'sess1');
+    expect(artifacts).toHaveLength(0);
   });
 });

--- a/src/renderer/services/artifactParser.ts
+++ b/src/renderer/services/artifactParser.ts
@@ -532,6 +532,21 @@ export function parseToolResultMediaArtifacts(
 
 const WRITE_TOOL_NAMES = new Set(['write', 'writefile', 'write_file']);
 
+/**
+ * Tool names whose tool_result content may contain bare file paths that should
+ * be detected as artifacts. Other tools (e.g. Bash running `find` / `ls`) can
+ * produce file listings in their output which should NOT become artifacts.
+ */
+const IMAGE_GEN_TOOL_NAMES_FOR_PATH_DETECTION = new Set([
+  'image_generate',
+  'lobsterai_image_generate',
+]);
+
+export function shouldParseFilePathsFromToolResult(toolName: string | undefined | null): boolean {
+  if (!toolName) return false;
+  return IMAGE_GEN_TOOL_NAMES_FOR_PATH_DETECTION.has(toolName.toLowerCase());
+}
+
 function normalizeToolName(name: string): string {
   return name.toLowerCase().replace(/[_\s]/g, '');
 }


### PR DESCRIPTION
## Summary

- Limits `parseFilePathsFromText` on `tool_result` messages to only run when the originating tool is `image_generate` or `lobsterai_image_generate`
- Previously, ANY tool_result content was scanned for bare file paths, causing command output (e.g. `find . -name "*.png"`) to incorrectly display all matching files as artifact cards
- Adds `shouldParseFilePathsFromToolResult()` helper with unit tests

## Root Cause

`BARE_FILE_PATH_RE` matches paths with forward slashes (e.g. `./B-01-seedream.png` from `find` output on macOS). When an AI model runs shell commands that list directory contents, all output paths were detected as artifacts.

## Test plan

- [x] All 47 existing + new unit tests pass (`vitest run artifactParser.test.ts`)
- [ ] Manual: generate image via image_generate tool → artifact card still appears
- [ ] Manual: run a Bash tool that lists .png files → no spurious artifact cards

🤖 Generated with [Claude Code](https://claude.ai/claude-code)