### PR TITLE
fix(artifacts): show errors for missing local files

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7784,22 +7784,27 @@ if (!gotTheLock) {
   };
 
   const getFailedShellPathStatus = async (
+    operation: string,
     normalizedPath: string,
     fallbackError: string,
   ): Promise<{ success: false; error: string; reason: ShellOpenFailureReasonType }> => {
     try {
       await fs.promises.stat(normalizedPath);
-      return {
+      const status = {
         success: false,
         error: fallbackError,
         reason: ShellOpenFailureReason.OpenFailed,
-      };
+      } as const;
+      console.warn(`[Shell] failed to ${operation} because the system could not open the existing path:`, normalizedPath);
+      return status;
     } catch (error) {
-      return {
+      const status = {
         success: false,
         error: fallbackError,
         reason: getFileAccessFailureReason(error),
-      };
+      } as const;
+      console.warn(`[Shell] failed to ${operation} because the path is not accessible:`, normalizedPath, error);
+      return status;
     }
   };
 
@@ -7809,12 +7814,13 @@ if (!gotTheLock) {
       const normalizedPath = normalizeWindowsShellPath(filePath);
       const result = await shell.openPath(normalizedPath);
       if (result) {
-        return await getFailedShellPathStatus(normalizedPath, result);
+        return await getFailedShellPathStatus('open local path', normalizedPath, result);
       }
       return { success: true };
     } catch (error) {
       const normalizedPath = normalizeWindowsShellPath(filePath);
       return await getFailedShellPathStatus(
+        'open local path',
         normalizedPath,
         error instanceof Error ? error.message : 'Unknown error',
       );
@@ -7827,6 +7833,7 @@ if (!gotTheLock) {
       try {
         await fs.promises.stat(normalizedPath);
       } catch (error) {
+        console.warn('[Shell] failed to reveal local path because the path is not accessible:', normalizedPath, error);
         return {
           success: false,
           error: error instanceof Error ? error.message : 'Unknown error',
@@ -7836,6 +7843,7 @@ if (!gotTheLock) {
       shell.showItemInFolder(normalizedPath);
       return { success: true };
     } catch (error) {
+      console.warn('[Shell] failed to reveal local path because the system request failed:', filePath, error);
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Unknown error',
@@ -7888,6 +7896,7 @@ if (!gotTheLock) {
       return { success: true };
     } catch (error) {
       return await getFailedShellPathStatus(
+        'open local path with selected app',
         normalizedPath,
         error instanceof Error ? error.message : 'Unknown error',
       );

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -65,6 +65,8 @@ import {
 } from '../shared/localWebServices/constants';
 import { PlatformRegistry } from '../shared/platform';
 import { ProviderName } from '../shared/providers';
+import type { ShellOpenFailureReason as ShellOpenFailureReasonType } from '../shared/shell/constants';
+import { ShellOpenFailureReason } from '../shared/shell/constants';
 import { AgentManager } from './agentManager';
 import { APP_NAME } from './appConstants';
 import { authQuotaGateStateFromQuota, AuthSubscriptionStatus, createDefaultAuthQuotaGateState, normalizeAuthQuota } from './authQuota';
@@ -1048,14 +1050,16 @@ const safeDecodeURIComponent = (value: string): string => {
 };
 
 const normalizeWindowsShellPath = (inputPath: string): string => {
-  if (!isWindows) return inputPath;
-
   const trimmed = inputPath.trim();
   if (!trimmed) return inputPath;
 
   let normalized = trimmed;
-  if (/^file:\/\//i.test(normalized)) {
-    normalized = safeDecodeURIComponent(normalized.replace(/^file:\/\//i, ''));
+  if (/^(?:file|localfile):\/\//i.test(normalized)) {
+    normalized = safeDecodeURIComponent(normalized.replace(/^(?:file|localfile):\/\//i, ''));
+  }
+
+  if (!isWindows) {
+    return normalized;
   }
 
   if (/^\/[A-Za-z]:/.test(normalized)) {
@@ -7768,28 +7772,75 @@ if (!gotTheLock) {
     },
   );
 
+  const getFileAccessFailureReason = (error: unknown): ShellOpenFailureReasonType => {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT') {
+      return ShellOpenFailureReason.NotFound;
+    }
+    if (code === 'EACCES' || code === 'EPERM') {
+      return ShellOpenFailureReason.PermissionDenied;
+    }
+    return ShellOpenFailureReason.Unknown;
+  };
+
+  const getFailedShellPathStatus = async (
+    normalizedPath: string,
+    fallbackError: string,
+  ): Promise<{ success: false; error: string; reason: ShellOpenFailureReasonType }> => {
+    try {
+      await fs.promises.stat(normalizedPath);
+      return {
+        success: false,
+        error: fallbackError,
+        reason: ShellOpenFailureReason.OpenFailed,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: fallbackError,
+        reason: getFileAccessFailureReason(error),
+      };
+    }
+  };
+
   // Shell handlers - 打开文件/文件夹
   ipcMain.handle('shell:openPath', async (_event, filePath: string) => {
     try {
       const normalizedPath = normalizeWindowsShellPath(filePath);
       const result = await shell.openPath(normalizedPath);
       if (result) {
-        // 如果返回非空字符串，表示打开失败
-        return { success: false, error: result };
+        return await getFailedShellPathStatus(normalizedPath, result);
       }
       return { success: true };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+      const normalizedPath = normalizeWindowsShellPath(filePath);
+      return await getFailedShellPathStatus(
+        normalizedPath,
+        error instanceof Error ? error.message : 'Unknown error',
+      );
     }
   });
 
   ipcMain.handle('shell:showItemInFolder', async (_event, filePath: string) => {
     try {
       const normalizedPath = normalizeWindowsShellPath(filePath);
+      try {
+        await fs.promises.stat(normalizedPath);
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          reason: getFileAccessFailureReason(error),
+        };
+      }
       shell.showItemInFolder(normalizedPath);
       return { success: true };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        reason: ShellOpenFailureReason.Unknown,
+      };
     }
   });
 
@@ -7830,12 +7881,16 @@ if (!gotTheLock) {
   });
 
   ipcMain.handle('shell:openPathWithApp', async (_event, filePath: string, appPath: string) => {
+    const normalizedPath = normalizeWindowsShellPath(filePath);
     try {
       const { openFileWithApp } = await import('./shellApps');
-      await openFileWithApp(filePath, appPath);
+      await openFileWithApp(normalizedPath, appPath);
       return { success: true };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+      return await getFailedShellPathStatus(
+        normalizedPath,
+        error instanceof Error ? error.message : 'Unknown error',
+      );
     }
   });
 

--- a/src/renderer/components/MarkdownContent.tsx
+++ b/src/renderer/components/MarkdownContent.tsx
@@ -12,6 +12,7 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 
 import { i18nService } from '../services/i18n';
+import { type ShellActionResult, showShellFailureToast, showToast } from '../utils/localFileActions';
 import CodeBlock from './CodeBlock';
 
 const SAFE_URL_PROTOCOLS = new Set(['http', 'https', 'mailto', 'tel', 'file', 'localfile']);
@@ -170,10 +171,6 @@ const openExternalViaAnchorFallback = (url: string): void => {
   document.body.appendChild(anchor);
   anchor.click();
   document.body.removeChild(anchor);
-};
-
-const dispatchAppToast = (message: string): void => {
-  window.dispatchEvent(new CustomEvent('app:showToast', { detail: message }));
 };
 
 const safeDecodeURIComponent = (value: string): string => {
@@ -481,12 +478,15 @@ const createMarkdownComponents = (
             const fallbackResult = await window.electron.shell.openPath(fallbackPath);
             if (!fallbackResult?.success) {
               console.error('Failed to open file (fallback):', fallbackPath, fallbackResult?.error);
+              showShellFailureToast(fallbackResult, 'openFileFailed');
             }
           } else {
             console.error('Failed to open file:', filePath, result?.error);
+            showShellFailureToast(result, 'openFileFailed');
           }
         } catch (error) {
           console.error('Failed to open file:', filePath, error);
+          showToast(i18nService.t('openFileFailed'));
         }
       };
 
@@ -495,9 +495,11 @@ const createMarkdownComponents = (
         e.stopPropagation();
         const anchor = e.currentTarget.parentElement?.querySelector('a');
         const linkedAnchor = anchor instanceof HTMLAnchorElement ? anchor : null;
+        let lastResult: ShellActionResult | null = null;
 
         const tryReveal = async (targetPath: string): Promise<boolean> => {
           const result = await window.electron.shell.showItemInFolder(targetPath);
+          lastResult = result ?? null;
           if (result?.success) {
             return true;
           }
@@ -519,10 +521,10 @@ const createMarkdownComponents = (
             return;
           }
 
-          dispatchAppToast(i18nService.t('showInFolderFailed'));
+          showShellFailureToast(lastResult, 'showInFolderFailed');
         } catch (error) {
           console.error('Failed to show item in folder:', filePath, error);
-          dispatchAppToast(i18nService.t('showInFolderFailed'));
+          showToast(i18nService.t('showInFolderFailed'));
         }
       };
 

--- a/src/renderer/components/artifacts/ArtifactPanel.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanel.tsx
@@ -32,6 +32,7 @@ import {
   ArtifactTypeValue,
   PREVIEWABLE_ARTIFACT_TYPES,
 } from '@/types/artifact';
+import { openLocalPathWithToast, revealLocalPathWithToast } from '@/utils/localFileActions';
 
 import CopyIcon from '../icons/CopyIcon';
 import ArtifactRenderer from './ArtifactRenderer';
@@ -585,7 +586,7 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
 
   const handleRevealInFolder = useCallback(() => {
     if (!selectedArtifact?.filePath) return;
-    window.electron?.shell?.showItemInFolder(selectedArtifact.filePath);
+    void revealLocalPathWithToast(selectedArtifact.filePath);
   }, [selectedArtifact]);
 
   const handleOpenInBrowser = useCallback(() => {
@@ -606,7 +607,7 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
     // non-ASCII characters (e.g. Chinese) — ERROR_FILE_NOT_FOUND (0x2).
     // Use shell.openPath which handles native Unicode paths correctly.
     if (selectedArtifact.filePath) {
-      window.electron?.shell?.openPath(selectedArtifact.filePath);
+      void openLocalPathWithToast(selectedArtifact.filePath);
       return;
     }
 
@@ -870,7 +871,7 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
       if (/^\/[A-Za-z]:/.test(filePath)) {
         filePath = filePath.slice(1);
       }
-      window.electron?.shell?.openPath(filePath);
+      void openLocalPathWithToast(filePath);
     }
   }, [selectedArtifact]);
 

--- a/src/renderer/components/artifacts/ArtifactPreviewCard.tsx
+++ b/src/renderer/components/artifacts/ArtifactPreviewCard.tsx
@@ -7,6 +7,7 @@ import { useDispatch } from 'react-redux';
 import { i18nService } from '@/services/i18n';
 import { openArtifactPreviewTab } from '@/store/slices/artifactSlice';
 import { type Artifact, type ArtifactType, ArtifactTypeValue } from '@/types/artifact';
+import { revealLocalPathWithToast, showShellFailureToast } from '@/utils/localFileActions';
 
 const t = (key: string) => i18nService.t(key);
 
@@ -204,21 +205,35 @@ const OpenDropdown: React.FC<OpenDropdownProps> = ({ anchorRef, filePath, onClos
     };
   }, [anchorRef, onClose]);
 
-  const handleOpenWithSpecificApp = useCallback((appPath: string) => {
+  const handleOpenWithSpecificApp = useCallback(async (appPath: string) => {
     const normalized = normalizeFilePath(filePath);
-    window.electron?.shell?.openPathWithApp(normalized, appPath);
+    try {
+      const result = await window.electron?.shell?.openPathWithApp(normalized, appPath);
+      if (!result?.success) {
+        showShellFailureToast(result, 'openFileFailed');
+      }
+    } catch {
+      showShellFailureToast(null, 'openFileFailed');
+    }
     onClose();
   }, [filePath, onClose]);
 
-  const handleOpenWithDefault = useCallback(() => {
+  const handleOpenWithDefault = useCallback(async () => {
     const normalized = normalizeFilePath(filePath);
-    window.electron?.shell?.openPath(normalized);
+    try {
+      const result = await window.electron?.shell?.openPath(normalized);
+      if (!result?.success) {
+        showShellFailureToast(result, 'openFileFailed');
+      }
+    } catch {
+      showShellFailureToast(null, 'openFileFailed');
+    }
     onClose();
   }, [filePath, onClose]);
 
-  const handleRevealInFolder = useCallback(() => {
+  const handleRevealInFolder = useCallback(async () => {
     const normalized = normalizeFilePath(filePath);
-    window.electron?.shell?.showItemInFolder(normalized);
+    await revealLocalPathWithToast(normalized);
     onClose();
   }, [filePath, onClose]);
 

--- a/src/renderer/components/artifacts/renderers/DocumentRenderer.tsx
+++ b/src/renderer/components/artifacts/renderers/DocumentRenderer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { i18nService } from '@/services/i18n';
 import type { Artifact } from '@/types/artifact';
+import { openLocalPathWithToast } from '@/utils/localFileActions';
 
 import { SheetRenderer } from './sheet/SheetRenderer';
 
@@ -1154,7 +1155,7 @@ const FileInfoFallback: React.FC<{ artifact: Artifact }> = ({ artifact }) => {
 
   const handleOpenWithApp = useCallback(() => {
     if (artifact.filePath) {
-      window.electron?.shell?.openPath(artifact.filePath);
+      void openLocalPathWithToast(artifact.filePath);
     }
   }, [artifact.filePath]);
 

--- a/src/renderer/components/cowork/AssistantTurnBlock.tsx
+++ b/src/renderer/components/cowork/AssistantTurnBlock.tsx
@@ -6,6 +6,7 @@ import { getScheduledReminderDisplayText } from '../../../scheduledTask/reminder
 import { i18nService } from '../../services/i18n';
 import type { Artifact } from '../../types/artifact';
 import type { CoworkMessage, CoworkMessageMetadata } from '../../types/cowork';
+import { revealLocalPathWithToast } from '../../utils/localFileActions';
 import { ArtifactPreviewCard } from '../artifacts';
 import ExclamationTriangleIcon from '../icons/ExclamationTriangleIcon';
 import InformationCircleIcon from '../icons/InformationCircleIcon';
@@ -115,11 +116,7 @@ const VideoArtifactPathList: React.FC<{ artifacts: Artifact[] }> = ({ artifacts 
           <span className="truncate">{getDisplayPath(artifact.filePath!)}</span>
           <button
             className="flex items-center gap-1 text-primary hover:underline flex-shrink-0"
-            onClick={() => {
-              window.electron.shell.showItemInFolder(artifact.filePath!).catch(() => {
-                // ignore
-              });
-            }}
+            onClick={() => void revealLocalPathWithToast(artifact.filePath!)}
           >
             <FolderIcon className="h-3.5 w-3.5" />
             <span>{i18nService.t('showInFolder')}</span>

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -486,6 +486,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: '最多上传 10 张图片',
     imageReadError: '读取图片失败',
     imageInputNotSupported: '当前模型不支持图像输入',
+    localFileNotFound: '文件不存在，可能已被移动或删除',
+    localFilePermissionDenied: '没有权限打开该文件',
 
     // 模型选择
     selectModel: '选择模型',
@@ -2739,6 +2741,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageLimitReached: 'Up to 10 images',
     imageReadError: 'Failed to read image',
     imageInputNotSupported: 'Current model does not support images',
+    localFileNotFound: 'The file does not exist. It may have been moved or deleted.',
+    localFilePermissionDenied: 'You do not have permission to open this file.',
 
     // Model Selection
     selectModel: 'Select Model',

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -13,6 +13,7 @@ import type {
   ListLocalWebServicesOptions,
   LocalWebService,
 } from '../../shared/localWebServices/constants';
+import type { ShellOpenFailureReason } from '../../shared/shell/constants';
 interface ApiResponse {
   ok: boolean;
   status: number;
@@ -27,6 +28,12 @@ interface ApiStreamResponse {
   status: number;
   statusText: string;
   error?: string;
+}
+
+interface ShellActionResponse {
+  success: boolean;
+  error?: string;
+  reason?: ShellOpenFailureReason;
 }
 
 // Cowork types for IPC
@@ -758,8 +765,8 @@ interface IElectronAPI {
     }) => Promise<{ response: number }>;
   };
   shell: {
-    openPath: (filePath: string) => Promise<{ success: boolean; error?: string }>;
-    showItemInFolder: (filePath: string) => Promise<{ success: boolean; error?: string }>;
+    openPath: (filePath: string) => Promise<ShellActionResponse>;
+    showItemInFolder: (filePath: string) => Promise<ShellActionResponse>;
     openExternal: (url: string) => Promise<{ success: boolean; error?: string }>;
     openHtmlInBrowser: (htmlContent: string) => Promise<{ success: boolean; error?: string }>;
     getAppsForFile: (
@@ -772,7 +779,7 @@ interface IElectronAPI {
     openPathWithApp: (
       filePath: string,
       appPath: string,
-    ) => Promise<{ success: boolean; error?: string }>;
+    ) => Promise<ShellActionResponse>;
   };
   clipboard: {
     writeImageFromFile: (filePath: string) => Promise<{ success: boolean; error?: string }>;

--- a/src/renderer/utils/localFileActions.ts
+++ b/src/renderer/utils/localFileActions.ts
@@ -35,6 +35,18 @@ export const showShellFailureToast = (
   showToast(getShellFailureMessage(result, fallbackKey));
 };
 
+const logLocalFileActionFailure = (
+  operation: string,
+  filePath: string,
+  result: ShellActionResult | undefined | null,
+): void => {
+  console.warn(
+    `[LocalFileActions] failed to ${operation} local path because ${result?.reason || 'the shell request failed'}:`,
+    filePath,
+    result?.error,
+  );
+};
+
 export const openLocalPathWithToast = async (
   filePath: string,
   fallbackKey = 'openFileFailed',
@@ -42,9 +54,11 @@ export const openLocalPathWithToast = async (
   try {
     const result = await window.electron?.shell?.openPath(filePath);
     if (result?.success) return true;
+    logLocalFileActionFailure('open', filePath, result);
     showShellFailureToast(result, fallbackKey);
     return false;
-  } catch {
+  } catch (error) {
+    console.warn('[LocalFileActions] failed to open local path because the shell call threw:', filePath, error);
     showToast(i18nService.t(fallbackKey));
     return false;
   }
@@ -57,11 +71,12 @@ export const revealLocalPathWithToast = async (
   try {
     const result = await window.electron?.shell?.showItemInFolder(filePath);
     if (result?.success) return true;
+    logLocalFileActionFailure('reveal', filePath, result);
     showShellFailureToast(result, fallbackKey);
     return false;
-  } catch {
+  } catch (error) {
+    console.warn('[LocalFileActions] failed to reveal local path because the shell call threw:', filePath, error);
     showToast(i18nService.t(fallbackKey));
     return false;
   }
 };
-

--- a/src/renderer/utils/localFileActions.ts
+++ b/src/renderer/utils/localFileActions.ts
@@ -1,0 +1,67 @@
+import type { ShellOpenFailureReason as ShellOpenFailureReasonType } from '../../shared/shell/constants';
+import { ShellOpenFailureReason } from '../../shared/shell/constants';
+import { i18nService } from '../services/i18n';
+
+export interface ShellActionResult {
+  success: boolean;
+  error?: string;
+  reason?: ShellOpenFailureReasonType;
+}
+
+export const showToast = (message: string): void => {
+  window.dispatchEvent(new CustomEvent('app:showToast', { detail: message }));
+};
+
+export const getShellFailureMessage = (
+  result: ShellActionResult | undefined | null,
+  fallbackKey: string,
+): string => {
+  switch (result?.reason) {
+    case ShellOpenFailureReason.NotFound:
+      return i18nService.t('localFileNotFound');
+    case ShellOpenFailureReason.PermissionDenied:
+      return i18nService.t('localFilePermissionDenied');
+    case ShellOpenFailureReason.OpenFailed:
+    case ShellOpenFailureReason.Unknown:
+    default:
+      return result?.error || i18nService.t(fallbackKey);
+  }
+};
+
+export const showShellFailureToast = (
+  result: ShellActionResult | undefined | null,
+  fallbackKey = 'openFileFailed',
+): void => {
+  showToast(getShellFailureMessage(result, fallbackKey));
+};
+
+export const openLocalPathWithToast = async (
+  filePath: string,
+  fallbackKey = 'openFileFailed',
+): Promise<boolean> => {
+  try {
+    const result = await window.electron?.shell?.openPath(filePath);
+    if (result?.success) return true;
+    showShellFailureToast(result, fallbackKey);
+    return false;
+  } catch {
+    showToast(i18nService.t(fallbackKey));
+    return false;
+  }
+};
+
+export const revealLocalPathWithToast = async (
+  filePath: string,
+  fallbackKey = 'showInFolderFailed',
+): Promise<boolean> => {
+  try {
+    const result = await window.electron?.shell?.showItemInFolder(filePath);
+    if (result?.success) return true;
+    showShellFailureToast(result, fallbackKey);
+    return false;
+  } catch {
+    showToast(i18nService.t(fallbackKey));
+    return false;
+  }
+};
+

--- a/src/shared/shell/constants.ts
+++ b/src/shared/shell/constants.ts
@@ -1,0 +1,10 @@
+export const ShellOpenFailureReason = {
+  NotFound: 'not_found',
+  PermissionDenied: 'permission_denied',
+  OpenFailed: 'open_failed',
+  Unknown: 'unknown',
+} as const;
+
+export type ShellOpenFailureReason =
+  typeof ShellOpenFailureReason[keyof typeof ShellOpenFailureReason];
+


### PR DESCRIPTION
Report clear toast messages when generated local file links or artifact
file actions fail because the file was moved, deleted, or inaccessible.

Keep remote links unchanged and preserve existing platform-specific path
handling for macOS and Windows.