### PR TITLE
fix(cowork): support deleting subagent sessions

### DIFF
--- a/src/main/ipcHandlers/coworkSubagent/handlers.ts
+++ b/src/main/ipcHandlers/coworkSubagent/handlers.ts
@@ -1,0 +1,84 @@
+import { ipcMain } from 'electron';
+
+import { CoworkIpcChannel } from '../../../shared/cowork/constants';
+
+export interface CoworkSubagentRuntimeAdapter {
+  getSubTaskHistory: (
+    parentSessionId: string,
+    agentId: string,
+    sessionKey?: string,
+  ) => Promise<unknown>;
+  listSubagentRuns: (parentSessionId: string) => unknown[];
+}
+
+export interface CoworkSubagentEngineRouter {
+  deleteSubagentSession: (parentSessionId: string, runId: string) => Promise<boolean>;
+}
+
+export interface CoworkSubagentHandlerDeps {
+  getOpenClawRuntimeAdapter: () => CoworkSubagentRuntimeAdapter | null;
+  getCoworkEngineRouter: () => CoworkSubagentEngineRouter;
+}
+
+export function registerCoworkSubagentHandlers(deps: CoworkSubagentHandlerDeps): void {
+  const { getOpenClawRuntimeAdapter, getCoworkEngineRouter } = deps;
+
+  ipcMain.handle(
+    CoworkIpcChannel.SubTaskHistory,
+    async (
+      _event,
+      options: {
+        parentSessionId: string;
+        agentId: string;
+        sessionKey?: string;
+      },
+    ) => {
+      const adapter = getOpenClawRuntimeAdapter();
+      if (!adapter) {
+        return { success: false, error: 'Runtime adapter not available' };
+      }
+      try {
+        const messages = await adapter.getSubTaskHistory(
+          options.parentSessionId,
+          options.agentId,
+          options.sessionKey,
+        );
+        return { success: true, messages };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to fetch subagent history',
+        };
+      }
+    },
+  );
+
+  ipcMain.handle(CoworkIpcChannel.SubagentList, async (_event, options: { parentSessionId: string }) => {
+    const adapter = getOpenClawRuntimeAdapter();
+    if (!adapter) return { success: true, runs: [] };
+    const runs = adapter.listSubagentRuns(options.parentSessionId);
+    return { success: true, runs };
+  });
+
+  ipcMain.handle(
+    CoworkIpcChannel.SubagentDelete,
+    async (_event, options: { parentSessionId: string; runId: string }) => {
+      const adapter = getOpenClawRuntimeAdapter();
+      if (!adapter) {
+        return { success: false, error: 'Runtime adapter not available' };
+      }
+      try {
+        const deleted = await getCoworkEngineRouter().deleteSubagentSession(
+          options.parentSessionId,
+          options.runId,
+        );
+        return { success: true, deleted };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to delete subagent session',
+        };
+      }
+    },
+  );
+}

--- a/src/main/ipcHandlers/coworkSubagent/index.ts
+++ b/src/main/ipcHandlers/coworkSubagent/index.ts
@@ -1,0 +1,2 @@
+export type { CoworkSubagentHandlerDeps } from './handlers';
+export { registerCoworkSubagentHandlers } from './handlers';

--- a/src/main/libs/agentEngine/coworkEngineRouter.ts
+++ b/src/main/libs/agentEngine/coworkEngineRouter.ts
@@ -132,6 +132,13 @@ export class CoworkEngineRouter extends EventEmitter implements CoworkRuntime {
     return this.runtime.getSessionConfirmationMode(sessionId);
   }
 
+  async deleteSubagentSession(parentSessionId: string, runId: string): Promise<boolean> {
+    if (!this.runtime.deleteSubagentSession) {
+      return false;
+    }
+    return this.runtime.deleteSubagentSession(parentSessionId, runId);
+  }
+
   onSessionDeleted(sessionId: string): void {
     this.sessionEngine.delete(sessionId);
     this.clearRequestEngineBySession(sessionId);

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -6906,6 +6906,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     return this.subagentTracker.getSubTaskHistory(parentSessionId, agentId, sessionKey);
   }
 
+  async deleteSubagentSession(parentSessionId: string, runId: string): Promise<boolean> {
+    return this.subagentTracker.deleteSubagentRun(parentSessionId, runId);
+  }
+
   /**
    * Called when a session is deleted from the store.
    * Purges all in-memory references so that new channel messages

--- a/src/main/libs/agentEngine/subagentTracker.test.ts
+++ b/src/main/libs/agentEngine/subagentTracker.test.ts
@@ -1,0 +1,159 @@
+import BetterSqlite3 from 'better-sqlite3';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { SubagentMessageStore } from '../../subagentMessageStore';
+import { SubagentRunStore } from '../../subagentRunStore';
+import { type GatewayClientLike, SubagentTracker } from './subagentTracker';
+
+let db: BetterSqlite3.Database;
+let runStore: SubagentRunStore;
+let messageStore: SubagentMessageStore;
+
+const setupDb = (): void => {
+  db = new BetterSqlite3(':memory:');
+  db.exec(`
+    CREATE TABLE subagent_runs (
+      id TEXT PRIMARY KEY,
+      parent_session_id TEXT NOT NULL,
+      session_key TEXT,
+      agent_id TEXT,
+      task TEXT,
+      label TEXT,
+      status TEXT NOT NULL DEFAULT 'running',
+      created_at INTEGER NOT NULL,
+      ended_at INTEGER,
+      messages_persisted INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  db.exec(`
+    CREATE TABLE subagent_messages (
+      id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL DEFAULT '',
+      metadata TEXT,
+      created_at INTEGER NOT NULL,
+      sequence INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  runStore = new SubagentRunStore(db);
+  messageStore = new SubagentMessageStore(db);
+};
+
+beforeEach(() => {
+  setupDb();
+});
+
+test('deleteSubagentRun removes a single run, messages, and gateway transcript', async () => {
+  const gatewayClient: GatewayClientLike = {
+    request: vi.fn().mockResolvedValue({}),
+  };
+  const tracker = new SubagentTracker(runStore, messageStore, () => gatewayClient);
+
+  runStore.insertSubagentRun({
+    id: 'run-1',
+    parentSessionId: 'parent-1',
+    sessionKey: 'agent:main:subagent:run-1',
+    agentId: 'worker',
+    task: 'inspect files',
+    label: 'worker',
+    status: 'done',
+    createdAt: 1000,
+  });
+  messageStore.insertMessages('run-1', [{
+    id: 'message-1',
+    type: 'assistant',
+    content: 'done',
+    timestamp: 1001,
+    sequence: 1,
+  }]);
+
+  const deleted = await tracker.deleteSubagentRun('parent-1', 'run-1');
+
+  expect(deleted).toBe(true);
+  expect(runStore.getSubagentRun('run-1')).toBeNull();
+  expect(messageStore.hasMessages('run-1')).toBe(false);
+  expect(gatewayClient.request).toHaveBeenCalledWith(
+    'sessions.delete',
+    { key: 'agent:main:subagent:run-1', deleteTranscript: true },
+    { timeoutMs: 5_000 },
+  );
+});
+
+test('deleteSubagentRun refuses to delete a run from another parent session', async () => {
+  const tracker = new SubagentTracker(runStore, messageStore, () => null);
+  runStore.insertSubagentRun({
+    id: 'run-1',
+    parentSessionId: 'parent-1',
+    sessionKey: null,
+    agentId: 'worker',
+    task: 'inspect files',
+    label: 'worker',
+    status: 'done',
+    createdAt: 1000,
+  });
+
+  const deleted = await tracker.deleteSubagentRun('parent-2', 'run-1');
+
+  expect(deleted).toBe(false);
+  expect(runStore.getSubagentRun('run-1')).not.toBeNull();
+});
+
+test('onSessionDeleted removes subagent runs and messages for the parent session', () => {
+  const tracker = new SubagentTracker(runStore, messageStore, () => null);
+  runStore.insertSubagentRun({
+    id: 'run-1',
+    parentSessionId: 'parent-1',
+    sessionKey: null,
+    agentId: 'worker',
+    task: 'inspect files',
+    label: 'worker',
+    status: 'done',
+    createdAt: 1000,
+  });
+  runStore.insertSubagentRun({
+    id: 'run-2',
+    parentSessionId: 'parent-2',
+    sessionKey: null,
+    agentId: 'worker',
+    task: 'inspect files',
+    label: 'worker',
+    status: 'done',
+    createdAt: 1000,
+  });
+  messageStore.insertMessages('run-1', [{
+    id: 'message-1',
+    type: 'assistant',
+    content: 'done',
+    timestamp: 1001,
+    sequence: 1,
+  }]);
+
+  tracker.onSessionDeleted('parent-1');
+
+  expect(runStore.getSubagentRun('run-1')).toBeNull();
+  expect(messageStore.hasMessages('run-1')).toBe(false);
+  expect(runStore.getSubagentRun('run-2')).not.toBeNull();
+});
+
+test('deleted subagent run is not reinserted by late spawn results', async () => {
+  const tracker = new SubagentTracker(runStore, messageStore, () => null);
+  tracker.onToolStart('run-1', {
+    agentId: 'worker',
+    task: 'inspect files',
+    label: 'worker',
+  }, 'parent-1');
+  tracker.onSpawnResult('run-1', JSON.stringify({
+    childSessionKey: 'agent:main:subagent:run-1',
+    status: 'running',
+  }), {});
+
+  const deleted = await tracker.deleteSubagentRun('parent-1', 'run-1');
+  tracker.onSpawnResult('run-1', JSON.stringify({
+    childSessionKey: 'agent:main:subagent:run-1',
+    status: 'running',
+  }), {});
+
+  expect(deleted).toBe(true);
+  expect(runStore.getSubagentRun('run-1')).toBeNull();
+});

--- a/src/main/libs/agentEngine/subagentTracker.ts
+++ b/src/main/libs/agentEngine/subagentTracker.ts
@@ -80,6 +80,8 @@ export class SubagentTracker {
   private readonly subagentStatus = new Map<string, 'running' | 'done' | 'error'>();
   /** Reverse map: agentId → Set of toolCallIds (for lookups from sessions_resume args) */
   private readonly agentIdToToolCallIds = new Map<string, Set<string>>();
+  /** Run ids explicitly deleted by the user. Suppresses late spawn/backfill re-inserts. */
+  private readonly deletedSubagentRunIds = new Set<string>();
   /** Pending spawn info stored at tool start, used for DB insertion when result arrives */
   private readonly pendingSpawnInfo = new Map<string, {
     agentId: string;
@@ -107,6 +109,7 @@ export class SubagentTracker {
     args: Record<string, unknown>,
     sessionId: string,
   ): void {
+    this.deletedSubagentRunIds.delete(toolCallId);
     const agentId = typeof args?.agentId === 'string' && args.agentId
       ? args.agentId
       : typeof args?.taskName === 'string' && args.taskName
@@ -145,6 +148,7 @@ export class SubagentTracker {
    */
   onSpawnResult(toolCallId: string, resultText: string, _args: Record<string, unknown>): void {
     if (!resultText) return;
+    if (this.deletedSubagentRunIds.has(toolCallId)) return;
     if (!this.subagentToolCallIdToAgentId.has(toolCallId)) return;
     try {
       const parsed = JSON.parse(resultText);
@@ -157,6 +161,7 @@ export class SubagentTracker {
    * Creates the DB record if not already done.
    */
   onBackfillResult(toolCallId: string, text: string): void {
+    if (this.deletedSubagentRunIds.has(toolCallId)) return;
     if (!this.subagentToolCallIdToAgentId.has(toolCallId)) return;
     try {
       const parsed = JSON.parse(text);
@@ -212,9 +217,17 @@ export class SubagentTracker {
    * Clears all in-memory subagent tracking state and removes persisted messages.
    */
   onSessionDeleted(parentSessionId?: string): void {
+    if (parentSessionId) {
+      for (const run of this.store.listSubagentRuns(parentSessionId)) {
+        this.deletedSubagentRunIds.add(run.id);
+      }
+    }
     // Clean up persisted messages for this parent session
     if (parentSessionId && this.messageStore) {
       this.messageStore.deleteByParentSession(parentSessionId);
+    }
+    if (parentSessionId) {
+      this.store.deleteSubagentRunsByParent(parentSessionId);
     }
     this.subagentSessionKeys.clear();
     this.subagentMessages.clear();
@@ -222,6 +235,28 @@ export class SubagentTracker {
     this.subagentToolCallIdToAgentId.clear();
     this.agentIdToToolCallIds.clear();
     this.pendingSpawnInfo.clear();
+  }
+
+  async deleteSubagentRun(parentSessionId: string, runId: string): Promise<boolean> {
+    const run = this.store.getSubagentRun(runId);
+    if (!run || run.parentSessionId !== parentSessionId) {
+      return false;
+    }
+
+    this.deletedSubagentRunIds.add(runId);
+    const sessionKey = this.subagentSessionKeys.get(runId) || run.sessionKey;
+    this.clearSubagentMemory(runId);
+
+    if (this.messageStore) {
+      this.messageStore.deleteByRunIds([runId]);
+    }
+    this.store.deleteSubagentRun(runId);
+
+    if (sessionKey) {
+      await this.deleteGatewaySession(sessionKey);
+    }
+
+    return true;
   }
 
   // ── Public query API ───────────────────────────────────────────────────
@@ -341,6 +376,7 @@ export class SubagentTracker {
    * Inserts the DB record (if not already done) with the correct status.
    */
   private commitSpawnResult(toolCallId: string, parsed: Record<string, unknown>): void {
+    if (this.deletedSubagentRunIds.has(toolCallId)) return;
     const childSessionKey = typeof parsed?.childSessionKey === 'string' ? parsed.childSessionKey : '';
     const isError = parsed?.status === 'error';
     const status = isError ? 'error' : 'running';
@@ -376,6 +412,37 @@ export class SubagentTracker {
       this.pendingSpawnInfo.delete(toolCallId);
       console.log('[SubagentTracker] committed spawn result:', toolCallId, status,
         isError ? parsed.error : '');
+    }
+  }
+
+  private clearSubagentMemory(runId: string): void {
+    const agentId = this.subagentToolCallIdToAgentId.get(runId);
+    this.subagentSessionKeys.delete(runId);
+    this.subagentMessages.delete(runId);
+    this.subagentStatus.delete(runId);
+    this.subagentToolCallIdToAgentId.delete(runId);
+    this.pendingSpawnInfo.delete(runId);
+
+    if (agentId) {
+      const toolCallIds = this.agentIdToToolCallIds.get(agentId);
+      toolCallIds?.delete(runId);
+      if (toolCallIds?.size === 0) {
+        this.agentIdToToolCallIds.delete(agentId);
+      }
+    }
+  }
+
+  private async deleteGatewaySession(sessionKey: string): Promise<void> {
+    const client = this.getGatewayClient();
+    if (!client) return;
+
+    try {
+      await client.request('sessions.delete', {
+        key: sessionKey,
+        deleteTranscript: true,
+      }, { timeoutMs: 5_000 });
+    } catch (error) {
+      console.warn('[SubagentTracker] Failed to delete gateway subagent session:', error);
     }
   }
 

--- a/src/main/libs/agentEngine/types.ts
+++ b/src/main/libs/agentEngine/types.ts
@@ -120,5 +120,6 @@ export interface CoworkRuntime {
   respondToPermission(requestId: string, result: PermissionResult): void;
   isSessionActive(sessionId: string): boolean;
   getSessionConfirmationMode(sessionId: string): 'modal' | 'text' | null;
+  deleteSubagentSession?(parentSessionId: string, runId: string): Promise<boolean>;
   onSessionDeleted?(sessionId: string): void;
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5576,7 +5576,7 @@ if (!gotTheLock) {
   // ── Subagent tracking IPC ──────────────────────────────────────────────
 
   ipcMain.handle(
-    'cowork:subTask:history',
+    CoworkIpcChannel.SubTaskHistory,
     async (
       _event,
       options: {
@@ -5604,11 +5604,32 @@ if (!gotTheLock) {
     },
   );
 
-  ipcMain.handle('cowork:subagent:list', async (_event, options: { parentSessionId: string }) => {
+  ipcMain.handle(CoworkIpcChannel.SubagentList, async (_event, options: { parentSessionId: string }) => {
     if (!openClawRuntimeAdapter) return { success: true, runs: [] };
     const runs = openClawRuntimeAdapter.listSubagentRuns(options.parentSessionId);
     return { success: true, runs };
   });
+
+  ipcMain.handle(
+    CoworkIpcChannel.SubagentDelete,
+    async (_event, options: { parentSessionId: string; runId: string }) => {
+      if (!openClawRuntimeAdapter) {
+        return { success: false, error: 'Runtime adapter not available' };
+      }
+      try {
+        const deleted = await getCoworkEngineRouter().deleteSubagentSession(
+          options.parentSessionId,
+          options.runId,
+        );
+        return { success: true, deleted };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to delete subagent session',
+        };
+      }
+    },
+  );
 
   ipcMain.handle('cowork:media:cancel', async (_event, taskId: string) => {
     try {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -92,6 +92,7 @@ import type {
   TelegramInstanceConfig,
   WecomInstanceConfig,
 } from './im/types';
+import { registerCoworkSubagentHandlers } from './ipcHandlers/coworkSubagent';
 import { registerKitHandlers } from './ipcHandlers/kits';
 import { registerNimQrLoginHandlers } from './ipcHandlers/nimQrLogin';
 import { registerPluginHandlers } from './ipcHandlers/plugins';
@@ -5575,61 +5576,10 @@ if (!gotTheLock) {
 
   // ── Subagent tracking IPC ──────────────────────────────────────────────
 
-  ipcMain.handle(
-    CoworkIpcChannel.SubTaskHistory,
-    async (
-      _event,
-      options: {
-        parentSessionId: string;
-        agentId: string;
-        sessionKey?: string;
-      },
-    ) => {
-      if (!openClawRuntimeAdapter) {
-        return { success: false, error: 'Runtime adapter not available' };
-      }
-      try {
-        const messages = await openClawRuntimeAdapter.getSubTaskHistory(
-          options.parentSessionId,
-          options.agentId,
-          options.sessionKey,
-        );
-        return { success: true, messages };
-      } catch (error) {
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : 'Failed to fetch subagent history',
-        };
-      }
-    },
-  );
-
-  ipcMain.handle(CoworkIpcChannel.SubagentList, async (_event, options: { parentSessionId: string }) => {
-    if (!openClawRuntimeAdapter) return { success: true, runs: [] };
-    const runs = openClawRuntimeAdapter.listSubagentRuns(options.parentSessionId);
-    return { success: true, runs };
+  registerCoworkSubagentHandlers({
+    getOpenClawRuntimeAdapter: () => openClawRuntimeAdapter,
+    getCoworkEngineRouter,
   });
-
-  ipcMain.handle(
-    CoworkIpcChannel.SubagentDelete,
-    async (_event, options: { parentSessionId: string; runId: string }) => {
-      if (!openClawRuntimeAdapter) {
-        return { success: false, error: 'Runtime adapter not available' };
-      }
-      try {
-        const deleted = await getCoworkEngineRouter().deleteSubagentSession(
-          options.parentSessionId,
-          options.runId,
-        );
-        return { success: true, deleted };
-      } catch (error) {
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : 'Failed to delete subagent session',
-        };
-      }
-    },
-  );
 
   ipcMain.handle('cowork:media:cancel', async (_event, taskId: string) => {
     try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -339,9 +339,11 @@ contextBridge.exposeInMainWorld('electron', {
       parentSessionId: string;
       agentId: string;
       sessionKey?: string;
-    }) => ipcRenderer.invoke('cowork:subTask:history', options),
+    }) => ipcRenderer.invoke(CoworkIpcChannel.SubTaskHistory, options),
     listSubagentSessions: (parentSessionId: string) =>
-      ipcRenderer.invoke('cowork:subagent:list', { parentSessionId }),
+      ipcRenderer.invoke(CoworkIpcChannel.SubagentList, { parentSessionId }),
+    deleteSubagentSession: (options: { parentSessionId: string; runId: string }) =>
+      ipcRenderer.invoke(CoworkIpcChannel.SubagentDelete, options),
 
     // Media task management
     cancelMediaTask: (taskId: string) =>

--- a/src/main/subagentRunStore.ts
+++ b/src/main/subagentRunStore.ts
@@ -84,6 +84,38 @@ export class SubagentRunStore {
     }));
   }
 
+  getSubagentRun(id: string): SubagentRun | null {
+    interface Row {
+      id: string;
+      parent_session_id: string;
+      session_key: string | null;
+      agent_id: string | null;
+      task: string | null;
+      label: string | null;
+      status: string;
+      created_at: number;
+      ended_at: number | null;
+    }
+
+    const row = this.db
+      .prepare('SELECT * FROM subagent_runs WHERE id = ?')
+      .get(id) as Row | undefined;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      parentSessionId: row.parent_session_id,
+      sessionKey: row.session_key,
+      agentId: row.agent_id,
+      task: row.task,
+      label: row.label,
+      status: row.status as SubagentRunStatus,
+      createdAt: row.created_at,
+      endedAt: row.ended_at,
+    };
+  }
+
   markMessagesPersisted(id: string): void {
     this.db.prepare('UPDATE subagent_runs SET messages_persisted = 1 WHERE id = ?')
       .run(id);
@@ -106,5 +138,10 @@ export class SubagentRunStore {
   deleteSubagentRunsByParent(parentSessionId: string): void {
     this.db.prepare('DELETE FROM subagent_runs WHERE parent_session_id = ?')
       .run(parentSessionId);
+  }
+
+  deleteSubagentRun(id: string): void {
+    this.db.prepare('DELETE FROM subagent_runs WHERE id = ?')
+      .run(id);
   }
 }

--- a/src/renderer/components/agentSidebar/AgentTreeNode.tsx
+++ b/src/renderer/components/agentSidebar/AgentTreeNode.tsx
@@ -26,6 +26,7 @@ interface AgentTreeNodeProps {
   subagentsBySessionId?: Record<string, SubagentSessionSummary[]>;
   selectedSubagentId?: string | null;
   onSelectSubagent?: (subagent: SubagentSessionSummary) => void;
+  onDeleteSubagent?: (subagent: SubagentSessionSummary) => Promise<void>;
   onToggleExpanded: (agentId: string) => void;
   onEditAgent: (agent: AgentSidebarAgentNode) => void;
   onCreateTask: (agent: AgentSidebarAgentNode) => void;
@@ -73,6 +74,7 @@ const AgentTreeNode: React.FC<AgentTreeNodeProps> = ({
   subagentsBySessionId,
   selectedSubagentId,
   onSelectSubagent,
+  onDeleteSubagent,
   onToggleExpanded,
   onEditAgent,
   onCreateTask,
@@ -423,6 +425,7 @@ const AgentTreeNode: React.FC<AgentTreeNodeProps> = ({
                       subagent={sub}
                       isSelected={sub.id === selectedSubagentId}
                       onSelect={() => onSelectSubagent?.(sub)}
+                      onDelete={() => onDeleteSubagent?.(sub) ?? Promise.resolve()}
                     />
                   ))}
                 </React.Fragment>

--- a/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
+++ b/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
@@ -48,7 +48,10 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [settingsAgentId, setSettingsAgentId] = useState<string | null>(null);
   const [selectedSubagentId, setSelectedSubagentId] = useState<string | null>(null);
-  const { subagentsBySessionId, refetchSubagents } = useSubagentSessions(currentSessionId, currentSessionStatus);
+  const { subagentsBySessionId, refetchSubagents, removeSubagent } = useSubagentSessions(
+    currentSessionId,
+    currentSessionStatus,
+  );
   const {
     agentNodes,
     patchTaskPreview,
@@ -94,6 +97,18 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
     const deleted = await coworkService.deleteSession(task.id);
     if (deleted) {
       removeTaskPreview(task.id);
+    }
+  };
+
+  const handleDeleteSubagent = async (subagent: SubagentSessionSummary) => {
+    if (!subagent.parentSessionId) return;
+
+    const deleted = await coworkService.deleteSubagentSession(subagent.parentSessionId, subagent.id);
+    if (deleted) {
+      removeSubagent(subagent.parentSessionId, subagent.id);
+      if (selectedSubagentId === subagent.id) {
+        window.dispatchEvent(new CustomEvent(CoworkUiEvent.SelectSubagent, { detail: null }));
+      }
     }
   };
 
@@ -181,6 +196,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
         onShowCowork();
         window.dispatchEvent(new CustomEvent(CoworkUiEvent.SelectSubagent, { detail: sub }));
       }}
+      onDeleteSubagent={handleDeleteSubagent}
       onToggleExpanded={toggleAgentExpanded}
       onEditAgent={(agent) => setSettingsAgentId(agent.id)}
       onCreateTask={(agent) => void handleCreateTask(agent)}

--- a/src/renderer/components/agentSidebar/SubagentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/SubagentTaskRow.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import React, { useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
 import type { SubagentSessionSummary } from '../../types/cowork';
+import Modal from '../common/Modal';
 import LoadingIcon from '../icons/LoadingIcon';
+import TrashIcon from '../icons/TrashIcon';
 
 interface SubagentTaskRowProps {
   subagent: SubagentSessionSummary;
   isSelected?: boolean;
   onSelect: () => void;
+  onDelete: () => Promise<void>;
 }
 
 const formatDuration = (createdAt: number): string => {
@@ -22,40 +26,96 @@ const formatDuration = (createdAt: number): string => {
   return `${days}d`;
 };
 
-const SubagentTaskRow: React.FC<SubagentTaskRowProps> = ({ subagent, isSelected = false, onSelect }) => {
+const SubagentTaskRow: React.FC<SubagentTaskRowProps> = ({ subagent, isSelected = false, onSelect, onDelete }) => {
+  const [showConfirmDelete, setShowConfirmDelete] = useState(false);
   const displayName = subagent.label ?? subagent.agentId ?? i18nService.t('subagentUnnamed');
   const duration = formatDuration(subagent.createdAt);
 
   return (
-    <div
-      className={`group relative -ml-[6px] flex h-[26px] w-[calc(100%+12px)] cursor-pointer items-center gap-1.5 rounded-md pl-[52px] pr-2.5 text-[13px] font-normal transition-colors ${
-        isSelected
-          ? 'bg-black/[0.06] text-foreground/80 dark:bg-white/[0.07]'
-          : 'text-foreground/60 hover:bg-black/[0.03] hover:text-foreground/80 dark:hover:bg-white/[0.04]'
-      }`}
-      onClick={onSelect}
-      role="treeitem"
-      aria-level={3}
-      aria-selected={isSelected}
-    >
-      <span className="min-w-0 flex-1 truncate">
-        {displayName}
-      </span>
+    <>
+      <div
+        className={`group relative -ml-[6px] flex h-[26px] w-[calc(100%+12px)] cursor-pointer items-center gap-1.5 rounded-md pl-[52px] pr-2.5 text-[13px] font-normal transition-colors ${
+          isSelected
+            ? 'bg-black/[0.06] text-foreground/80 dark:bg-white/[0.07]'
+            : 'text-foreground/60 hover:bg-black/[0.03] hover:text-foreground/80 dark:hover:bg-white/[0.04]'
+        }`}
+        onClick={onSelect}
+        role="treeitem"
+        aria-level={3}
+        aria-selected={isSelected}
+      >
+        <span className="min-w-0 flex-1 truncate pr-5">
+          {displayName}
+        </span>
 
-      {subagent.status === 'running' ? (
-        <span className="inline-flex h-3 w-3 shrink-0 items-center justify-center">
-          <LoadingIcon className="h-3 w-3 animate-spin text-secondary" aria-hidden="true" />
-        </span>
-      ) : subagent.status === 'error' ? (
-        <span className="shrink-0 whitespace-nowrap text-[11px] font-normal text-red-500/60">
-          {i18nService.t('subagentError') || 'Error'}
-        </span>
-      ) : (
-        <span className="shrink-0 whitespace-nowrap text-[11px] font-normal text-foreground opacity-[0.28]">
-          {duration}
-        </span>
+        {subagent.status === 'running' ? (
+          <span className="inline-flex h-3 w-3 shrink-0 items-center justify-center transition-opacity group-hover:opacity-0">
+            <LoadingIcon className="h-3 w-3 animate-spin text-secondary" aria-hidden="true" />
+          </span>
+        ) : subagent.status === 'error' ? (
+          <span className="shrink-0 whitespace-nowrap text-[11px] font-normal text-red-500/60 transition-opacity group-hover:opacity-0">
+            {i18nService.t('subagentError') || 'Error'}
+          </span>
+        ) : (
+          <span className="shrink-0 whitespace-nowrap text-[11px] font-normal text-foreground opacity-[0.28] transition-opacity group-hover:opacity-0">
+            {duration}
+          </span>
+        )}
+
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            setShowConfirmDelete(true);
+          }}
+          className="absolute right-1 top-1/2 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-foreground opacity-0 transition-opacity hover:opacity-[0.46] group-hover:opacity-[0.3]"
+          aria-label={i18nService.t('deleteSession')}
+          title={i18nService.t('deleteSession')}
+        >
+          <TrashIcon className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {showConfirmDelete && (
+        <Modal
+          onClose={() => setShowConfirmDelete(false)}
+          className="w-full max-w-sm mx-4 bg-surface rounded-2xl shadow-xl overflow-hidden"
+        >
+          <div className="flex items-center gap-3 px-5 py-4">
+            <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
+              <ExclamationTriangleIcon className="h-5 w-5 text-red-600 dark:text-red-500" />
+            </div>
+            <h2 className="text-base font-semibold text-foreground">
+              {i18nService.t('deleteTaskConfirmTitle')}
+            </h2>
+          </div>
+          <div className="px-5 pb-4">
+            <p className="text-sm text-secondary">
+              {i18nService.t('deleteTaskConfirmMessage')}
+            </p>
+          </div>
+          <div className="flex items-center justify-end gap-3 px-5 py-4 border-t border-border">
+            <button
+              type="button"
+              onClick={() => setShowConfirmDelete(false)}
+              className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
+            >
+              {i18nService.t('cancel')}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowConfirmDelete(false);
+                void onDelete();
+              }}
+              className="px-4 py-2 text-sm font-medium rounded-lg bg-red-500 text-white transition-colors hover:bg-red-600"
+            >
+              {i18nService.t('deleteSession')}
+            </button>
+          </div>
+        </Modal>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/renderer/components/agentSidebar/useSubagentSessions.ts
+++ b/src/renderer/components/agentSidebar/useSubagentSessions.ts
@@ -46,6 +46,16 @@ export const useSubagentSessions = (
     }
   }, []);
 
+  const removeSubagent = useCallback((parentSessionId: string, runId: string) => {
+    setSubagentsBySessionId((prev) => {
+      const existing = prev[parentSessionId];
+      if (!existing) return prev;
+      const next = existing.filter((subagent) => subagent.id !== runId);
+      if (next.length === existing.length) return prev;
+      return { ...prev, [parentSessionId]: next };
+    });
+  }, []);
+
   useEffect(() => {
     if (pollingRef.current) {
       clearInterval(pollingRef.current);
@@ -73,5 +83,5 @@ export const useSubagentSessions = (
     };
   }, [currentSessionId, currentSessionStatus, fetchSubagents]);
 
-  return { subagentsBySessionId, refetchSubagents: fetchSubagents };
+  return { subagentsBySessionId, refetchSubagents: fetchSubagents, removeSubagent };
 };

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -759,6 +759,19 @@ class CoworkService {
     return false;
   }
 
+  async deleteSubagentSession(parentSessionId: string, runId: string): Promise<boolean> {
+    const cowork = window.electron?.cowork;
+    if (!cowork?.deleteSubagentSession) return false;
+
+    const result = await cowork.deleteSubagentSession({ parentSessionId, runId });
+    if (result.success) {
+      return result.deleted ?? true;
+    }
+
+    console.error('Failed to delete subagent session:', result.error);
+    return false;
+  }
+
   async setSessionPinned(sessionId: string, pinned: boolean): Promise<{ success: boolean; pinOrder: number | null }> {
     const cowork = window.electron?.cowork;
     if (!cowork?.setSessionPinned) return { success: false, pinOrder: null };

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -663,6 +663,10 @@ interface IElectronAPI {
       }>;
       error?: string;
     }>;
+    deleteSubagentSession: (options: {
+      parentSessionId: string;
+      runId: string;
+    }) => Promise<{ success: boolean; deleted?: boolean; error?: string }>;
     respondToPermission: (options: {
       requestId: string;
       result: CoworkPermissionResult;

--- a/src/shared/cowork/constants.ts
+++ b/src/shared/cowork/constants.ts
@@ -6,6 +6,9 @@ export const COWORK_MESSAGE_PAGE_SIZE = 30;
 
 export const CoworkIpcChannel = {
   MediaStatusPollUpdate: 'cowork:media:statusPollUpdate',
+  SubTaskHistory: 'cowork:subTask:history',
+  SubagentList: 'cowork:subagent:list',
+  SubagentDelete: 'cowork:subagent:delete',
 } as const;
 export type CoworkIpcChannel = typeof CoworkIpcChannel[keyof typeof CoworkIpcChannel];
 


### PR DESCRIPTION
## Summary
- add subagent delete IPC/runtime/store cleanup path
- remove deleted subagents from the sidebar and return to the parent session when needed
- add tracker tests for deletion, parent cleanup, and late spawn suppression

## Verification
- npm test -- subagentTracker
- npm run compile:electron
- npm run build
- npx eslint <changed files>

Note: full npm run lint still fails on pre-existing repo-wide lint issues outside this change.