### PR TITLE
feat(kits): localize installed skill descriptions

### DIFF
--- a/src/main/ipcHandlers/kits/handlers.ts
+++ b/src/main/ipcHandlers/kits/handlers.ts
@@ -5,7 +5,11 @@ import http from 'http';
 import https from 'https';
 import path from 'path';
 
-import type { InstalledKitRecord } from '../../../shared/kit/constants';
+import type {
+  InstalledKitRecord,
+  KitSkillMetadata,
+  LocalizedText,
+} from '../../../shared/kit/constants';
 import { cpRecursiveSync } from '../../fsCompat';
 import type { SkillManager } from '../../skillManager';
 import type { SqliteStore } from '../../sqliteStore';
@@ -50,6 +54,47 @@ type InstalledKitsMap = Record<string, InstalledKitRecord>;
 const normalizeCapabilityList = (value: unknown): unknown[] => (
   Array.isArray(value) ? value : []
 );
+
+const normalizeLocalizedText = (value: unknown): string | LocalizedText | undefined => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const en = typeof record.en === 'string' ? record.en.trim() : '';
+  const zh = typeof record.zh === 'string' ? record.zh.trim() : '';
+  if (!en && !zh) return undefined;
+  return {
+    en: en || zh,
+    zh: zh || en,
+  };
+};
+
+const normalizeKitSkillMetadataList = (value: unknown): Map<string, KitSkillMetadata> => {
+  const metadata = new Map<string, KitSkillMetadata>();
+  if (!Array.isArray(value)) return metadata;
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const record = item as Record<string, unknown>;
+    const id = typeof record.id === 'string' ? record.id.trim() : '';
+    if (!id) continue;
+
+    const name = normalizeLocalizedText(record.name);
+    const description = normalizeLocalizedText(record.description);
+    metadata.set(id, {
+      id,
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    });
+  }
+
+  return metadata;
+};
 
 function getSkillsRoot(): string {
   return path.resolve(app.getPath('userData'), SKILLS_DIR_NAME);
@@ -107,6 +152,7 @@ function collectSkillDirs(source: string): string[] {
 function listSkillDirs(root: string): string[] {
   if (!fs.existsSync(root)) return [];
   return fs.readdirSync(root)
+    .sort((a, b) => a.localeCompare(b))
     .map(entry => path.join(root, entry))
     .filter(entryPath => {
       try {
@@ -174,6 +220,7 @@ export function registerKitHandlers(deps: KitHandlerDeps): void {
     bundleUrl: string;
     version: string;
     skillListIds: string[];
+    skillList?: KitSkillMetadata[];
     mcpServers?: unknown[] | null;
     connectors?: unknown[] | null;
   }) => {
@@ -211,6 +258,8 @@ export function registerKitHandlers(deps: KitHandlerDeps): void {
       // 4. Copy skills to user SKILLs directory
       const root = ensureSkillsRoot();
       const installedSkillIds: string[] = [];
+      const installedSkillMetadata: Record<string, KitSkillMetadata> = {};
+      const sourceSkillMetadata = normalizeKitSkillMetadataList(params.skillList);
 
       for (const skillDir of skillDirs) {
         const folderName = normalizeFolderName(path.basename(skillDir));
@@ -222,7 +271,18 @@ export function registerKitHandlers(deps: KitHandlerDeps): void {
         }
         cpRecursiveSync(skillDir, targetDir);
         normalizeWindowsAttrs(targetDir);
-        installedSkillIds.push(path.basename(targetDir));
+        const installedSkillId = path.basename(targetDir);
+        installedSkillIds.push(installedSkillId);
+
+        const sourceSkillId = path.basename(skillDir);
+        const metadata = sourceSkillMetadata.get(sourceSkillId) ?? sourceSkillMetadata.get(folderName);
+        if (metadata?.name || metadata?.description) {
+          installedSkillMetadata[installedSkillId] = {
+            id: installedSkillId,
+            ...(metadata.name ? { name: metadata.name } : {}),
+            ...(metadata.description ? { description: metadata.description } : {}),
+          };
+        }
       }
 
       // 5. Enable installed skills
@@ -239,7 +299,12 @@ export function registerKitHandlers(deps: KitHandlerDeps): void {
         id: kitId,
         version,
         installedAt: Date.now(),
-        skills: installedSkillIds.length > 0 ? { skillIds: installedSkillIds } : null,
+        skills: installedSkillIds.length > 0
+          ? {
+            skillIds: installedSkillIds,
+            ...(Object.keys(installedSkillMetadata).length > 0 ? { metadata: installedSkillMetadata } : {}),
+          }
+          : null,
         mcpServers: normalizeCapabilityList(params.mcpServers),
         connectors: normalizeCapabilityList(params.connectors),
       };

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -11,6 +11,7 @@ import { DialogIpc } from '../shared/dialog/constants';
 import { type HtmlShareAccessMode, HtmlShareIpc } from '../shared/htmlShare/constants';
 import type {
   KitReference,
+  KitSkillMetadata,
   ResolvedKitCapabilities,
 } from '../shared/kit/constants';
 import {
@@ -75,6 +76,7 @@ contextBridge.exposeInMainWorld('electron', {
       bundleUrl: string;
       version: string;
       skillListIds: string[];
+      skillList?: KitSkillMetadata[];
       mcpServers?: unknown[] | null;
       connectors?: unknown[] | null;
     }) =>

--- a/src/renderer/components/cowork/selectedKitContextPrompt.ts
+++ b/src/renderer/components/cowork/selectedKitContextPrompt.ts
@@ -77,7 +77,7 @@ const buildSkillRefs = (
   if (marketplaceSkillRefs.length > 0) {
     return marketplaceSkillRefs.map(skill => ({
       id: skill.id,
-      name: skill.name,
+      name: resolveLocalizedText(skill.name),
     }));
   }
 

--- a/src/renderer/components/kits/KitsManager.tsx
+++ b/src/renderer/components/kits/KitsManager.tsx
@@ -206,7 +206,7 @@ const KitsManager: React.FC<KitsManagerProps> = ({ onTryAsking }) => {
                   key={skill.id}
                   className="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-lg bg-surface-raised text-secondary border border-border"
                 >
-                  {skill.name.replace(/^\//, '')}
+                  {resolveLocalizedText(skill.name).replace(/^\//, '')}
                 </span>
               ))}
             </div>

--- a/src/renderer/services/kit.ts
+++ b/src/renderer/services/kit.ts
@@ -52,6 +52,7 @@ class KitService {
       bundleUrl: kit.skills.bundle,
       version: kit.version ?? '0.0.0',
       skillListIds: kit.skills.list.map(s => s.id),
+      skillList: kit.skills.list,
       mcpServers: kit.mcpServers ?? null,
       connectors: kit.connectors ?? null,
     });

--- a/src/renderer/services/skill.ts
+++ b/src/renderer/services/skill.ts
@@ -38,6 +38,7 @@ class SkillService {
   private initialized = false;
   private localSkillDescriptions: Map<string, string | LocalizedText> = new Map();
   private marketplaceSkillDescriptions: Map<string, string | LocalizedText> = new Map();
+  private installedKitSkillDescriptions: Map<string, string | LocalizedText> = new Map();
   private marketplaceCache: { skills: MarketplaceSkill[]; tags: MarketTag[] } | null = null;
   private marketplaceFetchPromise: Promise<{ skills: MarketplaceSkill[]; tags: MarketTag[] }> | null = null;
 
@@ -55,6 +56,7 @@ class SkillService {
       } else {
         this.skills = [];
       }
+      await this.loadInstalledKitSkillDescriptions();
       return this.skills;
     } catch (error) {
       console.error('Failed to load skills:', error);
@@ -226,7 +228,9 @@ class SkillService {
     }
   }
   hasLocalizedSkillDescriptions(): boolean {
-    return this.localSkillDescriptions.size > 0 || this.marketplaceSkillDescriptions.size > 0;
+    return this.localSkillDescriptions.size > 0
+      || this.marketplaceSkillDescriptions.size > 0
+      || this.installedKitSkillDescriptions.size > 0;
   }
 
   async fetchMarketplaceSkills(): Promise<{ skills: MarketplaceSkill[]; tags: MarketTag[] }> {
@@ -275,11 +279,32 @@ class SkillService {
     }
   }
 
+  private async loadInstalledKitSkillDescriptions(): Promise<void> {
+    this.installedKitSkillDescriptions.clear();
+    try {
+      const result = await window.electron.kits.listInstalled();
+      if (!result.success || !result.installed) return;
+
+      for (const kit of Object.values(result.installed)) {
+        const metadata = kit.skills?.metadata ?? {};
+        for (const [skillId, skillMetadata] of Object.entries(metadata)) {
+          if (skillMetadata.description != null) {
+            this.installedKitSkillDescriptions.set(skillId, skillMetadata.description);
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load installed kit skill descriptions:', error);
+    }
+  }
+
   getLocalizedSkillDescription(skillId: string, skillName: string, fallback: string): string {
     const localDesc = this.localSkillDescriptions.get(skillName) ?? this.localSkillDescriptions.get(skillId);
     if (localDesc != null) return resolveLocalizedText(localDesc);
     const marketDesc = this.marketplaceSkillDescriptions.get(skillId);
     if (marketDesc != null) return resolveLocalizedText(marketDesc);
+    const kitDesc = this.installedKitSkillDescriptions.get(skillId);
+    if (kitDesc != null) return resolveLocalizedText(kitDesc);
     return fallback;
   }
 }

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -12,6 +12,7 @@ import type { HtmlShareAccessMode, HtmlShareStatus } from '../../shared/htmlShar
 import type {
   InstalledKitRecord,
   KitReference,
+  KitSkillMetadata,
   ResolvedKitCapabilities,
 } from '../../shared/kit/constants';
 import type {
@@ -403,6 +404,7 @@ interface IElectronAPI {
       bundleUrl: string;
       version: string;
       skillListIds: string[];
+      skillList?: KitSkillMetadata[];
       mcpServers?: unknown[] | null;
       connectors?: unknown[] | null;
     }) => Promise<{ success: boolean; skillIds?: string[]; error?: string }>;

--- a/src/renderer/types/kit.ts
+++ b/src/renderer/types/kit.ts
@@ -1,9 +1,9 @@
-import type { InstalledKitRecord } from '../../shared/kit/constants';
-import type { LocalizedText } from './skill';
+import type { InstalledKitRecord, LocalizedText } from '../../shared/kit/constants';
 
 export interface KitSkillRef {
   id: string;
-  name: string;
+  name: string | LocalizedText;
+  description?: string | LocalizedText;
 }
 
 export interface KitSkillBundle {

--- a/src/shared/kit/constants.ts
+++ b/src/shared/kit/constants.ts
@@ -30,8 +30,20 @@ export interface ResolvedKitCapabilities {
   connectors: unknown[];
 }
 
+export interface LocalizedText {
+  en: string;
+  zh: string;
+}
+
+export interface KitSkillMetadata {
+  id: string;
+  name?: string | LocalizedText;
+  description?: string | LocalizedText;
+}
+
 export interface InstalledKitSkills {
   skillIds: string[];
+  metadata?: Record<string, KitSkillMetadata>;
 }
 
 export interface InstalledKitRecord {


### PR DESCRIPTION
## Summary

- Persist kit-provided skill metadata during kit installation, keyed by the actual installed skill IDs.
- Use installed kit skill metadata as an additional source for localized skill descriptions in the Skills UI.
- Keep skill names as their existing English identifiers, matching the current Skill Marketplace behavior.

## Notes

- The generated kit store payload must include `skills.list[].description.en` and `skills.list[].description.zh` for newly installed kits to display localized descriptions.
- Already installed kits do not automatically receive metadata; reinstall after the online kit store config is updated.

## Verification

- `npx tsc --noEmit`
- `npx tsc --project electron-tsconfig.json --noEmit`
- `npx vitest run src/renderer/services/kitCapability.test.ts src/renderer/components/cowork/selectedKitContextPrompt.test.ts`
- Focused eslint on changed files