### PR TITLE
fix: enable image input support for MiniMax-M3

### DIFF
--- a/src/renderer/services/config.ts
+++ b/src/renderer/services/config.ts
@@ -206,7 +206,7 @@ const ADDED_PROVIDER_MODELS: Record<string, { models: ProviderModel[]; position:
   },
   minimax: {
     models: [
-      { id: 'MiniMax-M3', name: 'MiniMax M3', supportsImage: false, contextWindow: 1_000_000 },
+      { id: 'MiniMax-M3', name: 'MiniMax M3', supportsImage: true, contextWindow: 1_000_000 },
       { id: 'MiniMax-M2.7', name: 'MiniMax M2.7', supportsImage: false },
     ],
     position: 'start',

--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -306,7 +306,7 @@ const PROVIDER_DEFINITIONS = [
     region: 'china',
     enPriority: 0,
     defaultModels: [
-      { id: 'MiniMax-M3', name: 'MiniMax M3', supportsImage: false, contextWindow: 1_000_000 },
+      { id: 'MiniMax-M3', name: 'MiniMax M3', supportsImage: true, contextWindow: 1_000_000 },
       { id: 'MiniMax-M2.7', name: 'MiniMax M2.7', supportsImage: false },
       { id: 'MiniMax-M2.5', name: 'MiniMax M2.5', supportsImage: false },
     ],


### PR DESCRIPTION
## Summary
- MiniMax-M3 now supports image input, but was hardcoded as `supportsImage: false` (carried over from M2.5/M2.7 which don't support images)
- The hardcoded `false` value in provider definitions takes highest priority in `resolveModelSupportsImage()`, so even when users enable image support in custom model config, it gets overridden
- Fix: set `supportsImage: true` for MiniMax-M3 in both `constants.ts` and `config.ts`

## Test plan
- [ ] Configure MiniMax-M3 as active model
- [ ] Send a message with an image attachment
- [ ] Verify image is sent to the model successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)