### PR TITLE
fix(cowork): support subagent batch deletion

### DIFF
--- a/src/main/libs/agentEngine/subagentTracker.test.ts
+++ b/src/main/libs/agentEngine/subagentTracker.test.ts
@@ -1,5 +1,5 @@
 import BetterSqlite3 from 'better-sqlite3';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import { SubagentMessageStore } from '../../subagentMessageStore';
 import { SubagentRunStore } from '../../subagentRunStore';
@@ -44,6 +44,11 @@ beforeEach(() => {
   setupDb();
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
 test('deleteSubagentRun removes a single run, messages, and gateway transcript', async () => {
   const gatewayClient: GatewayClientLike = {
     request: vi.fn().mockResolvedValue({}),
@@ -78,6 +83,70 @@ test('deleteSubagentRun removes a single run, messages, and gateway transcript',
     { key: 'agent:main:subagent:run-1', deleteTranscript: true },
     { timeoutMs: 5_000 },
   );
+});
+
+test('deleteSubagentRun returns after local deletion without waiting for gateway cleanup', async () => {
+  let resolveGatewayDelete: (() => void) | null = null;
+  const gatewayDeletePromise = new Promise<void>((resolve) => {
+    resolveGatewayDelete = resolve;
+  });
+  const gatewayClient: GatewayClientLike = {
+    request: vi.fn().mockReturnValue(gatewayDeletePromise),
+  };
+  const tracker = new SubagentTracker(runStore, messageStore, () => gatewayClient);
+
+  runStore.insertSubagentRun({
+    id: 'run-1',
+    parentSessionId: 'parent-1',
+    sessionKey: 'agent:main:subagent:run-1',
+    agentId: 'worker',
+    task: 'inspect files',
+    label: 'worker',
+    status: 'done',
+    createdAt: 1000,
+  });
+
+  const deleted = await tracker.deleteSubagentRun('parent-1', 'run-1');
+
+  expect(deleted).toBe(true);
+  expect(runStore.getSubagentRun('run-1')).toBeNull();
+  expect(gatewayClient.request).toHaveBeenCalledTimes(1);
+
+  resolveGatewayDelete?.();
+});
+
+test('gateway cleanup retries are capped when delete keeps failing', async () => {
+  vi.useFakeTimers();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const gatewayClient: GatewayClientLike = {
+    request: vi.fn().mockRejectedValue(new Error('gateway busy')),
+  };
+  const tracker = new SubagentTracker(runStore, messageStore, () => gatewayClient);
+
+  runStore.insertSubagentRun({
+    id: 'run-1',
+    parentSessionId: 'parent-1',
+    sessionKey: 'agent:main:subagent:run-1',
+    agentId: 'worker',
+    task: 'inspect files',
+    label: 'worker',
+    status: 'done',
+    createdAt: 1000,
+  });
+
+  const deleted = await tracker.deleteSubagentRun('parent-1', 'run-1');
+
+  expect(deleted).toBe(true);
+  expect(gatewayClient.request).toHaveBeenCalledTimes(1);
+
+  await vi.advanceTimersByTimeAsync(5_000);
+  expect(gatewayClient.request).toHaveBeenCalledTimes(2);
+
+  await vi.advanceTimersByTimeAsync(10_000);
+  expect(gatewayClient.request).toHaveBeenCalledTimes(3);
+
+  await vi.advanceTimersByTimeAsync(20_000);
+  expect(gatewayClient.request).toHaveBeenCalledTimes(3);
 });
 
 test('deleteSubagentRun refuses to delete a run from another parent session', async () => {

--- a/src/main/libs/agentEngine/subagentTracker.ts
+++ b/src/main/libs/agentEngine/subagentTracker.ts
@@ -62,6 +62,16 @@ export type GatewayClientLike = {
   ) => Promise<T>;
 };
 
+interface GatewaySessionDeleteTask {
+  sessionKey: string;
+  attempt: number;
+}
+
+const GATEWAY_SESSION_DELETE_CONCURRENCY = 2;
+const GATEWAY_SESSION_DELETE_MAX_ATTEMPTS = 3;
+const GATEWAY_SESSION_DELETE_BASE_DELAY_MS = 5_000;
+const GATEWAY_SESSION_DELETE_MAX_DELAY_MS = 20_000;
+
 /**
  * Encapsulates all subagent (child session) tracking logic:
  * state maps, lifecycle detection, history fetching, and persistence.
@@ -82,6 +92,9 @@ export class SubagentTracker {
   private readonly agentIdToToolCallIds = new Map<string, Set<string>>();
   /** Run ids explicitly deleted by the user. Suppresses late spawn/backfill re-inserts. */
   private readonly deletedSubagentRunIds = new Set<string>();
+  private readonly gatewaySessionDeleteQueue = new Map<string, GatewaySessionDeleteTask>();
+  private readonly gatewaySessionDeleteInFlight = new Set<string>();
+  private readonly gatewaySessionDeleteRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
   /** Pending spawn info stored at tool start, used for DB insertion when result arrives */
   private readonly pendingSpawnInfo = new Map<string, {
     agentId: string;
@@ -253,7 +266,7 @@ export class SubagentTracker {
     this.store.deleteSubagentRun(runId);
 
     if (sessionKey) {
-      await this.deleteGatewaySession(sessionKey);
+      this.enqueueGatewaySessionDelete(sessionKey);
     }
 
     return true;
@@ -432,17 +445,79 @@ export class SubagentTracker {
     }
   }
 
-  private async deleteGatewaySession(sessionKey: string): Promise<void> {
+  private enqueueGatewaySessionDelete(sessionKey: string): void {
+    if (
+      this.gatewaySessionDeleteQueue.has(sessionKey)
+      || this.gatewaySessionDeleteInFlight.has(sessionKey)
+      || this.gatewaySessionDeleteRetryTimers.has(sessionKey)
+    ) {
+      return;
+    }
+
+    this.gatewaySessionDeleteQueue.set(sessionKey, { sessionKey, attempt: 1 });
+    this.processGatewaySessionDeleteQueue();
+  }
+
+  private processGatewaySessionDeleteQueue(): void {
+    while (
+      this.gatewaySessionDeleteInFlight.size < GATEWAY_SESSION_DELETE_CONCURRENCY
+      && this.gatewaySessionDeleteQueue.size > 0
+    ) {
+      const task = this.gatewaySessionDeleteQueue.values().next().value as GatewaySessionDeleteTask | undefined;
+      if (!task) return;
+      this.gatewaySessionDeleteQueue.delete(task.sessionKey);
+      this.gatewaySessionDeleteInFlight.add(task.sessionKey);
+      void this.runGatewaySessionDeleteTask(task);
+    }
+  }
+
+  private async runGatewaySessionDeleteTask(task: GatewaySessionDeleteTask): Promise<void> {
+    try {
+      const deleted = await this.deleteGatewaySession(task.sessionKey);
+      if (!deleted) {
+        this.scheduleGatewaySessionDeleteRetry(task);
+      }
+    } finally {
+      this.gatewaySessionDeleteInFlight.delete(task.sessionKey);
+      this.processGatewaySessionDeleteQueue();
+    }
+  }
+
+  private scheduleGatewaySessionDeleteRetry(task: GatewaySessionDeleteTask): void {
+    if (task.attempt >= GATEWAY_SESSION_DELETE_MAX_ATTEMPTS) {
+      console.warn('[SubagentTracker] gateway subagent session cleanup reached the retry limit');
+      return;
+    }
+
+    const delayMs = Math.min(
+      GATEWAY_SESSION_DELETE_BASE_DELAY_MS * (2 ** (task.attempt - 1)),
+      GATEWAY_SESSION_DELETE_MAX_DELAY_MS,
+    );
+    const timer = setTimeout(() => {
+      this.gatewaySessionDeleteRetryTimers.delete(task.sessionKey);
+      this.gatewaySessionDeleteQueue.set(task.sessionKey, {
+        sessionKey: task.sessionKey,
+        attempt: task.attempt + 1,
+      });
+      this.processGatewaySessionDeleteQueue();
+    }, delayMs);
+    this.gatewaySessionDeleteRetryTimers.set(task.sessionKey, timer);
+    console.warn('[SubagentTracker] gateway subagent session cleanup failed, retrying later');
+  }
+
+  private async deleteGatewaySession(sessionKey: string): Promise<boolean> {
     const client = this.getGatewayClient();
-    if (!client) return;
+    if (!client) return false;
 
     try {
       await client.request('sessions.delete', {
         key: sessionKey,
         deleteTranscript: true,
       }, { timeoutMs: 5_000 });
+      return true;
     } catch (error) {
       console.warn('[SubagentTracker] Failed to delete gateway subagent session:', error);
+      return false;
     }
   }
 

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -13,6 +13,12 @@ import {
 } from '../store/selectors/coworkSelectors';
 import type { CoworkSessionSummary } from '../types/cowork';
 import { getAgentDisplayNameById } from '../utils/agentDisplay';
+import {
+  type AgentSidebarBatchItem,
+  AgentSidebarBatchItemKind,
+  type AgentSidebarSubagentBatchItem,
+  createSessionBatchKey,
+} from './agentSidebar/batchSelection';
 import MyAgentSidebarTree from './agentSidebar/MyAgentSidebarTree';
 import Modal from './common/Modal';
 import CoworkSearchModal from './cowork/CoworkSearchModal';
@@ -75,9 +81,10 @@ const Sidebar: React.FC<SidebarProps> = ({
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isBatchMode, setIsBatchMode] = useState(false);
   const [batchAgentId, setBatchAgentId] = useState<string | null>(null);
-  const [batchSelectableIds, setBatchSelectableIds] = useState<string[]>([]);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [batchSelectableItems, setBatchSelectableItems] = useState<AgentSidebarBatchItem[]>([]);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
   const [deletedSessionIds, setDeletedSessionIds] = useState<string[]>([]);
+  const [deletedSubagentItems, setDeletedSubagentItems] = useState<AgentSidebarSubagentBatchItem[]>([]);
   const [showBatchDeleteConfirm, setShowBatchDeleteConfirm] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
   const [isResizing, setIsResizing] = useState(false);
@@ -87,12 +94,20 @@ const Sidebar: React.FC<SidebarProps> = ({
   const resizeStartWidthRef = useRef(DEFAULT_SIDEBAR_WIDTH);
   const agentScrollContainerRef = useRef<HTMLDivElement>(null);
   const isMac = window.electron.platform === 'darwin';
-  const batchSelectableIdSet = useMemo(() => new Set(batchSelectableIds), [batchSelectableIds]);
+  const batchSelectableKeySet = useMemo(
+    () => new Set(batchSelectableItems.map((item) => item.key)),
+    [batchSelectableItems],
+  );
+  const batchSelectableItemByKey = useMemo(() => {
+    const itemByKey = new Map<string, AgentSidebarBatchItem>();
+    batchSelectableItems.forEach((item) => itemByKey.set(item.key, item));
+    return itemByKey;
+  }, [batchSelectableItems]);
   const selectedBatchSelectableCount = useMemo(() => {
-    return batchSelectableIds.filter((sessionId) => selectedIds.has(sessionId)).length;
-  }, [batchSelectableIds, selectedIds]);
+    return batchSelectableItems.filter((item) => selectedKeys.has(item.key)).length;
+  }, [batchSelectableItems, selectedKeys]);
   const isBatchSelectAllChecked =
-    batchSelectableIds.length > 0 && selectedBatchSelectableCount === batchSelectableIds.length;
+    batchSelectableItems.length > 0 && selectedBatchSelectableCount === batchSelectableItems.length;
   const batchAgentName = batchAgentId ? getAgentDisplayNameById(batchAgentId, agents) : null;
 
   useEffect(() => {
@@ -111,8 +126,8 @@ const Sidebar: React.FC<SidebarProps> = ({
     setIsSearchOpen(false);
     setIsBatchMode(false);
     setBatchAgentId(null);
-    setBatchSelectableIds([]);
-    setSelectedIds(new Set());
+    setBatchSelectableItems([]);
+    setSelectedKeys(new Set());
     setShowBatchDeleteConfirm(false);
   }, [isCollapsed]);
 
@@ -129,24 +144,24 @@ const Sidebar: React.FC<SidebarProps> = ({
   const handleEnterBatchMode = useCallback((sessionId: string, agentId: string) => {
     setIsBatchMode(true);
     setBatchAgentId(agentId);
-    setBatchSelectableIds([]);
-    setSelectedIds(new Set([sessionId]));
+    setBatchSelectableItems([]);
+    setSelectedKeys(new Set([createSessionBatchKey(sessionId)]));
   }, []);
 
   const handleExitBatchMode = useCallback(() => {
     setIsBatchMode(false);
     setBatchAgentId(null);
-    setBatchSelectableIds([]);
-    setSelectedIds(new Set());
+    setBatchSelectableItems([]);
+    setSelectedKeys(new Set());
     setShowBatchDeleteConfirm(false);
   }, []);
 
-  const handleBatchSelectableIdsChange = useCallback((sessionIds: string[]) => {
-    setBatchSelectableIds(sessionIds);
-    setSelectedIds((previous) => {
-      if (!batchAgentId || sessionIds.length === 0) return previous;
-      const sessionIdSet = new Set(sessionIds);
-      const next = new Set(Array.from(previous).filter((sessionId) => sessionIdSet.has(sessionId)));
+  const handleBatchSelectableItemsChange = useCallback((items: AgentSidebarBatchItem[]) => {
+    setBatchSelectableItems(items);
+    setSelectedKeys((previous) => {
+      if (!batchAgentId || items.length === 0) return previous;
+      const itemKeySet = new Set(items.map((item) => item.key));
+      const next = new Set(Array.from(previous).filter((key) => itemKeySet.has(key)));
       return next.size === previous.size ? previous : next;
     });
   }, [batchAgentId]);
@@ -177,46 +192,72 @@ const Sidebar: React.FC<SidebarProps> = ({
     updateAgentScrollEdges(event.currentTarget);
   }, [updateAgentScrollEdges]);
 
-  const handleToggleSelection = useCallback((sessionId: string, agentId: string) => {
+  const handleToggleSelection = useCallback((selectionKey: string, agentId: string) => {
     if (batchAgentId && normalizeAgentId(agentId) !== batchAgentId) return;
-    setSelectedIds(prev => {
+    setSelectedKeys(prev => {
       const next = new Set(prev);
-      if (next.has(sessionId)) {
-        next.delete(sessionId);
+      if (next.has(selectionKey)) {
+        next.delete(selectionKey);
       } else {
-        next.add(sessionId);
+        next.add(selectionKey);
       }
       return next;
     });
   }, [batchAgentId]);
 
   const handleSelectAll = useCallback(() => {
-    if (batchSelectableIds.length === 0) return;
-    setSelectedIds(prev => {
-      const selectedVisibleCount = batchSelectableIds.filter((sessionId) => prev.has(sessionId)).length;
-      if (selectedVisibleCount === batchSelectableIds.length) {
+    if (batchSelectableItems.length === 0) return;
+    setSelectedKeys(prev => {
+      const selectedVisibleCount = batchSelectableItems.filter((item) => prev.has(item.key)).length;
+      if (selectedVisibleCount === batchSelectableItems.length) {
         return new Set();
       }
-      return new Set(batchSelectableIds);
+      return new Set(batchSelectableItems.map((item) => item.key));
     });
-  }, [batchSelectableIds]);
+  }, [batchSelectableItems]);
 
   const handleBatchDeleteClick = useCallback(() => {
-    if (selectedIds.size === 0) return;
+    if (selectedKeys.size === 0) return;
     setShowBatchDeleteConfirm(true);
-  }, [selectedIds.size]);
+  }, [selectedKeys.size]);
 
   const handleBatchDelete = useCallback(async () => {
-    if (selectedIds.size === 0) return;
-    const ids = Array.from(selectedIds).filter((sessionId) => {
-      return batchSelectableIdSet.size === 0 || batchSelectableIdSet.has(sessionId);
-    });
-    if (ids.length === 0) return;
-    const deleted = await coworkService.deleteSessions(ids);
-    if (!deleted) return;
-    setDeletedSessionIds(ids);
+    if (selectedKeys.size === 0) return;
+    const items = Array.from(selectedKeys)
+      .filter((key) => batchSelectableKeySet.size === 0 || batchSelectableKeySet.has(key))
+      .map((key) => batchSelectableItemByKey.get(key))
+      .filter((item): item is AgentSidebarBatchItem => Boolean(item));
+    if (items.length === 0) return;
+
+    const subagentItems = items.filter(
+      (item): item is AgentSidebarSubagentBatchItem => item.kind === AgentSidebarBatchItemKind.Subagent,
+    );
+    const sessionIds = items
+      .filter((item) => item.kind === AgentSidebarBatchItemKind.Session)
+      .map((item) => item.sessionId);
+
+    const deletedSubagents: AgentSidebarSubagentBatchItem[] = [];
+    for (const item of subagentItems) {
+      const deleted = await coworkService.deleteSubagentSession(item.parentSessionId, item.runId);
+      if (deleted) {
+        deletedSubagents.push(item);
+      }
+    }
+
+    let deletedSessions = false;
+    if (sessionIds.length > 0) {
+      deletedSessions = await coworkService.deleteSessions(sessionIds);
+    }
+
+    if (!deletedSessions && deletedSubagents.length === 0) return;
+    if (deletedSessions) {
+      setDeletedSessionIds(sessionIds);
+    }
+    if (deletedSubagents.length > 0) {
+      setDeletedSubagentItems(deletedSubagents);
+    }
     handleExitBatchMode();
-  }, [batchSelectableIdSet, selectedIds, handleExitBatchMode]);
+  }, [batchSelectableItemByKey, batchSelectableKeySet, selectedKeys, handleExitBatchMode]);
 
   const handleResizeStart = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     if (isCollapsed) return;
@@ -385,11 +426,12 @@ const Sidebar: React.FC<SidebarProps> = ({
             isBatchMode={isBatchMode}
             batchAgentId={batchAgentId}
             deletedSessionIds={deletedSessionIds}
-            selectedIds={selectedIds}
+            deletedSubagentItems={deletedSubagentItems}
+            selectedKeys={selectedKeys}
             onShowCowork={onShowCowork}
             onToggleSelection={handleToggleSelection}
             onEnterBatchMode={handleEnterBatchMode}
-            onBatchSelectableIdsChange={handleBatchSelectableIdsChange}
+            onBatchSelectableItemsChange={handleBatchSelectableItemsChange}
           />
         </div>
         <div
@@ -428,7 +470,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               {i18nService
                 .t('batchSelectionScope')
                 .replace('{agent}', batchAgentName ?? '')
-                .replace('{count}', String(selectedIds.size))}
+                .replace('{count}', String(selectedKeys.size))}
             </span>
             <button
               type="button"
@@ -444,7 +486,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                 type="checkbox"
                 checked={isBatchSelectAllChecked}
                 onChange={handleSelectAll}
-                disabled={batchSelectableIds.length === 0}
+                disabled={batchSelectableItems.length === 0}
                 className="h-3.5 w-3.5 shrink-0 rounded border-gray-300 accent-primary disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
               />
               <span className="truncate">{i18nService.t('batchSelectAll')}</span>
@@ -452,15 +494,15 @@ const Sidebar: React.FC<SidebarProps> = ({
             <button
               type="button"
               onClick={handleBatchDeleteClick}
-              disabled={selectedIds.size === 0}
+              disabled={selectedKeys.size === 0}
               className={`inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md px-2 text-[13px] font-medium transition-colors ${
-                selectedIds.size > 0
+                selectedKeys.size > 0
                   ? 'bg-red-500 text-white hover:bg-red-600'
                   : 'cursor-not-allowed bg-gray-200 text-gray-400 dark:bg-gray-700 dark:text-gray-500'
               }`}
             >
               <TrashIcon className="h-3.5 w-3.5" />
-              {i18nService.t('batchDelete')} ({selectedIds.size})
+              {i18nService.t('batchDelete')} ({selectedKeys.size})
             </button>
           </div>
         </div>
@@ -500,7 +542,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             <p className="text-sm text-secondary">
               {i18nService
                 .t('batchDeleteConfirmMessage')
-                .replace('{count}', String(selectedIds.size))}
+                .replace('{count}', String(selectedKeys.size))}
             </p>
           </div>
           <div className="flex items-center justify-end gap-3 px-5 py-4 border-t border-border">
@@ -514,7 +556,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               onClick={handleBatchDelete}
               className="px-4 py-2 text-sm font-medium rounded-lg bg-red-500 hover:bg-red-600 text-white transition-colors"
             >
-              {i18nService.t('batchDelete')} ({selectedIds.size})
+              {i18nService.t('batchDelete')} ({selectedKeys.size})
             </button>
           </div>
         </Modal>

--- a/src/renderer/components/agentSidebar/AgentTreeNode.tsx
+++ b/src/renderer/components/agentSidebar/AgentTreeNode.tsx
@@ -13,6 +13,7 @@ import EllipsisHorizontalIcon from '../icons/EllipsisHorizontalIcon';
 import PushPinIcon from '../icons/PushPinIcon';
 import TrashIcon from '../icons/TrashIcon';
 import AgentTaskRow from './AgentTaskRow';
+import { createSessionBatchKey, createSubagentBatchKey } from './batchSelection';
 import ExpandAgentTasksRow from './ExpandAgentTasksRow';
 import SubagentTaskRow from './SubagentTaskRow';
 import type { AgentSidebarAgentNode, AgentSidebarTaskNode } from './types';
@@ -21,7 +22,7 @@ interface AgentTreeNodeProps {
   agent: AgentSidebarAgentNode;
   isBatchMode: boolean;
   batchAgentId: string | null;
-  selectedIds: Set<string>;
+  selectedKeys: Set<string>;
   showBatchOption?: boolean;
   subagentsBySessionId?: Record<string, SubagentSessionSummary[]>;
   selectedSubagentId?: string | null;
@@ -41,7 +42,7 @@ interface AgentTreeNodeProps {
   onShareTask: (task: AgentSidebarTaskNode) => Promise<void>;
   onToggleTaskPin: (task: AgentSidebarTaskNode, pinned: boolean) => Promise<void>;
   onRenameTask: (task: AgentSidebarTaskNode, title: string) => Promise<void>;
-  onToggleSelection: (sessionId: string, agentId: string) => void;
+  onToggleSelection: (selectionKey: string, agentId: string) => void;
   onEnterBatchMode: (task: AgentSidebarTaskNode) => void;
 }
 
@@ -70,7 +71,7 @@ const AgentTreeNode: React.FC<AgentTreeNodeProps> = ({
   agent,
   isBatchMode,
   batchAgentId,
-  selectedIds,
+  selectedKeys,
   showBatchOption = false,
   subagentsBySessionId,
   selectedSubagentId,
@@ -409,7 +410,7 @@ const AgentTreeNode: React.FC<AgentTreeNodeProps> = ({
                   <AgentTaskRow
                     task={task}
                     isBatchMode={isBatchAgent}
-                    isSelected={selectedIds.has(task.id)}
+                    isSelected={selectedKeys.has(createSessionBatchKey(task.id))}
                     isSelectionDisabled={isOutsideBatchAgent}
                     showBatchOption={showBatchOption && !isBatchMode}
                     hasActiveSubagent={task.isSelected && selectedSubagentId != null}
@@ -419,16 +420,25 @@ const AgentTreeNode: React.FC<AgentTreeNodeProps> = ({
                     onShare={() => onShareTask(task)}
                     onTogglePin={(pinned) => onToggleTaskPin(task, pinned)}
                     onRename={(title) => onRenameTask(task, title)}
-                    onToggleSelection={() => onToggleSelection(task.id, task.agentId)}
+                    onToggleSelection={() => onToggleSelection(createSessionBatchKey(task.id), task.agentId)}
                     onEnterBatchMode={() => onEnterBatchMode(task)}
                   />
                   {task.isSelected && subagentsBySessionId?.[task.id]?.map((sub) => (
                     <SubagentTaskRow
                       key={sub.id}
                       subagent={sub}
-                      isSelected={sub.id === selectedSubagentId}
+                      isBatchMode={isBatchAgent}
+                      isSelected={
+                        isBatchAgent
+                          ? selectedKeys.has(createSubagentBatchKey(task.id, sub.id))
+                          : sub.id === selectedSubagentId
+                      }
                       onSelect={() => onSelectSubagent?.(sub)}
                       onDelete={() => onDeleteSubagent?.(sub) ?? Promise.resolve()}
+                      onToggleSelection={() => onToggleSelection(
+                        createSubagentBatchKey(task.id, sub.id),
+                        task.agentId,
+                      )}
                     />
                   ))}
                 </React.Fragment>

--- a/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
+++ b/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
@@ -12,6 +12,12 @@ import AgentCreateModal from '../agent/AgentCreateModal';
 import AgentSettingsPanel from '../agent/AgentSettingsPanel';
 import { type CoworkOpenShareOptionsEventDetail,CoworkUiEvent } from '../cowork/constants';
 import AgentTreeNode from './AgentTreeNode';
+import {
+  type AgentSidebarBatchItem,
+  type AgentSidebarSubagentBatchItem,
+  createSessionBatchItem,
+  createSubagentBatchItem,
+} from './batchSelection';
 import MyAgentSidebarHeader from './MyAgentSidebarHeader';
 import type { AgentSidebarAgentNode, AgentSidebarTaskNode } from './types';
 import { useAgentSidebarState } from './useAgentSidebarState';
@@ -21,11 +27,12 @@ interface MyAgentSidebarTreeProps {
   isBatchMode: boolean;
   batchAgentId: string | null;
   deletedSessionIds: string[];
-  selectedIds: Set<string>;
+  deletedSubagentItems: AgentSidebarSubagentBatchItem[];
+  selectedKeys: Set<string>;
   onShowCowork: () => void;
-  onToggleSelection: (sessionId: string, agentId: string) => void;
+  onToggleSelection: (selectionKey: string, agentId: string) => void;
   onEnterBatchMode: (sessionId: string, agentId: string) => void;
-  onBatchSelectableIdsChange: (sessionIds: string[]) => void;
+  onBatchSelectableItemsChange: (items: AgentSidebarBatchItem[]) => void;
   onSelectSubagent?: (subagent: SubagentSessionSummary) => void;
 }
 
@@ -33,11 +40,12 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
   isBatchMode,
   batchAgentId,
   deletedSessionIds,
-  selectedIds,
+  deletedSubagentItems,
+  selectedKeys,
   onShowCowork,
   onToggleSelection,
   onEnterBatchMode,
-  onBatchSelectableIdsChange,
+  onBatchSelectableItemsChange,
   onSelectSubagent,
 }) => {
   const currentAgentId = useSelector((state: RootState) => state.agent.currentAgentId);
@@ -203,7 +211,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
       agent={agent}
       isBatchMode={isBatchMode}
       batchAgentId={batchAgentId}
-      selectedIds={selectedIds}
+      selectedKeys={selectedKeys}
       showBatchOption
       subagentsBySessionId={subagentsBySessionId}
       selectedSubagentId={selectedSubagentId}
@@ -242,14 +250,36 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
   }, [deletedSessionIds, removeTaskPreviews]);
 
   useEffect(() => {
+    if (deletedSubagentItems.length === 0) return;
+    deletedSubagentItems.forEach((item) => {
+      removeSubagent(item.parentSessionId, item.runId);
+    });
+    if (deletedSubagentItems.some((item) => item.runId === selectedSubagentId)) {
+      window.dispatchEvent(new CustomEvent(CoworkUiEvent.SelectSubagent, { detail: null }));
+    }
+  }, [deletedSubagentItems, removeSubagent, selectedSubagentId]);
+
+  useEffect(() => {
     if (!batchAgentId) {
-      onBatchSelectableIdsChange([]);
+      onBatchSelectableItemsChange([]);
       return;
     }
 
     const batchAgent = agentNodes.find((agent) => agent.id === batchAgentId);
-    onBatchSelectableIdsChange(batchAgent?.tasks.map((task) => task.id) ?? []);
-  }, [agentNodes, batchAgentId, onBatchSelectableIdsChange]);
+    if (!batchAgent) {
+      onBatchSelectableItemsChange([]);
+      return;
+    }
+
+    const items = batchAgent.tasks.flatMap((task): AgentSidebarBatchItem[] => {
+      const taskSubagents = subagentsBySessionId[task.id] ?? [];
+      return [
+        createSessionBatchItem(task.id),
+        ...taskSubagents.map((subagent) => createSubagentBatchItem(task.id, subagent.id)),
+      ];
+    });
+    onBatchSelectableItemsChange(items);
+  }, [agentNodes, batchAgentId, onBatchSelectableItemsChange, subagentsBySessionId]);
 
   return (
     <div className="pb-3" role="tree" aria-label={i18nService.t('myAgents')}>

--- a/src/renderer/components/agentSidebar/SubagentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/SubagentTaskRow.tsx
@@ -9,9 +9,11 @@ import TrashIcon from '../icons/TrashIcon';
 
 interface SubagentTaskRowProps {
   subagent: SubagentSessionSummary;
+  isBatchMode?: boolean;
   isSelected?: boolean;
   onSelect: () => void;
   onDelete: () => Promise<void>;
+  onToggleSelection?: () => void;
 }
 
 const formatDuration = (createdAt: number): string => {
@@ -26,24 +28,53 @@ const formatDuration = (createdAt: number): string => {
   return `${days}d`;
 };
 
-const SubagentTaskRow: React.FC<SubagentTaskRowProps> = ({ subagent, isSelected = false, onSelect, onDelete }) => {
+const SubagentTaskRow: React.FC<SubagentTaskRowProps> = ({
+  subagent,
+  isBatchMode = false,
+  isSelected = false,
+  onSelect,
+  onDelete,
+  onToggleSelection,
+}) => {
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
   const displayName = subagent.label ?? subagent.agentId ?? i18nService.t('subagentUnnamed');
   const duration = formatDuration(subagent.createdAt);
+  const handleRowClick = () => {
+    if (isBatchMode) {
+      onToggleSelection?.();
+      return;
+    }
+    onSelect();
+  };
 
   return (
     <>
       <div
-        className={`group relative -ml-[6px] flex h-[26px] w-[calc(100%+12px)] cursor-pointer items-center gap-1.5 rounded-md pl-[52px] pr-2.5 text-[13px] font-normal transition-colors ${
+        className={`group relative -ml-[6px] flex h-[26px] w-[calc(100%+12px)] cursor-pointer items-center gap-1.5 rounded-md ${
+          isBatchMode ? 'pl-9' : 'pl-[52px]'
+        } pr-2.5 text-[13px] font-normal transition-colors ${
           isSelected
             ? 'bg-black/[0.06] text-foreground/80 dark:bg-white/[0.07]'
             : 'text-foreground/60 hover:bg-black/[0.03] hover:text-foreground/80 dark:hover:bg-white/[0.04]'
         }`}
-        onClick={onSelect}
+        onClick={handleRowClick}
         role="treeitem"
         aria-level={3}
         aria-selected={isSelected}
       >
+        {isBatchMode && (
+          <input
+            type="checkbox"
+            checked={isSelected}
+            onChange={(event) => {
+              event.stopPropagation();
+              onToggleSelection?.();
+            }}
+            onClick={(event) => event.stopPropagation()}
+            className="h-3.5 w-3.5 shrink-0 rounded border-gray-300 accent-primary"
+          />
+        )}
+
         <span className="min-w-0 flex-1 truncate pr-5">
           {displayName}
         </span>
@@ -62,18 +93,20 @@ const SubagentTaskRow: React.FC<SubagentTaskRowProps> = ({ subagent, isSelected 
           </span>
         )}
 
-        <button
-          type="button"
-          onClick={(event) => {
-            event.stopPropagation();
-            setShowConfirmDelete(true);
-          }}
-          className="absolute right-1 top-1/2 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-foreground opacity-0 transition-opacity hover:opacity-[0.46] group-hover:opacity-[0.3]"
-          aria-label={i18nService.t('deleteSession')}
-          title={i18nService.t('deleteSession')}
-        >
-          <TrashIcon className="h-3.5 w-3.5" />
-        </button>
+        {!isBatchMode && (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              setShowConfirmDelete(true);
+            }}
+            className="absolute right-1 top-1/2 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-foreground opacity-0 transition-opacity hover:opacity-[0.46] group-hover:opacity-[0.3]"
+            aria-label={i18nService.t('deleteSession')}
+            title={i18nService.t('deleteSession')}
+          >
+            <TrashIcon className="h-3.5 w-3.5" />
+          </button>
+        )}
       </div>
 
       {showConfirmDelete && (

--- a/src/renderer/components/agentSidebar/batchSelection.ts
+++ b/src/renderer/components/agentSidebar/batchSelection.ts
@@ -1,0 +1,47 @@
+export const AgentSidebarBatchItemKind = {
+  Session: 'session',
+  Subagent: 'subagent',
+} as const;
+export type AgentSidebarBatchItemKind =
+  typeof AgentSidebarBatchItemKind[keyof typeof AgentSidebarBatchItemKind];
+
+export interface AgentSidebarSessionBatchItem {
+  kind: typeof AgentSidebarBatchItemKind.Session;
+  key: string;
+  sessionId: string;
+}
+
+export interface AgentSidebarSubagentBatchItem {
+  kind: typeof AgentSidebarBatchItemKind.Subagent;
+  key: string;
+  parentSessionId: string;
+  runId: string;
+}
+
+export type AgentSidebarBatchItem =
+  | AgentSidebarSessionBatchItem
+  | AgentSidebarSubagentBatchItem;
+
+export const createSessionBatchKey = (sessionId: string): string => (
+  `${AgentSidebarBatchItemKind.Session}:${encodeURIComponent(sessionId)}`
+);
+
+export const createSubagentBatchKey = (parentSessionId: string, runId: string): string => (
+  `${AgentSidebarBatchItemKind.Subagent}:${encodeURIComponent(parentSessionId)}:${encodeURIComponent(runId)}`
+);
+
+export const createSessionBatchItem = (sessionId: string): AgentSidebarSessionBatchItem => ({
+  kind: AgentSidebarBatchItemKind.Session,
+  key: createSessionBatchKey(sessionId),
+  sessionId,
+});
+
+export const createSubagentBatchItem = (
+  parentSessionId: string,
+  runId: string,
+): AgentSidebarSubagentBatchItem => ({
+  kind: AgentSidebarBatchItemKind.Subagent,
+  key: createSubagentBatchKey(parentSessionId, runId),
+  parentSessionId,
+  runId,
+});


### PR DESCRIPTION
## Summary
- include subagent sessions in sidebar batch selection and route deletes through the subagent delete path
- make subagent gateway transcript cleanup asynchronous after local run/message deletion
- limit gateway cleanup concurrency and cap retries to avoid adding pressure when the gateway is busy

## Verification
- npx eslint src/main/libs/agentEngine/subagentTracker.ts src/main/libs/agentEngine/subagentTracker.test.ts src/renderer/components/Sidebar.tsx src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx src/renderer/components/agentSidebar/AgentTreeNode.tsx src/renderer/components/agentSidebar/SubagentTaskRow.tsx src/renderer/components/agentSidebar/batchSelection.ts
- npx tsc --noEmit
- npx vitest run src/main/libs/agentEngine/subagentTracker.test.ts (previously passed after npm rebuild better-sqlite3; latest rerun blocked by a local Windows file lock on better_sqlite3.node, and npm rebuild better-sqlite3 could not replace the locked binary)