### PR TITLE
fix(mcp): keep managed installs node-aware

### DIFF
--- a/src/main/mcp/mcpLaunchResolverManager.ts
+++ b/src/main/mcp/mcpLaunchResolverManager.ts
@@ -3,7 +3,10 @@ import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
-import { getElectronNodeRuntimePath } from '../libs/coworkUtil';
+import {
+  ensureElectronNodeShim,
+  getElectronNodeRuntimePath,
+} from '../libs/coworkUtil';
 import { findSystemNodePath } from '../libs/resolveStdioCommand';
 import {
   createMcpLaunchSourceFingerprint,
@@ -53,6 +56,28 @@ function log(level: 'INFO' | 'WARN' | 'ERROR', message: string, error?: unknown)
 
 function sanitizeForPath(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'mcp';
+}
+
+function prependPathEntries(
+  env: Record<string, string>,
+  entries: string[],
+): Record<string, string> {
+  const next = { ...env };
+  const pathKeys = Object.keys(next).filter(key => key.toLowerCase() === 'path');
+  const pathKey = pathKeys.find(key => key === 'PATH') || pathKeys[0] || 'PATH';
+  const pathValues = pathKeys
+    .map(key => next[key])
+    .filter((value): value is string => Boolean(value));
+  const mergedPath = [...entries.filter(Boolean), ...pathValues]
+    .filter(Boolean)
+    .join(path.delimiter);
+  for (const key of pathKeys) {
+    delete next[key];
+  }
+  if (mergedPath) {
+    next[pathKey] = mergedPath;
+  }
+  return next;
 }
 
 function parsePackageSpec(spec: string): { packageName: string; requestedVersion: string } | null {
@@ -171,10 +196,14 @@ async function runCommand(
   },
 ): Promise<RunResult> {
   const startedAt = Date.now();
+  const childEnv = prependPathEntries(
+    { ...process.env, ...(options.env || {}) } as Record<string, string>,
+    [],
+  );
   return await new Promise<RunResult>((resolve, reject) => {
     const child = spawn(command, args, {
       cwd: options.cwd,
-      env: { ...process.env, ...(options.env || {}) },
+      env: childEnv,
       windowsHide: true,
     });
     let stdout = '';
@@ -213,18 +242,34 @@ function resolveNpmCommand(): NpmCommand {
 
   const systemNode = findSystemNodePath();
   if (systemNode) {
+    const systemNodeDir = path.dirname(systemNode);
     const systemNpmCli = path.join(path.dirname(systemNode), 'node_modules', 'npm', 'bin', 'npm-cli.js');
     if (fs.existsSync(systemNpmCli)) {
-      return { command: systemNode, baseArgs: [systemNpmCli], env: {} };
+      return {
+        command: systemNode,
+        baseArgs: [systemNpmCli],
+        env: prependPathEntries({}, [systemNodeDir]),
+      };
     }
   }
 
   const bundledNpmCli = npmCliCandidates.find(candidate => fs.existsSync(candidate));
   if (bundledNpmCli) {
+    const npmBinDir = path.dirname(bundledNpmCli);
+    const shimDir = ensureElectronNodeShim(electronNode, npmBinDir);
     return {
       command: systemNode || electronNode,
       baseArgs: [bundledNpmCli],
-      env: systemNode ? {} : { ELECTRON_RUN_AS_NODE: '1' },
+      env: prependPathEntries(
+        systemNode
+          ? {}
+          : {
+            ELECTRON_RUN_AS_NODE: '1',
+            LOBSTERAI_ELECTRON_PATH: electronNode,
+            LOBSTERAI_NPM_BIN_DIR: npmBinDir,
+          },
+        [systemNode ? path.dirname(systemNode) : '', shimDir || ''],
+      ),
     };
   }
 
@@ -382,6 +427,9 @@ export class McpLaunchResolverManager {
         'INFO',
         `resolved npm metadata for "${server.name}" in ${Date.now() - viewStartedAt}ms (exit=${viewResult.code})`,
       );
+      if (viewResult.code !== 0) {
+        throw new Error(viewResult.stderr.trim() || `npm view exited with code ${viewResult.code}`);
+      }
 
       const installStartedAt = Date.now();
       const installResult = await runCommand(

--- a/src/main/mcp/mcpRuntime.ts
+++ b/src/main/mcp/mcpRuntime.ts
@@ -185,6 +185,25 @@ export class McpRuntime {
     const npmBinDir = app.isPackaged
       ? path.join(process.resourcesPath, 'app.asar.unpacked', 'node_modules', 'npm', 'bin')
       : '';
+    const buildShimEnv = (): Record<string, string> => {
+      const shimEnv: Record<string, string> = {
+        LOBSTERAI_ELECTRON_PATH: electronPath,
+      };
+      if (npmBinDir) {
+        shimEnv.LOBSTERAI_NPM_BIN_DIR = npmBinDir;
+      }
+      return shimEnv;
+    };
+    const pushRawStdioServer = async (server: typeof enabledServers[number]): Promise<void> => {
+      const r = await resolveStdioCommand(server);
+      resolved.push({
+        name: server.name,
+        transportType: 'stdio',
+        command: r.command,
+        args: r.args,
+        env: { ...buildShimEnv(), ...(r.env || {}) },
+      });
+    };
 
     for (const server of enabledServers) {
       if (server.transportType === 'stdio') {
@@ -213,22 +232,17 @@ export class McpRuntime {
           const status = server.launchResolution?.sourceFingerprint === fingerprint
             ? server.launchResolution.status
             : McpLaunchResolutionStatus.Pending;
-          if (status === McpLaunchResolutionStatus.Unsupported) {
+          if (
+            status === McpLaunchResolutionStatus.Unsupported
+            || status === McpLaunchResolutionStatus.Failed
+          ) {
             rawCount++;
-            const r = await resolveStdioCommand(server);
-            const shimEnv: Record<string, string> = {
-              LOBSTERAI_ELECTRON_PATH: electronPath,
-            };
-            if (npmBinDir) {
-              shimEnv.LOBSTERAI_NPM_BIN_DIR = npmBinDir;
+            if (status === McpLaunchResolutionStatus.Failed) {
+              console.warn(
+                `[MCP] using raw stdio command for server "${server.name}" because managed launch resolution failed`,
+              );
             }
-            resolved.push({
-              name: server.name,
-              transportType: 'stdio',
-              command: r.command,
-              args: r.args,
-              env: { ...shimEnv, ...(r.env || {}) },
-            });
+            await pushRawStdioServer(server);
             continue;
           }
 
@@ -243,20 +257,7 @@ export class McpRuntime {
         }
 
         rawCount++;
-        const r = await resolveStdioCommand(server);
-        const shimEnv: Record<string, string> = {
-          LOBSTERAI_ELECTRON_PATH: electronPath,
-        };
-        if (npmBinDir) {
-          shimEnv.LOBSTERAI_NPM_BIN_DIR = npmBinDir;
-        }
-        resolved.push({
-          name: server.name,
-          transportType: 'stdio',
-          command: r.command,
-          args: r.args,
-          env: { ...shimEnv, ...(r.env || {}) },
-        });
+        await pushRawStdioServer(server);
       } else {
         resolved.push({
           name: server.name,


### PR DESCRIPTION
## Summary
- inject the resolved Node toolchain path into managed MCP npm install commands
- preserve Electron node/npm shim env for fallback stdio launches
- fall back to raw stdio config when managed launch resolution fails instead of dropping the MCP server from OpenClaw config

## Cause
QA logs showed managed MCP installs running npm successfully, but package lifecycle scripts such as Playwright's `node install.js` failed in packaged Windows builds because `node` was not available on PATH. A separate Fetch failure was caused by online marketplace configuration pointing at a non-existent npm package; that entry has been removed from online config and is not handled specially in this PR.

## Validation
- `npx eslint src/main/mcp/mcpLaunchResolverManager.ts src/main/mcp/mcpRuntime.ts`
- `npm run compile:electron`
- `npm test -- mcpLaunchResolverManager`