### PR TITLE
fix(ui): improve kits and skills popover interactions

### DIFF
--- a/src/renderer/components/ModelSelector.test.ts
+++ b/src/renderer/components/ModelSelector.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+
+import { resolveHoverCardTop } from './ModelSelector';
+
+test('keeps model hover card above the viewport bottom', () => {
+  expect(resolveHoverCardTop(790, 260, 900)).toBe(632);
+});
+
+test('keeps model hover card below the viewport top margin', () => {
+  expect(resolveHoverCardTop(-20, 120, 900)).toBe(8);
+});
+
+test('does not move a fully visible model hover card', () => {
+  expect(resolveHoverCardTop(240, 180, 900)).toBe(240);
+});
+
+test('pins model hover card to the margin when it is taller than the viewport', () => {
+  expect(resolveHoverCardTop(160, 1000, 900)).toBe(8);
+});

--- a/src/renderer/components/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector.tsx
@@ -34,12 +34,26 @@ interface ModelSelectorProps {
 const DROPDOWN_MAX_HEIGHT = 344; // list max-h-72 plus the tab area
 const DROPDOWN_WIDTH = 300;
 const DROPDOWN_VIEWPORT_MARGIN = 8;
+const HOVER_CARD_WIDTH = 220;
+const HOVER_CARD_GAP = 8;
+const HOVER_CARD_VIEWPORT_MARGIN = 8;
 const MODEL_ICON_CLASS_NAME = 'h-[18px] w-[18px]';
 const ModelSelectorGroup = {
   Server: 'server',
   User: 'user',
 } as const;
 type ModelSelectorGroup = typeof ModelSelectorGroup[keyof typeof ModelSelectorGroup];
+
+export function resolveHoverCardTop(
+  desiredTop: number,
+  cardHeight: number,
+  viewportHeight: number,
+  viewportMargin = HOVER_CARD_VIEWPORT_MARGIN,
+): number {
+  const maxTop = Math.max(viewportMargin, viewportHeight - cardHeight - viewportMargin);
+  return Math.min(Math.max(desiredTop, viewportMargin), maxTop);
+}
+
 const MODEL_ICON_PROVIDER_HINTS: Array<{ pattern: RegExp; providerName: ProviderName | ProviderIconId }> = [
   { pattern: /doubao|豆包/i, providerName: ProviderIconId.Doubao },
   { pattern: /deepseek/i, providerName: ProviderName.DeepSeek },
@@ -74,6 +88,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
   const selectedItemRef = React.useRef<HTMLButtonElement>(null);
   const [hoveredModel, setHoveredModel] = React.useState<Model | null>(null);
   const [hoverCardStyle, setHoverCardStyle] = React.useState<React.CSSProperties>({});
+  const hoverCardRef = React.useRef<HTMLDivElement>(null);
   const hoverTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const controlled = onChange !== undefined;
@@ -225,6 +240,19 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
     if (!isOpen) setHoveredModel(null);
   }, [isOpen]);
 
+  React.useLayoutEffect(() => {
+    if (!hoveredModel || !hoverCardRef.current) return;
+
+    const cardRect = hoverCardRef.current.getBoundingClientRect();
+    const currentTop = typeof hoverCardStyle.top === 'number'
+      ? hoverCardStyle.top
+      : cardRect.top;
+    const nextTop = resolveHoverCardTop(currentTop, cardRect.height, window.innerHeight);
+
+    if (Math.abs(nextTop - currentTop) < 0.5) return;
+    setHoverCardStyle(style => ({ ...style, top: nextTop }));
+  }, [hoveredModel, hoverCardStyle.top]);
+
   // 如果没有可用模型，显示提示
   if (availableModels.length === 0) {
     return (
@@ -282,16 +310,15 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
       if (!dropdownEl) return;
       const dropdownRect = dropdownEl.getBoundingClientRect();
       const spaceRight = window.innerWidth - dropdownRect.right;
-      const cardWidth = 220;
       const style: React.CSSProperties = {
         position: 'fixed',
         top: itemRect.top,
         zIndex: 10001,
       };
-      if (spaceRight >= cardWidth + 8) {
-        style.left = dropdownRect.right + 8;
+      if (spaceRight >= HOVER_CARD_WIDTH + HOVER_CARD_GAP) {
+        style.left = dropdownRect.right + HOVER_CARD_GAP;
       } else {
-        style.right = window.innerWidth - dropdownRect.left + 8;
+        style.right = window.innerWidth - dropdownRect.left + HOVER_CARD_GAP;
       }
       setHoverCardStyle(style);
       setHoveredModel(model);
@@ -351,7 +378,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
   const renderHoverCard = () => {
     if (!hoveredModel) return null;
     const card = (
-      <div style={hoverCardStyle} className="w-[220px] rounded-xl border border-border bg-surface shadow-popover p-3 pointer-events-none">
+      <div ref={hoverCardRef} style={hoverCardStyle} className="w-[220px] rounded-xl border border-border bg-surface shadow-popover p-3 pointer-events-none">
         <div className="text-[13px] font-semibold text-foreground leading-5">{hoveredModel.name}</div>
         {hoveredModel.description && (
           <div className="mt-1 text-[11px] text-secondary leading-4">{hoveredModel.description}</div>

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -280,7 +280,6 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const readOnlyContextGroupRef = useRef<HTMLDivElement>(null);
     const dragDepthRef = useRef(0);
     const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const skillPopoverCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const modelPatchRequestIdRef = useRef(0);
 
   // 暴露方法给父组件
@@ -522,12 +521,14 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       const target = event.target as Node;
       if (!addMenuButtonRef.current?.contains(target) && !addMenuRef.current?.contains(target)) {
         setShowAddMenu(false);
+        setShowSkillsPopover(false);
       }
     };
 
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setShowAddMenu(false);
+        setShowSkillsPopover(false);
       }
     };
 
@@ -541,21 +542,9 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
 
   useEffect(() => {
     if (!showAddMenu) {
-      if (skillPopoverCloseTimerRef.current) {
-        clearTimeout(skillPopoverCloseTimerRef.current);
-        skillPopoverCloseTimerRef.current = null;
-      }
       setShowSkillsPopover(false);
     }
   }, [showAddMenu]);
-
-  useEffect(() => {
-    return () => {
-      if (skillPopoverCloseTimerRef.current) {
-        clearTimeout(skillPopoverCloseTimerRef.current);
-      }
-    };
-  }, []);
 
   useEffect(() => {
     modelPatchRequestIdRef.current += 1;
@@ -1186,31 +1175,13 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   }, [addAttachment, effectiveSelectedModel, isAddingFile, disabled, isStreaming, modelSupportsImage]);
 
   const handleOpenAddMenu = useCallback(() => {
-    if (skillPopoverCloseTimerRef.current) {
-      clearTimeout(skillPopoverCloseTimerRef.current);
-      skillPopoverCloseTimerRef.current = null;
-    }
     setShowSkillsPopover(false);
     setShowAddMenu(prev => !prev);
   }, []);
 
   const handleOpenSkillsPopover = useCallback(() => {
-    if (skillPopoverCloseTimerRef.current) {
-      clearTimeout(skillPopoverCloseTimerRef.current);
-      skillPopoverCloseTimerRef.current = null;
-    }
     setShowAddMenu(true);
     setShowSkillsPopover(true);
-  }, []);
-
-  const handleScheduleCloseSkillsPopover = useCallback(() => {
-    if (skillPopoverCloseTimerRef.current) {
-      clearTimeout(skillPopoverCloseTimerRef.current);
-    }
-    skillPopoverCloseTimerRef.current = setTimeout(() => {
-      setShowSkillsPopover(false);
-      skillPopoverCloseTimerRef.current = null;
-    }, 320);
   }, []);
 
   const handleRemoveAttachment = useCallback((path: string) => {
@@ -1406,18 +1377,10 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
           ref={addMenuRef}
           className="absolute bottom-full left-0 z-50 mb-2 w-48 rounded-xl border border-border bg-surface py-1 shadow-popover"
           role="menu"
-          onMouseEnter={() => {
-            if (skillPopoverCloseTimerRef.current) {
-              clearTimeout(skillPopoverCloseTimerRef.current);
-              skillPopoverCloseTimerRef.current = null;
-            }
-          }}
-          onMouseLeave={handleScheduleCloseSkillsPopover}
         >
           <button
             type="button"
             onClick={handleAddFile}
-            onMouseEnter={handleScheduleCloseSkillsPopover}
             disabled={disabled || isStreaming || isAddingFile}
             className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm text-foreground transition-colors hover:bg-surface-raised disabled:cursor-not-allowed disabled:opacity-50"
             role="menuitem"
@@ -1425,14 +1388,6 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
             <PaperClipIcon className="h-5 w-5 shrink-0 text-secondary" />
             <span className="min-w-0 truncate">{i18nService.t('coworkAddFile')}</span>
           </button>
-          {showSkillsPopover && (
-            <div
-              aria-hidden="true"
-              className="absolute bottom-0 left-[calc(100%-1px)] z-[55] h-80 w-40"
-              onMouseEnter={handleOpenSkillsPopover}
-              onMouseLeave={handleScheduleCloseSkillsPopover}
-            />
-          )}
           <button
             ref={skillMenuItemRef}
             type="button"
@@ -1459,8 +1414,6 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
             anchorRef={skillMenuItemRef as React.RefObject<HTMLElement>}
             asSubmenu
             autoFocusSearch={false}
-            onMouseEnter={handleOpenSkillsPopover}
-            onMouseLeave={handleScheduleCloseSkillsPopover}
           />
         </div>
       )}

--- a/src/renderer/components/kits/KitsManager.tsx
+++ b/src/renderer/components/kits/KitsManager.tsx
@@ -296,7 +296,7 @@ const KitsManager: React.FC<KitsManagerProps> = ({ onTryAsking }) => {
         <button
           type="button"
           onClick={() => setSelectedKit(null)}
-          className="non-draggable inline-flex items-center gap-1.5 text-sm text-secondary hover:text-foreground transition-colors"
+          className="non-draggable relative z-30 inline-flex items-center gap-1.5 text-sm text-secondary hover:text-foreground transition-colors"
         >
           <ArrowLeftIcon className="h-4 w-4" />
           {i18nService.t('kitBack')}

--- a/src/renderer/components/skills/SkillsPopover.tsx
+++ b/src/renderer/components/skills/SkillsPopover.tsx
@@ -144,11 +144,9 @@ const SkillsPopover: React.FC<SkillsPopoverProps> = ({
   const listClassName = asSubmenu
     ? 'overflow-y-auto px-2 py-1.5'
     : 'overflow-y-auto py-1';
-  const listStyle: React.CSSProperties = asSubmenu
-    ? { height: `${maxListHeight}px` }
-    : { maxHeight: `${maxListHeight}px` };
+  const listStyle: React.CSSProperties = { maxHeight: `${maxListHeight}px` };
   const emptyStateClassName = asSubmenu
-    ? 'flex h-full items-center justify-center px-3 py-5 text-center text-[13px] text-secondary'
+    ? 'flex h-[50px] items-center justify-center px-3 text-center text-[13px] leading-5 text-secondary'
     : 'px-4 py-6 text-center text-sm text-secondary';
 
   return (


### PR DESCRIPTION
- Fix ModelSelector hover card overflowing viewport by adding resolveHoverCardTop utility with layout effect repositioning
- Remove timer-based delayed close for skills popover in favor of immediate close on outside click or Escape key
- Fix SkillsPopover submenu using fixed height instead of maxHeight
- Add z-index to KitsManager back button for correct stacking
