### PR TITLE
feat(cowork): improve channel session sync and cleanup

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -3604,6 +3604,76 @@ test('prefetchChannelUserMessages also consumes existing reminder history backlo
   expect(getSystemMessages(session).length).toBe(0);
 });
 
+test('prefetchChannelUserMessages uses latest user only for recreated channel sessions', async () => {
+  const { session, store, getReplaceCallCount } = createReconcileStore([]);
+  const historyMessages = [
+    { role: 'user', content: 'old user' },
+    { role: 'assistant', content: 'old assistant' },
+    { role: 'user', content: 'new user turn' },
+  ];
+
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  adapter.gatewayClient = {
+    start: () => {},
+    stop: () => {},
+    request: async () => ({ messages: historyMessages }),
+  };
+  adapter.reCreatedChannelSessionIds.add(session.id);
+
+  await adapter.prefetchChannelUserMessages(
+    session.id,
+    'agent:main:feishu:3e462f80:direct:ou_ca9972aed8fa926570225cf3714aa63a',
+  );
+
+  expect(getReplaceCallCount()).toBe(0);
+  expect(session.messages.filter((message) => message.type === 'user').map((message) => message.content)).toEqual([
+    'new user turn',
+  ]);
+  expect(session.messages.some((message) => message.content === 'old user')).toBe(false);
+  expect(adapter.channelSyncCursor.get(session.id)).toBe(3);
+  expect(adapter.gatewayHistoryCountBySession.get(session.id)).toBe(historyMessages.length);
+});
+
+test('onSessionDeleted deletes gateway transcripts for all session keys', async () => {
+  const request = vi.fn(async () => ({}));
+  const subagentRunStore = {
+    listSubagentRuns: () => [],
+    deleteSubagentRunsByParent: vi.fn(),
+  };
+  const adapter = new OpenClawRuntimeAdapter({} as never, {}, {}, subagentRunStore as never);
+  const channelSessionKey = 'agent:main:feishu:3e462f80:direct:ou_ca9972aed8fa926570225cf3714aa63a';
+  const managedSessionKey = 'agent:main:lobsterai:session-1';
+  adapter.gatewayClient = {
+    start: () => {},
+    stop: () => {},
+    request,
+  };
+  adapter.channelSessionSync = {
+    isChannelSessionKey: (key: string) => key === channelSessionKey,
+    onSessionDeleted: vi.fn(),
+  } as never;
+  adapter.sessionIdBySessionKey.set(channelSessionKey, 'session-1');
+  adapter.sessionIdBySessionKey.set(managedSessionKey, 'session-1');
+
+  adapter.onSessionDeleted('session-1');
+
+  await vi.waitFor(() => {
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenCalledWith(
+      'sessions.delete',
+      { key: channelSessionKey, deleteTranscript: true },
+      { timeoutMs: 5_000 },
+    );
+    expect(request).toHaveBeenCalledWith(
+      'sessions.delete',
+      { key: managedSessionKey, deleteTranscript: true },
+      { timeoutMs: 5_000 },
+    );
+  });
+  expect(adapter.deletedChannelKeys.has(channelSessionKey)).toBe(true);
+  expect(adapter.deletedChannelKeys.has(managedSessionKey)).toBe(false);
+});
+
 test('syncSystemMessagesFromHistory skips pure heartbeat ack system messages', () => {
   const { session, store } = createHistoryStore([]);
   const adapter = new OpenClawRuntimeAdapter(store, {});

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1405,6 +1405,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private static readonly VISIBLE_FINAL_LARGE_TOOL_CONFIRMATION_GRACE_MS = 8_000;
   private static readonly VISIBLE_FINAL_TOOL_RESULT_CHAR_THRESHOLD = 20_000;
   private static readonly VISIBLE_FINAL_SHORT_TEXT_CHAR_THRESHOLD = 600;
+  private static readonly GATEWAY_SESSION_DELETE_TIMEOUT_MS = 5_000;
 
   private gatewayClient: GatewayClientLike | null = null;
   private gatewayClientVersion: string | null = null;
@@ -6738,6 +6739,34 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
   }
 
+  private async syncLatestChannelUserMessage(sessionId: string, sessionKey: string): Promise<void> {
+    const client = this.gatewayClient;
+    if (!client) {
+      console.log('[ChannelSync] no gateway client, skipping latest channel user sync');
+      return;
+    }
+
+    const history = await client.request<{ messages?: unknown[] }>('chat.history', {
+      sessionKey,
+      limit: FINAL_HISTORY_SYNC_LIMIT,
+    }, { timeoutMs: 10_000 });
+    if (!Array.isArray(history?.messages) || history.messages.length === 0) {
+      this.channelSyncCursor.set(sessionId, 0);
+      return;
+    }
+
+    this.markGatewayHistoryWindowConsumed(sessionId, history.messages);
+    this.syncChannelUserMessages(
+      sessionId,
+      history.messages,
+      true,
+      sessionKey.includes(':discord:'),
+      sessionKey.includes(':qqbot:'),
+      sessionKey.includes(':moltbot-popo:'),
+      sessionKey.includes(':feishu:'),
+    );
+  }
+
   private async syncFinalAssistantWithHistory(sessionId: string, turn: ActiveTurn): Promise<void> {
     console.debug('[OpenClawRuntime] syncFinalAssistant — sessionId:', sessionId);
     const client = this.gatewayClient;
@@ -7231,6 +7260,11 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
    * Delegates to reconcileWithHistory which handles diff and update.
    */
   private async incrementalChannelSync(sessionId: string, sessionKey: string): Promise<void> {
+    if (this.reCreatedChannelSessionIds.has(sessionId)) {
+      await this.syncLatestChannelUserMessage(sessionId, sessionKey);
+      return;
+    }
+
     await this.reconcileWithHistory(sessionId, sessionKey);
   }
 
@@ -7379,10 +7413,18 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       }
     }
 
+    const removedChannelKeys = removedKeys.filter((key) =>
+      this.channelSessionSync?.isChannelSessionKey(key) ?? false,
+    );
+
     // Suppress polling re-creation for deleted channel keys.
     // Only real-time events (new IM messages) will re-create the session.
-    for (const key of removedKeys) {
+    for (const key of removedChannelKeys) {
       this.deletedChannelKeys.add(key);
+    }
+
+    if (removedKeys.length > 0) {
+      void this.deleteGatewaySessionTranscripts(removedKeys);
     }
 
     // Allow polling to rediscover channel sessions
@@ -7415,6 +7457,27 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     // Clean up subagent tracking state and persisted messages
     this.subagentTracker.onSessionDeleted(sessionId);
+  }
+
+  private async deleteGatewaySessionTranscripts(sessionKeys: string[]): Promise<void> {
+    const client = this.gatewayClient;
+    if (!client) {
+      console.warn('[OpenClawRuntime] could not delete gateway session transcripts because the gateway client is unavailable');
+      return;
+    }
+
+    const uniqueKeys = Array.from(new Set(sessionKeys.filter(Boolean)));
+    for (const sessionKey of uniqueKeys) {
+      try {
+        await client.request('sessions.delete', {
+          key: sessionKey,
+          deleteTranscript: true,
+        }, { timeoutMs: OpenClawRuntimeAdapter.GATEWAY_SESSION_DELETE_TIMEOUT_MS });
+        console.log(`[OpenClawRuntime] deleted gateway session transcript for ${sessionKey}`);
+      } catch (error) {
+        console.warn(`[OpenClawRuntime] failed to delete gateway session transcript for ${sessionKey}:`, error);
+      }
+    }
   }
 
   /**
@@ -7537,7 +7600,11 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
       try {
         const beforeCount = this.getUserMessageCount(sessionId);
-        await this.reconcileWithHistory(sessionId, sessionKey);
+        if (this.reCreatedChannelSessionIds.has(sessionId)) {
+          await this.syncLatestChannelUserMessage(sessionId, sessionKey);
+        } else {
+          await this.reconcileWithHistory(sessionId, sessionKey);
+        }
         const afterCount = this.getUserMessageCount(sessionId);
         const newUserMessages = afterCount - beforeCount;
         console.log('[Debug:prefetch] reconciled (attempt', attempt, ') synced user messages:', newUserMessages, '(before:', beforeCount, 'after:', afterCount, ')');

--- a/src/renderer/components/cowork/AssistantMessageItem.tsx
+++ b/src/renderer/components/cowork/AssistantMessageItem.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react';
 import { i18nService } from '../../services/i18n';
 import type { CoworkMessage, CoworkMessageMetadata } from '../../types/cowork';
 import { formatMessageDateTime } from '../../utils/tokenFormat';
-import ForkBranchIcon from '../icons/ForkBranchIcon';
+import MessageForkIcon from '../icons/MessageForkIcon';
 import MessageCopyIcon from '../icons/MessageCopyIcon';
 import MarkdownContent from '../MarkdownContent';
 import ImagePreviewModal, { type ImagePreviewSource } from './ImagePreviewModal';
@@ -84,7 +84,7 @@ const ForkButton: React.FC<{
     title={i18nService.t('coworkForkFromMessage')}
     aria-label={i18nService.t('coworkForkFromMessage')}
   >
-    <ForkBranchIcon className="w-4 h-4 text-[var(--icon-secondary)]" />
+    <MessageForkIcon className="w-4 h-4 text-[var(--icon-secondary)]" />
   </button>
 );
 

--- a/src/renderer/components/icons/MessageForkIcon.tsx
+++ b/src/renderer/components/icons/MessageForkIcon.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+const MessageForkIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    className={className}
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M4.94116 11.2943H12.3361L18.7059 4.58838"
+      stroke="currentColor"
+      strokeWidth="1.69412"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M14.1177 4.23535H19.0589V9.17653"
+      stroke="currentColor"
+      strokeWidth="1.69412"
+      strokeLinecap="round"
+    />
+    <path
+      d="M13.4117 14.1177L19.0588 19.7647"
+      stroke="currentColor"
+      strokeWidth="1.69412"
+      strokeLinecap="round"
+    />
+    <path
+      d="M19.0589 14.8235V19.7647H14.1177"
+      stroke="currentColor"
+      strokeWidth="1.69412"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+export default MessageForkIcon;


### PR DESCRIPTION
- Add syncLatestChannelUserMessage for recreated channel sessions to only sync latest user turn
- Delete gateway session transcripts when session is removed
- Only mark channel keys in deletedChannelKeys
- Replace ForkBranchIcon with MessageForkIcon component