### PR TITLE
fix(voice): request mac microphone permission

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -10,5 +10,7 @@
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -77,6 +77,7 @@
     "entitlementsInherit": "build/entitlements.mac.plist",
     "extendInfo": {
       "CFBundleIconName": "icon",
+      "NSMicrophoneUsageDescription": "LobsterAI 需要访问您的麦克风来录制语音输入并进行语音识别。",
       "NSCalendarsUsageDescription": "LobsterAI 需要访问您的日历来帮助您查看和管理日程安排，例如查找事件、创建会议等。",
       "NSRemindersUsageDescription": "LobsterAI 需要访问您的提醒事项来帮助您管理待办事项。",
       "NSAppleEventsUsageDescription": "LobsterAI 需要使用 Apple Events 来控制 Calendar 应用执行自动化操作。"

--- a/src/main/ipcHandlers/asr/handlers.ts
+++ b/src/main/ipcHandlers/asr/handlers.ts
@@ -38,6 +38,7 @@ export function registerAsrIpcHandlers({
         }
 
         const audioBuffer = Buffer.from(audioBase64, 'base64');
+        console.log(`[ASR] submitting voice input audio (${audioBuffer.length} bytes)`);
         const form = new FormData();
         form.append(
           'file',
@@ -62,6 +63,8 @@ export function registerAsrIpcHandlers({
         if (resp.ok && body?.code === 0 && body.data) {
           return { success: true, data: body.data as AsrRecognizeData };
         }
+
+        console.warn(`[ASR] recognition request was rejected with code ${body?.code ?? resp.status} and HTTP status ${resp.status}`);
 
         return {
           success: false,

--- a/src/main/ipcHandlers/permissions/handlers.ts
+++ b/src/main/ipcHandlers/permissions/handlers.ts
@@ -1,0 +1,54 @@
+import type { IpcMain } from 'electron';
+
+import { PermissionIpcChannel, SystemPermissionStatus } from '../../../shared/permissions/constants';
+import { checkCalendarPermission, requestCalendarPermission } from '../../permissions/calendarPermission';
+
+export interface PermissionHandlerDeps {
+  ipcMain: IpcMain;
+  isDev: boolean;
+}
+
+export function registerPermissionIpcHandlers({ ipcMain, isDev }: PermissionHandlerDeps): void {
+  ipcMain.handle(PermissionIpcChannel.CheckCalendar, async () => {
+    try {
+      const status = await checkCalendarPermission();
+
+      if (isDev && status === SystemPermissionStatus.NotDetermined && process.platform === 'darwin') {
+        console.log('[Permissions] Development mode: Auto-requesting calendar permission...');
+        try {
+          await requestCalendarPermission();
+          const newStatus = await checkCalendarPermission();
+          console.log(
+            '[Permissions] Development mode: Permission status after request:',
+            newStatus,
+          );
+          return { success: true, status: newStatus, autoRequested: true };
+        } catch (requestError) {
+          console.warn('[Permissions] Development mode: Auto-request failed:', requestError);
+        }
+      }
+
+      return { success: true, status };
+    } catch (error) {
+      console.error('[Main] Error checking calendar permission:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to check permission',
+      };
+    }
+  });
+
+  ipcMain.handle(PermissionIpcChannel.RequestCalendar, async () => {
+    try {
+      const granted = await requestCalendarPermission();
+      const status = await checkCalendarPermission();
+      return { success: true, granted, status };
+    } catch (error) {
+      console.error('[Main] Error requesting calendar permission:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to request permission',
+      };
+    }
+  });
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -34,7 +34,6 @@ import { AgentId, AgentIpcChannel } from '../shared/agent/constants';
 import { AppUpdateIpc } from '../shared/appUpdate/constants';
 import { ArtifactBrowserPartition, ArtifactPreviewIpc, ArtifactPreviewProtocol } from '../shared/artifactPreview/constants';
 import { AuthIpcChannel } from '../shared/auth/constants';
-import { canonicalizeMediaModelId, mediaModelDisplayName } from '../shared/mediaModelAliases';
 import {
   type BrowserDiagnosticResultStep,
   BrowserDiagnosticStatus,
@@ -82,6 +81,7 @@ import {
   type LocalWebService,
   LocalWebServicesIpc,
 } from '../shared/localWebServices/constants';
+import { canonicalizeMediaModelId, mediaModelDisplayName } from '../shared/mediaModelAliases';
 import {
   OpenClawEngineIpc,
   OpenClawGatewayRepairErrorCode,
@@ -120,6 +120,7 @@ import { registerCoworkSubagentHandlers } from './ipcHandlers/coworkSubagent';
 import { registerKitHandlers } from './ipcHandlers/kits';
 import { registerMcpHandlers } from './ipcHandlers/mcp';
 import { registerNimQrLoginHandlers } from './ipcHandlers/nimQrLogin';
+import { registerPermissionIpcHandlers } from './ipcHandlers/permissions/handlers';
 import { registerPluginHandlers } from './ipcHandlers/plugins';
 import {
   getCronJobService,
@@ -264,6 +265,7 @@ import {
   loadOpenClawSessionPolicyConfig,
   saveOpenClawSessionPolicyConfig,
 } from './openclawSessionPolicy/store';
+import { registerVoiceInputPermissionHandler } from './permissions/voiceInputPermission';
 import { SkillManager } from './skillManager';
 import { getSkillServiceManager } from './skillServices';
 import { SqliteStore } from './sqliteStore';
@@ -1109,108 +1111,6 @@ const normalizeWindowsShellPath = (inputPath: string): string => {
   }
 
   return normalized;
-};
-
-// ==================== macOS Permissions ====================
-
-/**
- * Check calendar permission on macOS by attempting to access Calendar app
- * Returns: 'authorized' | 'denied' | 'restricted' | 'not-determined'
- * On Windows, checks if Outlook is available
- * On Linux, returns 'not-supported'
- */
-const checkCalendarPermission = async (): Promise<string> => {
-  if (process.platform === 'darwin') {
-    try {
-      // Try to access Calendar to check permission
-      const { exec } = require('child_process');
-      const util = require('util');
-      const execAsync = util.promisify(exec);
-
-      // Quick test to see if we can access Calendar
-      await execAsync('osascript -l JavaScript -e \'Application("Calendar").name()\'', {
-        timeout: 5000,
-      });
-      console.log('[Permissions] macOS Calendar access: authorized');
-      return 'authorized';
-    } catch (error: unknown) {
-      const stderr =
-        typeof error === 'object' && error && 'stderr' in error
-          ? String((error as { stderr?: unknown }).stderr ?? '')
-          : '';
-      // Check if it's a permission error
-      if (
-        stderr.includes('不能获取对象') ||
-        stderr.includes('not authorized') ||
-        stderr.includes('Permission denied')
-      ) {
-        console.log('[Permissions] macOS Calendar access: not-determined (needs permission)');
-        return 'not-determined';
-      }
-      console.warn('[Permissions] Failed to check macOS calendar permission:', error);
-      return 'not-determined';
-    }
-  }
-
-  if (process.platform === 'win32') {
-    // Windows doesn't have a system-level calendar permission like macOS
-    // Instead, we check if Outlook is available
-    try {
-      const { exec } = require('child_process');
-      const util = require('util');
-      const execAsync = util.promisify(exec);
-
-      // Check if Outlook COM object is accessible
-      const checkScript = `
-        try {
-          $Outlook = New-Object -ComObject Outlook.Application
-          $Outlook.Version
-        } catch { exit 1 }
-      `;
-      await execAsync('powershell -Command "' + checkScript + '"', { timeout: 10000 });
-      console.log('[Permissions] Windows Outlook is available');
-      return 'authorized';
-    } catch {
-      console.log('[Permissions] Windows Outlook not available or not accessible');
-      return 'not-determined';
-    }
-  }
-
-  return 'not-supported';
-};
-
-/**
- * Request calendar permission on macOS
- * On Windows, attempts to initialize Outlook COM object
- */
-const requestCalendarPermission = async (): Promise<boolean> => {
-  if (process.platform === 'darwin') {
-    try {
-      // On macOS, we trigger permission by trying to access Calendar
-      // The system will show permission dialog if needed
-      const { exec } = require('child_process');
-      const util = require('util');
-      const execAsync = util.promisify(exec);
-
-      await execAsync(
-        'osascript -l JavaScript -e \'Application("Calendar").calendars()[0].name()\'',
-        { timeout: 10000 },
-      );
-      return true;
-    } catch (error) {
-      console.warn('[Permissions] Failed to request macOS calendar permission:', error);
-      return false;
-    }
-  }
-
-  if (process.platform === 'win32') {
-    // Windows doesn't have a permission dialog for COM objects
-    // We just check if Outlook is available
-    const status = await checkCalendarPermission();
-    return status === 'authorized';
-  }
-
-  return false;
 };
 
 // 配置应用
@@ -6563,53 +6463,7 @@ if (!gotTheLock) {
     pollNimQrLogin,
   });
 
-  // ==================== Permissions IPC Handlers ====================
-
-  ipcMain.handle('permissions:checkCalendar', async () => {
-    try {
-      const status = await checkCalendarPermission();
-
-      // Development mode: Auto-request permission if not determined
-      // This provides a better dev experience without affecting production
-      if (isDev && status === 'not-determined' && process.platform === 'darwin') {
-        console.log('[Permissions] Development mode: Auto-requesting calendar permission...');
-        try {
-          await requestCalendarPermission();
-          const newStatus = await checkCalendarPermission();
-          console.log(
-            '[Permissions] Development mode: Permission status after request:',
-            newStatus,
-          );
-          return { success: true, status: newStatus, autoRequested: true };
-        } catch (requestError) {
-          console.warn('[Permissions] Development mode: Auto-request failed:', requestError);
-        }
-      }
-
-      return { success: true, status };
-    } catch (error) {
-      console.error('[Main] Error checking calendar permission:', error);
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to check permission',
-      };
-    }
-  });
-
-  ipcMain.handle('permissions:requestCalendar', async () => {
-    try {
-      // Request permission and check status
-      const granted = await requestCalendarPermission();
-      const status = await checkCalendarPermission();
-      return { success: true, granted, status };
-    } catch (error) {
-      console.error('[Main] Error requesting calendar permission:', error);
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to request permission',
-      };
-    }
-  });
+  registerPermissionIpcHandlers({ ipcMain, isDev });
 
   // ==================== IM Gateway IPC Handlers ====================
 
@@ -9444,6 +9298,12 @@ if (!gotTheLock) {
     // sees the loading UI within ~1-2 s instead of waiting for the full
     // skill bootstrap (~6-8 s previously).
     setContentSecurityPolicy();
+    registerVoiceInputPermissionHandler({
+      session: session.defaultSession,
+      getMainWindow: () => mainWindow,
+      isDev,
+      startUrl: process.env.ELECTRON_START_URL,
+    });
 
     profiler.mark('createWindow');
     console.log('[Main] initApp: creating window');

--- a/src/main/permissions/calendarPermission.ts
+++ b/src/main/permissions/calendarPermission.ts
@@ -1,0 +1,75 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+import { SystemPermissionStatus, type SystemPermissionStatus as SystemPermissionStatusValue } from '../../shared/permissions/constants';
+
+const execAsync = promisify(exec);
+
+export async function checkCalendarPermission(): Promise<SystemPermissionStatusValue> {
+  if (process.platform === 'darwin') {
+    try {
+      await execAsync('osascript -l JavaScript -e \'Application("Calendar").name()\'', {
+        timeout: 5000,
+      });
+      console.log('[Permissions] macOS Calendar access: authorized');
+      return SystemPermissionStatus.Authorized;
+    } catch (error: unknown) {
+      const stderr =
+        typeof error === 'object' && error && 'stderr' in error
+          ? String((error as { stderr?: unknown }).stderr ?? '')
+          : '';
+
+      if (
+        stderr.includes('不能获取对象') ||
+        stderr.includes('not authorized') ||
+        stderr.includes('Permission denied')
+      ) {
+        console.log('[Permissions] macOS Calendar access: not-determined (needs permission)');
+        return SystemPermissionStatus.NotDetermined;
+      }
+      console.warn('[Permissions] Failed to check macOS calendar permission:', error);
+      return SystemPermissionStatus.NotDetermined;
+    }
+  }
+
+  if (process.platform === 'win32') {
+    try {
+      const checkScript = `
+        try {
+          $Outlook = New-Object -ComObject Outlook.Application
+          $Outlook.Version
+        } catch { exit 1 }
+      `;
+      await execAsync(`powershell -Command "${checkScript}"`, { timeout: 10000 });
+      console.log('[Permissions] Windows Outlook is available');
+      return SystemPermissionStatus.Authorized;
+    } catch {
+      console.log('[Permissions] Windows Outlook not available or not accessible');
+      return SystemPermissionStatus.NotDetermined;
+    }
+  }
+
+  return SystemPermissionStatus.NotSupported;
+}
+
+export async function requestCalendarPermission(): Promise<boolean> {
+  if (process.platform === 'darwin') {
+    try {
+      await execAsync(
+        'osascript -l JavaScript -e \'Application("Calendar").calendars()[0].name()\'',
+        { timeout: 10000 },
+      );
+      return true;
+    } catch (error) {
+      console.warn('[Permissions] Failed to request macOS calendar permission:', error);
+      return false;
+    }
+  }
+
+  if (process.platform === 'win32') {
+    const status = await checkCalendarPermission();
+    return status === SystemPermissionStatus.Authorized;
+  }
+
+  return false;
+}

--- a/src/main/permissions/types.ts
+++ b/src/main/permissions/types.ts
@@ -1,0 +1,8 @@
+import type { BrowserWindow, Session } from 'electron';
+
+export interface VoiceInputPermissionHandlerOptions {
+  session: Session;
+  getMainWindow: () => BrowserWindow | null;
+  isDev: boolean;
+  startUrl?: string;
+}

--- a/src/main/permissions/voiceInputPermission.ts
+++ b/src/main/permissions/voiceInputPermission.ts
@@ -1,0 +1,86 @@
+import { systemPreferences } from 'electron';
+
+import type { VoiceInputPermissionHandlerOptions } from './types';
+
+const isLocalhost = (hostname: string): boolean =>
+  hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
+
+function isTrustedRendererMediaUrl(requestUrl: string, isDev: boolean, startUrl?: string): boolean {
+  try {
+    const url = new URL(requestUrl);
+    if (url.protocol === 'file:') return true;
+    if (!isDev || (url.protocol !== 'http:' && url.protocol !== 'https:')) return false;
+
+    if (startUrl) {
+      try {
+        return url.origin === new URL(startUrl).origin;
+      } catch {
+        return false;
+      }
+    }
+
+    return isLocalhost(url.hostname) && url.port === '5175';
+  } catch {
+    return false;
+  }
+}
+
+async function requestMacMicrophoneAccess(): Promise<boolean> {
+  if (process.platform !== 'darwin') return true;
+
+  const status = systemPreferences.getMediaAccessStatus('microphone');
+  if (status === 'granted') return true;
+  if (status === 'denied' || status === 'restricted') {
+    console.warn(`[VoiceInput] macOS microphone access is ${status}`);
+    return false;
+  }
+
+  try {
+    const granted = await systemPreferences.askForMediaAccess('microphone');
+    if (!granted) {
+      console.warn('[VoiceInput] macOS microphone access was not granted');
+    }
+    return granted;
+  } catch (error) {
+    console.warn('[VoiceInput] macOS microphone access request failed:', error);
+    return false;
+  }
+}
+
+function getPermissionMediaTypes(details: unknown): string[] {
+  if (!details || typeof details !== 'object' || !('mediaTypes' in details)) return [];
+  const mediaTypes = (details as { mediaTypes?: unknown }).mediaTypes;
+  return Array.isArray(mediaTypes) ? mediaTypes.filter((mediaType): mediaType is string => typeof mediaType === 'string') : [];
+}
+
+export function registerVoiceInputPermissionHandler({
+  session,
+  getMainWindow,
+  isDev,
+  startUrl,
+}: VoiceInputPermissionHandlerOptions): void {
+  session.setPermissionRequestHandler((webContents, permission, callback, details) => {
+    if (permission !== 'media') {
+      callback(false);
+      return;
+    }
+
+    const mediaTypes = getPermissionMediaTypes(details);
+    if (!mediaTypes.includes('audio')) {
+      callback(false);
+      return;
+    }
+
+    const requestingUrl = details.requestingUrl || webContents.getURL();
+    const mainWindow = getMainWindow();
+    if (mainWindow?.webContents !== webContents || !isTrustedRendererMediaUrl(requestingUrl, isDev, startUrl)) {
+      console.warn(`[VoiceInput] blocked microphone permission request from ${requestingUrl || 'unknown origin'}`);
+      callback(false);
+      return;
+    }
+
+    void requestMacMicrophoneAccess().then(granted => {
+      callback(granted);
+    });
+  });
+}

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -30,6 +30,7 @@ import {
 } from '../shared/localWebServices/constants';
 import { McpIpcChannel } from '../shared/mcp/constants';
 import { OpenClawEngineIpc } from '../shared/openclawEngine/constants';
+import { PermissionIpcChannel } from '../shared/permissions/constants';
 import type { Platform } from '../shared/platform';
 import { NimQrLoginIpc } from './ipcHandlers/nimQrLogin';
 import { OpenClawSessionIpc } from './openclawSession/constants';
@@ -102,8 +103,8 @@ contextBridge.exposeInMainWorld('electron', {
     listInstalled: () => ipcRenderer.invoke('kits:listInstalled'),
   },
   permissions: {
-    checkCalendar: () => ipcRenderer.invoke('permissions:checkCalendar'),
-    requestCalendar: () => ipcRenderer.invoke('permissions:requestCalendar'),
+    checkCalendar: () => ipcRenderer.invoke(PermissionIpcChannel.CheckCalendar),
+    requestCalendar: () => ipcRenderer.invoke(PermissionIpcChannel.RequestCalendar),
   },
   enterprise: {
     getConfig: () => ipcRenderer.invoke('enterprise:getConfig'),

--- a/src/shared/permissions/constants.ts
+++ b/src/shared/permissions/constants.ts
@@ -1,0 +1,16 @@
+export const PermissionIpcChannel = {
+  CheckCalendar: 'permissions:checkCalendar',
+  RequestCalendar: 'permissions:requestCalendar',
+} as const;
+
+export type PermissionIpcChannel = typeof PermissionIpcChannel[keyof typeof PermissionIpcChannel];
+
+export const SystemPermissionStatus = {
+  Authorized: 'authorized',
+  Denied: 'denied',
+  Restricted: 'restricted',
+  NotDetermined: 'not-determined',
+  NotSupported: 'not-supported',
+} as const;
+
+export type SystemPermissionStatus = typeof SystemPermissionStatus[keyof typeof SystemPermissionStatus];


### PR DESCRIPTION
## Summary
- add macOS microphone usage metadata and audio-input entitlement for voice input
- register a trusted renderer media permission policy for voice input microphone access
- move system permission helpers and IPC registration out of main.ts
- add ASR request diagnostics for uploaded audio size and rejection status

## Verification
- npx tsc --project electron-tsconfig.json
- npx eslint src/main/main.ts src/main/preload.ts src/main/ipcHandlers/asr/handlers.ts src/main/ipcHandlers/permissions/handlers.ts src/main/permissions/calendarPermission.ts src/main/permissions/voiceInputPermission.ts src/main/permissions/types.ts src/shared/permissions/constants.ts
- git diff --check

Note: npm run compile:electron was also attempted, but precompile hit an EBUSY lock on node_modules/better-sqlite3/build/Release/better_sqlite3.node during native dependency rebuild. The underlying TypeScript compile command passed.