### PR TITLE
feat(cowork): improve error UX and empty-state guides

### DIFF
--- a/src/common/coworkErrorClassify.test.ts
+++ b/src/common/coworkErrorClassify.test.ts
@@ -44,6 +44,10 @@ test('billing: OpenAI insufficient_quota', () => {
   expect(classifyError('You exceeded your current quota, please check your plan and billing details. insufficient_quota')).toBe('coworkErrorInsufficientBalance');
 });
 
+test('billing: LobsterAI free quota exhausted', () => {
+  expect(classifyError('免费额度已用完，请升级套餐')).toBe('coworkErrorFreeQuotaExhausted');
+});
+
 test('billing: OpenRouter insufficient credits', () => {
   expect(classifyError('insufficient credits')).toBe('coworkErrorInsufficientBalance');
 });

--- a/src/common/coworkErrorClassify.ts
+++ b/src/common/coworkErrorClassify.ts
@@ -6,6 +6,8 @@
 const ERROR_RULES: Array<[RegExp, string]> = [
   // Auth: Anthropic, DeepSeek, OpenAI, Gemini, HTTP 401
   [/authentication[_ ](error|fails?)|api[_ ]key.*(invalid|expired|not[_ ]valid)|invalid.*api.*key|incorrect.*api.*key|unauthorized|PERMISSION_DENIED|\b401\b/i, 'coworkErrorAuthInvalid'],
+  // LobsterAI free tier quota.
+  [/免费额度.*(用完|耗尽)|free.*quota.*(exhausted|used up|limit)/i, 'coworkErrorFreeQuotaExhausted'],
   // Rate limit: HTTP 429, Anthropic/DeepSeek overloaded, Gemini RESOURCE_EXHAUSTED
   // (must precede billing so "RESOURCE_EXHAUSTED: quota exceeded" maps to rate-limit)
   [/\b429\b|rate[_ ]limit|too many requests|overloaded|RESOURCE_EXHAUSTED/i, 'coworkErrorRateLimit'],

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -50,6 +50,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Cowork error messages (shared with renderer via classifyErrorKey)
     coworkErrorAuthInvalid: 'API 密钥无效或已过期，请检查配置。',
+    coworkErrorFreeQuotaExhausted:
+      '当前模型的免费额度已用完，升级套餐后可继续使用。\n\n[立即升级](https://c.youdao.com/dict/hardware/octopus/lobsterai-portal.html)',
     coworkErrorInsufficientBalance: 'API 余额不足，请充值后重试。',
     coworkErrorInputTooLong: '输入内容过长，超出模型上下文限制。',
     coworkErrorMessageTooLarge:
@@ -313,6 +315,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Cowork error messages
     coworkErrorAuthInvalid: 'Invalid or expired API key. Please check your configuration.',
+    coworkErrorFreeQuotaExhausted:
+      'The current model\'s free quota has been used up. Upgrade your plan to continue.\n\n[Upgrade now](https://c.youdao.com/dict/hardware/octopus/lobsterai-portal.html)',
     coworkErrorInsufficientBalance: 'Insufficient API balance. Please top up and try again.',
     coworkErrorInputTooLong: 'Input too long, exceeding model context limit.',
     coworkErrorMessageTooLarge:

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -218,15 +218,8 @@ const App: React.FC = () => {
             }
           });
         }
-        const fallbackModels = config.model.availableModels.map(model => ({
-          id: model.id,
-          name: model.name,
-          providerKey: undefined,
-          supportsImage: model.supportsImage ?? false,
-        }));
-        const resolvedModels = providerModels.length > 0 ? providerModels : fallbackModels;
-        if (resolvedModels.length > 0) {
-          dispatch(setAvailableModels(resolvedModels));
+        dispatch(setAvailableModels(providerModels));
+        if (providerModels.length > 0) {
           const allModels = store.getState().model.availableModels;
           const preferredModel = allModels.find(
             model => model.id === config.model.defaultModel
@@ -579,9 +572,7 @@ const App: React.FC = () => {
           });
         }
       });
-      if (allModels.length > 0) {
-        dispatch(setAvailableModels(allModels));
-      }
+      dispatch(setAvailableModels(allModels));
     }
   };
 

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -554,41 +554,44 @@ const SendShortcutSelect: React.FC<{ value: string; onChange: (v: string) => voi
   })();
 
   return (
-    <div ref={containerRef} className="relative">
-      <div
-        onClick={() => setOpen(!open)}
-        className={`w-28 rounded-lg border px-2.5 py-1 text-xs cursor-pointer select-none text-center outline-none transition-colors
-          dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset dark:text-claude-darkText text-claude-text
-          ${open
-            ? 'border-claude-accent ring-1 ring-claude-accent/30'
-            : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
-          }`}
-      >
-        {currentLabel}
-      </div>
-      {open && (
-        <div className="absolute right-0 mt-1 z-50 min-w-[160px] rounded-xl border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset shadow-elevated py-1">
-          {SEND_SHORTCUT_OPTIONS.map((option) => {
-            const label = isMacPlatform ? option.labelMac : option.label;
-            const isActive = value === option.value;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => { onChange(option.value); setOpen(false); }}
-                className={`flex items-center justify-between w-full px-3 py-1.5 text-xs transition-colors
-                  ${isActive
-                    ? 'dark:text-claude-accent text-claude-accent font-medium'
-                    : 'dark:text-claude-darkText text-claude-text'
-                  } hover:bg-claude-accent/10`}
-              >
-                <span>{label}</span>
-                {isActive && <span className="text-claude-accent">✓</span>}
-              </button>
-            );
-          })}
+    <div ref={containerRef} className="flex items-center gap-2">
+      <div className="relative">
+        <div
+          onClick={() => setOpen(!open)}
+          className={`w-28 rounded-lg border px-2.5 py-1 text-xs cursor-pointer select-none text-center outline-none transition-colors
+            dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset dark:text-claude-darkText text-claude-text
+            ${open
+              ? 'border-claude-accent ring-1 ring-claude-accent/30'
+              : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
+            }`}
+        >
+          {currentLabel}
         </div>
-      )}
+        {open && (
+          <div className="absolute right-0 mt-1 z-50 min-w-[160px] rounded-xl border dark:border-claude-darkBorder border-claude-border dark:bg-claude-darkSurfaceInset bg-claude-surfaceInset shadow-elevated py-1">
+            {SEND_SHORTCUT_OPTIONS.map((option) => {
+              const label = isMacPlatform ? option.labelMac : option.label;
+              const isActive = value === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => { onChange(option.value); setOpen(false); }}
+                  className={`flex items-center justify-between w-full px-3 py-1.5 text-xs transition-colors
+                    ${isActive
+                      ? 'dark:text-claude-accent text-claude-accent font-medium'
+                      : 'dark:text-claude-darkText text-claude-text'
+                    } hover:bg-claude-accent/10`}
+                >
+                  <span>{label}</span>
+                  {isActive && <span className="text-claude-accent">✓</span>}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      <span className="h-6 w-6 shrink-0" aria-hidden="true" />
     </div>
   );
 };
@@ -3672,7 +3675,7 @@ const Settings: React.FC<SettingsProps> = ({
             <div className="overflow-hidden rounded-xl border border-border bg-surface">
               {filteredShortcutGroups.length > 0 ? filteredShortcutGroups.map((group, groupIndex) => (
                 <div key={group.titleKey}>
-                  <div className={`border-border bg-surface-raised/60 px-4 py-2 text-xs font-medium uppercase tracking-wide text-secondary ${
+                  <div className={`border-border-subtle bg-surface-raised/60 px-4 py-2 text-xs font-medium uppercase tracking-wide text-secondary ${
                     groupIndex === 0 ? '' : 'border-t'
                   }`}>
                     {i18nService.t(group.titleKey)}
@@ -3684,7 +3687,7 @@ const Settings: React.FC<SettingsProps> = ({
                       <div
                         key={command.key}
                         className={`group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-2.5 ${
-                          commandIndex === 0 ? '' : 'border-t border-border/70'
+                          commandIndex === 0 ? '' : 'border-t border-border-subtle'
                         }`}
                       >
                         <div className="min-w-0">
@@ -3695,7 +3698,7 @@ const Settings: React.FC<SettingsProps> = ({
                             {getShortcutCommandText(command, 'descriptionKey')}
                           </div>
                         </div>
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center justify-end gap-2">
                           {command.inputType === 'send' ? (
                             <SendShortcutSelect
                               value={value}
@@ -3708,7 +3711,7 @@ const Settings: React.FC<SettingsProps> = ({
                               onChange={(nextValue) => handleShortcutChange(command.key, nextValue)}
                             />
                           )}
-                          {value && (
+                          {value ? (
                             <button
                               type="button"
                               onClick={() => handleShortcutChange(command.key, '')}
@@ -3718,6 +3721,8 @@ const Settings: React.FC<SettingsProps> = ({
                             >
                               <TrashIcon className="h-3.5 w-3.5" />
                             </button>
+                          ) : (
+                            <span className="h-6 w-6 shrink-0" aria-hidden="true" />
                           )}
                         </div>
                       </div>

--- a/src/renderer/components/cowork/AssistantTurnBlock.tsx
+++ b/src/renderer/components/cowork/AssistantTurnBlock.tsx
@@ -1,6 +1,7 @@
 import { FolderIcon } from '@heroicons/react/24/outline';
 import React, { useEffect, useMemo, useRef } from 'react';
 
+import { classifyErrorKey } from '../../../common/coworkErrorClassify';
 import { ContextCompactionStatus } from '../../../common/coworkSystemMessages';
 import { getScheduledReminderDisplayText } from '../../../scheduledTask/reminderText';
 import { i18nService } from '../../services/i18n';
@@ -10,6 +11,7 @@ import { revealLocalPathWithToast } from '../../utils/localFileActions';
 import { ArtifactPreviewCard } from '../artifacts';
 import ExclamationTriangleIcon from '../icons/ExclamationTriangleIcon';
 import InformationCircleIcon from '../icons/InformationCircleIcon';
+import MarkdownContent from '../MarkdownContent';
 import AssistantMessageItem from './AssistantMessageItem';
 import MediaPollingIndicator from './MediaPollingIndicator';
 import {
@@ -96,6 +98,14 @@ const TypingDots: React.FC = () => (
     <div className="w-2 h-2 rounded-full bg-primary animate-bounce" style={{ animationDelay: '300ms' }} />
   </div>
 );
+
+const getSystemMessageDisplayContent = (message: CoworkMessage, content: string): string => {
+  const errorText = typeof message.metadata?.error === 'string' ? message.metadata.error : null;
+  if (!errorText) return content;
+
+  const key = classifyErrorKey(errorText) ?? classifyErrorKey(content);
+  return key ? i18nService.t(key) : content;
+};
 
 // ── VideoArtifactPathList ────────────────────────────────────────────────────
 
@@ -208,7 +218,8 @@ const AssistantTurnBlock: React.FC<{
       return null;
     }
     const normalizedContent = getScheduledReminderDisplayText(rawContent) ?? rawContent;
-    const content = mapDisplayText ? mapDisplayText(normalizedContent) : normalizedContent;
+    const displayContent = getSystemMessageDisplayContent(message, normalizedContent);
+    const content = mapDisplayText ? mapDisplayText(displayContent) : displayContent;
     if (!content.trim() && !isContextCompactionMessage(message)) return null;
 
     if (isContextCompactionMessage(message)) {
@@ -228,8 +239,11 @@ const AssistantTurnBlock: React.FC<{
             ? <ExclamationTriangleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
             : <InformationCircleIcon className="h-4 w-4 text-secondary flex-shrink-0" />
           }
-          <div className="text-xs whitespace-pre-wrap text-secondary">
-            {content}
+          <div className="min-w-0 text-xs text-secondary">
+            <MarkdownContent
+              content={content}
+              className="!text-xs !leading-5 [&_a]:!text-primary [&_p]:!my-0 [&_p]:!text-secondary [&_p]:!leading-5"
+            />
           </div>
         </div>
       </div>

--- a/src/renderer/components/kits/KitsPopover.tsx
+++ b/src/renderer/components/kits/KitsPopover.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon } from '@heroicons/react/24/outline';
+import { CheckIcon, PlusIcon } from '@heroicons/react/24/outline';
 import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -13,6 +13,16 @@ import SidebarKitsIcon from '../icons/SidebarKitsIcon';
 
 const MIN_SEARCHABLE_KIT_COUNT = 3;
 
+const KitsGuideIcon: React.FC = () => (
+  <div className="relative h-16 w-16">
+    <div className="absolute inset-0 rounded-[18px] bg-gradient-to-br from-primary/20 via-primary/10 to-primary/5 ring-1 ring-inset ring-primary/15" />
+    <SidebarKitsIcon className="absolute inset-0 m-auto h-9 w-9 text-primary" />
+    <span className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-white shadow ring-2 ring-surface">
+      <PlusIcon className="h-3 w-3" strokeWidth={3} />
+    </span>
+  </div>
+);
+
 interface KitsPopoverProps {
   isOpen: boolean;
   onClose: () => void;
@@ -25,6 +35,7 @@ const KitsPopover: React.FC<KitsPopoverProps> = ({
   isOpen,
   onClose,
   onSelectKit,
+  onManageKits,
   anchorRef,
 }) => {
   const dispatch = useDispatch();
@@ -38,8 +49,10 @@ const KitsPopover: React.FC<KitsPopoverProps> = ({
   const marketplaceKits = useSelector((state: RootState) => state.kit.marketplaceKits);
   const activeKitIds = useSelector((state: RootState) => state.kit.activeKitIds);
 
+  const installedKitIds = Object.keys(installedKits);
+
   // Build display list: only installed kits, with marketplace metadata for display
-  const installedKitList: MarketplaceKit[] = Object.keys(installedKits)
+  const installedKitList: MarketplaceKit[] = installedKitIds
     .map(kitId => marketplaceKits.find(mk => mk.id === kitId))
     .filter((k): k is MarketplaceKit => k !== undefined);
   const shouldShowSearch = installedKitList.length >= MIN_SEARCHABLE_KIT_COUNT;
@@ -136,12 +149,21 @@ const KitsPopover: React.FC<KitsPopoverProps> = ({
     // Don't close popover to allow multi-selection
   };
 
+  const handleOpenMarketplace = () => {
+    onClose();
+    onManageKits();
+  };
+
   if (!isOpen) return null;
+
+  const shouldShowInstallGuide = !isLoading && installedKitIds.length === 0;
 
   return (
     <div
       ref={popoverRef}
-      className="absolute bottom-full left-0 z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-border bg-surface shadow-popover"
+      className={`absolute bottom-full left-0 z-50 mb-2 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-border bg-surface shadow-popover ${
+        shouldShowInstallGuide ? 'w-60' : 'w-80'
+      }`}
       role="menu"
     >
       {shouldShowSearch && (
@@ -161,14 +183,32 @@ const KitsPopover: React.FC<KitsPopoverProps> = ({
       )}
 
       {/* Kits list */}
-      <div className="overflow-y-auto px-2 py-1.5" style={{ maxHeight: `${maxListHeight}px` }}>
+      <div
+        className={shouldShowInstallGuide ? 'px-4 py-5' : 'overflow-y-auto px-2 py-1.5'}
+        style={shouldShowInstallGuide ? undefined : { maxHeight: `${maxListHeight}px` }}
+      >
         {isLoading ? (
           <div className="px-3 py-5 text-center text-[13px] text-secondary">
             {i18nService.t('kitLoading')}
           </div>
-        ) : installedKitList.length === 0 ? (
-          <div className="px-3 py-5 text-center text-[13px] text-secondary">
-            {i18nService.t('noKitsInstalled')}
+        ) : shouldShowInstallGuide ? (
+          <div>
+            <div className="mb-3 flex justify-center">
+              <KitsGuideIcon />
+            </div>
+            <div className="text-center text-[13px] font-medium text-foreground">
+              {i18nService.t('noKitsInstalled')}
+            </div>
+            <div className="mt-1 text-center text-[12px] text-secondary">
+              {i18nService.t('kitInstallGuideDescription')}
+            </div>
+            <button
+              type="button"
+              onClick={handleOpenMarketplace}
+              className="mt-3 w-full rounded-lg bg-primary px-3 py-1.5 text-[12px] font-medium text-white transition-colors hover:bg-primary/90"
+            >
+              {i18nService.t('kitGoInstall')}
+            </button>
           </div>
         ) : filteredKits.length === 0 ? (
           <div className="px-3 py-5 text-center text-[13px] text-secondary">

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -58,9 +58,42 @@ import type {
 } from '../types/cowork';
 import { i18nService } from './i18n';
 
+const STREAM_ERROR_DUPLICATE_WINDOW_MS = 10_000;
+
 const classifyError = (error: string): string => {
   const key = classifyErrorKey(error);
   return key ? i18nService.t(key) : error;
+};
+
+const normalizeErrorText = (text: string): string => text.trim();
+
+const hasRecentMatchingErrorMessage = (
+  session: CoworkSession | null | undefined,
+  rawError: string,
+  displayError: string,
+): boolean => {
+  if (!session) return false;
+
+  const expectedTexts = new Set(
+    [rawError, displayError]
+      .map(normalizeErrorText)
+      .filter(Boolean),
+  );
+  if (expectedTexts.size === 0) return false;
+
+  const duplicateAfter = Date.now() - STREAM_ERROR_DUPLICATE_WINDOW_MS;
+  return session.messages.some((message) => {
+    if (message.type !== 'system' || message.timestamp < duplicateAfter) {
+      return false;
+    }
+
+    const messageTexts = [
+      message.content,
+      typeof message.metadata?.error === 'string' ? message.metadata.error : '',
+    ].map(normalizeErrorText);
+
+    return messageTexts.some((text) => expectedTexts.has(text));
+  });
 };
 
 const CONTEXT_USAGE_REFRESH_DELAY_MS = 800;
@@ -255,12 +288,18 @@ class CoworkService {
       store.dispatch(updateSessionStatus({ sessionId, status: 'error' }));
       // Surface the error as a visible message so the user knows what happened.
       if (error) {
+        const displayError = classifyError(error);
+        const currentSession = store.getState().cowork.currentSession;
+        const session = currentSession?.id === sessionId ? currentSession : null;
+        if (hasRecentMatchingErrorMessage(session, error, displayError)) {
+          return;
+        }
         store.dispatch(addMessage({
           sessionId,
           message: {
             id: `error-${Date.now()}`,
             type: 'system',
-            content: classifyError(error),
+            content: displayError,
             timestamp: Date.now(),
           },
         }));

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1185,6 +1185,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Cowork 错误消息
     coworkErrorAuthInvalid: 'API 密钥无效或已过期，请在设置中检查并更新您的 API 密钥。',
+    coworkErrorFreeQuotaExhausted:
+      '当前模型的免费额度已用完，升级套餐后可继续使用。\n\n[立即升级](https://c.youdao.com/dict/hardware/octopus/lobsterai-portal.html)',
     coworkErrorInsufficientBalance: 'API 余额不足，请充值后重试。',
     coworkErrorInputTooLong: '输入内容过长，超出模型上下文限制，请缩短对话内容后重试。',
     coworkErrorMessageTooLarge:
@@ -1411,7 +1413,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     manageKits: '管理套件',
     searchKits: '搜索套件',
     clearKit: '清除套件',
-    noKitsInstalled: '暂无已安装专家套件',
+    noKitsInstalled: '暂未安装专家套件',
+    kitInstallGuideDescription: '基于工作场景的标准能力包',
+    kitGoInstall: '去安装',
     kitSearchNoResults: '未找到匹配套件',
     kitInstallRequired: '需要安装',
     kitInstallRequiredDesc: '该套件尚未安装，是否立即安装并体验？',
@@ -3636,6 +3640,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Cowork error messages
     coworkErrorAuthInvalid:
       'Invalid or expired API key. Please check and update your API key in settings.',
+    coworkErrorFreeQuotaExhausted:
+      'The current model\'s free quota has been used up. Upgrade your plan to continue.\n\n[Upgrade now](https://c.youdao.com/dict/hardware/octopus/lobsterai-portal.html)',
     coworkErrorInsufficientBalance: 'Insufficient API balance. Please top up and try again.',
     coworkErrorInputTooLong:
       'Input too long, exceeding model context limit. Please shorten the conversation and try again.',
@@ -3872,7 +3878,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     manageKits: 'Manage Kits',
     searchKits: 'Search kits',
     clearKit: 'Clear Kit',
-    noKitsInstalled: 'No expert kits installed',
+    noKitsInstalled: 'No expert kits installed yet',
+    kitInstallGuideDescription: 'Standard capability packs for work scenarios',
+    kitGoInstall: 'Install kits',
     kitSearchNoResults: 'No matching kits found',
     kitInstallRequired: 'Installation Required',
     kitInstallRequiredDesc: 'This kit is not installed yet. Install it now to try?',

--- a/src/renderer/store/slices/modelSlice.test.ts
+++ b/src/renderer/store/slices/modelSlice.test.ts
@@ -102,6 +102,32 @@ describe('setServerModels / clearServerModels', () => {
     expect(state.availableModels[0]).toEqual(lockedServerModel);
   });
 
+  test('setServerModels displays a locked server model when no custom models exist', () => {
+    let state = makeState({
+      availableModels: [],
+      defaultSelectedModel: modelA,
+      selectedModelByAgent: {},
+    });
+
+    state = modelReducer(state, setServerModels([lockedServerModel]));
+
+    expect(state.availableModels).toEqual([lockedServerModel]);
+    expect(state.defaultSelectedModel).toEqual(lockedServerModel);
+  });
+
+  test('setAvailableModels clears fallback custom models while preserving locked server models', () => {
+    let state = makeState({
+      availableModels: [lockedServerModel, modelA],
+      defaultSelectedModel: modelA,
+      selectedModelByAgent: {},
+    });
+
+    state = modelReducer(state, setAvailableModels([]));
+
+    expect(state.availableModels).toEqual([lockedServerModel]);
+    expect(state.defaultSelectedModel).toEqual(lockedServerModel);
+  });
+
   test('setServerModels clears per-agent selections that resolve to locked server models', () => {
     let state = makeState({
       availableModels: [lockedServerModel, modelA],

--- a/src/renderer/store/slices/modelSlice.ts
+++ b/src/renderer/store/slices/modelSlice.ts
@@ -50,7 +50,7 @@ function selectPreferredAccessibleModel(
   if (isModelAccessible(matchedModel)) {
     return matchedModel;
   }
-  return allAvailableModels.find(isModelAccessible) ?? currentModel;
+  return allAvailableModels.find(isModelAccessible) ?? matchedModel ?? allAvailableModels[0] ?? currentModel;
 }
 
 // 从 providers 配置中构建初始可用模型列表


### PR DESCRIPTION
- Classify LobsterAI free-quota-exhausted errors and surface a markdown upgrade link in system messages.
- Deduplicate consecutive stream error messages within a 10s window to avoid repeated banners.
- Add an install guide in the kits popover when no expert kits are installed.
- Align shortcut select rows when the clear button is hidden so layouts stay consistent.
- Preserve locked server models when the custom model list becomes empty and pick a sensible fallback in `selectPreferredAccessibleModel`.
