### PR TITLE
fix(config): preserve deleted provider models after migration

### DIFF
--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -70,6 +70,7 @@ export interface AppConfig {
     defaultModelProvider?: string;
   };
   providers?: Record<string, ProviderConfig>;
+  providerModelMigrationVersions?: Record<string, number>;
   // 主题配置
   theme: 'light' | 'dark' | 'system';
   // 语言配置

--- a/src/renderer/services/config.test.ts
+++ b/src/renderer/services/config.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { type AppConfig, CONFIG_KEYS, defaultConfig } from '../config';
 
-const makeLegacyConfigWithoutMiniMaxM3 = (): AppConfig => ({
+const makeLegacyConfigWithoutMiniMaxAddedModels = (): AppConfig => ({
   ...defaultConfig,
   providers: {
     ...defaultConfig.providers,
@@ -12,7 +12,7 @@ const makeLegacyConfigWithoutMiniMaxM3 = (): AppConfig => ({
       enabled: true,
       apiKey: 'sk-minimax',
       models: defaultConfig.providers![ProviderName.Minimax].models?.filter(
-        model => model.id !== 'MiniMax-M3'
+        model => model.id !== 'MiniMax-M3' && model.id !== 'MiniMax-M2.7'
       ),
     },
   },
@@ -83,6 +83,40 @@ const makeConfigWithCustomContextWindows = (): AppConfig => ({
   },
 });
 
+const makeConfigWithDeletedProviderModel = (
+  providerName: ProviderName,
+  deletedModelId: string,
+): AppConfig => ({
+  ...defaultConfig,
+  providerModelMigrationVersions: {
+    [providerName]: 1,
+  },
+  providers: {
+    ...defaultConfig.providers,
+    [providerName]: {
+      ...defaultConfig.providers![providerName],
+      enabled: true,
+      apiKey: `sk-${providerName}`,
+      models: defaultConfig.providers![providerName].models?.filter(
+        model => model.id !== deletedModelId
+      ),
+    },
+  },
+});
+
+const addedProviderMigrationCases: Array<{ providerName: ProviderName; deletedModelId: string }> = [
+  { providerName: ProviderName.DeepSeek, deletedModelId: 'deepseek-v4-flash' },
+  { providerName: ProviderName.Moonshot, deletedModelId: 'kimi-k2.6' },
+  { providerName: ProviderName.Minimax, deletedModelId: 'MiniMax-M3' },
+  { providerName: ProviderName.Zhipu, deletedModelId: 'glm-5.1' },
+  { providerName: ProviderName.Qianfan, deletedModelId: 'kimi-k2.5' },
+  { providerName: ProviderName.Xiaomi, deletedModelId: 'mimo-v2.5-pro' },
+  { providerName: ProviderName.OpenAI, deletedModelId: 'gpt-5.4' },
+  { providerName: ProviderName.Gemini, deletedModelId: 'gemini-3.1-flash-lite' },
+  { providerName: ProviderName.Anthropic, deletedModelId: 'claude-opus-4-7' },
+  { providerName: ProviderName.OpenRouter, deletedModelId: 'anthropic/claude-sonnet-4.6' },
+];
+
 async function loadConfigServiceWithStoredConfig(storedConfig: AppConfig) {
   vi.resetModules();
   const storeData: Record<string, unknown> = {
@@ -119,7 +153,7 @@ afterEach(() => {
 describe('configService provider migrations', () => {
   test('persists injected provider models during init', async () => {
     const { configService, storeData, setItem } = await loadConfigServiceWithStoredConfig(
-      makeLegacyConfigWithoutMiniMaxM3()
+      makeLegacyConfigWithoutMiniMaxAddedModels()
     );
 
     await configService.init();
@@ -133,7 +167,7 @@ describe('configService provider migrations', () => {
   });
 
   test('preserves injected provider models when saving partial config updates', async () => {
-    const legacyConfig = makeLegacyConfigWithoutMiniMaxM3();
+    const legacyConfig = makeLegacyConfigWithoutMiniMaxAddedModels();
     const { configService, storeData } = await loadConfigServiceWithStoredConfig(legacyConfig);
 
     await configService.updateConfig({
@@ -206,5 +240,103 @@ describe('configService provider migrations', () => {
     expect(savedConfig.providers?.[ProviderName.DeepSeek].models?.find(model => model.id === 'deepseek-v4-pro')?.contextWindow).toBe(384_000);
     expect(savedConfig.providers?.[ProviderName.Xiaomi].models?.find(model => model.id === 'mimo-v2.5-pro')?.contextWindow).toBe(640_000);
     expect(savedConfig.providers?.[ProviderName.Xiaomi].models?.find(model => model.id === 'mimo-v2.5')?.contextWindow).toBe(768_000);
+  });
+
+  test.each(addedProviderMigrationCases)(
+    'does not re-inject a deleted $providerName model after migration is applied',
+    async ({ providerName, deletedModelId }) => {
+      const { configService, storeData } = await loadConfigServiceWithStoredConfig(
+        makeConfigWithDeletedProviderModel(providerName, deletedModelId)
+      );
+
+      await configService.init();
+
+      const savedConfig = storeData[CONFIG_KEYS.APP_CONFIG] as AppConfig;
+      expect(savedConfig.providers?.[providerName].models?.map(model => model.id)).not.toContain(deletedModelId);
+    }
+  );
+
+  test('treats a provider with any migrated model as already migrated', async () => {
+    const deletedModelId = 'kimi-k2.5';
+    const storedConfig: AppConfig = {
+      ...defaultConfig,
+      providerModelMigrationVersions: undefined,
+      providers: {
+        ...defaultConfig.providers,
+        [ProviderName.Qianfan]: {
+          ...defaultConfig.providers![ProviderName.Qianfan],
+          enabled: true,
+          apiKey: 'sk-qianfan',
+          models: defaultConfig.providers![ProviderName.Qianfan].models?.filter(
+            model => model.id !== deletedModelId
+          ),
+        },
+      },
+    };
+    const { configService, storeData } = await loadConfigServiceWithStoredConfig(storedConfig);
+
+    await configService.init();
+
+    const savedConfig = storeData[CONFIG_KEYS.APP_CONFIG] as AppConfig;
+    expect(savedConfig.providerModelMigrationVersions?.[ProviderName.Qianfan]).toBe(1);
+    expect(savedConfig.providers?.[ProviderName.Qianfan].models?.map(model => model.id)).not.toContain(deletedModelId);
+  });
+
+  test('does not re-inject a deleted Xiaomi model after migration is applied', async () => {
+    const deletedModelId = 'mimo-v2.5-pro';
+    const legacyConfig = makeConfigWithDeletedProviderModel(ProviderName.Xiaomi, deletedModelId);
+    const { configService, storeData } = await loadConfigServiceWithStoredConfig(legacyConfig);
+
+    await configService.updateConfig({
+      model: {
+        ...legacyConfig.model,
+        defaultModel: 'mimo-v2.5',
+        defaultModelProvider: ProviderName.Xiaomi,
+      },
+    });
+
+    const savedConfig = storeData[CONFIG_KEYS.APP_CONFIG] as AppConfig;
+    expect(savedConfig.providers?.[ProviderName.Xiaomi].models?.map(model => model.id)).not.toContain(deletedModelId);
+    expect(savedConfig.model.defaultModel).toBe('mimo-v2.5');
+    expect(savedConfig.model.defaultModelProvider).toBe(ProviderName.Xiaomi);
+  });
+
+  test('marks provider model migrations when saving provider edits from default config', async () => {
+    vi.resetModules();
+    const storeData: Record<string, unknown> = {};
+    const getItem = vi.fn(async (key: string) => storeData[key] ?? null);
+    const setItem = vi.fn(async (key: string, value: unknown) => {
+      storeData[key] = value;
+    });
+
+    vi.doMock('./store', () => ({
+      localStore: {
+        getItem,
+        setItem,
+        removeItem: vi.fn(),
+      },
+    }));
+
+    (globalThis as unknown as { window?: unknown }).window = {
+      dispatchEvent: vi.fn(),
+    };
+
+    const { configService } = await import('./config');
+    const deletedModelId = 'kimi-k2.5';
+    await configService.updateConfig({
+      providers: {
+        ...defaultConfig.providers,
+        [ProviderName.Qianfan]: {
+          ...defaultConfig.providers![ProviderName.Qianfan],
+          models: defaultConfig.providers![ProviderName.Qianfan].models?.filter(
+            model => model.id !== deletedModelId
+          ),
+        },
+      },
+    });
+
+    const savedConfig = storeData[CONFIG_KEYS.APP_CONFIG] as AppConfig;
+    expect(savedConfig.providerModelMigrationVersions?.[ProviderName.Qianfan]).toBe(1);
+    expect(savedConfig.providers?.[ProviderName.Qianfan].models?.map(model => model.id)).not.toContain(deletedModelId);
   });
 });

--- a/src/renderer/services/config.ts
+++ b/src/renderer/services/config.ts
@@ -237,12 +237,11 @@ const REMOVED_PROVIDER_MODELS: Record<string, string[]> = {
   ],
 };
 
-// Models to inject into existing saved configs (for existing users).
-// These models will be added on every startup if missing from the stored config.
-// Note: users cannot permanently remove these models — they will be re-injected
-// on next launch. Once all users have upgraded, entries here should be removed
-// so the models follow normal user-editable behavior (same as other models).
+// Models to inject into existing saved configs once per migration version.
+// After the migration marker is persisted, user edits to these model lists
+// must be respected across restarts.
 // position: 'start' inserts at the beginning, 'end' appends at the end.
+const ADDED_PROVIDER_MODELS_MIGRATION_VERSION = 1;
 const ADDED_PROVIDER_MODELS: Record<string, { models: ProviderModel[]; position: 'start' | 'end' }> = {
   deepseek: {
     models: [
@@ -317,6 +316,27 @@ const ADDED_PROVIDER_MODELS: Record<string, { models: ProviderModel[]; position:
   },
 };
 
+const markCurrentProviderModelMigrationsApplied = (
+  versions: AppConfig['providerModelMigrationVersions'],
+): NonNullable<AppConfig['providerModelMigrationVersions']> => {
+  const nextVersions = { ...(versions ?? {}) };
+  Object.keys(ADDED_PROVIDER_MODELS).forEach((providerKey) => {
+    nextVersions[providerKey] = Math.max(
+      nextVersions[providerKey] ?? 0,
+      ADDED_PROVIDER_MODELS_MIGRATION_VERSION,
+    );
+  });
+  return nextVersions;
+};
+
+const getNewlyAppliedProviderModelMigrations = (
+  previousVersions: AppConfig['providerModelMigrationVersions'],
+  nextVersions: AppConfig['providerModelMigrationVersions'],
+): string[] => Object.keys(ADDED_PROVIDER_MODELS).filter(
+  providerKey => (previousVersions?.[providerKey] ?? 0) < ADDED_PROVIDER_MODELS_MIGRATION_VERSION
+    && (nextVersions?.[providerKey] ?? 0) >= ADDED_PROVIDER_MODELS_MIGRATION_VERSION
+);
+
 const PROVIDER_MODEL_CONTEXT_WINDOW_OVERRIDES: Record<string, Record<string, number>> = {
   [ProviderName.Minimax]: {
     'MiniMax-M3': 1_000_000,
@@ -384,6 +404,9 @@ const alignProviderModelOrder = (
 };
 
 const hydrateStoredConfig = (storedConfig: AppConfig): AppConfig => {
+  const providerModelMigrationVersions = {
+    ...(storedConfig.providerModelMigrationVersions ?? {}),
+  };
   const mergedProviders = storedConfig.providers
     ? Object.fromEntries(
         Object.entries({
@@ -405,14 +428,23 @@ const hydrateStoredConfig = (storedConfig: AppConfig): AppConfig => {
             }
             // Inject added models (for existing users who already have saved config)
             const addedConfig = ADDED_PROVIDER_MODELS[providerKey];
-            if (addedConfig && mergedProvider.models) {
-              const existingIds = new Set(mergedProvider.models.map((m: { id: string }) => m.id));
+            const existingIds = new Set(
+              (mergedProvider.models as Array<{ id: string }> | undefined)?.map(model => model.id) ?? []
+            );
+            const hasAnyAddedModel = addedConfig?.models.some(model => existingIds.has(model.id)) ?? false;
+            const hasAppliedAddedModelsMigration =
+              (providerModelMigrationVersions[providerKey] ?? 0) >= ADDED_PROVIDER_MODELS_MIGRATION_VERSION
+              || hasAnyAddedModel;
+            if (addedConfig && mergedProvider.models && !hasAppliedAddedModelsMigration) {
               const newModels = addedConfig.models.filter(m => !existingIds.has(m.id));
               if (newModels.length > 0) {
                 mergedProvider.models = addedConfig.position === 'start'
                   ? [...newModels, ...mergedProvider.models]
                   : [...mergedProvider.models, ...newModels];
               }
+            }
+            if (addedConfig && mergedProvider.models) {
+              providerModelMigrationVersions[providerKey] = ADDED_PROVIDER_MODELS_MIGRATION_VERSION;
             }
             if (mergedProvider.models) {
               mergedProvider.models = applyProviderModelContextWindowOverrides(
@@ -465,6 +497,7 @@ const hydrateStoredConfig = (storedConfig: AppConfig): AppConfig => {
     },
     shortcuts: normalizeShortcutsConfig(storedConfig.shortcuts),
     providers: mergedProviders as AppConfig['providers'],
+    providerModelMigrationVersions,
     browserWebAccess: normalizeBrowserWebAccessConfig(storedConfig.browserWebAccess),
   });
 };
@@ -479,10 +512,18 @@ class ConfigService {
         console.warn('[ConfigService] init: no stored config found, using defaults');
       }
       if (storedConfig) {
+        const previousMigrationVersions = storedConfig.providerModelMigrationVersions;
         this.config = hydrateStoredConfig(storedConfig);
         if (JSON.stringify(this.config) !== JSON.stringify(storedConfig)) {
           try {
             await localStore.setItem(CONFIG_KEYS.APP_CONFIG, this.config);
+            const appliedProviders = getNewlyAppliedProviderModelMigrations(
+              previousMigrationVersions,
+              this.config.providerModelMigrationVersions,
+            );
+            if (appliedProviders.length > 0) {
+              console.log(`[ConfigService] applied provider model migrations for ${appliedProviders.join(', ')}`);
+            }
           } catch (persistError) {
             console.warn('[ConfigService] init: failed to persist migrated config:', persistError);
           }
@@ -510,6 +551,9 @@ class ConfigService {
       ...base,
       ...newConfig,
       ...(normalizedProviders ? { providers: normalizedProviders } : {}),
+      ...(normalizedProviders
+        ? { providerModelMigrationVersions: markCurrentProviderModelMigrationsApplied(base.providerModelMigrationVersions) }
+        : {}),
       browserWebAccess: normalizeBrowserWebAccessConfig(
         newConfig.browserWebAccess ?? base.browserWebAccess,
       ),


### PR DESCRIPTION
## Summary
- Track provider model migration versions so added default models are injected only once.
- Preserve user-deleted provider models across app restarts.
- Add regression coverage for all providers affected by added-model migrations.

## Testing
- `npm test -- config`
- `npx eslint src/renderer/config.ts src/renderer/services/config.ts src/renderer/services/config.test.ts`