### PR TITLE
fix(data-migration): restore data in place and preserve runtime locks

### DIFF
--- a/src/main/libs/dataMigration/dataMigrationService.test.ts
+++ b/src/main/libs/dataMigration/dataMigrationService.test.ts
@@ -165,6 +165,35 @@ test('performPendingDataMigrationRestoreSync creates rollback and restores backu
   expect(fs.readFileSync(path.join(targetUserData, 'SKILLs', 'demo', 'SKILL.md'), 'utf8')).toBe('# Demo');
 });
 
+test('performPendingDataMigrationRestoreSync replaces data in place and preserves runtime locks', () => {
+  const root = makeTempDir();
+  const sourceUserData = path.join(root, 'source', 'LobsterAI');
+  const targetUserData = path.join(root, 'target', 'LobsterAI');
+  const rollbackRoot = path.join(root, 'rollbacks');
+  const archivePath = path.join(root, 'source-backup.tar.gz');
+
+  writeFile(path.join(sourceUserData, DB_FILENAME), 'source-db');
+  writeFile(path.join(sourceUserData, 'openclaw', 'state', 'openclaw.json'), '{"source":true}');
+  writeFile(path.join(targetUserData, DB_FILENAME), 'target-db');
+  writeFile(path.join(targetUserData, 'old-only.txt'), 'old');
+  writeFile(path.join(targetUserData, 'SingletonLock'), 'runtime-lock');
+
+  createMigrationArchiveSync({ userDataPath: sourceUserData, outputPath: archivePath });
+  writePendingRestoreRequestSync(targetUserData, archivePath);
+
+  const result = performPendingDataMigrationRestoreSync({
+    userDataPath: targetUserData,
+    rollbackRootPath: rollbackRoot,
+    now: new Date('2026-06-08T01:02:03Z'),
+  });
+
+  expect(result?.status).toBe(DataMigrationRestoreStatus.Success);
+  expect(fs.readFileSync(path.join(targetUserData, DB_FILENAME), 'utf8')).toBe('source-db');
+  expect(fs.readFileSync(path.join(targetUserData, 'openclaw', 'state', 'openclaw.json'), 'utf8')).toBe('{"source":true}');
+  expect(fs.existsSync(path.join(targetUserData, 'old-only.txt'))).toBe(false);
+  expect(fs.readFileSync(path.join(targetUserData, 'SingletonLock'), 'utf8')).toBe('runtime-lock');
+});
+
 test('performPendingDataMigrationRestoreSync keeps existing data when restore fails', () => {
   const root = makeTempDir();
   const targetUserData = path.join(root, 'target', 'LobsterAI');

--- a/src/main/libs/dataMigration/dataMigrationService.ts
+++ b/src/main/libs/dataMigration/dataMigrationService.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -25,9 +24,13 @@ const EXCLUDED_TOP_LEVEL_NAMES = new Set([
   'DawnGraphiteCache',
   'DawnWebGPUCache',
   'Service Worker',
+  'SingletonCookie',
+  'SingletonLock',
+  'SingletonSocket',
   'blob_storage',
   'Crashpad',
   'logs',
+  'lockfile',
   PENDING_RESTORE_FILE_NAME,
   LAST_RESTORE_RESULT_FILE_NAME,
 ]);
@@ -435,10 +438,26 @@ const buildFailedRestoreResult = (
   error: error instanceof Error ? error.message : String(error),
 });
 
-const restoreOldUserDataIfNeeded = (userDataPath: string, oldUserDataPath: string | null): void => {
-  if (!oldUserDataPath || !fs.existsSync(oldUserDataPath)) return;
-  removeDirIfExistsSync(userDataPath);
-  fs.renameSync(oldUserDataPath, userDataPath);
+const clearRestorableUserDataSync = (userDataPath: string): void => {
+  ensureDirSync(userDataPath);
+  for (const entry of fs.readdirSync(userDataPath)) {
+    if (isExcludedTopLevelEntry(entry)) continue;
+    removeDirIfExistsSync(path.join(userDataPath, entry));
+  }
+};
+
+const replaceRestorableUserDataSync = (sourceRoot: string, userDataPath: string): void => {
+  clearRestorableUserDataSync(userDataPath);
+  copyDirectorySync(sourceRoot, userDataPath);
+};
+
+const restoreRollbackArchiveSync = (rollbackPath: string, userDataPath: string): void => {
+  const rollback = extractMigrationArchiveToTempSync(rollbackPath);
+  try {
+    replaceRestorableUserDataSync(rollback.sourceRoot, userDataPath);
+  } finally {
+    removeDirIfExistsSync(rollback.tempRoot);
+  }
 };
 
 export const performPendingDataMigrationRestoreSync = (
@@ -450,8 +469,9 @@ export const performPendingDataMigrationRestoreSync = (
 
   const now = input.now ?? new Date();
   let rollbackPath: string | undefined;
+  let rollbackReady = false;
   let extractedTempRoot: string | null = null;
-  let oldUserDataPath: string | null = null;
+  let targetWasTouched = false;
 
   try {
     try {
@@ -469,19 +489,14 @@ export const performPendingDataMigrationRestoreSync = (
         now,
         archiveKind: 'rollback',
       });
+      rollbackReady = true;
     }
 
     const extracted = extractMigrationArchiveToTempSync(request.archivePath);
     extractedTempRoot = extracted.tempRoot;
-    oldUserDataPath = path.join(
-      path.dirname(input.userDataPath),
-      `.${path.basename(input.userDataPath)}.restore-old-${formatDataMigrationTimestamp(now)}-${crypto.randomUUID()}`,
-    );
 
-    if (fs.existsSync(input.userDataPath)) {
-      fs.renameSync(input.userDataPath, oldUserDataPath);
-    }
-    copyDirectorySync(extracted.sourceRoot, input.userDataPath);
+    targetWasTouched = true;
+    replaceRestorableUserDataSync(extracted.sourceRoot, input.userDataPath);
 
     const result: DataMigrationLastRestoreResult = {
       status: DataMigrationRestoreStatus.Success,
@@ -490,15 +505,14 @@ export const performPendingDataMigrationRestoreSync = (
       restoredAt: now.toISOString(),
     };
     writeRestoreResultSync(input.userDataPath, result);
-    if (oldUserDataPath) {
-      removeDirIfExistsSync(oldUserDataPath);
-    }
     return result;
   } catch (error) {
-    try {
-      restoreOldUserDataIfNeeded(input.userDataPath, oldUserDataPath);
-    } catch {
-      // Leave the original error as the reported failure.
+    if (targetWasTouched && rollbackReady && rollbackPath) {
+      try {
+        restoreRollbackArchiveSync(rollbackPath, input.userDataPath);
+      } catch {
+        // Leave the original error as the reported failure.
+      }
     }
     const result = buildFailedRestoreResult(request.archivePath, rollbackPath, error, now);
     try {

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1983,6 +1983,7 @@ const Settings: React.FC<SettingsProps> = ({
     setNoticeMessage(null);
     setIsRestoringOpenClawData(true);
     try {
+      await waitForNextPaint();
       const result = await window.electron.openclaw.dataMigration.restore();
       if (!result.success) {
         setError(result.error || i18nService.t('openClawDataMigrationFailed'));
@@ -4314,21 +4315,29 @@ const Settings: React.FC<SettingsProps> = ({
             </div>
           )}
 
-          {isBackingUpOpenClawData && (
+          {(isBackingUpOpenClawData || isRestoringOpenClawData) && (
             <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/45 px-4">
               <div className="w-full max-w-md rounded-2xl border border-border bg-surface px-5 py-5 text-center shadow-xl">
                 <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-full bg-primary-muted text-primary">
                   <ArrowPathIcon className="h-5 w-5 animate-spin" />
                 </div>
                 <h3 className="mt-4 text-base font-semibold text-foreground">
-                  {i18nService.t('openClawDataBackupBlockingTitle')}
+                  {i18nService.t(isBackingUpOpenClawData
+                    ? 'openClawDataBackupBlockingTitle'
+                    : 'openClawDataMigrationBlockingTitle')}
                 </h3>
                 <p className="mt-2 text-sm leading-6 text-secondary">
-                  {i18nService.t('openClawDataBackupBlockingDesc')}
+                  {i18nService.t(isBackingUpOpenClawData
+                    ? 'openClawDataBackupBlockingDesc'
+                    : 'openClawDataMigrationBlockingDesc')}
                 </p>
                 <div className="mt-4 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-left text-xs leading-5 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200">
                   <ExclamationTriangleIcon className="mt-0.5 h-4 w-4 shrink-0" />
-                  <span>{i18nService.t('openClawDataBackupBlockingWarning')}</span>
+                  <span>
+                    {i18nService.t(isBackingUpOpenClawData
+                      ? 'openClawDataBackupBlockingWarning'
+                      : 'openClawDataMigrationBlockingWarning')}
+                  </span>
                 </div>
               </div>
             </div>

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -712,6 +712,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     openClawDataMigrationSuccess: '数据迁移已完成。',
     openClawDataMigrationFailed: '数据迁移失败',
     openClawDataMigrationRestarting: '已选择备份文件，应用将重启并导入数据。',
+    openClawDataMigrationBlockingTitle: '正在准备导入 LobsterAI 数据',
+    openClawDataMigrationBlockingDesc: '导入期间应用会暂时锁定。选择备份文件后，应用会自动重启并完成导入。',
+    openClawDataMigrationBlockingWarning: '请不要关闭应用。关闭应用会中断导入准备流程，可能需要重新选择备份文件。',
     openClawDataMigrationConfirmTitle: '导入 LobsterAI 数据备份？',
     openClawDataMigrationConfirmDesc: '导入会替换当前应用数据，包括登录态、会话、配置、技能、记忆和 OpenClaw 状态。',
     openClawDataMigrationConfirmSafeDesc: '应用会先为当前数据生成回滚备份，然后重启并完成导入。项目工作目录不会被导入包覆盖。',
@@ -3184,6 +3187,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
     openClawDataMigrationSuccess: 'Data migration completed.',
     openClawDataMigrationFailed: 'Data migration failed',
     openClawDataMigrationRestarting: 'Backup file selected. The app will restart and import the data.',
+    openClawDataMigrationBlockingTitle: 'Preparing to import LobsterAI data',
+    openClawDataMigrationBlockingDesc:
+      'The app is temporarily locked during import preparation. After you choose a backup file, the app will restart and finish the import.',
+    openClawDataMigrationBlockingWarning:
+      'Do not close the app. Closing it will interrupt import preparation and may require choosing the backup file again.',
     openClawDataMigrationConfirmTitle: 'Import LobsterAI data backup?',
     openClawDataMigrationConfirmDesc:
       'Importing replaces current app data, including login state, sessions, settings, skills, memory, and OpenClaw state.',


### PR DESCRIPTION
Replace restorable user data entries instead of renaming the whole user data directory, so runtime lock files (SingletonLock/Socket/Cookie, lockfile) are preserved and excluded from restore. On failure, roll back from the rollback archive only when the target was touched and the rollback is ready.

Surface the blocking overlay during restore (not just backup) and yield a paint frame before invoking restore so the overlay renders. Add the matching i18n keys for both languages.