### PR TITLE
fix(auth): improve Windows focus after callback login

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2791,9 +2791,18 @@ if (!gotTheLock) {
     try {
       if (mainWindow.isMinimized()) mainWindow.restore();
       if (!mainWindow.isVisible()) mainWindow.show();
+      mainWindow.moveTop();
       if (!mainWindow.isFocused()) mainWindow.focus();
       if (process.platform === 'darwin') {
         app.focus({ steal: true });
+      }
+      if (process.platform === 'win32') {
+        const wasAlwaysOnTop = mainWindow.isAlwaysOnTop();
+        mainWindow.setAlwaysOnTop(true, 'normal');
+        mainWindow.show();
+        mainWindow.focus();
+        mainWindow.setAlwaysOnTop(wasAlwaysOnTop, 'normal');
+        mainWindow.flashFrame(false);
       }
       console.log(`[Main] focused main window after ${reason}`);
     } catch (error) {


### PR DESCRIPTION
Bring the main window to the top after local callback or deep link login. On Windows, briefly toggle always-on-top and stop taskbar flashing so the desktop app is more likely to open after the browser login completes.