### PR TITLE
chore(auth): add login callback diagnostics

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4084,6 +4084,7 @@ if (!gotTheLock) {
     let localCallback: Awaited<ReturnType<typeof startAuthLocalCallback>> | null = null;
 
     try {
+      console.log('[Auth] starting browser login with local callback server');
       localCallback = await startAuthLocalCallback({
         onCode: code => {
           authCallbackRouter.handleAuthCode(code);
@@ -4099,6 +4100,7 @@ if (!gotTheLock) {
         redirect_uri: appendCallbackReturnTo(localCallback.redirectUri, returnTo),
         state: localCallback.state,
       });
+      console.log('[Auth] opening portal login with local callback redirect');
       await shell.openExternal(finalUrl);
       return { success: true };
     } catch (error) {

--- a/src/renderer/services/auth.ts
+++ b/src/renderer/services/auth.ts
@@ -96,6 +96,7 @@ class AuthService {
       if (response.ok && typeof response.data === 'object' && response.data !== null) {
         const value = (response.data as any)?.data?.value;
         if (typeof value === 'string' && value.trim()) {
+          console.log('[Auth] fetched login URL from overmind');
           return value.trim();
         }
       }
@@ -104,6 +105,7 @@ class AuthService {
     }
     // Fallback: use Portal login page directly
     const { getPortalLoginUrl } = await import('./endpoints');
+    console.log('[Auth] using fallback portal login URL');
     return getPortalLoginUrl();
   }
 


### PR DESCRIPTION
Log whether the client uses an overmind or fallback portal login URL, and whether the desktop login opens with a local callback redirect.

This makes Windows dev-mode callback fallback issues easier to diagnose.
