### PR TITLE
fix(cowork): prevent stopped startup turns from sending chat

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -849,6 +849,29 @@ test('continueSession waits for an in-flight model patch before chat.send', asyn
   ]);
 });
 
+test('continueSession stopped before active turn creation does not send chat', async () => {
+  const {
+    adapter,
+    requests,
+    firstModelPatchStarted,
+    releaseFirstModelPatch,
+  } = createRunTurnAdapter({
+    holdFirstModelPatch: true,
+  });
+
+  const continuePromise = adapter.continueSession('session-1', 'hello');
+  await firstModelPatchStarted;
+
+  adapter.stopSession('session-1');
+  releaseFirstModelPatch();
+  await continuePromise;
+
+  expect(requests.map((request) => request.method)).toEqual(['sessions.patch']);
+  expect(adapter.isSessionActive('session-1')).toBe(false);
+  expect((adapter as unknown as { stoppedSessions: Map<string, number> }).stoppedSessions.has('session-1')).toBe(false);
+  expect((adapter as unknown as { manuallyStoppedSessions: Set<string> }).manuallyStoppedSessions.has('session-1')).toBe(false);
+});
+
 test('continueSession sends the session cwd to OpenClaw chat.send', async () => {
   const { adapter, requests } = createRunTurnAdapter({
     sessionCwd: '/tmp/lobsterai-selected-project',

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -2817,6 +2817,11 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           console.warn('[OpenClawRuntime] Failed to abort chat run:', error);
         });
       }
+    } else {
+      console.log(
+        '[OpenClawRuntime] received stop before a gateway run became active.',
+        `Session ${sessionId}.`,
+      );
     }
 
     // Record the stop timestamp so that late-arriving gateway events
@@ -2826,8 +2831,27 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     this.cleanupSessionTurn(sessionId);
     this.clearPendingApprovalsBySession(sessionId);
     this.store.updateSession(sessionId, { status: 'idle' });
+    this.emitSessionStatus(sessionId, 'idle');
     this.emit('sessionStopped', sessionId);
     this.resolveTurn(sessionId);
+  }
+
+  private cancelTurnStartupIfStopped(sessionId: string, checkpoint: string): boolean {
+    if (!this.stoppedSessions.has(sessionId)) {
+      return false;
+    }
+    console.log(
+      '[OpenClawRuntime] cancelled turn startup after user stop.',
+      `Session ${sessionId}.`,
+      `Checkpoint ${checkpoint}.`,
+    );
+    this.cleanupSessionTurn(sessionId);
+    this.stoppedSessions.delete(sessionId);
+    this.manuallyStoppedSessions.delete(sessionId);
+    this.store.updateSession(sessionId, { status: 'idle' });
+    this.emitSessionStatus(sessionId, 'idle');
+    this.resolveTurn(sessionId);
+    return true;
   }
 
   stopAllSessions(): void {
@@ -3084,6 +3108,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     setCoworkProxySessionId(sessionId);
     firstResponseTiming.gatewayReadyStartedAtMs = Date.now();
     await this.ensureGatewayClientReady();
+    if (this.cancelTurnStartupIfStopped(sessionId, 'gateway client became ready')) {
+      return;
+    }
     firstResponseTiming.gatewayReadyEndedAtMs = Date.now();
     console.log(
       '[OpenClawRuntimeTiming] gateway client ready.',
@@ -3116,6 +3143,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           ? SessionModelPatchSource.SessionOverride
           : SessionModelPatchSource.AgentModel,
       });
+      if (this.cancelTurnStartupIfStopped(sessionId, 'session model sync finished')) {
+        return;
+      }
       firstResponseTiming.modelPatchEndedAtMs = Date.now();
       console.log(
         '[OpenClawRuntimeTiming] session model sync finished.',
@@ -3148,6 +3178,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       options.selectedTextSnippets,
       firstResponseTiming,
     );
+    if (this.cancelTurnStartupIfStopped(sessionId, 'outbound prompt built')) {
+      return;
+    }
     firstResponseTiming.promptBuildEndedAtMs = Date.now();
     console.log(
       '[OpenClawRuntimeTiming] outbound prompt built.',

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -780,14 +780,16 @@ class CoworkService {
     const cowork = window.electron?.cowork;
     if (!cowork) return false;
 
+    this.logDiagnostic('info', `stop requested for session ${sessionId}.`);
     const result = await cowork.stopSession(sessionId);
     if (result.success) {
       store.dispatch(setStreaming(false));
       store.dispatch(updateSessionStatus({ sessionId, status: 'idle' }));
+      this.logDiagnostic('info', `stop completed for session ${sessionId}.`);
       return true;
     }
 
-    console.error('Failed to stop session:', result.error);
+    this.logDiagnostic('warn', `stop failed for session ${sessionId}: ${result.error ?? 'Unknown error'}.`);
     return false;
   }
 


### PR DESCRIPTION
Cancel OpenClaw turn startup when a user stop arrives before the gateway run becomes active, and emit idle session status after stop.

Add renderer stop diagnostics and cover the startup-stop race with a runtime adapter test.