### PR TITLE
fix(kits): keep expert suite controls sticky

### DIFF
--- a/src/renderer/components/kits/KitsManager.tsx
+++ b/src/renderer/components/kits/KitsManager.tsx
@@ -468,42 +468,42 @@ const KitsManager: React.FC<KitsManagerProps> = ({ onTryAsking }) => {
   // List view
   return (
     <div className="space-y-4">
-      <div className="space-y-1.5">
-        <h1 className="text-xl font-semibold text-foreground">
-          {i18nService.t('kits')}
-        </h1>
-        <p className="text-[13px] text-secondary">
-          {i18nService.t('kitDescription')}
-        </p>
-      </div>
+      <p className="text-sm text-secondary">
+        {i18nService.t('kitDescription')}
+      </p>
 
-      {/* Search */}
-      <div className="relative">
-        <SearchIcon className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-secondary" />
-        <input
-          type="text"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          placeholder={i18nService.t('kitSearchPlaceholder')}
-          className="h-10 w-full rounded-lg border border-border bg-surface px-3.5 pl-10 text-[13px] text-foreground transition-colors placeholder:text-secondary/75 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-        />
-        {searchQuery && (
-          <button
-            type="button"
-            onClick={() => setSearchQuery('')}
-            className="absolute right-3 top-1/2 -translate-y-1/2 rounded p-1 text-secondary transition-colors hover:text-foreground"
-          >
-            <XMarkIcon className="h-4 w-4" />
-          </button>
-        )}
-      </div>
+      {/* Sticky toolbar: Search + Marketplace tab */}
+      <div className="sticky top-0 z-10 space-y-4 bg-claude-bg pb-4 shadow-sm dark:bg-claude-darkBg">
+        {/* Search */}
+        <div className="flex items-center gap-3">
+          <div className="relative flex-1">
+            <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-secondary" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={i18nService.t('kitSearchPlaceholder')}
+              className="w-full rounded-xl border border-border bg-surface py-2 pl-9 pr-8 text-sm text-foreground placeholder-secondary focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-secondary transition-colors hover:text-primary"
+              >
+                <XMarkIcon className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        </div>
 
-      {/* Market section */}
-      <div className="flex items-center border-b border-border">
-        <h2 className="relative px-2.5 pb-2.5 pt-0.5 text-[13px] font-semibold text-foreground">
-          {i18nService.t('kitMarketplace')}
-          <div className="absolute bottom-[-1px] left-0 right-0 h-0.5 rounded-full bg-primary" />
-        </h2>
+        {/* Market section */}
+        <div className="flex items-center border-b border-border">
+          <h2 className="relative px-2.5 pb-2.5 pt-0.5 text-[13px] font-semibold text-foreground">
+            {i18nService.t('kitMarketplace')}
+            <div className="absolute bottom-[-1px] left-0 right-0 h-0.5 rounded-full bg-primary" />
+          </h2>
+        </div>
       </div>
 
       {/* Kit grid */}

--- a/src/renderer/components/kits/KitsView.tsx
+++ b/src/renderer/components/kits/KitsView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { i18nService } from '../../services/i18n';
 import ComposeIcon from '../icons/ComposeIcon';
 import SidebarToggleIcon from '../icons/SidebarToggleIcon';
 import WindowTitleBar from '../window/WindowTitleBar';
@@ -16,10 +17,9 @@ interface KitsViewProps {
 const KitsView: React.FC<KitsViewProps> = ({ isSidebarCollapsed, onToggleSidebar, onNewChat, updateBadge, onTryAsking }) => {
   const isMac = window.electron.platform === 'darwin';
   return (
-    <div className="relative flex-1 flex flex-col bg-background h-full">
-      <div className="draggable pointer-events-auto absolute left-80 right-32 top-0 z-20 h-10" />
-      <div className="pointer-events-none absolute inset-x-0 top-0 z-20 flex h-11 items-center justify-between px-4">
-        <div className="pointer-events-auto flex items-center space-x-3 h-8">
+    <div className="flex-1 flex flex-col bg-background h-full">
+      <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border shrink-0">
+        <div className="flex items-center space-x-3 h-8">
           {isSidebarCollapsed && (
             <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
               <button
@@ -39,12 +39,15 @@ const KitsView: React.FC<KitsViewProps> = ({ isSidebarCollapsed, onToggleSidebar
               {updateBadge}
             </div>
           )}
+          <h1 className="text-lg font-semibold text-foreground">
+            {i18nService.t('kits')}
+          </h1>
         </div>
-        <WindowTitleBar inline className="pointer-events-auto" />
+        <WindowTitleBar inline />
       </div>
 
       <div className="flex-1 overflow-y-auto min-h-0 [scrollbar-gutter:stable]">
-        <div className={`mx-auto w-full max-w-[1120px] px-6 pb-8 ${isSidebarCollapsed ? 'pt-14' : 'pt-6'}`}>
+        <div className="mx-auto w-full max-w-[1120px] px-6 py-6">
           <KitsManager onTryAsking={onTryAsking} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Move the expert suite page title into a fixed header matching Skills/MCP pages
- Make the expert suite search and marketplace tab use a sticky toolbar
- Align search input styling with Skills/MCP behavior

## Verification
- npx eslint src/renderer/components/kits/KitsView.tsx src/renderer/components/kits/KitsManager.tsx
- npm run build

Note: full npm run lint still reports pre-existing import-sort and hook warnings outside these changed files.