### PR TITLE
fix(cowork): preserve same-name package model selection

### DIFF
--- a/src/main/libs/openclawAgentModels.test.ts
+++ b/src/main/libs/openclawAgentModels.test.ts
@@ -67,6 +67,35 @@ describe('buildAgentEntry', () => {
     });
   });
 
+  test('keeps explicit server model.primary when a custom provider has the same model id', () => {
+    const result = buildAgentEntry({
+      id: 'main',
+      name: 'main',
+      description: '',
+      systemPrompt: '',
+      identity: '',
+      model: 'lobsterai-server/kimi-k2.6',
+      workingDirectory: '',
+      icon: '',
+      skillIds: [],
+      enabled: true,
+      isDefault: true,
+      source: 'custom',
+      presetId: '',
+      createdAt: 0,
+      updatedAt: 0,
+    }, 'deepseek/deepseek-v4-flash', {
+      availableProviders: {
+        moonshot: { models: [{ id: 'kimi-k2.6' }] },
+      },
+    });
+
+    expect(result).toMatchObject({
+      id: 'main',
+      model: { primary: 'lobsterai-server/kimi-k2.6' },
+    });
+  });
+
   test('falls back to the default model when agent model is an ambiguous bare id', () => {
     const result = buildAgentEntry({
       id: 'main',
@@ -343,6 +372,18 @@ describe('resolveQualifiedAgentModelRef', () => {
     })).toEqual({
       status: 'qualified',
       primaryModel: 'openai-codex/gpt-5.3-codex',
+    });
+  });
+
+  test('keeps explicit server refs when a custom provider has the same model id', () => {
+    expect(resolveQualifiedAgentModelRef({
+      agentModel: 'lobsterai-server/kimi-k2.6',
+      availableProviders: {
+        moonshot: { models: [{ id: 'kimi-k2.6' }] },
+      },
+    })).toEqual({
+      status: 'qualified',
+      primaryModel: 'lobsterai-server/kimi-k2.6',
     });
   });
 });

--- a/src/main/libs/openclawAgentModels.ts
+++ b/src/main/libs/openclawAgentModels.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 
 import { isDesignedAgentAvatarIcon } from '../../shared/agent/avatar';
+import { OpenClawProviderId } from '../../shared/providers/constants';
 import type { Agent } from '../coworkStore';
 
 type BuildManagedAgentEntriesInput = {
@@ -22,6 +23,10 @@ export type QualifiedAgentModelRefResolution =
   | { status: 'qualified'; primaryModel: string }
   | { status: 'ambiguous'; modelId: string; providerIds: string[] }
   | { status: 'unresolved'; modelId: string };
+
+const LegacyQualifiedProviderMigration: Record<string, readonly string[]> = {
+  [OpenClawProviderId.OpenAI]: [OpenClawProviderId.OpenAICodex],
+};
 
 export function parsePrimaryModelRef(primaryModel: string): ManagedSessionModelTarget | null {
   const normalized = primaryModel.trim();
@@ -129,8 +134,12 @@ export function resolveQualifiedAgentModelRef(options: {
       };
     }
 
+    const migrationProviders = LegacyQualifiedProviderMigration[explicitTarget.providerId] ?? [];
     const matchingProviders = Object.entries(options.availableProviders)
-      .filter(([, config]) => config.models.some((model) => model.id === explicitTarget.modelId))
+      .filter(([providerId, config]) => (
+        migrationProviders.includes(providerId)
+        && config.models.some((model) => model.id === explicitTarget.modelId)
+      ))
       .map(([providerId]) => providerId);
 
     if (matchingProviders.length === 1) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -94,7 +94,7 @@ import {
   OpenClawGatewayRepairErrorCode,
 } from '../shared/openclawEngine/constants';
 import { PlatformRegistry } from '../shared/platform';
-import { ProviderName } from '../shared/providers';
+import { OpenClawProviderId, ProviderName } from '../shared/providers';
 import type { ShellOpenFailureReason as ShellOpenFailureReasonType } from '../shared/shell/constants';
 import { ShellOpenFailureReason } from '../shared/shell/constants';
 import { AgentManager } from './agentManager';
@@ -841,6 +841,32 @@ const buildAvailableOpenClawProviders = (): Record<string, { models: Array<{ id:
   }
 
   return providerMap;
+};
+
+const openClawConfigHasServerModels = (modelIds: string[]): boolean => {
+  const normalizedModelIds = modelIds.map(modelId => modelId.trim()).filter(Boolean);
+  if (normalizedModelIds.length === 0) return true;
+
+  try {
+    const configPath = getOpenClawEngineManager().getConfigPath();
+    const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
+      models?: {
+        providers?: Record<string, { models?: Array<{ id?: string }> }>;
+      };
+    };
+    const serverProviderModels = parsed.models?.providers?.[OpenClawProviderId.LobsteraiServer]?.models;
+    if (!Array.isArray(serverProviderModels)) return false;
+
+    const configuredModelIds = new Set(
+      serverProviderModels
+        .map(model => (typeof model.id === 'string' ? model.id.trim() : ''))
+        .filter(Boolean),
+    );
+    return normalizedModelIds.every(modelId => configuredModelIds.has(modelId));
+  } catch (error) {
+    console.debug('[Auth:getModels] OpenClaw config inspection failed; scheduling model sync.', error);
+    return false;
+  }
 };
 
 const normalizeOpenClawModelRef = (modelRef: string): string => {
@@ -4311,8 +4337,12 @@ if (!gotTheLock) {
 
   const syncOpenClawConfigIfAuthQuotaGateChanged = (previous: ReturnType<typeof getAuthQuotaGateState>) => {
     if (hasAuthQuotaGateStateChanged(previous)) {
-      syncOpenClawConfig({ reason: MEDIA_ENTITLEMENT_SYNC_REASON, restartGatewayIfRunning: true }).catch(() => {});
+      syncOpenClawConfig({ reason: MEDIA_ENTITLEMENT_SYNC_REASON, restartGatewayIfRunning: true }).catch((error) => {
+        console.warn('[Auth] failed to sync OpenClaw config after quota gate changed:', error);
+      });
+      return true;
     }
+    return false;
   };
 
   const resetAuthQuotaGateState = () => {
@@ -4514,15 +4544,33 @@ if (!gotTheLock) {
       clearServerModelMetadata();
       const previousQuotaGateState = getAuthQuotaGateState();
       resetAuthQuotaGateState();
-      syncOpenClawConfigIfAuthQuotaGateChanged(previousQuotaGateState);
+      const quotaGateSyncScheduled = syncOpenClawConfigIfAuthQuotaGateChanged(previousQuotaGateState);
+      if (!quotaGateSyncScheduled) {
+        syncOpenClawConfig({
+          reason: 'auth-logout-server-models-cleared',
+          restartGatewayIfRunning: false,
+        }).catch((error) => {
+          console.warn('[Auth] failed to sync OpenClaw config after logout:', error);
+        });
+      }
+      console.log('[Auth] cleared login state and scheduled server model config refresh');
       return { success: true };
-    } catch {
+    } catch (error) {
+      console.warn('[Auth] logout cleanup encountered an error; clearing local state anyway:', error);
       const previousQuotaGateState = getAuthQuotaGateState();
       clearAuthTokens();
       clearAuthUser();
       clearServerModelMetadata();
       resetAuthQuotaGateState();
-      syncOpenClawConfigIfAuthQuotaGateChanged(previousQuotaGateState);
+      const quotaGateSyncScheduled = syncOpenClawConfigIfAuthQuotaGateChanged(previousQuotaGateState);
+      if (!quotaGateSyncScheduled) {
+        syncOpenClawConfig({
+          reason: 'auth-logout-server-models-cleared',
+          restartGatewayIfRunning: false,
+        }).catch((syncError) => {
+          console.warn('[Auth] failed to sync OpenClaw config after logout cleanup:', syncError);
+        });
+      }
       return { success: true };
     }
   });
@@ -4616,14 +4664,21 @@ if (!gotTheLock) {
       if (data.code !== 0) return { success: false };
       // Cache server model metadata for use in OpenClaw config sync (supportsImage, etc.)
       const serverModelsChanged = updateServerModelMetadata(data.data);
+      const serverModelIds = data.data.map(model => model.modelId);
+      const serverModelsMissingFromConfig = !openClawConfigHasServerModels(serverModelIds);
       // Re-sync so the gateway picks up the correct supportsImage values for server models.
       // This IPC can run after normal chat completion when the renderer refreshes quota/model
       // state, so server model updates must not force a hard gateway restart.
-      if (serverModelsChanged) {
+      if (serverModelsChanged || serverModelsMissingFromConfig) {
+        console.log(
+          `[Auth:getModels] scheduling OpenClaw config sync for ${serverModelIds.length} server model(s); metadataChanged=${serverModelsChanged} missingFromConfig=${serverModelsMissingFromConfig}`,
+        );
         syncOpenClawConfig({
-          reason: 'server-models-updated',
+          reason: serverModelsChanged ? 'server-models-updated' : 'server-models-restored',
           restartGatewayIfRunning: false,
-        }).catch(() => {});
+        }).catch((error) => {
+          console.warn('[Auth:getModels] failed to sync OpenClaw config after loading server models:', error);
+        });
       } else {
         console.debug('[Auth:getModels] server model metadata unchanged, skipping config sync');
       }

--- a/src/renderer/components/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector.tsx
@@ -338,7 +338,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
       return;
     }
     if (controlled) {
-      onChange(model, { group: visibleGroup });
+      onChange(model, { group: getModelGroup(model) ?? visibleGroup });
     } else if (model) {
       dispatch(setSelectedModel({ agentId: currentAgentId, model }));
     }

--- a/src/renderer/components/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector.tsx
@@ -20,7 +20,7 @@ interface ModelSelectorProps {
    */
   value?: Model | null;
   /** Controlled mode callback. `null` means the user picked "default". */
-  onChange?: (model: Model | null) => void;
+  onChange?: (model: Model | null, meta: ModelSelectorChangeMeta) => void;
   /** Show a "default" option at the top of the dropdown (controlled mode only). */
   defaultLabel?: string;
   /** Disable interaction while the selected model is being persisted. */
@@ -43,11 +43,16 @@ const HOVER_CARD_WIDTH = 220;
 const HOVER_CARD_GAP = 8;
 const HOVER_CARD_VIEWPORT_MARGIN = 8;
 const MODEL_ICON_CLASS_NAME = 'h-[18px] w-[18px]';
-const ModelSelectorGroup = {
+export const ModelSelectorGroup = {
   Server: 'server',
   User: 'user',
 } as const;
 type ModelSelectorGroup = typeof ModelSelectorGroup[keyof typeof ModelSelectorGroup];
+
+export interface ModelSelectorChangeMeta {
+  group: ModelSelectorGroup;
+}
+
 export const ModelAccessPromptKind = {
   Login: 'login',
   Subscribe: 'subscribe',
@@ -333,7 +338,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
       return;
     }
     if (controlled) {
-      onChange(model);
+      onChange(model, { group: visibleGroup });
     } else if (model) {
       dispatch(setSelectedModel({ agentId: currentAgentId, model }));
     }

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -79,6 +79,18 @@ import { useCoworkVoiceInput } from './voiceInput/useCoworkVoiceInput';
 import VoiceInputButton from './voiceInput/VoiceInputButton';
 import VoiceInputRecordingStatus from './voiceInput/VoiceInputRecordingStatus';
 
+const logPromptModelSelection = (
+  level: 'debug' | 'warn',
+  message: string,
+): void => {
+  if (level === 'warn') {
+    console.warn(`[CoworkPromptInput] ${message}`);
+  } else {
+    console.debug(`[CoworkPromptInput] ${message}`);
+  }
+  window.electron?.log?.fromRenderer?.(level, 'CoworkPromptInput', message);
+};
+
 // CoworkAttachment is aliased from the Redux-persisted DraftAttachment type
 // so that attachment state survives view switches (cowork ↔ skills, etc.)
 type CoworkAttachment = DraftAttachment;
@@ -1382,7 +1394,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         disabled={isPatchingModel || isPersistingAgentModel}
         value={agentModelIsInvalid && currentSession?.modelOverride
           ? { id: '__invalid__', name: currentSession.modelOverride.split('/').pop() || currentSession.modelOverride } as Model
-          : agentSelectedModel}
+          : effectiveSelectedModel}
         onChange={async (nextModel, meta: ModelSelectorChangeMeta) => {
           if (isPatchingModel || isPersistingAgentModel) return;
           if (!nextModel) return;
@@ -1402,8 +1414,9 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
               : '';
 
             setIsPatchingModel(true);
-            console.debug(
-              `[CoworkPromptInput] switching session ${sessionId} to ${modelRef}; selectorGroup=${meta.group} serverModel=${selectedModel.isServerModel === true}`,
+            logPromptModelSelection(
+              'debug',
+              `switching session ${sessionId} to ${modelRef}; selector group is ${meta.group}; server model is ${selectedModel.isServerModel === true}`,
             );
             dispatch(updateCurrentSessionModelOverride({ sessionId, modelOverride: modelRef }));
 
@@ -1416,14 +1429,14 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                   sessionId,
                   modelOverride: previousModelOverride,
                 }));
-                console.warn(`[CoworkPromptInput] model switch for session ${sessionId} returned no session`);
+                logPromptModelSelection('warn', `model switch for session ${sessionId} returned no session`);
                 window.dispatchEvent(new CustomEvent('app:showToast', {
                   detail: i18nService.t('coworkModelSwitchFailed'),
                 }));
                 return;
               }
 
-              console.debug(`[CoworkPromptInput] switched session ${sessionId} to ${patchedSession.modelOverride || modelRef}`);
+              logPromptModelSelection('debug', `switched session ${sessionId} to ${patchedSession.modelOverride || modelRef}`);
               if (currentAgent && agentModelIsInvalid) {
                 void agentService.updateAgent(currentAgent.id, { model: modelRef });
               }
@@ -1435,6 +1448,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                   modelOverride: previousModelOverride,
                 }));
                 console.warn(`[CoworkPromptInput] model switch for session ${sessionId} failed:`, error);
+                window.electron?.log?.fromRenderer?.('warn', 'CoworkPromptInput', `model switch for session ${sessionId} failed`);
                 window.dispatchEvent(new CustomEvent('app:showToast', {
                   detail: i18nService.t('coworkModelSwitchFailed'),
                 }));
@@ -1446,6 +1460,10 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
             }
             return;
           }
+          logPromptModelSelection(
+            'debug',
+            `persisting agent ${currentAgentId} model ${modelRef}; selector group is ${meta.group}; server model is ${selectedModel.isServerModel === true}`,
+          );
           await persistAgentModelSelection(selectedModel);
         }}
       />

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -49,7 +49,12 @@ import SkillIcon from '../icons/SkillIcon';
 import TaskPauseIcon from '../icons/TaskPauseIcon';
 import XMarkIcon from '../icons/XMarkIcon';
 import { ActiveKitBadge, KitsButton } from '../kits';
-import ModelSelector, { ModelAccessPromptKind, ModelAccessPromptModal } from '../ModelSelector';
+import ModelSelector, {
+  ModelAccessPromptKind,
+  ModelAccessPromptModal,
+  type ModelSelectorChangeMeta,
+  ModelSelectorGroup,
+} from '../ModelSelector';
 import { ActiveSkillBadge, SkillsPopover } from '../skills';
 import { resolveAgentModelSelection, resolveEffectiveModel, useAgentSelectedModel } from './agentModelSelection';
 import AttachmentCard from './AttachmentCard';
@@ -1378,10 +1383,17 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         value={agentModelIsInvalid && currentSession?.modelOverride
           ? { id: '__invalid__', name: currentSession.modelOverride.split('/').pop() || currentSession.modelOverride } as Model
           : agentSelectedModel}
-        onChange={async (nextModel) => {
+        onChange={async (nextModel, meta: ModelSelectorChangeMeta) => {
           if (isPatchingModel || isPersistingAgentModel) return;
           if (!nextModel) return;
-          const modelRef = toOpenClawModelRef(nextModel);
+          const selectedModel = meta.group === ModelSelectorGroup.Server
+            ? availableModels.find(model => (
+              model.isServerModel
+              && model.id === nextModel.id
+              && model.accessible !== false
+            )) ?? nextModel
+            : nextModel;
+          const modelRef = toOpenClawModelRef(selectedModel);
           if (sessionId) {
             const requestId = modelPatchRequestIdRef.current + 1;
             modelPatchRequestIdRef.current = requestId;
@@ -1390,6 +1402,9 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
               : '';
 
             setIsPatchingModel(true);
+            console.debug(
+              `[CoworkPromptInput] switching session ${sessionId} to ${modelRef}; selectorGroup=${meta.group} serverModel=${selectedModel.isServerModel === true}`,
+            );
             dispatch(updateCurrentSessionModelOverride({ sessionId, modelOverride: modelRef }));
 
             try {
@@ -1401,22 +1416,25 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
                   sessionId,
                   modelOverride: previousModelOverride,
                 }));
+                console.warn(`[CoworkPromptInput] model switch for session ${sessionId} returned no session`);
                 window.dispatchEvent(new CustomEvent('app:showToast', {
                   detail: i18nService.t('coworkModelSwitchFailed'),
                 }));
                 return;
               }
 
+              console.debug(`[CoworkPromptInput] switched session ${sessionId} to ${patchedSession.modelOverride || modelRef}`);
               if (currentAgent && agentModelIsInvalid) {
                 void agentService.updateAgent(currentAgent.id, { model: modelRef });
               }
               void coworkService.refreshContextUsage(sessionId, { notifyCompaction: false });
-            } catch {
+            } catch (error) {
               if (requestId === modelPatchRequestIdRef.current) {
                 dispatch(updateCurrentSessionModelOverride({
                   sessionId,
                   modelOverride: previousModelOverride,
                 }));
+                console.warn(`[CoworkPromptInput] model switch for session ${sessionId} failed:`, error);
                 window.dispatchEvent(new CustomEvent('app:showToast', {
                   detail: i18nService.t('coworkModelSwitchFailed'),
                 }));
@@ -1428,7 +1446,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
             }
             return;
           }
-          await persistAgentModelSelection(nextModel);
+          await persistAgentModelSelection(selectedModel);
         }}
       />
       {agentModelIsInvalid && (

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -38,6 +38,11 @@ import CoworkSessionDetail from './CoworkSessionDetail';
 import { buildCoworkContinuationSystemPrompt, buildCoworkSystemPrompt } from './skillSystemPrompt';
 import SubagentSessionDetail from './SubagentSessionDetail';
 
+const logCoworkViewModel = (message: string): void => {
+  console.debug(`[CoworkView] ${message}`);
+  window.electron?.log?.fromRenderer?.('debug', 'CoworkView', message);
+};
+
 export interface CoworkViewProps {
   onRequestAppSettings?: (options?: SettingsOpenOptions) => void;
   onShowSkills?: () => void;
@@ -359,7 +364,9 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
 
       // Start the actual session immediately with fallback title
       const sessionModelOverride = currentAgentSelectedModel ? toOpenClawModelRef(currentAgentSelectedModel) : '';
-      console.log('[CoworkView] creating session:', { modelId: currentAgentSelectedModel?.id, providerKey: currentAgentSelectedModel?.providerKey, isServerModel: currentAgentSelectedModel?.isServerModel, sessionModelOverride, agentModel: currentAgent?.model });
+      logCoworkViewModel(
+        `creating session with model ${sessionModelOverride || 'default'}; agent model is ${currentAgent?.model || 'empty'}; server model is ${currentAgentSelectedModel?.isServerModel === true}`,
+      );
       const { session: startedSession, error: startError } = await coworkService.startSession({
         prompt,
         title: fallbackTitle,

--- a/src/renderer/components/cowork/agentModelSelection.test.ts
+++ b/src/renderer/components/cowork/agentModelSelection.test.ts
@@ -8,6 +8,8 @@ const models: Model[] = [
   { id: 'claude-sonnet-4', name: 'Claude Sonnet 4', providerKey: 'anthropic' },
   { id: 'deepseek-v3.2', name: 'DeepSeek', providerKey: 'anthropic' },
   { id: 'deepseek-v3.2', name: 'DeepSeek Server', providerKey: 'openai', isServerModel: true },
+  { id: 'kimi-k2.6', name: 'Kimi K2.6', providerKey: 'moonshot' },
+  { id: 'kimi-k2.6', name: 'Kimi K2.6 Server', providerKey: 'lobsterai-server', isServerModel: true },
 ];
 
 const visionModel: Model = { id: 'qwen3.5-plus', name: 'Qwen3.5 Plus', providerKey: 'qwen', supportsImage: true };
@@ -37,6 +39,35 @@ describe('resolveAgentModelSelection', () => {
     });
 
     expect(result.selectedModel?.id).toBe('gpt-4o');
+    expect(result.usesFallback).toBe(false);
+    expect(result.hasInvalidExplicitModel).toBe(false);
+  });
+
+  test('resolves same-id server session model to the server model', () => {
+    const result = resolveAgentModelSelection({
+      sessionModel: 'lobsterai-server/kimi-k2.6',
+      agentModel: 'moonshot/kimi-k2.6',
+      availableModels: models,
+      fallbackModel: models[0],
+      engine: 'openclaw',
+    });
+
+    expect(result.selectedModel?.providerKey).toBe('lobsterai-server');
+    expect(result.selectedModel?.isServerModel).toBe(true);
+    expect(result.usesFallback).toBe(false);
+    expect(result.hasInvalidExplicitModel).toBe(false);
+  });
+
+  test('resolves same-id server agent model to the server model', () => {
+    const result = resolveAgentModelSelection({
+      agentModel: 'lobsterai-server/kimi-k2.6',
+      availableModels: models,
+      fallbackModel: models[0],
+      engine: 'openclaw',
+    });
+
+    expect(result.selectedModel?.providerKey).toBe('lobsterai-server');
+    expect(result.selectedModel?.isServerModel).toBe(true);
     expect(result.usesFallback).toBe(false);
     expect(result.hasInvalidExplicitModel).toBe(false);
   });

--- a/src/renderer/components/cowork/usePersistAgentModelSelection.ts
+++ b/src/renderer/components/cowork/usePersistAgentModelSelection.ts
@@ -7,6 +7,15 @@ import type { Model } from '../../store/slices/modelSlice';
 import { setDefaultSelectedModel,setSelectedModel } from '../../store/slices/modelSlice';
 import { toOpenClawModelRef } from '../../utils/openclawModelRef';
 
+const logAgentModelPersistence = (level: 'debug' | 'warn', message: string): void => {
+  if (level === 'warn') {
+    console.warn(`[AgentModelSelection] ${message}`);
+  } else {
+    console.debug(`[AgentModelSelection] ${message}`);
+  }
+  window.electron?.log?.fromRenderer?.(level, 'AgentModelSelection', message);
+};
+
 export function usePersistAgentModelSelection({
   agentId,
   syncDefaultModel,
@@ -21,16 +30,22 @@ export function usePersistAgentModelSelection({
   const persistAgentModelSelection = useCallback(async (model: Model): Promise<boolean> => {
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
+    const modelRef = toOpenClawModelRef(model);
     setIsPersistingAgentModel(true);
+    logAgentModelPersistence(
+      'debug',
+      `saving agent ${agentId} model ${modelRef}; server model is ${model.isServerModel === true}`,
+    );
 
     try {
       const updatedAgent = await agentService.updateAgent(agentId, {
-        model: toOpenClawModelRef(model),
+        model: modelRef,
       });
       if (requestId !== requestIdRef.current) {
         return false;
       }
       if (!updatedAgent) {
+        logAgentModelPersistence('warn', `saving agent ${agentId} model ${modelRef} returned no agent`);
         window.dispatchEvent(new CustomEvent('app:showToast', {
           detail: i18nService.t('agentSaveFailed'),
         }));
@@ -41,6 +56,7 @@ export function usePersistAgentModelSelection({
       if (syncDefaultModel) {
         dispatch(setDefaultSelectedModel(model));
       }
+      logAgentModelPersistence('debug', `saved agent ${agentId} model ${modelRef}`);
       return true;
     } finally {
       if (requestId === requestIdRef.current) {

--- a/src/renderer/services/auth.ts
+++ b/src/renderer/services/auth.ts
@@ -307,9 +307,12 @@ class AuthService {
           restrictionHint: m.restrictionHint ?? undefined,
         }));
         store.dispatch(setServerModels(serverModels));
+        console.debug(`[Auth] loaded ${serverModels.length} server model(s) into renderer state`);
+      } else {
+        console.debug('[Auth] server model load returned no models');
       }
-    } catch {
-      // ignore — server models are optional
+    } catch (error) {
+      console.warn('[Auth] failed to load server models:', error);
     }
   }
 

--- a/src/renderer/store/slices/modelSlice.test.ts
+++ b/src/renderer/store/slices/modelSlice.test.ts
@@ -16,6 +16,8 @@ const modelB: Model = { id: 'glm-5.1', name: 'GLM 5.1', providerKey: 'zhipu' };
 const modelC: Model = { id: 'claude-3-sonnet', name: 'Claude 3 Sonnet', providerKey: 'anthropic' };
 const serverModel: Model = { id: 'server-model', name: 'Server Model', providerKey: 'lobsterai-server', isServerModel: true };
 const lockedServerModel: Model = { ...serverModel, accessible: false };
+const customKimiModel: Model = { id: 'kimi-k2.6', name: 'Kimi K2.6', providerKey: 'moonshot' };
+const serverKimiModel: Model = { id: 'kimi-k2.6', name: 'Kimi K2.6', providerKey: 'lobsterai-server', isServerModel: true };
 
 function makeState(overrides?: Partial<ReturnType<typeof modelReducer>>) {
   const base = modelReducer(undefined, { type: 'init' });
@@ -149,6 +151,32 @@ describe('setServerModels / clearServerModels', () => {
     expect(state.selectedModelByAgent['agent-1'].supportsImage).toBe(true);
   });
 
+  test('setServerModels does not replace a same-id custom model selection', () => {
+    let state = makeState({
+      availableModels: [customKimiModel],
+      defaultSelectedModel: customKimiModel,
+      selectedModelByAgent: { 'agent-1': customKimiModel },
+    });
+
+    state = modelReducer(state, setServerModels([serverKimiModel]));
+
+    expect(state.defaultSelectedModel).toEqual(customKimiModel);
+    expect(state.selectedModelByAgent['agent-1']).toEqual(customKimiModel);
+  });
+
+  test('setAvailableModels does not replace a same-id server model selection', () => {
+    let state = makeState({
+      availableModels: [serverKimiModel],
+      defaultSelectedModel: serverKimiModel,
+      selectedModelByAgent: { 'agent-1': serverKimiModel },
+    });
+
+    state = modelReducer(state, setAvailableModels([customKimiModel]));
+
+    expect(state.defaultSelectedModel).toEqual(serverKimiModel);
+    expect(state.selectedModelByAgent['agent-1']).toEqual(serverKimiModel);
+  });
+
   test('clearServerModels removes server model entries from per-agent map', () => {
     let state = modelReducer(undefined, setSelectedModel({ agentId: 'agent-1', model: serverModel }));
     // Ensure there's at least one non-server model available
@@ -182,6 +210,30 @@ describe('selectAgentSelectedModel', () => {
 
     const result = selectAgentSelectedModel(state, 'agent-1', 'openai/gpt-4o');
     expect(result.id).toBe('gpt-4o');
+  });
+
+  test('uses explicit server agent model ref over a same-id custom override', () => {
+    const state = makeState({
+      selectedModelByAgent: { 'agent-1': customKimiModel },
+      availableModels: [serverKimiModel, customKimiModel],
+      defaultSelectedModel: customKimiModel,
+    });
+
+    const result = selectAgentSelectedModel(state, 'agent-1', 'lobsterai-server/kimi-k2.6');
+
+    expect(result).toEqual(serverKimiModel);
+  });
+
+  test('uses explicit custom agent model ref over a same-id server override', () => {
+    const state = makeState({
+      selectedModelByAgent: { 'agent-1': serverKimiModel },
+      availableModels: [serverKimiModel, customKimiModel],
+      defaultSelectedModel: serverKimiModel,
+    });
+
+    const result = selectAgentSelectedModel(state, 'agent-1', 'moonshot/kimi-k2.6');
+
+    expect(result).toEqual(customKimiModel);
   });
 
   test('ignores explicit agent model refs that resolve to locked server models', () => {

--- a/src/renderer/store/slices/modelSlice.ts
+++ b/src/renderer/store/slices/modelSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { ProviderName } from '@shared/providers/constants';
 
 import { defaultConfig, getProviderDisplayName } from '../../config';
 import { resolveOpenClawModelRef } from '../../utils/openclawModelRef';
@@ -20,15 +21,22 @@ export interface Model {
   restrictionHint?: string; // 限制提示（如 "订阅套餐/购买加油包可用"）
 }
 
-export function getModelIdentityKey(model: Pick<Model, 'id' | 'providerKey'>): string {
+function isServerModelIdentity(model: Pick<Model, 'providerKey' | 'isServerModel'>): boolean {
+  return model.isServerModel === true || model.providerKey === ProviderName.LobsteraiServer;
+}
+
+export function getModelIdentityKey(model: Pick<Model, 'id' | 'providerKey' | 'isServerModel'>): string {
   return `${model.providerKey ?? ''}::${model.id}`;
 }
 
 export function isSameModelIdentity(
-  modelA: Pick<Model, 'id' | 'providerKey'>,
-  modelB: Pick<Model, 'id' | 'providerKey'>
+  modelA: Pick<Model, 'id' | 'providerKey' | 'isServerModel'>,
+  modelB: Pick<Model, 'id' | 'providerKey' | 'isServerModel'>
 ): boolean {
   if (modelA.id !== modelB.id) {
+    return false;
+  }
+  if (isServerModelIdentity(modelA) !== isServerModelIdentity(modelB)) {
     return false;
   }
   if (modelA.providerKey && modelB.providerKey) {
@@ -98,12 +106,15 @@ export function selectAgentSelectedModel(
   agentModelRef: string,
 ): Model {
   const override = modelState.selectedModelByAgent[agentId];
-  if (isModelAccessible(override)) return override;
   const trimmed = agentModelRef.trim();
   if (trimmed) {
     const resolved = resolveOpenClawModelRef(trimmed, modelState.availableModels);
-    if (resolved && isModelAccessible(resolved)) return resolved;
+    if (resolved && isModelAccessible(resolved)) {
+      if (!isModelAccessible(override)) return resolved;
+      return isSameModelIdentity(override, resolved) ? override : resolved;
+    }
   }
+  if (isModelAccessible(override)) return override;
   if (isModelAccessible(modelState.defaultSelectedModel)) {
     return modelState.defaultSelectedModel;
   }


### PR DESCRIPTION
## Summary

- Preserve explicit `lobsterai-server/...` model refs during OpenClaw model normalization.
- Distinguish same-id package and custom models in renderer model selection state.
- Add low-frequency renderer logs for model selection, persistence, and session creation.
- Add regression tests for same-name package/custom model selection.

## Validation

- `npm run compile:electron`
- `npm test -- openclawAgentModels openclawConfigSync openclawRuntimeAdapter modelSlice agentModelSelection scheduledTask TaskForm imScheduledTaskHandler imCoworkHandler openclawChannelSessionSync subagentTracker`
- `npm run build`
- `git diff --check`