### PR TITLE
fix(cowork): show model metadata after stopped streams

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -1552,6 +1552,7 @@ function createActiveTurn(sessionId: string, sessionKey: string, runId: string) 
     sessionId,
     sessionKey,
     runId,
+    model: '',
     turnToken: 1,
     startedAtMs: 1,
     knownRunIds: new Set([runId]),
@@ -1560,6 +1561,7 @@ function createActiveTurn(sessionId: string, sessionKey: string, runId: string) 
     currentAssistantSegmentText: '',
     currentText: '',
     agentAssistantTextLength: 0,
+    hasSeenAgentAssistantStream: false,
     currentContentText: '',
     currentContentBlocks: [],
     sawNonTextContentBlocks: false,
@@ -1577,6 +1579,64 @@ function createActiveTurn(sessionId: string, sessionKey: string, runId: string) 
     bufferedAgentPayloads: [],
   };
 }
+
+test('stopSession finalizes streamed assistant metadata with the active model', () => {
+  const model = 'lobsterai-server/qwen3.6-plus';
+  const { session, store } = createReconcileStore([
+    { id: 'msg-1', type: 'user', content: 'hello', timestamp: 1, metadata: {} },
+    {
+      id: 'msg-2',
+      type: 'assistant',
+      content: 'partial',
+      timestamp: 2,
+      metadata: { isStreaming: true, isFinal: false },
+    },
+  ]);
+  session.modelOverride = model;
+  session.status = 'running';
+
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const abortSpy = vi.fn(async () => ({}));
+  const messageUpdateSpy = vi.fn();
+  adapter.gatewayClient = {
+    start: () => {},
+    stop: () => {},
+    request: abortSpy,
+  };
+  adapter.on('messageUpdate', messageUpdateSpy);
+
+  const sessionKey = `agent:main:lobsterai:${session.id}`;
+  const turn = createActiveTurn(session.id, sessionKey, 'run-stop');
+  turn.model = model;
+  turn.assistantMessageId = 'msg-2';
+  turn.currentAssistantSegmentText = 'partial answer';
+  adapter.activeTurns.set(session.id, turn);
+
+  adapter.stopSession(session.id);
+
+  const assistantMessage = session.messages.find((message) => message.id === 'msg-2');
+  expect(assistantMessage?.content).toBe('partial answer');
+  expect(assistantMessage?.metadata).toMatchObject({
+    isStreaming: false,
+    isFinal: true,
+    model,
+  });
+  expect(messageUpdateSpy).toHaveBeenCalledWith(
+    session.id,
+    'msg-2',
+    'partial answer',
+    expect.objectContaining({
+      isStreaming: false,
+      isFinal: true,
+      model,
+    }),
+  );
+  expect(abortSpy).toHaveBeenCalledWith('chat.abort', {
+    sessionKey,
+    runId: 'run-stop',
+  });
+  expect(session.status).toBe('idle');
+});
 
 test('reconcileWithHistory: already in sync — skips replace', async () => {
   const { session, store, getReplaceCallCount } = createReconcileStore([

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -60,9 +60,9 @@ import { AgentLifecyclePhase, type AgentLifecyclePhase as AgentLifecyclePhaseVal
 import {
   buildCoworkContinuityCapsule,
   ContinuityCapsuleSource,
+  type ContinuityCapsuleSource as ContinuityCapsuleSourceValue,
   formatCoworkContinuityCapsuleBridge,
   formatCoworkMiniContinuityCapsuleBridge,
-  type ContinuityCapsuleSource as ContinuityCapsuleSourceValue,
 } from './coworkContinuityCapsule';
 import { buildCoworkTopKEvidenceBridgeResult } from './coworkTopKEvidence';
 import { buildCoworkWorkspaceRehydrationBridge } from './coworkWorkspaceRehydration';
@@ -362,6 +362,7 @@ type ActiveTurn = {
   sessionId: string;
   sessionKey: string;
   runId: string;
+  model: string;
   turnToken: number;
   /** Timestamp when this turn was created (for abort diagnostics). */
   startedAtMs: number;
@@ -3094,6 +3095,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (turn) {
       turn.stopRequested = true;
       this.manuallyStoppedSessions.add(sessionId);
+      this.finalizeStoppedStreamingMessages(sessionId, turn);
       const client = this.gatewayClient;
       if (client) {
         console.log(`[OpenClawRuntime] user requested stop, aborting gateway run ${turn.runId}.`);
@@ -3496,6 +3498,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       sessionId,
       sessionKey,
       runId,
+      model: currentModel,
       turnToken,
       knownRunIds: new Set([runId]),
       assistantMessageId: null,
@@ -4205,6 +4208,73 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       clearTimeout(timer);
       this.pendingStoreUpdateTimer.delete(messageId);
     }
+  }
+
+  private resolveCurrentModelForSession(sessionId: string): string {
+    const session = this.store.getSession(sessionId);
+    if (session?.modelOverride) {
+      return session.modelOverride;
+    }
+    const agent = session?.agentId ? this.store.getAgent(session.agentId) : null;
+    const rawCurrentModel = agent?.model || '';
+    if (!rawCurrentModel) return '';
+    return this.normalizeModelRef(rawCurrentModel);
+  }
+
+  private finalizeStoppedStreamingMessage(
+    sessionId: string,
+    messageId: string | null,
+    content: string,
+    model: string,
+  ): void {
+    if (!messageId) return;
+
+    this.clearPendingStoreUpdate(messageId);
+    this.clearPendingMessageUpdate(messageId);
+    this.lastStoreUpdateTime.delete(messageId);
+    this.lastMessageUpdateEmitTime.delete(messageId);
+
+    const session = this.store.getSession(sessionId);
+    const message = session?.messages.find((item) => item.id === messageId);
+    if (!message) return;
+
+    const finalContent = content || message.content;
+    const existingModel = typeof message.metadata?.model === 'string' && message.metadata.model.trim()
+      ? message.metadata.model
+      : '';
+    const metadata: CoworkMessageMetadata = {
+      ...message.metadata,
+      isStreaming: false,
+      isFinal: true,
+      ...(existingModel ? { model: existingModel } : model ? { model } : {}),
+    };
+
+    this.store.updateMessage(sessionId, messageId, {
+      content: finalContent,
+      metadata,
+    });
+    console.debug(
+      `[OpenClawRuntime] finalized stopped streaming message for session ${sessionId}.`,
+      `Message ${messageId}.`,
+      `Model ${metadata.model ?? 'none'}.`,
+    );
+    this.emit('messageUpdate', sessionId, messageId, finalContent, metadata);
+  }
+
+  private finalizeStoppedStreamingMessages(sessionId: string, turn: ActiveTurn): void {
+    const model = turn.model || this.resolveCurrentModelForSession(sessionId);
+    this.finalizeStoppedStreamingMessage(
+      sessionId,
+      turn.thinkingMessageId,
+      turn.currentThinkingText,
+      model,
+    );
+    this.finalizeStoppedStreamingMessage(
+      sessionId,
+      turn.assistantMessageId,
+      turn.currentAssistantSegmentText || turn.currentText,
+      model,
+    );
   }
 
   private syncToolResultsFromHistory(
@@ -8002,6 +8072,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       sessionId,
       sessionKey,
       runId: turnRunId,
+      model: this.resolveCurrentModelForSession(sessionId),
       turnToken,
       knownRunIds: new Set(runId ? [runId] : [turnRunId]),
       assistantMessageId: null,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3185,7 +3185,10 @@ if (!gotTheLock) {
   };
 
   ipcMain.on('log:fromRenderer', (_event, level: string, tag: string, message: string) => {
-    const fn = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
+    const fn = level === 'error' ? console.error
+      : level === 'warn' ? console.warn
+        : level === 'debug' ? console.debug
+          : console.log;
     fn(`[Renderer][${tag}] ${message}`);
   });
 

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -212,6 +212,12 @@ class CoworkService {
       if (metadata?.isFinal !== true && session?.status !== 'completed') {
         store.dispatch(updateSessionStatus({ sessionId, status: 'running' }));
       }
+      if (metadata?.isFinal === true && typeof metadata.model === 'string' && metadata.model.trim()) {
+        this.logDiagnostic(
+          'debug',
+          `received final message metadata for session ${sessionId}, message ${messageId}, model ${metadata.model}`,
+        );
+      }
       store.dispatch(updateMessageContent({ sessionId, messageId, content, metadata }));
     });
     this.streamListenerCleanups.push(messageUpdateCleanup);


### PR DESCRIPTION
## Summary

- finalize active streaming assistant messages before abort cleanup
- preserve model metadata for manually stopped partial replies
- add regression coverage for stopped stream metadata
- forward renderer debug logs as debug in the main process

## Testing

- npm test -- openclawRuntimeAdapter
- npm run compile:electron
- npm run build
- npx eslint src/main/main.ts src/main/libs/agentEngine/openclawRuntimeAdapter.ts src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts src/renderer/services/cowork.ts