### PR TITLE
fix(cowork): search tasks from database

### DIFF
--- a/specs/bugfixes/cowork-search-scope/2026-06-16-cowork-search-scope-fix-design.md
+++ b/specs/bugfixes/cowork-search-scope/2026-06-16-cowork-search-scope-fix-design.md
@@ -1,0 +1,189 @@
+# Cowork 任务搜索范围受限修复 Spec
+
+## 问题描述
+
+用户在左侧导航点击“搜索任务”打开 Cowork 搜索弹窗后，输入关键词只能命中弹窗当前加载到的任务。若目标任务不在最近一批任务中，即使标题完全匹配，也不会出现在搜索结果里。
+
+### 现象
+
+- 搜索弹窗默认展示近期任务
+- 输入关键词后，只在弹窗已加载的任务中做过滤
+- 历史任务数量超过当前搜索加载上限时，较早任务无法被搜索到
+- 首页左侧“我的 Agent”历史任务列表展开后能看到更多任务，但搜索弹窗仍无法命中这些较早任务
+
+---
+
+## 根因分析
+
+搜索弹窗和首页历史任务列表不是复用同一份前端状态，但它们共用底层 Cowork 会话表与 `cowork:session:list` IPC。
+
+| 入口 | 前端状态 | 数据请求 | 搜索/分页行为 |
+|------|----------|----------|---------------|
+| 搜索弹窗 | `CoworkSearchModal.searchSessions` | `coworkService.listSessionsForSearch(100, 0)` | 拉取最近 100 条后在前端过滤 |
+| 首页历史任务列表 | `useAgentSidebarState.taskPreviewsByAgentId` | `coworkService.listSessionsForAgentPreview(agentId, limit, offset)` | 按 Agent 分页加载，展开时继续拉取 |
+| Redux Cowork 会话列表 | `cowork.sessions` | `coworkService.loadSessions(agentId?)` | 当前 Agent 的首屏分页数据 |
+
+当前搜索弹窗存在两个限制：
+
+1. `SEARCH_SESSION_LIMIT = 100`，打开弹窗只请求 `limit=100, offset=0`
+2. 关键词过滤发生在渲染器侧，只过滤 `searchSessions`，没有将搜索词传到 SQLite 查询层
+
+因此搜索实际范围是“最近 100 条任务”，不是全量历史任务。
+
+### 关键路径
+
+1. `CoworkSearchModal` 打开时调用 `listSessionsForSearch(SEARCH_SESSION_LIMIT, 0)`
+2. `coworkService.listSessionsForSearch` 直接调用 `window.electron.cowork.listSessions({ limit, offset })`
+3. 主进程 `cowork:session:list` 调用 `store.listSessions(limit, offset, agentId)`
+4. `CoworkStore.listSessions` 执行 `ORDER BY ... LIMIT ? OFFSET ?`，没有搜索条件
+5. 弹窗输入框变化后，`filteredSessions` 在前端对这批结果做 `title.includes(query)` 与 `agentName.includes(query)`
+
+---
+
+## 解决方案
+
+### 修复 1：为列表 IPC 增加可选搜索参数
+
+扩展 `cowork:session:list` 的 options，新增可选字段：
+
+```typescript
+{
+  limit?: number;
+  offset?: number;
+  agentId?: string;
+  searchQuery?: string;
+}
+```
+
+兼容原则：
+
+- `searchQuery` 为空或只包含空白字符时，保持现有 `listSessions/countSessions` 行为不变
+- 只有搜索弹窗传入非空 `searchQuery` 时，才走数据库搜索分支
+- 不改变默认排序、分页语义、返回结构和 `hasMore` 计算方式
+
+### 修复 2：在 CoworkStore 增加数据库侧搜索方法
+
+新增专用方法，避免改变现有 `listSessions` 的默认行为：
+
+```typescript
+searchSessions(options: {
+  query: string;
+  limit?: number;
+  offset?: number;
+  agentId?: string;
+}): CoworkSessionSummary[]
+
+countSearchSessions(options: {
+  query: string;
+  agentId?: string;
+}): number
+```
+
+搜索范围：
+
+- 首期只搜索任务标题 `cowork_sessions.title`
+- 可选按 `agentId` 限定，用于后续复用到 Agent 内搜索时保持一致
+- 匹配使用 SQLite `LIKE`，并对 `%`、`_`、`\` 做转义，避免用户输入通配符导致结果范围异常
+
+排序规则：
+
+- 与现有列表保持一致：
+  - pinned 任务优先
+  - pinned 按 `pin_order/updated_at/created_at` 升序
+  - 非 pinned 按 `updated_at` 降序
+  - 最后按 `updated_at` 降序兜底
+
+### 修复 3：搜索弹窗改为查询数据库，而不是只过滤已加载结果
+
+搜索弹窗行为调整：
+
+- 无关键词时：继续展示近期任务，使用现有 `listSessionsForSearch(limit, offset)`
+- 有关键词时：调用 `listSessionsForSearch(limit, offset, searchQuery)`，由主进程返回数据库搜索结果
+- 输入变化加短 debounce，避免每次按键立即 IPC 请求
+- 请求使用递增 request id 或 cancelled 标记，避免较慢的旧请求覆盖新结果
+- 保留本地 agent 名称过滤作为补充，但不作为唯一搜索范围
+
+建议首期限制：
+
+- 每次搜索返回 `SEARCH_SESSION_LIMIT` 条
+- 不在本次修复中新增“加载更多搜索结果”交互，避免扩大 UI 改动面
+- `hasMore=true` 时可后续增加滚动加载，本次只保证搜索范围从“已加载 100 条”提升为“数据库全量匹配的前 100 条”
+
+---
+
+## 影响控制
+
+### 不应改变的行为
+
+| 场景 | 保持方式 |
+|------|----------|
+| 首页左侧历史任务首屏 | 不传 `searchQuery`，继续走原 `listSessions` |
+| 首页“展开显示”分页 | 不传 `searchQuery`，继续按 Agent 分页加载 |
+| 快捷键打开第 N 个任务 | 不传 `searchQuery`，保持当前排序和分页 |
+| Cowork Redux 会话列表 | `loadSessions(agentId?)` 不传搜索词，行为不变 |
+| 删除、置顶、重命名后的列表更新 | 不修改现有 reducer 和列表合并逻辑 |
+
+### 需要避免的风险
+
+1. 不要直接把 `listSessions` 改成默认搜索逻辑，否则可能影响所有历史任务列表入口
+2. 不要改变 `cowork:session:list` 的默认返回排序，否则快捷键任务槽位和首页列表顺序会变化
+3. 不要将搜索结果写入 Redux `cowork.sessions`，否则会污染首页历史任务状态
+4. 不要用前端一次性拉全量任务再过滤，历史数据较多时会放大 IPC 和渲染开销
+
+---
+
+## 涉及文件
+
+| 文件 | 变更 |
+|------|------|
+| `src/main/coworkStore.ts` | 新增 `searchSessions` / `countSearchSessions`，复用现有 summary row 映射与排序规则 |
+| `src/main/main.ts` | 扩展 `cowork:session:list` options；当 `searchQuery` 非空时调用搜索方法 |
+| `src/main/preload.ts` | 扩展 `listSessions` options 类型，新增 `searchQuery?: string` |
+| `src/renderer/types/electron.d.ts` | 同步扩展 `window.electron.cowork.listSessions` 类型 |
+| `src/renderer/services/cowork.ts` | 扩展 `listSessionsForSearch` 参数，搜索弹窗专用，不写 Redux |
+| `src/renderer/components/cowork/CoworkSearchModal.tsx` | 输入关键词时请求数据库搜索结果；无关键词时保留近期任务展示 |
+| `src/main/coworkStore.test.ts` | 增加搜索范围、转义、agentId 限定、排序与计数测试 |
+
+---
+
+## 验证方法
+
+### 功能验证
+
+1. 准备超过 100 条 Cowork 任务，其中第 101 条之后包含唯一标题，例如 `深层历史任务搜索验证`
+2. 打开“搜索任务”弹窗
+3. 输入 `深层历史任务搜索验证`
+4. 验证目标任务出现在搜索结果中
+5. 清空输入框，验证弹窗恢复展示近期任务
+6. 点击搜索结果，验证能正常切换到对应会话
+
+### 回归验证
+
+| 场景 | 预期 |
+|------|------|
+| 首页左侧 Main Agent 任务列表 | 首屏仍显示 6 条，顺序不变 |
+| 点击“展开显示” | 能继续分页加载更多任务 |
+| 置顶任务 | 首页与搜索弹窗默认近期列表中仍优先显示 |
+| 搜索不存在的标题 | 显示“未找到匹配任务” |
+| 搜索包含 `%`、`_`、`\` 的标题 | 按普通字符匹配，不扩大结果 |
+| 快捷键打开当前 Agent 第 1-9 个任务 | 仍按首页列表顺序打开 |
+| 删除或重命名任务后再搜索 | 搜索结果反映最新 SQLite 数据 |
+
+### 自动化验证
+
+- 运行 `npm run lint`
+- 运行 `npm test -- coworkStore`
+- 若后续新增渲染器测试，覆盖：
+  - 输入非空搜索词会调用带 `searchQuery` 的 `listSessions`
+  - 清空搜索词会回到近期任务请求
+  - 旧请求不会覆盖新请求结果
+
+---
+
+## 已知边界
+
+1. 首期只搜索任务标题，不搜索消息正文、工作目录、Agent 名称或 tool 输出内容。
+2. 搜索弹窗仍只展示前 `SEARCH_SESSION_LIMIT` 条匹配结果；若匹配结果超过上限，本次不新增滚动加载交互。
+3. Agent 名称匹配如果继续保留在前端，只能作用于当前返回结果；完整 Agent 名称数据库搜索需额外维护 agent 元数据索引，不纳入本次修复。
+4. SQLite `LIKE` 的大小写行为受 SQLite 默认规则影响；中英文标题的包含匹配满足当前需求，不引入 FTS 索引。
+5. 本次修复不改变现有首页历史任务列表的数据加载策略，避免影响首屏性能与快捷键任务槽位。

--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -23,8 +23,8 @@ import BetterSqlite3 from 'better-sqlite3';
 import { CoworkSystemMessageKind } from '../common/coworkSystemMessages';
 import { AgentAvatarSvg, DefaultAgentAvatarIcon, encodeAgentAvatarIcon } from '../shared/agent/avatar';
 import { CoworkForkMode } from '../shared/cowork/constants';
-import { ContinuityCapsuleSource } from './libs/agentEngine/coworkContinuityCapsule';
 import { CoworkStore } from './coworkStore';
+import { ContinuityCapsuleSource } from './libs/agentEngine/coworkContinuityCapsule';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -148,12 +148,19 @@ function setupDb(): void {
 }
 
 /** Insert a session row directly. */
-function insertSession(id: string, agentId: string | null = 'main'): void {
-  const now = Date.now();
+function insertSession(
+  id: string,
+  agentId: string | null = 'main',
+  title = 'test',
+  updatedAt = Date.now(),
+  pinned = 0,
+  pinOrder: number | null = null,
+): void {
+  const now = updatedAt;
   db.prepare(
     `INSERT INTO cowork_sessions (id, title, claude_session_id, status, pinned, pin_order, cwd, system_prompt, execution_mode, active_skill_ids, agent_id, created_at, updated_at)
-     VALUES (?, 'test', NULL, 'idle', 0, NULL, '/tmp', '', 'local', '[]', ?, ?, ?)`,
-  ).run(id, agentId, now, now);
+     VALUES (?, ?, NULL, 'idle', ?, ?, '/tmp', '', 'local', '[]', ?, ?, ?)`,
+  ).run(id, title, pinned, pinOrder, agentId, now, now);
 }
 
 /** Insert a message row directly, bypassing CoworkStore.addMessage. */
@@ -205,6 +212,78 @@ test('getSession returns all messages when one has corrupt metadata', () => {
   // Null metadata → undefined
   const nullMsg = session!.messages.find((m) => m.id === 'msg-null')!;
   expect(nullMsg.metadata).toBeUndefined();
+});
+
+test('searchSessions finds matching titles beyond the recent page', () => {
+  for (let index = 0; index < 105; index += 1) {
+    insertSession(`recent-${index}`, 'main', `Recent filler ${index}`, 2000 + index);
+  }
+  insertSession('deep-match', 'main', 'Deep history search needle', 1000);
+
+  expect(store.listSessions(100, 0).some((session) => session.id === 'deep-match')).toBe(false);
+
+  const results = store.searchSessions({
+    query: 'history search needle',
+    limit: 10,
+    offset: 0,
+  });
+
+  expect(results.map((session) => session.id)).toEqual(['deep-match']);
+  expect(store.countSearchSessions({ query: 'history search needle' })).toBe(1);
+});
+
+test('searchSessions preserves pinned ordering and pagination', () => {
+  insertSession('unpinned-old', 'main', 'Shared searchable task', 1000);
+  insertSession('unpinned-new', 'main', 'Shared searchable task', 3000);
+  insertSession('pinned-second', 'main', 'Shared searchable task', 2000, 1, 20);
+  insertSession('pinned-first', 'main', 'Shared searchable task', 1500, 1, 10);
+
+  const firstPage = store.searchSessions({
+    query: 'searchable',
+    limit: 3,
+    offset: 0,
+  });
+  const secondPage = store.searchSessions({
+    query: 'searchable',
+    limit: 3,
+    offset: 3,
+  });
+
+  expect(firstPage.map((session) => session.id)).toEqual([
+    'pinned-first',
+    'pinned-second',
+    'unpinned-new',
+  ]);
+  expect(secondPage.map((session) => session.id)).toEqual(['unpinned-old']);
+});
+
+test('searchSessions treats LIKE wildcard characters as literal input', () => {
+  insertSession('literal-wildcards', 'main', 'Report 100%_complete marker', 1000);
+  insertSession('expanded-match', 'main', 'Report 100AAcomplete marker', 2000);
+
+  const results = store.searchSessions({
+    query: '100%_complete',
+    limit: 10,
+    offset: 0,
+  });
+
+  expect(results.map((session) => session.id)).toEqual(['literal-wildcards']);
+  expect(store.countSearchSessions({ query: '100%_complete' })).toBe(1);
+});
+
+test('searchSessions can be limited to one agent', () => {
+  insertSession('main-task', 'main', 'Agent scoped search task', 1000);
+  insertSession('writer-task', 'writer', 'Agent scoped search task', 2000);
+
+  const results = store.searchSessions({
+    query: 'scoped search',
+    agentId: 'writer',
+    limit: 10,
+    offset: 0,
+  });
+
+  expect(results.map((session) => session.id)).toEqual(['writer-task']);
+  expect(store.countSearchSessions({ query: 'scoped search', agentId: 'writer' })).toBe(1);
 });
 
 test('continuity capsule upsert stores one rolling capsule per session', () => {

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -647,6 +647,27 @@ interface CoworkUserMemoryRow {
   last_used_at: number | null;
 }
 
+interface CoworkSessionSummaryRow {
+  id: string;
+  title: string;
+  status: string;
+  pinned: number | null;
+  pin_order: number | null;
+  agent_id: string | null;
+  parent_session_id?: string | null;
+  forked_at?: number | null;
+  fork_mode?: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface CoworkSessionSearchOptions {
+  query: string;
+  limit?: number;
+  offset?: number;
+  agentId?: string;
+}
+
 export class CoworkStore {
   private db: Database.Database;
 
@@ -676,6 +697,26 @@ export class CoworkStore {
 
   private getAll<T>(sql: string, params: (string | number | null)[] = []): T[] {
     return this.db.prepare(sql).all(...params) as T[];
+  }
+
+  private escapeLikePattern(value: string): string {
+    return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+  }
+
+  private mapSessionSummaryRow(row: CoworkSessionSummaryRow): CoworkSessionSummary {
+    return {
+      id: row.id,
+      title: row.title,
+      status: row.status as CoworkSessionStatus,
+      pinned: Boolean(row.pinned),
+      pinOrder: row.pin_order ?? null,
+      agentId: row.agent_id || 'main',
+      parentSessionId: row.parent_session_id ?? null,
+      forkedAt: row.forked_at ?? null,
+      forkMode: (row.fork_mode as CoworkForkModeType | undefined) ?? CoworkForkMode.None,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
   }
 
   private upsertConfig(key: string, value: string, now: number): void {
@@ -1335,23 +1376,9 @@ export class CoworkStore {
   }
 
   listSessions(limit = COWORK_SESSION_PAGE_SIZE, offset = 0, agentId?: string): CoworkSessionSummary[] {
-    interface SessionSummaryRow {
-      id: string;
-      title: string;
-      status: string;
-      pinned: number | null;
-      pin_order: number | null;
-      agent_id: string | null;
-      parent_session_id?: string | null;
-      forked_at?: number | null;
-      fork_mode?: string | null;
-      created_at: number;
-      updated_at: number;
-    }
-
-    let rows: SessionSummaryRow[];
+    let rows: CoworkSessionSummaryRow[];
     if (agentId) {
-      rows = this.getAll<SessionSummaryRow>(
+      rows = this.getAll<CoworkSessionSummaryRow>(
         `
         SELECT id, title, status, pinned, pin_order, agent_id,
                parent_session_id, forked_at, fork_mode,
@@ -1367,7 +1394,7 @@ export class CoworkStore {
         [agentId, limit, offset],
       );
     } else {
-      rows = this.getAll<SessionSummaryRow>(
+      rows = this.getAll<CoworkSessionSummaryRow>(
         `
         SELECT id, title, status, pinned, pin_order, agent_id,
                parent_session_id, forked_at, fork_mode,
@@ -1383,19 +1410,84 @@ export class CoworkStore {
       );
     }
 
-    return rows.map(row => ({
-      id: row.id,
-      title: row.title,
-      status: row.status as CoworkSessionStatus,
-      pinned: Boolean(row.pinned),
-      pinOrder: row.pin_order ?? null,
-      agentId: row.agent_id || 'main',
-      parentSessionId: row.parent_session_id ?? null,
-      forkedAt: row.forked_at ?? null,
-      forkMode: (row.fork_mode as CoworkForkModeType | undefined) ?? CoworkForkMode.None,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-    }));
+    return rows.map(row => this.mapSessionSummaryRow(row));
+  }
+
+  countSearchSessions(options: CoworkSessionSearchOptions): number {
+    const query = options.query.trim();
+    if (!query) return this.countSessions(options.agentId);
+
+    const pattern = `%${this.escapeLikePattern(query)}%`;
+    if (options.agentId) {
+      const row = this.db
+        .prepare(
+          `
+          SELECT COUNT(*) as count
+          FROM cowork_sessions
+          WHERE title LIKE ? ESCAPE '\\'
+            AND COALESCE(NULLIF(TRIM(agent_id), ''), 'main') = ?
+        `,
+        )
+        .get(pattern, options.agentId) as { count: number } | undefined;
+      return row?.count || 0;
+    }
+
+    const row = this.db
+      .prepare(
+        `
+        SELECT COUNT(*) as count
+        FROM cowork_sessions
+        WHERE title LIKE ? ESCAPE '\\'
+      `,
+      )
+      .get(pattern) as { count: number } | undefined;
+    return row?.count || 0;
+  }
+
+  searchSessions(options: CoworkSessionSearchOptions): CoworkSessionSummary[] {
+    const query = options.query.trim();
+    const limit = options.limit ?? COWORK_SESSION_PAGE_SIZE;
+    const offset = options.offset ?? 0;
+    if (!query) return this.listSessions(limit, offset, options.agentId);
+
+    const pattern = `%${this.escapeLikePattern(query)}%`;
+    let rows: CoworkSessionSummaryRow[];
+    if (options.agentId) {
+      rows = this.getAll<CoworkSessionSummaryRow>(
+        `
+        SELECT id, title, status, pinned, pin_order, agent_id,
+               parent_session_id, forked_at, fork_mode,
+               created_at, updated_at
+        FROM cowork_sessions
+        WHERE title LIKE ? ESCAPE '\\'
+          AND COALESCE(NULLIF(TRIM(agent_id), ''), 'main') = ?
+        ORDER BY pinned DESC,
+          CASE WHEN pinned = 1 THEN COALESCE(pin_order, updated_at, created_at) END ASC,
+          CASE WHEN pinned = 0 THEN updated_at END DESC,
+          updated_at DESC
+        LIMIT ? OFFSET ?
+      `,
+        [pattern, options.agentId, limit, offset],
+      );
+    } else {
+      rows = this.getAll<CoworkSessionSummaryRow>(
+        `
+        SELECT id, title, status, pinned, pin_order, agent_id,
+               parent_session_id, forked_at, fork_mode,
+               created_at, updated_at
+        FROM cowork_sessions
+        WHERE title LIKE ? ESCAPE '\\'
+        ORDER BY pinned DESC,
+          CASE WHEN pinned = 1 THEN COALESCE(pin_order, updated_at, created_at) END ASC,
+          CASE WHEN pinned = 0 THEN updated_at END DESC,
+          updated_at DESC
+        LIMIT ? OFFSET ?
+      `,
+        [pattern, limit, offset],
+      );
+    }
+
+    return rows.map(row => this.mapSessionSummaryRow(row));
   }
 
   resetRunningSessions(): number {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6231,16 +6231,28 @@ if (!gotTheLock) {
 
   ipcMain.handle(
     'cowork:session:list',
-    async (_event, options?: { limit?: number; offset?: number; agentId?: string }) => {
+    async (_event, options?: { limit?: number; offset?: number; agentId?: string; searchQuery?: string }) => {
       try {
         const limit = options?.limit ?? COWORK_SESSION_PAGE_SIZE;
         const offset = options?.offset ?? 0;
         const agentId = options?.agentId;
+        const searchQuery = options?.searchQuery?.trim() ?? '';
         const store = getCoworkStore();
-        const sessions = store.listSessions(limit, offset, agentId);
-        const total = store.countSessions(agentId);
+        const startedAt = searchQuery ? Date.now() : 0;
+        const sessions = searchQuery
+          ? store.searchSessions({ query: searchQuery, limit, offset, agentId })
+          : store.listSessions(limit, offset, agentId);
+        const total = searchQuery
+          ? store.countSearchSessions({ query: searchQuery, agentId })
+          : store.countSessions(agentId);
+        if (searchQuery) {
+          console.debug(
+            `[CoworkIPC] searched sessions; query length ${searchQuery.length}, returned ${sessions.length} of ${total} from offset ${offset} in ${Date.now() - startedAt}ms.`,
+          );
+        }
         return { success: true, sessions, hasMore: offset + sessions.length < total };
       } catch (error) {
+        console.error('[CoworkIPC] failed to list sessions:', error);
         return {
           success: false,
           error: error instanceof Error ? error.message : 'Failed to list sessions',

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -370,7 +370,7 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.invoke(CoworkIpcChannel.OpenSessionFromNotificationReady),
     remoteManaged: (sessionId: string) =>
       ipcRenderer.invoke('cowork:session:remoteManaged', sessionId),
-    listSessions: (options?: { limit?: number; offset?: number; agentId?: string }) =>
+    listSessions: (options?: { limit?: number; offset?: number; agentId?: string; searchQuery?: string }) =>
       ipcRenderer.invoke('cowork:session:list', options),
     getSessionMessages: (options: { sessionId: string; limit?: number; offset?: number }) =>
       ipcRenderer.invoke('cowork:session:getMessages', options),

--- a/src/renderer/components/cowork/CoworkSearchModal.tsx
+++ b/src/renderer/components/cowork/CoworkSearchModal.tsx
@@ -11,9 +11,24 @@ import { getAgentDisplayNameById } from '../../utils/agentDisplay';
 import Modal from '../common/Modal';
 
 const SEARCH_SESSION_LIMIT = 100;
+const SEARCH_DEBOUNCE_MS = 180;
 
 const getSessionAgentId = (session: CoworkSessionSummary) => {
   return session.agentId?.trim() || AgentId.Main;
+};
+
+const mergeUniqueSessions = (
+  primary: CoworkSessionSummary[],
+  secondary: CoworkSessionSummary[],
+): CoworkSessionSummary[] => {
+  const seen = new Set<string>();
+  const result: CoworkSessionSummary[] = [];
+  [...primary, ...secondary].forEach((session) => {
+    if (seen.has(session.id)) return;
+    seen.add(session.id);
+    result.push(session);
+  });
+  return result;
 };
 
 interface CoworkSearchModalProps {
@@ -33,28 +48,38 @@ const CoworkSearchModal: React.FC<CoworkSearchModalProps> = ({
 }) => {
   const agents = useSelector((state: RootState) => state.agent.agents);
   const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+  const [searchResultQuery, setSearchResultQuery] = useState('');
   const [searchSessions, setSearchSessions] = useState<CoworkSessionSummary[]>(sessions);
+  const [recentSessions, setRecentSessions] = useState<CoworkSessionSummary[]>(sessions);
   const [isLoading, setIsLoading] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const requestIdRef = useRef(0);
+
+  const displayedSessions = useMemo(() => {
+    const trimmedQuery = searchQuery.trim().toLowerCase();
+    if (!trimmedQuery) return recentSessions;
+    const resultQuery = searchResultQuery.trim().toLowerCase();
+    const titleMatches = resultQuery === trimmedQuery ? searchSessions : [];
+
+    const recentMatches = recentSessions.filter((session) => {
+      const agentId = getSessionAgentId(session);
+      const agentName = getAgentDisplayNameById(agentId, agents) ?? agentId;
+      return session.title.toLowerCase().includes(trimmedQuery)
+        || agentName.toLowerCase().includes(trimmedQuery);
+    });
+
+    return mergeUniqueSessions(titleMatches, recentMatches);
+  }, [agents, recentSessions, searchQuery, searchResultQuery, searchSessions]);
 
   const agentNameBySessionId = useMemo(() => {
     const names = new Map<string, string>();
-    searchSessions.forEach((session) => {
+    displayedSessions.forEach((session) => {
       const agentId = getSessionAgentId(session);
       names.set(session.id, getAgentDisplayNameById(agentId, agents) ?? agentId);
     });
     return names;
-  }, [agents, searchSessions]);
-
-  const filteredSessions = useMemo(() => {
-    const trimmedQuery = searchQuery.trim().toLowerCase();
-    if (!trimmedQuery) return searchSessions;
-    return searchSessions.filter((session) => {
-      const agentName = agentNameBySessionId.get(session.id) ?? '';
-      return session.title.toLowerCase().includes(trimmedQuery)
-        || agentName.toLowerCase().includes(trimmedQuery);
-    });
-  }, [agentNameBySessionId, searchQuery, searchSessions]);
+  }, [agents, displayedSessions]);
 
   useEffect(() => {
     if (isOpen) {
@@ -65,32 +90,53 @@ const CoworkSearchModal: React.FC<CoworkSearchModalProps> = ({
       return;
     }
     setSearchQuery('');
+    setDebouncedSearchQuery('');
+    setSearchResultQuery('');
   }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) {
       setSearchSessions(sessions);
+      setRecentSessions(sessions);
+      setSearchResultQuery('');
     }
   }, [isOpen, sessions]);
 
   useEffect(() => {
     if (!isOpen) return;
-    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery.trim());
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [isOpen, searchQuery]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    const query = debouncedSearchQuery.trim();
     setIsLoading(true);
-    void coworkService.listSessionsForSearch(SEARCH_SESSION_LIMIT, 0)
+    void coworkService.listSessionsForSearch(SEARCH_SESSION_LIMIT, 0, query)
       .then((result) => {
-        if (cancelled || !result.success || !result.sessions) return;
+        if (requestId !== requestIdRef.current) return;
+        if (!result.success || !result.sessions) {
+          console.warn('[CoworkSearch] failed to load task search results:', result.error);
+          setSearchSessions([]);
+          setSearchResultQuery(query);
+          return;
+        }
         setSearchSessions(result.sessions);
+        setSearchResultQuery(query);
+        if (!query) {
+          setRecentSessions(result.sessions);
+        }
       })
       .finally(() => {
-        if (!cancelled) {
+        if (requestId === requestIdRef.current) {
           setIsLoading(false);
         }
       });
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen]);
+  }, [debouncedSearchQuery, isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -150,12 +196,12 @@ const CoworkSearchModal: React.FC<CoworkSearchModalProps> = ({
             {i18nService.t('searchRecentTasks')}
           </div>
           <div className="max-h-[320px] overflow-y-auto">
-            {filteredSessions.length === 0 ? (
+            {displayedSessions.length === 0 ? (
               <div className="py-10 text-center text-sm text-secondary">
                 {isLoading ? i18nService.t('loading') : i18nService.t('searchNoResults')}
               </div>
             ) : (
-              filteredSessions.map((session) => {
+              displayedSessions.map((session) => {
                 const agentName = agentNameBySessionId.get(session.id) ?? getSessionAgentId(session);
                 const isSelected = session.id === currentSessionId;
                 const isRunning = session.status === CoworkSessionStatusValue.Running;

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -620,9 +620,41 @@ class CoworkService {
     return result ?? { success: false, error: 'Cowork IPC is unavailable' };
   }
 
-  async listSessionsForSearch(limit: number, offset: number): Promise<CoworkSessionListResult> {
-    const result = await window.electron?.cowork?.listSessions({ limit, offset });
-    return result ?? { success: false, error: 'Cowork IPC is unavailable' };
+  async listSessionsForSearch(
+    limit: number,
+    offset: number,
+    searchQuery?: string,
+  ): Promise<CoworkSessionListResult> {
+    const trimmedQuery = searchQuery?.trim();
+    const startedAt = performance.now();
+    console.debug('[CoworkSearch] requesting task sessions for the search modal', {
+      hasQuery: !!trimmedQuery,
+      queryLength: trimmedQuery?.length ?? 0,
+      limit,
+      offset,
+    });
+
+    try {
+      const result = await window.electron?.cowork?.listSessions({
+        limit,
+        offset,
+        ...(trimmedQuery ? { searchQuery: trimmedQuery } : {}),
+      });
+      const resolved = result ?? { success: false, error: 'Cowork IPC is unavailable' };
+      console.debug('[CoworkSearch] task session request finished', {
+        success: resolved.success,
+        resultCount: resolved.sessions?.length ?? 0,
+        hasMore: resolved.hasMore ?? false,
+        durationMs: Math.round(performance.now() - startedAt),
+      });
+      return resolved;
+    } catch (error) {
+      console.warn('[CoworkSearch] task session request failed:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to search sessions',
+      };
+    }
   }
 
   async loadMoreSessions(): Promise<boolean> {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -663,7 +663,7 @@ interface IElectronAPI {
     remoteManaged: (
       sessionId: string,
     ) => Promise<{ success: boolean; remoteManaged: boolean; error?: string }>;
-    listSessions: (options?: { limit?: number; offset?: number; agentId?: string }) => Promise<{
+    listSessions: (options?: { limit?: number; offset?: number; agentId?: string; searchQuery?: string }) => Promise<{
       success: boolean;
       sessions?: CoworkSessionSummary[];
       hasMore?: boolean;


### PR DESCRIPTION
Search Cowork task titles through the backing SQLite store instead of filtering only the search modal's preloaded recent sessions.

Keep existing session list behavior unchanged when no search query is provided, preserving the home sidebar, agent previews, pagination, and shortcut task slots.

Add focused store tests for deep-history matches, pinned ordering, LIKE wildcard escaping, and agent-scoped search.