### PR TITLE
fix(cowork): reduce rail navigation jank in long sessions

### DIFF
--- a/specs/bugfixes/cowork-rail-navigation-jank/2026-06-16-cowork-rail-navigation-jank-fix-design.md
+++ b/specs/bugfixes/cowork-rail-navigation-jank/2026-06-16-cowork-rail-navigation-jank-fix-design.md
@@ -1,0 +1,137 @@
+# Cowork 右侧轨道长距离跳转卡顿修复 Spec
+
+## 问题描述
+
+用户反馈 LobsterAI 在超长 Cowork 对话中，从底部点击右侧轨道标题/刻度跳转到顶部时会出现卡顿。当前 macOS 环境未能稳定复现，但代码路径存在明确性能风险，Windows 或低性能设备更容易放大该问题。
+
+### 现象
+
+- 对话总内容很长时，从底部点击右侧轨道顶部项会短时间卡顿
+- macOS 高性能设备可能无感
+- 消息数量少但单条消息体很长时仍可能触发
+
+---
+
+## 根因分析
+
+右侧轨道点击调用 `scrollIntoView({ behavior: 'smooth' })` 做长距离平滑滚动。超长对话中，这会在滚动途中持续触发：
+
+1. `onScroll` 中的轨道索引计算和滚动状态更新
+2. `LazyRenderTurn` 的 `IntersectionObserver` 可见性切换
+3. 长消息进入视口后的 Markdown 渲染和 `ResizeObserver` 高度缓存更新
+4. 未渲染目标消息从 placeholder 切换为真实内容时的布局重排
+
+因此该问题不是单纯的滚动慢，而是长距离 smooth scroll 与懒渲染/长 Markdown 内容共同造成的主线程压力。
+
+### 关键路径
+
+| 文件 | 风险点 |
+|------|--------|
+| `src/renderer/components/cowork/CoworkSessionDetail.tsx` | `navigateToRailItem()` 使用长距离 `smooth` 跳转 |
+| `src/renderer/components/cowork/LazyRenderTurn.tsx` | 滚动途中逐段触发真实内容渲染和高度缓存 |
+| `src/renderer/components/MarkdownContent.tsx` | 长内容进入可见区域后触发 Markdown/代码块渲染 |
+
+---
+
+## 解决方案
+
+本次修复只优化右侧轨道点击跳转路径，不改变消息加载、普通滚动、自动滚动到底部、懒渲染策略和 Markdown 渲染逻辑。
+
+### 修复 1：轨道长距离跳转禁用 smooth
+
+在 `navigateToRailItem()` 中根据目标距离选择滚动行为：
+
+- 距离较近：保留 `smooth`，维持日常点击手感
+- 距离超过若干屏：使用 `auto`，避免沿途逐段唤醒懒渲染内容
+- 用户开启 `prefers-reduced-motion` 时始终使用 `auto`
+
+示意：
+
+```typescript
+const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+const distance = Math.abs(targetElement.offsetTop - container.scrollTop);
+const isLongJump = distance > container.clientHeight * 2.5;
+const behavior = prefersReducedMotion || isLongJump
+  ? 'auto'
+  : 'smooth';
+
+targetElement.scrollIntoView({ behavior, block: 'start' });
+```
+
+选择像素距离而不是 turn 数量作为判断依据，是因为该问题可由“少量但超长消息体”触发；实际滚动距离比消息条数更接近性能压力来源。
+
+### 修复 2：缓存轨道 items 计算
+
+将轨道 items 的构建从 render 内联 IIFE 提取为 `useMemo`：
+
+- 避免每次 hover/current index 更新都重新扫描全部 turns
+- 避免对超长 assistant 内容反复执行 markdown strip 正则
+- memo 依赖 `turns`，确保新消息、流式内容更新、历史消息加载后及时重算
+- `railItemCountRef` 与 `turnToRailRangeRef` 通过 `useEffect` 从 memo 结果同步，避免 render 阶段写 ref 副作用
+
+示意：
+
+```typescript
+const railItems = useMemo(() => buildRailItems(turns), [turns]);
+
+useEffect(() => {
+  railItemCountRef.current = railItems.length;
+  turnToRailRangeRef.current = buildTurnToRailRange(railItems);
+}, [railItems]);
+```
+
+`hoveredRailIndex`、`currentRailIndex`、tooltip 状态只影响显示高亮和浮层，不参与 `railItems` 计算依赖，避免 UI 交互导致长内容重复解析。
+
+### 不变更范围
+
+- 不修改 `LazyRenderTurn` 的可见性判断、`rootMargin` 和高度缓存策略
+- 不修改 `handleMessagesScroll()` 的历史消息加载和轨道当前项计算
+- 不修改流式输出时的自动滚动到底部逻辑
+- 不修改 `handleScrollToBottom()` 按钮行为
+- 不修改 Markdown 大内容预览和代码块渲染策略
+
+### 诊断日志
+
+仅在轨道导航发生长距离 instant scroll、遵循 reduced-motion 使用 instant scroll，或目标 turn 异常缺失时写 renderer debug 日志。短距离正常点击不写日志，避免高频交互污染日志。
+
+---
+
+## 涉及文件
+
+| 文件 | 变更 |
+|------|------|
+| `src/renderer/components/cowork/CoworkSessionDetail.tsx` | 优化 `navigateToRailItem()` 滚动行为；抽取并缓存轨道 items 构建逻辑 |
+
+---
+
+## 验证方法
+
+### 功能验证
+
+1. 准备包含多轮长消息的 Cowork 会话
+2. 滚动到底部，点击右侧轨道最顶部条目
+3. 验证页面能快速跳到目标消息，且无明显长时间卡顿
+4. 点击相邻轨道条目，验证短距离跳转仍保持平滑体验
+5. 验证滚动到底部按钮、自动滚动、加载历史消息不受影响
+
+### 回归验证
+
+| 场景 | 预期 |
+|------|------|
+| 短对话点击轨道 | 行为无明显变化 |
+| 相邻轨道项跳转 | 继续使用平滑滚动 |
+| 超长对话底部跳顶部 | 避免长时间 smooth scroll 卡顿 |
+| 顶部跳底部 | 能正常跳转并更新当前轨道高亮 |
+| 流式输出中轨道 items | 新增内容后轨道数量、长度和 tooltip 及时更新 |
+| 加载更早历史消息后轨道 items | 轨道项和 turn 映射及时更新 |
+| Windows 环境 | 长距离跳转主线程压力降低 |
+| macOS 环境 | 日常短距离轨道点击手感保留 |
+
+---
+
+## 已知边界
+
+1. 该方案不改变消息渲染模型，只规避长距离 smooth scroll 的性能放大路径。
+2. 如果单条目标消息本身极长，首次渲染该消息仍可能产生短暂开销，但不再叠加沿途所有消息的渲染成本。
+3. 当前问题在 macOS 上可能无法复现，验证重点应覆盖 Windows 或低性能设备。
+4. 如果上游状态管理原地 mutation `messages` 而不产生新引用，`turns` 与 `railItems` 的 memo 都可能无法重算；这不应在当前 Redux 数据流中发生，若发现需优先修正状态更新方式。

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -64,6 +64,7 @@ import LazyRenderTurn, { clearHeightCache } from './LazyRenderTurn';
 import {
   buildConversationTurns,
   buildDisplayItems,
+  type ConversationTurn,
   COWORK_DETAIL_CONTENT_CLASS,
   COWORK_DETAIL_GUTTER_CLASS,
   hasRenderableAssistantContent,
@@ -101,6 +102,24 @@ const SELECTED_TEXT_ACTION_SUPPRESS_MS = 250;
 const EXPANDED_CONVERSATION_PREVIEW_COLLAPSED_MAX_LENGTH = 140;
 const EXPANDED_CONVERSATION_PREVIEW_ITEM_MAX_LENGTH = 520;
 const EXPANDED_CONVERSATION_PREVIEW_ITEM_LIMIT = 8;
+const RAIL_LONG_JUMP_VIEWPORT_MULTIPLIER = 2.5;
+const RAIL_LINE_MIN_WIDTH = 6;
+const RAIL_LINE_MAX_WIDTH = 16;
+
+type RailItem = {
+  key: string;
+  turnIndex: number;
+  label: string;
+  contentLen: number;
+  isUser: boolean;
+};
+
+type RailNavigationDecision = {
+  behavior: ScrollBehavior;
+  distance: number;
+  threshold: number;
+  reason: 'long_distance' | 'nearby' | 'reduced_motion';
+};
 
 type ExpandedConversationPreviewItem = {
   id: string;
@@ -112,6 +131,108 @@ type ExpandedConversationPreviewItem = {
 type ExpandedConversationPreview = {
   latest: ExpandedConversationPreviewItem;
   items: ExpandedConversationPreviewItem[];
+};
+
+const stripRailLabelMarkdown = (value: string): string => value
+  .replace(/^#+\s+/gm, '')
+  .replace(/```[\s\S]*?```/g, ' ')
+  .replace(/`[^`]*`/g, ' ')
+  .replace(/[*_~>]/g, '')
+  .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+const getRailLabel = (content: string, fallback: string): string => {
+  const stripped = stripRailLabelMarkdown(content);
+  return stripped.slice(0, 50) || fallback;
+};
+
+const buildRailItems = (turns: ConversationTurn[]): RailItem[] => {
+  const items: RailItem[] = [];
+
+  for (let index = 0; index < turns.length; index += 1) {
+    const turn = turns[index];
+    if (turn.userMessage) {
+      const content = turn.userMessage.content ?? '';
+      items.push({
+        key: `${turn.id}-user`,
+        turnIndex: index,
+        label: getRailLabel(content, `Turn ${index + 1}`),
+        contentLen: content.length,
+        isUser: true,
+      });
+    }
+
+    let assistantContent = '';
+    for (const item of turn.assistantItems) {
+      if (item.type === 'assistant' && item.message?.content) {
+        assistantContent += item.message.content;
+      }
+    }
+
+    if (assistantContent) {
+      items.push({
+        key: `${turn.id}-asst`,
+        turnIndex: index,
+        label: getRailLabel(assistantContent, 'LobsterAI'),
+        contentLen: assistantContent.length,
+        isUser: false,
+      });
+    }
+  }
+
+  return items;
+};
+
+const buildTurnToRailRange = (railItems: RailItem[]): { first: number; last: number }[] => {
+  const rangeMap: { first: number; last: number }[] = [];
+  for (let index = 0; index < railItems.length; index += 1) {
+    const turnIndex = railItems[index].turnIndex;
+    if (!rangeMap[turnIndex]) {
+      rangeMap[turnIndex] = { first: index, last: index };
+    } else {
+      rangeMap[turnIndex].last = index;
+    }
+  }
+  return rangeMap;
+};
+
+const prefersReducedMotion = (): boolean => (
+  typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+);
+
+const getRailNavigationDecision = (
+  container: HTMLDivElement,
+  targetElement: HTMLElement,
+): RailNavigationDecision => {
+  const containerRect = container.getBoundingClientRect();
+  const targetRect = targetElement.getBoundingClientRect();
+  const targetScrollTop = container.scrollTop + targetRect.top - containerRect.top;
+  const distance = Math.abs(targetScrollTop - container.scrollTop);
+  const threshold = Math.max(1, container.clientHeight) * RAIL_LONG_JUMP_VIEWPORT_MULTIPLIER;
+  if (prefersReducedMotion()) {
+    return {
+      behavior: 'auto',
+      distance,
+      threshold,
+      reason: 'reduced_motion',
+    };
+  }
+  if (distance > threshold) {
+    return {
+      behavior: 'auto',
+      distance,
+      threshold,
+      reason: 'long_distance',
+    };
+  }
+  return {
+    behavior: 'smooth',
+    distance,
+    threshold,
+    reason: 'nearby',
+  };
 };
 
 function normalizeExpandedConversationPreviewText(value: string): string {
@@ -224,6 +345,11 @@ const formatExportTimestamp = (value: Date): string => {
 const logDetailDiagnostic = (message: string): void => {
   console.log(`[CoworkSessionDetail] ${message}`);
   window.electron?.log?.fromRenderer?.('info', 'CoworkSessionDetail', message);
+};
+
+const logRailNavigationDiagnostic = (message: string): void => {
+  console.debug(`[CoworkSessionDetail] ${message}`);
+  window.electron?.log?.fromRenderer?.('debug', 'CoworkSessionDetail', message);
 };
 
 const getSelectionAnchorRect = (range: Range): DOMRect => {
@@ -2403,13 +2529,30 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     if (container) {
       const el = container.querySelector<HTMLElement>(`[data-rail-index="${railIndex}"]`);
       if (el) {
-        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        const decision = getRailNavigationDecision(container, el);
+        if (decision.behavior === 'auto') {
+          logRailNavigationDiagnostic(
+            `rail navigation used instant scroll for item ${railIndex}; reason=${decision.reason}; distance=${Math.round(decision.distance)}px; threshold=${Math.round(decision.threshold)}px.`,
+          );
+        }
+        el.scrollIntoView({ behavior: decision.behavior, block: 'start' });
       } else if (targetTurnIdx >= 0) {
         // Fallback: scroll to the turn element (always in DOM)
         const turnEls = turnElsCacheRef.current;
         if (targetTurnIdx < turnEls.length) {
-          turnEls[targetTurnIdx].scrollIntoView({ behavior: 'smooth', block: 'start' });
+          const targetEl = turnEls[targetTurnIdx];
+          const decision = getRailNavigationDecision(container, targetEl);
+          if (decision.behavior === 'auto') {
+            logRailNavigationDiagnostic(
+              `rail navigation used instant fallback scroll for item ${railIndex}; reason=${decision.reason}; distance=${Math.round(decision.distance)}px; threshold=${Math.round(decision.threshold)}px.`,
+            );
+          }
+          targetEl.scrollIntoView({ behavior: decision.behavior, block: 'start' });
+        } else {
+          logRailNavigationDiagnostic(`rail navigation skipped item ${railIndex} because target turn ${targetTurnIdx} is not mounted.`);
         }
+      } else {
+        logRailNavigationDiagnostic(`rail navigation skipped item ${railIndex} because no target turn was found.`);
       }
     }
 
@@ -2531,6 +2674,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const messages = currentSession?.messages;
   const displayItems = useMemo(() => messages ? buildDisplayItems(messages) : [], [messages]);
   const turns = useMemo(() => buildConversationTurns(displayItems), [displayItems]);
+  const railItems = useMemo(() => buildRailItems(turns), [turns]);
+  const railMaxContentLength = useMemo(
+    () => railItems.reduce((acc, item) => Math.max(acc, item.contentLen), 1),
+    [railItems],
+  );
 
   // Cache turn-level DOM elements (data-turn-index, always in DOM even for lazy turns)
   useEffect(() => {
@@ -2540,6 +2688,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       container.querySelectorAll<HTMLElement>('[data-turn-index]')
     );
   }, [turns]);
+
+  useLayoutEffect(() => {
+    railItemCountRef.current = railItems.length;
+    turnToRailRangeRef.current = buildTurnToRailRange(railItems);
+  }, [railItems]);
 
   // Sync rail index when turns change or rail first appears (isScrollable becomes true)
   useEffect(() => {
@@ -2632,6 +2785,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const shouldShowTurnNavigationRail = turns.length > 1 && isScrollable;
   const shouldShowScrollToBottom = isScrollable && !shouldAutoScroll;
   const expandedConversationPreview = getExpandedConversationPreview(currentSession.messages);
+  const resolvedRailIndex = currentRailIndex < 0 || currentRailIndex >= railItems.length
+    ? railItems.length - 1
+    : currentRailIndex;
 
   const renderConversationTurns = () => {
     let railCounter = 0;
@@ -3145,79 +3301,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               className="overflow-y-auto min-h-0 flex-1"
               style={{ scrollbarWidth: 'none' }}
             >
-            {(() => {
-              // Build flat list of messages with their content length and turn index
-              const MIN_W = 6;  // px
-              const MAX_W = 16; // px
-              // Strip common markdown syntax for tooltip display
-              const stripMd = (s: string) => s
-                .replace(/^#+\s+/gm, '')
-                .replace(/```[\s\S]*?```/g, ' ')
-                .replace(/`[^`]*`/g, ' ')
-                .replace(/[*_~>]/g, '')
-                .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-                .replace(/\s+/g, ' ')
-                .trim();
-              // Get first meaningful text snippet from content
-              const getLabel = (content: string, fallback: string) => {
-                const stripped = stripMd(content);
-                return stripped.slice(0, 50) || fallback;
-              };
-              type RailItem = { key: string; turnIndex: number; label: string; contentLen: number; isUser: boolean };
-              const items: RailItem[] = [];
-              for (let i = 0; i < turns.length; i++) {
-                const turn = turns[i];
-                if (turn.userMessage) {
-                  const content = turn.userMessage.content ?? '';
-                  items.push({
-                    key: `${turn.id}-user`,
-                    turnIndex: i,
-                    label: getLabel(content, `Turn ${i + 1}`),
-                    contentLen: content.length,
-                    isUser: true,
-                  });
-                }
-                // Aggregate all assistant content into one line per turn
-                let asstContent = '';
-                for (const item of turn.assistantItems) {
-                  if (item.type === 'assistant' && item.message?.content) {
-                    asstContent += item.message.content;
-                  }
-                }
-                if (asstContent) {
-                  items.push({
-                    key: `${turn.id}-asst`,
-                    turnIndex: i,
-                    label: getLabel(asstContent, 'LobsterAI'),
-                    contentLen: asstContent.length,
-                    isUser: false,
-                  });
-                }
-              }
-              const maxLen = items.reduce((acc, m) => Math.max(acc, m.contentLen), 1);
-              // Sync rail item count and turn-to-rail mapping
-              railItemCountRef.current = items.length;
-              const rangeMap: { first: number; last: number }[] = [];
-              for (let ri = 0; ri < items.length; ri++) {
-                const ti = items[ri].turnIndex;
-                if (!rangeMap[ti]) {
-                  rangeMap[ti] = { first: ri, last: ri };
-                } else {
-                  rangeMap[ti].last = ri;
-                }
-              }
-              turnToRailRangeRef.current = rangeMap;
-
-              // Clamp rail index to valid range
-              const resolvedRailIndex = currentRailIndex < 0 || currentRailIndex >= items.length
-                ? items.length - 1
-                : currentRailIndex;
-
-              return items.map((msg, idx) => {
+              {railItems.map((msg, idx) => {
                 const isActive = idx === resolvedRailIndex;
                 const isHovered = idx === hoveredRailIndex;
-                const ratio = msg.contentLen / maxLen;
-                const lineW = Math.round(MIN_W + ratio * (MAX_W - MIN_W));
+                const ratio = msg.contentLen / railMaxContentLength;
+                const lineW = Math.round(RAIL_LINE_MIN_WIDTH + ratio * (RAIL_LINE_MAX_WIDTH - RAIL_LINE_MIN_WIDTH));
                 return (
                   <button
                     key={msg.key}
@@ -3245,12 +3333,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                           ? 'bg-neutral-800 dark:bg-neutral-200'
                           : 'bg-neutral-300 dark:bg-neutral-600'
                       }`}
-                      style={{ width: isActive || isHovered ? MAX_W : lineW }}
+                      style={{ width: isActive || isHovered ? RAIL_LINE_MAX_WIDTH : lineW }}
                     />
                   </button>
                 );
-              });
-            })()}
+              })}
             </div>
 
             {/* Down Arrow */}


### PR DESCRIPTION
Avoid smooth scrolling for long-distance Cowork rail jumps and memoize rail items so hover and active-state updates do not repeatedly scan long messages.

Add targeted renderer debug logs for instant rail navigation and abnormal missing-target cases.
