### PR TITLE
fix(cowork): render user messages as plain text

### DIFF
--- a/src/renderer/components/MarkdownContent.test.ts
+++ b/src/renderer/components/MarkdownContent.test.ts
@@ -37,6 +37,19 @@ test('large markdown preview can be disabled for full document renderers', () =>
   expect(fullHtml).toContain('Full file');
 });
 
+test('compact spacing reduces list margins for user message rendering', () => {
+  const content = '内容包含：\n\n1. 项目介绍和解决方案\n2. 核心功能';
+  const defaultHtml = renderToStaticMarkup(React.createElement(MarkdownContent, { content }));
+  const compactHtml = renderToStaticMarkup(React.createElement(MarkdownContent, {
+    content,
+    spacing: 'compact',
+  }));
+
+  expect(defaultHtml).toContain('my-3');
+  expect(compactHtml).toContain('leading-[1.55]');
+  expect(compactHtml).toContain('my-1');
+});
+
 test('kit links are treated as safe internal links', () => {
   expect(safeUrlTransform('kit://design@lobsterai-kits')).toBe('kit://design@lobsterai-kits');
   expect(isInternalHref('kit://design@lobsterai-kits')).toBe(true);

--- a/src/renderer/components/MarkdownContent.tsx
+++ b/src/renderer/components/MarkdownContent.tsx
@@ -21,6 +21,7 @@ const LINK_CLASS_NAME = 'text-primary hover:text-primary-hover underline decorat
 const LARGE_MARKDOWN_RENDER_THRESHOLD = 8 * 1024;
 const LARGE_MARKDOWN_PREVIEW_HEAD_LENGTH = 4 * 1024;
 const LARGE_MARKDOWN_PREVIEW_TAIL_LENGTH = 8 * 1024;
+type MarkdownSpacing = 'normal' | 'compact';
 
 export const shouldUseLargeMarkdownPreview = (content: string): boolean =>
   content.length > LARGE_MARKDOWN_RENDER_THRESHOLD;
@@ -373,9 +374,10 @@ const createMarkdownComponents = (
   resolveLocalFilePath?: (href: string, text: string) => string | null,
   showRevealInFolderAction = false,
   onImageClick?: (image: { src: string; alt?: string | null }) => void,
+  spacing: MarkdownSpacing = 'normal',
 ) => ({
   p: ({ node: _node, className: _className, children, ...props }: any) => (
-    <p className="my-3 first:mt-0 last:mb-0 text-foreground/90" {...props}>
+    <p className={`${spacing === 'compact' ? 'my-1' : 'my-3'} first:mt-0 last:mb-0 text-foreground/90`} {...props}>
       {children}
     </p>
   ),
@@ -385,42 +387,42 @@ const createMarkdownComponents = (
     </strong>
   ),
   h1: ({ node: _node, className: _className, children, ...props }: any) => (
-    <h1 className="text-xl font-semibold leading-snug mt-6 mb-3 first:mt-0 text-foreground" {...props}>
+    <h1 className={`${spacing === 'compact' ? 'mt-3 mb-1.5' : 'mt-6 mb-3'} text-xl font-semibold leading-snug first:mt-0 text-foreground`} {...props}>
       {children}
     </h1>
   ),
   h2: ({ node: _node, className: _className, children, ...props }: any) => (
-    <h2 className="text-[17px] font-semibold leading-snug mt-5 mb-2.5 first:mt-0 text-foreground" {...props}>
+    <h2 className={`${spacing === 'compact' ? 'mt-2.5 mb-1' : 'mt-5 mb-2.5'} text-[17px] font-semibold leading-snug first:mt-0 text-foreground`} {...props}>
       {children}
     </h2>
   ),
   h3: ({ node: _node, className: _className, children, ...props }: any) => (
-    <h3 className="text-base font-semibold leading-snug mt-4 mb-2 first:mt-0 text-foreground" {...props}>
+    <h3 className={`${spacing === 'compact' ? 'mt-2 mb-1' : 'mt-4 mb-2'} text-base font-semibold leading-snug first:mt-0 text-foreground`} {...props}>
       {children}
     </h3>
   ),
   h4: ({ node: _node, className: _className, children, ...props }: any) => (
-    <h4 className="text-[15px] font-semibold leading-snug mt-4 mb-1.5 first:mt-0 text-foreground" {...props}>
+    <h4 className={`${spacing === 'compact' ? 'mt-2 mb-1' : 'mt-4 mb-1.5'} text-[15px] font-semibold leading-snug first:mt-0 text-foreground`} {...props}>
       {children}
     </h4>
   ),
   ul: ({ node: _node, className: _className, children, ...props }: any) => (
-    <ul className="list-disc pl-5 my-3 first:mt-0 last:mb-0 [li>&]:my-1.5 marker:text-foreground/40 text-foreground/90" {...props}>
+    <ul className={`${spacing === 'compact' ? 'my-1 [li>&]:my-0.5' : 'my-3 [li>&]:my-1.5'} list-disc pl-5 first:mt-0 last:mb-0 marker:text-foreground/40 text-foreground/90`} {...props}>
       {children}
     </ul>
   ),
   ol: ({ node: _node, className: _className, children, ...props }: any) => (
-    <ol className="list-decimal pl-6 my-3 first:mt-0 last:mb-0 [li>&]:my-1.5 marker:text-foreground/55 text-foreground/90" {...props}>
+    <ol className={`${spacing === 'compact' ? 'my-1 [li>&]:my-0.5' : 'my-3 [li>&]:my-1.5'} list-decimal pl-6 first:mt-0 last:mb-0 marker:text-foreground/55 text-foreground/90`} {...props}>
       {children}
     </ol>
   ),
   li: ({ node: _node, className: _className, children, ...props }: any) => (
-    <li className="my-1.5 pl-1 text-foreground/90" {...props}>
+    <li className={`${spacing === 'compact' ? 'my-0.5' : 'my-1.5'} pl-1 text-foreground/90`} {...props}>
       {children}
     </li>
   ),
   blockquote: ({ node: _node, className: _className, children, ...props }: any) => (
-    <blockquote className="border-l-4 border-primary pl-4 py-1 my-3 bg-surface-raised/30 rounded-r-lg text-foreground/90 overflow-x-auto" {...props}>
+    <blockquote className={`${spacing === 'compact' ? 'my-1.5' : 'my-3'} border-l-4 border-primary pl-4 py-1 bg-surface-raised/30 rounded-r-lg text-foreground/90 overflow-x-auto`} {...props}>
       {children}
     </blockquote>
   ),
@@ -429,7 +431,7 @@ const createMarkdownComponents = (
   ),
   code: CodeBlock,
   table: ({ node: _node, className: _className, children, ...props }: any) => (
-    <div className="my-4 overflow-x-auto rounded-xl border border-border">
+    <div className={`${spacing === 'compact' ? 'my-2' : 'my-4'} overflow-x-auto rounded-xl border border-border`}>
       <table className="border-collapse w-full" {...props}>
         {children}
       </table>
@@ -465,7 +467,7 @@ const createMarkdownComponents = (
     const altText = typeof alt === 'string' ? alt : null;
     return (
       <img
-        className={`max-w-full max-h-96 object-contain rounded-xl my-4${onImageClick ? ' cursor-pointer hover:opacity-90 transition-opacity' : ''}`}
+        className={`max-w-full max-h-96 object-contain rounded-xl ${spacing === 'compact' ? 'my-2' : 'my-4'}${onImageClick ? ' cursor-pointer hover:opacity-90 transition-opacity' : ''}`}
         src={resolvedSrc}
         alt={altText ?? undefined}
         onClick={onImageClick && resolvedSrc ? () => onImageClick({ src: resolvedSrc, alt: altText }) : undefined}
@@ -474,7 +476,7 @@ const createMarkdownComponents = (
     );
   },
   hr: ({ node: _node, ...props }: any) => (
-    <hr className="my-5 border-border" {...props} />
+    <hr className={`${spacing === 'compact' ? 'my-2' : 'my-5'} border-border`} {...props} />
   ),
   a: ({ node: _node, href, className: _className, children, ...props }: any) => {
     if (typeof href === 'string' && href.startsWith('#artifact-')) {
@@ -653,6 +655,7 @@ const createMarkdownComponents = (
 interface MarkdownContentProps {
   content: string;
   className?: string;
+  spacing?: MarkdownSpacing;
   resolveLocalFilePath?: (href: string, text: string) => string | null;
   showRevealInFolderAction?: boolean;
   enableLargePreview?: boolean;
@@ -662,6 +665,7 @@ interface MarkdownContentProps {
 const MarkdownContent: React.FC<MarkdownContentProps> = ({
   content,
   className = '',
+  spacing = 'normal',
   resolveLocalFilePath,
   showRevealInFolderAction = false,
   enableLargePreview = true,
@@ -671,9 +675,10 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
   const canUseLargePreview = enableLargePreview && shouldUseLargeMarkdownPreview(content);
   const useLargePreview = canUseLargePreview && !isExpanded;
   const components = useMemo(
-    () => createMarkdownComponents(resolveLocalFilePath, showRevealInFolderAction, onImageClick),
-    [resolveLocalFilePath, showRevealInFolderAction, onImageClick]
+    () => createMarkdownComponents(resolveLocalFilePath, showRevealInFolderAction, onImageClick, spacing),
+    [resolveLocalFilePath, showRevealInFolderAction, onImageClick, spacing]
   );
+  const leadingClassName = spacing === 'compact' ? 'leading-[1.55]' : 'leading-[1.75]';
   const normalizedContent = useMemo(() => {
     if (useLargePreview) {
       return '';
@@ -683,7 +688,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
 
   if (useLargePreview) {
     return (
-      <div className={`markdown-content min-w-0 max-w-full text-[15px] leading-[1.75] ${className}`}>
+      <div className={`markdown-content min-w-0 max-w-full text-[15px] ${leadingClassName} ${className}`}>
         <div className="rounded-lg border border-border bg-surface-raised/60">
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-3 py-2 text-xs text-muted">
             <span>
@@ -706,7 +711,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
   }
 
   return (
-    <div className={`markdown-content min-w-0 max-w-full text-[15px] leading-[1.75] ${className}`}>
+    <div className={`markdown-content min-w-0 max-w-full text-[15px] ${leadingClassName} ${className}`}>
       {canUseLargePreview && (
         <div className="mb-2 flex justify-end">
           <button

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -101,6 +101,13 @@ const logPromptModelSelection = (
   window.electron?.log?.fromRenderer?.(level, 'CoworkPromptInput', message);
 };
 
+const summarizePromptShape = (prompt: string): string => {
+  const lines = prompt.length > 0 ? prompt.split('\n') : [];
+  const blankLines = lines.filter(line => line.trim().length === 0).length;
+  const orderedListLines = lines.filter(line => /^\s*\d+\.\s+/.test(line)).length;
+  return `chars=${prompt.length}, lines=${lines.length}, blankLines=${blankLines}, orderedListLines=${orderedListLines}`;
+};
+
 // CoworkAttachment is aliased from the Redux-persisted DraftAttachment type
 // so that attachment state survives view switches (cowork ↔ skills, etc.)
 type CoworkAttachment = DraftAttachment;
@@ -918,6 +925,11 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const finalPrompt = trimmedValue
       ? (attachmentLines ? `${trimmedValue}\n\n${attachmentLines}` : trimmedValue)
       : attachmentLines;
+
+    logPromptModelSelection(
+      'debug',
+      `submitting prompt summary: ${summarizePromptShape(finalPrompt)}, attachments=${attachments.length}, imageAttachments=${imageAtts.length}`
+    );
 
     if (imageAtts.length > 0) {
       console.log('[CoworkPromptInput] handleSubmit: passing imageAtts to onSubmit', {

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -76,6 +76,7 @@ import {
   type CoworkTextExportFormat as CoworkTextExportFormatValue,
   mergeCoworkTextExportMessages,
 } from './sessionExport';
+import UserMessageContent from './UserMessageContent';
 import UserMessageItem from './UserMessageItem';
 interface CoworkSessionDetailProps {
   onManageSkills?: () => void;
@@ -3489,16 +3490,19 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                               : 'min-w-0 flex-1 px-1 py-1 text-foreground'
                           }
                         >
-                          <MarkdownContent
-                            content={item.content}
-                            className={
-                              item.role === 'user'
-                                ? 'max-w-none whitespace-pre-wrap break-words text-xs leading-5'
-                                : 'prose dark:prose-invert max-w-none text-xs leading-5'
-                            }
-                            resolveLocalFilePath={resolveLocalFilePath}
-                            showRevealInFolderAction={item.role === 'assistant'}
-                          />
+                          {item.role === 'user' ? (
+                            <UserMessageContent
+                              content={item.content}
+                              className="max-w-none text-xs leading-5"
+                            />
+                          ) : (
+                            <MarkdownContent
+                              content={item.content}
+                              className="prose dark:prose-invert max-w-none text-xs leading-5"
+                              resolveLocalFilePath={resolveLocalFilePath}
+                              showRevealInFolderAction
+                            />
+                          )}
                         </div>
                       </div>
                     ))}

--- a/src/renderer/components/cowork/UserMessageContent.test.ts
+++ b/src/renderer/components/cowork/UserMessageContent.test.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { expect, test } from 'vitest';
+
+import UserMessageContent from './UserMessageContent';
+
+test('renders numbered user input as plain text instead of a markdown list', () => {
+  const content = '内容包括:\n1. 项目\n2. 核心';
+  const html = renderToStaticMarkup(React.createElement(UserMessageContent, { content }));
+
+  expect(html).not.toContain('<ol');
+  expect(html).toContain('内容包括:');
+  expect(html).toContain('1. 项目');
+  expect(html).toContain('2. 核心');
+});

--- a/src/renderer/components/cowork/UserMessageContent.tsx
+++ b/src/renderer/components/cowork/UserMessageContent.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import MarkdownContent from '../MarkdownContent';
+
+const MARKDOWN_IMAGE_LINE_RE = /^\s*!\[[^\]]*\]\((?:file|localfile|https?|data|blob):[^)]+\)\s*$/i;
+
+const flushText = (
+  nodes: React.ReactNode[],
+  buffer: string[],
+  keyPrefix: string,
+): void => {
+  if (buffer.length === 0) return;
+  const text = buffer.join('\n');
+  buffer.length = 0;
+  if (!text.trim()) return;
+  nodes.push(
+    <div
+      key={`${keyPrefix}-${nodes.length}`}
+      className="whitespace-pre-wrap break-words text-foreground/90"
+    >
+      {text}
+    </div>
+  );
+};
+
+const renderUserMessageParts = (
+  content: string,
+  onImageClick?: (image: { src: string; alt?: string | null }) => void,
+): React.ReactNode[] => {
+  const nodes: React.ReactNode[] = [];
+  const textBuffer: string[] = [];
+
+  content.split('\n').forEach((line, index) => {
+    if (!MARKDOWN_IMAGE_LINE_RE.test(line)) {
+      textBuffer.push(line);
+      return;
+    }
+
+    flushText(nodes, textBuffer, `text-${index}`);
+    nodes.push(
+      <MarkdownContent
+        key={`image-${index}`}
+        content={line.trim()}
+        spacing="compact"
+        className="max-w-none"
+        onImageClick={onImageClick}
+      />
+    );
+  });
+
+  flushText(nodes, textBuffer, 'text-tail');
+  return nodes;
+};
+
+interface UserMessageContentProps {
+  content: string;
+  className?: string;
+  onImageClick?: (image: { src: string; alt?: string | null }) => void;
+}
+
+const UserMessageContent: React.FC<UserMessageContentProps> = ({
+  content,
+  className = '',
+  onImageClick,
+}) => {
+  return (
+    <div className={`min-w-0 max-w-full text-[15px] leading-[1.55] ${className}`}>
+      {renderUserMessageParts(content, onImageClick)}
+    </div>
+  );
+};
+
+export default UserMessageContent;

--- a/src/renderer/components/cowork/UserMessageItem.tsx
+++ b/src/renderer/components/cowork/UserMessageItem.tsx
@@ -16,7 +16,6 @@ import EditIcon from '../icons/EditIcon';
 import MessageCopyIcon from '../icons/MessageCopyIcon';
 import SidebarKitsIcon from '../icons/SidebarKitsIcon';
 import SkillIcon from '../icons/SkillIcon';
-import MarkdownContent from '../MarkdownContent';
 import ImagePreviewModal, { type ImagePreviewSource } from './ImagePreviewModal';
 import {
   COWORK_DETAIL_CONTENT_CLASS,
@@ -25,6 +24,7 @@ import {
   messageMetaClassName,
 } from './messageDisplayUtils';
 import SelectedTextSnippetBadge from './SelectedTextSnippetBadge';
+import UserMessageContent from './UserMessageContent';
 
 // ── CopyButton (local) ──────────────────────────────────────────────────────
 
@@ -243,9 +243,9 @@ const UserMessageItem: React.FC<{
                   </div>
                 )}
                 {displayContent?.trim() && (
-                  <MarkdownContent
+                  <UserMessageContent
                     content={displayContent}
-                    className="max-w-none whitespace-pre-wrap break-words"
+                    className="max-w-none"
                     onImageClick={setExpandedImage}
                   />
                 )}


### PR DESCRIPTION
Preserve user-entered line breaks in sent message bubbles. Add safe prompt shape diagnostics for future spacing issues.


