### PR TITLE
fix(openclaw): support upgraded im plugin installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,17 +14,17 @@
       {
         "id": "dingtalk-connector",
         "npm": "@dingtalk-real-ai/dingtalk-connector",
-        "version": "0.8.16"
+        "version": "0.8.23"
       },
       {
         "id": "openclaw-lark",
         "npm": "@larksuite/openclaw-lark",
-        "version": "2026.4.8"
+        "version": "2026.6.10"
       },
       {
         "id": "wecom-openclaw-plugin",
         "npm": "@wecom/wecom-openclaw-plugin",
-        "version": "2026.4.22"
+        "version": "2026.5.25"
       },
       {
         "id": "openclaw-weixin",
@@ -34,7 +34,7 @@
       {
         "id": "moltbot-popo",
         "npm": "moltbot-popo",
-        "version": "2.1.8",
+        "version": "2.1.13",
         "registry": "https://npm.nie.netease.com",
         "optional": true
       },

--- a/scripts/ensure-openclaw-plugins.cjs
+++ b/scripts/ensure-openclaw-plugins.cjs
@@ -24,13 +24,16 @@ const os = require('os');
 const path = require('path');
 
 const { applyOpenClawPluginPatches } = require('./openclaw-plugin-patches/index.cjs');
+const {
+  BEE_PACKAGE_NAME,
+  prepareOpenClawNeteaseBeePackage,
+} = require('./prepare-openclaw-netease-bee.cjs');
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 const rootDir = path.resolve(__dirname, '..');
-
 function log(msg) {
   console.log(`[openclaw-plugins] ${msg}`);
 }
@@ -41,7 +44,65 @@ function die(msg) {
 }
 
 function copyDirRecursive(src, dest) {
-  fs.cpSync(src, dest, { recursive: true, force: true });
+  const linkedOpenClawPeer = path.join(src, 'node_modules', 'openclaw');
+  const shouldExcludeLinkedPeer =
+    fs.existsSync(linkedOpenClawPeer) && fs.lstatSync(linkedOpenClawPeer).isSymbolicLink();
+
+  fs.cpSync(src, dest, {
+    recursive: true,
+    force: true,
+    filter: sourcePath =>
+      !shouldExcludeLinkedPeer || path.resolve(sourcePath) !== path.resolve(linkedOpenClawPeer),
+  });
+}
+
+function isSameOrDescendant(candidatePath, targetPath) {
+  const relative = path.relative(path.resolve(targetPath), path.resolve(candidatePath));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function findContainingNodeModulesDir(packageDir) {
+  const parentDir = path.dirname(packageDir);
+  if (path.basename(parentDir) === 'node_modules') {
+    return parentDir;
+  }
+
+  const grandparentDir = path.dirname(parentDir);
+  if (path.basename(grandparentDir) === 'node_modules' && path.basename(parentDir).startsWith('@')) {
+    return grandparentDir;
+  }
+
+  return null;
+}
+
+function shouldCopyProjectDependency(sourcePath, installedDir, projectNodeModulesDir) {
+  if (isSameOrDescendant(sourcePath, installedDir)) {
+    return false;
+  }
+
+  const openclawPeer = path.join(projectNodeModulesDir, 'openclaw');
+  if (isSameOrDescendant(sourcePath, openclawPeer)) {
+    return false;
+  }
+
+  return true;
+}
+
+function copyInstalledPluginToCache(installedDir, cacheDir) {
+  copyDirRecursive(installedDir, cacheDir);
+
+  const projectNodeModulesDir = findContainingNodeModulesDir(installedDir);
+  if (!projectNodeModulesDir) {
+    return;
+  }
+
+  const cacheNodeModulesDir = path.join(cacheDir, 'node_modules');
+  fs.cpSync(projectNodeModulesDir, cacheNodeModulesDir, {
+    recursive: true,
+    force: true,
+    filter: sourcePath =>
+      shouldCopyProjectDependency(sourcePath, installedDir, projectNodeModulesDir),
+  });
 }
 
 /**
@@ -161,6 +222,84 @@ function readJsonFile(filePath) {
   }
 }
 
+function listDirectPackageDirs(nodeModulesDir) {
+  if (!fs.existsSync(nodeModulesDir)) {
+    return [];
+  }
+
+  const packageDirs = [];
+  for (const entry of fs.readdirSync(nodeModulesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const entryPath = path.join(nodeModulesDir, entry.name);
+    if (!entry.name.startsWith('@')) {
+      packageDirs.push(entryPath);
+      continue;
+    }
+
+    for (const scopedEntry of fs.readdirSync(entryPath, { withFileTypes: true })) {
+      if (scopedEntry.isDirectory()) {
+        packageDirs.push(path.join(entryPath, scopedEntry.name));
+      }
+    }
+  }
+
+  return packageDirs;
+}
+
+function selectInstalledPluginDir(candidateDirs, plugin) {
+  const candidates = candidateDirs
+    .filter(
+      candidateDir =>
+        fs.existsSync(path.join(candidateDir, 'openclaw.plugin.json')) ||
+        fs.existsSync(path.join(candidateDir, 'package.json')),
+    )
+    .map(candidateDir => ({
+      dir: candidateDir,
+      manifest: readJsonFile(path.join(candidateDir, 'openclaw.plugin.json')),
+      packageJson: readJsonFile(path.join(candidateDir, 'package.json')),
+    }));
+
+  const exactManifestMatch = candidates.find(({ manifest }) => manifest?.id === plugin.id);
+  if (exactManifestMatch) return exactManifestMatch.dir;
+
+  const exactPackageMatch = candidates.find(({ packageJson }) => packageJson?.name === plugin.npm);
+  if (exactPackageMatch) return exactPackageMatch.dir;
+
+  const pluginCandidates = candidates.filter(({ manifest }) => manifest);
+  return pluginCandidates.length === 1 ? pluginCandidates[0].dir : null;
+}
+
+function findInstalledPluginDir(stagingDir, plugin) {
+  const extensionsDir = path.join(stagingDir, 'extensions');
+  const expectedExtensionDir = path.join(extensionsDir, plugin.id);
+  if (fs.existsSync(expectedExtensionDir)) {
+    return expectedExtensionDir;
+  }
+
+  const extensionCandidates = fs.existsSync(extensionsDir)
+    ? fs
+        .readdirSync(extensionsDir, { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => path.join(extensionsDir, entry.name))
+    : [];
+  const extensionMatch = selectInstalledPluginDir(extensionCandidates, plugin);
+  if (extensionMatch) return extensionMatch;
+
+  // OpenClaw 2026.6+ installs npm plugins into an isolated npm project and
+  // records only the enabled plugin id under OPENCLAW_STATE_DIR.
+  const npmProjectsDir = path.join(stagingDir, 'npm', 'projects');
+  if (!fs.existsSync(npmProjectsDir)) {
+    return null;
+  }
+
+  const npmCandidates = fs
+    .readdirSync(npmProjectsDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .flatMap(entry => listDirectPackageDirs(path.join(npmProjectsDir, entry.name, 'node_modules')));
+  return selectInstalledPluginDir(npmCandidates, plugin);
+}
+
 function buildNpmPackEnv() {
   return {
     ...process.env,
@@ -193,11 +332,17 @@ function runOpenClawCli(args, opts = {}) {
     throw new Error(`OpenClaw CLI not found at ${openclawMjs}`);
   }
 
+  const bundledPluginsDir = path.join(path.dirname(openclawMjs), 'dist', 'extensions');
+  const env = { ...process.env };
+  if (fs.existsSync(bundledPluginsDir) && !env.OPENCLAW_BUNDLED_PLUGINS_DIR) {
+    env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledPluginsDir;
+  }
+
   const result = spawnSync(process.execPath, [openclawMjs, ...args], {
     encoding: 'utf-8',
     stdio: opts.stdio || 'inherit',
     cwd: opts.cwd || rootDir,
-    env: { ...process.env, ...opts.env },
+    env: { ...env, ...opts.env },
     timeout: opts.timeout || 5 * 60 * 1000,
   });
 
@@ -491,6 +636,14 @@ function main() {
           installSpec = source.installSpec;
         }
 
+        if (id === BEE_PACKAGE_NAME || npmSpec === BEE_PACKAGE_NAME) {
+          log('  Preparing NetEase Bee package for OpenClaw 2026.6 runtime install.');
+          if (!fs.existsSync(installSpec) || fs.statSync(installSpec).isDirectory()) {
+            installSpec = npmPack(`${BEE_PACKAGE_NAME}@${version}`, plugin.registry, stagingDir);
+          }
+          installSpec = prepareOpenClawNeteaseBeePackage(installSpec, stagingDir, { log });
+        }
+
         runOpenClawCli(
           ['plugins', 'install', installSpec, '--force', '--dangerously-force-unsafe-install'],
           {
@@ -507,38 +660,18 @@ function main() {
           }
         );
 
-        // The CLI installs to {OPENCLAW_STATE_DIR}/extensions/{pluginId}/
-        const installedDir = path.join(stagingDir, 'extensions', id);
-        if (!fs.existsSync(installedDir)) {
-          // Some plugins use a different directory name than the declared id.
-          // Scan the extensions directory for the installed plugin.
-          const extDir = path.join(stagingDir, 'extensions');
-          const entries = fs.existsSync(extDir) ? fs.readdirSync(extDir) : [];
-          if (entries.length === 0) {
-            throw new Error(`No plugin found in staging directory after install`);
-          }
-          // Use the first (and likely only) directory
-          const actualDir = path.join(extDir, entries[0]);
-          if (!fs.existsSync(path.join(actualDir, 'openclaw.plugin.json')) &&
-              !fs.existsSync(path.join(actualDir, 'package.json'))) {
-            throw new Error(`Installed plugin directory ${entries[0]} has no plugin manifest`);
-          }
-          // Copy the actual directory
-          if (fs.existsSync(cacheDir)) {
-            fs.rmSync(cacheDir, { recursive: true, force: true });
-          }
-          ensureDir(path.dirname(cacheDir));
-          copyDirRecursive(actualDir, cacheDir);
-          fixBinSymlinks(cacheDir);
-        } else {
-          // Replace cache dir with new content
-          if (fs.existsSync(cacheDir)) {
-            fs.rmSync(cacheDir, { recursive: true, force: true });
-          }
-          ensureDir(path.dirname(cacheDir));
-          copyDirRecursive(installedDir, cacheDir);
-          fixBinSymlinks(cacheDir);
+        const installedDir = findInstalledPluginDir(stagingDir, plugin);
+        if (!installedDir) {
+          throw new Error('No plugin found in staging directory after install');
         }
+
+        // Replace cache dir with new content
+        if (fs.existsSync(cacheDir)) {
+          fs.rmSync(cacheDir, { recursive: true, force: true });
+        }
+        ensureDir(path.dirname(cacheDir));
+        copyInstalledPluginToCache(installedDir, cacheDir);
+        fixBinSymlinks(cacheDir);
 
         // Write install info for cache validation
         fs.writeFileSync(
@@ -610,6 +743,9 @@ if (require.main === module) {
 module.exports = {
   buildNpmPackEnv,
   buildGitEnv,
+  copyDirRecursive,
+  copyInstalledPluginToCache,
+  findInstalledPluginDir,
   gitCloneAndPack,
   isGitSpec,
   isLocalPathSpec,

--- a/scripts/openclaw-plugin-patches/dingtalk.cjs
+++ b/scripts/openclaw-plugin-patches/dingtalk.cjs
@@ -5,21 +5,26 @@ const path = require('path');
 
 function patchMessageHandler(dingtalkMsgHandlerPath, log) {
   if (!fs.existsSync(dingtalkMsgHandlerPath)) {
-    log('dingtalk-connector not found, skipping file:// URL patch');
+    log(`${path.basename(dingtalkMsgHandlerPath)} not found, skipping file:// URL patch`);
     return;
   }
 
   let dtSrc = fs.readFileSync(dingtalkMsgHandlerPath, 'utf8');
-  const brokenPattern = "imageLocalPaths.map(p => `![image](file://${p})`)";
-  if (dtSrc.includes(brokenPattern)) {
-    dtSrc = dtSrc.replace(
-      brokenPattern,
-      "imageLocalPaths.map(p => { if (process.platform !== 'win32') return `![image](file://${p})`; const n = p.replace(/\\\\/g, '/'); return `![image](file:///${n})`; })"
-    );
+  const brokenPatterns = [
+    "imageLocalPaths.map(p => `![image](file://${p})`)",
+    'imageLocalPaths.map((p) => `![image](file://${p})`)',
+  ];
+  const replacement =
+    "imageLocalPaths.map(p => { if (process.platform !== 'win32') return `![image](file://${p})`; const n = p.replace(/\\\\/g, '/'); return `![image](file:///${n})`; })";
+  const appliedPattern = brokenPatterns.find(pattern => dtSrc.includes(pattern));
+  if (appliedPattern) {
+    dtSrc = dtSrc.replace(appliedPattern, replacement);
     fs.writeFileSync(dingtalkMsgHandlerPath, dtSrc);
-    log('Patched dingtalk-connector/message-handler.ts: fixed file:// URL format for Windows');
+    log(`Patched ${path.relative(process.cwd(), dingtalkMsgHandlerPath)}: fixed file:// URL format for Windows`);
+  } else if (dtSrc.includes("file:///${n}")) {
+    log(`${path.relative(process.cwd(), dingtalkMsgHandlerPath)} file:// URL patch already applied, skipping`);
   } else {
-    log('dingtalk-connector/message-handler.ts: file:// pattern not found or already patched, skipping');
+    log(`${path.relative(process.cwd(), dingtalkMsgHandlerPath)}: file:// pattern not found, skipping`);
   }
 
   const exactAccountPattern = 'if (match.accountId && match.accountId !== accountId) continue;';
@@ -33,6 +38,18 @@ function patchMessageHandler(dingtalkMsgHandlerPath, log) {
   } else {
     log('dingtalk-connector/message-handler.ts: account binding pattern not found, skipping wildcard patch');
   }
+}
+
+function findDingtalkDistMessageHandlers(pluginDir) {
+  const distDir = path.join(pluginDir, 'dist');
+  if (!fs.existsSync(distDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(distDir, { withFileTypes: true })
+    .filter(entry => entry.isFile() && /^message-handler-.*\.mjs$/.test(entry.name))
+    .map(entry => path.join(distDir, entry.name));
 }
 
 function patchDingtalkAgentWorkspaceResolver(resolverPath, label, log) {
@@ -66,6 +83,21 @@ function patchDingtalkAgentWorkspaceResolver(resolverPath, label, log) {
     return path.join(expandWorkspacePath(fallbackWorkspace), agentId);
   }
   return path.join(os.homedir(), ".openclaw", \`workspace-\${agentId}\`);
+}`;
+
+  const replacementBundledMjs = `function resolveAgentWorkspaceDir(cfg, agentId) {
+	const expandWorkspacePath = (workspace) => /* ${workspacePatchMarker} */ workspace.startsWith("~") ? path$1.join(os.homedir(), workspace.slice(1)) : workspace;
+	const agentConfig = cfg.agents?.list?.find((a) => a.id === agentId);
+	const configuredWorkspace = agentConfig?.workspace?.trim();
+	if (configuredWorkspace) return expandWorkspacePath(configuredWorkspace);
+	const defaultAgentId = cfg.defaultAgent || cfg.agents?.list?.find((a) => a?.default === true)?.id || "main";
+	const fallbackWorkspace = cfg.agents?.defaults?.workspace?.trim();
+	if (agentId === "main" || agentId === defaultAgentId) {
+		if (fallbackWorkspace) return expandWorkspacePath(fallbackWorkspace);
+		return path$1.join(os.homedir(), ".openclaw", "workspace");
+	}
+	if (fallbackWorkspace) return path$1.join(expandWorkspacePath(fallbackWorkspace), agentId);
+	return path$1.join(os.homedir(), ".openclaw", \`workspace-\${agentId}\`);
 }`;
 
   const replacementTs = `export function resolveAgentWorkspaceDir(
@@ -116,6 +148,18 @@ function patchDingtalkAgentWorkspaceResolver(resolverPath, label, log) {
     return;
   }
 
+  if (label.endsWith('.mjs')) {
+    const pattern = /function resolveAgentWorkspaceDir\(cfg, agentId\) \{[\s\S]*?return path\$1\.join\(os\.homedir\(\), "\.openclaw", `workspace-\$\{agentId\}`\);\r?\n\}/;
+    if (pattern.test(src)) {
+      src = src.replace(pattern, replacementBundledMjs);
+      fs.writeFileSync(resolverPath, src);
+      log(`Patched ${label}: agent workspace resolver now reads agents.defaults.workspace`);
+    } else {
+      log(`${label}: workspace resolver pattern not found, skipping patch`);
+    }
+    return;
+  }
+
   const pattern = /export function resolveAgentWorkspaceDir\(\s*cfg: ClawdbotConfig,\s*agentId: string,\s*\): string \{[\s\S]*?return path\.join\(os\.homedir\(\), '\.openclaw', `workspace-\$\{agentId\}`\);\s*\}/;
   if (pattern.test(src)) {
     src = src.replace(pattern, replacementTs);
@@ -127,23 +171,35 @@ function patchDingtalkAgentWorkspaceResolver(resolverPath, label, log) {
 }
 
 function patchDingtalk({ runtimeExtensionsDir, log }) {
-  patchMessageHandler(
-    path.join(runtimeExtensionsDir, 'dingtalk-connector', 'src', 'core', 'message-handler.ts'),
-    log
-  );
+  const pluginDir = path.join(runtimeExtensionsDir, 'dingtalk-connector');
+  const messageHandlerPaths = [
+    path.join(pluginDir, 'src', 'core', 'message-handler.ts'),
+    ...findDingtalkDistMessageHandlers(pluginDir),
+  ];
+  for (const messageHandlerPath of messageHandlerPaths) {
+    patchMessageHandler(messageHandlerPath, log);
+  }
 
   patchDingtalkAgentWorkspaceResolver(
-    path.join(runtimeExtensionsDir, 'dingtalk-connector', 'index.js'),
+    path.join(pluginDir, 'index.js'),
     'dingtalk-connector/index.js',
     log
   );
   patchDingtalkAgentWorkspaceResolver(
-    path.join(runtimeExtensionsDir, 'dingtalk-connector', 'src', 'utils', 'agent.ts'),
+    path.join(pluginDir, 'src', 'utils', 'agent.ts'),
     'dingtalk-connector/src/utils/agent.ts',
     log
   );
+  for (const messageHandlerPath of findDingtalkDistMessageHandlers(pluginDir)) {
+    patchDingtalkAgentWorkspaceResolver(
+      messageHandlerPath,
+      `dingtalk-connector/dist/${path.basename(messageHandlerPath)}`,
+      log
+    );
+  }
 }
 
 module.exports = {
+  findDingtalkDistMessageHandlers,
   patchDingtalk,
 };

--- a/scripts/prepare-openclaw-netease-bee.cjs
+++ b/scripts/prepare-openclaw-netease-bee.cjs
@@ -1,0 +1,181 @@
+'use strict';
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const esbuild = require('esbuild');
+const tar = require('tar');
+
+const BEE_PACKAGE_NAME = 'openclaw-netease-bee';
+
+function readJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
+function writeJsonFile(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+function normalizePackageRelativePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function assertInsideDirectory(parentDir, childPath) {
+  const parent = path.resolve(parentDir);
+  const child = path.resolve(childPath);
+  const relative = path.relative(parent, child);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Refusing to write outside package directory: ${childPath}`);
+  }
+}
+
+function buildNpmPackEnv() {
+  return {
+    ...process.env,
+    npm_config_prefer_offline: '',
+    npm_config_prefer_online: '',
+    NPM_CONFIG_PREFER_OFFLINE: '',
+    NPM_CONFIG_PREFER_ONLINE: '',
+  };
+}
+
+function npmPackDirectory(sourceDir, outputDir) {
+  const isWin = process.platform === 'win32';
+  const npmBin = isWin ? 'npm.cmd' : 'npm';
+  const args = ['pack', sourceDir, '--pack-destination', outputDir];
+
+  const result = spawnSync(npmBin, args, {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: outputDir,
+    env: buildNpmPackEnv(),
+    shell: isWin,
+    timeout: 3 * 60 * 1000,
+    windowsVerbatimArguments: isWin,
+  });
+
+  if (result.error) {
+    throw new Error(`npm pack ${sourceDir} failed: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').trim();
+    throw new Error(
+      `npm pack ${sourceDir} exited with code ${result.status}` +
+        (stderr ? `\n${stderr}` : ''),
+    );
+  }
+
+  const tgzName = (result.stdout || '').trim().split('\n').pop();
+  return path.join(outputDir, tgzName);
+}
+
+function isTypescriptRuntimeEntry(entry) {
+  return typeof entry === 'string' && /\.tsx?$/i.test(entry);
+}
+
+function toMjsRuntimeEntry(entry) {
+  return `./${normalizePackageRelativePath(entry).replace(/\.tsx?$/i, '.mjs')}`;
+}
+
+function ensureFileIncluded(pkg, relativePath) {
+  const normalized = normalizePackageRelativePath(relativePath);
+  if (!Array.isArray(pkg.files)) {
+    return;
+  }
+  if (!pkg.files.some(entry => normalizePackageRelativePath(entry) === normalized)) {
+    pkg.files.push(normalized);
+  }
+}
+
+function patchBeePackageDirectory(packageDir, opts = {}) {
+  const log = opts.log || (() => {});
+  const packageJsonPath = path.join(packageDir, 'package.json');
+  const pkg = readJsonFile(packageJsonPath);
+
+  if (pkg.name && pkg.name !== BEE_PACKAGE_NAME) {
+    throw new Error(`Expected ${BEE_PACKAGE_NAME}, got ${pkg.name}`);
+  }
+
+  const extensions = pkg.openclaw?.extensions;
+  if (!Array.isArray(extensions)) {
+    return { changed: false, compiledEntries: [] };
+  }
+
+  const compiledEntries = [];
+  const nextExtensions = extensions.map(entry => {
+    if (!isTypescriptRuntimeEntry(entry)) {
+      return entry;
+    }
+
+    const entryRelativePath = normalizePackageRelativePath(entry);
+    const outputEntry = toMjsRuntimeEntry(entry);
+    const outputRelativePath = normalizePackageRelativePath(outputEntry);
+    const entryPath = path.join(packageDir, entryRelativePath);
+    const outputPath = path.join(packageDir, outputRelativePath);
+
+    assertInsideDirectory(packageDir, entryPath);
+    assertInsideDirectory(packageDir, outputPath);
+
+    if (!fs.existsSync(entryPath)) {
+      throw new Error(`Bee TypeScript runtime entry is missing: ${entry}`);
+    }
+
+    esbuild.buildSync({
+      entryPoints: [entryPath],
+      outfile: outputPath,
+      bundle: true,
+      packages: 'external',
+      platform: 'node',
+      format: 'esm',
+      target: 'node20',
+      sourcemap: false,
+      logLevel: 'silent',
+    });
+
+    ensureFileIncluded(pkg, outputRelativePath);
+    compiledEntries.push(outputEntry);
+    return outputEntry;
+  });
+
+  if (compiledEntries.length === 0) {
+    return { changed: false, compiledEntries: [] };
+  }
+
+  pkg.openclaw.extensions = nextExtensions;
+  if (!pkg.main || isTypescriptRuntimeEntry(pkg.main)) {
+    pkg.main = compiledEntries[0];
+  }
+  writeJsonFile(packageJsonPath, pkg);
+
+  log(`  Prepared ${BEE_PACKAGE_NAME} runtime entry: ${compiledEntries.join(', ')}`);
+  return { changed: true, compiledEntries };
+}
+
+function prepareOpenClawNeteaseBeePackage(inputTgzPath, outputDir, opts = {}) {
+  if (!fs.existsSync(inputTgzPath)) {
+    throw new Error(`Bee package tarball not found: ${inputTgzPath}`);
+  }
+
+  const sourceDir = fs.mkdtempSync(path.join(outputDir, 'openclaw-netease-bee-source-'));
+  tar.x({
+    file: inputTgzPath,
+    cwd: sourceDir,
+    strip: 1,
+    sync: true,
+  });
+
+  const result = patchBeePackageDirectory(sourceDir, opts);
+  if (!result.changed) {
+    return inputTgzPath;
+  }
+
+  const patchedPackDir = fs.mkdtempSync(path.join(outputDir, 'openclaw-netease-bee-patched-'));
+  return npmPackDirectory(sourceDir, patchedPackDir);
+}
+
+module.exports = {
+  BEE_PACKAGE_NAME,
+  patchBeePackageDirectory,
+  prepareOpenClawNeteaseBeePackage,
+};

--- a/specs/refactors/openclaw-upgrade/2026-06-18-openclaw-plugin-runtime-patch-audit.md
+++ b/specs/refactors/openclaw-upgrade/2026-06-18-openclaw-plugin-runtime-patch-audit.md
@@ -457,3 +457,102 @@ file:///Users/yangwn/a.jpg
 4. `scripts/openclaw-plugin-patches/dingtalk.cjs` 的 DingTalk `file://` patch 明确只在 `process.platform === 'win32'` 时重写；macOS/Linux 保留 `file://${p}`，对 `/Users/...` 会自然得到 `file:///Users/...`。
 
 仍需注意的风险是：代码库里还有一些解析器会手动剥离 `file://` 或 `localfile://` 前缀。已看到的核心解析器通常只在正则确认 Windows drive letter 时剥离前导 `/`，并已有 Unix path 单测覆盖；因此目前没有发现需要为 macOS 额外改动的点。后续如果发现 macOS 上的本地媒体无法显示，应优先检查是否产生了 `localfile://Users/...` 这种缺少第三个斜杠的非规范 URL。
+
+## 11. 2026-06-22 插件升级后 post-install patch 复核
+
+DingTalk 升级到 `0.8.23`、Lark/Feishu 升级到 `2026.6.10` 后，重新复核了 `scripts/openclaw-plugin-patches/` 下各渠道 patch 是否仍作用于 OpenClaw gateway 实际加载路径。
+
+### 11.1 DingTalk runtime 入口变化
+
+`@dingtalk-real-ai/dingtalk-connector@0.8.23` 的 `package.json#openclaw.extensions` 指向：
+
+```json
+["./dist/index.mjs"]
+```
+
+该版本会把 `src/core/message-handler.ts` 与 `src/utils/agent.ts` 的逻辑 bundle 到 hash 命名的 dist 文件中：
+
+```text
+dingtalk-connector/dist/message-handler-0NLKAqHU.mjs
+```
+
+因此只修改 `src/core/message-handler.ts` 或 `src/utils/agent.ts` 不足以影响实际运行时。
+
+已调整 `scripts/openclaw-plugin-patches/dingtalk.cjs`：
+
+1. 扫描 `dist/message-handler-*.mjs`。
+2. 对 dist message handler 同步应用 Windows `file://` 图片 URL 修复。
+3. 对 dist message handler 同步应用 `accountId: "*"` wildcard 修复。
+4. 对 dist message handler 内联的 `resolveAgentWorkspaceDir()` 同步应用 `agents.defaults.workspace` fallback 修复。
+
+当前 runtime 静态确认：
+
+```text
+dingtalk-connector/dist/message-handler-*.mjs contains file:///${n}
+dingtalk-connector/dist/message-handler-*.mjs contains match.accountId !== "*"
+dingtalk-connector/dist/message-handler-*.mjs contains dingtalk_agent_workspace_defaults_patch
+dingtalk-connector/dist/message-handler-*.mjs reads cfg.agents?.defaults?.workspace
+```
+
+新增测试：
+
+```text
+tests/openclaw-plugin-patches-dingtalk.test.ts
+```
+
+覆盖 hash dist 文件发现、Windows file URL 修复、dist workspace resolver 修复。
+
+### 11.2 Weixin patch 复核
+
+微信插件仍声明：
+
+```json
+{
+  "runtimeExtensions": ["./dist/index.js"]
+}
+```
+
+`weixin.cjs` 已同时覆盖 source 与 dist：
+
+```text
+openclaw-weixin/src/channel.ts
+openclaw-weixin/dist/src/channel.js
+openclaw-weixin/src/messaging/process-message.ts
+openclaw-weixin/dist/src/messaging/process-message.js
+```
+
+重新应用 patch 后，当前 runtime 静态确认：
+
+```text
+openclaw-weixin/dist/src/channel.js contains gatewayMethods
+openclaw-weixin/dist/src/messaging/process-message.js contains chanCfg_dmPolicy_patch
+openclaw-weixin/dist/src/messaging/process-message.js contains list.includes('*')
+```
+
+未发现新的 `src`/`dist` 旁路失效点。
+
+### 11.3 Lark/Feishu patch 复核
+
+`@larksuite/openclaw-lark@2026.6.10` 当前 `openclaw.extensions` 指向 `./index.js`，而 root `index.js` 直接 `require("./src/...")`。因此 `lark.cjs` 对 `src/messaging/outbound/media.js` 的文件名编码 patch 仍作用于实际运行路径。
+
+重新应用 patch 后，当前 runtime 静态确认：
+
+```text
+openclaw-lark/setup-entry.js contains listAccountIds / resolveAccount
+openclaw-lark/openclaw.plugin.json contains contracts.tools including feishu_doc_media
+openclaw-lark/src/messaging/outbound/media.js contains fixLatin1GarbledUtf8
+```
+
+未发现新的 dist 旁路失效点。
+
+### 11.4 验证
+
+已执行：
+
+```bash
+node --check scripts/openclaw-plugin-patches/dingtalk.cjs
+npx vitest run tests/openclaw-plugin-patches-dingtalk.test.ts
+node -e "const path=require('path'); const {applyOpenClawPluginPatches}=require('./scripts/openclaw-plugin-patches/index.cjs'); applyOpenClawPluginPatches({runtimeExtensionsDir:path.join(process.cwd(),'vendor/openclaw-runtime/current/third-party-extensions'), log: console.log});"
+```
+
+注意：这些 patch 作用于 runtime 文件，但运行中的 OpenClaw gateway 不会热重载已 import 的插件模块。验证 DingTalk 图片消息、DingTalk 入站图片 workspace、微信扫码/入站授权、Feishu setup metadata 前，需要重启 OpenClaw gateway 或整个 Electron dev 进程。

--- a/specs/refactors/openclaw-upgrade/2026-06-22-openclaw-im-plugin-upgrade.md
+++ b/specs/refactors/openclaw-upgrade/2026-06-22-openclaw-im-plugin-upgrade.md
@@ -1,0 +1,349 @@
+# OpenClaw IM 插件升级与安装兼容设计文档
+
+## 1. 概述
+
+### 1.1 问题/动机
+
+LobsterAI 在 OpenClaw `v2026.6.1` 基线上预装多个 IM 相关第三方插件。此次调整目标是升级部分插件到当前可用稳定版本，同时保持微信与 ClawEmail 不变：
+
+| 插件 | 原版本 | 目标版本 | 处理 |
+|------|--------|----------|------|
+| DingTalk connector | `0.8.16` | `0.8.23` | 升级 |
+| Lark/Feishu | `2026.4.8` | `2026.6.10` | 升级 |
+| WeCom | `2026.4.22` | `2026.5.25` | 升级 |
+| POPO | `2.1.8` | `2.1.13` | 升级 |
+| Weixin | `2.4.3` | `2.4.3` | 不改动 |
+| ClawEmail | `0.9.12` | `0.9.12` | 不改动 |
+| NetEase Bee | `0.1.3` | `0.1.3` | 不升级，但需要安装兼容 |
+| NIM channel | git tag `1.1.1` | git tag `1.1.1` | 不升级，仍为 optional |
+
+实际从零安装时暴露出四个和插件安装链路相关的问题：
+
+1. OpenClaw `v2026.6.1` 的 npm 插件安装布局发生变化，新版 CLI 会把 npm 插件放入临时 state 目录的 `npm/projects/.../node_modules/...`，而旧脚本只查找 `extensions/...`，导致“下载成功但被误判为失败”。
+2. 新版 npm project 布局下，插件依赖位于 project 级 `node_modules`，例如 `image-size`、`dingtalk-stream` 是插件包目录的 sibling dependency。只复制插件包目录会导致 gateway runtime 加载时缺依赖。
+3. OpenClaw CLI 在 LobsterAI 的构建子进程中没有稳定识别 bundled channel 目录，日志出现 `imessage` / `telegram` 的 `missing generated module` warning。Telegram 实际产物存在，但 setup/bundled metadata 扫描路径不确定。
+4. `openclaw-netease-bee@0.1.3` npm 包只发布了 TypeScript runtime entry `./index.ts`，没有发布 `index.js` / `dist/index.js` 等编译产物。OpenClaw `v2026.6.1` 对 npm 包安装不再接受 TypeScript runtime fallback，因此从零构建会在 Bee 插件安装阶段失败。
+
+### 1.2 目标
+
+- 完成指定 IM 插件版本升级，不改动微信与 ClawEmail 版本。
+- 兼容 OpenClaw 新旧插件安装布局，避免缓存缺失或从零构建时误判安装失败。
+- 消除 OpenClaw CLI 安装阶段的 bundled channel 目录探测 warning，避免 Telegram setup 能力被误判。
+- 为 Bee 提供 LobsterAI 侧临时兼容方案，直到上游发布带编译产物的新版本。
+- 保持插件最终仍通过 `openclaw plugins install` 安装，不绕过 OpenClaw 的 manifest 校验、安全扫描与依赖安装流程。
+
+## 2. 现状分析
+
+### 2.1 OpenClaw 插件安装布局变化
+
+旧版脚本假设 CLI 安装结果位于：
+
+```text
+{OPENCLAW_STATE_DIR}/extensions/{pluginId}
+```
+
+但 OpenClaw `v2026.6.1` 对 npm 插件会优先创建隔离 npm project：
+
+```text
+{OPENCLAW_STATE_DIR}/npm/projects/{projectId}/node_modules/{packageName}
+```
+
+这不是某个插件升级包单独引入的问题，而是 OpenClaw CLI 的安装布局变化。插件升级会让本地 `vendor/openclaw-plugins` 缓存失效，从而触发重新下载与新版布局，因此问题在升级时暴露；如果完全清空缓存，即使安装旧版本插件也可能触发同类问题。
+
+### 2.2 本地缓存对问题的遮蔽
+
+`vendor/openclaw-plugins` 和 `vendor/openclaw-runtime` 不进入 git。升级前已有本地缓存时，安装脚本直接复用缓存，不会调用新版 OpenClaw CLI 下载插件，因此不会经过 `npm/projects` 新布局，也就不会触发布局查找失败。
+
+从零构建或插件版本变更后，缓存 miss 才会进入真实下载路径，暴露新版布局兼容问题。
+
+如果在修复安装脚本前已经生成过缺依赖缓存，需要删除 `vendor/openclaw-plugins` 后重新执行安装脚本。该缓存清理属于本地修复动作，不应通过长期 cache schema 升级固化到代码中。
+
+### 2.3 npm project sibling dependencies
+
+在 OpenClaw `v2026.6.1` 的隔离 npm project 中，插件包和它的依赖位于同一个 project 级 `node_modules`：
+
+```text
+{OPENCLAW_STATE_DIR}/npm/projects/{projectId}/node_modules/@larksuite/openclaw-lark
+{OPENCLAW_STATE_DIR}/npm/projects/{projectId}/node_modules/image-size
+```
+
+以及：
+
+```text
+{OPENCLAW_STATE_DIR}/npm/projects/{projectId}/node_modules/@dingtalk-real-ai/dingtalk-connector
+{OPENCLAW_STATE_DIR}/npm/projects/{projectId}/node_modules/dingtalk-stream
+```
+
+因此如果 LobsterAI 只复制插件包目录到：
+
+```text
+vendor/openclaw-runtime/current/third-party-extensions/{pluginId}
+```
+
+运行时会报：
+
+```text
+Cannot find module 'image-size'
+Cannot find package 'dingtalk-stream'
+```
+
+这不是 Lark 或 DingTalk 插件本身漏声明依赖，而是 LobsterAI 从 staging 复制到 runtime 时丢失了 project 级 sibling dependencies。
+
+### 2.4 bundled channel warning
+
+构建日志中曾出现：
+
+```text
+[channels] failed to load bundled channel setup entry imessage: missing generated module for bundled channel imessage
+[channels] failed to load bundled channel setup entry telegram: missing generated module for bundled channel telegram
+```
+
+复核 runtime 后确认 Telegram 的入口与 setup entry 文件存在：
+
+```text
+vendor/openclaw-runtime/current/dist/extensions/telegram/index.js
+vendor/openclaw-runtime/current/dist/extensions/telegram/setup-entry.js
+```
+
+因此该 warning 不是 Telegram 插件产物缺失，也不代表 Telegram runtime 一定不可用。它反映的是 OpenClaw CLI 子进程未稳定定位 bundled plugins 根目录，可能影响 setup/onboarding/config metadata 扫描，并造成构建日志噪声。
+
+### 2.5 Bee 包发布形态不满足 OpenClaw 6.1 npm 安装要求
+
+`openclaw-netease-bee@0.1.3` 的 npm 包内容包含：
+
+```text
+index.ts
+src/*.ts
+openclaw.plugin.json
+package.json
+```
+
+但缺少：
+
+```text
+index.js
+index.mjs
+dist/index.js
+dist/index.mjs
+```
+
+其 `package.json` 中声明：
+
+```json
+{
+  "openclaw": {
+    "extensions": ["./index.ts"]
+  }
+}
+```
+
+OpenClaw `v2026.6.1` 对 npm 包安装要求 runtime entry 指向已编译 JavaScript。TypeScript fallback 只支持源码 checkout 或本地开发路径，不支持 registry npm 包。因此 Bee 当前失败属于插件发布包缺少编译产物，不是 LobsterAI 本地配置错误。
+
+日志中的：
+
+```text
+Also not a valid hook pack: Error: package.json missing openclaw.hooks
+```
+
+是 OpenClaw CLI 在插件安装失败后尝试按 hook pack 解释同一包产生的附带信息，不是另一个独立根因。
+
+## 3. 方案设计
+
+### 3.1 插件版本升级
+
+在 `package.json` 的 `openclaw.plugins` 中只升级指定插件：
+
+- `@dingtalk-real-ai/dingtalk-connector` -> `0.8.23`
+- `@larksuite/openclaw-lark` -> `2026.6.10`
+- `@wecom/wecom-openclaw-plugin` -> `2026.5.25`
+- `moltbot-popo` -> `2.1.13`
+
+保持以下插件版本不变：
+
+- `@tencent-weixin/openclaw-weixin@2.4.3`
+- `@clawemail/email@0.9.12`
+- `openclaw-netease-bee@0.1.3`
+- `openclaw-nim-channel` git tag `1.1.1`
+
+### 3.2 兼容新旧安装布局
+
+`scripts/ensure-openclaw-plugins.cjs` 不再硬编码只读取 `extensions/{pluginId}`，而是按以下顺序查找实际安装目录：
+
+1. 旧布局精确路径：`extensions/{plugin.id}`。
+2. 旧布局扫描：`extensions/*`，按 `openclaw.plugin.json#id` 或 `package.json#name` 匹配。
+3. 新布局扫描：`npm/projects/*/node_modules/*`，支持 scoped package，按 manifest id 或 npm 包名匹配。
+
+这样同一脚本可以兼容 OpenClaw 旧版 `extensions` 布局与 `v2026.6.1` 的隔离 npm project 布局。
+
+对于新布局，复制缓存时不能只复制插件包目录，还需要将 project 级 `node_modules` 中除插件自身和 `openclaw` peer 链接以外的依赖复制到插件缓存的 `node_modules` 下，使 runtime 从插件目录解析依赖时仍能命中。
+
+### 3.3 避免复制 OpenClaw host peerDependency
+
+OpenClaw CLI 安装插件时会把插件的 peerDependency `openclaw` 链接到 LobsterAI bundled runtime：
+
+```text
+node_modules/openclaw -> vendor/openclaw-runtime/...
+```
+
+如果直接 `fs.cpSync` 复制安装目录，Windows 下 junction/symlink 可能导致复制整个 runtime，造成单个插件缓存膨胀到数百 MB。
+
+安装脚本复制插件缓存时需要过滤：
+
+```text
+node_modules/openclaw
+```
+
+该过滤只移除 host runtime peer 链接，不影响插件自己的真实 dependencies。
+
+### 3.4 固定 bundled plugins 根目录
+
+`runOpenClawCli()` 调用 OpenClaw CLI 时，如果 runtime 中存在：
+
+```text
+vendor/openclaw-runtime/current/dist/extensions
+```
+
+则注入：
+
+```text
+OPENCLAW_BUNDLED_PLUGINS_DIR=vendor/openclaw-runtime/current/dist/extensions
+```
+
+这让 OpenClaw CLI 在插件安装期间稳定使用正确的 bundled channel 根目录，避免把 bundled channels 错误解析到不存在 generated module 的位置。
+
+### 3.5 Bee 专用临时兼容脚本
+
+不在 `package.json` 增加通用标识，也不把 Bee 的特殊处理混入主安装逻辑。新增独立脚本：
+
+```text
+scripts/prepare-openclaw-netease-bee.cjs
+```
+
+主安装脚本只在插件 id 或 npm 包名为 `openclaw-netease-bee` 时调用该脚本。
+
+Bee 兼容流程：
+
+1. `npm pack openclaw-netease-bee@0.1.3` 得到原始 tgz。
+2. 解压 tgz 到临时目录。
+3. 读取包内 `package.json.openclaw.extensions`。
+4. 如果 runtime entry 已经是 JavaScript，则不处理。
+5. 如果 runtime entry 指向 `.ts`，用 esbuild 编译为 `.mjs`。
+6. 更新包内 `package.json`：
+   - `openclaw.extensions` 从 `["./index.ts"]` 改为 `["./index.mjs"]`
+   - `main` 从 `./index.ts` 改为 `./index.mjs`
+   - `files` 增加 `index.mjs`
+7. 对修补后的目录重新 `npm pack`。
+8. 将修补后的 tgz 交给 `openclaw plugins install`。
+
+该方案保留 OpenClaw CLI 的最终安装与校验职责，只在 CLI 之前补齐 Bee npm 包缺失的编译产物。
+
+## 4. 实施步骤
+
+1. 修改 `package.json`，升级 DingTalk、Lark/Feishu、WeCom、POPO，保持微信与 ClawEmail 不变。
+2. 修改 `scripts/ensure-openclaw-plugins.cjs`：
+   - 支持新旧插件安装布局查找。
+   - 复制缓存时过滤 `node_modules/openclaw` host peer 链接。
+   - 调用 OpenClaw CLI 时注入 `OPENCLAW_BUNDLED_PLUGINS_DIR`。
+   - Bee 插件安装前调用专用预处理脚本。
+3. 新增 `scripts/prepare-openclaw-netease-bee.cjs`，封装 Bee tgz 修补、编译与重打包逻辑。
+4. 新增/补充测试：
+   - 旧 `extensions` 布局查找。
+   - 新 `npm/projects/.../node_modules` 布局查找。
+   - 新 npm project 布局下 sibling dependencies 复制。
+   - 复制插件时不复制 OpenClaw host peer 链接。
+   - Bee TypeScript runtime entry 编译与 package metadata 更新。
+   - Bee 已经是 JavaScript runtime entry 时不重复处理。
+5. 清理本地插件/runtime 缓存后复测从零构建路径。
+
+## 5. 涉及文件
+
+| 文件 | 作用 |
+|------|------|
+| `package.json` | 更新指定 OpenClaw IM 插件版本 |
+| `scripts/ensure-openclaw-plugins.cjs` | 插件安装主流程；兼容新旧布局；设置 bundled plugins 目录；接入 Bee 专用预处理 |
+| `scripts/prepare-openclaw-netease-bee.cjs` | Bee npm 包临时修补、编译和重打包 |
+| `tests/ensure-openclaw-plugins.test.ts` | 覆盖安装布局查找与 peer 链接过滤 |
+| `tests/prepare-openclaw-netease-bee.test.ts` | 覆盖 Bee 预处理脚本 |
+
+## 6. 验证计划
+
+### 6.1 静态检查
+
+```bash
+node --check scripts/ensure-openclaw-plugins.cjs
+node --check scripts/prepare-openclaw-netease-bee.cjs
+```
+
+### 6.2 单元测试
+
+```bash
+npm test -- ensure-openclaw-plugins prepare-openclaw-netease-bee
+```
+
+预期：
+
+- 所有安装脚本相关测试通过。
+- Bee 编译测试生成 `index.mjs`，并更新 `openclaw.extensions`。
+
+### 6.3 插件安装验证
+
+```bash
+npm run openclaw:plugins
+```
+
+预期：
+
+- DingTalk、Lark/Feishu、WeCom、POPO 安装目标版本。
+- 微信与 ClawEmail 版本保持不变。
+- 不再出现 `telegram` / `imessage` 的 bundled channel `missing generated module` warning。
+- Bee 安装成功，最终 runtime 中：
+
+```text
+third-party-extensions/openclaw-netease-bee/package.json
+third-party-extensions/openclaw-netease-bee/index.mjs
+```
+
+并且 `package.json.openclaw.extensions` 指向：
+
+```json
+["./index.mjs"]
+```
+
+- Lark 与 DingTalk 的运行时依赖可从插件目录解析：
+
+```text
+openclaw-lark/node_modules/image-size
+dingtalk-connector/node_modules/dingtalk-stream
+```
+
+### 6.4 预编译与构建验证
+
+```bash
+npm run openclaw:precompile
+npm run build
+```
+
+预期：
+
+- `openclaw:precompile` 不因 Bee 的 TypeScript runtime entry 失败。
+- `npm run build` 通过。
+
+## 7. 已知限制与后续处理
+
+### 7.1 Bee 兼容方案是临时方案
+
+Bee 的根因是上游 npm 包没有发布已编译 runtime JavaScript。LobsterAI 当前方案只用于保证 OpenClaw `v2026.6.1` 从零构建可用。上游发布修复版本后，应移除 Bee 专用预处理逻辑，并恢复为普通 npm 插件安装路径。
+
+### 7.2 NIM channel 仍为 optional
+
+当前 NIM channel 仍可能在 OpenClaw `v2026.6.1` 安装阶段因为包形态或 TypeScript entry 失败。该插件在 `package.json` 中为 optional，失败不会阻断构建。本次变更不处理 NIM，以避免扩大升级范围。
+
+### 7.3 POPO suspicious code pattern warning
+
+POPO 安装时可能提示：
+
+```text
+Plugin "moltbot-popo" has suspicious code pattern(s)
+```
+
+这是 OpenClaw CLI 的安全扫描 warning；当前安装命令使用 `--dangerously-force-unsafe-install` 允许继续安装。该 warning 与本次布局兼容、Bee 编译兼容无直接关系。如需进一步确认，应单独运行 OpenClaw security audit 并评估 POPO 插件内容。

--- a/tests/ensure-openclaw-plugins.test.ts
+++ b/tests/ensure-openclaw-plugins.test.ts
@@ -1,8 +1,15 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { describe, expect, test } from 'vitest';
 
 const {
   buildGitEnv,
   buildNpmPackEnv,
+  copyDirRecursive,
+  copyInstalledPluginToCache,
+  findInstalledPluginDir,
   isGitSpec,
   isLocalPathSpec,
   parseGitSpec,
@@ -113,5 +120,100 @@ describe('ensure-openclaw-plugins', () => {
       installSpec: '/tmp/local-plugin',
       pinnedDisplaySpec: '/tmp/local-plugin',
     });
+  });
+
+  test('finds plugins installed in the legacy extensions directory', () => {
+    const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-plugin-layout-'));
+    const pluginDir = path.join(stagingDir, 'extensions', 'actual-plugin-id');
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, 'openclaw.plugin.json'),
+      JSON.stringify({ id: 'actual-plugin-id' }),
+    );
+
+    expect(
+      findInstalledPluginDir(stagingDir, {
+        id: 'actual-plugin-id',
+        npm: '@example/plugin',
+      }),
+    ).toBe(pluginDir);
+
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  });
+
+  test('finds npm plugins installed in isolated OpenClaw projects', () => {
+    const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-plugin-layout-'));
+    const pluginDir = path.join(
+      stagingDir,
+      'npm',
+      'projects',
+      'example-plugin-123',
+      'node_modules',
+      '@example',
+      'plugin',
+    );
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, 'openclaw.plugin.json'),
+      JSON.stringify({ id: 'manifest-id-differs' }),
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, 'package.json'),
+      JSON.stringify({ name: '@example/plugin' }),
+    );
+
+    expect(
+      findInstalledPluginDir(stagingDir, {
+        id: 'configured-plugin-id',
+        npm: '@example/plugin',
+      }),
+    ).toBe(pluginDir);
+
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  });
+
+  test('does not copy the OpenClaw host peer link into plugin caches', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-plugin-copy-'));
+    const sourceDir = path.join(tempDir, 'source');
+    const targetDir = path.join(tempDir, 'target');
+    const hostDir = path.join(tempDir, 'host-openclaw');
+    fs.mkdirSync(path.join(sourceDir, 'node_modules'), { recursive: true });
+    fs.mkdirSync(hostDir, { recursive: true });
+    fs.writeFileSync(path.join(sourceDir, 'index.js'), 'export {};\n');
+    fs.writeFileSync(path.join(hostDir, 'host.js'), 'export {};\n');
+    fs.symlinkSync(hostDir, path.join(sourceDir, 'node_modules', 'openclaw'), 'junction');
+
+    copyDirRecursive(sourceDir, targetDir);
+
+    expect(fs.existsSync(path.join(targetDir, 'index.js'))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, 'node_modules', 'openclaw'))).toBe(false);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('copies isolated npm project dependencies into plugin caches', () => {
+    const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-plugin-project-'));
+    const projectNodeModulesDir = path.join(stagingDir, 'npm', 'projects', 'example', 'node_modules');
+    const pluginDir = path.join(projectNodeModulesDir, '@example', 'plugin');
+    const dependencyDir = path.join(projectNodeModulesDir, 'image-size');
+    const openclawPeerDir = path.join(stagingDir, 'host-openclaw');
+    const cacheDir = path.join(stagingDir, 'cache');
+
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.mkdirSync(dependencyDir, { recursive: true });
+    fs.mkdirSync(openclawPeerDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, 'index.js'), "require('image-size');\n");
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ name: '@example/plugin' }));
+    fs.writeFileSync(path.join(dependencyDir, 'index.js'), 'module.exports = {};\n');
+    fs.symlinkSync(openclawPeerDir, path.join(projectNodeModulesDir, 'openclaw'), 'junction');
+
+    copyInstalledPluginToCache(pluginDir, cacheDir);
+
+    expect(fs.existsSync(path.join(cacheDir, 'index.js'))).toBe(true);
+    expect(fs.existsSync(path.join(cacheDir, 'node_modules', 'image-size', 'index.js'))).toBe(true);
+    expect(fs.existsSync(path.join(cacheDir, 'node_modules', '@example', 'plugin'))).toBe(false);
+    expect(fs.existsSync(path.join(cacheDir, 'node_modules', 'openclaw'))).toBe(false);
+
+    fs.rmSync(stagingDir, { recursive: true, force: true });
   });
 });

--- a/tests/openclaw-plugin-patches-dingtalk.test.ts
+++ b/tests/openclaw-plugin-patches-dingtalk.test.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const {
+  findDingtalkDistMessageHandlers,
+  patchDingtalk,
+} = require('../scripts/openclaw-plugin-patches/dingtalk.cjs');
+
+describe('openclaw DingTalk plugin patches', () => {
+  test('patches Windows file URLs in source and dist message handlers', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dingtalk-plugin-patch-'));
+    const pluginDir = path.join(tempDir, 'dingtalk-connector');
+    const sourceHandler = path.join(pluginDir, 'src', 'core', 'message-handler.ts');
+    const distHandler = path.join(pluginDir, 'dist', 'message-handler-test.mjs');
+    fs.mkdirSync(path.dirname(sourceHandler), { recursive: true });
+    fs.mkdirSync(path.dirname(distHandler), { recursive: true });
+    fs.mkdirSync(path.join(pluginDir, 'src', 'utils'), { recursive: true });
+
+    fs.writeFileSync(
+      sourceHandler,
+      "const imageMarkdown = imageLocalPaths.map(p => `![image](file://${p})`).join('\\n');\n",
+    );
+    fs.writeFileSync(
+      distHandler,
+      'const imageMarkdown = imageLocalPaths.map((p) => `![image](file://${p})`).join("\\n");\n',
+    );
+    fs.writeFileSync(path.join(pluginDir, 'src', 'utils', 'agent.ts'), 'export {};\n');
+
+    patchDingtalk({ runtimeExtensionsDir: tempDir, log: () => {} });
+
+    const patchedSource = fs.readFileSync(sourceHandler, 'utf-8');
+    const patchedDist = fs.readFileSync(distHandler, 'utf-8');
+    expect(patchedSource).toContain('file:///${n}');
+    expect(patchedDist).toContain('file:///${n}');
+    expect(patchedDist).not.toContain('imageLocalPaths.map((p) => `![image](file://${p})`)');
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('finds hashed dist message handler bundles', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dingtalk-plugin-patch-'));
+    const pluginDir = path.join(tempDir, 'dingtalk-connector');
+    const distDir = path.join(pluginDir, 'dist');
+    fs.mkdirSync(distDir, { recursive: true });
+    fs.writeFileSync(path.join(distDir, 'message-handler-abc123.mjs'), 'export {};\n');
+    fs.writeFileSync(path.join(distDir, 'message-handler-abc123.d.mts'), 'export {};\n');
+    fs.writeFileSync(path.join(distDir, 'runtime-abc123.mjs'), 'export {};\n');
+
+    expect(findDingtalkDistMessageHandlers(pluginDir)).toEqual([
+      path.join(distDir, 'message-handler-abc123.mjs'),
+    ]);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('patches bundled dist workspace resolver', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dingtalk-plugin-patch-'));
+    const pluginDir = path.join(tempDir, 'dingtalk-connector');
+    const sourceHandler = path.join(pluginDir, 'src', 'core', 'message-handler.ts');
+    const distHandler = path.join(pluginDir, 'dist', 'message-handler-test.mjs');
+    fs.mkdirSync(path.dirname(sourceHandler), { recursive: true });
+    fs.mkdirSync(path.dirname(distHandler), { recursive: true });
+    fs.mkdirSync(path.join(pluginDir, 'src', 'utils'), { recursive: true });
+    fs.writeFileSync(sourceHandler, 'export {};\n');
+    fs.writeFileSync(
+      distHandler,
+      [
+        'function resolveAgentWorkspaceDir(cfg, agentId) {',
+        '\tconst agentConfig = cfg.agents?.list?.find((a) => a.id === agentId);',
+        '\tif (agentConfig?.workspace) return agentConfig.workspace.startsWith("~") ? path$1.join(os.homedir(), agentConfig.workspace.slice(1)) : agentConfig.workspace;',
+        '\tif (agentId === "main" || agentId === cfg.defaultAgent) return path$1.join(os.homedir(), ".openclaw", "workspace");',
+        '\treturn path$1.join(os.homedir(), ".openclaw", `workspace-${agentId}`);',
+        '}',
+      ].join('\n'),
+    );
+    fs.writeFileSync(path.join(pluginDir, 'src', 'utils', 'agent.ts'), 'export {};\n');
+
+    patchDingtalk({ runtimeExtensionsDir: tempDir, log: () => {} });
+
+    const patchedDist = fs.readFileSync(distHandler, 'utf-8');
+    expect(patchedDist).toContain('dingtalk_agent_workspace_defaults_patch');
+    expect(patchedDist).toContain('cfg.agents?.defaults?.workspace?.trim()');
+    expect(patchedDist).toContain('path$1.join(expandWorkspacePath(fallbackWorkspace), agentId)');
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+});

--- a/tests/prepare-openclaw-netease-bee.test.ts
+++ b/tests/prepare-openclaw-netease-bee.test.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const {
+  patchBeePackageDirectory,
+} = require('../scripts/prepare-openclaw-netease-bee.cjs');
+
+describe('prepare-openclaw-netease-bee', () => {
+  test('compiles TypeScript runtime entries and updates package metadata', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-netease-bee-'));
+    fs.writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'openclaw-netease-bee',
+          version: '0.1.3',
+          main: './index.ts',
+          files: ['index.ts', 'src', 'openclaw.plugin.json'],
+          openclaw: {
+            extensions: ['./index.ts'],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    fs.writeFileSync(
+      path.join(tempDir, 'index.ts'),
+      "export function activate() { return 'bee'; }\n",
+    );
+    fs.writeFileSync(path.join(tempDir, 'openclaw.plugin.json'), JSON.stringify({ id: 'bee' }));
+
+    const result = patchBeePackageDirectory(tempDir);
+    const pkg = JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf-8'));
+
+    expect(result).toEqual({ changed: true, compiledEntries: ['./index.mjs'] });
+    expect(fs.existsSync(path.join(tempDir, 'index.mjs'))).toBe(true);
+    expect(pkg.main).toBe('./index.mjs');
+    expect(pkg.files).toContain('index.mjs');
+    expect(pkg.openclaw.extensions).toEqual(['./index.mjs']);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('leaves already compiled runtime entries unchanged', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-netease-bee-'));
+    fs.writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'openclaw-netease-bee',
+        version: '0.1.3',
+        openclaw: {
+          extensions: ['./index.mjs'],
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(tempDir, 'index.mjs'), 'export {};\n');
+
+    expect(patchBeePackageDirectory(tempDir)).toEqual({ changed: false, compiledEntries: [] });
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary

- Upgrade selected preinstalled OpenClaw IM plugins: DingTalk, Lark/Feishu, WeCom, and POPO.
- Support OpenClaw 2026.6.1 plugin install layouts under both `extensions/` and `npm/projects/.../node_modules/`.
- Copy npm project sibling dependencies into plugin runtime caches while excluding the host `openclaw` peer link.
- Set bundled plugin scan directory for OpenClaw CLI installs to avoid bundled channel setup warnings.
- Add a temporary NetEase Bee package preparation step that compiles the TypeScript runtime entry before handing the package to OpenClaw CLI.
- Document the IM plugin upgrade rationale and validation plan.

## Verification

- `node --check scripts\ensure-openclaw-plugins.cjs`
- `node --check scripts\prepare-openclaw-netease-bee.cjs`
- `npm test -- ensure-openclaw-plugins prepare-openclaw-netease-bee`
- `npm run openclaw:plugins`
- `npm run openclaw:precompile`
- `npm run build`