### PR TITLE
fix(openclaw): include cwd in reply options patch

### DIFF
--- a/scripts/patches/v2026.6.1/openclaw-im-bound-agent-run-cwd.patch
+++ b/scripts/patches/v2026.6.1/openclaw-im-bound-agent-run-cwd.patch
@@ -99,6 +99,18 @@ index 236122671c..c1259b93a7 100644
        abortedLastRun,
        autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
      }),
+diff --git a/src/auto-reply/get-reply-options.types.ts b/src/auto-reply/get-reply-options.types.ts
+--- a/src/auto-reply/get-reply-options.types.ts
++++ b/src/auto-reply/get-reply-options.types.ts
+@@ -49,6 +49,8 @@ export type GetReplyOptions = {
+   runId?: string;
+   /** Abort signal for the underlying agent run. */
+   abortSignal?: AbortSignal;
++  /** Override the working directory for this agent run. */
++  cwd?: string;
+   /** Optional inbound images (used for webchat attachments). */
+   images?: ImageContent[];
+   /** Original inline/offloaded attachment order for inbound images. */
 diff --git a/src/config/types.agent-defaults.ts b/src/config/types.agent-defaults.ts
 index 6d4d29a7bd..297aad77b2 100644
 --- a/src/config/types.agent-defaults.ts


### PR DESCRIPTION
## Summary
- add the missing GetReplyOptions.cwd field to the OpenClaw v2026.6.1 run-cwd patch
- fixes plugin SDK declaration generation after chat send starts passing cwd through reply options

## Verification
- Applied all v2026.6.1 OpenClaw patches on a clean temporary worktree
- Ran: node scripts/run-tsgo.mjs -p tsconfig.plugin-sdk.dts.json --declaration true