### PR TITLE
fix(openclaw): migrate legacy cron storage on startup

### DIFF
--- a/specs/refactors/openclaw-upgrade/2026-06-23-openclaw-cron-legacy-migration.md
+++ b/specs/refactors/openclaw-upgrade/2026-06-23-openclaw-cron-legacy-migration.md
@@ -1,0 +1,140 @@
+# OpenClaw 定时任务 legacy 存储迁移设计文档
+
+## 1. 概述
+
+### 1.1 问题/动机
+
+OpenClaw 升级到 `v2026.6.1` 后，cron 定时任务的权威存储从 legacy JSON 文件迁移到 OpenClaw shared SQLite state database。QA 升级后反馈定时任务列表为空，日志未发现 `cron.remove` 或任务删除行为，而是 OpenClaw 启动时直接读取到 `jobs=0`。
+
+QA 导出的状态数据进一步确认：
+
+- `openclaw/state/cron/jobs.json` 中仍有 legacy 定时任务。
+- `openclaw/state/state/openclaw.sqlite` 中已有 cron 表，但当前 Windows store key 下没有对应任务。
+- 日志中未出现 OpenClaw `doctor --fix` 的 legacy cron import 记录。
+
+因此问题不是任务被删除，而是升级后 legacy cron JSON 没有按 OpenClaw 官方路径导入 SQLite。
+
+### 1.2 目标
+
+- 遵循 OpenClaw 官方迁移指引：升级时运行 `openclaw doctor --fix` 导入 legacy cron JSON、state 和 run logs。
+- 只在检测到 legacy cron 文件时触发迁移，避免普通启动增加额外成本。
+- 不在 LobsterAI 中复制 OpenClaw cron schema、normalize、SQLite projection 和 run-log import 规则。
+- 迁移失败不阻断应用启动，避免修复路径引入启动失败。
+- 确保后续启动依赖 OpenClaw `.migrated` 归档机制自然跳过，不额外引入 LobsterAI 迁移 marker。
+
+## 2. 现状分析
+
+OpenClaw 官方文档 `vendor/openclaw-runtime/current/docs/automation/cron-jobs.md` 说明：
+
+- cron job definitions、runtime state、run history 已持久化到 shared SQLite state database。
+- 升级时运行 `openclaw doctor --fix`，把 legacy `cron/jobs.json`、`jobs-state.json`、`runs/*.jsonl` 导入 SQLite，并将 legacy 文件归档为 `.migrated`。
+- `cron.store` 仍作为 logical store key 和 legacy doctor import path。
+
+OpenClaw cron doctor 逻辑并非简单 JSON 导入，包含：
+
+- legacy `jobs.json` / `jobs-state.json` 读取和状态合并；
+- 旧字段规范化，例如 `jobId`、`schedule.cron`、旧 payload/delivery 字段；
+- 无效 job quarantine；
+- SQLite 已有任务和 legacy-only 任务合并；
+- legacy run logs 去重导入；
+- 成功后归档 `.migrated`。
+
+因此 LobsterAI 不应自行实现这套迁移细节。
+
+## 3. 方案设计
+
+### 3.1 显式写入 cron.store
+
+OpenClaw config sync 生成：
+
+```ts
+cron: {
+  enabled: true,
+  store: path.join(stateDir, 'cron', 'jobs.json'),
+  skipMissedJobs,
+  maxConcurrentRuns: 3,
+  sessionRetention: '7d',
+}
+```
+
+这样 doctor import path 与 gateway runtime 使用的 logical store key 保持一致。
+
+### 3.2 Gateway 启动前 legacy cron preflight
+
+在 OpenClaw gateway fork 前执行轻量 preflight：
+
+1. 检查是否存在：
+   - `openclaw/state/cron/jobs.json`
+   - `openclaw/state/cron/jobs-state.json`
+   - `openclaw/state/cron/runs/*.jsonl`
+2. 不存在则直接跳过。
+3. 存在时写入一个临时最小 OpenClaw config：
+
+```json
+{
+  "gateway": { "mode": "local" },
+  "cron": {
+    "enabled": true,
+    "store": "<stateDir>/cron/jobs.json"
+  }
+}
+```
+
+4. 调用 bundled OpenClaw CLI：
+
+```text
+openclaw.mjs doctor --non-interactive --fix
+```
+
+运行环境与 gateway 保持一致：
+
+- `OPENCLAW_HOME`
+- `OPENCLAW_STATE_DIR`
+- `OPENCLAW_CONFIG_PATH` 指向临时最小 config，而不是真实 `openclaw.json`
+- `ELECTRON_RUN_AS_NODE=1`
+
+使用临时 config 的原因是完整 doctor 可能修复非 cron 配置，例如 skills、plugins、gateway auth 等。cron 迁移只依赖 `cron.store` 和 state dir，因此临时 config 可以复用 OpenClaw 官方 cron migration 逻辑，同时避免改写 LobsterAI 生成的真实配置。
+
+### 3.3 失败策略
+
+doctor 退出非 0 或超时：
+
+- 记录 warning 和有限长度输出尾部；
+- 继续启动 gateway；
+- 不删除、不移动 legacy 文件。
+
+这样用户仍可打开应用，后续仍可人工或下一次升级修复。
+
+## 4. 实施步骤
+
+1. 新增 `src/main/libs/openclawCronLegacyMigration.ts`：
+   - legacy 文件探测；
+   - official doctor 命令执行；
+   - 超时、失败和日志处理。
+2. 在 `OpenClawEngineManager.startGateway()` 中，fork gateway 前调用 preflight。
+3. 在 `openclawConfigSync` 生成的 `cron` 配置中写入 `store`。
+4. 增加 Vitest 覆盖：
+   - 无 legacy 文件时跳过；
+   - `jobs.json` 存在时调用 doctor；
+   - 仅有 `runs/*.jsonl` 时调用 doctor；
+   - CLI 缺失时跳过；
+   - doctor 非 0 时返回失败但不抛出。
+
+## 5. 涉及文件
+
+- `src/main/libs/openclawCronLegacyMigration.ts`
+- `src/main/libs/openclawCronLegacyMigration.test.ts`
+- `src/main/libs/openclawEngineManager.ts`
+- `src/main/libs/openclawConfigSync.ts`
+- `src/main/libs/openclawConfigSync.runtime.test.ts`
+
+## 6. 验证计划
+
+- 运行新增迁移模块单测。
+- 运行 OpenClaw config sync 相关单测。
+- 运行 touched TypeScript 文件 ESLint。
+- 使用 QA 导出的 legacy cron 数据在临时目录验证：
+  - doctor 前 legacy JSON 有任务；
+  - doctor 后 SQLite 当前 store key 下可读到任务；
+  - legacy JSON / run logs 被归档为 `.migrated`；
+  - 第二次 preflight 不再触发 doctor。

--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -204,6 +204,7 @@ describe('OpenClawConfigSync runtime config output', () => {
     const mainEntry = config.agents.list.find((entry: { id?: string }) => entry.id === 'main');
 
     expect(config.cron.skipMissedJobs).toBe(true);
+    expect(config.cron.store).toBe(path.join(stateDir, 'cron', 'jobs.json'));
     expect(config.agents.defaults.cwd).toBe(path.resolve(mainAgentWorkingDirectory));
     expect(mainEntry.cwd).toBe(path.resolve(mainAgentWorkingDirectory));
   });

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -1594,6 +1594,7 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
       },
       cron: {
         enabled: true,
+        store: path.join(this.engineManager.getStateDir(), 'cron', 'jobs.json'),
         skipMissedJobs: coworkConfig.skipMissedJobs === true,
         maxConcurrentRuns: 3,
         sessionRetention: '7d',

--- a/src/main/libs/openclawCronLegacyMigration.test.ts
+++ b/src/main/libs/openclawCronLegacyMigration.test.ts
@@ -1,0 +1,160 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  hasLegacyCronStorage,
+  type LegacyCronMigrationRunner,
+  migrateLegacyCronStorageWithDoctor,
+  resolveLegacyCronStorePath,
+} from './openclawCronLegacyMigration';
+
+let tmpDir = '';
+let stateDir = '';
+let runtimeRoot = '';
+let electronNodeRuntimePath = '';
+
+function mkdirp(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function writeFile(filePath: string, content: string): void {
+  mkdirp(path.dirname(filePath));
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+describe('openclawCronLegacyMigration', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lobsterai-openclaw-cron-migration-'));
+    stateDir = path.join(tmpDir, 'openclaw', 'state');
+    runtimeRoot = path.join(tmpDir, 'runtime');
+    electronNodeRuntimePath = process.execPath;
+    mkdirp(runtimeRoot);
+    writeFile(path.join(runtimeRoot, 'openclaw.mjs'), 'console.log("openclaw");\n');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('skips when no legacy cron storage exists', async () => {
+    const runner = vi.fn<LegacyCronMigrationRunner>();
+
+    expect(hasLegacyCronStorage(stateDir)).toBe(false);
+
+    const result = await migrateLegacyCronStorageWithDoctor({
+      stateDir,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: {},
+      runner,
+    });
+
+    expect(result).toEqual({ status: 'skipped', reason: 'no-legacy-cron-files' });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  test('runs official doctor fix when jobs.json exists', async () => {
+    writeFile(resolveLegacyCronStorePath(stateDir), '{"version":1,"jobs":[]}\n');
+    const runner = vi.fn<LegacyCronMigrationRunner>().mockResolvedValue({
+      code: 0,
+      stdout: 'ok',
+      stderr: '',
+    });
+
+    const result = await migrateLegacyCronStorageWithDoctor({
+      stateDir,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: { EXISTING: '1' },
+      runner,
+    });
+
+    expect(result).toEqual({ status: 'migrated', code: 0 });
+    expect(runner).toHaveBeenCalledTimes(1);
+    const [command, args, options] = runner.mock.calls[0];
+    expect(command).toBe(electronNodeRuntimePath);
+    expect(args).toEqual([
+      path.join(runtimeRoot, 'openclaw.mjs'),
+      'doctor',
+      '--non-interactive',
+      '--fix',
+    ]);
+    expect(options.cwd).toBe(runtimeRoot);
+    expect(options.timeoutMs).toBeGreaterThan(0);
+    expect(options.env.EXISTING).toBe('1');
+    expect(options.env.OPENCLAW_HOME).toBe(path.dirname(stateDir));
+    expect(options.env.OPENCLAW_STATE_DIR).toBe(stateDir);
+    expect(options.env.OPENCLAW_CONFIG_PATH).toBe(path.join(stateDir, '.lobsterai-cron-doctor-openclaw.json'));
+    expect(options.env.ELECTRON_RUN_AS_NODE).toBe('1');
+    expect(JSON.parse(fs.readFileSync(options.env.OPENCLAW_CONFIG_PATH ?? '', 'utf8'))).toEqual({
+      gateway: { mode: 'local' },
+      cron: {
+        enabled: true,
+        store: resolveLegacyCronStorePath(stateDir),
+      },
+    });
+  });
+
+  test('runs doctor when only legacy run logs exist', async () => {
+    writeFile(path.join(stateDir, 'cron', 'runs', 'job-1.jsonl'), '{"status":"ok"}\n');
+    const runner = vi.fn<LegacyCronMigrationRunner>().mockResolvedValue({
+      code: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    expect(hasLegacyCronStorage(stateDir)).toBe(true);
+
+    const result = await migrateLegacyCronStorageWithDoctor({
+      stateDir,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: {},
+      runner,
+    });
+
+    expect(result).toEqual({ status: 'migrated', code: 0 });
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  test('skips when legacy files exist but bundled OpenClaw CLI is missing', async () => {
+    fs.rmSync(path.join(runtimeRoot, 'openclaw.mjs'), { force: true });
+    writeFile(resolveLegacyCronStorePath(stateDir), '{"version":1,"jobs":[]}\n');
+    const runner = vi.fn<LegacyCronMigrationRunner>();
+
+    const result = await migrateLegacyCronStorageWithDoctor({
+      stateDir,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: {},
+      runner,
+    });
+
+    expect(result).toEqual({ status: 'skipped', reason: 'missing-openclaw-cli' });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  test('returns failed when doctor exits non-zero', async () => {
+    writeFile(resolveLegacyCronStorePath(stateDir), '{"version":1,"jobs":[]}\n');
+    const runner = vi.fn<LegacyCronMigrationRunner>().mockResolvedValue({
+      code: 2,
+      stdout: 'preview',
+      stderr: 'failed',
+    });
+
+    const result = await migrateLegacyCronStorageWithDoctor({
+      stateDir,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: {},
+      runner,
+    });
+
+    expect(result).toEqual({ status: 'failed', code: 2 });
+  });
+});

--- a/src/main/libs/openclawCronLegacyMigration.ts
+++ b/src/main/libs/openclawCronLegacyMigration.ts
@@ -1,0 +1,179 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const LEGACY_CRON_DOCTOR_TIMEOUT_MS = 180_000;
+const LOG_TAIL_LIMIT = 4_000;
+
+export type LegacyCronMigrationRunResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+export type LegacyCronMigrationRunner = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    timeoutMs: number;
+  },
+) => Promise<LegacyCronMigrationRunResult>;
+
+export type LegacyCronMigrationResult =
+  | { status: 'skipped'; reason: 'no-legacy-cron-files' | 'missing-openclaw-cli' }
+  | { status: 'migrated'; code: number | null }
+  | { status: 'failed'; code: number | null; error?: string };
+
+export function resolveLegacyCronStorePath(stateDir: string): string {
+  return path.join(stateDir, 'cron', 'jobs.json');
+}
+
+function resolveLegacyCronStatePath(stateDir: string): string {
+  return path.join(stateDir, 'cron', 'jobs-state.json');
+}
+
+function legacyCronRunLogsExist(stateDir: string): boolean {
+  const runsDir = path.join(stateDir, 'cron', 'runs');
+  try {
+    return fs.readdirSync(runsDir, { withFileTypes: true })
+      .some((entry) => entry.isFile() && entry.name.endsWith('.jsonl'));
+  } catch {
+    return false;
+  }
+}
+
+export function hasLegacyCronStorage(stateDir: string): boolean {
+  return (
+    fs.existsSync(resolveLegacyCronStorePath(stateDir)) ||
+    fs.existsSync(resolveLegacyCronStatePath(stateDir)) ||
+    legacyCronRunLogsExist(stateDir)
+  );
+}
+
+function tailLog(text: string): string {
+  if (text.length <= LOG_TAIL_LIMIT) {
+    return text;
+  }
+  return text.slice(text.length - LOG_TAIL_LIMIT);
+}
+
+function resolveDoctorConfigPath(stateDir: string): string {
+  return path.join(stateDir, '.lobsterai-cron-doctor-openclaw.json');
+}
+
+function writeDoctorCronConfig(stateDir: string): string {
+  const configPath = resolveDoctorConfigPath(stateDir);
+  const storePath = resolveLegacyCronStorePath(stateDir);
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      gateway: { mode: 'local' },
+      cron: {
+        enabled: true,
+        store: storePath,
+      },
+    }, null, 2) + '\n',
+    'utf8',
+  );
+  return configPath;
+}
+
+export function runProcess(
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    timeoutMs: number;
+  },
+): Promise<LegacyCronMigrationRunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`OpenClaw legacy cron migration timed out after ${options.timeoutMs}ms`));
+    }, options.timeoutMs);
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+export async function migrateLegacyCronStorageWithDoctor(params: {
+  stateDir: string;
+  runtimeRoot: string;
+  electronNodeRuntimePath: string;
+  env: NodeJS.ProcessEnv;
+  runner?: LegacyCronMigrationRunner;
+}): Promise<LegacyCronMigrationResult> {
+  if (!hasLegacyCronStorage(params.stateDir)) {
+    return { status: 'skipped', reason: 'no-legacy-cron-files' };
+  }
+
+  const openclawCliPath = path.join(params.runtimeRoot, 'openclaw.mjs');
+  if (!fs.existsSync(openclawCliPath)) {
+    console.warn(`[OpenClaw] Legacy cron storage detected but OpenClaw CLI is missing: ${openclawCliPath}`);
+    return { status: 'skipped', reason: 'missing-openclaw-cli' };
+  }
+
+  const runner = params.runner ?? runProcess;
+  const doctorConfigPath = writeDoctorCronConfig(params.stateDir);
+  const env: NodeJS.ProcessEnv = {
+    ...params.env,
+    OPENCLAW_HOME: path.dirname(params.stateDir),
+    OPENCLAW_STATE_DIR: params.stateDir,
+    OPENCLAW_CONFIG_PATH: doctorConfigPath,
+    ELECTRON_RUN_AS_NODE: '1',
+  };
+  const args = [openclawCliPath, 'doctor', '--non-interactive', '--fix'];
+
+  console.log(`[OpenClaw] Legacy cron storage detected; running official doctor migration: ${JSON.stringify(args.slice(1))}`);
+  try {
+    const result = await runner(params.electronNodeRuntimePath, args, {
+      cwd: params.runtimeRoot,
+      env,
+      timeoutMs: LEGACY_CRON_DOCTOR_TIMEOUT_MS,
+    });
+
+    if (result.code === 0) {
+      console.log('[OpenClaw] Legacy cron doctor migration completed.');
+      return { status: 'migrated', code: result.code };
+    }
+
+    console.warn(
+      [
+        `[OpenClaw] Legacy cron doctor migration failed with exit code ${result.code}.`,
+        result.stderr ? `stderr tail:\n${tailLog(result.stderr)}` : '',
+        result.stdout ? `stdout tail:\n${tailLog(result.stdout)}` : '',
+      ].filter(Boolean).join('\n'),
+    );
+    return { status: 'failed', code: result.code };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn('[OpenClaw] Legacy cron doctor migration failed before gateway startup:', error);
+    return { status: 'failed', code: null, error: message };
+  }
+}

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -17,6 +17,7 @@ import {
   pruneGatewayLogs,
 } from './gatewayLogRotation';
 import { getCodexHomeDir } from './openaiCodexAuth';
+import { migrateLegacyCronStorageWithDoctor } from './openclawCronLegacyMigration';
 import { cleanupStaleThirdPartyPluginsFromBundledDir, listLocalOpenClawExtensionIds,syncLocalOpenClawExtensionsIntoRuntime } from './openclawLocalExtensions';
 import { ensureOpenClawWorkerShims } from './openclawWorkerShims';
 import { appendPythonRuntimeToEnv } from './pythonRuntime';
@@ -574,6 +575,13 @@ export class OpenClawEngineManager extends EventEmitter {
         console.log(`[OpenClaw] Injected system proxy for gateway via ${targetUrl}:`, proxyUrl);
       }
     }
+
+    await migrateLegacyCronStorageWithDoctor({
+      stateDir: this.stateDir,
+      runtimeRoot: runtime.root,
+      electronNodeRuntimePath,
+      env,
+    });
 
     const forkArgs = ['gateway', '--bind', 'loopback', '--port', String(port), '--token', token, '--verbose'];
     const gatewayExecArgv = buildOpenClawGatewayExecArgv(process.env.NODE_OPTIONS);


### PR DESCRIPTION
## Summary
- detect legacy OpenClaw cron JSON/run-log storage before gateway startup
- run the official OpenClaw doctor migration with a minimal temporary cron config
- explicitly sync cron.store and document the upgrade migration design

## Verification
- npm test -- openclawCronLegacyMigration openclawConfigSync.runtime
- npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/openclawCronLegacyMigration.ts src/main/libs/openclawCronLegacyMigration.test.ts src/main/libs/openclawEngineManager.ts src/main/libs/openclawConfigSync.ts src/main/libs/openclawConfigSync.runtime.test.ts
- npm run compile:electron
- QA cron data dry run in temp state: imported 11 legacy jobs and 13 run logs without modifying the real generated openclaw.json