### PR TITLE
fix(scheduled-task): clarify startup state

### DIFF
--- a/specs/refactors/openclaw-upgrade/2026-06-23-scheduled-task-startup-state.md
+++ b/specs/refactors/openclaw-upgrade/2026-06-23-scheduled-task-startup-state.md
@@ -1,0 +1,43 @@
+# 定时任务启动状态适配设计文档
+
+## 1. 概述
+
+### 1.1 问题/动机
+
+应用窗口早于 OpenClaw Gateway WebSocket 握手完成。定时任务 IPC 在 Gateway client
+尚未可用时返回成功的空数组，Renderer 因而把“服务启动中”误显示为“暂无任务”；历史页在请求等待期间也直接显示空状态。
+
+### 1.2 目标
+
+- 区分服务启动中、数据加载中、加载成功但为空和加载失败。
+- Gateway 握手成功后立即刷新，不额外等待 15 秒轮询周期。
+- 不增加本地任务定义缓存，继续以 OpenClaw cron 数据为权威来源。
+
+## 2. 方案设计
+
+1. 定时任务列表与全局历史 IPC 在 Gateway 未连接时返回 `ready: false`。
+2. Renderer 分别维护任务列表和全局历史的 `starting/loading/ready/error` 状态。
+3. 定时任务页面内容区在启动期间展示“定时任务服务正在启动...”，首次成功查询后才允许展示真正的空状态。
+4. Gateway `onHelloOk` 后通知 `CronJobService` 立即轮询并发送全量刷新事件。
+5. 加载失败时在页面内容区显示重试操作；任务列表就绪前禁用“新建任务”。
+
+## 3. 一次性任务生命周期记录
+
+OpenClaw 对 `schedule.kind = at` 的任务默认设置 `deleteAfterRun = true`。成功执行后任务定义会被删除，任务列表不再展示，但运行历史继续保留；失败任务会按策略重试，重试耗尽后禁用并保留。本次修改维持该行为。
+
+## 4. 涉及文件
+
+- `src/main/ipcHandlers/scheduledTask/handlers.ts`
+- `src/main/libs/agentEngine/openclawRuntimeAdapter.ts`
+- `src/scheduledTask/cronJobService.ts`
+- `src/renderer/services/scheduledTask.ts`
+- `src/renderer/store/slices/scheduledTaskSlice.ts`
+- `src/renderer/components/scheduledTasks/`
+- `src/renderer/services/i18n.ts`
+
+## 5. 验证计划
+
+- 单元测试覆盖 Gateway 从未就绪转为就绪时的即时轮询。
+- 单元测试覆盖任务与历史状态独立转换。
+- 执行变更文件 ESLint、定向 Vitest 和 Electron main/preload 编译。
+- 手工验证冷启动时两个 Tab 不显示错误空状态，Gateway 就绪后自动展示真实数据。

--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -108,10 +108,10 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
       // to avoid blocking the renderer init. Tasks will be loaded later via the
       // onRefresh listener when the gateway becomes available.
       if (!getOpenClawRuntimeAdapter()?.getGatewayClient()) {
-        return { success: true, tasks: [] };
+        return { success: true, ready: false, tasks: [] };
       }
       const tasks = await getCronJobService().listJobs();
-      return { success: true, tasks };
+      return { success: true, ready: true, tasks };
     } catch (error) {
       return {
         success: false,
@@ -253,8 +253,11 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
       filter?: import('../../../scheduledTask/types').RunFilter,
     ) => {
       try {
+        if (!getOpenClawRuntimeAdapter()?.getGatewayClient()) {
+          return { success: true, ready: false, runs: [] };
+        }
         const runs = await getCronJobService().listAllRuns(limit, offset, filter);
-        return { success: true, runs };
+        return { success: true, ready: true, runs };
       } catch (error) {
         return {
           success: false,

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -297,6 +297,7 @@ type GatewayClientCtor = new (options: Record<string, unknown>) => GatewayClient
 
 type OpenClawRuntimeAdapterOptions = {
   normalizeModelRef?: (modelRef: string) => string;
+  onGatewayClientReady?: () => void;
 };
 
 const SessionModelPatchSource = {
@@ -4261,6 +4262,11 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         this.gatewayClientEntryPath = connection.clientEntryPath;
         this.resetGatewayRpcHealth();
         settleResolve();
+        try {
+          this.options.onGatewayClientReady?.();
+        } catch (error) {
+          console.warn('[OpenClawRuntime] gateway ready callback failed:', error);
+        }
         this.lastTickTimestamp = Date.now();
         this.startTickWatchdog();
       },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2439,6 +2439,7 @@ const getCoworkEngineRouter = () => {
         getOpenClawEngineManager(),
         {
           normalizeModelRef: normalizeOpenClawModelRef,
+          onGatewayClientReady: () => getCronJobService().notifyGatewayReady(),
         },
         new SubagentRunStore(getStore().getDatabase()),
         new SubagentMessageStore(getStore().getDatabase()),

--- a/src/renderer/components/scheduledTasks/AllRunsHistory.tsx
+++ b/src/renderer/components/scheduledTasks/AllRunsHistory.tsx
@@ -2,13 +2,14 @@ import { ClockIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { TaskStatus } from '../../../scheduledTask/constants';
+import { ScheduledTaskDataStatus, TaskStatus } from '../../../scheduledTask/constants';
 import type { RunFilter, ScheduledTaskRunWithName } from '../../../scheduledTask/types';
 import { i18nService } from '../../services/i18n';
 import { scheduledTaskService } from '../../services/scheduledTask';
 import { RootState } from '../../store';
 import DateInput from './DateInput';
 import RunSessionModal from './RunSessionModal';
+import ScheduledTaskDataState from './ScheduledTaskDataState';
 import { formatDateTime, formatDuration } from './utils';
 
 const STATUS_OPTIONS = [
@@ -62,6 +63,8 @@ const EMPTY_FILTER: RunFilter = {};
 const AllRunsHistory: React.FC = () => {
   const allRuns = useSelector((state: RootState) => state.scheduledTask.allRuns);
   const allRunsHasMore = useSelector((state: RootState) => state.scheduledTask.allRunsHasMore);
+  const allRunsStatus = useSelector((state: RootState) => state.scheduledTask.allRunsStatus);
+  const allRunsError = useSelector((state: RootState) => state.scheduledTask.allRunsError);
   const [viewingRun, setViewingRun] = useState<ScheduledTaskRunWithName | null>(null);
   const [filter, setFilter] = useState<RunFilter>(EMPTY_FILTER);
 
@@ -108,6 +111,20 @@ const AllRunsHistory: React.FC = () => {
   };
 
   const isEmpty = displayedRuns.length === 0;
+
+  if (allRunsStatus !== ScheduledTaskDataStatus.Ready) {
+    return (
+      <div className={historyPageClass}>
+        <div className={historyContentClass}>
+          <ScheduledTaskDataState
+            status={allRunsStatus}
+            error={allRunsError}
+            onRetry={() => loadInitial(filter)}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={historyPageClass}>

--- a/src/renderer/components/scheduledTasks/ScheduledTaskDataState.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTaskDataState.tsx
@@ -1,0 +1,56 @@
+import { ArrowPathIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import React from 'react';
+
+import {
+  ScheduledTaskDataStatus,
+  type ScheduledTaskDataStatus as ScheduledTaskDataStatusValue,
+} from '../../../scheduledTask/constants';
+import { i18nService } from '../../services/i18n';
+
+interface ScheduledTaskDataStateProps {
+  status: ScheduledTaskDataStatusValue;
+  error?: string | null;
+  onRetry: () => void;
+}
+
+const ScheduledTaskDataState: React.FC<ScheduledTaskDataStateProps> = ({
+  status,
+  error,
+  onRetry,
+}) => {
+  if (status === ScheduledTaskDataStatus.Ready) return null;
+
+  if (status === ScheduledTaskDataStatus.Error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <ExclamationTriangleIcon className="mb-3 h-8 w-8 text-red-500" />
+        <p className="text-sm font-medium text-foreground">
+          {i18nService.t('scheduledTasksLoadFailed')}
+        </p>
+        {error && <p className="mt-1 max-w-md text-xs text-secondary">{error}</p>}
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 inline-flex items-center gap-1.5 text-sm text-primary transition-colors hover:text-primary-hover"
+        >
+          <ArrowPathIcon className="h-4 w-4" />
+          {i18nService.t('scheduledTasksRetry')}
+        </button>
+      </div>
+    );
+  }
+
+  const label =
+    status === ScheduledTaskDataStatus.Starting
+      ? i18nService.t('scheduledTasksServiceStarting')
+      : i18nService.t('scheduledTasksLoading');
+
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <ArrowPathIcon className="mb-3 h-6 w-6 animate-spin text-primary" />
+      <p className="text-sm text-secondary">{label}</p>
+    </div>
+  );
+};
+
+export default ScheduledTaskDataState;

--- a/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
@@ -2,6 +2,7 @@ import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { ScheduledTaskDataStatus } from '../../../scheduledTask/constants';
 import { i18nService } from '../../services/i18n';
 import { scheduledTaskService } from '../../services/scheduledTask';
 import { RootState } from '../../store';
@@ -38,6 +39,7 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
   const viewMode = useSelector((state: RootState) => state.scheduledTask.viewMode);
   const selectedTaskId = useSelector((state: RootState) => state.scheduledTask.selectedTaskId);
   const tasks = useSelector((state: RootState) => state.scheduledTask.tasks);
+  const taskListStatus = useSelector((state: RootState) => state.scheduledTask.taskListStatus);
   const selectedTask = selectedTaskId ? (tasks.find(t => t.id === selectedTaskId) ?? null) : null;
   const [activeTab, setActiveTab] = useState<TabType>('tasks');
   const [deleteTaskInfo, setDeleteTaskInfo] = useState<{ id: string; name: string } | null>(null);
@@ -187,7 +189,8 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
                 <button
                   type="button"
                   onClick={() => dispatch(setViewMode('create'))}
-                  className="px-3 py-1 text-[14px] font-normal leading-5 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+                  disabled={taskListStatus !== ScheduledTaskDataStatus.Ready}
+                  className="px-3 py-1 text-[14px] font-normal leading-5 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-primary"
                 >
                   {i18nService.t('scheduledTasksNewTask')}
                 </button>

--- a/src/renderer/components/scheduledTasks/TaskList.tsx
+++ b/src/renderer/components/scheduledTasks/TaskList.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { ScheduledTaskDataStatus } from '../../../scheduledTask/constants';
 import type { ScheduledTask } from '../../../scheduledTask/types';
 import { i18nService } from '../../services/i18n';
 import { scheduledTaskService } from '../../services/scheduledTask';
@@ -14,6 +15,7 @@ import { RootState } from '../../store';
 import { selectTask, setViewMode } from '../../store/slices/scheduledTaskSlice';
 import EditIcon from '../icons/EditIcon';
 import TrashIcon from '../icons/TrashIcon';
+import ScheduledTaskDataState from './ScheduledTaskDataState';
 import {
   formatNextRunRelative,
   formatScheduleLabel,
@@ -234,13 +236,18 @@ interface TaskListProps {
 
 const TaskList: React.FC<TaskListProps> = ({ onRequestDelete }) => {
   const tasks = useSelector((state: RootState) => state.scheduledTask.tasks);
-  const loading = useSelector((state: RootState) => state.scheduledTask.loading);
+  const status = useSelector((state: RootState) => state.scheduledTask.taskListStatus);
+  const error = useSelector((state: RootState) => state.scheduledTask.taskListError);
 
-  if (loading) {
+  if (status !== ScheduledTaskDataStatus.Ready) {
     return (
       <div className={listPageClass}>
-        <div className={`${listContentClass} flex items-center justify-center py-16`}>
-          <div className="text-secondary">{i18nService.t('loading')}</div>
+        <div className={listContentClass}>
+          <ScheduledTaskDataState
+            status={status}
+            error={error}
+            onRetry={() => void scheduledTaskService.loadTasks()}
+          />
         </div>
       </div>
     );

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -2163,6 +2163,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksTemplateMonthlyAdminSchedule: '每月 25 日 10:00',
     scheduledTasksTemplateMonthlyAdminPrompt:
       '请提醒我整理本月行政待办，包括发票、报销、订阅续费、合同、设备和其他月底前需要处理的事项。请输出一份可勾选清单，并标出建议优先级。',
+    scheduledTasksServiceStarting: '定时任务服务正在启动...',
+    scheduledTasksLoading: '正在加载定时任务...',
+    scheduledTasksLoadFailed: '定时任务数据加载失败',
+    scheduledTasksRetry: '重试',
     scheduledTasksEmptyState: '暂无定时任务',
     scheduledTasksEmptyHint: '创建定时任务，让 AI 按计划自动执行',
     scheduledTasksListColTitle: '标题',
@@ -4791,6 +4795,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     scheduledTasksTemplateMonthlyAdminSchedule: 'Monthly on the 25th at 10:00',
     scheduledTasksTemplateMonthlyAdminPrompt:
       "Remind me to organize this month's admin tasks, including invoices, expenses, subscription renewals, contracts, equipment, and other items that should be handled before month end. Output a checklist and mark suggested priority.",
+    scheduledTasksServiceStarting: 'Starting scheduled task service...',
+    scheduledTasksLoading: 'Loading scheduled tasks...',
+    scheduledTasksLoadFailed: 'Failed to load scheduled task data',
+    scheduledTasksRetry: 'Retry',
     scheduledTasksEmptyState: 'No scheduled tasks',
     scheduledTasksEmptyHint: 'Create scheduled tasks to automate AI execution on a schedule',
     scheduledTasksListColTitle: 'Title',

--- a/src/renderer/services/scheduledTask.test.ts
+++ b/src/renderer/services/scheduledTask.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { ScheduledTaskDataStatus } from '../../scheduledTask/constants';
+import {
+  setAllRunsStatus,
+  setTaskListStatus,
+  setTasks,
+} from '../store/slices/scheduledTaskSlice';
+
+const { dispatch } = vi.hoisted(() => ({ dispatch: vi.fn() }));
+
+vi.mock('../store', () => ({ store: { dispatch } }));
+vi.mock('./i18n', () => ({
+  i18nService: { t: (key: string) => key },
+}));
+
+import { ScheduledTaskService } from './scheduledTask';
+
+function stubScheduledTaskApi(overrides: Record<string, unknown>): void {
+  vi.stubGlobal('window', {
+    dispatchEvent: vi.fn(),
+    electron: {
+      scheduledTasks: {
+        list: vi.fn(async () => ({ success: true, ready: true, tasks: [] })),
+        listAllRuns: vi.fn(async () => ({ success: true, ready: true, runs: [] })),
+        ...overrides,
+      },
+    },
+  });
+}
+
+afterEach(() => {
+  dispatch.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe('ScheduledTaskService startup state', () => {
+  test('keeps the task list in starting state while the gateway is unavailable', async () => {
+    stubScheduledTaskApi({
+      list: vi.fn(async () => ({ success: true, ready: false, tasks: [] })),
+    });
+    const service = new ScheduledTaskService();
+
+    await service.loadTasks();
+
+    expect(dispatch.mock.calls.map(call => call[0])).toEqual([
+      setTaskListStatus(ScheduledTaskDataStatus.Loading),
+      setTaskListStatus(ScheduledTaskDataStatus.Starting),
+    ]);
+  });
+
+  test('marks an empty task list ready only after a successful gateway query', async () => {
+    stubScheduledTaskApi({});
+    const service = new ScheduledTaskService();
+
+    await service.loadTasks();
+
+    expect(dispatch.mock.calls.map(call => call[0])).toEqual([
+      setTaskListStatus(ScheduledTaskDataStatus.Loading),
+      setTasks([]),
+    ]);
+  });
+
+  test('keeps global history in starting state while the gateway is unavailable', async () => {
+    stubScheduledTaskApi({
+      listAllRuns: vi.fn(async () => ({ success: true, ready: false, runs: [] })),
+    });
+    const service = new ScheduledTaskService();
+
+    await service.loadAllRuns(50, 0);
+
+    expect(dispatch.mock.calls.map(call => call[0])).toEqual([
+      setAllRunsStatus(ScheduledTaskDataStatus.Loading),
+      setAllRunsStatus(ScheduledTaskDataStatus.Starting),
+    ]);
+  });
+});

--- a/src/renderer/services/scheduledTask.ts
+++ b/src/renderer/services/scheduledTask.ts
@@ -1,3 +1,4 @@
+import { ScheduledTaskDataStatus } from '../../scheduledTask/constants';
 import type {
   RunFilter,
   ScheduledTask,
@@ -15,9 +16,12 @@ import {
   appendRuns,
   removeTask,
   setAllRuns,
+  setAllRunsError,
+  setAllRunsStatus,
   setError,
-  setLoading,
   setRuns,
+  setTaskListError,
+  setTaskListStatus,
   setTasks,
   updateTask,
   updateTaskState,
@@ -54,11 +58,13 @@ function checkTasksForAnomalies(tasks: ScheduledTask[]): void {
   showToast(msg);
 }
 
-class ScheduledTaskService {
+export class ScheduledTaskService {
   private cleanupFns: (() => void)[] = [];
   private initialized = false;
+  private taskListRequestId = 0;
   private allRunsRequestId = 0;
   private runRequestIds = new Map<string, number>();
+  private lastAllRunsRequest: { limit?: number; filter?: RunFilter } | null = null;
 
   async init(): Promise<void> {
     if (this.initialized) return;
@@ -95,7 +101,14 @@ class ScheduledTaskService {
 
     // Listen for full refresh events (e.g., after first poll or migration)
     const cleanupRefresh = api.onRefresh(() => {
-      this.loadTasks();
+      void this.loadTasks();
+      if (this.lastAllRunsRequest) {
+        void this.loadAllRuns(
+          this.lastAllRunsRequest.limit,
+          0,
+          this.lastAllRunsRequest.filter,
+        );
+      }
     });
     this.cleanupFns.push(cleanupRefresh);
   }
@@ -104,17 +117,28 @@ class ScheduledTaskService {
     const api = window.electron?.scheduledTasks;
     if (!api) return;
 
-    store.dispatch(setLoading(true));
+    const requestId = this.taskListRequestId + 1;
+    this.taskListRequestId = requestId;
+    store.dispatch(setTaskListStatus(ScheduledTaskDataStatus.Loading));
     try {
       const result = await api.list();
+      if (this.taskListRequestId !== requestId) return;
+      if (result.ready === false) {
+        store.dispatch(setTaskListStatus(ScheduledTaskDataStatus.Starting));
+        return;
+      }
       if (result.success && result.tasks) {
         checkTasksForAnomalies(result.tasks);
         store.dispatch(setTasks(result.tasks));
+      } else {
+        const message = result.error || 'Failed to load scheduled tasks';
+        store.dispatch(setTaskListError(message));
       }
     } catch (err: unknown) {
-      store.dispatch(setError(err instanceof Error ? err.message : String(err)));
-    } finally {
-      store.dispatch(setLoading(false));
+      if (this.taskListRequestId !== requestId) return;
+      const message = err instanceof Error ? err.message : String(err);
+      store.dispatch(setTaskListError(message));
+      store.dispatch(setError(message));
     }
   }
 
@@ -243,11 +267,20 @@ class ScheduledTaskService {
     const api = window.electron?.scheduledTasks;
     if (!api) return;
 
+    const isInitialRequest = !offset || offset <= 0;
+    if (isInitialRequest) {
+      this.lastAllRunsRequest = { limit, filter };
+      store.dispatch(setAllRunsStatus(ScheduledTaskDataStatus.Loading));
+    }
     const requestId = this.allRunsRequestId + 1;
     this.allRunsRequestId = requestId;
     try {
       const result = await api.listAllRuns(limit, offset, filter);
       if (this.allRunsRequestId !== requestId) return;
+      if (result.ready === false) {
+        store.dispatch(setAllRunsStatus(ScheduledTaskDataStatus.Starting));
+        return;
+      }
       if (result.success && result.runs) {
         const hasMore = (result.runs as unknown[]).length >= (limit ?? 50);
         if (offset && offset > 0) {
@@ -255,10 +288,16 @@ class ScheduledTaskService {
         } else {
           store.dispatch(setAllRuns({ runs: result.runs, hasMore }));
         }
+      } else if (isInitialRequest) {
+        store.dispatch(setAllRunsError(result.error || 'Failed to load scheduled task history'));
       }
     } catch (err: unknown) {
       if (this.allRunsRequestId !== requestId) return;
-      store.dispatch(setError(err instanceof Error ? err.message : String(err)));
+      const message = err instanceof Error ? err.message : String(err);
+      if (isInitialRequest) {
+        store.dispatch(setAllRunsError(message));
+      }
+      store.dispatch(setError(message));
     }
   }
 

--- a/src/renderer/store/slices/scheduledTaskSlice.test.ts
+++ b/src/renderer/store/slices/scheduledTaskSlice.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest';
+
+import { ScheduledTaskDataStatus } from '../../../scheduledTask/constants';
+import scheduledTaskReducer, {
+  setAllRuns,
+  setAllRunsError,
+  setAllRunsStatus,
+  setTaskListError,
+  setTaskListStatus,
+  setTasks,
+} from './scheduledTaskSlice';
+
+describe('scheduledTaskSlice data status', () => {
+  test('distinguishes service startup from a loaded empty task list', () => {
+    const initial = scheduledTaskReducer(undefined, { type: 'init' });
+    expect(initial.taskListStatus).toBe(ScheduledTaskDataStatus.Starting);
+
+    const loading = scheduledTaskReducer(
+      initial,
+      setTaskListStatus(ScheduledTaskDataStatus.Loading),
+    );
+    expect(loading.taskListStatus).toBe(ScheduledTaskDataStatus.Loading);
+
+    const ready = scheduledTaskReducer(loading, setTasks([]));
+    expect(ready.taskListStatus).toBe(ScheduledTaskDataStatus.Ready);
+    expect(ready.tasks).toEqual([]);
+  });
+
+  test('tracks task and history failures independently', () => {
+    const taskError = scheduledTaskReducer(undefined, setTaskListError('task failure'));
+    expect(taskError.taskListStatus).toBe(ScheduledTaskDataStatus.Error);
+    expect(taskError.taskListError).toBe('task failure');
+    expect(taskError.allRunsStatus).toBe(ScheduledTaskDataStatus.Starting);
+
+    const historyLoading = scheduledTaskReducer(
+      taskError,
+      setAllRunsStatus(ScheduledTaskDataStatus.Loading),
+    );
+    const historyError = scheduledTaskReducer(
+      historyLoading,
+      setAllRunsError('history failure'),
+    );
+    expect(historyError.allRunsStatus).toBe(ScheduledTaskDataStatus.Error);
+    expect(historyError.allRunsError).toBe('history failure');
+
+    const historyReady = scheduledTaskReducer(
+      historyError,
+      setAllRuns({ runs: [], hasMore: false }),
+    );
+    expect(historyReady.allRunsStatus).toBe(ScheduledTaskDataStatus.Ready);
+    expect(historyReady.allRunsError).toBeNull();
+  });
+});

--- a/src/renderer/store/slices/scheduledTaskSlice.ts
+++ b/src/renderer/store/slices/scheduledTaskSlice.ts
@@ -1,5 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+import {
+  ScheduledTaskDataStatus,
+  type ScheduledTaskDataStatus as ScheduledTaskDataStatusValue,
+} from '../../../scheduledTask/constants';
 import type {
   ScheduledTask,
   ScheduledTaskRun,
@@ -16,7 +20,10 @@ interface ScheduledTaskState {
   runsHasMore: Record<string, boolean>;
   allRuns: ScheduledTaskRunWithName[];
   allRunsHasMore: boolean;
-  loading: boolean;
+  taskListStatus: ScheduledTaskDataStatusValue;
+  allRunsStatus: ScheduledTaskDataStatusValue;
+  taskListError: string | null;
+  allRunsError: string | null;
   error: string | null;
 }
 
@@ -28,7 +35,10 @@ const initialState: ScheduledTaskState = {
   runsHasMore: {},
   allRuns: [],
   allRunsHasMore: false,
-  loading: false,
+  taskListStatus: ScheduledTaskDataStatus.Starting,
+  allRunsStatus: ScheduledTaskDataStatus.Starting,
+  taskListError: null,
+  allRunsError: null,
   error: null,
 };
 
@@ -36,15 +46,33 @@ const scheduledTaskSlice = createSlice({
   name: 'scheduledTask',
   initialState,
   reducers: {
-    setLoading(state, action: PayloadAction<boolean>) {
-      state.loading = action.payload;
+    setTaskListStatus(state, action: PayloadAction<ScheduledTaskDataStatusValue>) {
+      state.taskListStatus = action.payload;
+      if (action.payload !== ScheduledTaskDataStatus.Error) {
+        state.taskListError = null;
+      }
+    },
+    setAllRunsStatus(state, action: PayloadAction<ScheduledTaskDataStatusValue>) {
+      state.allRunsStatus = action.payload;
+      if (action.payload !== ScheduledTaskDataStatus.Error) {
+        state.allRunsError = null;
+      }
+    },
+    setTaskListError(state, action: PayloadAction<string>) {
+      state.taskListStatus = ScheduledTaskDataStatus.Error;
+      state.taskListError = action.payload;
+    },
+    setAllRunsError(state, action: PayloadAction<string>) {
+      state.allRunsStatus = ScheduledTaskDataStatus.Error;
+      state.allRunsError = action.payload;
     },
     setError(state, action: PayloadAction<string | null>) {
       state.error = action.payload;
     },
     setTasks(state, action: PayloadAction<ScheduledTask[]>) {
       state.tasks = action.payload;
-      state.loading = false;
+      state.taskListStatus = ScheduledTaskDataStatus.Ready;
+      state.taskListError = null;
     },
     addTask(state, action: PayloadAction<ScheduledTask>) {
       state.tasks.unshift(action.payload);
@@ -117,6 +145,8 @@ const scheduledTaskSlice = createSlice({
     ) {
       state.allRuns = action.payload.runs;
       state.allRunsHasMore = action.payload.hasMore;
+      state.allRunsStatus = ScheduledTaskDataStatus.Ready;
+      state.allRunsError = null;
     },
     appendAllRuns(
       state,
@@ -129,7 +159,10 @@ const scheduledTaskSlice = createSlice({
 });
 
 export const {
-  setLoading,
+  setTaskListStatus,
+  setAllRunsStatus,
+  setTaskListError,
+  setAllRunsError,
   setError,
   setTasks,
   addTask,

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1254,6 +1254,7 @@ interface IElectronAPI {
   scheduledTasks: {
     list: () => Promise<{
       success: boolean;
+      ready?: boolean;
       tasks?: import('../../scheduledTask/types').ScheduledTask[];
       error?: string;
     }>;
@@ -1304,6 +1305,7 @@ interface IElectronAPI {
       filter?: import('../../scheduledTask/types').RunFilter,
     ) => Promise<{
       success: boolean;
+      ready?: boolean;
       runs?: import('../../scheduledTask/types').ScheduledTaskRunWithName[];
       error?: string;
     }>;

--- a/src/scheduledTask/constants.ts
+++ b/src/scheduledTask/constants.ts
@@ -80,6 +80,15 @@ export const TaskStatus = {
 } as const;
 export type TaskStatus = typeof TaskStatus[keyof typeof TaskStatus];
 
+export const ScheduledTaskDataStatus = {
+  Starting: 'starting',
+  Loading: 'loading',
+  Ready: 'ready',
+  Error: 'error',
+} as const;
+export type ScheduledTaskDataStatus =
+  typeof ScheduledTaskDataStatus[keyof typeof ScheduledTaskDataStatus];
+
 // ─── Gateway Status (OpenClaw wire format) ────────────────────────────────���─
 export const GatewayStatus = {
   Ok: 'ok',

--- a/src/scheduledTask/cronJobService.test.ts
+++ b/src/scheduledTask/cronJobService.test.ts
@@ -173,6 +173,30 @@ describe('CronJobService internal task filtering', () => {
   });
 });
 
+describe('CronJobService gateway readiness', () => {
+  test('polls immediately when the gateway becomes ready after polling started', async () => {
+    let gatewayClient: { request: <T>() => Promise<T> } | null = null;
+    const request = vi.fn(async <T>() => ({ jobs: [] }) as T);
+    const service = new CronJobService({
+      getGatewayClient: () => gatewayClient,
+      ensureGatewayReady: async () => {},
+    });
+
+    service.startPolling();
+    await Promise.resolve();
+    expect(request).not.toHaveBeenCalled();
+
+    gatewayClient = { request };
+    service.notifyGatewayReady();
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith('cron.list', {
+      includeDisabled: true,
+      limit: 200,
+    }));
+    service.stopPolling();
+  });
+});
+
 describe('CronJobService run history filtering', () => {
   test('filters global runs by application status after reading gateway entries', async () => {
     const job = makeGatewayJob({ id: 'job-1', name: 'User task' });

--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -763,10 +763,18 @@ export class CronJobService {
   startPolling(): void {
     if (this.polling) return;
     this.polling = true;
-    this.pollOnce();
+    void this.pollOnce();
     this.pollingTimer = setInterval(() => {
       void this.pollOnce();
     }, CronJobService.POLL_INTERVAL_MS);
+  }
+
+  notifyGatewayReady(): void {
+    if (!this.polling) {
+      this.startPolling();
+      return;
+    }
+    void this.pollOnce(true);
   }
 
   stopPolling(): void {
@@ -782,7 +790,7 @@ export class CronJobService {
     this.firstPollDone = false;
   }
 
-  private async pollOnce(): Promise<void> {
+  private async pollOnce(forceFullRefresh = false): Promise<void> {
     if (!this.polling) return;
 
     try {
@@ -842,7 +850,7 @@ export class CronJobService {
         }
       }
 
-      if (!this.firstPollDone) {
+      if (forceFullRefresh || !this.firstPollDone) {
         this.firstPollDone = true;
         this.emitFullRefresh();
       }

--- a/src/scheduledTask/design.md
+++ b/src/scheduledTask/design.md
@@ -747,6 +747,10 @@ flowchart TD
 | 运行历史 | `~/.openclaw/cron/runs/{jobId}.jsonl` | `runLog.maxBytes` (2MB) + `runLog.keepLines` (2000) |
 | 隔离会话 | OpenClaw sessions | `sessionRetention` (默认 24h) |
 
+**一次性任务生命周期：** `schedule.kind = at` 在未显式指定时由 OpenClaw 设置
+`deleteAfterRun = true`。任务成功执行后会从 Job 定义中删除，因此不再出现在任务列表；
+对应运行记录仍由独立的运行历史存储保留。执行失败的任务会按策略重试，重试耗尽后禁用并保留，便于排查。
+
 ---
 
 ## 完整生命周期：端到端流程


### PR DESCRIPTION
## Summary
- distinguish scheduled-task startup, loading, ready, and error states in the task and history tabs
- refresh cron data immediately after the OpenClaw gateway handshake instead of waiting for the next polling interval
- document the existing one-shot task deletion behavior in the scheduled-task design and upgrade notes

## Verification
- `npx vitest run cronJobService scheduledTaskSlice scheduledTask.test` (27 tests)
- changed-file ESLint with zero warnings
- `npx tsc --noEmit`
- `npm run build`
- `npm run compile:electron`
- development logs confirm `cron.list` runs immediately after `onHelloOk`

## Electron impact
- scheduled-task list and global-history IPC responses now expose gateway readiness
- no storage schema changes, OpenClaw patches, or runtime restart behavior changes

## Screenshots
- Not included: this change affects a transient cold-start state; the running-state layout is unchanged.