### PR TITLE
fix(cowork): normalize bold-only plan headings

### DIFF
--- a/src/renderer/components/cowork/proposedPlanParser.test.ts
+++ b/src/renderer/components/cowork/proposedPlanParser.test.ts
@@ -56,6 +56,44 @@ describe('parseProposedPlanBlock', () => {
       didNormalizePlanText: true,
     });
   });
+
+  test('normalizes heading-style section labels with bodies on the same line', () => {
+    expect(parseProposedPlanBlock([
+      '<proposed_plan>',
+      '## Summary 创建生日派对邀请函网页。 ## Implementation Approach 1. 创建 index.html。',
+      '</proposed_plan>',
+    ].join('\n'))).toEqual({
+      visibleText: '',
+      planText: [
+        '## Summary',
+        '',
+        '创建生日派对邀请函网页。',
+        '## Implementation Approach',
+        '',
+        '1. 创建 index.html。',
+      ].join('\n'),
+      didNormalizePlanText: true,
+    });
+  });
+
+  test('normalizes bold section labels with bodies on the same line', () => {
+    expect(parseProposedPlanBlock([
+      '<proposed_plan>',
+      '**Summary** 制作季度汇报 PPT。 **Implementation Approach** 1. 使用 html2pptx 工作流。',
+      '</proposed_plan>',
+    ].join('\n'))).toEqual({
+      visibleText: '',
+      planText: [
+        '## Summary',
+        '',
+        '制作季度汇报 PPT。',
+        '## Implementation Approach',
+        '',
+        '1. 使用 html2pptx 工作流。',
+      ].join('\n'),
+      didNormalizePlanText: true,
+    });
+  });
 });
 
 describe('normalizeProposedPlanMarkdown', () => {

--- a/src/renderer/components/cowork/proposedPlanParser.test.ts
+++ b/src/renderer/components/cowork/proposedPlanParser.test.ts
@@ -94,6 +94,28 @@ describe('parseProposedPlanBlock', () => {
       didNormalizePlanText: true,
     });
   });
+
+  test('normalizes bold-only section labels before bodies on the next line', () => {
+    expect(parseProposedPlanBlock([
+      '<proposed_plan>',
+      '**Summary**',
+      '为「麦田烘焙」制作一个温馨文艺风格的单页展示网站。',
+      '',
+      '**Implementation Approach**',
+      '1. 使用纯 HTML + CSS + JS 创建 index.html。',
+      '</proposed_plan>',
+    ].join('\n'))).toEqual({
+      visibleText: '',
+      planText: [
+        '## Summary',
+        '为「麦田烘焙」制作一个温馨文艺风格的单页展示网站。',
+        '',
+        '## Implementation Approach',
+        '1. 使用纯 HTML + CSS + JS 创建 index.html。',
+      ].join('\n'),
+      didNormalizePlanText: true,
+    });
+  });
 });
 
 describe('normalizeProposedPlanMarkdown', () => {

--- a/src/renderer/components/cowork/proposedPlanParser.ts
+++ b/src/renderer/components/cowork/proposedPlanParser.ts
@@ -2,7 +2,21 @@ const OPEN_TAG_PATTERN = /<proposed_plan\b[^>]*>/i;
 const CLOSE_TAG_PATTERN = /<\/proposed_plan\s*>/i;
 const OPEN_TAG_PREFIX = '<proposed_plan';
 const FENCE_PATTERN = /^\s*(```|~~~)/;
-const PLAN_SECTION_LABEL_PATTERN = /^(?:(#{1,6})\s*)?(?:\*\*)?(Summary|Implementation Approach|Key Changes|Validation|Assumptions or Questions)(?:\*\*)?(?:\s*[:：](?:\*\*)?\s+|\s*(?=为))(.+)$/i;
+const PLAN_SECTION_LABELS = 'Summary|Implementation Approach|Key Changes|Validation|Assumptions or Questions';
+const PLAN_SECTION_LABEL_PATTERN = new RegExp(
+  [
+    `^(#{1,6})\\s*(${PLAN_SECTION_LABELS})(?:\\*\\*)?(?:\\s*[:：])?\\s+(.+)$`,
+    `^\\*\\*(${PLAN_SECTION_LABELS})\\*\\*(?:\\s*[:：])?\\s+(.+)$`,
+    `^(?:\\*\\*)?(${PLAN_SECTION_LABELS})(?:\\*\\*)?\\s*[:：](?:\\*\\*)?\\s+(.+)$`,
+    `^(?:\\*\\*)?(${PLAN_SECTION_LABELS})(?:\\*\\*)?\\s*(?=为)(.+)$`,
+  ].join('|'),
+  'i',
+);
+const INLINE_HEADING_SECTION_PATTERN = new RegExp(`\\s+(#{1,6}\\s*(?:${PLAN_SECTION_LABELS})(?=\\s*[:：]?\\s+))`, 'gi');
+const INLINE_BOLD_SECTION_PATTERN = new RegExp(`\\s+(\\*\\*(?:${PLAN_SECTION_LABELS})\\*\\*(?=\\s*[:：]?\\s+))`, 'gi');
+const INLINE_COLON_SECTION_PATTERN = new RegExp(`\\s+((?:${PLAN_SECTION_LABELS})\\s*[:：])`, 'gi');
+const INLINE_CHINESE_CONNECTOR_SECTION_PATTERN = new RegExp(`\\s+((?:${PLAN_SECTION_LABELS})(?=为))`, 'gi');
+const TRAILING_HEADING_MARKER_PATTERN = /(?:^|\n)\s*#{1,6}\s*$/;
 
 export interface ProposedPlanParseResult {
   visibleText: string;
@@ -20,6 +34,43 @@ const findTrailingOpenTagPrefixIndex = (content: string): number => {
   return -1;
 };
 
+const splitInlinePlanSectionLabels = (line: string): string[] => line
+  .replace(INLINE_HEADING_SECTION_PATTERN, '\n$1')
+  .replace(INLINE_BOLD_SECTION_PATTERN, '\n$1')
+  .replace(INLINE_COLON_SECTION_PATTERN, (match, section: string, offset: number, fullText: string) => {
+    if (TRAILING_HEADING_MARKER_PATTERN.test(fullText.slice(0, offset))) return match;
+    return `\n${section}`;
+  })
+  .replace(INLINE_CHINESE_CONNECTOR_SECTION_PATTERN, (match, section: string, offset: number, fullText: string) => {
+    if (TRAILING_HEADING_MARKER_PATTERN.test(fullText.slice(0, offset))) return match;
+    return `\n${section}`;
+  })
+  .split('\n');
+
+const readPlanSectionMatch = (line: string): { headingMarker?: string; label: string; body: string } | null => {
+  const match = PLAN_SECTION_LABEL_PATTERN.exec(line);
+  if (!match) return null;
+
+  const [
+    ,
+    headingMarker,
+    headingLabel,
+    headingBody,
+    boldLabel,
+    boldBody,
+    colonLabel,
+    colonBody,
+    connectorLabel,
+    connectorBody,
+  ] = match;
+
+  const label = headingLabel ?? boldLabel ?? colonLabel ?? connectorLabel;
+  const body = headingBody ?? boldBody ?? colonBody ?? connectorBody;
+  if (!label || !body) return null;
+
+  return { headingMarker, label, body };
+};
+
 const normalizeProposedPlanMarkdownWithFlag = (content: string): { text: string; didNormalize: boolean } => {
   let isInFence = false;
   let didNormalize = false;
@@ -34,16 +85,18 @@ const normalizeProposedPlanMarkdownWithFlag = (content: string): { text: string;
 
       if (isInFence) return [line];
 
-      const match = PLAN_SECTION_LABEL_PATTERN.exec(line);
-      if (!match) return [line];
+      return splitInlinePlanSectionLabels(line).flatMap((segment) => {
+        const match = readPlanSectionMatch(segment);
+        if (!match) return [segment];
 
-      const [, headingMarker, label, body] = match;
-      didNormalize = true;
-      return [
-        `${headingMarker ?? '##'} ${label}`,
-        '',
-        body,
-      ];
+        const { headingMarker, label, body } = match;
+        didNormalize = true;
+        return [
+          `${headingMarker ?? '##'} ${label}`,
+          '',
+          body,
+        ];
+      });
     })
     .join('\n');
 

--- a/src/renderer/components/cowork/proposedPlanParser.ts
+++ b/src/renderer/components/cowork/proposedPlanParser.ts
@@ -5,6 +5,8 @@ const FENCE_PATTERN = /^\s*(```|~~~)/;
 const PLAN_SECTION_LABELS = 'Summary|Implementation Approach|Key Changes|Validation|Assumptions or Questions';
 const PLAN_SECTION_LABEL_PATTERN = new RegExp(
   [
+    `^(#{1,6})\\s*(${PLAN_SECTION_LABELS})\\s*$`,
+    `^\\*\\*(${PLAN_SECTION_LABELS})\\*\\*\\s*$`,
     `^(#{1,6})\\s*(${PLAN_SECTION_LABELS})(?:\\*\\*)?(?:\\s*[:：])?\\s+(.+)$`,
     `^\\*\\*(${PLAN_SECTION_LABELS})\\*\\*(?:\\s*[:：])?\\s+(.+)$`,
     `^(?:\\*\\*)?(${PLAN_SECTION_LABELS})(?:\\*\\*)?\\s*[:：](?:\\*\\*)?\\s+(.+)$`,
@@ -47,7 +49,7 @@ const splitInlinePlanSectionLabels = (line: string): string[] => line
   })
   .split('\n');
 
-const readPlanSectionMatch = (line: string): { headingMarker?: string; label: string; body: string } | null => {
+const readPlanSectionMatch = (line: string): { headingMarker?: string; label: string; body?: string } | null => {
   const match = PLAN_SECTION_LABEL_PATTERN.exec(line);
   if (!match) return null;
 
@@ -55,7 +57,10 @@ const readPlanSectionMatch = (line: string): { headingMarker?: string; label: st
     ,
     headingMarker,
     headingLabel,
-    headingBody,
+    boldOnlyLabel,
+    bodyHeadingMarker,
+    bodyHeadingLabel,
+    bodyHeadingBody,
     boldLabel,
     boldBody,
     colonLabel,
@@ -64,11 +69,11 @@ const readPlanSectionMatch = (line: string): { headingMarker?: string; label: st
     connectorBody,
   ] = match;
 
-  const label = headingLabel ?? boldLabel ?? colonLabel ?? connectorLabel;
-  const body = headingBody ?? boldBody ?? colonBody ?? connectorBody;
-  if (!label || !body) return null;
+  const label = headingLabel ?? boldOnlyLabel ?? bodyHeadingLabel ?? boldLabel ?? colonLabel ?? connectorLabel;
+  const body = bodyHeadingBody ?? boldBody ?? colonBody ?? connectorBody;
+  if (!label) return null;
 
-  return { headingMarker, label, body };
+  return { headingMarker: headingMarker ?? bodyHeadingMarker, label, body };
 };
 
 const normalizeProposedPlanMarkdownWithFlag = (content: string): { text: string; didNormalize: boolean } => {
@@ -91,11 +96,8 @@ const normalizeProposedPlanMarkdownWithFlag = (content: string): { text: string;
 
         const { headingMarker, label, body } = match;
         didNormalize = true;
-        return [
-          `${headingMarker ?? '##'} ${label}`,
-          '',
-          body,
-        ];
+        if (!body) return [`${headingMarker ?? '##'} ${label}`];
+        return [`${headingMarker ?? '##'} ${label}`, '', body];
       });
     })
     .join('\n');


### PR DESCRIPTION
Render plan labels like "**Summary**" as headings when the body starts on the
next line. Add regression coverage for Kimi-style proposed plan output.