### PR TITLE
fix(openclaw): avoid extra dock apps during shell snapshots

### DIFF
--- a/scripts/patches/v2026.6.1/openclaw-shell-snapshot-electron-node-env.patch
+++ b/scripts/patches/v2026.6.1/openclaw-shell-snapshot-electron-node-env.patch
@@ -1,0 +1,32 @@
+diff --git a/src/agents/shell-snapshot.ts b/src/agents/shell-snapshot.ts
+--- a/src/agents/shell-snapshot.ts
++++ b/src/agents/shell-snapshot.ts
+@@ -53,6 +53,7 @@ const SECRET_SHELL_STATE_PATTERNS = [
+   /\b(ghp_|github_pat_|sk-[A-Za-z0-9]|xox[baprs]-|ya29\.|AIza[0-9A-Za-z_-]|AKIA[0-9A-Z]{16})/,
+   /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+ ] as const;
++const IS_ELECTRON_RUNTIME = Boolean(process.versions.electron);
+ 
+ type ShellSnapshot = {
+   path: string;
+@@ -261,7 +262,7 @@ async function captureShellSnapshot(opts: ShellSnapshotWrapOptions): Promise<str
+     buildAliasCaptureScript(shellName),
+     "(typeset -f 2>/dev/null || declare -f 2>/dev/null || true)",
+     `printf '\\n%s\\n' ${shQuote(ENV_MARKER)}`,
+-    `${shQuote(process.execPath)} -e ${shQuote(ENV_CAPTURE_NODE_SCRIPT)}`,
++    buildEnvCaptureNodeCommand(),
+     `} > ${shQuote(captureOutputPath)}`,
+   ].join("\n");
+ 
+@@ -329,6 +330,11 @@ function buildAliasCaptureScript(shellName: string): string {
+   return shellName === "zsh" ? "alias -L 2>/dev/null || true" : "alias 2>/dev/null || true";
+ }
+ 
++function buildEnvCaptureNodeCommand(): string {
++  const command = `${shQuote(process.execPath)} -e ${shQuote(ENV_CAPTURE_NODE_SCRIPT)}`;
++  return IS_ELECTRON_RUNTIME ? `ELECTRON_RUN_AS_NODE=1 ${command}` : command;
++}
++
+ const ENV_CAPTURE_NODE_SCRIPT = `
+ const safe = new Set(${JSON.stringify([...SAFE_ENV_NAMES].toSorted())});
+ const blocked = ${SECRET_ENV_PATTERN.toString()};

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from 'child_process';
 import crypto from 'crypto';
-import { app } from 'electron';
+import { app, type UtilityProcess, utilityProcess } from 'electron';
 import { EventEmitter } from 'events';
 import fs from 'fs';
 import net from 'net';
@@ -32,7 +32,7 @@ const gwDiagTs = (): string => {
 };
 import { isSystemProxyEnabled, resolveSystemProxyUrlForTargets } from './systemProxy';
 
-type GatewayProcess = ChildProcess;
+type GatewayProcess = UtilityProcess | ChildProcess;
 
 const DEFAULT_OPENCLAW_VERSION = '2026.2.23';
 const DEFAULT_GATEWAY_PORT = 18789;
@@ -590,22 +590,37 @@ export class OpenClawEngineManager extends EventEmitter {
     } else {
       console.log('[OpenClaw] gateway V8 old-space limit is controlled by existing NODE_OPTIONS');
     }
-    console.log(`[OpenClaw] spawning gateway with Electron Node mode: entry=${openclawEntry}, cwd=${runtime.root}, port=${port}, args=${JSON.stringify(forkArgs)}`);
+    console.log(`[OpenClaw] forking gateway: entry=${openclawEntry}, cwd=${runtime.root}, port=${port}, args=${JSON.stringify(forkArgs)}`);
 
-    // Run the gateway through Electron's Node mode on every platform. Keeping
-    // ELECTRON_RUN_AS_NODE=1 in the gateway environment also prevents nested
-    // Electron child invocations from treating Node arguments as app paths.
-    const child = spawn(
-      process.execPath,
-      [...gatewayExecArgv, openclawEntry, ...forkArgs],
-      {
-        cwd: runtime.root,
-        env: { ...env, ELECTRON_RUN_AS_NODE: '1' },
-        stdio: ['ignore', 'pipe', 'pipe'],
-        windowsHide: process.platform === 'win32',
-      },
-    );
-    console.log(`[OpenClaw] startGateway: gateway process created (${elapsed()}), platform=${process.platform}, launcher=spawn, electronRunAsNode=1`);
+    // On Windows, use child_process.spawn with ELECTRON_RUN_AS_NODE=1 instead of
+    // utilityProcess.fork(). Benchmark shows utilityProcess has ~5x overhead for
+    // cold ESM compilation on Windows (163s vs 34s for a 28MB bundle).
+    let child: GatewayProcess;
+    if (process.platform === 'win32') {
+      child = spawn(
+        process.execPath,
+        [...gatewayExecArgv, openclawEntry, ...forkArgs],
+        {
+          cwd: runtime.root,
+          env: { ...env, ELECTRON_RUN_AS_NODE: '1' },
+          stdio: ['ignore', 'pipe', 'pipe'],
+          windowsHide: true,
+        },
+      );
+    } else {
+      child = utilityProcess.fork(
+        openclawEntry,
+        forkArgs,
+        {
+          cwd: runtime.root,
+          execArgv: gatewayExecArgv,
+          env,
+          stdio: 'pipe',
+          serviceName: 'OpenClaw Gateway',
+        },
+      );
+    }
+    console.log(`[OpenClaw] startGateway: gateway process created (${elapsed()}), platform=${process.platform}, launcher=${process.platform === 'win32' ? 'spawn' : 'utilityProcess'}`);
 
     this.gatewayProcess = child;
     this.gatewaySpawnedAt = Date.now();


### PR DESCRIPTION
Keep the OpenClaw gateway on utilityProcess for macOS/Linux while retaining the Windows Electron Node spawn path for startup performance.

Scope ELECTRON_RUN_AS_NODE to the shell snapshot env-capture command so Electron does not treat inline Node scripts as app paths during plan-mode execution.
