### PR TITLE
fix(cowork): keep polling running subagents after parent completion

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -5197,6 +5197,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
 
     if (!sessionId) {
+      if (stream === 'lifecycle'
+        && (lifecyclePhase === AgentLifecyclePhase.End || lifecyclePhase === AgentLifecyclePhase.Error)) {
+        console.warn(
+          '[OpenClawRuntime] dropping terminal agent lifecycle event because no sessionId resolved',
+          `phase=${lifecyclePhase}`,
+          `runId=${runId || 'unknown'}`,
+          `sessionKey=${sessionKey || 'unknown'}`,
+        );
+      }
       console.log('[Debug:handleAgentEvent] no sessionId, dropping event. runId:', runId, 'sessionKey:', sessionKey);
       if (runId) {
         this.enqueuePendingAgentEvent(runId, agentPayload, seq);
@@ -5210,6 +5219,16 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     const turn = this.activeTurns.get(sessionId);
     if (!turn) {
+      if (stream === 'lifecycle'
+        && (lifecyclePhase === AgentLifecyclePhase.End || lifecyclePhase === AgentLifecyclePhase.Error)) {
+        console.warn(
+          '[OpenClawRuntime] dropping terminal agent lifecycle event because no active turn exists',
+          `phase=${lifecyclePhase}`,
+          `sessionId=${sessionId}`,
+          `runId=${runId || 'unknown'}`,
+          `sessionKey=${sessionKey || 'unknown'}`,
+        );
+      }
       console.log('[Debug:handleAgentEvent] no active turn for sessionId:', sessionId);
       return;
     }
@@ -6224,6 +6243,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     const sessionId = this.resolveSessionIdFromChatPayload(chatPayload);
     if (!sessionId) {
+      if (state === 'final' || state === 'aborted' || state === 'error') {
+        console.warn(
+          '[OpenClawRuntime] dropping terminal chat event because no sessionId resolved',
+          `state=${state}`,
+          `runId=${runId || 'unknown'}`,
+          `sessionKey=${typeof chatPayload.sessionKey === 'string' ? chatPayload.sessionKey : 'unknown'}`,
+          `message=${summarizeGatewayMessageShape(chatPayload.message)}`,
+        );
+      }
       console.debug('[OpenClawRuntime] handleChatEvent — no sessionId resolved, dropping event');
       return;
     }

--- a/src/renderer/components/agentSidebar/useSubagentSessions.test.ts
+++ b/src/renderer/components/agentSidebar/useSubagentSessions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+
+import { CoworkSessionStatusValue } from '../../types/cowork';
+import { shouldPollSubagentSessions } from './useSubagentSessions';
+
+describe('shouldPollSubagentSessions', () => {
+  test('polls while the parent session is running', () => {
+    expect(shouldPollSubagentSessions({
+      parentSessionStatus: CoworkSessionStatusValue.Running,
+      hasRunningSubagents: false,
+      postParentPollingDeadlineMs: 0,
+      nowMs: 10,
+    })).toBe(true);
+  });
+
+  test('polls running subagents after parent completion until the deadline', () => {
+    expect(shouldPollSubagentSessions({
+      parentSessionStatus: CoworkSessionStatusValue.Completed,
+      hasRunningSubagents: true,
+      postParentPollingDeadlineMs: 10_000,
+      nowMs: 5_000,
+    })).toBe(true);
+  });
+
+  test('stops post-parent polling after the deadline', () => {
+    expect(shouldPollSubagentSessions({
+      parentSessionStatus: CoworkSessionStatusValue.Completed,
+      hasRunningSubagents: true,
+      postParentPollingDeadlineMs: 10_000,
+      nowMs: 10_001,
+    })).toBe(false);
+  });
+
+  test('does not poll after parent completion when no subagents are running', () => {
+    expect(shouldPollSubagentSessions({
+      parentSessionStatus: CoworkSessionStatusValue.Completed,
+      hasRunningSubagents: false,
+      postParentPollingDeadlineMs: 10_000,
+      nowMs: 5_000,
+    })).toBe(false);
+  });
+});

--- a/src/renderer/components/agentSidebar/useSubagentSessions.ts
+++ b/src/renderer/components/agentSidebar/useSubagentSessions.ts
@@ -1,8 +1,28 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import type { SubagentSessionSummary } from '../../types/cowork';
+import {
+  type CoworkSessionStatus,
+  CoworkSessionStatusValue,
+  type SubagentSessionSummary,
+} from '../../types/cowork';
 
 const POLL_INTERVAL_MS = 5_000;
+export const POST_PARENT_COMPLETION_POLL_MS = 5 * 60_000;
+const POST_PARENT_REFRESH_DELAYS_MS = [1_000, 5_000, 15_000] as const;
+
+export function shouldPollSubagentSessions(options: {
+  parentSessionStatus?: CoworkSessionStatus;
+  hasRunningSubagents: boolean;
+  postParentPollingDeadlineMs: number | null;
+  nowMs: number;
+}): boolean {
+  if (options.parentSessionStatus === CoworkSessionStatusValue.Running) {
+    return true;
+  }
+  return options.hasRunningSubagents
+    && options.postParentPollingDeadlineMs !== null
+    && options.nowMs <= options.postParentPollingDeadlineMs;
+}
 
 /**
  * Fetches and polls subagent sessions for the currently selected session.
@@ -10,13 +30,15 @@ const POLL_INTERVAL_MS = 5_000;
  */
 export const useSubagentSessions = (
   currentSessionId: string | null,
-  currentSessionStatus?: string,
+  currentSessionStatus?: CoworkSessionStatus,
 ) => {
   const [subagentsBySessionId, setSubagentsBySessionId] = useState<
     Record<string, SubagentSessionSummary[]>
   >({});
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const lastFetchedSessionIdRef = useRef<string | null>(null);
+  const postParentPollingDeadlineRef = useRef<number | null>(null);
+  const terminalRefreshTimeoutsRef = useRef<Array<ReturnType<typeof setTimeout>>>([]);
+  const runningParentSessionIdRef = useRef<string | null>(null);
 
   const fetchSubagents = useCallback(async (sessionId: string) => {
     try {
@@ -56,6 +78,41 @@ export const useSubagentSessions = (
     });
   }, []);
 
+  const clearTerminalRefreshTimeouts = useCallback(() => {
+    for (const timeout of terminalRefreshTimeoutsRef.current) {
+      clearTimeout(timeout);
+    }
+    terminalRefreshTimeoutsRef.current = [];
+  }, []);
+
+  useEffect(() => {
+    postParentPollingDeadlineRef.current = null;
+    runningParentSessionIdRef.current = null;
+    clearTerminalRefreshTimeouts();
+  }, [clearTerminalRefreshTimeouts, currentSessionId]);
+
+  useEffect(() => {
+    if (!currentSessionId) return;
+
+    if (currentSessionStatus === CoworkSessionStatusValue.Running) {
+      runningParentSessionIdRef.current = currentSessionId;
+      postParentPollingDeadlineRef.current = null;
+      clearTerminalRefreshTimeouts();
+      return;
+    }
+
+    if (runningParentSessionIdRef.current !== currentSessionId) return;
+    runningParentSessionIdRef.current = null;
+    postParentPollingDeadlineRef.current = Date.now() + POST_PARENT_COMPLETION_POLL_MS;
+    clearTerminalRefreshTimeouts();
+
+    terminalRefreshTimeoutsRef.current = POST_PARENT_REFRESH_DELAYS_MS.map((delayMs) => setTimeout(() => {
+      void fetchSubagents(currentSessionId);
+    }, delayMs));
+
+    return clearTerminalRefreshTimeouts;
+  }, [clearTerminalRefreshTimeouts, currentSessionId, currentSessionStatus, fetchSubagents]);
+
   useEffect(() => {
     if (pollingRef.current) {
       clearInterval(pollingRef.current);
@@ -64,13 +121,38 @@ export const useSubagentSessions = (
 
     if (!currentSessionId) return;
 
+    const currentSubagents = subagentsBySessionId[currentSessionId] ?? [];
+    const hasRunningSubagents = currentSubagents.some((subagent) => subagent.status === 'running');
+    if (currentSessionStatus !== CoworkSessionStatusValue.Running) {
+      if (hasRunningSubagents && postParentPollingDeadlineRef.current === null) {
+        postParentPollingDeadlineRef.current = Date.now() + POST_PARENT_COMPLETION_POLL_MS;
+      } else if (!hasRunningSubagents) {
+        postParentPollingDeadlineRef.current = null;
+      }
+    }
+
     // Initial fetch
-    lastFetchedSessionIdRef.current = currentSessionId;
     void fetchSubagents(currentSessionId);
 
-    // Poll while parent session is running
-    if (currentSessionStatus === 'running') {
+    if (shouldPollSubagentSessions({
+      parentSessionStatus: currentSessionStatus,
+      hasRunningSubagents,
+      postParentPollingDeadlineMs: postParentPollingDeadlineRef.current,
+      nowMs: Date.now(),
+    })) {
       pollingRef.current = setInterval(() => {
+        if (!shouldPollSubagentSessions({
+          parentSessionStatus: currentSessionStatus,
+          hasRunningSubagents: true,
+          postParentPollingDeadlineMs: postParentPollingDeadlineRef.current,
+          nowMs: Date.now(),
+        })) {
+          if (pollingRef.current) {
+            clearInterval(pollingRef.current);
+            pollingRef.current = null;
+          }
+          return;
+        }
         void fetchSubagents(currentSessionId);
       }, POLL_INTERVAL_MS);
     }
@@ -81,7 +163,7 @@ export const useSubagentSessions = (
         pollingRef.current = null;
       }
     };
-  }, [currentSessionId, currentSessionStatus, fetchSubagents]);
+  }, [currentSessionId, currentSessionStatus, fetchSubagents, subagentsBySessionId]);
 
   return { subagentsBySessionId, refetchSubagents: fetchSubagents, removeSubagent };
 };


### PR DESCRIPTION
## Summary
- keep polling subagent sessions after the parent session completes while any child run remains running
- stop post-parent polling after a bounded 5-minute window and add delayed refreshes for late terminal updates
- add diagnostic logs for dropped terminal OpenClaw events without changing IM session status behavior

## Verification
- npm test -- useSubagentSessions
- npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/renderer/components/agentSidebar/useSubagentSessions.ts src/renderer/components/agentSidebar/useSubagentSessions.test.ts src/main/libs/agentEngine/openclawRuntimeAdapter.ts
- npm run compile:electron