### PR TITLE
fix(openclaw): dedupe yielded assistant final sync

### DIFF
--- a/src/main/libs/agentEngine/assistantMessageReconciliation.test.ts
+++ b/src/main/libs/agentEngine/assistantMessageReconciliation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest';
+
+import type { CoworkMessage } from '../../coworkStore';
+import {
+  extractThinkingFromCurrentTurn,
+  findMatchingThinkingMessageIdInCurrentTurn,
+  findRedundantFinalPrefixMessageId,
+  findReusableCommittedAssistantMessageId,
+  findReusableFinalAssistantMessageId,
+  isRedundantFinalPrefixSegment,
+} from './assistantMessageReconciliation';
+
+const message = (
+  id: string,
+  type: CoworkMessage['type'],
+  content: string,
+  metadata?: CoworkMessage['metadata'],
+): CoworkMessage => ({
+  id,
+  type,
+  content,
+  metadata,
+  timestamp: Number(id.replace(/\D/g, '')) || 1,
+});
+
+describe('assistant message reconciliation', () => {
+  test('extractThinkingFromCurrentTurn only reads assistant thinking after the last user', () => {
+    const result = extractThinkingFromCurrentTurn([
+      { role: 'user', content: 'old turn' },
+      { role: 'assistant', content: [{ type: 'thinking', thinking: 'old thinking' }] },
+      { role: 'user', content: 'new turn' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'first new thought' },
+          { type: 'text', text: 'visible text' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: 'second new thought' }],
+      },
+    ]);
+
+    expect(result).toBe('first new thought\n\nsecond new thought');
+  });
+
+  test('findMatchingThinkingMessageIdInCurrentTurn stops at the current user boundary', () => {
+    const messages = [
+      message('msg-1', 'assistant', 'same', { isThinking: true }),
+      message('msg-2', 'user', 'new turn'),
+      message('msg-3', 'assistant', 'visible'),
+      message('msg-4', 'assistant', 'same', { isThinking: true }),
+    ];
+
+    expect(findMatchingThinkingMessageIdInCurrentTurn(messages, 'same')).toBe('msg-4');
+    expect(findMatchingThinkingMessageIdInCurrentTurn(messages, 'missing')).toBeNull();
+  });
+
+  test('findReusableCommittedAssistantMessageId ignores thinking and mismatched content', () => {
+    const messages = [
+      message('msg-1', 'assistant', 'committed text'),
+      message('msg-2', 'assistant', 'committed text', { isThinking: true }),
+    ];
+
+    expect(findReusableCommittedAssistantMessageId(messages, 'msg-1', ' committed text ')).toBe('msg-1');
+    expect(findReusableCommittedAssistantMessageId(messages, 'msg-2', 'committed text')).toBeNull();
+    expect(findReusableCommittedAssistantMessageId(messages, 'msg-1', 'other text')).toBeNull();
+  });
+
+  test('findReusableFinalAssistantMessageId allows one trailing non-assistant message', () => {
+    const messages = [
+      message('msg-1', 'user', 'hello'),
+      message('msg-2', 'assistant', 'final text'),
+      message('msg-3', 'tool_result', 'ok'),
+    ];
+
+    expect(findReusableFinalAssistantMessageId(messages, 'final text')).toBe('msg-2');
+    expect(findReusableFinalAssistantMessageId([...messages, message('msg-4', 'tool_use', 'tool')], 'final text')).toBeNull();
+  });
+
+  test('redundant prefix detection keeps short prefixes and finds long partial final segments', () => {
+    const shortPrefix = 'short prefix';
+    const longPrefix = 'A'.repeat(90);
+    const finalText = `${longPrefix} ${'B'.repeat(80)}`;
+
+    expect(isRedundantFinalPrefixSegment(shortPrefix, `${shortPrefix} tail`)).toBe(false);
+    expect(isRedundantFinalPrefixSegment(longPrefix, finalText)).toBe(true);
+    expect(findRedundantFinalPrefixMessageId([
+      message('msg-1', 'user', 'start'),
+      message('msg-2', 'assistant', longPrefix),
+      message('msg-3', 'assistant', finalText),
+    ], 'msg-3', finalText)).toBe('msg-2');
+  });
+});

--- a/src/main/libs/agentEngine/assistantMessageReconciliation.ts
+++ b/src/main/libs/agentEngine/assistantMessageReconciliation.ts
@@ -1,0 +1,148 @@
+import type { CoworkMessage } from '../../coworkStore';
+import { extractGatewayMessageThinking } from '../openclawHistory';
+
+type GatewayHistoryMessage = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+};
+
+const isThinkingAssistantMessage = (message: CoworkMessage): boolean => {
+  return message.type === 'assistant'
+    && isRecord(message.metadata)
+    && message.metadata.isThinking === true;
+};
+
+export const isRedundantFinalPrefixSegment = (candidate: string, finalText: string): boolean => {
+  const normalizedCandidate = candidate.replace(/\s+/g, ' ').trim();
+  const normalizedFinal = finalText.replace(/\s+/g, ' ').trim();
+  if (normalizedCandidate.length < 80 || normalizedFinal.length <= normalizedCandidate.length) {
+    return false;
+  }
+  if (!normalizedFinal.startsWith(normalizedCandidate)) {
+    return false;
+  }
+  return normalizedCandidate.length / normalizedFinal.length >= 0.35;
+};
+
+export const extractThinkingFromCurrentTurn = (messages: unknown[]): string => {
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (isRecord(msg) && (msg as GatewayHistoryMessage).role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
+  const startIdx = lastUserIdx >= 0 ? lastUserIdx + 1 : 0;
+  const thinkingParts: string[] = [];
+  for (let i = startIdx; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!isRecord(msg)) continue;
+    const role = typeof msg.role === 'string' ? msg.role.trim().toLowerCase() : '';
+    if (role !== 'assistant') continue;
+    const thinking = extractGatewayMessageThinking(msg);
+    if (thinking) {
+      thinkingParts.push(thinking);
+    }
+  }
+  return thinkingParts.join('\n\n').trim();
+};
+
+export const findMatchingThinkingMessageIdInCurrentTurn = (
+  messages: CoworkMessage[],
+  thinkingText: string,
+): string | null => {
+  const targetText = thinkingText.trim();
+  if (!targetText) return null;
+
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.type === 'user') break;
+    if (!isThinkingAssistantMessage(message)) continue;
+    if (message.content.trim() === targetText) {
+      return message.id;
+    }
+  }
+  return null;
+};
+
+export const findReusableFinalAssistantMessageId = (
+  messages: CoworkMessage[],
+  content: string,
+): string | null => {
+  const normalizedContent = content.trim();
+  if (!normalizedContent) {
+    return null;
+  }
+
+  // Scan backward: in normal flow the assistant message is last; after a skill
+  // switch one user message may sit between the previous assistant reply and
+  // this sync. Allow at most one non-assistant message before giving up.
+  let nonAssistantCount = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.type === 'assistant') {
+      return !isThinkingAssistantMessage(msg) && msg.content.trim() === normalizedContent ? msg.id : null;
+    }
+    nonAssistantCount++;
+    if (nonAssistantCount > 1) {
+      return null;
+    }
+  }
+  return null;
+};
+
+export const findReusableCommittedAssistantMessageId = (
+  messages: CoworkMessage[],
+  messageId: string | null | undefined,
+  content: string,
+): string | null => {
+  const normalizedContent = content.trim();
+  if (!messageId || !normalizedContent) {
+    return null;
+  }
+
+  const message = messages.find((candidate) => candidate.id === messageId);
+  if (
+    !message
+    || message.type !== 'assistant'
+    || isThinkingAssistantMessage(message)
+    || message.content.trim() !== normalizedContent
+  ) {
+    return null;
+  }
+  return message.id;
+};
+
+export const findRedundantFinalPrefixMessageId = (
+  messages: CoworkMessage[],
+  finalMessageId: string | null | undefined,
+  finalText: string,
+): string | null => {
+  const normalizedFinalText = finalText.trim();
+  if (!normalizedFinalText) return null;
+
+  const finalIndex = finalMessageId
+    ? messages.findIndex((message) => message.id === finalMessageId)
+    : messages.length;
+  const scanStart = finalIndex >= 0 ? finalIndex - 1 : messages.length - 1;
+
+  for (let i = scanStart; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message.type === 'user') {
+      return null;
+    }
+    if (message.type !== 'assistant' || message.id === finalMessageId) {
+      continue;
+    }
+    if (isThinkingAssistantMessage(message)) {
+      continue;
+    }
+    return isRedundantFinalPrefixSegment(message.content, normalizedFinalText)
+      ? message.id
+      : null;
+  }
+  return null;
+};

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -1720,6 +1720,7 @@ function createActiveTurn(sessionId: string, sessionKey: string, runId: string) 
     knownRunIds: new Set([runId]),
     assistantMessageId: undefined,
     committedAssistantText: '',
+    lastCommittedAssistantMessageId: null,
     currentAssistantSegmentText: '',
     currentText: '',
     agentAssistantTextLength: 0,
@@ -2707,6 +2708,160 @@ test('chat final repairs last segment with corrupted committed text from tool ca
 
     await vi.advanceTimersByTimeAsync(800);
     expect(session.status).toBe('completed');
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('chat final reuses committed assistant segment after sessions_yield history sync', async () => {
+  vi.useFakeTimers();
+  try {
+    const startupText = [
+      '已启动两个 subagent：',
+      '',
+      '1. **random-stats** — 生成100个随机数并统计平均值/最大值/最小值，写入 `random_stats.txt`',
+      '2. **fun-facts** — 写3条编程冷知识到 `fun_facts.txt`',
+      '',
+      '两个都在跑，完成后会自动通知我。稍等结果',
+    ].join('\n');
+    const { session, store } = createReconcileStore([
+      { id: 'msg-1', type: 'user', content: '起两个subagent 随便做点什么，用于测试', timestamp: 1, metadata: {} },
+      { id: 'msg-2', type: 'assistant', content: startupText, timestamp: 2, metadata: { isStreaming: false, isFinal: true } },
+      { id: 'msg-3', type: 'tool_use', content: 'Using tool: sessions_yield', timestamp: 3, metadata: { toolUseId: 'call-yield', toolName: 'sessions_yield' } },
+      { id: 'msg-4', type: 'tool_result', content: '{"status":"yielded"}', timestamp: 4, metadata: { toolUseId: 'call-yield' } },
+    ]);
+
+    const adapter = new OpenClawRuntimeAdapter(store, {});
+    const sessionKey = `agent:main:lobsterai:${session.id}`;
+    adapter.gatewayClient = {
+      start: () => {},
+      stop: () => {},
+      request: async () => ({
+        messages: [
+          { role: 'user', content: '起两个subagent 随便做点什么，用于测试' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'Need to spawn two subagents.' },
+              { type: 'toolCall', id: 'call-spawn-1', name: 'sessions_spawn', arguments: {} },
+              { type: 'toolCall', id: 'call-spawn-2', name: 'sessions_spawn', arguments: {} },
+            ],
+          },
+          { role: 'toolResult', toolCallId: 'call-spawn-1', content: 'accepted' },
+          { role: 'toolResult', toolCallId: 'call-spawn-2', content: 'accepted' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: startupText },
+              { type: 'toolCall', id: 'call-yield', name: 'sessions_yield', arguments: { message: 'wait' } },
+            ],
+          },
+          { role: 'toolResult', toolCallId: 'call-yield', content: '{"status":"yielded"}' },
+        ],
+      }),
+    };
+
+    const turn = createActiveTurn(session.id, sessionKey, 'run-yield-final');
+    turn.assistantMessageId = null;
+    turn.committedAssistantText = startupText;
+    turn.lastCommittedAssistantMessageId = 'msg-2';
+    turn.currentText = startupText;
+    turn.currentContentText = startupText;
+    turn.currentContentBlocks = [startupText];
+    turn.toolUseMessageIdByToolCallId.set('call-yield', 'msg-3');
+    turn.toolResultMessageIdByToolCallId.set('call-yield', 'msg-4');
+    adapter.activeTurns.set(session.id, turn);
+    adapter.latestTurnTokenBySession.set(session.id, turn.turnToken);
+
+    adapter.handleChatEvent({
+      state: 'final',
+      runId: 'run-yield-final',
+      sessionKey,
+      message: { role: 'assistant', content: startupText },
+    }, 1);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const visibleStartupMessages = session.messages.filter((message) => (
+      message.type === 'assistant'
+      && message.metadata?.isThinking !== true
+      && message.content === startupText
+    ));
+    expect(visibleStartupMessages.map((message) => message.id)).toEqual(['msg-2']);
+    expect(turn.assistantMessageId).toBe('msg-2');
+    expect(session.messages.filter((message) => message.metadata?.isThinking === true)).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(800);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('chat final reuses identical finalized thinking from the current turn', async () => {
+  vi.useFakeTimers();
+  try {
+    const thinkingText = 'The user wants me to spawn two subagents to test. Let me do that.';
+    const finalText = 'fibonacci 也完成了。两个 subagent 测试都正常完成。';
+    const { session, store } = createReconcileStore([
+      { id: 'msg-1', type: 'user', content: '起两个subagent 随便做点什么，用于测试', timestamp: 1, metadata: {} },
+      {
+        id: 'msg-2',
+        type: 'assistant',
+        content: thinkingText,
+        timestamp: 2,
+        metadata: { isThinking: true, isStreaming: false, isFinal: true },
+      },
+      {
+        id: 'msg-3',
+        type: 'assistant',
+        content: 'summer-poem 已完成，还在等 fibonacci 的结果...',
+        timestamp: 3,
+        metadata: { isStreaming: false, isFinal: true },
+      },
+    ]);
+
+    const adapter = new OpenClawRuntimeAdapter(store, {});
+    const sessionKey = `agent:main:lobsterai:${session.id}`;
+    adapter.gatewayClient = {
+      start: () => {},
+      stop: () => {},
+      request: async () => ({
+        messages: [
+          { role: 'user', content: '起两个subagent 随便做点什么，用于测试' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: thinkingText },
+              { type: 'text', text: finalText },
+            ],
+          },
+        ],
+      }),
+    };
+
+    const turn = createActiveTurn(session.id, sessionKey, 'run-final');
+    adapter.activeTurns.set(session.id, turn);
+    adapter.latestTurnTokenBySession.set(session.id, turn.turnToken);
+
+    adapter.handleChatEvent({
+      state: 'final',
+      runId: 'run-final',
+      sessionKey,
+      message: { role: 'assistant', content: finalText },
+    }, 1);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const thinkingMessages = session.messages.filter((message) => message.metadata?.isThinking === true);
+    expect(thinkingMessages.map((message) => message.id)).toEqual(['msg-2']);
+    expect(thinkingMessages[0].content).toBe(thinkingText);
+    expect(session.messages.some((message) => (
+      message.type === 'assistant'
+      && message.metadata?.isThinking !== true
+      && message.content === finalText
+    ))).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(800);
   } finally {
     vi.useRealTimers();
   }
@@ -5117,6 +5272,112 @@ test('onSessionDeleted deletes gateway transcripts for all session keys', async 
   });
   expect(adapter.deletedChannelKeys.has(channelSessionKey)).toBe(true);
   expect(adapter.deletedChannelKeys.has(managedSessionKey)).toBe(false);
+});
+
+test('child lifecycle end marks matching subagent done before local session resolution', () => {
+  const runs = new Map<string, Record<string, unknown>>();
+  const subagentRunStore = {
+    insertSubagentRun: vi.fn((run: Record<string, unknown>) => {
+      runs.set(run.id as string, { ...run });
+    }),
+    updateSubagentRunStatus: vi.fn((id: string, status: string, endedAt?: number) => {
+      const run = runs.get(id);
+      if (run) {
+        run.status = status;
+        run.endedAt = endedAt;
+      }
+    }),
+    listSubagentRuns: () => [],
+  };
+  const adapter = new OpenClawRuntimeAdapter(
+    { getSession: () => null } as never,
+    {},
+    {},
+    subagentRunStore as never,
+  );
+  const childSessionKey = 'agent:main:subagent:e0fbd45e-25ef-4765-b1b1-a82035637f31';
+
+  adapter.subagentTracker.onToolStart(
+    'call-fibonacci',
+    { taskName: 'fibonacci', task: 'calculate fibonacci' },
+    'parent-session',
+  );
+  adapter.subagentTracker.onSpawnResult(
+    'call-fibonacci',
+    JSON.stringify({
+      status: 'accepted',
+      childSessionKey,
+      runId: '7d6f0db8-1066-4900-b6ea-a47b23825c8e',
+    }),
+    {},
+  );
+
+  adapter.handleAgentEvent({
+    runId: '7d6f0db8-1066-4900-b6ea-a47b23825c8e',
+    sessionKey: childSessionKey,
+    stream: 'lifecycle',
+    data: { phase: 'end' },
+  }, 1);
+
+  expect(subagentRunStore.updateSubagentRunStatus).toHaveBeenCalledWith(
+    'call-fibonacci',
+    'done',
+    expect.any(Number),
+  );
+  expect(runs.get('call-fibonacci')?.status).toBe('done');
+});
+
+test('child chat final marks matching subagent done before local session resolution', () => {
+  const runs = new Map<string, Record<string, unknown>>();
+  const subagentRunStore = {
+    insertSubagentRun: vi.fn((run: Record<string, unknown>) => {
+      runs.set(run.id as string, { ...run });
+    }),
+    updateSubagentRunStatus: vi.fn((id: string, status: string, endedAt?: number) => {
+      const run = runs.get(id);
+      if (run) {
+        run.status = status;
+        run.endedAt = endedAt;
+      }
+    }),
+    listSubagentRuns: () => [],
+  };
+  const adapter = new OpenClawRuntimeAdapter(
+    { getSession: () => null } as never,
+    {},
+    {},
+    subagentRunStore as never,
+  );
+  const childSessionKey = 'agent:main:subagent:e0fbd45e-25ef-4765-b1b1-a82035637f31';
+
+  adapter.subagentTracker.onToolStart(
+    'call-fibonacci',
+    { taskName: 'fibonacci', task: 'calculate fibonacci' },
+    'parent-session',
+  );
+  adapter.subagentTracker.onSpawnResult(
+    'call-fibonacci',
+    JSON.stringify({
+      status: 'accepted',
+      childSessionKey,
+      runId: '7d6f0db8-1066-4900-b6ea-a47b23825c8e',
+    }),
+    {},
+  );
+
+  adapter.handleChatEvent({
+    state: 'final',
+    runId: '7d6f0db8-1066-4900-b6ea-a47b23825c8e',
+    sessionKey: childSessionKey,
+    message: { role: 'assistant', content: '已完成。' },
+  }, 1);
+
+  expect(subagentRunStore.updateSubagentRunStatus).toHaveBeenCalledWith(
+    'call-fibonacci',
+    'done',
+    expect.any(Number),
+  );
+  expect(runs.get('call-fibonacci')?.status).toBe('done');
 });
 
 test('syncSystemMessagesFromHistory skips pure heartbeat ack system messages', () => {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -51,7 +51,6 @@ import {
 import {
   extractGatewayHistoryEntries,
   extractGatewayMessageText,
-  extractGatewayMessageThinking,
   isHeartbeatAckText,
   isPreCompactionMemoryFlushPromptText,
   isSilentReplyPrefixText,
@@ -61,6 +60,13 @@ import {
   stripTrailingSilentReplyToken,
 } from '../openclawHistory';
 import { buildOpenClawLocalTimeContextPrompt } from '../openclawLocalTimeContextPrompt';
+import {
+  extractThinkingFromCurrentTurn,
+  findMatchingThinkingMessageIdInCurrentTurn,
+  findRedundantFinalPrefixMessageId,
+  findReusableCommittedAssistantMessageId,
+  findReusableFinalAssistantMessageId,
+} from './assistantMessageReconciliation';
 import { AgentLifecyclePhase, type AgentLifecyclePhase as AgentLifecyclePhaseValue } from './constants';
 import {
   buildCoworkContinuityCapsule,
@@ -429,6 +435,8 @@ type ActiveTurn = {
   knownRunIds: Set<string>;
   assistantMessageId: string | null;
   committedAssistantText: string;
+  /** Last visible assistant segment finalized before a tool call. */
+  lastCommittedAssistantMessageId?: string | null;
   currentAssistantSegmentText: string;
   currentText: string;
   /** Highest text length from agent assistant events (immune to chat delta noise). */
@@ -1017,22 +1025,6 @@ const isSameHistoryEntry = (
   left: { role: 'user' | 'assistant'; text: string },
   right: { role: 'user' | 'assistant'; text: string },
 ): boolean => left.role === right.role && left.text === right.text;
-
-const normalizeAssistantSegmentForPrefixMatch = (value: string): string => {
-  return value.replace(/\s+/g, ' ').trim();
-};
-
-const isRedundantFinalPrefixSegment = (candidate: string, finalText: string): boolean => {
-  const normalizedCandidate = normalizeAssistantSegmentForPrefixMatch(candidate);
-  const normalizedFinal = normalizeAssistantSegmentForPrefixMatch(finalText);
-  if (normalizedCandidate.length < 80 || normalizedFinal.length <= normalizedCandidate.length) {
-    return false;
-  }
-  if (!normalizedFinal.startsWith(normalizedCandidate)) {
-    return false;
-  }
-  return normalizedCandidate.length / normalizedFinal.length >= 0.35;
-};
 
 const historyEntryKey = (entry: { role: 'user' | 'assistant'; text: string }): string => {
   return `${entry.role}\x1f${entry.text}`;
@@ -3876,6 +3868,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       knownRunIds: new Set([runId]),
       assistantMessageId: null,
       committedAssistantText: '',
+      lastCommittedAssistantMessageId: null,
       currentAssistantSegmentText: '',
       currentText: '',
       agentAssistantTextLength: 0,
@@ -5162,6 +5155,16 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       return;
     }
 
+    if (stream === 'lifecycle'
+      && (lifecyclePhase === AgentLifecyclePhase.End || lifecyclePhase === AgentLifecyclePhase.Error)
+      && sessionKey
+      && this.subagentTracker.tryMarkTerminalFromSessionKey(
+        sessionKey,
+        lifecyclePhase === AgentLifecyclePhase.Error ? 'error' : 'done',
+      )) {
+      return;
+    }
+
     const sessionIdByRunId = runId ? this.sessionIdByRunId.get(runId) : undefined;
     const sessionIdBySessionKey = sessionKey ? this.resolveSessionIdBySessionKey(sessionKey) ?? undefined : undefined;
     let sessionId = reopenedSessionId ?? sessionIdByRunId ?? sessionIdBySessionKey;
@@ -5516,38 +5519,48 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   private reuseFinalAssistantMessage(sessionId: string, content: string): string | null {
-    const normalizedContent = content.trim();
-    if (!normalizedContent) {
+    const session = this.store.getSession(sessionId);
+    const messages = session?.messages ?? [];
+    const messageId = findReusableFinalAssistantMessageId(messages, content);
+    if (!messageId) {
       return null;
     }
 
+    this.store.updateMessage(sessionId, messageId, {
+      content,
+      metadata: {
+        isStreaming: false,
+        isFinal: true,
+      },
+    });
+    return messageId;
+  }
+
+  private reuseCommittedAssistantMessage(
+    sessionId: string,
+    turn: ActiveTurn,
+    content: string,
+  ): string | null {
     const session = this.store.getSession(sessionId);
-    const messages = session?.messages ?? [];
-    // Scan backward: in normal flow the assistant message is last; after a skill switch
-    // one user message may sit between the previous assistant reply and this sync (Bug 2).
-    // Allow at most one non-assistant message before giving up.
-    let nonAssistantCount = 0;
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (msg.type === 'assistant') {
-        if (msg.content.trim() !== normalizedContent) {
-          return null;
-        }
-        this.store.updateMessage(sessionId, msg.id, {
-          content,
-          metadata: {
-            isStreaming: false,
-            isFinal: true,
-          },
-        });
-        return msg.id;
-      }
-      nonAssistantCount++;
-      if (nonAssistantCount > 1) {
-        return null;
-      }
+    const messageId = findReusableCommittedAssistantMessageId(
+      session?.messages ?? [],
+      turn.lastCommittedAssistantMessageId,
+      content,
+    );
+    if (!messageId) {
+      return null;
     }
-    return null;
+
+    const finalMetadata = {
+      isStreaming: false,
+      isFinal: true,
+    };
+    this.store.updateMessage(sessionId, messageId, {
+      content,
+      metadata: finalMetadata,
+    });
+    this.emit('messageUpdate', sessionId, messageId, content, finalMetadata);
+    return messageId;
   }
 
   private removeRedundantFinalPrefixSegment(
@@ -5555,40 +5568,20 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     finalMessageId: string | null | undefined,
     finalText: string,
   ): void {
-    const normalizedFinalText = finalText.trim();
-    if (!normalizedFinalText) return;
-
     const session = this.store.getSession(sessionId);
     const messages = session?.messages ?? [];
-    const finalIndex = finalMessageId
-      ? messages.findIndex((message) => message.id === finalMessageId)
-      : messages.length;
-    const scanStart = finalIndex >= 0 ? finalIndex - 1 : messages.length - 1;
-
-    for (let i = scanStart; i >= 0; i -= 1) {
-      const message = messages[i];
-      if (message.type === 'user') {
-        return;
-      }
-      if (message.type !== 'assistant' || message.id === finalMessageId) {
-        continue;
-      }
-      if (message.metadata?.isThinking === true) {
-        continue;
-      }
-      if (!isRedundantFinalPrefixSegment(message.content, normalizedFinalText)) {
-        return;
-      }
-
-      console.debug(
-        '[OpenClawRuntime] removing redundant assistant prefix segment before final.',
-        `sessionId=${sessionId}`,
-        `messageId=${message.id}`,
-        `finalMessageId=${finalMessageId ?? 'pending'}`,
-      );
-      this.deleteAssistantMessage(sessionId, message.id);
+    const redundantMessageId = findRedundantFinalPrefixMessageId(messages, finalMessageId, finalText);
+    if (!redundantMessageId) {
       return;
     }
+
+    console.debug(
+      '[OpenClawRuntime] removing redundant assistant prefix segment before final.',
+      `sessionId=${sessionId}`,
+      `messageId=${redundantMessageId}`,
+      `finalMessageId=${finalMessageId ?? 'pending'}`,
+    );
+    this.deleteAssistantMessage(sessionId, redundantMessageId);
   }
 
   private resolveAssistantMessageIdForUsage(sessionId: string, preferredMessageId?: string | null): string | undefined {
@@ -6252,6 +6245,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     const sessionId = this.resolveSessionIdFromChatPayload(chatPayload);
     if (!sessionId) {
+      const sessionKey = typeof chatPayload.sessionKey === 'string' ? chatPayload.sessionKey.trim() : '';
+      if ((state === 'final' || state === 'aborted' || state === 'error')
+        && sessionKey
+        && this.subagentTracker.tryMarkTerminalFromSessionKey(
+          sessionKey,
+          state === 'final' ? 'done' : 'error',
+        )) {
+        return;
+      }
       if (state === 'final' || state === 'aborted' || state === 'error') {
         console.warn(
           '[OpenClawRuntime] dropping terminal chat event because no sessionId resolved',
@@ -6576,30 +6578,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
   }
 
-  private extractThinkingFromCurrentTurn(messages: unknown[]): string {
-    let lastUserIdx = -1;
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (isRecord(msg) && (msg as Record<string, unknown>).role === 'user') {
-        lastUserIdx = i;
-        break;
-      }
-    }
-    const startIdx = lastUserIdx >= 0 ? lastUserIdx + 1 : 0;
-    const thinkingParts: string[] = [];
-    for (let i = startIdx; i < messages.length; i++) {
-      const msg = messages[i];
-      if (!isRecord(msg)) continue;
-      const role = typeof msg.role === 'string' ? msg.role.trim().toLowerCase() : '';
-      if (role !== 'assistant') continue;
-      const thinking = extractGatewayMessageThinking(msg);
-      if (thinking) {
-        thinkingParts.push(thinking);
-      }
-    }
-    return thinkingParts.join('\n\n').trim();
-  }
-
   private syncThinkingMessage(sessionId: string, turn: ActiveTurn): void {
     const thinkingText = turn.currentThinkingText;
     if (!thinkingText) return;
@@ -6630,6 +6608,24 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     this.throttledStoreUpdateMessage(sessionId, turn.thinkingMessageId,
       thinkingText, { isThinking: true, isStreaming: true, isFinal: false });
     this.throttledEmitMessageUpdate(sessionId, turn.thinkingMessageId, thinkingText);
+  }
+
+  private reuseFinalThinkingMessage(sessionId: string, turn: ActiveTurn): boolean {
+    const thinkingText = turn.currentThinkingText;
+    if (!thinkingText) return false;
+    const session = this.store.getSession(sessionId);
+    const messageId = findMatchingThinkingMessageIdInCurrentTurn(session?.messages ?? [], thinkingText);
+    if (!messageId) return false;
+
+    const finalMetadata = { isThinking: true, isStreaming: false, isFinal: true };
+    this.store.updateMessage(sessionId, messageId, {
+      content: thinkingText,
+      metadata: finalMetadata,
+    });
+    this.emit('messageUpdate', sessionId, messageId, thinkingText, finalMetadata);
+    turn.thinkingMessageId = null;
+    turn.currentThinkingText = '';
+    return true;
   }
 
   private finalizeThinkingMessage(sessionId: string, turn: ActiveTurn): void {
@@ -6669,6 +6665,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     if (storeContent) {
       turn.committedAssistantText = `${turn.committedAssistantText}${storeContent}`;
+      turn.lastCommittedAssistantMessageId = messageId;
     }
 
     const finalMetadata = { isStreaming: false, isFinal: true };
@@ -8124,11 +8121,13 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       }
 
       // Extract thinking from history messages and sync thinking message
-      const thinkingFromHistory = this.extractThinkingFromCurrentTurn(historyMessages);
+      const thinkingFromHistory = extractThinkingFromCurrentTurn(historyMessages);
       if (thinkingFromHistory && thinkingFromHistory !== turn.currentThinkingText) {
         turn.currentThinkingText = thinkingFromHistory;
-        this.syncThinkingMessage(sessionId, turn);
-        this.finalizeThinkingMessage(sessionId, turn);
+        if (!this.reuseFinalThinkingMessage(sessionId, turn)) {
+          this.syncThinkingMessage(sessionId, turn);
+          this.finalizeThinkingMessage(sessionId, turn);
+        }
       }
 
       // For channel sessions, append file paths from "message" tool calls as clickable links
@@ -8174,6 +8173,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       }
 
       if (!turn.assistantMessageId) {
+        const committedMessageId = this.reuseCommittedAssistantMessage(sessionId, turn, canonicalSegmentText);
+        if (committedMessageId) {
+          turn.assistantMessageId = committedMessageId;
+          return;
+        }
+
         const reusedMessageId = this.reuseFinalAssistantMessage(sessionId, canonicalSegmentText);
         if (reusedMessageId) {
           turn.assistantMessageId = reusedMessageId;

--- a/src/main/libs/agentEngine/subagentTracker.ts
+++ b/src/main/libs/agentEngine/subagentTracker.ts
@@ -227,6 +227,33 @@ export class SubagentTracker {
   }
 
   /**
+   * Child session lifecycle events use the subagent's own sessionKey, not the
+   * parent announce runId. Mark the matching parent run terminal before the
+   * adapter drops the event as an unknown local session.
+   */
+  tryMarkTerminalFromSessionKey(
+    sessionKey: string,
+    status: 'done' | 'error',
+  ): boolean {
+    if (!sessionKey) return false;
+    for (const [toolCallId, childSessionKey] of this.subagentSessionKeys) {
+      if (childSessionKey !== sessionKey) continue;
+      const currentStatus = this.subagentStatus.get(toolCallId);
+      if (currentStatus === 'done' && status === 'error') {
+        return true;
+      }
+      if (currentStatus !== status) {
+        this.subagentStatus.set(toolCallId, status);
+        this.store.updateSubagentRunStatus(toolCallId, status, Date.now());
+        console.log('[SubagentTracker] marked subagent as terminal via session key:', toolCallId, status);
+        this.tryPersistCachedMessages(toolCallId);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Clears all in-memory subagent tracking state and removes persisted messages.
    */
   onSessionDeleted(parentSessionId?: string): void {


### PR DESCRIPTION
## Summary
- Reuse committed assistant segments during final history sync after `sessions_yield` to avoid duplicated GLM visible replies.
- Reuse identical finalized thinking messages in the current turn to avoid repeated thinking blocks.
- Mark subagent runs terminal from child session terminal events before local session resolution drops them.
- Extract assistant message reconciliation helpers into a focused pure module with unit coverage.

## Verification
- `npx vitest run src/main/libs/agentEngine/assistantMessageReconciliation.test.ts src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts`
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/agentEngine/assistantMessageReconciliation.ts src/main/libs/agentEngine/assistantMessageReconciliation.test.ts src/main/libs/agentEngine/openclawRuntimeAdapter.ts src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts src/main/libs/agentEngine/subagentTracker.ts`
- `npx tsc --project electron-tsconfig.json`