### PR TITLE
fix(openclaw): keep browser plugin allowlisted

### DIFF
--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -1245,7 +1245,9 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(config.plugins.entries).not.toHaveProperty('feishu');
     expect(config.plugins.entries.qqbot).toEqual({ enabled: true });
     expect(config.plugins.entries.discord).toEqual({ enabled: false });
+    expect(config.plugins.entries.browser).toEqual({ enabled: true });
     expect(config.plugins.entries).not.toHaveProperty('openclaw-qqbot');
+    expect(config.plugins.allow).toContain('browser');
     expect(config.plugins.allow).toContain('qqbot');
     expect(config.plugins.allow).toContain('discord');
   });

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -279,6 +279,8 @@ const MANAGED_WEB_SEARCH_POLICY_PROMPT = [
   'Do not claim you searched the web unless you actually used `browser`, `web_fetch`, or the LobsterAI `web-search` skill.',
 ].join('\n');
 
+const BUNDLED_BROWSER_PLUGIN_ID = 'browser';
+
 const MANAGED_BROWSER_POLICY_PROMPT = [
   '## Browser Policy',
   '',
@@ -1648,6 +1650,7 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
           // plugins (moonshot, minimax, volcengine, browser, etc.) survive
           // config rewrites.  Our managed entries below override stale values.
           ...cleanedExistingEntries,
+          [BUNDLED_BROWSER_PLUGIN_ID]: { enabled: true },
           qqbot: { enabled: qqbotPluginEnabled },
           ...Object.fromEntries(
             preinstalledPlugins.map(plugin => {
@@ -1699,6 +1702,7 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
           : [];
         const trustedPluginAllow = Array.from(new Set([
           ...existingAllow,
+          BUNDLED_BROWSER_PLUGIN_ID,
           ...preinstalledPlugins.map(plugin => plugin.pluginId),
           ...userPlugins.filter(plugin => plugin.enabled).map(plugin => plugin.pluginId),
         ])).sort();


### PR DESCRIPTION
## Summary
- add the bundled browser plugin to managed OpenClaw plugin entries
- include browser in the generated plugins.allow list so browser control remains enabled under restrictive allowlists
- cover the generated config with runtime sync assertions

## Verification
- npm test -- openclawConfigSync.runtime
- npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/openclawConfigSync.ts src/main/libs/openclawConfigSync.runtime.test.ts
- npm run compile:electron