### PR TITLE
fix(openclaw): load precompiled local extension entries

### DIFF
--- a/openclaw-extensions/ask-user-question/package.json
+++ b/openclaw-extensions/ask-user-question/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
   "dependencies": {
     "@sinclair/typebox": "0.34.49"
   }

--- a/openclaw-extensions/lobster-media-generation/package.json
+++ b/openclaw-extensions/lobster-media-generation/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
   "dependencies": {
     "@sinclair/typebox": "0.34.49"
   }

--- a/scripts/electron-builder-hooks.cjs
+++ b/scripts/electron-builder-hooks.cjs
@@ -126,8 +126,23 @@ function verifyPreinstalledPlugins(runtimeRoot, buildHint) {
 
 function hasCompiledLocalExtension(runtimeRoot, extensionId) {
   const pluginDir = path.join(runtimeRoot, 'third-party-extensions', extensionId);
-  return existsSync(path.join(pluginDir, 'openclaw.plugin.json'))
-    && existsSync(path.join(pluginDir, 'index.js'));
+  if (!existsSync(path.join(pluginDir, 'openclaw.plugin.json'))
+    || !existsSync(path.join(pluginDir, 'index.js'))) {
+    return false;
+  }
+
+  const packageJsonPath = path.join(pluginDir, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    return false;
+  }
+
+  try {
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    return Array.isArray(pkg.openclaw?.extensions)
+      && pkg.openclaw.extensions.includes('./index.js');
+  } catch {
+    return false;
+  }
 }
 
 function precompileLocalExtensions(runtimeRoot, buildHint) {
@@ -146,7 +161,7 @@ function precompileLocalExtensions(runtimeRoot, buildHint) {
 }
 
 function ensureBundledLocalExtensions(runtimeRoot, buildHint) {
-  const requiredLocalExtensions = ['mcp-bridge', 'ask-user-question'];
+  const requiredLocalExtensions = ['mcp-bridge', 'ask-user-question', 'lobster-media-generation'];
   const missingCompiledExtensions = requiredLocalExtensions.filter(
     (extensionId) => !hasCompiledLocalExtension(runtimeRoot, extensionId),
   );

--- a/scripts/precompile-openclaw-extensions.cjs
+++ b/scripts/precompile-openclaw-extensions.cjs
@@ -139,14 +139,15 @@ async function main() {
         const pkgPath = path.join(pluginDir, 'package.json');
         try {
           const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-          if (Array.isArray(pkg.openclaw?.extensions)) {
-            pkg.openclaw.extensions = pkg.openclaw.extensions.map(e =>
-              e === entry.entryRel ? outRel : e,
-            );
-            fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
-          }
+          const openclaw = pkg.openclaw && typeof pkg.openclaw === 'object' ? pkg.openclaw : {};
+          const extensions = Array.isArray(openclaw.extensions) ? openclaw.extensions : [entry.entryRel];
+          pkg.openclaw = {
+            ...openclaw,
+            extensions: extensions.map(e => e === entry.entryRel ? outRel : e),
+          };
+          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
         } catch {
-          // Non-critical — jiti will still find index.js by convention
+          // Non-critical; plugins with explicit package metadata should still be fixed by source manifests.
         }
       }
 

--- a/src/main/libs/openclawExtensionManifests.test.ts
+++ b/src/main/libs/openclawExtensionManifests.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+
 import { describe, expect, test } from 'vitest';
 
 const repoRoot = path.resolve(__dirname, '../../../');
@@ -17,6 +18,14 @@ function readContractTools(extensionId: string): string[] {
     : [];
 }
 
+function readPackageOpenClawExtensions(extensionId: string): string[] {
+  const packagePath = path.join(repoRoot, 'openclaw-extensions', extensionId, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8')) as { openclaw?: { extensions?: unknown } };
+  return Array.isArray(pkg.openclaw?.extensions)
+    ? pkg.openclaw.extensions.filter((entry): entry is string => typeof entry === 'string')
+    : [];
+}
+
 describe('OpenClaw extension manifests', () => {
   test('declares the AskUserQuestion agent tool contract', () => {
     expect(readContractTools('ask-user-question')).toEqual(['AskUserQuestion']);
@@ -27,5 +36,11 @@ describe('OpenClaw extension manifests', () => {
       'lobsterai_image_generate',
       'lobsterai_video_generate',
     ]);
+  });
+
+  test('declares TypeScript entries for local extensions that are precompiled for packaging', () => {
+    expect(readPackageOpenClawExtensions('mcp-bridge')).toEqual(['./index.ts']);
+    expect(readPackageOpenClawExtensions('ask-user-question')).toEqual(['./index.ts']);
+    expect(readPackageOpenClawExtensions('lobster-media-generation')).toEqual(['./index.ts']);
   });
 });


### PR DESCRIPTION
## Summary
- declare OpenClaw TypeScript entries for local ask-user/media extensions so precompile can rewrite packaged runtime entries to index.js
- make extension precompile write JS entry metadata even when package.json did not previously declare openclaw.extensions
- tighten packaging checks so stale runtimes with index.js but TS package entries are rebuilt before packaging

## Verification
- node --check scripts/precompile-openclaw-extensions.cjs
- node --check scripts/electron-builder-hooks.cjs
- temporary runtime precompile: mcp-bridge, ask-user-question, lobster-media-generation all rewrite to ./index.js
- npm test -- openclawExtensionManifests
- npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/openclawExtensionManifests.test.ts