### PR TITLE
fix(cowork): parse block-level proposed plan tags

### DIFF
--- a/src/renderer/components/cowork/AssistantMessageItem.tsx
+++ b/src/renderer/components/cowork/AssistantMessageItem.tsx
@@ -80,6 +80,14 @@ const AssistantMessageItem: React.FC<{
       `Normalized inline section labels in proposed plan ${message.id}.`,
     );
   }, [message.id, proposedPlan.didNormalizePlanText]);
+  useEffect(() => {
+    if (!proposedPlan.ignoredInlineOpenTagCount) return;
+    window.electron?.log?.fromRenderer?.(
+      'debug',
+      'AssistantMessageItem',
+      `Ignored ${proposedPlan.ignoredInlineOpenTagCount} inline proposed plan tag mention(s) before block in message ${message.id}.`,
+    );
+  }, [message.id, proposedPlan.ignoredInlineOpenTagCount]);
   const handleBlur = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
     const nextTarget = event.relatedTarget;
     if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;

--- a/src/renderer/components/cowork/proposedPlanParser.test.ts
+++ b/src/renderer/components/cowork/proposedPlanParser.test.ts
@@ -41,6 +41,21 @@ describe('parseProposedPlanBlock', () => {
     });
   });
 
+  test('ignores inline tag mentions before the real plan block', () => {
+    expect(parseProposedPlanBlock([
+      'Plan Mode 要求我输出 <proposed_plan> 格式。',
+      '下面才是真正的计划内容：',
+      '<proposed_plan>',
+      'Summary',
+      '讲解一元二次方程。',
+      '</proposed_plan>',
+    ].join('\n'))).toEqual({
+      visibleText: 'Plan Mode 要求我输出 <proposed_plan> 格式。\n下面才是真正的计划内容：',
+      planText: 'Summary\n讲解一元二次方程。',
+      ignoredInlineOpenTagCount: 1,
+    });
+  });
+
   test('normalizes inline section labels in proposed plans', () => {
     expect(parseProposedPlanBlock('<proposed_plan>\nSummary: Build the page.\n</proposed_plan>')).toEqual({
       visibleText: '',

--- a/src/renderer/components/cowork/proposedPlanParser.ts
+++ b/src/renderer/components/cowork/proposedPlanParser.ts
@@ -1,4 +1,4 @@
-const OPEN_TAG_PATTERN = /<proposed_plan\b[^>]*>/i;
+const OPEN_TAG_SEARCH_PATTERN = /<proposed_plan\b[^>]*>/ig;
 const CLOSE_TAG_PATTERN = /<\/proposed_plan\s*>/i;
 const OPEN_TAG_PREFIX = '<proposed_plan';
 const FENCE_PATTERN = /^\s*(```|~~~)/;
@@ -24,6 +24,12 @@ export interface ProposedPlanParseResult {
   visibleText: string;
   planText: string | null;
   didNormalizePlanText?: boolean;
+  ignoredInlineOpenTagCount?: number;
+}
+
+interface ProposedPlanOpenMatch {
+  match: RegExpExecArray;
+  ignoredInlineOpenTagCount?: number;
 }
 
 const findTrailingOpenTagPrefixIndex = (content: string): number => {
@@ -34,6 +40,37 @@ const findTrailingOpenTagPrefixIndex = (content: string): number => {
     if (suffix.length >= 2 && OPEN_TAG_PREFIX.startsWith(suffix)) return index;
   }
   return -1;
+};
+
+const isBlockOpenTagMatch = (content: string, match: RegExpExecArray): boolean => {
+  const openIndex = match.index;
+  const previousNewlineIndex = content.lastIndexOf('\n', openIndex - 1);
+  const lineStartIndex = previousNewlineIndex < 0 ? 0 : previousNewlineIndex + 1;
+  return content.slice(lineStartIndex, openIndex).trim().length === 0;
+};
+
+const findProposedPlanOpenMatch = (content: string): ProposedPlanOpenMatch | null => {
+  let fallbackMatch: RegExpExecArray | null = null;
+  let inlineOpenTagCount = 0;
+  OPEN_TAG_SEARCH_PATTERN.lastIndex = 0;
+
+  for (let match = OPEN_TAG_SEARCH_PATTERN.exec(content); match; match = OPEN_TAG_SEARCH_PATTERN.exec(content)) {
+    if (isBlockOpenTagMatch(content, match)) {
+      return {
+        match,
+        ignoredInlineOpenTagCount: inlineOpenTagCount || undefined,
+      };
+    }
+
+    fallbackMatch ??= match;
+    inlineOpenTagCount += 1;
+  }
+
+  if (!fallbackMatch) return null;
+  return {
+    match: fallbackMatch,
+    ignoredInlineOpenTagCount: undefined,
+  };
 };
 
 const splitInlinePlanSectionLabels = (line: string): string[] => line
@@ -109,8 +146,8 @@ export const normalizeProposedPlanMarkdown = (content: string): string =>
   normalizeProposedPlanMarkdownWithFlag(content).text;
 
 export const parseProposedPlanBlock = (content: string): ProposedPlanParseResult => {
-  const openMatch = OPEN_TAG_PATTERN.exec(content);
-  if (!openMatch) {
+  const openResult = findProposedPlanOpenMatch(content);
+  if (!openResult) {
     const partialOpenIndex = findTrailingOpenTagPrefixIndex(content);
     if (partialOpenIndex >= 0) {
       return {
@@ -121,6 +158,7 @@ export const parseProposedPlanBlock = (content: string): ProposedPlanParseResult
     return { visibleText: content, planText: null };
   }
 
+  const { match: openMatch, ignoredInlineOpenTagCount } = openResult;
   const openIndex = openMatch.index;
   const contentStart = openIndex + openMatch[0].length;
   const closeMatch = CLOSE_TAG_PATTERN.exec(content.slice(contentStart));
@@ -131,6 +169,7 @@ export const parseProposedPlanBlock = (content: string): ProposedPlanParseResult
       visibleText,
       planText: normalizedPlan.text || null,
       didNormalizePlanText: normalizedPlan.didNormalize || undefined,
+      ignoredInlineOpenTagCount,
     };
   }
 
@@ -144,5 +183,6 @@ export const parseProposedPlanBlock = (content: string): ProposedPlanParseResult
     visibleText,
     planText: normalizedPlan.text || null,
     didNormalizePlanText: normalizedPlan.didNormalize || undefined,
+    ignoredInlineOpenTagCount,
   };
 };


### PR DESCRIPTION
Prefer block-level proposed_plan tags over inline tag mentions so GLM plan mode renders the real plan in the plan card instead of leaking tags into the message.

Add regression coverage and renderer debug logging for skipped inline tag mentions.