### PR TITLE
style(cowork): update plan mode icon

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, ChevronDownIcon, ChevronRightIcon, ClipboardDocumentCheckIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { CheckIcon, ChevronDownIcon, ChevronRightIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { ArrowUpIcon, FolderIcon } from '@heroicons/react/24/solid';
 import { AuthSubscriptionStatus } from '@shared/auth/constants';
 import { ProviderName } from '@shared/providers';
@@ -68,6 +68,7 @@ import {
 import Modal from '../common/Modal';
 import DefaultAgentIcon from '../icons/DefaultAgentIcon';
 import PaperClipIcon from '../icons/PaperClipIcon';
+import PlanModeIcon from '../icons/PlanModeIcon';
 import PromptAddIcon from '../icons/PromptAddIcon';
 import SkillIcon from '../icons/SkillIcon';
 import TaskPauseIcon from '../icons/TaskPauseIcon';
@@ -1760,7 +1761,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
             role="menuitemcheckbox"
             aria-checked={isPlanMode}
           >
-            <ClipboardDocumentCheckIcon className="h-5 w-5 shrink-0 text-secondary" />
+            <PlanModeIcon className="h-5 w-5 shrink-0 text-secondary" />
             <span className="min-w-0 flex-1 truncate">{i18nService.t('coworkPlanMode')}</span>
             <span
               className={`relative h-5 w-9 rounded-full transition-colors ${
@@ -1908,7 +1909,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       aria-label={i18nService.t('coworkClearPlanMode')}
     >
       <span className={ACTIVE_CONTEXT_BADGE_ICON_WRAP_CLASS}>
-        <ClipboardDocumentCheckIcon className={ACTIVE_CONTEXT_BADGE_ICON_CLASS} />
+        <PlanModeIcon className={ACTIVE_CONTEXT_BADGE_ICON_CLASS} />
         <XMarkIcon className={ACTIVE_CONTEXT_BADGE_REMOVE_ICON_CLASS} />
       </span>
       <span className="min-w-0 truncate">

--- a/src/renderer/components/icons/PlanModeIcon.tsx
+++ b/src/renderer/components/icons/PlanModeIcon.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const PlanModeIcon: React.FC<{ className?: string }> = ({ className }) => {
+  return (
+    <svg className={className} viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M6 10.7143L8.54545 13L13 9" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M16 12H29" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" />
+      <path d="M16 22H29" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" />
+      <circle cx="8.5" cy="22.5" r="2.5" stroke="currentColor" strokeWidth="2.4" />
+    </svg>
+  );
+};
+
+export default PlanModeIcon;


### PR DESCRIPTION
Replace the plan mode prompt icon with the provided theme-aware SVG component while preserving existing menu and badge sizing.