### PR TITLE
fix(settings): sync launch-at-login state with OS

### DIFF
--- a/src/main/autoLaunchManager.ts
+++ b/src/main/autoLaunchManager.ts
@@ -1,30 +1,100 @@
 import { app } from 'electron';
 
-export function getAutoLaunchEnabled(): boolean {
-  try {
+const AUTO_LAUNCH_ARGS = ['--auto-launched'];
+
+export type AutoLaunchStatus = {
+  enabled: boolean;
+  openAtLogin: boolean;
+  status?: string;
+  executableWillLaunchAtLogin?: boolean;
+  launchItems?: Array<{
+    name: string;
+    path: string;
+    args: string[];
+    enabled: boolean;
+    scope: string;
+  }>;
+};
+
+const getLoginItemSettings = () => {
+  if (process.platform === 'win32') {
     // Windows: must pass the same args used in setLoginItemSettings,
     // otherwise openAtLogin defaults to comparing against [] which
     // won't match the registered ['--auto-launched'] and returns false.
-    const settings = app.getLoginItemSettings({
-      args: ['--auto-launched'],
+    return app.getLoginItemSettings({
+      args: AUTO_LAUNCH_ARGS,
     });
-    return settings.openAtLogin;
-  } catch (error) {
-    console.error('Failed to get auto-launch settings:', error);
-    return false;
   }
+
+  return app.getLoginItemSettings();
+};
+
+export function getAutoLaunchStatus(): AutoLaunchStatus {
+  const settings = getLoginItemSettings();
+  const status = typeof settings.status === 'string' ? settings.status : undefined;
+  const enabled = process.platform === 'darwin' && status
+    ? status === 'enabled'
+    : process.platform === 'win32'
+      ? Boolean(settings.executableWillLaunchAtLogin)
+      : settings.openAtLogin;
+
+  return {
+    enabled,
+    openAtLogin: settings.openAtLogin,
+    status,
+    executableWillLaunchAtLogin: settings.executableWillLaunchAtLogin,
+    launchItems: Array.isArray(settings.launchItems)
+      ? settings.launchItems.map(item => ({
+          name: item.name,
+          path: item.path,
+          args: item.args,
+          enabled: item.enabled,
+          scope: item.scope,
+        }))
+      : undefined,
+  };
 }
+
+const disableWindowsLoginItems = () => {
+  const settings = getLoginItemSettings();
+  const launchItems = Array.isArray(settings.launchItems) ? settings.launchItems : [];
+  const currentExecutablePath = process.execPath.toLowerCase();
+  const matchingLaunchItems = launchItems.filter(item => item.path.toLowerCase() === currentExecutablePath);
+  for (const item of matchingLaunchItems) {
+    app.setLoginItemSettings({
+      openAtLogin: false,
+      path: item.path,
+      args: item.args,
+      name: item.name,
+    });
+  }
+
+  app.setLoginItemSettings({
+    openAtLogin: false,
+    args: AUTO_LAUNCH_ARGS,
+  });
+  app.setLoginItemSettings({
+    openAtLogin: false,
+    args: [],
+  });
+};
 
 export function setAutoLaunchEnabled(enabled: boolean): void {
   const isMac = process.platform === 'darwin';
+  const isWindows = process.platform === 'win32';
 
   try {
+    if (isWindows && !enabled) {
+      disableWindowsLoginItems();
+      return;
+    }
+
     app.setLoginItemSettings({
       openAtLogin: enabled,
-      // macOS: 自启后窗口不显示，M芯片和Intel均兼容
+      // macOS: kept for older versions; Electron marks this deprecated on macOS 13+.
       openAsHidden: isMac ? enabled : false,
       // Windows: 通过命令行参数标记自启动
-      args: enabled ? ['--auto-launched'] : [],
+      args: isWindows ? AUTO_LAUNCH_ARGS : [],
     });
   } catch (error) {
     console.error('Failed to set auto-launch settings:', error);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -30,6 +30,7 @@ import {
   migrateScheduledTasksToOpenclaw,
 } from '../scheduledTask/migrate';
 import { AgentId, AgentIpcChannel } from '../shared/agent/constants';
+import { AppSettingsAutoLaunchErrorCode, AppSettingsIpc } from '../shared/appSettings/constants';
 import { AppUpdateIpc } from '../shared/appUpdate/constants';
 import { ArtifactBrowserPartition, ArtifactPreviewIpc, ArtifactPreviewProtocol } from '../shared/artifactPreview/constants';
 import { AuthIpcChannel } from '../shared/auth/constants';
@@ -100,7 +101,7 @@ import { AgentManager } from './agentManager';
 import { APP_NAME, APP_USER_MODEL_ID, DB_FILENAME } from './appConstants';
 import { createLocalFileProtocolResponse } from './artifactLocalFileProtocol';
 import { authQuotaGateStateFromQuota, AuthSubscriptionStatus, createDefaultAuthQuotaGateState, normalizeAuthQuota } from './authQuota';
-import { getAutoLaunchEnabled, isAutoLaunched, setAutoLaunchEnabled } from './autoLaunchManager';
+import { type AutoLaunchStatus, getAutoLaunchStatus, isAutoLaunched, setAutoLaunchEnabled } from './autoLaunchManager';
 import { getRecentComputerUseLogEntries } from './computerUse/computerUseLogs';
 import { type CoworkForkContextMessage, type CoworkMessage, CoworkStore } from './coworkStore';
 import { setLanguage, t } from './i18n';
@@ -1327,6 +1328,19 @@ const getOpenClawEngineManager = (): OpenClawEngineManager => {
     openClawEngineManager = new OpenClawEngineManager();
   }
   return openClawEngineManager;
+};
+
+const formatAutoLaunchStatusForLog = (status: AutoLaunchStatus): string => {
+  const launchItems = status.launchItems
+    ?.map(item => `${item.name}:${item.enabled ? 'enabled' : 'disabled'}:${item.args.join(' ') || '(no-args)'}`)
+    .join(',');
+
+  return [
+    `status=${status.status ?? 'unknown'}`,
+    `openAtLogin=${status.openAtLogin}`,
+    `executableWillLaunchAtLogin=${status.executableWillLaunchAtLogin ?? 'unknown'}`,
+    launchItems ? `launchItems=${launchItems}` : null,
+  ].filter(Boolean).join(', ');
 };
 
 const getAppUpdateCoordinator = (): AppUpdateCoordinator => {
@@ -3346,25 +3360,46 @@ if (!gotTheLock) {
   });
 
   // Auto-launch IPC handlers
-  // Use SQLite store as the source of truth for UI state, because
-  // app.getLoginItemSettings() returns unreliable values on macOS and
-  // requires matching args on Windows.
-  ipcMain.handle('app:getAutoLaunch', () => {
+  ipcMain.handle(AppSettingsIpc.GetAutoLaunch, () => {
     const stored = getStore().get<boolean>('auto_launch_enabled');
-    // Fall back to OS API if SQLite has no record yet (e.g. upgraded from older version)
-    const enabled = stored ?? getAutoLaunchEnabled();
-    return { enabled };
+    try {
+      const status = getAutoLaunchStatus();
+      if (stored !== undefined && stored !== status.enabled) {
+        console.warn(
+          `[AutoLaunch] stored state (${stored}) differs from OS state (${status.enabled}); ${formatAutoLaunchStatusForLog(status)}`,
+        );
+        getStore().set('auto_launch_enabled', status.enabled);
+      }
+      return { enabled: status.enabled };
+    } catch (error) {
+      console.error('[AutoLaunch] failed to read OS state; falling back to stored state:', error);
+      return { enabled: stored ?? false };
+    }
   });
 
-  ipcMain.handle('app:setAutoLaunch', (_event, enabled: unknown) => {
+  ipcMain.handle(AppSettingsIpc.SetAutoLaunch, (_event, enabled: unknown) => {
     if (typeof enabled !== 'boolean') {
       return { success: false, error: 'Invalid parameter: enabled must be boolean' };
     }
     try {
       setAutoLaunchEnabled(enabled);
-      getStore().set('auto_launch_enabled', enabled);
-      return { success: true };
+      const status = getAutoLaunchStatus();
+      console.log(
+        `[AutoLaunch] set requested=${enabled}, actual=${status.enabled}; ${formatAutoLaunchStatusForLog(status)}`,
+      );
+      if (status.enabled !== enabled) {
+        return {
+          success: false,
+          enabled: status.enabled,
+          errorCode: status.status === 'requires-approval'
+            ? AppSettingsAutoLaunchErrorCode.RequiresApproval
+            : AppSettingsAutoLaunchErrorCode.UpdateFailed,
+        };
+      }
+      getStore().set('auto_launch_enabled', status.enabled);
+      return { success: true, enabled: status.enabled };
     } catch (error) {
+      console.error('[AutoLaunch] failed to update auto-launch setting:', error);
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to set auto-launch',
@@ -3372,12 +3407,12 @@ if (!gotTheLock) {
     }
   });
 
-  ipcMain.handle('app:getPreventSleep', () => {
+  ipcMain.handle(AppSettingsIpc.GetPreventSleep, () => {
     const enabled = getStore().get<boolean>('prevent_sleep_enabled') ?? false;
     return { enabled };
   });
 
-  ipcMain.handle('app:setPreventSleep', (_event, enabled: unknown) => {
+  ipcMain.handle(AppSettingsIpc.SetPreventSleep, (_event, enabled: unknown) => {
     if (typeof enabled !== 'boolean') {
       return { success: false, error: 'Invalid parameter: enabled must be boolean' };
     }
@@ -10390,11 +10425,22 @@ if (!gotTheLock) {
       }
     });
 
-    // 首次启动时默认开启开机自启动（先写标记再设置，避免崩溃后重复设置）
+    // 首次启动时默认开启开机自启动，并以系统登录项的实际状态回写本地标记。
     if (!getStore().get('auto_launch_initialized')) {
       getStore().set('auto_launch_initialized', true);
-      getStore().set('auto_launch_enabled', true);
-      setAutoLaunchEnabled(true);
+      try {
+        setAutoLaunchEnabled(true);
+        const status = getAutoLaunchStatus();
+        getStore().set('auto_launch_enabled', status.enabled);
+        if (!status.enabled) {
+          console.warn(
+            `[AutoLaunch] default enable did not take effect; ${formatAutoLaunchStatusForLog(status)}`,
+          );
+        }
+      } catch (error) {
+        getStore().set('auto_launch_enabled', false);
+        console.error('[AutoLaunch] default enable failed:', error);
+      }
     }
 
     // Restore prevent-sleep setting

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 import { IpcChannel as ScheduledTaskIpc } from '../scheduledTask/constants';
 import { AgentIpcChannel } from '../shared/agent/constants';
+import { AppSettingsIpc } from '../shared/appSettings/constants';
 import { AppUpdateIpc } from '../shared/appUpdate/constants';
 import { ArtifactPreviewIpc } from '../shared/artifactPreview/constants';
 import {
@@ -681,12 +682,12 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.invoke(LocalWebServicesIpc.List, options) as Promise<LocalWebService[]>,
   },
   autoLaunch: {
-    get: () => ipcRenderer.invoke('app:getAutoLaunch'),
-    set: (enabled: boolean) => ipcRenderer.invoke('app:setAutoLaunch', enabled),
+    get: () => ipcRenderer.invoke(AppSettingsIpc.GetAutoLaunch),
+    set: (enabled: boolean) => ipcRenderer.invoke(AppSettingsIpc.SetAutoLaunch, enabled),
   },
   preventSleep: {
-    get: () => ipcRenderer.invoke('app:getPreventSleep'),
-    set: (enabled: boolean) => ipcRenderer.invoke('app:setPreventSleep', enabled),
+    get: () => ipcRenderer.invoke(AppSettingsIpc.GetPreventSleep),
+    set: (enabled: boolean) => ipcRenderer.invoke(AppSettingsIpc.SetPreventSleep, enabled),
   },
   appInfo: {
     getVersion: () => ipcRenderer.invoke('app:getVersion'),

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -2,6 +2,7 @@ import { ArchiveBoxIcon, ArrowPathIcon, ArrowPathRoundedSquareIcon, ChatBubbleLe
 import React, { useCallback,useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { AppSettingsAutoLaunchErrorCode } from '../../shared/appSettings/constants';
 import { type AppUpdateInfo,type AppUpdateRuntimeState,AppUpdateSource,AppUpdateStatus } from '../../shared/appUpdate/constants';
 import {
   type BrowserWebAccessConfig,
@@ -80,6 +81,16 @@ const waitForNextPaint = (): Promise<void> => new Promise(resolve => {
     window.requestAnimationFrame(() => resolve());
   });
 });
+
+const getAutoLaunchErrorMessage = (errorCode?: string): string => {
+  if (errorCode === AppSettingsAutoLaunchErrorCode.RequiresApproval) {
+    return i18nService.t('autoLaunchRequiresApproval');
+  }
+  if (errorCode === AppSettingsAutoLaunchErrorCode.UpdateFailed) {
+    return i18nService.t('autoLaunchUpdateFailed');
+  }
+  return i18nService.t('autoLaunchUpdateFailed');
+};
 
 const formatBackupSize = (sizeBytes?: number): string => {
   if (!Number.isFinite(sizeBytes) || !sizeBytes || sizeBytes <= 0) return '';
@@ -1142,6 +1153,7 @@ const Settings: React.FC<SettingsProps> = ({
 
       // Load auto-launch setting
       window.electron.autoLaunch.get().then(({ enabled }) => {
+        console.log(`[Renderer][Settings] loaded auto-launch setting: enabled=${enabled}`);
         setAutoLaunchState(enabled);
       }).catch(err => {
         console.error('Failed to load auto-launch setting:', err);
@@ -3409,15 +3421,22 @@ const Settings: React.FC<SettingsProps> = ({
                 const next = !autoLaunch;
                 setIsUpdatingAutoLaunch(true);
                 try {
+                  console.log(`[Renderer][Settings] updating auto-launch setting: requested=${next}`);
                   const result = await window.electron.autoLaunch.set(next);
+                  console.log(
+                    `[Renderer][Settings] auto-launch update result: success=${result.success}, enabled=${result.enabled ?? 'unknown'}, error=${result.error ?? 'none'}`,
+                  );
                   if (result.success) {
-                    setAutoLaunchState(next);
+                    setAutoLaunchState(result.enabled ?? next);
                   } else {
-                    setError(result.error || 'Failed to update auto-launch setting');
+                    if (typeof result.enabled === 'boolean') {
+                      setAutoLaunchState(result.enabled);
+                    }
+                    setError(getAutoLaunchErrorMessage(result.errorCode));
                   }
                 } catch (err) {
                   console.error('Failed to set auto-launch:', err);
-                  setError('Failed to update auto-launch setting');
+                  setError(i18nService.t('autoLaunchUpdateFailed'));
                 } finally {
                   setIsUpdatingAutoLaunch(false);
                 }

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -2030,6 +2030,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // 通用设置
     autoLaunch: '开机自启动',
     autoLaunchDescription: '系统启动时自动运行应用',
+    autoLaunchRequiresApproval: '需要在系统设置中允许开机自启动',
+    autoLaunchUpdateFailed: '更新开机自启动设置失败',
     useSystemProxy: '使用系统代理',
     useSystemProxyDescription: '开启后网络请求将跟随系统代理（保存后生效）',
     browserWebAccessTab: '浏览器',
@@ -4661,6 +4663,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // General Settings
     autoLaunch: 'Launch at Login',
     autoLaunchDescription: 'Automatically start the app when you log in',
+    autoLaunchRequiresApproval: 'Launch at login requires approval in System Settings',
+    autoLaunchUpdateFailed: 'Failed to update launch at login setting',
     useSystemProxy: 'Use System Proxy',
     useSystemProxyDescription: 'When enabled, network requests follow system proxy settings (applies after Save)',
     browserWebAccessTab: 'Browser',

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -971,7 +971,7 @@ interface IElectronAPI {
   };
   autoLaunch: {
     get: () => Promise<{ enabled: boolean }>;
-    set: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;
+    set: (enabled: boolean) => Promise<{ success: boolean; enabled?: boolean; error?: string; errorCode?: string }>;
   };
   preventSleep: {
     get: () => Promise<{ enabled: boolean }>;

--- a/src/shared/appSettings/constants.ts
+++ b/src/shared/appSettings/constants.ts
@@ -1,0 +1,16 @@
+export const AppSettingsIpc = {
+  GetAutoLaunch: 'app:getAutoLaunch',
+  SetAutoLaunch: 'app:setAutoLaunch',
+  GetPreventSleep: 'app:getPreventSleep',
+  SetPreventSleep: 'app:setPreventSleep',
+} as const;
+
+export type AppSettingsIpc = typeof AppSettingsIpc[keyof typeof AppSettingsIpc];
+
+export const AppSettingsAutoLaunchErrorCode = {
+  RequiresApproval: 'requires_approval',
+  UpdateFailed: 'update_failed',
+} as const;
+
+export type AppSettingsAutoLaunchErrorCode =
+  typeof AppSettingsAutoLaunchErrorCode[keyof typeof AppSettingsAutoLaunchErrorCode];


### PR DESCRIPTION
Verify auto-launch changes against the OS before persisting local state. Handle Windows login item cleanup for historical argument variants, add diagnostic logs, and surface localized failure messages in settings.