### PR TITLE
fix(cowork): stabilize subagent progress tracking

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -5539,6 +5539,95 @@ test('deterministic subagent progress corrects stale announce progress text', ()
   ]);
 });
 
+test('deterministic subagent progress prunes duplicate progress in the current user turn', () => {
+  const progressText = '5/5 \u5b8c\u6210 - snake-game, breakout-game, game2048, tetris-game, memory-game \u2713';
+  const startupText = '5 \u4e2a\u5b50 agent \u5df2\u5168\u90e8\u542f\u52a8\uff0c\u7b49\u5f85\u5b8c\u6210\u4e2d...';
+  const session = {
+    id: 'parent-session',
+    title: 'parallel agents',
+    claudeSessionId: null,
+    status: 'running',
+    pinned: false,
+    cwd: '',
+    systemPrompt: '',
+    executionMode: 'local',
+    activeSkillIds: [],
+    createdAt: 1,
+    updatedAt: 1,
+    messages: [
+      { id: 'msg-old-user', type: 'user', content: 'previous turn', timestamp: 1, metadata: {} },
+      { id: 'msg-old-progress', type: 'assistant', content: progressText, timestamp: 2, metadata: {} },
+      { id: 'msg-current-user', type: 'user', content: 'start 5 subagents', timestamp: 3, metadata: {} },
+      { id: 'msg-startup', type: 'assistant', content: startupText, timestamp: 4, metadata: {} },
+      { id: 'msg-duplicate', type: 'assistant', content: progressText, timestamp: 5, metadata: {} },
+      { id: 'msg-thinking', type: 'assistant', content: 'thinking', timestamp: 6, metadata: { isThinking: true } },
+      { id: 'msg-target', type: 'assistant', content: progressText, timestamp: 7, metadata: {} },
+    ],
+  };
+  const runs = [
+    { id: 'call-snake', parentSessionId: session.id, agentId: 'snake-game', task: null, label: null, sessionKey: null, status: 'done', createdAt: 1, endedAt: 2 },
+    { id: 'call-breakout', parentSessionId: session.id, agentId: 'breakout-game', task: null, label: null, sessionKey: null, status: 'done', createdAt: 1, endedAt: 2 },
+    { id: 'call-2048', parentSessionId: session.id, agentId: 'game2048', task: null, label: null, sessionKey: null, status: 'done', createdAt: 1, endedAt: 2 },
+    { id: 'call-tetris', parentSessionId: session.id, agentId: 'tetris-game', task: null, label: null, sessionKey: null, status: 'done', createdAt: 1, endedAt: 2 },
+    { id: 'call-memory', parentSessionId: session.id, agentId: 'memory-game', task: null, label: null, sessionKey: null, status: 'done', createdAt: 1, endedAt: 2 },
+  ];
+  const store = {
+    getSession: (sessionId: string) => (sessionId === session.id ? session : null),
+    addMessage: vi.fn(),
+    updateMessage: vi.fn((sessionId: string, messageId: string, updates: Record<string, unknown>) => {
+      expect(sessionId).toBe(session.id);
+      const message = session.messages.find((entry) => entry.id === messageId);
+      expect(message).toBeTruthy();
+      Object.assign(message as Record<string, unknown>, updates);
+    }),
+    deleteMessage: vi.fn((sessionId: string, messageId: string) => {
+      expect(sessionId).toBe(session.id);
+      const index = session.messages.findIndex((message) => message.id === messageId);
+      if (index >= 0) {
+        session.messages.splice(index, 1);
+        return true;
+      }
+      return false;
+    }),
+  };
+  const subagentRunStore = {
+    getSubagentRun: (runId: string) => runs.find((run) => run.id === runId) ?? null,
+    listSubagentRuns: (parentSessionId: string) => runs.filter((run) => run.parentSessionId === parentSessionId),
+    updateSubagentRunStatus: vi.fn(),
+    updateSubagentRunSessionKey: vi.fn(),
+    insertSubagentRun: vi.fn(),
+  };
+  const adapter = new OpenClawRuntimeAdapter(
+    store as never,
+    {} as never,
+    {},
+    subagentRunStore as never,
+  );
+
+  adapter.applySubagentProgressForSession(session.id, {
+    createIfMissing: true,
+    preferLatestTextMatch: true,
+  });
+
+  expect(store.updateMessage).toHaveBeenCalledWith(
+    session.id,
+    'msg-target',
+    expect.objectContaining({
+      metadata: expect.objectContaining({ kind: 'subagent_progress' }),
+    }),
+  );
+  expect(store.deleteMessage).toHaveBeenCalledTimes(1);
+  expect(store.deleteMessage).toHaveBeenCalledWith(session.id, 'msg-duplicate');
+  expect(session.messages.map((message) => message.id)).toEqual([
+    'msg-old-user',
+    'msg-old-progress',
+    'msg-current-user',
+    'msg-startup',
+    'msg-thinking',
+    'msg-target',
+  ]);
+});
+
 test('syncSystemMessagesFromHistory skips pure heartbeat ack system messages', () => {
   const { session, store } = createHistoryStore([]);
   const adapter = new OpenClawRuntimeAdapter(store, {});

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -3721,6 +3721,72 @@ test('empty final with local tool messages waits when history only has interim a
   }
 });
 
+test('empty subagent announce final completes without deferred context maintenance', async () => {
+  vi.useFakeTimers();
+  try {
+    const announceRunId = 'announce:v1:agent:main:subagent:child-session:child-run';
+    const { session, store } = createReconcileStore([
+      { id: 'msg-1', type: 'user', content: 'start five subagents', timestamp: 1, metadata: {} },
+      { id: 'msg-2', type: 'tool_use', content: 'Spawn child', timestamp: 2, metadata: { toolUseId: 'call-1' } },
+      { id: 'msg-3', type: 'tool_result', content: 'child spawned', timestamp: 3, metadata: { toolUseId: 'call-1' } },
+    ]);
+    const adapter = new OpenClawRuntimeAdapter(store, {});
+    const sessionKey = `agent:main:lobsterai:${session.id}`;
+    const completeSpy = vi.fn();
+    const maintenanceSpy = vi.fn();
+
+    adapter.gatewayClient = {
+      start: () => {},
+      stop: () => {},
+      request: async (method: string) => {
+        if (method !== 'chat.history') return {};
+        return {
+          messages: [
+            { role: 'user', content: 'start five subagents' },
+            {
+              role: 'assistant',
+              content: [
+                { type: 'toolCall', id: 'call-1', name: 'sessions_yield', arguments: {} },
+              ],
+            },
+            { role: 'toolResult', toolCallId: 'call-1', content: 'child completed' },
+            { role: 'assistant', content: '5 subagents all started, waiting for completion.' },
+          ],
+        };
+      },
+    };
+
+    session.status = 'running';
+    adapter.on('complete', completeSpy);
+    adapter.on('contextMaintenance', maintenanceSpy);
+    adapter.activeTurns.set(session.id, createActiveTurn(session.id, sessionKey, announceRunId));
+    adapter.sessionIdByRunId.set(announceRunId, session.id);
+    adapter.latestTurnTokenBySession.set(session.id, 1);
+    adapter.rememberSessionKey(session.id, sessionKey);
+
+    adapter.handleChatEvent({
+      state: 'final',
+      runId: announceRunId,
+      sessionKey,
+    }, 1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(maintenanceSpy).not.toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalledWith(session.id, announceRunId);
+    expect(session.status).toBe('completed');
+    expect(adapter.activeTurns.has(session.id)).toBe(false);
+    expect(session.messages.some((message) => (
+      message.type === 'assistant'
+      && message.content === '5 subagents all started, waiting for completion.'
+    ))).toBe(true);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 test('visible short tool final waits with retry signal and accepts same-run continuation', async () => {
   vi.useFakeTimers();
   try {
@@ -5287,7 +5353,9 @@ test('child lifecycle end marks matching subagent done before local session reso
         run.endedAt = endedAt;
       }
     }),
-    listSubagentRuns: () => [],
+    getSubagentRun: (id: string) => runs.get(id) ?? null,
+    listSubagentRuns: (parentSessionId: string) => Array.from(runs.values())
+      .filter((run) => run.parentSessionId === parentSessionId),
   };
   const adapter = new OpenClawRuntimeAdapter(
     { getSession: () => null } as never,
@@ -5340,7 +5408,9 @@ test('child chat final marks matching subagent done before local session resolut
         run.endedAt = endedAt;
       }
     }),
-    listSubagentRuns: () => [],
+    getSubagentRun: (id: string) => runs.get(id) ?? null,
+    listSubagentRuns: (parentSessionId: string) => Array.from(runs.values())
+      .filter((run) => run.parentSessionId === parentSessionId),
   };
   const adapter = new OpenClawRuntimeAdapter(
     { getSession: () => null } as never,
@@ -5378,6 +5448,95 @@ test('child chat final marks matching subagent done before local session resolut
     expect.any(Number),
   );
   expect(runs.get('call-fibonacci')?.status).toBe('done');
+});
+
+test('deterministic subagent progress corrects stale announce progress text', () => {
+  const session = {
+    id: 'parent-session',
+    title: 'parallel agents',
+    claudeSessionId: null,
+    status: 'running',
+    pinned: false,
+    cwd: '',
+    systemPrompt: '',
+    executionMode: 'local',
+    activeSkillIds: [],
+    createdAt: 1,
+    updatedAt: 1,
+    messages: [
+      { id: 'msg-1', type: 'user', content: 'start 5 subagents', timestamp: 1, metadata: {} },
+      {
+        id: 'msg-2',
+        type: 'assistant',
+        content: '3/5 完成 - 翻牌记忆、2048、俄罗斯方块 ✓\n\n继续等待剩余 2 个子 agent 完成...',
+        timestamp: 2,
+        metadata: { isStreaming: false, isFinal: true },
+      },
+    ],
+  };
+  const runs = [
+    { id: 'call-snake', parentSessionId: session.id, agentId: 'game-snake', task: null, label: null, sessionKey: null, status: 'done', createdAt: 1, endedAt: 2 },
+    { id: 'call-breakout', parentSessionId: session.id, agentId: 'game-breakout', task: null, label: null, sessionKey: null, status: 'done', createdAt: 1, endedAt: 2 },
+    { id: 'call-2048', parentSessionId: session.id, agentId: 'game-2048', task: null, label: null, sessionKey: null, status: 'done', createdAt: 1, endedAt: 2 },
+    { id: 'call-tetris', parentSessionId: session.id, agentId: 'game-tetris', task: null, label: null, sessionKey: null, status: 'done', createdAt: 1, endedAt: 2 },
+    { id: 'call-memory', parentSessionId: session.id, agentId: 'game-memory', task: null, label: null, sessionKey: null, status: 'done', createdAt: 1, endedAt: 2 },
+  ];
+  const store = {
+    getSession: (sessionId: string) => (sessionId === session.id ? session : null),
+    addMessage: vi.fn(),
+    updateMessage: vi.fn((sessionId: string, messageId: string, updates: Record<string, unknown>) => {
+      expect(sessionId).toBe(session.id);
+      const message = session.messages.find((entry) => entry.id === messageId);
+      expect(message).toBeTruthy();
+      Object.assign(message as Record<string, unknown>, updates);
+    }),
+  };
+  const subagentRunStore = {
+    getSubagentRun: (runId: string) => runs.find((run) => run.id === runId) ?? null,
+    listSubagentRuns: (parentSessionId: string) => runs.filter((run) => run.parentSessionId === parentSessionId),
+    updateSubagentRunStatus: vi.fn(),
+    updateSubagentRunSessionKey: vi.fn(),
+    insertSubagentRun: vi.fn(),
+  };
+  const adapter = new OpenClawRuntimeAdapter(
+    store as never,
+    {} as never,
+    {},
+    subagentRunStore as never,
+  );
+  const messageUpdates: Array<{ messageId: string; content: string; metadata?: Record<string, unknown> }> = [];
+  adapter.on('messageUpdate', (_sessionId, messageId, content, metadata) => {
+    messageUpdates.push({ messageId, content, metadata });
+  });
+
+  adapter.applySubagentProgressForSession(session.id, {
+    createIfMissing: true,
+    preferLatestTextMatch: true,
+  });
+
+  expect(store.updateMessage).toHaveBeenCalledWith(
+    session.id,
+    'msg-2',
+    expect.objectContaining({
+      content: '5/5 完成 - game-snake、game-breakout、game-2048、game-tetris、game-memory ✓',
+      metadata: expect.objectContaining({
+        kind: 'subagent_progress',
+        subagentProgressTotal: 5,
+        subagentProgressDone: 5,
+        subagentProgressError: 0,
+        subagentProgressRunning: 0,
+      }),
+    }),
+  );
+  expect(session.messages[1].content).toBe(
+    '5/5 完成 - game-snake、game-breakout、game-2048、game-tetris、game-memory ✓',
+  );
+  expect(messageUpdates).toEqual([
+    expect.objectContaining({
+      messageId: 'msg-2',
+      content: '5/5 完成 - game-snake、game-breakout、game-2048、game-tetris、game-memory ✓',
+    }),
+  ]);
 });
 
 test('syncSystemMessagesFromHistory skips pure heartbeat ack system messages', () => {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -77,6 +77,7 @@ import {
 } from './coworkContinuityCapsule';
 import { buildCoworkTopKEvidenceBridgeResult } from './coworkTopKEvidence';
 import { buildCoworkWorkspaceRehydrationBridge } from './coworkWorkspaceRehydration';
+import type { SubagentProgressSnapshot } from './subagentTracker';
 import { SubagentTracker } from './subagentTracker';
 import type {
   CoworkContextUsage,
@@ -417,6 +418,14 @@ const OpenClawHistoryRole = {
   Tool: 'tool',
   ToolResult: 'toolResult',
 } as const;
+
+const SubagentProgressMessageKind = {
+  Progress: 'subagent_progress',
+} as const;
+
+const isSubagentAnnounceRunId = (runId: string | null | undefined): boolean => (
+  typeof runId === 'string' && /^announce:.*:subagent:/i.test(runId.trim())
+);
 
 type ActiveTurn = {
   sessionId: string;
@@ -856,6 +865,21 @@ type ReconciledConversationEntry = {
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+};
+
+const summarizeHistoryRolesForDiag = (messages: unknown[]): string => {
+  return messages.slice(-20).map((message) => {
+    if (!isRecord(message)) return 'unknown';
+    const role = typeof message.role === 'string' && message.role.trim()
+      ? message.role.trim()
+      : 'unknown';
+    const toolCallId = typeof message.toolCallId === 'string' && message.toolCallId.trim()
+      ? message.toolCallId.trim()
+      : typeof message.tool_call_id === 'string' && message.tool_call_id.trim()
+        ? message.tool_call_id.trim()
+        : '';
+    return toolCallId ? `${role}:${toolCallId.slice(0, 12)}` : role;
+  }).join('>');
 };
 
 export const resolveToolEventIsError = (data: unknown): boolean => {
@@ -2923,11 +2947,182 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     this.engineManager = engineManager;
     this.options = options;
     if (subagentRunStore) {
-      this.subagentTracker = new SubagentTracker(subagentRunStore, subagentMessageStore ?? null, () => this.gatewayClient);
+      this.subagentTracker = new SubagentTracker(
+        subagentRunStore,
+        subagentMessageStore ?? null,
+        () => this.gatewayClient,
+        (snapshot) => this.handleSubagentProgressSnapshot(snapshot),
+      );
     } else {
       // Fallback: create a no-op tracker (should not happen in production)
       this.subagentTracker = new SubagentTracker(null as unknown as SubagentRunStore, null, () => this.gatewayClient);
     }
+  }
+
+  private handleSubagentProgressSnapshot(snapshot: SubagentProgressSnapshot): void {
+    this.upsertSubagentProgressMessage(snapshot, {
+      createIfMissing: snapshot.allTerminal || snapshot.error > 0,
+      preferLatestTextMatch: false,
+    });
+  }
+
+  private applySubagentProgressForSession(
+    sessionId: string,
+    options: { preferLatestTextMatch?: boolean; createIfMissing?: boolean } = {},
+  ): void {
+    const snapshot = this.subagentTracker.getProgressSnapshot(sessionId);
+    if (!snapshot) return;
+    this.upsertSubagentProgressMessage(snapshot, {
+      createIfMissing: options.createIfMissing ?? true,
+      preferLatestTextMatch: options.preferLatestTextMatch ?? false,
+    });
+  }
+
+  private upsertSubagentProgressMessage(
+    snapshot: SubagentProgressSnapshot,
+    options: { preferLatestTextMatch: boolean; createIfMissing: boolean },
+  ): void {
+    if (snapshot.total <= 0) return;
+    const session = this.store.getSession(snapshot.parentSessionId);
+    if (!session) return;
+    const content = this.formatSubagentProgressContent(snapshot);
+    const target = this.findSubagentProgressMessage(
+      snapshot.parentSessionId,
+      options.preferLatestTextMatch,
+    );
+    const metadata: CoworkMessageMetadata = {
+      ...(target?.metadata ?? {}),
+      kind: SubagentProgressMessageKind.Progress,
+      isStreaming: false,
+      isFinal: true,
+      subagentProgress: true,
+      subagentProgressTotal: snapshot.total,
+      subagentProgressDone: snapshot.done,
+      subagentProgressError: snapshot.error,
+      subagentProgressRunning: snapshot.running,
+      subagentProgressUpdatedAt: Date.now(),
+    };
+
+    if (target) {
+      if (target.content === content && target.metadata?.subagentProgressTotal === snapshot.total
+          && target.metadata?.subagentProgressDone === snapshot.done
+          && target.metadata?.subagentProgressError === snapshot.error
+          && target.metadata?.subagentProgressRunning === snapshot.running) {
+        return;
+      }
+      this.store.updateMessage(snapshot.parentSessionId, target.id, { content, metadata });
+      this.emit('messageUpdate', snapshot.parentSessionId, target.id, content, metadata);
+      console.debug(
+        '[OpenClawRuntime] updated deterministic subagent progress message.',
+        `sessionId=${snapshot.parentSessionId}`,
+        `messageId=${target.id}`,
+        `progress=${snapshot.terminal}/${snapshot.total}`,
+        `done=${snapshot.done}`,
+        `error=${snapshot.error}`,
+        `running=${snapshot.running}`,
+      );
+      return;
+    }
+
+    if (!options.createIfMissing) return;
+    const message = this.store.addMessage(snapshot.parentSessionId, {
+      type: 'assistant',
+      content,
+      metadata,
+    });
+    this.emit('message', snapshot.parentSessionId, message);
+    console.debug(
+      '[OpenClawRuntime] added deterministic subagent progress message.',
+      `sessionId=${snapshot.parentSessionId}`,
+      `messageId=${message.id}`,
+      `progress=${snapshot.terminal}/${snapshot.total}`,
+      `done=${snapshot.done}`,
+      `error=${snapshot.error}`,
+      `running=${snapshot.running}`,
+    );
+  }
+
+  private findSubagentProgressMessage(
+    sessionId: string,
+    preferLatestTextMatch: boolean,
+  ): CoworkMessage | null {
+    const session = this.store.getSession(sessionId);
+    if (!session) return null;
+    const messages = [...session.messages].reverse();
+
+    if (preferLatestTextMatch) {
+      return messages.find((message) => this.isSubagentProgressMessage(message, true)) ?? null;
+    }
+
+    return messages.find((message) => this.isSubagentProgressMessage(message, false)) ?? null;
+  }
+
+  private isSubagentProgressMessage(message: CoworkMessage, allowTextMatch: boolean): boolean {
+    if (message.type !== 'assistant') return false;
+    if (message.metadata?.kind === SubagentProgressMessageKind.Progress
+        || message.metadata?.subagentProgress === true) {
+      return true;
+    }
+    if (!allowTextMatch || message.metadata?.isStreaming === true) return false;
+    return this.isSubagentProgressText(message.content);
+  }
+
+  private isSubagentProgressText(content: string): boolean {
+    const text = content.trim();
+    if (!text) return false;
+    return /\d+\s*\/\s*\d+\s*(?:完成|已完成|已结束)/.test(text)
+      || /继续等待.*子\s*agent/.test(text)
+      || /子\s*agent.*(?:完成|结束|出错)/.test(text);
+  }
+
+  private formatSubagentProgressContent(snapshot: SubagentProgressSnapshot): string {
+    const doneLabels = snapshot.runs
+      .filter((run) => run.status === 'done')
+      .map((run) => this.formatSubagentProgressRunLabel(run));
+    const errorLabels = snapshot.runs
+      .filter((run) => run.status === 'error')
+      .map((run) => this.formatSubagentProgressRunLabel(run));
+    const formattedDoneLabels = this.formatSubagentProgressLabels(doneLabels);
+    const formattedErrorLabels = this.formatSubagentProgressLabels(errorLabels);
+
+    if (snapshot.allTerminal && snapshot.error === 0) {
+      return `${snapshot.total}/${snapshot.total} 完成 - ${formattedDoneLabels} ✓`;
+    }
+
+    if (snapshot.allTerminal) {
+      const donePart = snapshot.done > 0 ? `${snapshot.done} 个完成` : '';
+      const errorPart = `${snapshot.error} 个出错`;
+      const summary = [donePart, errorPart].filter(Boolean).join('，');
+      const details = [
+        formattedDoneLabels ? `完成：${formattedDoneLabels}` : '',
+        formattedErrorLabels ? `出错：${formattedErrorLabels}` : '',
+      ].filter(Boolean).join('\n');
+      return `${snapshot.terminal}/${snapshot.total} 已结束（${summary}）${details ? `\n\n${details}` : ''}`;
+    }
+
+    if (snapshot.error === 0) {
+      const doneLine = snapshot.done > 0
+        ? `${snapshot.done}/${snapshot.total} 完成 - ${formattedDoneLabels} ✓`
+        : `0/${snapshot.total} 完成`;
+      return `${doneLine}\n\n继续等待剩余 ${snapshot.running} 个子 agent 完成...`;
+    }
+
+    const summary = `${snapshot.terminal}/${snapshot.total} 已结束（${snapshot.done} 个完成，${snapshot.error} 个出错）`;
+    const details = [
+      formattedDoneLabels ? `完成：${formattedDoneLabels}` : '',
+      formattedErrorLabels ? `出错：${formattedErrorLabels}` : '',
+    ].filter(Boolean).join('\n');
+    return `${summary}${details ? `\n\n${details}` : ''}\n\n继续等待剩余 ${snapshot.running} 个子 agent 完成...`;
+  }
+
+  private formatSubagentProgressRunLabel(run: SubagentProgressSnapshot['runs'][number]): string {
+    const label = run.label?.trim() || run.agentId?.trim() || run.id.trim();
+    return label || run.id.slice(0, 8);
+  }
+
+  private formatSubagentProgressLabels(labels: string[]): string {
+    if (labels.length <= 5) return labels.join('、');
+    return `${labels.slice(0, 5).join('、')} 等 ${labels.length} 个`;
   }
 
   private normalizeModelRef(modelRef: string): string {
@@ -4681,9 +4876,14 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       const hasKnownToolUse = turn.toolUseMessageIdByToolCallId.has(msgToolCallId);
       if (!hasKnownToolUse && !existingResultMsgId) {
         console.debug(
-          '[OpenClawRuntime] skipped a tool result from chat history because it is not part of the current turn.',
+          '[OpenClawRuntime][SubagentAnnounceDiag] skipped a tool result from chat history because it is not part of the current turn.',
           `sessionId=${sessionId}`,
+          `turnRunId=${turn.runId}`,
+          `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
           `toolCallId=${msgToolCallId}`,
+          `knownToolUses=${turn.toolUseMessageIdByToolCallId.size}`,
+          `knownToolResults=${turn.toolResultMessageIdByToolCallId.size}`,
+          `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
         );
         continue;
       }
@@ -5243,6 +5443,24 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       }
       console.log('[Debug:handleAgentEvent] no active turn for sessionId:', sessionId);
       return;
+    }
+
+    if (runId && runId !== turn.runId) {
+      console.debug(
+        '[OpenClawRuntime][SubagentAnnounceDiag] agent event will bind to an existing active turn.',
+        `sessionId=${sessionId}`,
+        `stream=${stream || 'unknown'}`,
+        `phase=${lifecyclePhase || 'none'}`,
+        `incomingRunId=${runId}`,
+        `turnRunId=${turn.runId}`,
+        `isIncomingAnnounce=${isSubagentAnnounceRunId(runId)}`,
+        `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
+        `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
+        `assistantMessageId=${turn.assistantMessageId ?? 'none'}`,
+        `currentTextLen=${turn.currentText.length}`,
+        `currentSegmentLen=${turn.currentAssistantSegmentText.length}`,
+        `finalCompletionPending=${Boolean(turn.finalCompletionTimer)}`,
+      );
     }
 
     if (sessionKey && !runId && turn.sessionKey !== sessionKey) {
@@ -6273,6 +6491,24 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       return;
     }
 
+    if (runId && runId !== turn.runId) {
+      console.debug(
+        '[OpenClawRuntime][SubagentAnnounceDiag] chat event arrived for an existing active turn with a different runId.',
+        `sessionId=${sessionId}`,
+        `state=${state}`,
+        `incomingRunId=${runId}`,
+        `turnRunId=${turn.runId}`,
+        `isIncomingAnnounce=${isSubagentAnnounceRunId(runId)}`,
+        `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
+        `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
+        `assistantMessageId=${turn.assistantMessageId ?? 'none'}`,
+        `currentTextLen=${turn.currentText.length}`,
+        `currentSegmentLen=${turn.currentAssistantSegmentText.length}`,
+        `finalCompletionPending=${Boolean(turn.finalCompletionTimer)}`,
+        `message=${summarizeGatewayMessageShape(chatPayload.message)}`,
+      );
+    }
+
     // Buffer chat events while user messages are being prefetched for channel sessions
     if (turn.pendingUserSync) {
       console.debug('[OpenClawRuntime] handleChatEvent — buffering (pendingUserSync), sessionId:', sessionId);
@@ -6304,7 +6540,16 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       if (runId) {
         this.subagentTracker.tryMarkDoneFromAnnounceRunId(runId);
       }
-      this.handleChatFinal(sessionId, turn, chatPayload);
+      const isSubagentAnnounceFinal = isSubagentAnnounceRunId(runId) || isSubagentAnnounceRunId(turn.runId);
+      const completion = this.handleChatFinal(sessionId, turn, chatPayload);
+      if (isSubagentAnnounceFinal) {
+        void completion.finally(() => {
+          this.applySubagentProgressForSession(sessionId, {
+            createIfMissing: true,
+            preferLatestTextMatch: true,
+          });
+        });
+      }
       return;
     }
 
@@ -6919,14 +7164,34 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
 
     if (!finalText.trim()) {
+      const isSubagentAnnounceFinal = isSubagentAnnounceRunId(payload.runId) || isSubagentAnnounceRunId(turn.runId);
+      const emptyFinalHasTurnToolWork = this.hasTurnToolWork(sessionId, turn);
       console.debug(
         '[OpenClawRuntime] handleChatFinal: final payload had no text, falling back to chat.history sync',
         `sessionId=${sessionId}`,
-        `runId=${payload.runId ?? turn.runId}`
+        `runId=${payload.runId ?? turn.runId}`,
+        `turnRunId=${turn.runId}`,
+        `isPayloadAnnounce=${isSubagentAnnounceRunId(payload.runId)}`,
+        `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
+        `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
+        `hasTurnToolWorkBeforeHistorySync=${emptyFinalHasTurnToolWork}`,
       );
       await this.syncFinalAssistantWithHistory(sessionId, turn);
       const syncedVisibleText = turn.currentAssistantSegmentText.trim() || turn.currentText.trim();
-      if (this.hasTurnToolWork(sessionId, turn)) {
+      const hasTurnToolWorkAfterHistorySync = this.hasTurnToolWork(sessionId, turn);
+      console.debug(
+        '[OpenClawRuntime][SubagentAnnounceDiag] empty final history fallback result.',
+        `sessionId=${sessionId}`,
+        `runId=${payload.runId ?? turn.runId}`,
+        `turnRunId=${turn.runId}`,
+        `isPayloadAnnounce=${isSubagentAnnounceRunId(payload.runId)}`,
+        `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
+        `syncedVisibleTextLen=${syncedVisibleText.length}`,
+        `hasTurnToolWorkAfterHistorySync=${hasTurnToolWorkAfterHistorySync}`,
+        `lastHistoryHadToolWork=${Boolean(turn.lastHistoryHadToolWork)}`,
+        `lastHistoryToolResultCharCount=${turn.lastHistoryToolResultCharCount ?? 0}`,
+      );
+      if (hasTurnToolWorkAfterHistorySync && !isSubagentAnnounceFinal) {
         const visibleRetryRisk = this.shouldWaitForVisibleFinalContinuation(
           sessionId,
           turn,
@@ -6944,6 +7209,16 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           pendingVisibleFinalContinuation: Boolean(syncedVisibleText),
         });
         return;
+      }
+      if (hasTurnToolWorkAfterHistorySync && isSubagentAnnounceFinal) {
+        console.debug(
+          '[OpenClawRuntime][SubagentAnnounceDiag] completed empty subagent announce final without deferred maintenance.',
+          `sessionId=${sessionId}`,
+          `runId=${payload.runId ?? turn.runId}`,
+          `turnRunId=${turn.runId}`,
+          `syncedVisibleTextLen=${syncedVisibleText.length}`,
+          `lastHistoryToolResultCharCount=${turn.lastHistoryToolResultCharCount ?? 0}`,
+        );
       }
       if (turn.hasContextMaintenanceTool && !turn.currentAssistantSegmentText.trim()) {
         this.waitForRecoverableOpenClawRetry(sessionId, turn, payload.runId ?? turn.runId, {
@@ -8071,6 +8346,16 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           continue;
         }
 
+        console.debug(
+          '[OpenClawRuntime][SubagentAnnounceDiag] syncFinalAssistant history window.',
+          `sessionId=${sessionId}`,
+          `turnRunId=${turn.runId}`,
+          `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
+          `messageCount=${history.messages.length}`,
+          `roles=${summarizeHistoryRolesForDiag(history.messages)}`,
+          `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
+        );
+
         historyMessages = history.messages;
         const previousHistoryCountKnown = this.gatewayHistoryCountBySession.has(sessionId);
         const previousHistoryCount = this.gatewayHistoryCountBySession.get(sessionId) ?? 0;
@@ -8161,6 +8446,17 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       console.debug('[Debug:syncFinal] canonicalSegmentText length:', canonicalSegmentText.length,
         'committed.length:', turn.committedAssistantText.length,
         'segment:', canonicalSegmentText.slice(0, 80));
+      console.debug(
+        '[OpenClawRuntime][SubagentAnnounceDiag] syncFinalAssistant extracted text.',
+        `sessionId=${sessionId}`,
+        `turnRunId=${turn.runId}`,
+        `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
+        `canonicalTextLen=${canonicalText.length}`,
+        `canonicalSegmentTextLen=${canonicalSegmentText.length}`,
+        `canonicalTextHead=${truncate(canonicalText, 120)}`,
+        `canonicalSegmentHead=${truncate(canonicalSegmentText, 120)}`,
+        `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
+      );
       turn.currentText = canonicalText;
       turn.currentAssistantSegmentText = canonicalSegmentText;
 

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -77,6 +77,12 @@ import {
 } from './coworkContinuityCapsule';
 import { buildCoworkTopKEvidenceBridgeResult } from './coworkTopKEvidence';
 import { buildCoworkWorkspaceRehydrationBridge } from './coworkWorkspaceRehydration';
+import {
+  buildSubagentProgressContent,
+  buildSubagentProgressMetadata,
+  findSubagentProgressMessage,
+  isSubagentProgressMessage,
+} from './subagentProgressMessage';
 import type { SubagentProgressSnapshot } from './subagentTracker';
 import { SubagentTracker } from './subagentTracker';
 import type {
@@ -417,10 +423,6 @@ const OpenClawKnownRuntimeError = {
 const OpenClawHistoryRole = {
   Tool: 'tool',
   ToolResult: 'toolResult',
-} as const;
-
-const SubagentProgressMessageKind = {
-  Progress: 'subagent_progress',
 } as const;
 
 const isSubagentAnnounceRunId = (runId: string | null | undefined): boolean => (
@@ -865,21 +867,6 @@ type ReconciledConversationEntry = {
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
-};
-
-const summarizeHistoryRolesForDiag = (messages: unknown[]): string => {
-  return messages.slice(-20).map((message) => {
-    if (!isRecord(message)) return 'unknown';
-    const role = typeof message.role === 'string' && message.role.trim()
-      ? message.role.trim()
-      : 'unknown';
-    const toolCallId = typeof message.toolCallId === 'string' && message.toolCallId.trim()
-      ? message.toolCallId.trim()
-      : typeof message.tool_call_id === 'string' && message.tool_call_id.trim()
-        ? message.tool_call_id.trim()
-        : '';
-    return toolCallId ? `${role}:${toolCallId.slice(0, 12)}` : role;
-  }).join('>');
 };
 
 export const resolveToolEventIsError = (data: unknown): boolean => {
@@ -2985,42 +2972,21 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (snapshot.total <= 0) return;
     const session = this.store.getSession(snapshot.parentSessionId);
     if (!session) return;
-    const content = this.formatSubagentProgressContent(snapshot);
-    const target = this.findSubagentProgressMessage(
-      snapshot.parentSessionId,
-      options.preferLatestTextMatch,
-    );
-    const metadata: CoworkMessageMetadata = {
-      ...(target?.metadata ?? {}),
-      kind: SubagentProgressMessageKind.Progress,
-      isStreaming: false,
-      isFinal: true,
-      subagentProgress: true,
-      subagentProgressTotal: snapshot.total,
-      subagentProgressDone: snapshot.done,
-      subagentProgressError: snapshot.error,
-      subagentProgressRunning: snapshot.running,
-      subagentProgressUpdatedAt: Date.now(),
-    };
+    const content = buildSubagentProgressContent(snapshot);
+    const target = findSubagentProgressMessage(session.messages, options.preferLatestTextMatch);
+    const metadata = buildSubagentProgressMetadata(snapshot, target?.metadata);
 
     if (target) {
       if (target.content === content && target.metadata?.subagentProgressTotal === snapshot.total
           && target.metadata?.subagentProgressDone === snapshot.done
           && target.metadata?.subagentProgressError === snapshot.error
           && target.metadata?.subagentProgressRunning === snapshot.running) {
+        this.pruneDuplicateSubagentProgressMessages(snapshot.parentSessionId, target.id);
         return;
       }
       this.store.updateMessage(snapshot.parentSessionId, target.id, { content, metadata });
       this.emit('messageUpdate', snapshot.parentSessionId, target.id, content, metadata);
-      console.debug(
-        '[OpenClawRuntime] updated deterministic subagent progress message.',
-        `sessionId=${snapshot.parentSessionId}`,
-        `messageId=${target.id}`,
-        `progress=${snapshot.terminal}/${snapshot.total}`,
-        `done=${snapshot.done}`,
-        `error=${snapshot.error}`,
-        `running=${snapshot.running}`,
-      );
+      this.pruneDuplicateSubagentProgressMessages(snapshot.parentSessionId, target.id);
       return;
     }
 
@@ -3031,98 +2997,26 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       metadata,
     });
     this.emit('message', snapshot.parentSessionId, message);
-    console.debug(
-      '[OpenClawRuntime] added deterministic subagent progress message.',
-      `sessionId=${snapshot.parentSessionId}`,
-      `messageId=${message.id}`,
-      `progress=${snapshot.terminal}/${snapshot.total}`,
-      `done=${snapshot.done}`,
-      `error=${snapshot.error}`,
-      `running=${snapshot.running}`,
-    );
+    this.pruneDuplicateSubagentProgressMessages(snapshot.parentSessionId, message.id);
   }
 
-  private findSubagentProgressMessage(
-    sessionId: string,
-    preferLatestTextMatch: boolean,
-  ): CoworkMessage | null {
+  private pruneDuplicateSubagentProgressMessages(sessionId: string, targetMessageId: string): void {
     const session = this.store.getSession(sessionId);
-    if (!session) return null;
-    const messages = [...session.messages].reverse();
+    if (!session) return;
+    const lastUserIndex = session.messages.reduce((latestIndex, message, index) => (
+      message.type === 'user' ? index : latestIndex
+    ), -1);
+    const duplicateIds = session.messages
+      .slice(lastUserIndex + 1)
+      .filter((message) => (
+        message.id !== targetMessageId
+        && isSubagentProgressMessage(message, true)
+      ))
+      .map((message) => message.id);
 
-    if (preferLatestTextMatch) {
-      return messages.find((message) => this.isSubagentProgressMessage(message, true)) ?? null;
+    for (const messageId of duplicateIds) {
+      this.deleteAssistantMessage(sessionId, messageId);
     }
-
-    return messages.find((message) => this.isSubagentProgressMessage(message, false)) ?? null;
-  }
-
-  private isSubagentProgressMessage(message: CoworkMessage, allowTextMatch: boolean): boolean {
-    if (message.type !== 'assistant') return false;
-    if (message.metadata?.kind === SubagentProgressMessageKind.Progress
-        || message.metadata?.subagentProgress === true) {
-      return true;
-    }
-    if (!allowTextMatch || message.metadata?.isStreaming === true) return false;
-    return this.isSubagentProgressText(message.content);
-  }
-
-  private isSubagentProgressText(content: string): boolean {
-    const text = content.trim();
-    if (!text) return false;
-    return /\d+\s*\/\s*\d+\s*(?:完成|已完成|已结束)/.test(text)
-      || /继续等待.*子\s*agent/.test(text)
-      || /子\s*agent.*(?:完成|结束|出错)/.test(text);
-  }
-
-  private formatSubagentProgressContent(snapshot: SubagentProgressSnapshot): string {
-    const doneLabels = snapshot.runs
-      .filter((run) => run.status === 'done')
-      .map((run) => this.formatSubagentProgressRunLabel(run));
-    const errorLabels = snapshot.runs
-      .filter((run) => run.status === 'error')
-      .map((run) => this.formatSubagentProgressRunLabel(run));
-    const formattedDoneLabels = this.formatSubagentProgressLabels(doneLabels);
-    const formattedErrorLabels = this.formatSubagentProgressLabels(errorLabels);
-
-    if (snapshot.allTerminal && snapshot.error === 0) {
-      return `${snapshot.total}/${snapshot.total} 完成 - ${formattedDoneLabels} ✓`;
-    }
-
-    if (snapshot.allTerminal) {
-      const donePart = snapshot.done > 0 ? `${snapshot.done} 个完成` : '';
-      const errorPart = `${snapshot.error} 个出错`;
-      const summary = [donePart, errorPart].filter(Boolean).join('，');
-      const details = [
-        formattedDoneLabels ? `完成：${formattedDoneLabels}` : '',
-        formattedErrorLabels ? `出错：${formattedErrorLabels}` : '',
-      ].filter(Boolean).join('\n');
-      return `${snapshot.terminal}/${snapshot.total} 已结束（${summary}）${details ? `\n\n${details}` : ''}`;
-    }
-
-    if (snapshot.error === 0) {
-      const doneLine = snapshot.done > 0
-        ? `${snapshot.done}/${snapshot.total} 完成 - ${formattedDoneLabels} ✓`
-        : `0/${snapshot.total} 完成`;
-      return `${doneLine}\n\n继续等待剩余 ${snapshot.running} 个子 agent 完成...`;
-    }
-
-    const summary = `${snapshot.terminal}/${snapshot.total} 已结束（${snapshot.done} 个完成，${snapshot.error} 个出错）`;
-    const details = [
-      formattedDoneLabels ? `完成：${formattedDoneLabels}` : '',
-      formattedErrorLabels ? `出错：${formattedErrorLabels}` : '',
-    ].filter(Boolean).join('\n');
-    return `${summary}${details ? `\n\n${details}` : ''}\n\n继续等待剩余 ${snapshot.running} 个子 agent 完成...`;
-  }
-
-  private formatSubagentProgressRunLabel(run: SubagentProgressSnapshot['runs'][number]): string {
-    const label = run.label?.trim() || run.agentId?.trim() || run.id.trim();
-    return label || run.id.slice(0, 8);
-  }
-
-  private formatSubagentProgressLabels(labels: string[]): string {
-    if (labels.length <= 5) return labels.join('、');
-    return `${labels.slice(0, 5).join('、')} 等 ${labels.length} 个`;
   }
 
   private normalizeModelRef(modelRef: string): string {
@@ -4876,14 +4770,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       const hasKnownToolUse = turn.toolUseMessageIdByToolCallId.has(msgToolCallId);
       if (!hasKnownToolUse && !existingResultMsgId) {
         console.debug(
-          '[OpenClawRuntime][SubagentAnnounceDiag] skipped a tool result from chat history because it is not part of the current turn.',
+          '[OpenClawRuntime] skipped a tool result from chat history because it is not part of the current turn.',
           `sessionId=${sessionId}`,
-          `turnRunId=${turn.runId}`,
-          `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
           `toolCallId=${msgToolCallId}`,
-          `knownToolUses=${turn.toolUseMessageIdByToolCallId.size}`,
-          `knownToolResults=${turn.toolResultMessageIdByToolCallId.size}`,
-          `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
         );
         continue;
       }
@@ -5443,24 +5332,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       }
       console.log('[Debug:handleAgentEvent] no active turn for sessionId:', sessionId);
       return;
-    }
-
-    if (runId && runId !== turn.runId) {
-      console.debug(
-        '[OpenClawRuntime][SubagentAnnounceDiag] agent event will bind to an existing active turn.',
-        `sessionId=${sessionId}`,
-        `stream=${stream || 'unknown'}`,
-        `phase=${lifecyclePhase || 'none'}`,
-        `incomingRunId=${runId}`,
-        `turnRunId=${turn.runId}`,
-        `isIncomingAnnounce=${isSubagentAnnounceRunId(runId)}`,
-        `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
-        `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
-        `assistantMessageId=${turn.assistantMessageId ?? 'none'}`,
-        `currentTextLen=${turn.currentText.length}`,
-        `currentSegmentLen=${turn.currentAssistantSegmentText.length}`,
-        `finalCompletionPending=${Boolean(turn.finalCompletionTimer)}`,
-      );
     }
 
     if (sessionKey && !runId && turn.sessionKey !== sessionKey) {
@@ -6491,24 +6362,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       return;
     }
 
-    if (runId && runId !== turn.runId) {
-      console.debug(
-        '[OpenClawRuntime][SubagentAnnounceDiag] chat event arrived for an existing active turn with a different runId.',
-        `sessionId=${sessionId}`,
-        `state=${state}`,
-        `incomingRunId=${runId}`,
-        `turnRunId=${turn.runId}`,
-        `isIncomingAnnounce=${isSubagentAnnounceRunId(runId)}`,
-        `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
-        `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
-        `assistantMessageId=${turn.assistantMessageId ?? 'none'}`,
-        `currentTextLen=${turn.currentText.length}`,
-        `currentSegmentLen=${turn.currentAssistantSegmentText.length}`,
-        `finalCompletionPending=${Boolean(turn.finalCompletionTimer)}`,
-        `message=${summarizeGatewayMessageShape(chatPayload.message)}`,
-      );
-    }
-
     // Buffer chat events while user messages are being prefetched for channel sessions
     if (turn.pendingUserSync) {
       console.debug('[OpenClawRuntime] handleChatEvent — buffering (pendingUserSync), sessionId:', sessionId);
@@ -7165,32 +7018,14 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     if (!finalText.trim()) {
       const isSubagentAnnounceFinal = isSubagentAnnounceRunId(payload.runId) || isSubagentAnnounceRunId(turn.runId);
-      const emptyFinalHasTurnToolWork = this.hasTurnToolWork(sessionId, turn);
       console.debug(
         '[OpenClawRuntime] handleChatFinal: final payload had no text, falling back to chat.history sync',
         `sessionId=${sessionId}`,
-        `runId=${payload.runId ?? turn.runId}`,
-        `turnRunId=${turn.runId}`,
-        `isPayloadAnnounce=${isSubagentAnnounceRunId(payload.runId)}`,
-        `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
-        `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
-        `hasTurnToolWorkBeforeHistorySync=${emptyFinalHasTurnToolWork}`,
+        `runId=${payload.runId ?? turn.runId}`
       );
       await this.syncFinalAssistantWithHistory(sessionId, turn);
       const syncedVisibleText = turn.currentAssistantSegmentText.trim() || turn.currentText.trim();
       const hasTurnToolWorkAfterHistorySync = this.hasTurnToolWork(sessionId, turn);
-      console.debug(
-        '[OpenClawRuntime][SubagentAnnounceDiag] empty final history fallback result.',
-        `sessionId=${sessionId}`,
-        `runId=${payload.runId ?? turn.runId}`,
-        `turnRunId=${turn.runId}`,
-        `isPayloadAnnounce=${isSubagentAnnounceRunId(payload.runId)}`,
-        `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
-        `syncedVisibleTextLen=${syncedVisibleText.length}`,
-        `hasTurnToolWorkAfterHistorySync=${hasTurnToolWorkAfterHistorySync}`,
-        `lastHistoryHadToolWork=${Boolean(turn.lastHistoryHadToolWork)}`,
-        `lastHistoryToolResultCharCount=${turn.lastHistoryToolResultCharCount ?? 0}`,
-      );
       if (hasTurnToolWorkAfterHistorySync && !isSubagentAnnounceFinal) {
         const visibleRetryRisk = this.shouldWaitForVisibleFinalContinuation(
           sessionId,
@@ -7209,16 +7044,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           pendingVisibleFinalContinuation: Boolean(syncedVisibleText),
         });
         return;
-      }
-      if (hasTurnToolWorkAfterHistorySync && isSubagentAnnounceFinal) {
-        console.debug(
-          '[OpenClawRuntime][SubagentAnnounceDiag] completed empty subagent announce final without deferred maintenance.',
-          `sessionId=${sessionId}`,
-          `runId=${payload.runId ?? turn.runId}`,
-          `turnRunId=${turn.runId}`,
-          `syncedVisibleTextLen=${syncedVisibleText.length}`,
-          `lastHistoryToolResultCharCount=${turn.lastHistoryToolResultCharCount ?? 0}`,
-        );
       }
       if (turn.hasContextMaintenanceTool && !turn.currentAssistantSegmentText.trim()) {
         this.waitForRecoverableOpenClawRetry(sessionId, turn, payload.runId ?? turn.runId, {
@@ -8346,16 +8171,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           continue;
         }
 
-        console.debug(
-          '[OpenClawRuntime][SubagentAnnounceDiag] syncFinalAssistant history window.',
-          `sessionId=${sessionId}`,
-          `turnRunId=${turn.runId}`,
-          `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
-          `messageCount=${history.messages.length}`,
-          `roles=${summarizeHistoryRolesForDiag(history.messages)}`,
-          `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
-        );
-
         historyMessages = history.messages;
         const previousHistoryCountKnown = this.gatewayHistoryCountBySession.has(sessionId);
         const previousHistoryCount = this.gatewayHistoryCountBySession.get(sessionId) ?? 0;
@@ -8446,17 +8261,6 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       console.debug('[Debug:syncFinal] canonicalSegmentText length:', canonicalSegmentText.length,
         'committed.length:', turn.committedAssistantText.length,
         'segment:', canonicalSegmentText.slice(0, 80));
-      console.debug(
-        '[OpenClawRuntime][SubagentAnnounceDiag] syncFinalAssistant extracted text.',
-        `sessionId=${sessionId}`,
-        `turnRunId=${turn.runId}`,
-        `isTurnAnnounce=${isSubagentAnnounceRunId(turn.runId)}`,
-        `canonicalTextLen=${canonicalText.length}`,
-        `canonicalSegmentTextLen=${canonicalSegmentText.length}`,
-        `canonicalTextHead=${truncate(canonicalText, 120)}`,
-        `canonicalSegmentHead=${truncate(canonicalSegmentText, 120)}`,
-        `knownRunIds=${Array.from(turn.knownRunIds).join(',')}`,
-      );
       turn.currentText = canonicalText;
       turn.currentAssistantSegmentText = canonicalSegmentText;
 

--- a/src/main/libs/agentEngine/subagentProgressMessage.ts
+++ b/src/main/libs/agentEngine/subagentProgressMessage.ts
@@ -1,0 +1,103 @@
+import type { CoworkMessage, CoworkMessageMetadata } from '../../coworkStore';
+import type { SubagentProgressSnapshot } from './subagentTracker';
+
+export const SubagentProgressMessageKind = {
+  Progress: 'subagent_progress',
+} as const;
+
+export const isSubagentProgressText = (content: string): boolean => {
+  const text = content.trim();
+  if (!text) return false;
+  return /\d+\s*\/\s*\d+\s*(?:完成|已完成|已结束)/.test(text)
+    || /继续等待.*子\s*agent/.test(text);
+};
+
+export const isSubagentProgressMessage = (
+  message: CoworkMessage,
+  allowTextMatch: boolean,
+): boolean => {
+  if (message.type !== 'assistant') return false;
+  if (message.metadata?.kind === SubagentProgressMessageKind.Progress
+      || message.metadata?.subagentProgress === true) {
+    return true;
+  }
+  if (!allowTextMatch || message.metadata?.isStreaming === true) return false;
+  return isSubagentProgressText(message.content);
+};
+
+export const findSubagentProgressMessage = (
+  messages: CoworkMessage[],
+  preferLatestTextMatch: boolean,
+): CoworkMessage | null => {
+  const reversed = [...messages].reverse();
+  if (preferLatestTextMatch) {
+    return reversed.find((message) => isSubagentProgressMessage(message, true)) ?? null;
+  }
+  return reversed.find((message) => isSubagentProgressMessage(message, false)) ?? null;
+};
+
+export const buildSubagentProgressMetadata = (
+  snapshot: SubagentProgressSnapshot,
+  existingMetadata?: CoworkMessageMetadata,
+): CoworkMessageMetadata => ({
+  ...(existingMetadata ?? {}),
+  kind: SubagentProgressMessageKind.Progress,
+  isStreaming: false,
+  isFinal: true,
+  subagentProgress: true,
+  subagentProgressTotal: snapshot.total,
+  subagentProgressDone: snapshot.done,
+  subagentProgressError: snapshot.error,
+  subagentProgressRunning: snapshot.running,
+  subagentProgressUpdatedAt: Date.now(),
+});
+
+export const buildSubagentProgressContent = (snapshot: SubagentProgressSnapshot): string => {
+  const doneLabels = snapshot.runs
+    .filter((run) => run.status === 'done')
+    .map(formatSubagentProgressRunLabel);
+  const errorLabels = snapshot.runs
+    .filter((run) => run.status === 'error')
+    .map(formatSubagentProgressRunLabel);
+  const formattedDoneLabels = formatSubagentProgressLabels(doneLabels);
+  const formattedErrorLabels = formatSubagentProgressLabels(errorLabels);
+
+  if (snapshot.allTerminal && snapshot.error === 0) {
+    return `${snapshot.total}/${snapshot.total} 完成 - ${formattedDoneLabels} ✓`;
+  }
+
+  if (snapshot.allTerminal) {
+    const donePart = snapshot.done > 0 ? `${snapshot.done} 个完成` : '';
+    const errorPart = `${snapshot.error} 个出错`;
+    const summary = [donePart, errorPart].filter(Boolean).join('，');
+    const details = [
+      formattedDoneLabels ? `完成：${formattedDoneLabels}` : '',
+      formattedErrorLabels ? `出错：${formattedErrorLabels}` : '',
+    ].filter(Boolean).join('\n');
+    return `${snapshot.terminal}/${snapshot.total} 已结束（${summary}）${details ? `\n\n${details}` : ''}`;
+  }
+
+  if (snapshot.error === 0) {
+    const doneLine = snapshot.done > 0
+      ? `${snapshot.done}/${snapshot.total} 完成 - ${formattedDoneLabels} ✓`
+      : `0/${snapshot.total} 完成`;
+    return `${doneLine}\n\n继续等待剩余 ${snapshot.running} 个子 agent 完成...`;
+  }
+
+  const summary = `${snapshot.terminal}/${snapshot.total} 已结束（${snapshot.done} 个完成，${snapshot.error} 个出错）`;
+  const details = [
+    formattedDoneLabels ? `完成：${formattedDoneLabels}` : '',
+    formattedErrorLabels ? `出错：${formattedErrorLabels}` : '',
+  ].filter(Boolean).join('\n');
+  return `${summary}${details ? `\n\n${details}` : ''}\n\n继续等待剩余 ${snapshot.running} 个子 agent 完成...`;
+};
+
+const formatSubagentProgressRunLabel = (run: SubagentProgressSnapshot['runs'][number]): string => {
+  const label = run.label?.trim() || run.agentId?.trim() || run.id.trim();
+  return label || run.id.slice(0, 8);
+};
+
+const formatSubagentProgressLabels = (labels: string[]): string => {
+  if (labels.length <= 5) return labels.join('、');
+  return `${labels.slice(0, 5).join('、')} 等 ${labels.length} 个`;
+};

--- a/src/main/libs/agentEngine/subagentTracker.test.ts
+++ b/src/main/libs/agentEngine/subagentTracker.test.ts
@@ -226,3 +226,54 @@ test('deleted subagent run is not reinserted by late spawn results', async () =>
   expect(deleted).toBe(true);
   expect(runStore.getSubagentRun('run-1')).toBeNull();
 });
+
+test('successful retry keeps the failed spawn and appends the replacement run', () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
+  const tracker = new SubagentTracker(runStore, messageStore, () => null);
+
+  tracker.onToolStart('call-failed-2048', {
+    taskName: '2048-game',
+    task: 'create a 2048 html game',
+  }, 'parent-1');
+  tracker.onSpawnResult('call-failed-2048', JSON.stringify({
+    status: 'error',
+    error: 'Invalid taskName "2048-game".',
+  }), {});
+
+  expect(runStore.getSubagentRun('call-failed-2048')?.status).toBe('error');
+
+  vi.setSystemTime(2_000);
+  tracker.onToolStart('call-retry-2048', {
+    taskName: 'game-2048',
+    task: 'create a 2048 html game',
+  }, 'parent-1');
+  tracker.onSpawnResult('call-retry-2048', JSON.stringify({
+    status: 'accepted',
+    childSessionKey: 'agent:main:subagent:retry-2048',
+  }), {});
+
+  expect(runStore.getSubagentRun('call-failed-2048')?.status).toBe('error');
+  expect(runStore.getSubagentRun('call-retry-2048')?.status).toBe('running');
+  expect(tracker.listSubagentRuns('parent-1').map((run) => run.id)).toEqual([
+    'call-failed-2048',
+    'call-retry-2048',
+  ]);
+});
+
+test('listSubagentRuns returns endedAt for terminal runs', () => {
+  const tracker = new SubagentTracker(runStore, messageStore, () => null);
+  runStore.insertSubagentRun({
+    id: 'run-1',
+    parentSessionId: 'parent-1',
+    sessionKey: 'agent:main:subagent:run-1',
+    agentId: 'worker',
+    task: 'inspect files',
+    label: 'worker',
+    status: 'done',
+    createdAt: 1_000,
+    endedAt: 3_500,
+  });
+
+  expect(tracker.listSubagentRuns('parent-1')[0]?.endedAt).toBe(3_500);
+});

--- a/src/main/libs/agentEngine/subagentTracker.ts
+++ b/src/main/libs/agentEngine/subagentTracker.ts
@@ -62,6 +62,32 @@ export type GatewayClientLike = {
   ) => Promise<T>;
 };
 
+export type SubagentRunStatus = 'running' | 'done' | 'error';
+
+export interface SubagentProgressRun {
+  id: string;
+  agentId: string | null;
+  task: string | null;
+  label: string | null;
+  status: SubagentRunStatus;
+}
+
+export interface SubagentProgressSnapshot {
+  parentSessionId: string;
+  total: number;
+  done: number;
+  error: number;
+  running: number;
+  terminal: number;
+  allTerminal: boolean;
+  updatedRunId?: string;
+  updatedStatus?: SubagentRunStatus;
+  reason?: string;
+  runs: SubagentProgressRun[];
+}
+
+export type SubagentProgressListener = (snapshot: SubagentProgressSnapshot) => void;
+
 interface GatewaySessionDeleteTask {
   sessionKey: string;
   attempt: number;
@@ -87,7 +113,7 @@ export class SubagentTracker {
   /** Maps toolCallId → agentId for correlating spawn start → result */
   private readonly subagentToolCallIdToAgentId = new Map<string, string>();
   /** Maps toolCallId → lifecycle status */
-  private readonly subagentStatus = new Map<string, 'running' | 'done' | 'error'>();
+  private readonly subagentStatus = new Map<string, SubagentRunStatus>();
   /** Reverse map: agentId → Set of toolCallIds (for lookups from sessions_resume args) */
   private readonly agentIdToToolCallIds = new Map<string, Set<string>>();
   /** Run ids explicitly deleted by the user. Suppresses late spawn/backfill re-inserts. */
@@ -108,6 +134,7 @@ export class SubagentTracker {
     private readonly store: SubagentRunStore,
     private readonly messageStore: SubagentMessageStore | null,
     private readonly getGatewayClient: () => GatewayClientLike | null,
+    private readonly onProgress?: SubagentProgressListener,
   ) {}
 
   // ── Event hooks (called by adapter at key points) ──────────────────────
@@ -197,6 +224,7 @@ export class SubagentTracker {
         this.store.updateSubagentRunStatus(tcId, 'done', Date.now());
         // Persist cached messages now that completion is confirmed
         this.tryPersistCachedMessages(tcId);
+        this.emitProgressForRun(tcId, 'done', 'resume-read-result');
       }
     }
   }
@@ -218,6 +246,7 @@ export class SubagentTracker {
           console.log('[SubagentTracker] marked subagent as done via announce:', toolCallId);
           // Persist cached messages now that completion is confirmed
           this.tryPersistCachedMessages(toolCallId);
+          this.emitProgressForRun(toolCallId, 'done', 'announce-run-id');
         }
         return true;
       }
@@ -233,7 +262,7 @@ export class SubagentTracker {
    */
   tryMarkTerminalFromSessionKey(
     sessionKey: string,
-    status: 'done' | 'error',
+    status: SubagentRunStatus,
   ): boolean {
     if (!sessionKey) return false;
     for (const [toolCallId, childSessionKey] of this.subagentSessionKeys) {
@@ -247,6 +276,7 @@ export class SubagentTracker {
         this.store.updateSubagentRunStatus(toolCallId, status, Date.now());
         console.log('[SubagentTracker] marked subagent as terminal via session key:', toolCallId, status);
         this.tryPersistCachedMessages(toolCallId);
+        this.emitProgressForRun(toolCallId, status, 'session-key-terminal');
       }
       return true;
     }
@@ -313,9 +343,11 @@ export class SubagentTracker {
     task: string | null;
     label: string | null;
     sessionKey: string | null;
-    status: 'running' | 'done' | 'error';
+    status: SubagentRunStatus;
     createdAt: number;
+    endedAt: number | null;
   }> {
+    if (!this.store) return [];
     const runs = this.store.listSubagentRuns(parentSessionId);
     return runs.map((run) => {
       const memoryStatus = this.subagentStatus.get(run.id);
@@ -333,6 +365,7 @@ export class SubagentTracker {
           sessionKey: memorySessionKey ?? run.sessionKey,
           status: 'error' as const,
           createdAt: run.createdAt,
+          endedAt: Date.now(),
         };
       }
 
@@ -344,8 +377,46 @@ export class SubagentTracker {
         sessionKey: memorySessionKey ?? run.sessionKey,
         status: memoryStatus ?? run.status,
         createdAt: run.createdAt,
+        endedAt: run.endedAt,
       };
     });
+  }
+
+  getProgressSnapshot(
+    parentSessionId: string,
+    options: {
+      updatedRunId?: string;
+      updatedStatus?: SubagentRunStatus;
+      reason?: string;
+    } = {},
+  ): SubagentProgressSnapshot | null {
+    if (!parentSessionId) return null;
+    const runs = this.listSubagentRuns(parentSessionId).map((run) => ({
+      id: run.id,
+      agentId: run.agentId,
+      task: run.task,
+      label: run.label,
+      status: run.status,
+    }));
+    if (runs.length === 0) return null;
+
+    const done = runs.filter((run) => run.status === 'done').length;
+    const error = runs.filter((run) => run.status === 'error').length;
+    const running = runs.filter((run) => run.status === 'running').length;
+    const terminal = done + error;
+    return {
+      parentSessionId,
+      total: runs.length,
+      done,
+      error,
+      running,
+      terminal,
+      allTerminal: running === 0,
+      updatedRunId: options.updatedRunId,
+      updatedStatus: options.updatedStatus,
+      reason: options.reason,
+      runs,
+    };
   }
 
   /**
@@ -420,6 +491,7 @@ export class SubagentTracker {
     const childSessionKey = typeof parsed?.childSessionKey === 'string' ? parsed.childSessionKey : '';
     const isError = parsed?.status === 'error';
     const status = isError ? 'error' : 'running';
+    const hadSessionKey = this.subagentSessionKeys.has(toolCallId);
 
     // Store session key in memory
     if (childSessionKey) {
@@ -429,7 +501,7 @@ export class SubagentTracker {
     // If already committed (e.g., onSpawnResult fired then backfill also fires), just update
     if (this.subagentStatus.has(toolCallId)) {
       // Update session key in DB if newly discovered
-      if (childSessionKey && !this.subagentSessionKeys.has(toolCallId)) {
+      if (childSessionKey && !hadSessionKey) {
         this.store.updateSubagentRunSessionKey(toolCallId, childSessionKey);
       }
       return;
@@ -448,11 +520,33 @@ export class SubagentTracker {
         label: pending.label,
         status,
         createdAt: pending.createdAt,
+        endedAt: isError ? Date.now() : null,
       });
       this.pendingSpawnInfo.delete(toolCallId);
       console.log('[SubagentTracker] committed spawn result:', toolCallId, status,
         isError ? parsed.error : '');
+      if (status === 'error') {
+        this.emitProgressForRun(toolCallId, status, 'spawn-result-error');
+      }
     }
+  }
+
+  private emitProgressForRun(
+    runId: string,
+    status: SubagentRunStatus,
+    reason: string,
+  ): void {
+    if (!this.onProgress) return;
+    if (!this.store) return;
+    const run = this.store.getSubagentRun(runId);
+    if (!run) return;
+    const snapshot = this.getProgressSnapshot(run.parentSessionId, {
+      updatedRunId: runId,
+      updatedStatus: status,
+      reason,
+    });
+    if (!snapshot) return;
+    this.onProgress(snapshot);
   }
 
   private clearSubagentMemory(runId: string): void {

--- a/src/main/subagentRunStore.ts
+++ b/src/main/subagentRunStore.ts
@@ -21,11 +21,11 @@ export class SubagentRunStore {
     this.db = db;
   }
 
-  insertSubagentRun(run: Omit<SubagentRun, 'endedAt'>): void {
+  insertSubagentRun(run: Omit<SubagentRun, 'endedAt'> & { endedAt?: number | null }): void {
     this.db
       .prepare(
-        `INSERT OR REPLACE INTO subagent_runs (id, parent_session_id, session_key, agent_id, task, label, status, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT OR REPLACE INTO subagent_runs (id, parent_session_id, session_key, agent_id, task, label, status, created_at, ended_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         run.id,
@@ -36,6 +36,7 @@ export class SubagentRunStore {
         run.label ?? null,
         run.status,
         run.createdAt,
+        run.endedAt ?? null,
       );
   }
 

--- a/src/renderer/components/agentSidebar/SubagentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/SubagentTaskRow.tsx
@@ -16,8 +16,8 @@ interface SubagentTaskRowProps {
   onToggleSelection?: () => void;
 }
 
-const formatDuration = (createdAt: number): string => {
-  const elapsed = Date.now() - createdAt;
+const formatDuration = (createdAt: number, endedAt?: number | null): string => {
+  const elapsed = Math.max(0, (endedAt ?? Date.now()) - createdAt);
   const seconds = Math.floor(elapsed / 1000);
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
@@ -38,7 +38,10 @@ const SubagentTaskRow: React.FC<SubagentTaskRowProps> = ({
 }) => {
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
   const displayName = subagent.label ?? subagent.agentId ?? i18nService.t('subagentUnnamed');
-  const duration = formatDuration(subagent.createdAt);
+  const duration = formatDuration(
+    subagent.createdAt,
+    subagent.status === 'running' ? null : subagent.endedAt,
+  );
   const handleRowClick = () => {
     if (isBatchMode) {
       onToggleSelection?.();

--- a/src/renderer/components/agentSidebar/useSubagentSessions.ts
+++ b/src/renderer/components/agentSidebar/useSubagentSessions.ts
@@ -54,6 +54,7 @@ export const useSubagentSessions = (
         parentSessionId: sessionId,
         status: run.status,
         createdAt: run.createdAt,
+        endedAt: run.endedAt,
       }));
 
       setSubagentsBySessionId((prev) => {

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -315,6 +315,7 @@ export interface SubagentSessionSummary {
   parentSessionId: string;
   status: 'running' | 'done' | 'error';
   createdAt: number;
+  endedAt: number | null;
 }
 
 // Start session options

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -756,6 +756,7 @@ interface IElectronAPI {
         sessionKey: string | null;
         status: 'running' | 'done' | 'error';
         createdAt: number;
+        endedAt: number | null;
       }>;
       error?: string;
     }>;


### PR DESCRIPTION
## Summary
- derive subagent progress from local `subagent_runs` instead of relying on model-authored announce text
- correct stale subagent announce progress after `chat.final`, including the observed `5/5` local state rendered as `3/5`
- preserve failed spawn rows while appending retry replacements and fix terminal subagent duration display
- keep diagnostic logs for subagent announce/history reconciliation paths

## Verification
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/agentEngine/openclawRuntimeAdapter.ts src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts src/main/libs/agentEngine/subagentTracker.ts src/main/libs/agentEngine/subagentTracker.test.ts src/main/subagentRunStore.ts src/renderer/components/agentSidebar/SubagentTaskRow.tsx src/renderer/components/agentSidebar/useSubagentSessions.ts src/renderer/types/cowork.ts src/renderer/types/electron.d.ts`
- `npx tsc --noEmit --pretty false --project electron-tsconfig.json`
- `npx vitest run src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts --testNamePattern "deterministic subagent progress|child chat final marks matching subagent done|child lifecycle end marks matching subagent done|empty subagent announce final|empty final with local tool messages"`
- `git diff --check` (CRLF warnings only)

## Note
- `src/main/libs/agentEngine/subagentTracker.test.ts` could not be executed in this local shell because the installed `better-sqlite3` native module was built for a different Node ABI.
