### PR TITLE
fix(openclaw): sort final patch decision test imports

### DIFF
--- a/src/main/libs/openclawPatches/finalUpgradePatchDecisions.test.ts
+++ b/src/main/libs/openclawPatches/finalUpgradePatchDecisions.test.ts
@@ -1,4 +1,5 @@
 import { describe, test } from 'vitest';
+
 import { expectCurrentOpenClawPatchMissing, expectPatchContains } from './patchTestUtils';
 
 describe('final OpenClaw 6.1 patch decisions', () => {


### PR DESCRIPTION
## Summary
- Sort imports in `src/main/libs/openclawPatches/finalUpgradePatchDecisions.test.ts` according to `simple-import-sort/imports`.

## Context
This is a targeted follow-up for merge commit `9023eb6e4d71c913c577773f4bd5460743deb215` (`Merge pull request #2209 from netease-youdao/feat/openclaw-2026-6-1-upgrade`).

The PR head checks for #2209 passed, but the post-merge `push` CI on merge commit `9023eb6e4d71c913c577773f4bd5460743deb215` failed in `CI / lint` because `src/main/libs/openclawPatches/finalUpgradePatchDecisions.test.ts` needed import sorting.

## Verification
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/openclawPatches/finalUpgradePatchDecisions.test.ts`