### PR TITLE
Liuzhq/fix skill search

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1465,6 +1465,12 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       clearTimeout(skillSubmenuCloseTimerRef.current);
     }
     skillSubmenuCloseTimerRef.current = setTimeout(() => {
+      const activeElement = document.activeElement;
+      if (activeElement && addMenuRef.current?.contains(activeElement)) {
+        logPromptModelSelection('debug', 'kept skill submenu open because focus remains inside prompt tools menu');
+        skillSubmenuCloseTimerRef.current = null;
+        return;
+      }
       setShowSkillsPopover(false);
       skillSubmenuCloseTimerRef.current = null;
     }, 120);

--- a/src/renderer/components/skills/SkillsPopover.tsx
+++ b/src/renderer/components/skills/SkillsPopover.tsx
@@ -144,7 +144,9 @@ const SkillsPopover: React.FC<SkillsPopoverProps> = ({
   const listClassName = asSubmenu
     ? 'overflow-y-auto px-2 py-1.5'
     : 'overflow-y-auto py-1';
-  const listStyle: React.CSSProperties = { maxHeight: `${maxListHeight}px` };
+  const listStyle: React.CSSProperties = asSubmenu
+    ? { height: `${maxListHeight}px` }
+    : { maxHeight: `${maxListHeight}px` };
   const emptyStateClassName = asSubmenu
     ? 'flex h-[50px] items-center justify-center px-3 text-center text-[13px] leading-5 text-secondary'
     : 'px-4 py-6 text-center text-sm text-secondary';


### PR DESCRIPTION
Prevent the prompt tools skill submenu from closing while focus remains inside the menu, and keep submenu list height stable when search results change.
