### PR TITLE
fix(renderer): stabilize Mermaid errors and skill search popover

### DIFF
--- a/src/renderer/components/artifacts/renderers/MermaidRenderer.tsx
+++ b/src/renderer/components/artifacts/renderers/MermaidRenderer.tsx
@@ -14,6 +14,26 @@ function initMermaid(isDark: boolean) {
   mermaidInitialized = true;
 }
 
+function cleanupMermaidRenderArtifacts(id: string) {
+  document.getElementById(id)?.remove();
+  document.getElementById(`d${id}`)?.remove();
+  document.getElementById(`i${id}`)?.remove();
+}
+
+function createMermaidRenderContainer(): HTMLDivElement {
+  const container = document.createElement('div');
+  container.setAttribute('data-lobster-mermaid-render-container', 'true');
+  container.style.position = 'absolute';
+  container.style.left = '0';
+  container.style.top = '0';
+  container.style.width = '100%';
+  container.style.visibility = 'hidden';
+  container.style.overflow = 'hidden';
+  container.style.pointerEvents = 'none';
+  document.body.appendChild(container);
+  return container;
+}
+
 interface MermaidRendererProps {
   artifact: Artifact;
 }
@@ -50,22 +70,34 @@ const MermaidRenderer: React.FC<MermaidRendererProps> = ({ artifact }) => {
 
     let cancelled = false;
     const renderDiagram = async () => {
+      const id = `mermaid-${artifact.id.replace(/[^a-zA-Z0-9]/g, '')}`;
+      let renderContainer: HTMLDivElement | null = null;
       try {
-        const id = `mermaid-${artifact.id.replace(/[^a-zA-Z0-9]/g, '')}`;
-        const { svg: rendered } = await mermaid.render(id, artifact.content);
+        cleanupMermaidRenderArtifacts(id);
+        await mermaid.parse(artifact.content);
+        renderContainer = createMermaidRenderContainer();
+        const { svg: rendered } = await mermaid.render(id, artifact.content, renderContainer);
         if (!cancelled) {
           setSvg(rendered);
           setError(null);
         }
       } catch (err) {
         if (!cancelled) {
+          setSvg('');
           setError(err instanceof Error ? err.message : 'Failed to render diagram');
         }
+      } finally {
+        renderContainer?.remove();
+        cleanupMermaidRenderArtifacts(id);
       }
     };
 
     renderDiagram();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      const id = `mermaid-${artifact.id.replace(/[^a-zA-Z0-9]/g, '')}`;
+      cleanupMermaidRenderArtifacts(id);
+    };
   }, [artifact.content, artifact.id]);
 
   if (error) {

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1465,6 +1465,12 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       clearTimeout(skillSubmenuCloseTimerRef.current);
     }
     skillSubmenuCloseTimerRef.current = setTimeout(() => {
+      const activeElement = document.activeElement;
+      if (activeElement && addMenuRef.current?.contains(activeElement)) {
+        logPromptModelSelection('debug', 'kept skill submenu open because focus remains inside prompt tools menu');
+        skillSubmenuCloseTimerRef.current = null;
+        return;
+      }
       setShowSkillsPopover(false);
       skillSubmenuCloseTimerRef.current = null;
     }, 120);

--- a/src/renderer/components/skills/SkillsPopover.tsx
+++ b/src/renderer/components/skills/SkillsPopover.tsx
@@ -144,7 +144,9 @@ const SkillsPopover: React.FC<SkillsPopoverProps> = ({
   const listClassName = asSubmenu
     ? 'overflow-y-auto px-2 py-1.5'
     : 'overflow-y-auto py-1';
-  const listStyle: React.CSSProperties = { maxHeight: `${maxListHeight}px` };
+  const listStyle: React.CSSProperties = asSubmenu
+    ? { height: `${maxListHeight}px` }
+    : { maxHeight: `${maxListHeight}px` };
   const emptyStateClassName = asSubmenu
     ? 'flex h-[50px] items-center justify-center px-3 text-center text-[13px] leading-5 text-secondary'
     : 'px-4 py-6 text-center text-sm text-secondary';


### PR DESCRIPTION
## Summary

- Prevent failed Mermaid renders from leaking hidden/error SVG artifacts into the document.
- Clean up Mermaid render containers on render completion and component unmount.
- Keep the prompt tools skill submenu open while focus remains inside the menu/search input.
- Stabilize the skill submenu list height so filtering results does not collapse the popover before users can select a skill.

## Verification

- [ ] Render a valid Mermaid artifact.
- [ ] Render an invalid Mermaid artifact and confirm only the error state is shown.
- [ ] Open prompt tools > Use Skill, type in the search box, and confirm the skill list remains selectable.
- [ ] Confirm the add-file and plan-mode menu items still behave normally.

## Notes

This PR only changes renderer UI behavior. It does not modify Electron IPC, local storage, SQLite migrations, OpenClaw runtime packaging, or config sync.