### PR TITLE
fix(cowork): clean navigation rail previews

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -79,6 +79,7 @@ import {
   COWORK_DETAIL_CONTENT_CLASS,
   COWORK_DETAIL_GUTTER_CLASS,
   hasRenderableAssistantContent,
+  MEDIA_TOKEN_DISPLAY_RE,
 } from './messageDisplayUtils';
 import { parseProposedPlanBlock } from './proposedPlanParser';
 import { buildSelectedKitContextPrompt } from './selectedKitContextPrompt';
@@ -185,18 +186,30 @@ type ExpandedConversationPreview = {
 };
 
 const stripRailLabelMarkdown = (value: string): string => value
+  .replace(MEDIA_TOKEN_DISPLAY_RE, ' ')
   .replace(/^#+\s+/gm, '')
   .replace(/```[\s\S]*?```/g, ' ')
   .replace(/`[^`]*`/g, ' ')
+  .replace(/<\/?proposed_?plan\b[^>]*>/gi, ' ')
   .replace(/[*_~>]/g, '')
   .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
   .replace(/\s+/g, ' ')
   .trim();
 
 const getRailLabel = (content: string, fallback: string): string => {
-  const stripped = stripRailLabelMarkdown(content);
+  const proposedPlan = parseProposedPlanBlock(content);
+  const labelSource = [proposedPlan.visibleText, proposedPlan.planText]
+    .filter((part): part is string => Boolean(part?.trim()))
+    .join('\n');
+  const stripped = stripRailLabelMarkdown(labelSource || content);
   return stripped.slice(0, 50) || fallback;
 };
+
+const isAssistantRailContentMessage = (message: CoworkMessage): boolean => (
+  message.type === 'assistant'
+  && !message.metadata?.isThinking
+  && Boolean(message.content)
+);
 
 const buildRailItems = (turns: ConversationTurn[]): RailItem[] => {
   const items: RailItem[] = [];
@@ -216,7 +229,7 @@ const buildRailItems = (turns: ConversationTurn[]): RailItem[] => {
 
     let assistantContent = '';
     for (const item of turn.assistantItems) {
-      if (item.type === 'assistant' && item.message?.content) {
+      if (item.type === 'assistant' && isAssistantRailContentMessage(item.message)) {
         assistantContent += item.message.content;
       }
     }
@@ -3039,7 +3052,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
       // Compute rail indices for user/assistant messages (must match rail IIFE logic)
       const hasAssistantContent = turn.assistantItems.some(
-        item => item.type === 'assistant' && Boolean(item.message?.content),
+        item => item.type === 'assistant' && isAssistantRailContentMessage(item.message),
       );
       const userRailIdx = turn.userMessage ? railCounter++ : -1;
       const asstRailIdx = hasAssistantContent ? railCounter++ : -1;


### PR DESCRIPTION
Filter thinking messages, proposed plan tags, and media artifact tokens from conversation rail tooltips so previews show only user-visible message content.
