### PR TITLE
fix(scheduled-task): restore gateway-backed run history

### DIFF
--- a/src/main/ipcHandlers/scheduledTask/handlers.test.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { registeredHandlers } = vi.hoisted(() => ({
+  registeredHandlers: new Map<string, (...args: unknown[]) => unknown>(),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      registeredHandlers.set(channel, handler);
+    }),
+  },
+}));
+
+import { IpcChannel as ScheduledTaskIpc } from '../../../scheduledTask/constants';
+import type { CronJobService } from '../../../scheduledTask/cronJobService';
+import { registerScheduledTaskHandlers, type ScheduledTaskHandlerDeps } from './handlers';
+
+function makeDeps() {
+  let gatewayClient: unknown = null;
+  const cronJobService = {
+    listJobs: vi.fn(async () => []),
+    listAllRuns: vi.fn(async () => []),
+  };
+  const adapter = {
+    getGatewayClient: vi.fn(() => gatewayClient),
+    connectGatewayIfNeeded: vi.fn(async () => {
+      gatewayClient = {};
+    }),
+    fetchSessionByKey: vi.fn(async () => null),
+  };
+  const deps: ScheduledTaskHandlerDeps = {
+    getCronJobService: () => cronJobService as unknown as CronJobService,
+    getIMGatewayManager: () => null,
+    getOpenClawRuntimeAdapter: () => adapter,
+  };
+
+  return { adapter, cronJobService, deps };
+}
+
+beforeEach(() => {
+  registeredHandlers.clear();
+});
+
+describe('registerScheduledTaskHandlers', () => {
+  test('connects the gateway client before listing scheduled tasks', async () => {
+    const { adapter, cronJobService, deps } = makeDeps();
+    registerScheduledTaskHandlers(deps);
+
+    const handler = registeredHandlers.get(ScheduledTaskIpc.List);
+    expect(handler).toBeDefined();
+
+    const result = await handler?.();
+
+    expect(adapter.connectGatewayIfNeeded).toHaveBeenCalledTimes(1);
+    expect(cronJobService.listJobs).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ success: true, ready: true, tasks: [] });
+  });
+
+  test('connects the gateway client before listing scheduled task history', async () => {
+    const { adapter, cronJobService, deps } = makeDeps();
+    registerScheduledTaskHandlers(deps);
+
+    const handler = registeredHandlers.get(ScheduledTaskIpc.ListAllRuns);
+    expect(handler).toBeDefined();
+
+    const result = await handler?.(undefined, 20, 0);
+
+    expect(adapter.connectGatewayIfNeeded).toHaveBeenCalledTimes(1);
+    expect(cronJobService.listAllRuns).toHaveBeenCalledWith(20, 0, undefined);
+    expect(result).toEqual({ success: true, ready: true, runs: [] });
+  });
+});

--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -44,7 +44,10 @@ export interface ScheduledTaskHandlerDeps {
   getOpenClawRuntimeAdapter: () => {
     getGatewayClient: () => unknown;
     connectGatewayIfNeeded: () => Promise<void>;
-    fetchSessionByKey: (sessionKey: string) => Promise<unknown>;
+    fetchSessionByKey: (
+      sessionKey: string,
+      options?: { sessionId?: string | null },
+    ) => Promise<unknown>;
   } | null;
 }
 
@@ -276,19 +279,29 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
     },
   );
 
-  ipcMain.handle(ScheduledTaskIpc.ResolveSession, async (_event, sessionKey: string) => {
-    try {
-      if (!sessionKey) return { success: true, session: null };
-      // Fetch session history from OpenClaw (returns transient session, not persisted)
-      const session = await getOpenClawRuntimeAdapter()?.fetchSessionByKey(sessionKey);
-      return { success: true, session: session ?? null };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to resolve session',
-      };
-    }
-  });
+  ipcMain.handle(
+    ScheduledTaskIpc.ResolveSession,
+    async (
+      _event,
+      input: string | { sessionId?: string | null; sessionKey?: string | null },
+    ) => {
+      try {
+        const sessionKey = typeof input === 'string' ? input : (input.sessionKey ?? '');
+        const sessionId = typeof input === 'string' ? null : (input.sessionId ?? null);
+        if (!sessionKey) return { success: true, session: null };
+        // Fetch session history from OpenClaw (returns transient session, not persisted)
+        const session = await getOpenClawRuntimeAdapter()?.fetchSessionByKey(sessionKey, {
+          sessionId,
+        });
+        return { success: true, session: session ?? null };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to resolve session',
+        };
+      }
+    },
+  );
 
   ipcMain.handle(ScheduledTaskIpc.ListChannels, async () => {
     try {

--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -43,6 +43,7 @@ export interface ScheduledTaskHandlerDeps {
   } | null;
   getOpenClawRuntimeAdapter: () => {
     getGatewayClient: () => unknown;
+    connectGatewayIfNeeded: () => Promise<void>;
     fetchSessionByKey: (sessionKey: string) => Promise<unknown>;
   } | null;
 }
@@ -99,15 +100,23 @@ async function applyAnnounceDeliveryNormalization(
   }
 }
 
+async function ensureScheduledTaskGatewayClient(
+  getOpenClawRuntimeAdapter: ScheduledTaskHandlerDeps['getOpenClawRuntimeAdapter'],
+): Promise<boolean> {
+  const adapter = getOpenClawRuntimeAdapter();
+  if (!adapter) return false;
+  if (adapter.getGatewayClient()) return true;
+
+  await adapter.connectGatewayIfNeeded();
+  return Boolean(adapter.getGatewayClient());
+}
+
 export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): void {
   const { getCronJobService, getIMGatewayManager, getOpenClawRuntimeAdapter } = deps;
 
   ipcMain.handle(ScheduledTaskIpc.List, async () => {
     try {
-      // If OpenClaw gateway is not connected yet, return empty list immediately
-      // to avoid blocking the renderer init. Tasks will be loaded later via the
-      // onRefresh listener when the gateway becomes available.
-      if (!getOpenClawRuntimeAdapter()?.getGatewayClient()) {
+      if (!(await ensureScheduledTaskGatewayClient(getOpenClawRuntimeAdapter))) {
         return { success: true, ready: false, tasks: [] };
       }
       const tasks = await getCronJobService().listJobs();
@@ -253,7 +262,7 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
       filter?: import('../../../scheduledTask/types').RunFilter,
     ) => {
       try {
-        if (!getOpenClawRuntimeAdapter()?.getGatewayClient()) {
+        if (!(await ensureScheduledTaskGatewayClient(getOpenClawRuntimeAdapter))) {
           return { success: true, ready: false, runs: [] };
         }
         const runs = await getCronJobService().listAllRuns(limit, offset, filter);

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -2917,7 +2917,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
    * First checks if a local session already exists via channel sync.
    * Returns a CoworkSession if successful, or null.
    */
-  async fetchSessionByKey(sessionKey: string): Promise<CoworkSession | null> {
+  async fetchSessionByKey(
+    sessionKey: string,
+    options?: { sessionId?: string | null },
+  ): Promise<CoworkSession | null> {
     const managedSession = parseManagedSessionKey(sessionKey);
     if (managedSession) {
       return this.store.getSession(managedSession.sessionId) ?? null;
@@ -2936,7 +2939,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     // 2. Fetch history from OpenClaw server and build a transient session object
     const client = this.gatewayClient;
-    if (!client) return null;
+    if (!client) {
+      return (
+        await this.readFromTranscript(sessionKey, options?.sessionId)
+        ?? await this.readFromDeletedTranscript(sessionKey, options?.sessionId)
+      );
+    }
 
     try {
       const history = await client.request<{ messages?: unknown[] }>('chat.history', {
@@ -2944,7 +2952,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         limit: OpenClawRuntimeAdapter.FULL_HISTORY_SYNC_LIMIT,
       }, { timeoutMs: 10_000 });
       if (!Array.isArray(history?.messages) || history.messages.length === 0) {
-        return this.readFromDeletedTranscript(sessionKey);
+        return (
+          await this.readFromTranscript(sessionKey, options?.sessionId)
+          ?? await this.readFromDeletedTranscript(sessionKey, options?.sessionId)
+        );
       }
 
       const now = Date.now();
@@ -3000,91 +3011,141 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
    * find the file (it only looks for the plain `.jsonl` path) and returns [].
    * This method reads the archived file directly from disk.
    */
-  private async readFromDeletedTranscript(sessionKey: string): Promise<CoworkSession | null> {
+  private resolveTranscriptSessionId(sessionKey: string, sessionId?: string | null): string | null {
+    const normalizedSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+    if (/^[0-9a-f-]{36}$/i.test(normalizedSessionId)) {
+      return normalizedSessionId;
+    }
+
+    const runMatch = sessionKey.match(/(?:^|:)run:([0-9a-f-]{36})(?:$|:)/i);
+    return runMatch?.[1] ?? null;
+  }
+
+  private async readTranscriptFile(
+    sessionKey: string,
+    filePath: string,
+  ): Promise<CoworkSession | null> {
+    const content = await fs.promises.readFile(filePath, 'utf-8');
+    const lines = content.split(/\r?\n/);
+
+    const messages: CoworkMessage[] = [];
+    let msgIndex = 0;
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const parsed = JSON.parse(line) as Record<string, unknown>;
+        if (parsed?.type !== 'message' || !parsed.message) continue;
+        const msg = parsed.message as { role?: string; content?: unknown; timestamp?: number };
+        const role = msg.role;
+        if (role !== 'user' && role !== 'assistant') continue;
+
+        const msgContent = msg.content;
+        const text = Array.isArray(msgContent)
+          ? (msgContent as Array<Record<string, unknown>>)
+              .filter(b => b?.type === 'text')
+              .map(b => b.text as string)
+              .join('\n')
+          : typeof msgContent === 'string' ? msgContent : '';
+
+        if (!text.trim()) continue;
+
+        const timestamp = typeof msg.timestamp === 'number'
+          ? msg.timestamp
+          : typeof parsed.timestamp === 'string' ? Date.parse(parsed.timestamp) : Date.now();
+
+        messages.push({
+          id: `transient-${msgIndex++}`,
+          type: role as 'user' | 'assistant',
+          content: text,
+          timestamp,
+          metadata: role === 'assistant' ? { isStreaming: false, isFinal: true } : {},
+        });
+      } catch {
+        // skip malformed lines
+      }
+    }
+
+    if (messages.length === 0) return null;
+
+    const firstTimestamp = messages[0]?.timestamp ?? Date.now();
+    return {
+      id: `transient-${sessionKey}`,
+      agentId: '',
+      title: sessionKey.split(':').pop() || 'Cron Session',
+      claudeSessionId: null,
+      status: 'completed' as CoworkSessionStatus,
+      pinned: false,
+      cwd: '',
+      systemPrompt: '',
+      modelOverride: '',
+      executionMode: 'local' as CoworkExecutionMode,
+      activeSkillIds: [],
+      messages,
+      messagesOffset: 0,
+      totalMessages: messages.length,
+      createdAt: firstTimestamp,
+      updatedAt: firstTimestamp,
+    };
+  }
+
+  private async readFromTranscript(
+    sessionKey: string,
+    sessionId?: string | null,
+  ): Promise<CoworkSession | null> {
+    try {
+      const agentMatch = sessionKey.match(/^agent:([^:]+):/);
+      const agentId = agentMatch?.[1] ?? 'main';
+      const resolvedSessionId = this.resolveTranscriptSessionId(sessionKey, sessionId);
+      if (!resolvedSessionId) return null;
+
+      const stateDir = this.engineManager.getStateDir();
+      const filePath = path.join(
+        stateDir,
+        'agents',
+        agentId,
+        'sessions',
+        `${resolvedSessionId}.jsonl`,
+      );
+
+      if (!fs.existsSync(filePath)) {
+        console.log('[OpenClawRuntime] readFromTranscript: no transcript found for sessionId:', resolvedSessionId);
+        return null;
+      }
+
+      console.log('[OpenClawRuntime] readFromTranscript: reading transcript:', filePath);
+      return await this.readTranscriptFile(sessionKey, filePath);
+    } catch (error) {
+      console.warn('[OpenClawRuntime] readFromTranscript failed:', error);
+      return null;
+    }
+  }
+
+  private async readFromDeletedTranscript(
+    sessionKey: string,
+    sessionId?: string | null,
+  ): Promise<CoworkSession | null> {
     try {
       // Extract agentId from "agent:{agentId}:..." pattern
       const agentMatch = sessionKey.match(/^agent:([^:]+):/);
       const agentId = agentMatch?.[1] ?? 'main';
 
-      // Extract sessionId from "...run:{uuid}" pattern (runId equals sessionId)
-      const runMatch = sessionKey.match(/(?:^|:)run:([0-9a-f-]{36})(?:$|:)/i);
-      const sessionId = runMatch?.[1];
-      if (!sessionId) return null;
+      const resolvedSessionId = this.resolveTranscriptSessionId(sessionKey, sessionId);
+      if (!resolvedSessionId) return null;
 
       const stateDir = this.engineManager.getStateDir();
       const sessionsDir = path.join(stateDir, 'agents', agentId, 'sessions');
 
       const files = await fs.promises.readdir(sessionsDir).catch(() => [] as string[]);
-      const deletedFile = files.find(f => f.startsWith(`${sessionId}.jsonl.deleted.`));
+      const deletedFile = files.find(f => f.startsWith(`${resolvedSessionId}.jsonl.deleted.`));
       if (!deletedFile) {
-        console.log('[OpenClawRuntime] readFromDeletedTranscript: no archived transcript found for sessionId:', sessionId);
+        console.log('[OpenClawRuntime] readFromDeletedTranscript: no archived transcript found for sessionId:', resolvedSessionId);
         return null;
       }
 
       console.log('[OpenClawRuntime] readFromDeletedTranscript: reading archived transcript:', deletedFile);
       const filePath = path.join(sessionsDir, deletedFile);
-      const content = await fs.promises.readFile(filePath, 'utf-8');
-      const lines = content.split(/\r?\n/);
-
-      const messages: CoworkMessage[] = [];
-      let msgIndex = 0;
-
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          const parsed = JSON.parse(line) as Record<string, unknown>;
-          if (parsed?.type !== 'message' || !parsed.message) continue;
-          const msg = parsed.message as { role?: string; content?: unknown; timestamp?: number };
-          const role = msg.role;
-          if (role !== 'user' && role !== 'assistant') continue;
-
-          const msgContent = msg.content;
-          const text = Array.isArray(msgContent)
-            ? (msgContent as Array<Record<string, unknown>>)
-                .filter(b => b?.type === 'text')
-                .map(b => b.text as string)
-                .join('\n')
-            : typeof msgContent === 'string' ? msgContent : '';
-
-          if (!text.trim()) continue;
-
-          const timestamp = typeof msg.timestamp === 'number'
-            ? msg.timestamp
-            : typeof parsed.timestamp === 'string' ? Date.parse(parsed.timestamp) : Date.now();
-
-          messages.push({
-            id: `transient-${msgIndex++}`,
-            type: role as 'user' | 'assistant',
-            content: text,
-            timestamp,
-            metadata: role === 'assistant' ? { isStreaming: false, isFinal: true } : {},
-          });
-        } catch {
-          // skip malformed lines
-        }
-      }
-
-      if (messages.length === 0) return null;
-
-      const firstTimestamp = messages[0]?.timestamp ?? Date.now();
-      return {
-        id: `transient-${sessionKey}`,
-        agentId: '',
-        title: sessionKey.split(':').pop() || 'Cron Session',
-        claudeSessionId: null,
-        status: 'completed' as CoworkSessionStatus,
-        pinned: false,
-        cwd: '',
-        systemPrompt: '',
-        modelOverride: '',
-        executionMode: 'local' as CoworkExecutionMode,
-        activeSkillIds: [],
-        messages,
-        messagesOffset: 0,
-        totalMessages: messages.length,
-        createdAt: firstTimestamp,
-        updatedAt: firstTimestamp,
-      };
+      return await this.readTranscriptFile(sessionKey, filePath);
     } catch (error) {
       console.warn('[OpenClawRuntime] readFromDeletedTranscript failed:', error);
       return null;

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -906,8 +906,8 @@ contextBridge.exposeInMainWorld('electron', {
     countRuns: (taskId: string) => ipcRenderer.invoke(ScheduledTaskIpc.CountRuns, taskId),
     listAllRuns: (limit?: number, offset?: number, filter?: any) =>
       ipcRenderer.invoke(ScheduledTaskIpc.ListAllRuns, limit, offset, filter),
-    resolveSession: (sessionKey: string) =>
-      ipcRenderer.invoke(ScheduledTaskIpc.ResolveSession, sessionKey),
+    resolveSession: (input: string | { sessionId?: string | null; sessionKey?: string | null }) =>
+      ipcRenderer.invoke(ScheduledTaskIpc.ResolveSession, input),
 
     // Delivery channels
     listChannels: () => ipcRenderer.invoke(ScheduledTaskIpc.ListChannels),

--- a/src/renderer/components/scheduledTasks/AllRunsHistory.tsx
+++ b/src/renderer/components/scheduledTasks/AllRunsHistory.tsx
@@ -124,7 +124,7 @@ const AllRunsHistory: React.FC = () => {
   };
 
   const handleViewSession = (run: ScheduledTaskRunWithName) => {
-    if (run.sessionId || run.sessionKey) {
+    if (run.sessionId || run.sessionKey || run.summary || run.error) {
       reportScheduledTaskAction('history_view_session', {
         source: 'scheduled_tasks_history',
         ...getRunAnalyticsParams(run),
@@ -250,12 +250,12 @@ const AllRunsHistory: React.FC = () => {
             <div className="p-2">
               {displayedRuns.map(run => {
                 const cfg = statusConfig[run.status];
-                const hasSession = run.sessionId || run.sessionKey;
+                const canViewRun = run.sessionId || run.sessionKey || run.summary || run.error;
                 return (
                   <div
                     key={run.id}
                     className={`${historyGridClass} rounded-md px-3 py-3 transition-colors ${
-                      hasSession ? 'hover:bg-surface-raised/60 cursor-pointer' : ''
+                      canViewRun ? 'hover:bg-surface-raised/60 cursor-pointer' : ''
                     }`}
                     onClick={() => handleViewSession(run)}
                   >
@@ -323,6 +323,8 @@ const AllRunsHistory: React.FC = () => {
           <RunSessionModal
             sessionId={viewingRun.sessionId}
             sessionKey={viewingRun.sessionKey}
+            runSummary={viewingRun.summary}
+            runError={viewingRun.error}
             onClose={() => setViewingRun(null)}
           />
         )}

--- a/src/renderer/components/scheduledTasks/RunSessionModal.tsx
+++ b/src/renderer/components/scheduledTasks/RunSessionModal.tsx
@@ -13,19 +13,31 @@ import UserMessageItem from '../cowork/UserMessageItem';
 interface RunSessionModalProps {
   sessionId?: string | null;
   sessionKey?: string | null;
+  runSummary?: string | null;
+  runError?: string | null;
   onClose: () => void;
 }
 
 const MAX_RETRIES = 5;
 const RETRY_INTERVAL_MS = 3000;
 
-const RunSessionModal: React.FC<RunSessionModalProps> = ({ sessionId, sessionKey, onClose }) => {
+const RunSessionModal: React.FC<RunSessionModalProps> = ({
+  sessionId,
+  sessionKey,
+  runSummary,
+  runError,
+  onClose,
+}) => {
   const [session, setSession] = useState<CoworkSession | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cancelledRef = useRef(false);
+  const runFallbackContent = useMemo(
+    () => runSummary?.trim() || runError?.trim() || '',
+    [runError, runSummary],
+  );
 
   const loadSession = useCallback(async (isRetry = false): Promise<boolean> => {
     if (!isRetry) {
@@ -51,7 +63,10 @@ const RunSessionModal: React.FC<RunSessionModalProps> = ({ sessionId, sessionKey
 
       // 2. If not found locally, try resolving via OpenClaw sessionKey
       if (!loadedSession && sessionKey) {
-        const result = await window.electron?.scheduledTasks?.resolveSession(sessionKey);
+        const result = await window.electron?.scheduledTasks?.resolveSession({
+          sessionId,
+          sessionKey,
+        });
         if (result?.success && result.session) {
           const s = result.session;
           loadedSession = {
@@ -70,11 +85,17 @@ const RunSessionModal: React.FC<RunSessionModalProps> = ({ sessionId, sessionKey
         setError(null);
         return true;
       }
+      if (runFallbackContent) {
+        setSession(null);
+        setLoading(false);
+        setError(null);
+        return true;
+      }
       return false;
     } catch {
       return false;
     }
-  }, [sessionId, sessionKey]);
+  }, [runFallbackContent, sessionId, sessionKey]);
 
   useEffect(() => {
     cancelledRef.current = false;
@@ -197,7 +218,15 @@ const RunSessionModal: React.FC<RunSessionModalProps> = ({ sessionId, sessionKey
             </div>
           )}
 
-          {!loading && !error && turns.length === 0 && (
+          {!loading && !error && turns.length === 0 && runFallbackContent && (
+            <div className="px-10 py-8">
+              <div className="whitespace-pre-wrap break-words text-sm leading-7 text-foreground">
+                {runFallbackContent}
+              </div>
+            </div>
+          )}
+
+          {!loading && !error && turns.length === 0 && !runFallbackContent && (
             <div className="flex items-center justify-center py-16">
               <span className="text-sm text-secondary">
                 {i18nService.t('scheduledTasksNoRuns')}

--- a/src/renderer/components/scheduledTasks/TaskRunHistory.tsx
+++ b/src/renderer/components/scheduledTasks/TaskRunHistory.tsx
@@ -221,7 +221,7 @@ const TaskRunHistory: React.FC<TaskRunHistoryProps> = ({ task, runs }) => {
                       {run.error}
                     </span>
                   )}
-                  {(run.sessionId || run.sessionKey) && (
+                  {(run.sessionId || run.sessionKey || run.summary || run.error) && (
                     <button
                       type="button"
                       onClick={() => {
@@ -258,6 +258,8 @@ const TaskRunHistory: React.FC<TaskRunHistoryProps> = ({ task, runs }) => {
         <RunSessionModal
           sessionId={viewingRun.sessionId}
           sessionKey={viewingRun.sessionKey}
+          runSummary={viewingRun.summary}
+          runError={viewingRun.error}
           onClose={() => setViewingRun(null)}
         />
       )}

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1323,7 +1323,9 @@ interface IElectronAPI {
       runs?: import('../../scheduledTask/types').ScheduledTaskRunWithName[];
       error?: string;
     }>;
-    resolveSession: (sessionKey: string) => Promise<{
+    resolveSession: (
+      input: string | { sessionId?: string | null; sessionKey?: string | null },
+    ) => Promise<{
       success: boolean;
       session?: import('./cowork').CoworkSession | null;
       error?: string;

--- a/src/scheduledTask/cronJobService.test.ts
+++ b/src/scheduledTask/cronJobService.test.ts
@@ -286,6 +286,7 @@ describe('mapGatewayRun', () => {
     const run = mapGatewayRun(baseEntry);
     expect(run.status).toBe(TaskStatus.Success);
     expect(run.error).toBeNull();
+    expect(run.summary).toBe('All good');
   });
 
   test('maps error status to error', () => {
@@ -304,16 +305,19 @@ describe('mapGatewayRun', () => {
   });
 
   test('suppresses delivery-only error to success', () => {
+    const deliveryError = '⚠️ ✉️ Message failed';
     const run = mapGatewayRun({
       ...baseEntry,
       status: GatewayStatus.Error,
-      error: '⚠️ ✉️ Message failed',
+      error: deliveryError,
       deliveryStatus: 'not-delivered',
-      deliveryError: '⚠️ ✉️ Message failed',
+      deliveryError,
       summary: 'Agent produced a valid summary',
     });
     expect(run.status).toBe(TaskStatus.Success);
     expect(run.error).toBeNull();
+    expect(run.summary).toBe('Agent produced a valid summary');
+    expect(run.deliveryError).toBe(deliveryError);
   });
 
   test('does not suppress error when error differs from deliveryError', () => {

--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -448,6 +448,8 @@ export function mapGatewayRun(entry: GatewayRunLogEntry): ScheduledTaskRun {
         : new Date(safeFiniteNumber(entry.ts, tsMs)).toISOString(),
     durationMs: safeFiniteNumberOrNull(entry.durationMs),
     error: status === TaskStatus.Success ? null : (entry.error ?? null),
+    summary: entry.summary ?? null,
+    deliveryError: entry.deliveryError ?? null,
   };
 }
 

--- a/src/scheduledTask/types.ts
+++ b/src/scheduledTask/types.ts
@@ -81,6 +81,8 @@ export interface ScheduledTaskRun {
   finishedAt: string | null;
   durationMs: number | null;
   error: string | null;
+  summary?: string | null;
+  deliveryError?: string | null;
 }
 
 export interface ScheduledTaskRunWithName extends ScheduledTaskRun {


### PR DESCRIPTION
## Summary
- Ensure scheduled task list/history IPC initializes the OpenClaw gateway client before reading cron jobs or run history, so startup no longer returns a false empty/not-ready result.
- Resolve scheduled task run sessions with both `sessionId` and `sessionKey`, including fallback reads from live and archived OpenClaw transcript files when `chat.history` has no messages.
- Preserve run `summary` and `deliveryError`, and let run history modals show summary/error content when no session transcript can be resolved.

## Testing
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/ipcHandlers/scheduledTask/handlers.test.ts src/main/ipcHandlers/scheduledTask/handlers.ts src/main/libs/agentEngine/openclawRuntimeAdapter.ts src/main/preload.ts src/renderer/components/scheduledTasks/AllRunsHistory.tsx src/renderer/components/scheduledTasks/RunSessionModal.tsx src/renderer/components/scheduledTasks/TaskRunHistory.tsx src/renderer/types/electron.d.ts src/scheduledTask/cronJobService.test.ts src/scheduledTask/cronJobService.ts src/scheduledTask/types.ts`
- `npx vitest run src/main/ipcHandlers/scheduledTask/handlers.test.ts src/scheduledTask/cronJobService.test.ts`
- `npm test -- scheduledTask` did not reach Vitest because `pretest` failed rebuilding `better-sqlite3`: Windows reported `better_sqlite3.node` was busy/locked (`EBUSY`/`EPERM`).