### PR TITLE
fix(cowork): delay plan recovery until abort settles

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -99,6 +99,39 @@ test('plan mode rejects a preface and accepts a structured implementation plan',
   expect(isPlanModeResponseComplete(completePlan)).toBe(true);
 });
 
+test('plan mode treats OpenClaw failure finals as system errors instead of proposed plans', async () => {
+  const { session, store } = createReconcileStore([
+    { id: 'msg-1', type: 'user', content: 'plan a web game', timestamp: 1, metadata: {} },
+  ]);
+  session.status = 'running';
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  adapter.on('error', vi.fn());
+  const sessionKey = `agent:main:lobsterai:${session.id}`;
+  const turn = createActiveTurn(session.id, sessionKey, 'run-lock-final');
+  turn.planMode = true;
+  adapter.activeTurns.set(session.id, turn);
+
+  await adapter.handleChatFinal(session.id, turn, {
+    state: 'final',
+    runId: 'run-lock-final',
+    sessionKey,
+    message: {
+      role: 'assistant',
+      content: [{
+        type: 'text',
+        text: '⚠️ Agent failed before reply: session file locked (timeout 60000ms): pid=47378 alive=true',
+      }],
+    },
+  });
+
+  expect(session.status).toBe('error');
+  expect(session.messages.some((message) => message.type === 'assistant')).toBe(false);
+  const systemMessage = session.messages.find((message) => message.type === 'system');
+  expect(systemMessage?.content).toContain('session file locked');
+  expect(systemMessage?.content).not.toContain('<proposed_plan>');
+  expect(adapter.activeTurns.has(session.id)).toBe(false);
+});
+
 test('assistant snapshot jitter does not count as a stream reset', () => {
   expect(isSignificantAssistantStreamReset(545, 544)).toBe(false);
   expect(isSignificantAssistantStreamReset(1000, 930)).toBe(false);
@@ -4804,93 +4837,109 @@ test('ordinary write tool does not trigger memory maintenance handling', async (
   expect(session.messages.find((message) => message.type === 'tool_use')?.metadata?.toolName).toBe('write');
 });
 
-test('blocked plan mode mutation aborts the unsafe run and resumes with a tool-free plan request', async () => {
-  const preface = 'Now let me read the workspace to understand the project structure.';
-  const { session, store } = createReconcileStore([
-    { id: 'msg-1', type: 'user', content: 'plan a bakery website', timestamp: 1, metadata: {} },
-    {
-      id: 'msg-2',
-      type: 'assistant',
-      content: preface,
-      timestamp: 2,
-      metadata: { isStreaming: true, isFinal: false },
-    },
-  ]);
-  session.status = 'running';
-  const adapter = new OpenClawRuntimeAdapter(store, {});
-  const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
-  const sessionKey = `agent:main:lobsterai:${session.id}`;
-  const turn = createActiveTurn(session.id, sessionKey, 'run-plan-unsafe');
-  turn.planMode = true;
-  turn.assistantMessageId = 'msg-2';
-  turn.currentText = preface;
-  turn.currentAssistantSegmentText = preface;
-  turn.agentAssistantTextLength = preface.length;
+test('blocked plan mode mutation waits for lifecycle end before safety recovery', async () => {
+  vi.useFakeTimers();
+  try {
+    const preface = 'Now let me read the workspace to understand the project structure.';
+    const { session, store } = createReconcileStore([
+      { id: 'msg-1', type: 'user', content: 'plan a bakery website', timestamp: 1, metadata: {} },
+      {
+        id: 'msg-2',
+        type: 'assistant',
+        content: preface,
+        timestamp: 2,
+        metadata: { isStreaming: true, isFinal: false },
+      },
+    ]);
+    session.status = 'running';
+    const adapter = new OpenClawRuntimeAdapter(store, {});
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const sessionKey = `agent:main:lobsterai:${session.id}`;
+    const turn = createActiveTurn(session.id, sessionKey, 'run-plan-unsafe');
+    turn.planMode = true;
+    turn.assistantMessageId = 'msg-2';
+    turn.currentText = preface;
+    turn.currentAssistantSegmentText = preface;
+    turn.agentAssistantTextLength = preface.length;
 
-  adapter.gatewayClient = {
-    start: () => {},
-    stop: () => {},
-    request: async (method: string, params?: unknown) => {
-      requests.push({ method, params: params as Record<string, unknown> });
-      return method === 'chat.send' ? { runId: 'run-plan-safe-recovery' } : {};
-    },
-  };
-  adapter.activeTurns.set(session.id, turn);
-  adapter.sessionIdByRunId.set('run-plan-unsafe', session.id);
+    adapter.gatewayClient = {
+      start: () => {},
+      stop: () => {},
+      request: async (method: string, params?: unknown) => {
+        requests.push({ method, params: params as Record<string, unknown> });
+        return method === 'chat.send' ? { runId: 'run-plan-safe-recovery' } : {};
+      },
+    };
+    adapter.activeTurns.set(session.id, turn);
+    adapter.sessionIdByRunId.set('run-plan-unsafe', session.id);
 
-  adapter.handleAgentEvent({
-    runId: 'run-plan-unsafe',
-    sessionKey,
-    stream: 'tool',
-    data: {
-      toolCallId: 'call-mkdir',
-      phase: 'start',
-      name: 'exec',
-      args: { command: 'mkdir -p /tmp/mcbakery' },
-    },
-  }, 1);
-  await Promise.resolve();
+    adapter.handleAgentEvent({
+      runId: 'run-plan-unsafe',
+      sessionKey,
+      stream: 'tool',
+      data: {
+        toolCallId: 'call-mkdir',
+        phase: 'start',
+        name: 'exec',
+        args: { command: 'mkdir -p /tmp/mcbakery' },
+      },
+    }, 1);
+    await Promise.resolve();
 
-  expect(requests.find((request) => request.method === 'chat.abort')?.params).toEqual({
-    sessionKey,
-    runId: 'run-plan-unsafe',
-  });
-  expect(turn.planModeSafetyRecoveryPending).toBe(true);
-  expect(turn.planModeRecoveryAttempted).toBe(true);
-  expect(session.status).toBe('running');
-  expect(session.messages.some((message) => message.type === 'system')).toBe(false);
+    expect(requests.find((request) => request.method === 'chat.abort')?.params).toEqual({
+      sessionKey,
+      runId: 'run-plan-unsafe',
+    });
+    expect(turn.planModeSafetyRecoveryPending).toBe(true);
+    expect(turn.planModeRecoveryAttempted).toBe(true);
+    expect(session.status).toBe('running');
+    expect(session.messages.some((message) => message.type === 'system')).toBe(false);
 
-  adapter.handleChatEvent({
-    state: 'aborted',
-    runId: 'run-plan-unsafe',
-    sessionKey,
-    stopReason: 'abort',
-  }, 2);
-  await Promise.resolve();
-  await Promise.resolve();
+    adapter.handleChatEvent({
+      state: 'aborted',
+      runId: 'run-plan-unsafe',
+      sessionKey,
+      stopReason: 'abort',
+    }, 2);
+    await Promise.resolve();
 
-  const recoveryRequest = requests.find((request) => request.method === 'chat.send');
-  expect(recoveryRequest?.params).toMatchObject({
-    sessionKey,
-    deliver: false,
-    message: expect.stringContaining('Plan Mode safety recovery instruction'),
-  });
-  expect(recoveryRequest?.params.message).toContain('Do not call any tools');
-  expect(turn.planModeSafetyRecoveryPending).toBe(false);
-  expect(turn.knownRunIds.has('run-plan-safe-recovery')).toBe(true);
-  expect(session.status).toBe('running');
-  expect(session.messages.some((message) => message.metadata?.isTimeout)).toBe(false);
+    expect(requests.some((request) => request.method === 'chat.send')).toBe(false);
 
-  const recoveredPlan = '<proposed_plan>\n## Summary\n- Build the bakery page.\n</proposed_plan>';
-  adapter.processAgentAssistantText({
-    runId: 'run-plan-safe-recovery',
-    sessionKey,
-    stream: 'assistant',
-    data: { text: recoveredPlan },
-  });
+    adapter.handleAgentEvent({
+      runId: 'run-plan-unsafe',
+      sessionKey,
+      stream: 'lifecycle',
+      data: { phase: 'end', aborted: true },
+    }, 3);
+    await vi.advanceTimersByTimeAsync(1499);
+    expect(requests.some((request) => request.method === 'chat.send')).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
 
-  expect(session.messages.find((message) => message.id === 'msg-2')?.content).toBe(recoveredPlan);
-  expect(session.messages.some((message) => message.content === preface)).toBe(false);
+    const recoveryRequest = requests.find((request) => request.method === 'chat.send');
+    expect(recoveryRequest?.params).toMatchObject({
+      sessionKey,
+      deliver: false,
+      message: expect.stringContaining('Plan Mode safety recovery instruction'),
+    });
+    expect(recoveryRequest?.params.message).toContain('Do not call any tools');
+    expect(turn.planModeSafetyRecoveryPending).toBe(false);
+    expect(turn.knownRunIds.has('run-plan-safe-recovery')).toBe(true);
+    expect(session.status).toBe('running');
+    expect(session.messages.some((message) => message.metadata?.isTimeout)).toBe(false);
+
+    const recoveredPlan = '<proposed_plan>\n## Summary\n- Build the bakery page.\n</proposed_plan>';
+    adapter.processAgentAssistantText({
+      runId: 'run-plan-safe-recovery',
+      sessionKey,
+      stream: 'assistant',
+      data: { text: recoveredPlan },
+    });
+
+    expect(session.messages.find((message) => message.id === 'msg-2')?.content).toBe(recoveredPlan);
+    expect(session.messages.some((message) => message.content === preface)).toBe(false);
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test('repeated blocked mutation in one plan turn stops instead of looping recovery', async () => {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -464,6 +464,11 @@ const OpenClawKnownRuntimeError = {
 } as const;
 const OPENCLAW_GENERIC_LLM_REQUEST_FAILED = 'LLM request failed.';
 
+const OpenClawFailureFinalText = {
+  AgentFailedBeforeReply: 'Agent failed before reply:',
+  SessionFileLocked: 'session file locked (timeout',
+} as const;
+
 const OpenClawHistoryRole = {
   Tool: 'tool',
   ToolResult: 'toolResult',
@@ -480,6 +485,10 @@ type ActiveTurn = {
   planModeRecoveryAttempted?: boolean;
   /** Expected abort while replacing a blocked mutating tool run with a plan-only recovery. */
   planModeSafetyRecoveryPending?: boolean;
+  /** Run id that must fully end before plan safety recovery can reuse the session file. */
+  planModeSafetyRecoveryAbortedRunId?: string;
+  /** Delayed recovery timer waiting for OpenClaw to release the aborted run's session file lock. */
+  planModeSafetyRecoveryTimer?: ReturnType<typeof setTimeout>;
   /** Timestamp when this turn was created (for abort diagnostics). */
   startedAtMs: number;
   firstResponseTiming: FirstResponseTiming;
@@ -828,6 +837,12 @@ export function isPlanModeResponseComplete(text: string): boolean {
   ];
   const sectionCount = sectionPatterns.filter((pattern) => pattern.test(content)).length;
   return structuralLineCount >= 8 || (structuralLineCount >= 5 && sectionCount >= 3);
+}
+
+function isOpenClawFailureFinalText(text: string): boolean {
+  const trimmed = text.trim();
+  return trimmed.includes(OpenClawFailureFinalText.AgentFailedBeforeReply)
+    || trimmed.includes(OpenClawFailureFinalText.SessionFileLocked);
 }
 
 export function isSignificantAssistantStreamReset(previousLength: number, nextLength: number): boolean {
@@ -1906,6 +1921,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private static readonly VISIBLE_FINAL_TOOL_RESULT_CHAR_THRESHOLD = 20_000;
   private static readonly VISIBLE_FINAL_SHORT_TEXT_CHAR_THRESHOLD = 600;
   private static readonly GATEWAY_SESSION_DELETE_TIMEOUT_MS = 5_000;
+  private static readonly PLAN_MODE_SAFETY_RECOVERY_AFTER_ABORT_FALLBACK_MS = 10_000;
+  private static readonly PLAN_MODE_SAFETY_RECOVERY_AFTER_LIFECYCLE_END_MS = 1_500;
 
   private gatewayClient: GatewayClientLike | null = null;
   private gatewayClientVersion: string | null = null;
@@ -5911,6 +5928,19 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       const endingRunId = eventRunId
         ?? endingTurn?.runId
         ?? (isRecord(data) && typeof data.runId === 'string' ? data.runId : null);
+      if (
+        endingTurn?.planMode
+        && endingTurn.planModeSafetyRecoveryPending
+        && (!endingRunId || !endingTurn.planModeSafetyRecoveryAbortedRunId || endingRunId === endingTurn.planModeSafetyRecoveryAbortedRunId)
+      ) {
+        this.schedulePlanModeSafetyRecovery(
+          sessionId,
+          endingTurn,
+          OpenClawRuntimeAdapter.PLAN_MODE_SAFETY_RECOVERY_AFTER_LIFECYCLE_END_MS,
+          'aborted run lifecycle ended',
+        );
+        return;
+      }
       if (endingTurn && this.isWaitingForRecoverableFollowup(endingTurn)) {
         this.scheduleLifecycleEndFallback(
           sessionId,
@@ -6294,6 +6324,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         }
         turn.planModeRecoveryAttempted = true;
         turn.planModeSafetyRecoveryPending = true;
+        turn.planModeSafetyRecoveryAbortedRunId = turn.runId;
         void Promise.resolve().then(() => this.requireGatewayClient().request('chat.abort', {
           sessionKey: turn.sessionKey,
           runId: turn.runId,
@@ -7048,9 +7079,11 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       ? messageRecord.errorMessage
       : undefined;
     const stoppedByToolUse = isToolUseStopReason(stopReason) || messageHasToolCallBlock(messageRecord);
-    const finalText = turn.planMode && !stoppedByToolUse
-      ? ensurePlanModeProposedPlanBlock(stripTrailingSilentReplyToken(rawFinalText))
-      : stripTrailingSilentReplyToken(rawFinalText);
+    const rawVisibleFinalText = stripTrailingSilentReplyToken(rawFinalText);
+    const finalTextIsOpenClawFailure = isOpenClawFailureFinalText(rawVisibleFinalText);
+    const finalText = turn.planMode && !stoppedByToolUse && !finalTextIsOpenClawFailure
+      ? ensurePlanModeProposedPlanBlock(rawVisibleFinalText)
+      : rawVisibleFinalText;
     console.debug(
       '[OpenClawRuntime] handleChatFinal:',
       `sessionId=${sessionId}`,
@@ -7101,6 +7134,25 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       this.emit('complete', sessionId, payload.runId ?? turn.runId);
       this.cleanupSessionTurn(sessionId);
       this.resolveTurn(sessionId);
+      return;
+    }
+    if (finalTextIsOpenClawFailure) {
+      const errorMessage = resolveOpenClawRuntimeErrorMessage(
+        finalText.trim() || 'OpenClaw run failed',
+        normalizeOpenClawSafeRuntimeErrorMetadata(payload),
+      );
+      const erroredSessionKey = turn.sessionKey;
+      this.store.updateSession(sessionId, { status: 'error' });
+      const errorMsg = this.store.addMessage(sessionId, {
+        type: 'system',
+        content: errorMessage,
+        metadata: { error: errorMessage },
+      });
+      this.emit('message', sessionId, errorMsg);
+      this.emit('error', sessionId, errorMessage);
+      this.cleanupSessionTurn(sessionId);
+      this.rejectTurn(sessionId, new Error(errorMessage));
+      void this.syncSessionHistoryFromGateway(sessionId, erroredSessionKey);
       return;
     }
     turn.currentText = finalText;
@@ -7238,7 +7290,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     const stoppedByError = stopReason === GatewayStopReason.Error;
     if (stoppedByError) {
-      const rawErrorMessage = payload.errorMessage?.trim() || errorMessageFromMessage?.trim() || 'OpenClaw run failed';
+      const rawErrorMessage = payload.errorMessage?.trim()
+        || errorMessageFromMessage?.trim()
+        || 'OpenClaw run failed';
       const errorMessage = resolveOpenClawRuntimeErrorMessage(
         rawErrorMessage,
         normalizeOpenClawSafeRuntimeErrorMetadata(payload),
@@ -7594,7 +7648,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private async recoverPlanModeAfterSafetyAbort(sessionId: string, turn: ActiveTurn): Promise<void> {
     if (this.activeTurns.get(sessionId) !== turn || turn.stopRequested) return;
 
+    if (turn.planModeSafetyRecoveryTimer) {
+      clearTimeout(turn.planModeSafetyRecoveryTimer);
+      turn.planModeSafetyRecoveryTimer = undefined;
+    }
     turn.planModeSafetyRecoveryPending = false;
+    turn.planModeSafetyRecoveryAbortedRunId = undefined;
     const recoveryRunId = randomUUID();
     const session = this.store.getSession(sessionId);
     const runCwd = session?.cwd?.trim() ? path.resolve(session.cwd.trim()) : undefined;
@@ -7657,12 +7716,39 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
   }
 
+  private schedulePlanModeSafetyRecovery(
+    sessionId: string,
+    turn: ActiveTurn,
+    delayMs: number,
+    reason: string,
+  ): void {
+    if (this.activeTurns.get(sessionId) !== turn || !turn.planModeSafetyRecoveryPending) return;
+    if (turn.planModeSafetyRecoveryTimer) {
+      clearTimeout(turn.planModeSafetyRecoveryTimer);
+    }
+    const turnToken = turn.turnToken;
+    turn.planModeSafetyRecoveryTimer = setTimeout(() => {
+      const currentTurn = this.activeTurns.get(sessionId);
+      if (!currentTurn || currentTurn.turnToken !== turnToken || !currentTurn.planModeSafetyRecoveryPending) return;
+      currentTurn.planModeSafetyRecoveryTimer = undefined;
+      void this.recoverPlanModeAfterSafetyAbort(sessionId, currentTurn);
+    }, delayMs);
+    console.debug(
+      `[OpenClawRuntime] scheduled plan mode safety recovery after ${delayMs}ms because ${reason} for session ${sessionId}.`,
+    );
+  }
+
   private handleChatAborted(sessionId: string, turn: ActiveTurn): void {
     if (turn.planMode && turn.planModeSafetyRecoveryPending) {
       console.warn(
         `[OpenClawRuntime] received the expected safety abort for plan mode session ${sessionId}.`,
       );
-      void this.recoverPlanModeAfterSafetyAbort(sessionId, turn);
+      this.schedulePlanModeSafetyRecovery(
+        sessionId,
+        turn,
+        OpenClawRuntimeAdapter.PLAN_MODE_SAFETY_RECOVERY_AFTER_ABORT_FALLBACK_MS,
+        'waiting for aborted run lifecycle end',
+      );
       return;
     }
     const elapsedSec = ((Date.now() - turn.startedAtMs) / 1000).toFixed(1);
@@ -8921,6 +9007,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       if (turn.lifecycleEndFallbackTimer) {
         clearTimeout(turn.lifecycleEndFallbackTimer);
         turn.lifecycleEndFallbackTimer = undefined;
+      }
+      if (turn.planModeSafetyRecoveryTimer) {
+        clearTimeout(turn.planModeSafetyRecoveryTimer);
+        turn.planModeSafetyRecoveryTimer = undefined;
       }
       if (turn.finalCompletionTimer) {
         clearTimeout(turn.finalCompletionTimer);


### PR DESCRIPTION
Wait for the aborted OpenClaw run lifecycle to end before sending plan-mode safety recovery, preventing session file lock collisions. Treat OpenClaw failure finals as system errors instead of proposed plans.

