### PR TITLE
fix(settings): prevent white screen when deleting active custom model

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -2042,6 +2042,16 @@ const Settings: React.FC<SettingsProps> = ({
       delete next[key];
       return next;
     });
+    // If the deleted provider was active, switch to first visible BEFORE the
+    // await below. Otherwise the intermediate render triggered while awaiting
+    // would still have activeProvider pointing at the just-deleted key, and the
+    // model settings render accesses providers[activeProvider].* without guards,
+    // crashing the whole view (white screen).
+    if (activeProvider === key) {
+      const visibleKeys = Object.keys(visibleProviders).filter(k => k !== key) as ProviderType[];
+      const firstEnabled = visibleKeys.find(k => visibleProviders[k]?.enabled);
+      setActiveProvider(firstEnabled ?? visibleKeys[0] ?? providerKeys[0]);
+    }
     // Persist the deletion immediately so it survives window close
     const updatedProviders = { ...currentConfig.providers };
     delete updatedProviders[key];
@@ -2058,12 +2068,6 @@ const Settings: React.FC<SettingsProps> = ({
       }
     } catch (deleteError) {
       console.warn('[Settings] failed to persist custom provider deletion:', deleteError);
-    }
-    // If the deleted provider was active, switch to first visible
-    if (activeProvider === key) {
-      const visibleKeys = Object.keys(visibleProviders).filter(k => k !== key) as ProviderType[];
-      const firstEnabled = visibleKeys.find(k => visibleProviders[k]?.enabled);
-      setActiveProvider(firstEnabled ?? visibleKeys[0] ?? providerKeys[0]);
     }
   };
 


### PR DESCRIPTION
Deleting the currently selected custom provider in Settings crashed the whole view to a white screen.

confirmDeleteCustomProvider is async: it removed the provider via setProviders and only switched activeProvider away from the deleted key after `await configService.updateConfig(...)`. The await flushes an intermediate render where activeProvider still points at the just-deleted key, and ModelSettingsSection reads providers[activeProvider].enabled / .apiKey / .baseUrl / .models without guards, throwing on undefined. The useEffect that normally repairs activeProvider only runs after render, too late to save the crashing frame.

Move the activeProvider switch to before the await so both state updates land in the same synchronous batch, keeping the intermediate render consistent (key removed + activeProvider already switched).

## Summary
<!-- Provide a brief summary of the changes in this PR -->
Fixes a white-screen crash in **Settings → Custom Model**: deleting the currently selected custom provider left `activeProvider` pointing at a deleted key during the render triggered by an `await`, causing an unguarded `providers[activeProvider].*` access to throw. The fix reorders the `activeProvider` switch to before the `await`.

## Related Issue
<!-- Link to the related issue(s) if applicable -->
N/A (no tracked issue)

## Changes Made
<!-- Describe the changes you've made -->
- Moved the `activeProvider` fallback-switch block in `confirmDeleteCustomProvider` to run immediately after `setProviders` and **before** `await configService.updateConfig(...)`.
- Added an inline comment explaining why the ordering matters (the intermediate render during the await must not see a deleted `activeProvider`).
- No logic changes, no new variables, and no edits to the render code in `ModelSettingsSection.tsx`.

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you've performed -->
- [x] Tested locally (`eslint` clean on `Settings.tsx`; `vitest run modelProviderUtils config modelSlice` → 168 passed)
- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed (recommended: `npm run electron:dev` → add + select a custom model config → delete → confirm the view switches to another provider instead of white-screening)

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->
N/A

## Checklist
<!-- Mark the completed items with [x] -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes
<!-- If your PR includes Electron-specific changes, describe them here -->
Renderer-only change. No main process, preload, IPC, storage, runtime, or OpenClaw config/restart behavior affected.
- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes
<!-- Any additional information that reviewers should know -->
The delete path only appears via `confirmDeleteCustomProvider`, so this is the single entry point affected. Deleting a **non-active** provider was already safe (the `if (activeProvider === key)` guard is false, so `activeProvider` stays valid); this fix specifically covers deleting the **active** one. The `.npmrc` / `package.json` (`@electron/asar`) changes from the same working session were intentionally excluded from this PR as unrelated environment/build workarounds.

I filled the template against what was actually done — note I marked "Manual testing performed" and "added tests" as unchecked, since I only ran lint + existing Vitest and recommended (but did not perform) the manual electron:dev check. Adjust those boxes if you run the manual test yourself.