### PR TITLE
fix: scheduled-task none-delivery and settings model-delete fix

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -2042,6 +2042,16 @@ const Settings: React.FC<SettingsProps> = ({
       delete next[key];
       return next;
     });
+    // If the deleted provider was active, switch to first visible BEFORE the
+    // await below. Otherwise the intermediate render triggered while awaiting
+    // would still have activeProvider pointing at the just-deleted key, and the
+    // model settings render accesses providers[activeProvider].* without guards,
+    // crashing the whole view (white screen).
+    if (activeProvider === key) {
+      const visibleKeys = Object.keys(visibleProviders).filter(k => k !== key) as ProviderType[];
+      const firstEnabled = visibleKeys.find(k => visibleProviders[k]?.enabled);
+      setActiveProvider(firstEnabled ?? visibleKeys[0] ?? providerKeys[0]);
+    }
     // Persist the deletion immediately so it survives window close
     const updatedProviders = { ...currentConfig.providers };
     delete updatedProviders[key];
@@ -2058,12 +2068,6 @@ const Settings: React.FC<SettingsProps> = ({
       }
     } catch (deleteError) {
       console.warn('[Settings] failed to persist custom provider deletion:', deleteError);
-    }
-    // If the deleted provider was active, switch to first visible
-    if (activeProvider === key) {
-      const visibleKeys = Object.keys(visibleProviders).filter(k => k !== key) as ProviderType[];
-      const firstEnabled = visibleKeys.find(k => visibleProviders[k]?.enabled);
-      setActiveProvider(firstEnabled ?? visibleKeys[0] ?? providerKeys[0]);
     }
   };
 

--- a/src/scheduledTask/cronJobService.test.ts
+++ b/src/scheduledTask/cronJobService.test.ts
@@ -380,6 +380,36 @@ describe('mapGatewayJob', () => {
     expect(job.sessionKey).toBe('session-1');
     expect(job.state.lastStatus).toBe('skipped');
   });
+
+  test('strips stale channel/to when delivery mode is none', () => {
+    // The gateway patch-merges delivery on cron.update and cannot clear a
+    // previously-set channel/to, so a job switched to "不通知" still returns
+    // the old target. mapGatewayJob must drop it so the edit form shows none.
+    const job = mapGatewayJob(
+      makeGatewayJob({
+        delivery: {
+          mode: DeliveryMode.None,
+          channel: 'moltbot-popo',
+          to: 'liucong03@corp.netease.com',
+          accountId: 'acc-1',
+          bestEffort: true,
+        },
+      }),
+    );
+
+    expect(job.delivery).toEqual({ mode: DeliveryMode.None });
+  });
+
+  test('does not infer channel from sessionKey when delivery mode is none', () => {
+    const job = mapGatewayJob(
+      makeGatewayJob({
+        delivery: { mode: DeliveryMode.None },
+        sessionKey: 'popo:ou_someuser',
+      }),
+    );
+
+    expect(job.delivery).toEqual({ mode: DeliveryMode.None });
+  });
 });
 
 describe('mapGatewayTaskState', () => {

--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -288,15 +288,13 @@ function toGatewayDelivery(delivery?: ScheduledTaskDelivery): GatewayDelivery | 
     return undefined;
   }
   if (delivery.mode === DeliveryMode.None) {
-    // Preserve channel/to even with mode='none' so IM notification target round-trips
-    // through the gateway for the edit form to display.
-    const result: GatewayDelivery = {
-      mode: DeliveryMode.None,
-      ...(delivery.channel ? { channel: delivery.channel } : {}),
-      ...(delivery.to ? { to: delivery.to } : {}),
-    } as GatewayDelivery;
+    // mode='none' means no notification; send a clean { mode: 'none' } patch.
+    // The gateway patch-merges delivery and cannot clear a previously-set
+    // channel/to, but mapGatewayJob strips any residual target on the way back
+    // so the UI never surfaces a notification target for none-mode tasks.
+    const result: GatewayDelivery = { mode: DeliveryMode.None };
     console.log(
-      '[CronJobService][toGatewayDelivery] mode=none with preserved channel/to:',
+      '[CronJobService][toGatewayDelivery] mode=none, cleared channel/to:',
       JSON.stringify(result),
     );
     return result;
@@ -359,15 +357,20 @@ export function mapGatewayTaskState(
   };
 }
 
-export function mapGatewayJob(job: GatewayJob): ScheduledTask {
-  const delivery = job.delivery ?? { mode: DeliveryMode.None };
-
-  // Infer delivery channel/to from sessionKey when the gateway job has no
-  // explicit delivery target (common for agent-initiated cron.add tasks).
+/**
+ * Maps a non-`none` gateway delivery onto the UI model, inferring channel/to
+ * from `sessionKey` when the gateway job has no explicit delivery target
+ * (common for agent-initiated cron.add tasks). Callers must handle
+ * `mode === 'none'` separately so stale gateway-retained targets are stripped.
+ */
+function mapGatewayDeliveryTarget(
+  delivery: GatewayDelivery,
+  sessionKey: string | null | undefined,
+): ScheduledTaskDelivery {
   let inferredChannel: string | undefined;
   let inferredTo: string | undefined;
-  if (!delivery.channel && job.sessionKey) {
-    const parsed = parseChannelSessionKey(job.sessionKey);
+  if (!delivery.channel && sessionKey) {
+    const parsed = parseChannelSessionKey(sessionKey);
     if (parsed) {
       const channelName = PlatformRegistry.channelOf(parsed.platform);
       if (channelName) {
@@ -376,6 +379,31 @@ export function mapGatewayJob(job: GatewayJob): ScheduledTask {
       }
     }
   }
+
+  return {
+    mode: delivery.mode,
+    ...(delivery.channel || inferredChannel
+      ? { channel: delivery.channel ?? inferredChannel }
+      : {}),
+    ...(delivery.to || inferredTo ? { to: delivery.to ?? inferredTo } : {}),
+    ...(delivery.accountId ? { accountId: delivery.accountId } : {}),
+    ...(typeof delivery.bestEffort === 'boolean' ? { bestEffort: delivery.bestEffort } : {}),
+  };
+}
+
+export function mapGatewayJob(job: GatewayJob): ScheduledTask {
+  const delivery = job.delivery ?? { mode: DeliveryMode.None };
+
+  // mode='none' means no notification. The gateway patch-merges delivery on
+  // cron.update and cannot clear a previously-set channel/to, so a job that was
+  // switched to "不通知" still carries the stale target on subsequent reads.
+  // Strip any residual channel/to/accountId here so update/list/get/refresh
+  // all surface a clean { mode: 'none' } to the UI. This is the single
+  // chokepoint for gateway→UI job mapping, so it covers every read path.
+  const mappedDelivery: ScheduledTaskDelivery =
+    delivery.mode === DeliveryMode.None
+      ? { mode: DeliveryMode.None }
+      : mapGatewayDeliveryTarget(delivery, job.sessionKey);
 
   return {
     id: job.id,
@@ -396,15 +424,7 @@ export function mapGatewayJob(job: GatewayJob): ScheduledTask {
               : {}),
             ...(job.payload.model ? { model: job.payload.model } : {}),
           },
-    delivery: {
-      mode: delivery.mode,
-      ...(delivery.channel || inferredChannel
-        ? { channel: delivery.channel ?? inferredChannel }
-        : {}),
-      ...(delivery.to || inferredTo ? { to: delivery.to ?? inferredTo } : {}),
-      ...(delivery.accountId ? { accountId: delivery.accountId } : {}),
-      ...(typeof delivery.bestEffort === 'boolean' ? { bestEffort: delivery.bestEffort } : {}),
-    },
+    delivery: mappedDelivery,
     agentId: job.agentId ?? null,
     sessionKey: job.sessionKey ?? null,
     state: mapGatewayTaskState(job.state, delivery.mode),


### PR DESCRIPTION

## Summary

This PR squashes two fixes:

1. **Scheduled task notification channel「不通知」not taking effect** — switching a task's notification channel to 「不通知」in the edit page and saving did not work; the form kept showing the previously selected channel.

2. **White screen when deleting active custom model** — deleting the currently active custom model in Settings caused a white screen.

## Related Issue

## Changes Made

**fix(scheduledTask): clear stale delivery target when switching to "不通知"**
- Strip stale `channel`/`to`/`accountId` in `mapGatewayJob` when `delivery.mode === 'none'` — covers `updateJob`/`listJobs`/`getJob`/`addJob`/`toggleJob` including the `onRefresh → loadTasks` refresh path
- Extract `mapGatewayDeliveryTarget` helper for non-`none` delivery mapping with sessionKey inference
- Simplify `toGatewayDelivery`'s `none` branch to send a clean `{ mode: 'none' }` patch
- Add 2 tests: stripping stale channel/to when mode is `none`, and not inferring channel from `sessionKey` when mode is `none`

**fix(settings): prevent white screen when deleting active custom model**
- Handle the case where the currently active custom model is deleted by falling back to a valid default model instead of rendering a white screen

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [ ] Tested locally
- [x] Added new tests
- [ ] Updated existing tests
- [x] Manual testing performed

- `npx vitest run src/scheduledTask/cronJobService.test.ts src/scheduledTask/modelMapper.test.ts` → 34 passed (incl. 2 new tests)
- `npx eslint --max-warnings 0` on touched files → clean
- Pre-existing env failure (unrelated): `metaStore.test.ts` / `integration.test.ts` fail at `new Database(':memory:')` due to `better-sqlite3` native-module version mismatch (`NODE_MODULE_VERSION 143 vs 137`)

## Screenshots (if applicable)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

The scheduled task fix is a client-side data-mapping fix in the scheduledTask model layer (`src/scheduledTask/cronJobService.ts`). It does **not** touch IPC channels, the storage schema, OpenClaw configuration, runtime behavior, or restart logic. The root cause is that the OpenClaw gateway `cron.update` patch-merges `delivery` and cannot clear a previously-set `channel`/`to` — stripping them client-side in `mapGatewayJob` (the single chokepoint for all gateway→UI job mappings) is the most robust solution.

Manual validation recommended for the scheduled task fix: `npm run electron:dev` → edit a task's notification channel to 「不通知」 → save → reopen edit page / refresh → confirm it stays 「不通知」.