### PR TITLE
fix(openclaw): stabilize DeepSeek prompt cache in long sessions

### DIFF
--- a/scripts/apply-openclaw-patches.cjs
+++ b/scripts/apply-openclaw-patches.cjs
@@ -134,6 +134,38 @@ const strongPatchValidators = {
       snippets: ['prompt-cache byte-identity', 'turn1AsCurrent', 'turn1AsHistorical'],
     },
   ],
+  'openclaw-live-tool-result-cache-stability.patch': [
+    {
+      file: 'src/agents/embedded-agent-runner/run/attempt.ts',
+      snippets: [
+        'truncateOversizedToolResultsInMessages(\n            activeSession.messages,',
+        'promptToolResultMaxChars,\n            null,',
+      ],
+    },
+    {
+      file: 'src/agents/embedded-agent-runner/tool-result-truncation.ts',
+      snippets: [
+        'aggregateMaxCharsOverride?: number | null',
+        'aggregateMaxCharsOverride === null',
+        'Number.POSITIVE_INFINITY',
+      ],
+    },
+    {
+      file: 'src/agents/embedded-agent-runner/tool-result-truncation.test.ts',
+      snippets: ['keeps prompt projections byte-stable as history grows'],
+    },
+  ],
+  'zz-openclaw-deepseek-cache-probe.patch': [
+    {
+      file: 'src/agents/openai-transport-stream.ts',
+      snippets: [
+        'DEEPSEEK_CACHE_PROBE_LOG_PREFIX = "[DeepSeekCacheProbe]"',
+        'logDeepSeekCacheRequestProbe',
+        'logDeepSeekCacheProbeResult',
+        'cacheRead / promptTokens',
+      ],
+    },
+  ],
 };
 
 function collectMissingStrongPatchSnippets(patchFile) {

--- a/scripts/patches/v2026.6.1/openclaw-live-tool-result-cache-stability.patch
+++ b/scripts/patches/v2026.6.1/openclaw-live-tool-result-cache-stability.patch
@@ -1,0 +1,114 @@
+diff --git a/src/agents/embedded-agent-runner/run/attempt.ts b/src/agents/embedded-agent-runner/run/attempt.ts
+index 077593828b..eae686a64b 100644
+--- a/src/agents/embedded-agent-runner/run/attempt.ts
++++ b/src/agents/embedded-agent-runner/run/attempt.ts
+@@ -542,8 +542,6 @@ export {
+ };
+ 
+ const MAX_BTW_SNAPSHOT_MESSAGES = 100;
+-const PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER = 4;
+-
+ function pluginMetadataSnapshotCoversProvider(
+   snapshot: PluginMetadataSnapshot | undefined,
+   provider: string,
+@@ -4176,17 +4174,14 @@ export async function runEmbeddedAttempt(
+             activeSession.messages,
+             contextTokenBudget,
+             promptToolResultMaxChars,
+-            promptToolResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER,
++            null,
+           );
+           if (promptToolResultTruncation.truncatedCount > 0) {
+             promptHistoryMessages = promptToolResultTruncation.messages;
+             log.info(
+               `[tool-result-truncation] Truncated ${promptToolResultTruncation.truncatedCount} ` +
+                 `tool result(s) for prompt history ` +
+-                `(maxChars=${promptToolResultMaxChars} ` +
+-                `aggregateBudgetChars=${
+-                  promptToolResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER
+-                }) ` +
++                `(maxChars=${promptToolResultMaxChars}) ` +
+                 `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
+             );
+           }
+@@ -4717,7 +4712,7 @@ export async function runEmbeddedAttempt(
+                     messages,
+                     contextTokenBudget,
+                     promptToolResultMaxChars,
+-                    promptToolResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER,
++                    null,
+                   );
+                   return providerPromptHistoryTruncation.truncatedCount > 0
+                     ? providerPromptHistoryTruncation.messages
+diff --git a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+index cf9d51c627..db91f7095b 100644
+--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
++++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+@@ -437,6 +437,34 @@ describe("truncateOversizedToolResultsInMessages", () => {
+       medium.length * 3,
+     );
+   });
++
++  it("keeps prompt projections byte-stable as history grows", () => {
++    const prefix = [
++      makeToolResult("p".repeat(15_000), "prefix_1"),
++      makeToolResult("q".repeat(15_000), "prefix_2"),
++    ];
++    const suffix = [
++      makeToolResult("x".repeat(15_000), "current_1"),
++      makeToolResult("y".repeat(15_000), "current_2"),
++    ];
++    const messages = [...prefix, ...suffix];
++
++    const first = truncateOversizedToolResultsInMessages(messages, 128_000, 12_000, null);
++    const second = truncateOversizedToolResultsInMessages(
++      [...messages, makeToolResult("z".repeat(15_000), "current_3")],
++      128_000,
++      12_000,
++      null,
++    );
++
++    expect(first.truncatedCount).toBe(4);
++    expect(second.truncatedCount).toBe(5);
++    expect(second.messages.slice(0, messages.length)).toEqual(first.messages);
++    expect(second.messages.every((message) => getToolResultTextLength(message) <= 12_000)).toBe(
++      true,
++    );
++    expect(messages).toEqual([...prefix, ...suffix]);
++  });
+ });
+ 
+ describe("truncateOversizedToolResultsInSession", () => {
+diff --git a/src/agents/embedded-agent-runner/tool-result-truncation.ts b/src/agents/embedded-agent-runner/tool-result-truncation.ts
+index 848b3d5f0d..464e27a45b 100644
+--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
++++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
+@@ -338,17 +338,22 @@ export function truncateOversizedToolResultsInMessages(
+   messages: AgentMessage[],
+   contextWindowTokens: number,
+   maxCharsOverride?: number,
+-  aggregateMaxCharsOverride?: number,
++  aggregateMaxCharsOverride?: number | null,
+ ): { messages: AgentMessage[]; truncatedCount: number } {
+   const maxChars = Math.max(
+     1,
+     maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
+   );
+-  const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
+-    contextWindowTokens,
+-    maxChars,
+-    aggregateMaxCharsOverride,
+-  );
++  // Live prompt assembly disables aggregate rewriting so unchanged history stays byte-stable
++  // for provider prefix caches; recovery and persisted-session callers keep the aggregate guard.
++  const aggregateBudgetChars =
++    aggregateMaxCharsOverride === null
++      ? Number.POSITIVE_INFINITY
++      : calculateRecoveryAggregateToolResultChars(
++          contextWindowTokens,
++          maxChars,
++          aggregateMaxCharsOverride,
++        );
+   const branch = messages.map((message, index) => ({
+     id: `message-${index}`,
+     type: "message",

--- a/scripts/patches/v2026.6.1/zz-openclaw-deepseek-cache-probe.patch
+++ b/scripts/patches/v2026.6.1/zz-openclaw-deepseek-cache-probe.patch
@@ -1,0 +1,233 @@
+diff --git a/src/agents/openai-transport-stream.ts b/src/agents/openai-transport-stream.ts
+index b8546c1673..4c58c1fd00 100644
+--- a/src/agents/openai-transport-stream.ts
++++ b/src/agents/openai-transport-stream.ts
+@@ -98,11 +98,193 @@ const OPENAI_COMPAT_EVENT_STREAM_CONTENT_TYPE = "text/event-stream";
+ const OPENAI_COMPAT_EMPTY_SSE_DATA_PREFIX = "data:";
+ const OPENAI_COMPAT_EMPTY_SSE_DATA_FRAME_LIMIT = 120;
+ const OPENAI_COMPAT_SSE_FRAME_BOUNDARIES = ["\r\n\r\n", "\n\n", "\r\r"] as const;
+-const OPENAI_COMPAT_EMPTY_SSE_ERROR =
+-  "Provider stream emitted too many empty SSE data frames.";
++const OPENAI_COMPAT_EMPTY_SSE_ERROR = "Provider stream emitted too many empty SSE data frames.";
++const DEEPSEEK_CACHE_PROBE_LOG_PREFIX = "[DeepSeekCacheProbe]";
++const DEEPSEEK_CACHE_PROBE_MAX_SESSIONS = 100;
+ const log = createSubsystemLogger("openai-transport");
+ const loggedOpenAIStrictToolDowngradeDiagnosticKeys = new Set<string>();
+ 
++type DeepSeekCacheProbeSnapshot = {
++  id: string;
++  envelopeHash: string;
++  messageParts: string[];
++  payloadHash: string;
++  toolParts: string[];
++  toolsHash: string;
++  usage?: {
++    cacheRead: number;
++    input: number;
++  };
++};
++
++type DeepSeekCacheProbeHandle = {
++  snapshot: DeepSeekCacheProbeSnapshot;
++};
++
++const deepSeekCacheProbeSnapshots = new Map<string, DeepSeekCacheProbeSnapshot>();
++
++function hashDeepSeekCacheProbeValue(value: string): string {
++  return createHash("sha256").update(value).digest("hex").slice(0, 16);
++}
++
++function serializeDeepSeekCacheProbeValue(value: unknown): string {
++  try {
++    return JSON.stringify(value) ?? "undefined";
++  } catch {
++    return "<unserializable>";
++  }
++}
++
++function isDeepSeekV4CacheProbeModel(model: Model): boolean {
++  const identity = `${model.provider}/${model.id}`.toLowerCase();
++  return /(?:^|[/_.-])deepseek-v4(?:$|[/_.-])/.test(identity);
++}
++
++function buildDeepSeekCacheProbeMessagePart(message: unknown, index: number): string {
++  const serialized = serializeDeepSeekCacheProbeValue(message);
++  const rawRole =
++    message && typeof message === "object" && !Array.isArray(message)
++      ? (message as { role?: unknown }).role
++      : undefined;
++  const role = typeof rawRole === "string" ? rawRole : "unknown";
++  return `${index}:${role}:${Buffer.byteLength(serialized, "utf8")}:${hashDeepSeekCacheProbeValue(serialized)}`;
++}
++
++function buildDeepSeekCacheProbeToolPart(tool: unknown, index: number): string {
++  const serialized = serializeDeepSeekCacheProbeValue(tool);
++  const functionValue =
++    tool && typeof tool === "object" && !Array.isArray(tool)
++      ? (tool as { function?: unknown }).function
++      : undefined;
++  const rawName =
++    functionValue && typeof functionValue === "object" && !Array.isArray(functionValue)
++      ? (functionValue as { name?: unknown }).name
++      : undefined;
++  const name = typeof rawName === "string" ? rawName : "unknown";
++  return `${index}:${name}:${Buffer.byteLength(serialized, "utf8")}:${hashDeepSeekCacheProbeValue(serialized)}`;
++}
++
++function findCommonDeepSeekCacheProbePartCount(
++  previous: readonly string[],
++  current: readonly string[],
++): number {
++  const limit = Math.min(previous.length, current.length);
++  let index = 0;
++  while (index < limit && previous[index] === current[index]) {
++    index += 1;
++  }
++  return index;
++}
++
++function rememberDeepSeekCacheProbeSnapshot(
++  key: string,
++  snapshot: DeepSeekCacheProbeSnapshot,
++): void {
++  deepSeekCacheProbeSnapshots.set(key, snapshot);
++  if (deepSeekCacheProbeSnapshots.size <= DEEPSEEK_CACHE_PROBE_MAX_SESSIONS) {
++    return;
++  }
++  const oldestKey = deepSeekCacheProbeSnapshots.keys().next().value;
++  if (typeof oldestKey === "string") {
++    deepSeekCacheProbeSnapshots.delete(oldestKey);
++  }
++}
++
++function logDeepSeekCacheRequestProbe(params: {
++  model: Model;
++  options: BaseStreamOptions | undefined;
++  payload: unknown;
++}): DeepSeekCacheProbeHandle | undefined {
++  if (!isDeepSeekV4CacheProbeModel(params.model)) {
++    return undefined;
++  }
++
++  const payloadRecord =
++    params.payload && typeof params.payload === "object" && !Array.isArray(params.payload)
++      ? (params.payload as Record<string, unknown>)
++      : {};
++  const messages = Array.isArray(payloadRecord.messages) ? payloadRecord.messages : [];
++  const tools = Array.isArray(payloadRecord.tools) ? payloadRecord.tools : [];
++  const envelope = { ...payloadRecord };
++  delete envelope.messages;
++  delete envelope.tools;
++  const messageParts = messages.map((message, index) =>
++    buildDeepSeekCacheProbeMessagePart(message, index),
++  );
++  const toolParts = tools.map((tool, index) => buildDeepSeekCacheProbeToolPart(tool, index));
++  const messageManifest = messageParts.join(",");
++  const sessionHash = hashDeepSeekCacheProbeValue(params.options?.sessionId ?? "no-session");
++  const key = `${params.model.provider}/${params.model.id}/${sessionHash}`;
++  const previous = deepSeekCacheProbeSnapshots.get(key);
++  const commonMessages = previous
++    ? findCommonDeepSeekCacheProbePartCount(previous.messageParts, messageParts)
++    : 0;
++  const firstDiff = previous && commonMessages < previous.messageParts.length ? commonMessages : -1;
++  const commonTools = previous
++    ? findCommonDeepSeekCacheProbePartCount(previous.toolParts, toolParts)
++    : 0;
++  const firstToolDiff = previous && commonTools < previous.toolParts.length ? commonTools : -1;
++  const snapshot: DeepSeekCacheProbeSnapshot = {
++    id: randomUUID().slice(0, 8),
++    envelopeHash: hashDeepSeekCacheProbeValue(serializeDeepSeekCacheProbeValue(envelope)),
++    messageParts,
++    payloadHash: hashDeepSeekCacheProbeValue(serializeDeepSeekCacheProbeValue(payloadRecord)),
++    toolParts,
++    toolsHash: hashDeepSeekCacheProbeValue(serializeDeepSeekCacheProbeValue(tools)),
++  };
++
++  log.warn(
++    `${DEEPSEEK_CACHE_PROBE_LOG_PREFIX} request id=${snapshot.id} session=${sessionHash} ` +
++      `model=${params.model.provider}/${params.model.id} messages=${messages.length} ` +
++      `tools=${tools.length} payloadHash=${snapshot.payloadHash} ` +
++      `envelopeHash=${snapshot.envelopeHash} toolsHash=${snapshot.toolsHash} ` +
++      `previous=${previous?.id ?? "none"} previousMessages=${previous?.messageParts.length ?? 0} ` +
++      `commonMessages=${commonMessages} firstDiff=${firstDiff} ` +
++      `previousTools=${previous?.toolParts.length ?? 0} commonTools=${commonTools} ` +
++      `firstToolDiff=${firstToolDiff} ` +
++      `previousEnvelopeHash=${previous?.envelopeHash ?? "none"} ` +
++      `previousToolsHash=${previous?.toolsHash ?? "none"} ` +
++      `previousInput=${previous?.usage?.input ?? -1} previousCacheRead=${previous?.usage?.cacheRead ?? -1}`,
++  );
++  log.warn(`${DEEPSEEK_CACHE_PROBE_LOG_PREFIX} messages id=${snapshot.id} ${messageManifest}`);
++  if (previous && firstDiff >= 0) {
++    log.warn(
++      `${DEEPSEEK_CACHE_PROBE_LOG_PREFIX} diff id=${snapshot.id} index=${firstDiff} ` +
++        `previous=${previous.messageParts[firstDiff] ?? "missing"} ` +
++        `current=${messageParts[firstDiff] ?? "missing"}`,
++    );
++  }
++  if (previous && firstToolDiff >= 0) {
++    log.warn(
++      `${DEEPSEEK_CACHE_PROBE_LOG_PREFIX} toolDiff id=${snapshot.id} index=${firstToolDiff} ` +
++        `previous=${previous.toolParts[firstToolDiff] ?? "missing"} ` +
++        `current=${toolParts[firstToolDiff] ?? "missing"}`,
++    );
++  }
++
++  rememberDeepSeekCacheProbeSnapshot(key, snapshot);
++  return { snapshot };
++}
++
++function logDeepSeekCacheProbeResult(
++  handle: DeepSeekCacheProbeHandle | undefined,
++  output: MutableAssistantOutput,
++): void {
++  if (!handle) {
++    return;
++  }
++  const input = output.usage.input ?? 0;
++  const cacheRead = output.usage.cacheRead ?? 0;
++  const promptTokens = input + cacheRead;
++  const hitPercent = promptTokens > 0 ? ((cacheRead / promptTokens) * 100).toFixed(1) : "0.0";
++  handle.snapshot.usage = { input, cacheRead };
++  log.warn(
++    `${DEEPSEEK_CACHE_PROBE_LOG_PREFIX} result id=${handle.snapshot.id} ` +
++      `stopReason=${output.stopReason} input=${input} cacheRead=${cacheRead} ` +
++      `promptTokens=${promptTokens} hitPercent=${hitPercent}`,
++  );
++}
++
+ type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };
+ type OpenAIResponsesReasoningReplayMetadata = {
+   v: 1;
+@@ -2829,6 +3011,7 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
+     const eventStream = createAssistantMessageEventStream();
+     const stream = eventStream as unknown as { push(event: unknown): void; end(): void };
+     void (async () => {
++      let cacheProbe: DeepSeekCacheProbeHandle | undefined;
+       const output: MutableAssistantOutput = {
+         role: "assistant" as const,
+         content: [],
+@@ -2869,6 +3052,11 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
+         if (compat.requiresNonEmptyUserOrAssistantMessage) {
+           assertOpenAICompletionsPayloadHasConversationTurn(params, model);
+         }
++        cacheProbe = logDeepSeekCacheRequestProbe({
++          model,
++          options: options as OpenAICompletionsOptions | undefined,
++          payload: params,
++        });
+         const emitReasoning = shouldEmitOpenAICompletionsReasoning(
+           model as OpenAIModeModel,
+           options as OpenAICompletionsOptions | undefined,
+@@ -2885,10 +3073,12 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
+         if (options?.signal?.aborted) {
+           throw new Error("Request was aborted");
+         }
++        logDeepSeekCacheProbeResult(cacheProbe, output);
+         stream.push({ type: "done", reason: output.stopReason as never, message: output as never });
+         stream.end();
+       } catch (error) {
+         assignTransportErrorDetails(output, error, options?.signal);
++        logDeepSeekCacheProbeResult(cacheProbe, output);
+         stream.push({ type: "error", reason: output.stopReason as never, error: output as never });
+         stream.end();
+       }

--- a/specs/bugfixes/deepseek-cache-stability/2026-07-02-deepseek-cache-probe-design.md
+++ b/specs/bugfixes/deepseek-cache-stability/2026-07-02-deepseek-cache-probe-design.md
@@ -1,0 +1,166 @@
+# DeepSeek 长会话缓存稳定性修复设计文档
+
+## 1. 概述
+
+### 1.1 问题
+
+LobsterAI 的 DeepSeek V4 Flash / Pro 长会话出现 prompt cache 命中率从 90% 以上下降到约 50% 的情况。用户侧表现为短输入和连续工具调用仍产生较高积分消耗。
+
+本地会话 `0df7bfb2-4015-49b9-8977-8a4d0bcf9efe` 已观察到稳定坏形态：
+
+- 2026-07-02 17:06 至 17:11，连续调用命中率约为 91% 至 99%。
+- 17:12 出现上游 error 后，17:14 至 17:16 的 `cacheRead` 固定在 78,592 tokens，命中率约为 49%。
+- 17:24 的新 user turn 首次调用恢复至 95.8%，进入工具循环后又固定在约 50%。
+- 17:46 的新 user turn 首次调用只有 4.2%，后续工具循环稳定在约 50%。
+
+初始 trajectory 只能证明缓存断点存在，无法确定最终 provider payload 中首个变化字段。为此增加最终 provider payload 指纹探针，并在 2026-07-02 19:10 的复现中定位到实际变化源。
+
+### 1.2 根因
+
+OpenClaw v2026.6.1 在实时请求组装时，同时执行两层 tool result 截断：
+
+1. 单条 tool result 不超过 64,000 字符；
+2. 全部 tool result 合计不超过 `4 × 64,000 = 256,000` 字符。
+
+第二层聚合预算会在每次 LLM 调用前重新计算，并优先削减最旧的 tool result。随着工具循环产生新结果，同一条历史消息被连续改写：
+
+```text
+message[46]: 40,886 -> 40,454 -> 39,715 -> 30,920 bytes
+```
+
+这破坏了 DeepSeek 基于请求前缀的 prompt cache。实测中 system message、238 个 tool 定义和其他顶层参数保持不变，但相邻请求从历史 `message[46]` 开始不同，缓存命中率仅为 49.6% 至 52.4%。对应 gateway 日志在同一请求前明确记录：
+
+```text
+[tool-result-truncation] Truncated 31 tool result(s) for prompt history
+(maxChars=64000 aggregateBudgetChars=256000)
+```
+
+因此，本次低缓存并非 system prompt 动态段、tool schema、套餐代理或 `stopReason=error/aborted` replay 导致；error/aborted 只是较早的怀疑方向，不是这次已复现坏 case 的根因。
+
+### 1.3 已排除项
+
+1. 五次 run 的 system prompt 均为 49,622 字符，hash 均为 `5476a5b39b30...`。
+2. skills prompt hash、tool schema 字符数和 trajectory 中保留的 tool fingerprint 均一致。
+3. OpenClaw pinned commit 的共享 `transformMessages()` 已过滤 `stopReason=error` 和 `stopReason=aborted`；额外 provider 过滤属于重复逻辑。
+4. 本分支先前移植的 [openclaw/openclaw#95311](https://github.com/openclaw/openclaw/pull/95311) 尚未证明能解决 LobsterAI 的实际坏 case，且会改变 DeepSeek 请求布局，因此本轮已移除。
+5. 19:10 复现中，最终请求的 system message hash、`envelopeHash`、`toolsHash` 和全部 238 个 tool 定义在连续调用间保持一致。
+
+相关背景：
+
+- [openclaw/openclaw#94518](https://github.com/openclaw/openclaw/issues/94518)
+- [openclaw/openclaw#95311](https://github.com/openclaw/openclaw/pull/95311)
+- [openclaw/openclaw@a60947fb3e](https://github.com/openclaw/openclaw/commit/a60947fb3e92f45ea7eb2581da8877b10a8bebb2)
+- [netease-youdao/LobsterAI#2219](https://github.com/netease-youdao/LobsterAI/pull/2219)
+
+## 2. 目标
+
+1. 在不记录消息正文、tool schema 或凭证的前提下，定位相邻 DeepSeek V4 请求的首个结构差异。
+2. 区分 system/message replay、tool inventory 和其他顶层参数变化。
+3. 将请求指纹与 provider 返回的 `input`、`cacheRead` 和 `stopReason` 关联。
+4. 同时覆盖直接 DeepSeek 和 `lobsterai-server` 套餐 DeepSeek V4 模型。
+5. 保证实时请求中未变化的历史 tool result 保持字节稳定，同时继续限制单条超大结果和保留 overflow recovery 能力。
+
+## 3. 实现方案
+
+诊断 patch：
+
+```text
+scripts/patches/v2026.6.1/zz-openclaw-deepseek-cache-probe.patch
+```
+
+诊断点位于 `openai-transport-stream.ts`：完成 `onPayload`、code-mode 和兼容性调整后，在 OpenAI SDK 发出最终请求前记录 request probe；stream 完成或失败时记录 result probe。
+
+仅当 `provider/model` 标识匹配 DeepSeek V4 时启用。日志统一使用：
+
+```text
+[DeepSeekCacheProbe]
+```
+
+请求日志字段：
+
+| 字段 | 含义 |
+|---|---|
+| `payloadHash` | 最终请求对象的 SHA-256 截断值 |
+| `envelopeHash` | 排除 `messages`、`tools` 后的顶层参数指纹 |
+| `toolsHash` | 完整有序 tools 数组指纹 |
+| `commonMessages` | 当前请求与上一请求从第 0 条开始完全相同的 message 数量 |
+| `firstDiff` | 首个变化的 message 下标；`-1` 表示上一请求 messages 是当前请求的完整前缀 |
+| `commonTools` | 相邻请求相同的 tool 前缀数量 |
+| `firstToolDiff` | 首个变化的 tool 下标 |
+| message manifest | 每条 message 的 `index:role:utf8Bytes:hash`，不含正文 |
+
+结果日志记录 `input`、`cacheRead`、`promptTokens`、命中率和 `stopReason`。request/result 通过八位 probe id 关联。
+
+进程内最多保留 100 个 session/model 快照，避免诊断状态无界增长。
+
+### 3.1 修复 patch
+
+```text
+scripts/patches/v2026.6.1/openclaw-live-tool-result-cache-stability.patch
+```
+
+该 patch 定向移植上游提交 `a60947fb3e` 的缓存稳定性改动：
+
+- 实时 prompt projection 传入 `aggregateMaxCharsOverride=null`，关闭会随历史增长而重新分配的聚合截断；
+- 继续对每条 tool result 应用 `toolResultMaxChars`，DeepSeek V4 当前仍为 64,000 字符；
+- 持久化 session recovery 和 context overflow recovery 继续使用聚合预算，不改变其防溢出行为；
+- 增加“历史增长后既有 projection 保持字节一致”的回归测试。
+
+这不是关闭 tool result 防护。它只把固定总预算从正常实时请求路径移除，避免为了节省尚未溢出的上下文而反复改写可缓存历史；真正接近上下文上限时仍由既有 precheck、compaction 和 recovery 处理。
+
+## 4. 复现与修复验证
+
+1. 重新构建并启动 OpenClaw runtime。
+2. 打开上述已有长会话，发送短消息，例如“继续阅读”。
+3. 允许模型连续执行数次 read/exec 工具调用，不要在首个调用后立即停止。
+4. 在 gateway 日志中筛选：
+
+```powershell
+Select-String -Path "$env:APPDATA\LobsterAI\openclaw\logs\gateway-*.log" -Pattern '\[DeepSeekCacheProbe\]'
+```
+
+5. 按相同 probe id 对齐 request、messages、diff/toolDiff 和 result。
+
+修复前预期可见：
+
+- `[tool-result-truncation]` 包含 `aggregateBudgetChars=256000`；
+- 连续 tool loop 的 `firstDiff` 落在既有历史 tool message；
+- 该 message 的字节数逐轮减少；
+- `hitPercent` 维持在约 50%。
+
+修复后预期可见：
+
+- 实时截断日志不再包含 `aggregateBudgetChars`；
+- 未超过单条 64,000 字符上限的历史 tool message 不再被截断；
+- 相邻请求的既有 messages 构成完整稳定前缀，通常表现为 `firstDiff=-1`；
+- 缓存命中率随新增尾部消息小幅变化，而不再固定丢失约一半前缀。
+
+## 5. 判读规则
+
+| 现象 | 优先排查方向 |
+|---|---|
+| `firstDiff=0` | system/developer message 构造变化 |
+| `firstDiff=1` 或首条历史 user 变化 | user-turn 时间戳、内容形态或 instruction replacement |
+| 首个变化为历史 assistant/tool | reasoning、tool call ID/arguments 或 tool result replay |
+| `firstDiff=-1` 且 `toolsHash` 不变 | LobsterAI payload 前缀稳定，继续排查套餐代理或 DeepSeek cache backend |
+| `firstToolDiff>=0` | tool 动态注册、排序或 schema 序列化变化 |
+| `envelopeHash` 变化 | reasoning effort、tool choice、采样参数等顶层字段变化 |
+
+## 6. 安全与边界
+
+- 不输出消息正文、tool description/schema、API key、URL query 或 headers。
+- session id 只输出 SHA-256 截断值。
+- hash 用于同一进程内比较，不作为安全签名。
+- 使用 warn 级别是为了确保本地复现日志可见；定位完成后应删除该 patch，不随正式修复长期保留。
+- 正式保留的是 `openclaw-live-tool-result-cache-stability.patch`；诊断 patch 仅用于本轮端侧复验。
+
+## 7. 验收标准
+
+1. 全部 OpenClaw version patch 可从 clean pinned commit 顺序应用。
+2. `src/agents/embedded-agent-runner/tool-result-truncation.test.ts` 通过新增的字节稳定性用例。
+3. `src/agents/openai-transport-stream.test.ts` 通过。
+4. 连续新增 tool result 时，既有实时 prompt projection 不发生二次截断或 hash 变化。
+5. 单条超过 `toolResultMaxChars` 的结果仍被截断，持久化和 overflow recovery 的聚合保护仍然生效。
+6. 非 DeepSeek V4 模型不产生 probe 日志。
+7. 直接 DeepSeek V4 和套餐 DeepSeek V4 均产生 request/result 日志。
+8. 日志不包含用户正文和 tool schema 原文。


### PR DESCRIPTION
## Summary

- disable aggregate tool-result rewriting on the live prompt path so unchanged history remains byte-stable for provider prefix caches
- retain the per-result size cap and existing persisted-session / overflow recovery protections
- keep a privacy-safe DeepSeek V4 cache probe for diagnosing future direct and package-model cache regressions
- add strong patch sentinels and document the reproduction evidence, root cause, implementation, and verification procedure

## Root cause

OpenClaw v2026.6.1 reapplied a 256,000-character aggregate budget to all historical tool results before every LLM call. As new tool results were appended, older results were repeatedly shortened. In the reproduced session, one historical tool message changed from 40,886 to 40,454, 39,715, and then 30,920 bytes, breaking DeepSeek's prefix cache at the same position on every call. Observed cache hit rates stayed around 49.6%-52.4% while the system prompt, request envelope, and all 238 tool definitions remained stable.

The fix ports upstream OpenClaw commit [a60947fb3e](https://github.com/openclaw/openclaw/commit/a60947fb3e92f45ea7eb2581da8877b10a8bebb2). It disables aggregate rewriting only for live prompt projection; individual tool results remain capped and recovery paths retain aggregate protection.

Related upstream context: [openclaw/openclaw#94518](https://github.com/openclaw/openclaw/issues/94518), [openclaw/openclaw#95311](https://github.com/openclaw/openclaw/pull/95311).

## Verification

- all 18 version-scoped OpenClaw patches apply from clean pinned v2026.6.1
- tool-result truncation coverage: 2 test files, 76 tests passed
- OpenAI transport probe coverage: 245 tests passed
- formatting checks passed for touched OpenClaw TypeScript files
- patch strong validators passed

## Electron / runtime impact

This changes the bundled OpenClaw request assembly path only. It does not change renderer UI, IPC, LobsterAI storage, provider payload layout, or billing logic. The diagnostic probe records hashes, roles, byte counts, cache usage, and stop reasons; it does not log message contents or tool schemas.