### PR TITLE
fix(cowork): repair subagent panel timestamps

### DIFF
--- a/src/main/libs/agentEngine/subagentTracker.test.ts
+++ b/src/main/libs/agentEngine/subagentTracker.test.ts
@@ -205,6 +205,42 @@ test('onSessionDeleted removes subagent runs and messages for the parent session
   expect(runStore.getSubagentRun('run-2')).not.toBeNull();
 });
 
+test('getSubTaskHistory preserves persisted message timestamps', async () => {
+  const gatewayClient: GatewayClientLike = {
+    request: vi.fn().mockResolvedValue({ messages: [] }),
+  };
+  const tracker = new SubagentTracker(runStore, messageStore, () => gatewayClient);
+  runStore.insertSubagentRun({
+    id: 'run-1',
+    parentSessionId: 'parent-1',
+    sessionKey: 'agent:main:subagent:run-1',
+    agentId: 'worker',
+    task: 'inspect files',
+    label: 'worker',
+    status: 'done',
+    createdAt: 1000,
+  });
+  messageStore.insertMessages('run-1', [{
+    id: 'message-1',
+    type: 'assistant',
+    content: 'done',
+    timestamp: 1001,
+    sequence: 1,
+  }]);
+  runStore.markMessagesPersisted('run-1');
+
+  const messages = await tracker.getSubTaskHistory('parent-1', 'run-1');
+
+  expect(messages).toEqual([{
+    id: 'message-1',
+    type: 'assistant',
+    content: 'done',
+    timestamp: 1001,
+    metadata: undefined,
+  }]);
+  expect(gatewayClient.request).not.toHaveBeenCalled();
+});
+
 test('deleted subagent run is not reinserted by late spawn results', async () => {
   const tracker = new SubagentTracker(runStore, messageStore, () => null);
   tracker.onToolStart('run-1', {

--- a/src/main/subagentMessageStore.ts
+++ b/src/main/subagentMessageStore.ts
@@ -57,7 +57,19 @@ export class SubagentMessageStore {
    */
   getMessages(runId: string): SubagentMessage[] {
     return this.db
-      .prepare('SELECT * FROM subagent_messages WHERE run_id = ? ORDER BY sequence ASC')
+      .prepare(`
+        SELECT
+          id,
+          run_id AS runId,
+          type,
+          content,
+          metadata,
+          created_at AS createdAt,
+          sequence
+        FROM subagent_messages
+        WHERE run_id = ?
+        ORDER BY sequence ASC
+      `)
       .all(runId) as SubagentMessage[];
   }
 

--- a/src/renderer/components/cowork/SubagentTurnLinks.tsx
+++ b/src/renderer/components/cowork/SubagentTurnLinks.tsx
@@ -35,7 +35,7 @@ const SubagentTurnLinks: React.FC<SubagentTurnLinksProps> = ({
           type="button"
           onClick={() => onSelectSubagent(subagent)}
           className="inline-flex h-8 max-w-full items-center gap-2 rounded-full border border-border bg-background px-3 text-sm text-secondary shadow-sm transition-colors hover:border-primary/40 hover:text-foreground"
-          title={subagent.task || getDisplayName(subagent)}
+          aria-label={getDisplayName(subagent)}
         >
           <span
             className={`h-2 w-2 shrink-0 rounded-full ${

--- a/src/renderer/utils/tokenFormat.test.ts
+++ b/src/renderer/utils/tokenFormat.test.ts
@@ -59,3 +59,8 @@ test('formatMessageDateTime: always shows YYYY/MM/DD + time', () => {
   expect(result).toBe('2026/05/07 17:02');
   vi.useRealTimers();
 });
+
+test('message time formatting returns empty string for invalid timestamps', () => {
+  expect(formatMessageTime(Number.NaN)).toBe('');
+  expect(formatMessageDateTime(Number.NaN)).toBe('');
+});

--- a/src/renderer/utils/tokenFormat.ts
+++ b/src/renderer/utils/tokenFormat.ts
@@ -1,5 +1,9 @@
+const isValidDate = (date: Date): boolean => Number.isFinite(date.getTime());
+
 export function formatMessageTime(timestamp: number): string {
   const date = new Date(timestamp);
+  if (!isValidDate(date)) return '';
+
   const now = new Date();
   const time = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
 
@@ -18,6 +22,8 @@ export function formatMessageTime(timestamp: number): string {
 
 export function formatMessageDateTime(timestamp: number): string {
   const date = new Date(timestamp);
+  if (!isValidDate(date)) return '';
+
   const pad = (value: number): string => String(value).padStart(2, '0');
 
   return `${date.getFullYear()}/${pad(date.getMonth() + 1)}/${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;


### PR DESCRIPTION
## Summary
- remove the native hover tooltip from subagent turn chips
- alias persisted subagent message timestamps correctly when reading SQLite rows
- guard message time formatting against invalid timestamps

## Verification
- npm test -- src/renderer/utils/tokenFormat.test.ts src/main/libs/agentEngine/subagentTracker.test.ts
- npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/agentEngine/subagentTracker.test.ts src/main/subagentMessageStore.ts src/renderer/components/cowork/SubagentTurnLinks.tsx src/renderer/utils/tokenFormat.ts src/renderer/utils/tokenFormat.test.ts
- git diff --check