### PR TITLE
fix(mcp): clear stale transport config

### DIFF
--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -2009,4 +2009,33 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(result.changedTopLevelKeys).toContain('mcp');
     expect(result.restartImpact).toBe(OpenClawConfigImpact.Restart);
   });
+
+  test('writes all remote MCP headers to openclaw config', async () => {
+    const sync = await createSync({
+      getResolvedMcpServers: () => [{
+        name: 'Remote MCP',
+        transportType: 'http',
+        url: 'https://mcp.example.com/stream',
+        headers: {
+          Authorization: 'Bearer test-token',
+          'X-Tenant-Id': 'tenant-123',
+          'X-Client-Id': 'client-456',
+        },
+      }],
+    });
+
+    const result = sync.sync('mcp-server-updated');
+
+    expect(result.ok).toBe(true);
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.mcp.servers['Remote MCP']).toMatchObject({
+      url: 'https://mcp.example.com/stream',
+      transport: 'streamable-http',
+      headers: {
+        authorization: 'Bearer test-token',
+        'x-tenant-id': 'tenant-123',
+        'x-client-id': 'client-456',
+      },
+    });
+  });
 });

--- a/src/main/mcp/mcpStore.test.ts
+++ b/src/main/mcp/mcpStore.test.ts
@@ -1,0 +1,121 @@
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { McpStore } from './mcpStore';
+
+describe('McpStore', () => {
+  let db: Database.Database | undefined;
+  let store: McpStore;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE mcp_servers (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        description TEXT NOT NULL DEFAULT '',
+        enabled INTEGER NOT NULL DEFAULT 1,
+        transport_type TEXT NOT NULL DEFAULT 'stdio',
+        config_json TEXT NOT NULL DEFAULT '{}',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE mcp_launch_resolutions (
+        server_id TEXT PRIMARY KEY,
+        resolver_kind TEXT NOT NULL,
+        source_fingerprint TEXT NOT NULL,
+        status TEXT NOT NULL,
+        package_name TEXT,
+        requested_version TEXT,
+        resolved_version TEXT,
+        install_dir TEXT,
+        command TEXT,
+        args_json TEXT,
+        env_json TEXT,
+        error TEXT,
+        installed_at INTEGER,
+        resolved_at INTEGER,
+        last_probe_at INTEGER,
+        last_probe_status TEXT,
+        updated_at INTEGER NOT NULL
+      );
+    `);
+    store = new McpStore(db);
+  });
+
+  afterEach(() => {
+    db?.close();
+    db = undefined;
+  });
+
+  test('clears remote headers when update passes an empty headers object', () => {
+    const server = store.createServer({
+      name: 'remote',
+      description: '',
+      transportType: 'http',
+      url: 'https://mcp.example.com',
+      headers: {
+        Authorization: 'Bearer token',
+        'X-Tenant-Id': 'tenant-123',
+      },
+    });
+
+    const updated = store.updateServer(server.id, { headers: {} });
+
+    expect(updated?.headers).toBeUndefined();
+    expect(updated?.url).toBe('https://mcp.example.com');
+  });
+
+  test('drops stale remote fields when switching to stdio', () => {
+    const server = store.createServer({
+      name: 'switchable',
+      description: '',
+      transportType: 'http',
+      url: 'https://mcp.example.com',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    const updated = store.updateServer(server.id, {
+      transportType: 'stdio',
+      command: 'node',
+      args: ['server.js'],
+      env: { API_KEY: 'key' },
+    });
+
+    expect(updated).toMatchObject({
+      transportType: 'stdio',
+      command: 'node',
+      args: ['server.js'],
+      env: { API_KEY: 'key' },
+    });
+    expect(updated?.url).toBeUndefined();
+    expect(updated?.headers).toBeUndefined();
+  });
+
+  test('drops stale stdio fields when switching to remote', () => {
+    const server = store.createServer({
+      name: 'stdio-server',
+      description: '',
+      transportType: 'stdio',
+      command: 'node',
+      args: ['server.js'],
+      env: { API_KEY: 'key' },
+    });
+
+    const updated = store.updateServer(server.id, {
+      transportType: 'sse',
+      url: 'https://mcp.example.com/sse',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(updated).toMatchObject({
+      transportType: 'sse',
+      url: 'https://mcp.example.com/sse',
+      headers: { Authorization: 'Bearer token' },
+    });
+    expect(updated?.command).toBeUndefined();
+    expect(updated?.args).toBeUndefined();
+    expect(updated?.env).toBeUndefined();
+  });
+});

--- a/src/main/mcp/mcpStore.ts
+++ b/src/main/mcp/mcpStore.ts
@@ -219,6 +219,23 @@ export class McpStore {
     return JSON.stringify(config);
   }
 
+  private normalizeTransportConfig(data: McpServerFormData): McpServerFormData {
+    if (data.transportType === 'stdio') {
+      return {
+        ...data,
+        url: undefined,
+        headers: undefined,
+      };
+    }
+
+    return {
+      ...data,
+      command: undefined,
+      args: undefined,
+      env: undefined,
+    };
+  }
+
   listServers(): McpServerRecord[] {
     const rows = this.db
       .prepare(
@@ -241,14 +258,15 @@ export class McpStore {
   createServer(data: McpServerFormData): McpServerRecord {
     const id = crypto.randomUUID();
     const now = Date.now();
-    const configJson = this.serializeConfig(data);
+    const normalized = this.normalizeTransportConfig(data);
+    const configJson = this.serializeConfig(normalized);
 
     this.db
       .prepare(
         `INSERT INTO mcp_servers (id, name, description, enabled, transport_type, config_json, created_at, updated_at)
        VALUES (?, ?, ?, 1, ?, ?, ?, ?)`,
       )
-      .run(id, data.name, data.description, data.transportType, configJson, now, now);
+      .run(id, normalized.name, normalized.description, normalized.transportType, configJson, now, now);
 
     return this.getServer(id)!;
   }
@@ -258,7 +276,7 @@ export class McpStore {
     if (!existing) return null;
 
     const now = Date.now();
-    const merged: McpServerFormData = {
+    const merged = this.normalizeTransportConfig({
       name: data.name ?? existing.name,
       description: data.description ?? existing.description,
       transportType: data.transportType ?? existing.transportType,
@@ -270,7 +288,7 @@ export class McpStore {
       isBuiltIn: data.isBuiltIn !== undefined ? data.isBuiltIn : existing.isBuiltIn,
       githubUrl: data.githubUrl !== undefined ? data.githubUrl : existing.githubUrl,
       registryId: data.registryId !== undefined ? data.registryId : existing.registryId,
-    };
+    });
 
     const configJson = this.serializeConfig(merged);
 

--- a/src/renderer/components/mcp/McpServerFormModal.tsx
+++ b/src/renderer/components/mcp/McpServerFormModal.tsx
@@ -184,11 +184,11 @@ const McpServerFormModal: React.FC<McpServerFormModalProps> = ({
 
     if (transportType === 'stdio') {
       data.command = command.trim();
-      if (args.length > 0) data.args = args;
-      if (Object.keys(env).length > 0) data.env = env;
+      data.args = args;
+      data.env = env;
     } else {
       data.url = normalizedUrl;
-      if (Object.keys(headers).length > 0) data.headers = headers;
+      data.headers = headers;
     }
 
     // Attach registry metadata if installing from registry


### PR DESCRIPTION
## Summary
- Normalize MCP server config by transport type so stale headers/env/args are cleared when editing or switching transport.
- Send empty header/env/arg objects from the MCP form so clearing fields is persisted.
- Add coverage for clearing stale MCP fields and syncing multiple remote headers to OpenClaw config.

## Verification
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/mcp/mcpStore.ts src/main/mcp/mcpStore.test.ts src/renderer/components/mcp/McpServerFormModal.tsx src/main/libs/openclawConfigSync.runtime.test.ts`
- `git diff --check`

## Notes
- `npm test -- mcpStore openclawConfigSync.runtime`, `npx vitest run mcpStore openclawConfigSync.runtime`, and `npm run compile:electron` were blocked locally because `node_modules/better-sqlite3/build/Release/better_sqlite3.node` was locked by a running process / compiled for the Electron ABI while the Node test runner needed the Node ABI.