### PR TITLE
feat(openclaw): add heartbeat toggle setting

### DIFF
--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -953,6 +953,12 @@ test('getConfig defaults skipMissedJobs to true when config is missing', () => {
   expect(config.skipMissedJobs).toBe(true);
 });
 
+test('getConfig defaults OpenClaw heartbeat to enabled when config is missing', () => {
+  const config = store.getConfig();
+
+  expect(config.openClawHeartbeatEnabled).toBe(true);
+});
+
 test('backfillEmptyAgentModels assigns the current default model to empty agents only', () => {
   const now = Date.now();
   db.prepare(

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -544,6 +544,7 @@ export interface CoworkConfig {
   memoryGuardLevel: CoworkMemoryGuardLevel;
   memoryUserMemoriesMaxItems: number;
   skipMissedJobs: boolean;
+  openClawHeartbeatEnabled: boolean;
   embeddingEnabled: boolean;
   embeddingProvider: string;
   embeddingModel: string;
@@ -568,6 +569,7 @@ CoworkConfig,
   | 'memoryGuardLevel'
   | 'memoryUserMemoriesMaxItems'
   | 'skipMissedJobs'
+  | 'openClawHeartbeatEnabled'
   | 'embeddingEnabled'
   | 'embeddingProvider'
   | 'embeddingModel'
@@ -1999,6 +2001,7 @@ export class CoworkStore {
       'memoryGuardLevel',
       'memoryUserMemoriesMaxItems',
       'skipMissedJobs',
+      'openClawHeartbeatEnabled',
       'embeddingEnabled',
       'embeddingProvider',
       'embeddingModel',
@@ -2036,6 +2039,7 @@ export class CoworkStore {
         Number(cfg.get('memoryUserMemoriesMaxItems')),
       ),
       skipMissedJobs: parseBooleanConfig(cfg.get('skipMissedJobs'), true),
+      openClawHeartbeatEnabled: parseBooleanConfig(cfg.get('openClawHeartbeatEnabled'), true),
       embeddingEnabled: parseBooleanConfig(cfg.get('embeddingEnabled'), DEFAULT_EMBEDDING_ENABLED),
       embeddingProvider: cfg.get('embeddingProvider') || DEFAULT_EMBEDDING_PROVIDER,
       embeddingModel: cfg.get('embeddingModel') || DEFAULT_EMBEDDING_MODEL,
@@ -2079,6 +2083,9 @@ export class CoworkStore {
     }
     if (config.skipMissedJobs !== undefined) {
       this.upsertConfig('skipMissedJobs', config.skipMissedJobs ? '1' : '0', now);
+    }
+    if (config.openClawHeartbeatEnabled !== undefined) {
+      this.upsertConfig('openClawHeartbeatEnabled', config.openClawHeartbeatEnabled ? '1' : '0', now);
     }
     if (config.embeddingEnabled !== undefined) {
       this.upsertConfig('embeddingEnabled', config.embeddingEnabled ? '1' : '0', now);

--- a/src/main/libs/openclawConfigImpact.test.ts
+++ b/src/main/libs/openclawConfigImpact.test.ts
@@ -165,6 +165,18 @@ describe('OpenClaw config impact classification', () => {
     });
   });
 
+  test('classifies OpenClaw heartbeat changes as sync', () => {
+    const result = classifyCoworkConfigChange(
+      { openClawHeartbeatEnabled: true },
+      { openClawHeartbeatEnabled: false },
+    );
+
+    expect(result).toEqual({
+      impact: OpenClawConfigImpact.Sync,
+      reasons: [OpenClawConfigImpactReason.CoworkOpenClawConfig],
+    });
+  });
+
   test('classifies dreaming changes as restart', () => {
     const result = classifyCoworkConfigChange(
       { dreamingEnabled: false, dreamingFrequency: '0 3 * * *' },

--- a/src/main/libs/openclawConfigImpact.ts
+++ b/src/main/libs/openclawConfigImpact.ts
@@ -63,6 +63,7 @@ const COWORK_SYNC_FIELDS = new Set([
   'agentEngine',
   'workingDirectory',
   'skipMissedJobs',
+  'openClawHeartbeatEnabled',
   'embeddingEnabled',
   'embeddingProvider',
   'embeddingModel',

--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -231,6 +231,50 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(config.agents.defaults.mediaMaxMb).toBe(30);
   });
 
+  test('enables optimized OpenClaw heartbeat by default', async () => {
+    const sync = await createSync();
+
+    const result = sync.sync('heartbeat-enabled-default');
+    expect(result.ok).toBe(true);
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.agents.defaults.heartbeat).toEqual({
+      every: '1h',
+      target: 'none',
+      lightContext: true,
+      isolatedSession: true,
+    });
+  });
+
+  test('writes disabled OpenClaw heartbeat cadence when user disables heartbeat', async () => {
+    const sync = await createSync({
+      getCoworkConfig: () => ({
+        workingDirectory: tmpDir,
+        systemPrompt: '',
+        executionMode: 'local',
+        agentEngine: 'openclaw',
+        memoryEnabled: false,
+        memoryImplicitUpdateEnabled: false,
+        memoryLlmJudgeEnabled: false,
+        memoryGuardLevel: 'balanced',
+        memoryUserMemoriesMaxItems: 100,
+        skipMissedJobs: false,
+        openClawHeartbeatEnabled: false,
+      }),
+    });
+
+    const result = sync.sync('heartbeat-disabled');
+    expect(result.ok).toBe(true);
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.agents.defaults.heartbeat).toEqual({
+      every: '0m',
+      target: 'none',
+      lightContext: true,
+      isolatedSession: true,
+    });
+  });
+
   test('writes model provider env-proxy transport when system proxy is enabled', async () => {
     const { setSystemProxyEnabled } = await import('./systemProxy');
     setSystemProxyEnabled(true);

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -87,6 +87,8 @@ const mapExecutionModeToSandboxMode = (
  * Also used by the runtime adapter's client-side timeout watchdog.
  */
 export const OPENCLAW_AGENT_TIMEOUT_SECONDS = 3600;
+export const OPENCLAW_HEARTBEAT_EVERY_ENABLED = '1h';
+export const OPENCLAW_HEARTBEAT_EVERY_DISABLED = '0m';
 const DINGTALK_OPENCLAW_CHANNEL = 'dingtalk-connector';
 export const OPENCLAW_BINDING_ANY_ACCOUNT_ID = '*';
 const OPENCLAW_DEFAULT_MODEL_MAX_TOKENS = 8192;
@@ -1853,7 +1855,9 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
             },
           } : {}),
           heartbeat: {
-            every: '1h',
+            every: coworkConfig.openClawHeartbeatEnabled === false
+              ? OPENCLAW_HEARTBEAT_EVERY_DISABLED
+              : OPENCLAW_HEARTBEAT_EVERY_ENABLED,
             target: 'none',
             lightContext: true,
             isolatedSession: true,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7757,6 +7757,7 @@ if (!gotTheLock) {
     memoryGuardLevel?: 'strict' | 'standard' | 'relaxed';
     memoryUserMemoriesMaxItems?: number;
     skipMissedJobs?: boolean;
+    openClawHeartbeatEnabled?: boolean;
     embeddingEnabled?: boolean;
     embeddingProvider?: string;
     embeddingModel?: string;
@@ -7797,6 +7798,9 @@ if (!gotTheLock) {
       const normalizedSkipMissedJobs = typeof config.skipMissedJobs === 'boolean'
         ? config.skipMissedJobs
         : undefined;
+      const normalizedOpenClawHeartbeatEnabled = typeof config.openClawHeartbeatEnabled === 'boolean'
+        ? config.openClawHeartbeatEnabled
+        : undefined;
       const normalizedEmbedding = normalizeEmbeddingConfig(config);
       const normalizedConfig: Parameters<CoworkStore['setConfig']>[0] = {
         ...config,
@@ -7808,6 +7812,7 @@ if (!gotTheLock) {
         memoryGuardLevel: normalizedMemoryGuardLevel,
         memoryUserMemoriesMaxItems: normalizedMemoryUserMemoriesMaxItems,
         skipMissedJobs: normalizedSkipMissedJobs,
+        openClawHeartbeatEnabled: normalizedOpenClawHeartbeatEnabled,
         ...normalizedEmbedding,
       };
       const previousConfig = getCoworkStore().getConfig();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -458,6 +458,7 @@ contextBridge.exposeInMainWorld('electron', {
       memoryGuardLevel?: 'strict' | 'standard' | 'relaxed';
       memoryUserMemoriesMaxItems?: number;
       skipMissedJobs?: boolean;
+      openClawHeartbeatEnabled?: boolean;
       embeddingEnabled?: boolean;
       embeddingProvider?: string;
       embeddingModel?: string;

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1654,6 +1654,7 @@ const Settings: React.FC<SettingsProps> = ({
   const [coworkMemoryEnabled, setCoworkMemoryEnabled] = useState<boolean>(coworkConfig.memoryEnabled ?? true);
   const [coworkMemoryLlmJudgeEnabled, setCoworkMemoryLlmJudgeEnabled] = useState<boolean>(coworkConfig.memoryLlmJudgeEnabled ?? false);
   const [skipMissedJobs, setSkipMissedJobs] = useState<boolean>(coworkConfig.skipMissedJobs ?? true);
+  const [openClawHeartbeatEnabled, setOpenClawHeartbeatEnabled] = useState<boolean>(coworkConfig.openClawHeartbeatEnabled ?? true);
   const [embeddingEnabled, setEmbeddingEnabled] = useState<boolean>(coworkConfig.embeddingEnabled ?? false);
   const [embeddingProvider, setEmbeddingProvider] = useState<string>(coworkConfig.embeddingProvider ?? 'openai');
   const [embeddingModel, setEmbeddingModel] = useState<string>(coworkConfig.embeddingModel ?? '');
@@ -1691,6 +1692,7 @@ const Settings: React.FC<SettingsProps> = ({
     setCoworkMemoryEnabled(coworkConfig.memoryEnabled ?? true);
     setCoworkMemoryLlmJudgeEnabled(coworkConfig.memoryLlmJudgeEnabled ?? false);
     setSkipMissedJobs(coworkConfig.skipMissedJobs ?? true);
+    setOpenClawHeartbeatEnabled(coworkConfig.openClawHeartbeatEnabled ?? true);
     setEmbeddingEnabled(coworkConfig.embeddingEnabled ?? false);
     setEmbeddingProvider(coworkConfig.embeddingProvider ?? 'openai');
     setEmbeddingModel(coworkConfig.embeddingModel ?? '');
@@ -1709,6 +1711,7 @@ const Settings: React.FC<SettingsProps> = ({
     coworkConfig.memoryLlmJudgeEnabled,
     coworkConfig.openClawSessionPolicy?.keepAlive,
     coworkConfig.skipMissedJobs,
+    coworkConfig.openClawHeartbeatEnabled,
     coworkConfig.embeddingEnabled,
     coworkConfig.embeddingProvider,
     coworkConfig.embeddingModel,
@@ -2635,6 +2638,7 @@ const Settings: React.FC<SettingsProps> = ({
     || coworkMemoryEnabled !== coworkConfig.memoryEnabled
     || coworkMemoryLlmJudgeEnabled !== coworkConfig.memoryLlmJudgeEnabled
     || skipMissedJobs !== (coworkConfig.skipMissedJobs ?? true)
+    || openClawHeartbeatEnabled !== (coworkConfig.openClawHeartbeatEnabled ?? true)
     || openClawSessionKeepAlive !== (coworkConfig.openClawSessionPolicy?.keepAlive || OpenClawSessionKeepAliveValues.ThirtyDays)
     || embeddingEnabled !== (coworkConfig.embeddingEnabled ?? false)
     || embeddingProvider !== (coworkConfig.embeddingProvider ?? 'openai')
@@ -3154,6 +3158,7 @@ const Settings: React.FC<SettingsProps> = ({
         ? normalizeProvidersForSettingsSave(previousConfig.providers as ProvidersConfig)
         : normalizedProviders;
       const previousSkipMissedJobs = coworkConfig.skipMissedJobs ?? true;
+      const previousOpenClawHeartbeatEnabled = coworkConfig.openClawHeartbeatEnabled ?? true;
       const previousAgentEngine = coworkConfig.agentEngine || 'openclaw';
       const previousOpenClawSessionKeepAlive = coworkConfig.openClawSessionPolicy?.keepAlive
         || OpenClawSessionKeepAliveValues.ThirtyDays;
@@ -3269,6 +3274,7 @@ const Settings: React.FC<SettingsProps> = ({
           memoryEnabled: coworkMemoryEnabled,
           memoryLlmJudgeEnabled: coworkMemoryLlmJudgeEnabled,
           skipMissedJobs,
+          openClawHeartbeatEnabled,
           embeddingEnabled,
           embeddingProvider,
           embeddingModel,
@@ -3355,6 +3361,13 @@ const Settings: React.FC<SettingsProps> = ({
         }
         if (previousAgentEngine !== coworkAgentEngine) {
           reportAgentEngineSettingChanged('agentEngine', coworkAgentEngine, previousAgentEngine);
+        }
+        if (previousOpenClawHeartbeatEnabled !== openClawHeartbeatEnabled) {
+          reportAgentEngineSettingChanged(
+            'openClawHeartbeatEnabled',
+            openClawHeartbeatEnabled,
+            previousOpenClawHeartbeatEnabled,
+          );
         }
         if (previousOpenClawSessionKeepAlive !== openClawSessionKeepAlive) {
           reportAgentEngineSettingChanged(
@@ -4634,6 +4647,23 @@ const Settings: React.FC<SettingsProps> = ({
                         )}
                       </div>
                     </div>
+                  </div>
+                </section>
+
+                <section className="space-y-3">
+                  <h4 className="text-sm font-medium text-foreground">
+                    {i18nService.t('openClawBackgroundRuntimeTitle')}
+                  </h4>
+
+                  <div className="rounded-xl border border-border bg-surface p-4">
+                    <SettingsToggleRow
+                      title={i18nService.t('openClawHeartbeatEnabled')}
+                      description={i18nService.t('openClawHeartbeatEnabledDescription')}
+                      checked={openClawHeartbeatEnabled}
+                      onToggle={() => {
+                        setOpenClawHeartbeatEnabled((prev) => !prev);
+                      }}
+                    />
                   </div>
                 </section>
 

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -792,6 +792,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkAgentEngineOpenClaw: 'OpenClaw（默认）',
     coworkAgentEngineOpenClawHint: '个人 AI 助理',
     openClawRuntimeStatusTitle: '运行状态',
+    openClawBackgroundRuntimeTitle: '后台运行',
+    openClawHeartbeatEnabled: '启用 OpenClaw 心跳',
+    openClawHeartbeatEnabledDescription:
+      '开启后 OpenClaw 会每 1 小时自动检查一次后台提醒和任务状态。关闭后可减少空闲时的 token 消耗，但提醒、任务完成通知等后台更新可能延迟或无法主动触达。',
     openClawGatewayAddress: '网关地址',
     openClawStartupProgressLabel: '启动进度',
     openClawStatusBadgeReady: '已就绪',
@@ -3521,6 +3525,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkAgentEngineOpenClaw: 'OpenClaw (Default)',
     coworkAgentEngineOpenClawHint: 'Personal AI assistant',
     openClawRuntimeStatusTitle: 'Runtime status',
+    openClawBackgroundRuntimeTitle: 'Background runtime',
+    openClawHeartbeatEnabled: 'Enable OpenClaw heartbeat',
+    openClawHeartbeatEnabledDescription:
+      'When enabled, OpenClaw checks background reminders and task status once every 1 hour. Turning it off can reduce idle token usage, but reminders, task completion notifications, and other background updates may be delayed or may not be delivered proactively.',
     openClawGatewayAddress: 'Gateway address',
     openClawStartupProgressLabel: 'Startup progress',
     openClawStatusBadgeReady: 'Ready',

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -43,6 +43,7 @@ test('defaults hidden OpenClaw session policy to thirty days', () => {
     keepAlive: '30d',
   });
   expect(state.config.skipMissedJobs).toBe(true);
+  expect(state.config.openClawHeartbeatEnabled).toBe(true);
 });
 
 test('setConfig preserves loaded OpenClaw session policy', () => {
@@ -57,6 +58,7 @@ test('setConfig preserves loaded OpenClaw session policy', () => {
     memoryGuardLevel: 'strict',
     memoryUserMemoriesMaxItems: 12,
     skipMissedJobs: false,
+    openClawHeartbeatEnabled: false,
     embeddingEnabled: false,
     embeddingProvider: 'openai',
     embeddingModel: '',
@@ -74,6 +76,7 @@ test('setConfig preserves loaded OpenClaw session policy', () => {
   }));
 
   expect(state.config.openClawSessionPolicy.keepAlive).toBe('365d');
+  expect(state.config.openClawHeartbeatEnabled).toBe(false);
 });
 
 test('updateCurrentSessionModelOverride only patches the active session', () => {

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -115,6 +115,7 @@ const initialState: CoworkState = {
     memoryGuardLevel: 'strict',
     memoryUserMemoriesMaxItems: 12,
     skipMissedJobs: true,
+    openClawHeartbeatEnabled: true,
     embeddingEnabled: false,
     embeddingProvider: 'openai',
     embeddingModel: '',

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -180,6 +180,7 @@ export interface CoworkConfig {
   memoryGuardLevel: 'strict' | 'standard' | 'relaxed';
   memoryUserMemoriesMaxItems: number;
   skipMissedJobs: boolean;
+  openClawHeartbeatEnabled: boolean;
   embeddingEnabled: boolean;
   embeddingProvider: string;
   embeddingModel: string;
@@ -205,6 +206,7 @@ export type CoworkConfigUpdate = Partial<Pick<
   | 'memoryGuardLevel'
   | 'memoryUserMemoriesMaxItems'
   | 'skipMissedJobs'
+  | 'openClawHeartbeatEnabled'
   | 'embeddingEnabled'
   | 'embeddingProvider'
   | 'embeddingModel'

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -153,6 +153,7 @@ interface CoworkConfig {
   memoryGuardLevel: 'strict' | 'standard' | 'relaxed';
   memoryUserMemoriesMaxItems: number;
   skipMissedJobs: boolean;
+  openClawHeartbeatEnabled: boolean;
   embeddingEnabled: boolean;
   embeddingProvider: string;
   embeddingModel: string;
@@ -175,6 +176,7 @@ type CoworkConfigUpdate = Partial<
     | 'memoryGuardLevel'
     | 'memoryUserMemoriesMaxItems'
     | 'skipMissedJobs'
+    | 'openClawHeartbeatEnabled'
     | 'embeddingEnabled'
     | 'embeddingProvider'
     | 'embeddingModel'


### PR DESCRIPTION
## Summary
- add a Settings > Agent Engine toggle for OpenClaw heartbeat, enabled by default
- persist the preference through Cowork config and sync it into `agents.defaults.heartbeat.every`
- write `1h` when enabled and `0m` when disabled, preserving the existing `target: none`, `lightContext`, and `isolatedSession` optimization

## Notes
- OpenClaw documents `agents.defaults.heartbeat.every: 0m` as the disable path.
- The UI copy keeps the explanation focused on the 1-hour default cadence, token savings, and delayed/missing proactive background notifications when disabled.

## Verification
- `npm test -- coworkStore coworkSlice openclawConfigImpact openclawConfigSync.runtime`
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/coworkStore.ts src/main/coworkStore.test.ts src/main/main.ts src/main/preload.ts src/main/libs/openclawConfigImpact.ts src/main/libs/openclawConfigImpact.test.ts src/main/libs/openclawConfigSync.ts src/main/libs/openclawConfigSync.runtime.test.ts src/renderer/components/Settings.tsx src/renderer/services/i18n.ts src/renderer/store/slices/coworkSlice.ts src/renderer/store/slices/coworkSlice.test.ts src/renderer/types/cowork.ts src/renderer/types/electron.d.ts`
- `npm run compile:electron`
- `npm run build`