### PR TITLE
fix(plugins): hide bundled xai plugin from sync

### DIFF
--- a/src/main/plugins/pluginManager.test.ts
+++ b/src/main/plugins/pluginManager.test.ts
@@ -14,7 +14,7 @@ vi.mock('electron', () => ({
 
 vi.mock('../libs/nodeRuntime', () => nodeRuntimeMocks);
 
-import { __pluginManagerTestUtils } from './pluginManager';
+import { __pluginManagerTestUtils, isHiddenUserPluginId } from './pluginManager';
 
 afterEach(() => {
   nodeRuntimeMocks.resolveNodePackageCliCommand.mockReset();
@@ -31,4 +31,8 @@ test('resolveNpmCommand delegates to shared npm runtime resolution', () => {
 
   expect(__pluginManagerTestUtils.resolveNpmCommand()).toBe(resolved);
   expect(nodeRuntimeMocks.resolveNodePackageCliCommand).toHaveBeenCalledWith('npm');
+});
+
+test('hides OpenClaw built-in xai provider plugin from user plugin sync', () => {
+  expect(isHiddenUserPluginId('xai')).toBe(true);
 });

--- a/src/main/plugins/pluginManager.ts
+++ b/src/main/plugins/pluginManager.ts
@@ -845,6 +845,7 @@ const INTERNAL_PLUGIN_IDS = [
   // Provider plugins auto-injected by OpenClaw runtime — not user-installable.
   // Keep in sync with OpenClawProviderId in src/shared/providers/constants.ts.
   'google',
+  'xai',
   'anthropic',
   'openai',
   'openai-codex',


### PR DESCRIPTION
## Summary
- add the OpenClaw built-in xai provider plugin to the hidden plugin sync list
- add coverage for hiding xai from user plugin sync

## Verification
- npm test -- pluginManager
- npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/plugins/pluginManager.ts src/main/plugins/pluginManager.test.ts