### PR TITLE
fix(cowork): prevent stale final sync from restarting context mainten…

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -4202,6 +4202,82 @@ test('chat error clears context maintenance after compaction starts', () => {
   ))).toBe(true);
 });
 
+test('chat error prevents stale empty final history sync from restarting context maintenance', async () => {
+  let markHistoryRequested: (() => void) | undefined;
+  const historyRequested = new Promise<void>((resolve) => {
+    markHistoryRequested = resolve;
+  });
+  let resolveHistory: (() => void) | undefined;
+  const historyCanReturn = new Promise<void>((resolve) => {
+    resolveHistory = resolve;
+  });
+  const { session, store } = createReconcileStore([
+    { id: 'msg-1', type: 'user', content: '整理一下未读邮件', timestamp: 1, metadata: {} },
+    { id: 'msg-2', type: 'tool_use', content: 'Using imap.js', timestamp: 2, metadata: { toolUseId: 'call-1' } },
+    { id: 'msg-3', type: 'tool_result', content: 'mailbox list', timestamp: 3, metadata: { toolUseId: 'call-1' } },
+  ]);
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const sessionKey = `agent:main:lobsterai:${session.id}`;
+  const maintenanceSpy = vi.fn();
+  const errorSpy = vi.fn();
+
+  adapter.gatewayClient = {
+    start: () => {},
+    stop: () => {},
+    request: async (method: string) => {
+      if (method !== 'chat.history') return {};
+      markHistoryRequested?.();
+      await historyCanReturn;
+      return {
+        messages: [
+          { role: 'user', content: '整理一下未读邮件' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'toolCall', id: 'call-1', name: 'exec', arguments: { command: 'node scripts/imap.js list-mailboxes' } },
+            ],
+          },
+          { role: 'toolResult', toolCallId: 'call-1', content: 'mailbox list' },
+        ],
+      };
+    },
+  };
+
+  session.status = 'running';
+  adapter.on('contextMaintenance', maintenanceSpy);
+  adapter.on('error', errorSpy);
+  const turn = createActiveTurn(session.id, sessionKey, 'run-email-timeout');
+  turn.toolUseMessageIdByToolCallId.set('call-1', 'msg-2');
+  turn.toolResultMessageIdByToolCallId.set('call-1', 'msg-3');
+  adapter.activeTurns.set(session.id, turn);
+  adapter.sessionIdByRunId.set('run-email-timeout', session.id);
+
+  const finalPromise = adapter.handleChatFinal(session.id, turn, {
+    state: 'final',
+    runId: 'run-email-timeout',
+    sessionKey,
+    message: { role: 'assistant', content: '' },
+  });
+  await historyRequested;
+
+  adapter.handleChatEvent({
+    state: 'error',
+    runId: 'run-email-timeout',
+    sessionKey,
+    errorMessage: 'LLM request failed.',
+    providerRuntimeFailureKind: 'timeout',
+    rawErrorPreview: 'LLM idle timeout (120s): no response from model',
+  }, 2);
+
+  resolveHistory?.();
+  await finalPromise;
+
+  expect(session.status).toBe('error');
+  expect(adapter.activeTurns.has(session.id)).toBe(false);
+  expect(errorSpy).toHaveBeenCalledWith(session.id, expect.stringContaining('网络连接失败'));
+  expect(maintenanceSpy).not.toHaveBeenCalledWith(session.id, true);
+});
+
 test('compaction stream reuses active structured message for duplicate start events', () => {
   const { session, store } = createReconcileStore([
     { id: 'msg-1', type: 'user', content: 'continue the task', timestamp: 1, metadata: {} },

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -2553,6 +2553,16 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       pendingVisibleFinalContinuation?: boolean;
     },
   ): void {
+    if (this.activeTurns.get(sessionId) !== turn || turn.stopRequested) {
+      console.debug(
+        '[OpenClawRuntime] skipped recoverable follow-up wait for stale turn.',
+        `sessionId=${sessionId}`,
+        `runId=${runId}`,
+        `reason=${options.reason}`,
+      );
+      return;
+    }
+
     turn.pendingRecoverableFollowup = true;
     turn.pendingOpenClawRetry = true;
     turn.lastRecoverableFinalAtMs = Date.now();


### PR DESCRIPTION


Guard recoverable follow-up waits against stale turns after chat errors, so late empty-final history syncs cannot return errored sessions to a context maintenance state.

Add regression coverage for timeout errors racing with empty final history sync.

