### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ The renderer dev server runs at `http://localhost:5175`.
 
 ```bash
 # Production renderer bundle
+
+[![Listed on TakoAPI](https://takoapi.com/api/badge/netease-youdao-lobsterai)](https://takoapi.com/agents/netease-youdao-lobsterai)
+
 npm run build
 
 # Electron main/preload TypeScript build


### PR DESCRIPTION
Hi! 👋 **LobsterAI** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/netease-youdao-lobsterai

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building LobsterAI! 🙏