### PR TITLE
fix(openclaw): default memory search to local FTS

### DIFF
--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -221,6 +221,45 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(config.models.pricing).toEqual({ enabled: false });
   });
 
+  test('defaults memory search to local FTS-only when embeddings are disabled', async () => {
+    const sync = await createSync({
+      getCoworkConfig: () => ({
+        workingDirectory: tmpDir,
+        systemPrompt: '',
+        executionMode: 'local',
+        agentEngine: 'openclaw',
+        memoryEnabled: true,
+        memoryImplicitUpdateEnabled: false,
+        memoryLlmJudgeEnabled: false,
+        memoryGuardLevel: 'balanced',
+        memoryUserMemoriesMaxItems: 100,
+        skipMissedJobs: false,
+        embeddingEnabled: false,
+        embeddingProvider: 'openai',
+        embeddingModel: '',
+        embeddingLocalModelPath: '',
+        embeddingVectorWeight: 0.7,
+        embeddingRemoteBaseUrl: '',
+        embeddingRemoteApiKey: '',
+      }),
+    });
+
+    const result = sync.sync('memory-search-default-fts');
+    expect(result.ok).toBe(true);
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.agents.defaults.memorySearch).toMatchObject({
+      enabled: true,
+      provider: 'none',
+      fallback: 'none',
+      store: {
+        fts: { tokenizer: 'trigram' },
+        vector: { enabled: false },
+      },
+    });
+    expect(config.agents.defaults.memorySearch.remote).toBeUndefined();
+  });
+
   test('configures OpenClaw chat image attachment limit to 30MB', async () => {
     const sync = await createSync();
 

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -1854,30 +1854,35 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
           workspace: path.resolve(mainWorkspacePath),
           mediaMaxMb: 30,
           ...(taskWorkingDirectory ? { cwd: path.resolve(taskWorkingDirectory) } : {}),
-          ...(coworkConfig.embeddingEnabled ? {
-            memorySearch: {
-              enabled: true,
-              provider: (['openai', 'gemini', 'voyage', 'mistral', 'ollama'].includes(coworkConfig.embeddingProvider)
+          memorySearch: {
+            enabled: true,
+            provider: coworkConfig.embeddingEnabled
+              ? (['openai', 'gemini', 'voyage', 'mistral', 'ollama'].includes(coworkConfig.embeddingProvider)
                 ? coworkConfig.embeddingProvider
-                : 'openai'),
-              ...(coworkConfig.embeddingModel ? { model: coworkConfig.embeddingModel } : {}),
+                : 'openai')
+              : 'none',
+            ...(coworkConfig.embeddingEnabled && coworkConfig.embeddingModel ? { model: coworkConfig.embeddingModel } : {}),
+            ...(coworkConfig.embeddingEnabled ? {
               remote: {
                 ...(coworkConfig.embeddingRemoteBaseUrl ? { baseUrl: coworkConfig.embeddingRemoteBaseUrl } : {}),
                 ...(coworkConfig.embeddingRemoteApiKey ? { apiKey: coworkConfig.embeddingRemoteApiKey } : {}),
-              },
-              store: {
-                // Use trigram tokenizer for FTS5 — unicode61 (the openclaw default)
-                // cannot tokenize CJK characters, so Chinese/Japanese/Korean memory
-                // content is invisible to keyword search.
-                fts: { tokenizer: 'trigram' },
               },
               query: {
                 hybrid: {
                   vectorWeight: coworkConfig.embeddingVectorWeight ?? 0.7,
                 },
               },
+            } : {
+              fallback: 'none',
+            }),
+            store: {
+              // Use trigram tokenizer for FTS5 — unicode61 (the openclaw default)
+              // cannot tokenize CJK characters, so Chinese/Japanese/Korean memory
+              // content is invisible to keyword search.
+              fts: { tokenizer: 'trigram' },
+              ...(!coworkConfig.embeddingEnabled ? { vector: { enabled: false } } : {}),
             },
-          } : {}),
+          },
           heartbeat: {
             every: coworkConfig.openClawHeartbeatEnabled === false
               ? OPENCLAW_HEARTBEAT_EVERY_DISABLED

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -19,6 +19,7 @@ import {
 import { getCodexHomeDir } from './openaiCodexAuth';
 import { migrateLegacyCronStorageWithDoctor } from './openclawCronLegacyMigration';
 import { cleanupStaleThirdPartyPluginsFromBundledDir, listLocalOpenClawExtensionIds,syncLocalOpenClawExtensionsIntoRuntime } from './openclawLocalExtensions';
+import { migrateMainFtsOnlyMemoryIndex } from './openclawMemoryIndexMigration';
 import { ensureOpenClawWorkerShims } from './openclawWorkerShims';
 import { appendPythonRuntimeToEnv } from './pythonRuntime';
 
@@ -594,6 +595,14 @@ export class OpenClawEngineManager extends EventEmitter {
 
     await migrateLegacyCronStorageWithDoctor({
       stateDir: this.stateDir,
+      runtimeRoot: runtime.root,
+      electronNodeRuntimePath,
+      env,
+    });
+
+    await migrateMainFtsOnlyMemoryIndex({
+      stateDir: this.stateDir,
+      configPath: this.configPath,
       runtimeRoot: runtime.root,
       electronNodeRuntimePath,
       env,

--- a/src/main/libs/openclawMemoryIndexMigration.test.ts
+++ b/src/main/libs/openclawMemoryIndexMigration.test.ts
@@ -1,0 +1,281 @@
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  type MemoryIndexMigrationRunner,
+  migrateMainFtsOnlyMemoryIndex,
+  resolveMainMemoryIndexMigrationNeed,
+} from './openclawMemoryIndexMigration';
+
+let tmpDir = '';
+let stateDir = '';
+let runtimeRoot = '';
+let configPath = '';
+let dbPath = '';
+let electronNodeRuntimePath = '';
+
+function mkdirp(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function writeFile(filePath: string, content: string): void {
+  mkdirp(path.dirname(filePath));
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+function writeConfig(memorySearch: Record<string, unknown>, agentMemorySearch?: Record<string, unknown>): void {
+  const mainAgent: Record<string, unknown> = { id: 'main', default: true };
+  if (agentMemorySearch) {
+    mainAgent.memorySearch = agentMemorySearch;
+  }
+  writeFile(
+    configPath,
+    `${JSON.stringify({
+      gateway: { mode: 'local' },
+      agents: {
+        defaults: {
+          workspace: path.join(stateDir, 'workspace-main'),
+          memorySearch,
+        },
+        list: [mainAgent],
+      },
+    }, null, 2)}\n`,
+  );
+}
+
+function writeIndexMeta(meta: Record<string, unknown> | null): void {
+  mkdirp(path.dirname(dbPath));
+  const db = new Database(dbPath);
+  try {
+    db.exec('CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)');
+    if (meta) {
+      db
+        .prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)')
+        .run('memory_index_meta_v1', JSON.stringify(meta));
+    }
+  } finally {
+    db.close();
+  }
+}
+
+function writeEmptySqlite(): void {
+  mkdirp(path.dirname(dbPath));
+  const db = new Database(dbPath);
+  db.close();
+}
+
+function ftsOnlyMemorySearch(): Record<string, unknown> {
+  return {
+    enabled: true,
+    provider: 'none',
+    fallback: 'none',
+    store: {
+      fts: { tokenizer: 'trigram' },
+      vector: { enabled: false },
+    },
+  };
+}
+
+describe('openclawMemoryIndexMigration', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lobsterai-openclaw-memory-migration-'));
+    stateDir = path.join(tmpDir, 'openclaw', 'state');
+    runtimeRoot = path.join(tmpDir, 'runtime');
+    configPath = path.join(stateDir, 'openclaw.json');
+    dbPath = path.join(stateDir, 'memory', 'main.sqlite');
+    electronNodeRuntimePath = process.execPath;
+    mkdirp(runtimeRoot);
+    writeFile(path.join(runtimeRoot, 'openclaw.mjs'), 'console.log("openclaw");\n');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('skips when config still uses an embedding provider', async () => {
+    writeConfig({
+      enabled: true,
+      provider: 'gemini',
+      model: 'gemini-embedding-001',
+      store: { fts: { tokenizer: 'trigram' } },
+    });
+    writeIndexMeta({
+      model: 'gemini-embedding-001',
+      provider: 'gemini',
+      ftsTokenizer: 'trigram',
+    });
+    const runner = vi.fn<MemoryIndexMigrationRunner>();
+
+    const result = await migrateMainFtsOnlyMemoryIndex({
+      stateDir,
+      configPath,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: {},
+      runner,
+    });
+
+    expect(result).toEqual({ status: 'skipped', reason: 'not-fts-only-config' });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  test('skips when main agent overrides defaults with an embedding provider', async () => {
+    writeConfig(ftsOnlyMemorySearch(), {
+      enabled: true,
+      provider: 'gemini',
+      model: 'gemini-embedding-001',
+      store: { fts: { tokenizer: 'trigram' } },
+    });
+    writeIndexMeta({
+      model: 'gemini-embedding-001',
+      provider: 'gemini',
+      ftsTokenizer: 'trigram',
+    });
+
+    expect(resolveMainMemoryIndexMigrationNeed({ configPath, stateDir })).toEqual({
+      shouldMigrate: false,
+      reason: 'not-fts-only-config',
+    });
+  });
+
+  test('skips when FTS-only index metadata is current', async () => {
+    writeConfig(ftsOnlyMemorySearch());
+    writeIndexMeta({
+      model: 'fts-only',
+      provider: 'none',
+      ftsTokenizer: 'trigram',
+    });
+    const runner = vi.fn<MemoryIndexMigrationRunner>();
+
+    const result = await migrateMainFtsOnlyMemoryIndex({
+      stateDir,
+      configPath,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: {},
+      runner,
+    });
+
+    expect(result).toEqual({ status: 'skipped', reason: 'index-meta-current' });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  test('runs official forced reindex when old embedding metadata exists under FTS-only config', async () => {
+    writeConfig(ftsOnlyMemorySearch());
+    writeIndexMeta({
+      model: 'gemini-embedding-001',
+      provider: 'gemini',
+      ftsTokenizer: 'unicode61',
+    });
+    const runner = vi.fn<MemoryIndexMigrationRunner>().mockResolvedValue({
+      code: 0,
+      stdout: 'updated',
+      stderr: '',
+    });
+
+    const result = await migrateMainFtsOnlyMemoryIndex({
+      stateDir,
+      configPath,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: { EXISTING: '1' },
+      runner,
+    });
+
+    expect(result.status).toBe('migrated');
+    expect(runner).toHaveBeenCalledTimes(1);
+    const [command, args, options] = runner.mock.calls[0];
+    expect(command).toBe(electronNodeRuntimePath);
+    expect(args).toEqual([
+      path.join(runtimeRoot, 'openclaw.mjs'),
+      'memory',
+      'index',
+      '--force',
+      '--agent',
+      'main',
+    ]);
+    expect(options.cwd).toBe(runtimeRoot);
+    expect(options.timeoutMs).toBeGreaterThan(0);
+    expect(options.env.EXISTING).toBe('1');
+    expect(options.env.OPENCLAW_HOME).toBe(path.dirname(stateDir));
+    expect(options.env.OPENCLAW_STATE_DIR).toBe(stateDir);
+    expect(options.env.OPENCLAW_CONFIG_PATH).toBe(configPath);
+    expect(options.env.ELECTRON_RUN_AS_NODE).toBe('1');
+  });
+
+  test('runs forced reindex when metadata is missing', async () => {
+    writeConfig(ftsOnlyMemorySearch());
+    writeIndexMeta(null);
+
+    expect(resolveMainMemoryIndexMigrationNeed({ configPath, stateDir })).toMatchObject({
+      shouldMigrate: true,
+      dbPath,
+      reason: 'index metadata is missing',
+    });
+  });
+
+  test('runs forced reindex when sqlite meta table is missing', async () => {
+    writeConfig(ftsOnlyMemorySearch());
+    writeEmptySqlite();
+
+    expect(resolveMainMemoryIndexMigrationNeed({ configPath, stateDir })).toMatchObject({
+      shouldMigrate: true,
+      dbPath,
+      reason: 'index metadata is missing',
+    });
+  });
+
+  test('skips when bundled OpenClaw CLI is missing', async () => {
+    fs.rmSync(path.join(runtimeRoot, 'openclaw.mjs'), { force: true });
+    writeConfig(ftsOnlyMemorySearch());
+    writeIndexMeta({
+      model: 'gemini-embedding-001',
+      provider: 'gemini',
+      ftsTokenizer: 'unicode61',
+    });
+    const runner = vi.fn<MemoryIndexMigrationRunner>();
+
+    const result = await migrateMainFtsOnlyMemoryIndex({
+      stateDir,
+      configPath,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: {},
+      runner,
+    });
+
+    expect(result).toEqual({ status: 'skipped', reason: 'missing-openclaw-cli' });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  test('returns failed when forced reindex exits non-zero', async () => {
+    writeConfig(ftsOnlyMemorySearch());
+    writeIndexMeta({
+      model: 'gemini-embedding-001',
+      provider: 'gemini',
+      ftsTokenizer: 'unicode61',
+    });
+    const runner = vi.fn<MemoryIndexMigrationRunner>().mockResolvedValue({
+      code: 2,
+      stdout: '',
+      stderr: 'failed',
+    });
+
+    const result = await migrateMainFtsOnlyMemoryIndex({
+      stateDir,
+      configPath,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: {},
+      runner,
+    });
+
+    expect(result).toEqual({ status: 'failed', code: 2 });
+  });
+});

--- a/src/main/libs/openclawMemoryIndexMigration.ts
+++ b/src/main/libs/openclawMemoryIndexMigration.ts
@@ -1,0 +1,321 @@
+import Database from 'better-sqlite3';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const MEMORY_INDEX_REBUILD_TIMEOUT_MS = 180_000;
+const LOG_TAIL_LIMIT = 4_000;
+const MEMORY_INDEX_META_KEY = 'memory_index_meta_v1';
+const MAIN_AGENT_ID = 'main';
+
+export type MemoryIndexMigrationRunResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+export type MemoryIndexMigrationRunner = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    timeoutMs: number;
+  },
+) => Promise<MemoryIndexMigrationRunResult>;
+
+export type MemoryIndexMigrationResult =
+  | {
+      status: 'skipped';
+      reason: MemoryIndexMigrationSkippedReason;
+    }
+  | { status: 'migrated'; code: number | null; reason: string }
+  | { status: 'failed'; code: number | null; error?: string };
+
+export type MemoryIndexMigrationSkippedReason =
+  | 'missing-config'
+  | 'invalid-config'
+  | 'not-fts-only-config'
+  | 'missing-openclaw-cli'
+  | 'no-index-db'
+  | 'index-meta-current';
+
+type JsonRecord = Record<string, unknown>;
+
+type MemoryIndexMeta = {
+  model?: string;
+  provider?: string;
+  ftsTokenizer?: string;
+};
+
+export type MemoryIndexMigrationNeed =
+  | { shouldMigrate: false; reason: MemoryIndexMigrationSkippedReason }
+  | { shouldMigrate: true; dbPath: string; reason: string };
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readJsonFile(filePath: string): JsonRecord | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function findAgentEntry(config: JsonRecord, agentId: string): JsonRecord | null {
+  const agents = isRecord(config.agents) ? config.agents : null;
+  const list = Array.isArray(agents?.list) ? agents.list : [];
+  for (const entry of list) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    if (entry.id === agentId) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+function resolveMainMemorySearchConfig(config: JsonRecord): JsonRecord | null {
+  const agents = isRecord(config.agents) ? config.agents : null;
+  const defaults = isRecord(agents?.defaults) ? agents.defaults : null;
+  const defaultMemorySearch = isRecord(defaults?.memorySearch) ? defaults.memorySearch : null;
+  const mainAgent = findAgentEntry(config, MAIN_AGENT_ID);
+  const mainMemorySearch = isRecord(mainAgent?.memorySearch) ? mainAgent.memorySearch : null;
+  return mainMemorySearch ?? defaultMemorySearch;
+}
+
+function isFtsOnlyMemorySearch(memorySearch: JsonRecord | null): boolean {
+  if (!memorySearch) {
+    return false;
+  }
+  const store = isRecord(memorySearch.store) ? memorySearch.store : {};
+  const vector = isRecord(store.vector) ? store.vector : {};
+  return memorySearch.provider === 'none' && vector.enabled === false;
+}
+
+function resolveFtsTokenizer(memorySearch: JsonRecord): string | undefined {
+  const store = isRecord(memorySearch.store) ? memorySearch.store : {};
+  const fts = isRecord(store.fts) ? store.fts : {};
+  return typeof fts.tokenizer === 'string' && fts.tokenizer.trim()
+    ? fts.tokenizer.trim()
+    : undefined;
+}
+
+function resolveUserPath(filePath: string): string {
+  if (filePath === '~') {
+    return os.homedir();
+  }
+  if (filePath.startsWith(`~${path.sep}`) || filePath.startsWith('~/') || filePath.startsWith('~\\')) {
+    return path.join(os.homedir(), filePath.slice(2));
+  }
+  return path.resolve(filePath);
+}
+
+export function resolveMainMemoryIndexPath(params: {
+  memorySearch: JsonRecord;
+  stateDir: string;
+}): string {
+  const store = isRecord(params.memorySearch.store) ? params.memorySearch.store : {};
+  const configuredPath = typeof store.path === 'string' && store.path.trim()
+    ? store.path.trim().replace(/\{agentId\}/g, MAIN_AGENT_ID)
+    : null;
+  if (configuredPath) {
+    return resolveUserPath(configuredPath);
+  }
+  return path.join(params.stateDir, 'memory', `${MAIN_AGENT_ID}.sqlite`);
+}
+
+function readMemoryIndexMeta(dbPath: string): MemoryIndexMeta | null {
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    let row: { value?: unknown } | undefined;
+    try {
+      row = db
+        .prepare('SELECT value FROM meta WHERE key = ?')
+        .get(MEMORY_INDEX_META_KEY) as { value?: unknown } | undefined;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (/no such table: meta/i.test(message)) {
+        return null;
+      }
+      throw error;
+    }
+    if (typeof row?.value !== 'string' || !row.value.trim()) {
+      return null;
+    }
+    const parsed = JSON.parse(row.value);
+    return isRecord(parsed) ? parsed : null;
+  } finally {
+    db.close();
+  }
+}
+
+export function resolveMainMemoryIndexMigrationNeed(params: {
+  configPath: string;
+  stateDir: string;
+}): MemoryIndexMigrationNeed {
+  if (!fs.existsSync(params.configPath)) {
+    return { shouldMigrate: false, reason: 'missing-config' };
+  }
+
+  const config = readJsonFile(params.configPath);
+  if (!config) {
+    return { shouldMigrate: false, reason: 'invalid-config' };
+  }
+
+  const memorySearch = resolveMainMemorySearchConfig(config);
+  if (!isFtsOnlyMemorySearch(memorySearch)) {
+    return { shouldMigrate: false, reason: 'not-fts-only-config' };
+  }
+
+  const dbPath = resolveMainMemoryIndexPath({
+    memorySearch,
+    stateDir: params.stateDir,
+  });
+  if (!fs.existsSync(dbPath)) {
+    return { shouldMigrate: false, reason: 'no-index-db' };
+  }
+
+  const expectedTokenizer = resolveFtsTokenizer(memorySearch);
+  const meta = readMemoryIndexMeta(dbPath);
+  if (
+    meta?.model === 'fts-only' &&
+    meta.provider === 'none' &&
+    (!expectedTokenizer || meta.ftsTokenizer === expectedTokenizer)
+  ) {
+    return { shouldMigrate: false, reason: 'index-meta-current' };
+  }
+
+  const reason = meta
+    ? `index meta is ${JSON.stringify({
+        model: meta.model,
+        provider: meta.provider,
+        ftsTokenizer: meta.ftsTokenizer,
+      })}, expected fts-only/${expectedTokenizer ?? 'default'}`
+    : 'index metadata is missing';
+  return { shouldMigrate: true, dbPath, reason };
+}
+
+function tailLog(text: string): string {
+  if (text.length <= LOG_TAIL_LIMIT) {
+    return text;
+  }
+  return text.slice(text.length - LOG_TAIL_LIMIT);
+}
+
+export function runProcess(
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    timeoutMs: number;
+  },
+): Promise<MemoryIndexMigrationRunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`OpenClaw memory index migration timed out after ${options.timeoutMs}ms`));
+    }, options.timeoutMs);
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+export async function migrateMainFtsOnlyMemoryIndex(params: {
+  stateDir: string;
+  configPath: string;
+  runtimeRoot: string;
+  electronNodeRuntimePath: string;
+  env: NodeJS.ProcessEnv;
+  runner?: MemoryIndexMigrationRunner;
+}): Promise<MemoryIndexMigrationResult> {
+  let need: MemoryIndexMigrationNeed;
+  try {
+    need = resolveMainMemoryIndexMigrationNeed({
+      configPath: params.configPath,
+      stateDir: params.stateDir,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn('[OpenClaw] Failed to inspect memory index metadata before migration:', error);
+    return { status: 'failed', code: null, error: message };
+  }
+
+  if (need.shouldMigrate === false) {
+    return { status: 'skipped', reason: need.reason };
+  }
+
+  const openclawCliPath = path.join(params.runtimeRoot, 'openclaw.mjs');
+  if (!fs.existsSync(openclawCliPath)) {
+    console.warn(`[OpenClaw] Memory index migration needed but OpenClaw CLI is missing: ${openclawCliPath}`);
+    return { status: 'skipped', reason: 'missing-openclaw-cli' };
+  }
+
+  const runner = params.runner ?? runProcess;
+  const env: NodeJS.ProcessEnv = {
+    ...params.env,
+    OPENCLAW_HOME: path.dirname(params.stateDir),
+    OPENCLAW_STATE_DIR: params.stateDir,
+    OPENCLAW_CONFIG_PATH: params.configPath,
+    ELECTRON_RUN_AS_NODE: '1',
+  };
+  const args = [openclawCliPath, 'memory', 'index', '--force', '--agent', MAIN_AGENT_ID];
+
+  console.log(
+    `[OpenClaw] FTS-only memory index migration needed for ${need.dbPath}; running official reindex: ${JSON.stringify(args.slice(1))}`,
+  );
+  try {
+    const result = await runner(params.electronNodeRuntimePath, args, {
+      cwd: params.runtimeRoot,
+      env,
+      timeoutMs: MEMORY_INDEX_REBUILD_TIMEOUT_MS,
+    });
+
+    if (result.code === 0) {
+      console.log(`[OpenClaw] FTS-only memory index migration completed: ${need.reason}`);
+      return { status: 'migrated', code: result.code, reason: need.reason };
+    }
+
+    console.warn(
+      [
+        `[OpenClaw] FTS-only memory index migration failed with exit code ${result.code}.`,
+        result.stderr ? `stderr tail:\n${tailLog(result.stderr)}` : '',
+        result.stdout ? `stdout tail:\n${tailLog(result.stdout)}` : '',
+      ].filter(Boolean).join('\n'),
+    );
+    return { status: 'failed', code: result.code };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn('[OpenClaw] FTS-only memory index migration failed before gateway startup:', error);
+    return { status: 'failed', code: null, error: message };
+  }
+}


### PR DESCRIPTION
## Summary
- Generate OpenClaw `memorySearch` config even when embedding search is disabled.
- Use provider `none`, fallback `none`, disable vector storage, and keep trigram FTS for the default local keyword-search path.
- Add a gateway-startup migration for upgraded users whose existing memory index was built with an embedding provider: when the current main-agent config is FTS-only and the index meta is stale, run `openclaw memory index --force --agent main` before starting the gateway.
- Keep current embedding-enabled configurations untouched; the migration skips when the effective main-agent memory search config still uses an embedding provider.

## Validation
- `npm test -- openclawConfigSync.runtime`
- `npm test -- openclawMemoryIndexMigration`
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/openclawConfigSync.ts src/main/libs/openclawConfigSync.runtime.test.ts`
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/openclawMemoryIndexMigration.ts src/main/libs/openclawMemoryIndexMigration.test.ts src/main/libs/openclawEngineManager.ts`
- `npm run compile:electron`
- `git diff --check`