### PR TITLE
fix(im): scope channel session mappings by agent

### DIFF
--- a/specs/bugfixes/im-agent-scoped-session-mapping/2026-07-08-im-agent-scoped-session-mapping-fix-design.md
+++ b/specs/bugfixes/im-agent-scoped-session-mapping/2026-07-08-im-agent-scoped-session-mapping-fix-design.md
@@ -1,0 +1,106 @@
+# IM 同群多 Agent 机器人会话映射修复设计文档
+
+## 1. 概述
+
+### 1.1 问题
+
+同一个 IM 群聊中拉入多个机器人，并且这些机器人分别绑定到不同 Agent 时，OpenClaw 可以正确按 `sessionKey` 路由到目标 Agent，但 LobsterAI 本地会话映射只按 `(platform, im_conversation_id)` 查找，导致不同 Agent 的同群会话被压成一条本地 mapping。
+
+典型脱敏 key 形态如下：
+
+```text
+agent:main:feishu:group:oc_622a147f6d4****
+agent:2ebabf09-1718-4137-xxxx-a8789d8a8325:feishu:group:oc_622a147f6d4****
+```
+
+上面两个 key 指向同一个飞书群 `group:oc_622a147f6d4****`，但属于不同 Agent。旧映射会只保留一条：
+
+```text
+platform = feishu
+im_conversation_id = group:oc_622a147f6d4****
+agent_id = main
+```
+
+因此非 main Agent 的群聊消息虽然能在移动端收到回复，但不会同步到正确的 LobsterAI 本地会话。
+
+### 1.2 根因
+
+`OpenClawChannelSessionSync.parseChannelSessionKey()` 能从 `sessionKey` 提取平台和 conversationId，`extractAgentIdFromKey()` 也能提取 Agent ID，但后续持久化查询使用的是旧主键：
+
+```text
+(im_conversation_id, platform)
+```
+
+当两个 key 的 `platform` 和 `im_conversation_id` 相同、`agentId` 不同时，本地映射无法区分它们。
+
+## 2. 用户场景
+
+**Given** 飞书同一个群中有两个机器人，分别绑定 main Agent 和自定义 Agent。
+
+**When** 用户在群里 `@` 自定义 Agent 对应机器人。
+
+**Then** OpenClaw 的 `agent:<agentId>:feishu:group:<chatId>` 会话应同步到该 Agent 名下的 LobsterAI 会话，而不是复用 main Agent 的同群会话。
+
+## 3. 功能需求
+
+### FR-1: 同群不同 Agent 独立映射
+
+`im_session_mappings` 需要支持同一个 `(platform, im_conversation_id)` 下存在多个不同 `agent_id` 的 mapping。
+
+### FR-2: OpenClaw sessionKey 精确优先
+
+同步 channel session 时，优先通过真实 `openclaw_session_key` 命中 mapping；找不到时再按 `(platform, im_conversation_id, agent_id)` 查找。
+
+### FR-3: 历史数据保持可读
+
+迁移旧表时保留现有行，默认使用原有 `agent_id`，没有 agent 字段的历史行使用 `main`。
+
+### FR-4: 列表去重保留不同 Agent
+
+定时任务等 IM 会话列表可以继续按 peer 去重，但不能把同 peer 不同 Agent 的 mapping 合并掉。
+
+## 4. 实现方案
+
+### 4.1 数据模型
+
+`im_session_mappings` 主键从：
+
+```text
+PRIMARY KEY (im_conversation_id, platform)
+```
+
+迁移为：
+
+```text
+PRIMARY KEY (im_conversation_id, platform, agent_id)
+```
+
+同时增加 `openclaw_session_key` 索引，用于快速精确查找真实 OpenClaw channel session。
+
+### 4.2 同步流程
+
+`resolveOrCreateSession(sessionKey)` 使用以下顺序：
+
+1. 跳过 LobsterAI 本地 session key。
+2. 解析 `platform`、`im_conversation_id` 和 `agentId`。
+3. 按 `openclaw_session_key` 精确查找 mapping。
+4. 按 `(platform, im_conversation_id, agentId)` 查找 mapping。
+5. 仅当 legacy mapping 的 `agentId` 与当前 key 的 `agentId` 一致时才复用。
+6. 找不到时，为当前 `agentId` 新建 Cowork session，并创建 agent-scoped mapping。
+
+## 5. 边界情况
+
+| 场景 | 处理方式 |
+|------|----------|
+| 旧库只有 main Agent 的同群 mapping | 继续保留，非 main Agent key 新建独立 mapping |
+| 历史 mapping 没有 `openclaw_session_key` | channel sync 重新发现时按 agent-scoped mapping 回填 |
+| sessionKey 没有 accountId 但有 agentId | 信任 key 中的 agentId，不用平台级绑定把它过滤掉 |
+| 定时任务列表看到同群多 Agent | 按 `agentId + peerKind + peerId` 去重，保留不同 Agent |
+
+## 6. 验收标准
+
+1. 同一个飞书群下 `agent:main:feishu:group:oc_****` 和 `agent:<custom-agent>:feishu:group:oc_****` 会生成两条 mapping。
+2. main Agent 的历史群聊会话不被覆盖或迁移到自定义 Agent。
+3. 自定义 Agent 的群聊消息出现在该 Agent 名下的 LobsterAI 会话。
+4. `openclaw_session_key` 精确查找可以命中正确 mapping。
+5. 定时任务 IM 会话列表不会折叠同群不同 Agent 的 mapping。

--- a/src/main/im/imStore.test.ts
+++ b/src/main/im/imStore.test.ts
@@ -18,7 +18,12 @@ class FakeDb {
 
   pragma(_name: string) {
     // Report migrated columns as already present to skip ALTER TABLE migrations.
-    return [{ name: 'agent_id' }, { name: 'openclaw_session_key' }];
+    return [
+      { name: 'im_conversation_id', pk: 1 },
+      { name: 'platform', pk: 2 },
+      { name: 'agent_id', pk: 3 },
+      { name: 'openclaw_session_key', pk: 0 },
+    ];
   }
 
   prepare(sql: string) {
@@ -50,12 +55,14 @@ class FakeDb {
             created_at: Number(params[5]),
             last_active_at: Number(params[6]),
           };
-          this.mappings.set(this.mappingKey(row.im_conversation_id, row.platform), row);
+          this.mappings.set(this.mappingKey(row.im_conversation_id, row.platform, row.agent_id), row);
           this.writeCount++;
           return;
         }
-        if (sql.includes('UPDATE im_session_mappings SET openclaw_session_key = ?')) {
-          const key = this.mappingKey(String(params[2]), String(params[3]));
+        if (sql.includes('UPDATE im_session_mappings') && sql.includes('SET openclaw_session_key = ?')) {
+          const key = params.length >= 5
+            ? this.mappingKey(String(params[2]), String(params[3]), String(params[4]))
+            : this.findMappingKey(String(params[2]), String(params[3]));
           const row = this.mappings.get(key);
           if (row) {
             row.openclaw_session_key = String(params[0]);
@@ -64,8 +71,10 @@ class FakeDb {
           this.writeCount++;
           return;
         }
-        if (sql.includes('UPDATE im_session_mappings SET cowork_session_id = ?')) {
-          const key = this.mappingKey(String(params[4]), String(params[5]));
+        if (sql.includes('UPDATE im_session_mappings') && sql.includes('SET cowork_session_id = ?')) {
+          const key = params.length >= 7
+            ? this.mappingKey(String(params[4]), String(params[5]), String(params[6]))
+            : this.findMappingKey(String(params[4]), String(params[5]));
           const row = this.mappings.get(key);
           if (row) {
             row.cowork_session_id = String(params[0]);
@@ -78,8 +87,10 @@ class FakeDb {
           this.writeCount++;
           return;
         }
-        if (sql.includes('UPDATE im_session_mappings SET last_active_at = ?')) {
-          const key = this.mappingKey(String(params[1]), String(params[2]));
+        if (sql.includes('UPDATE im_session_mappings') && sql.includes('SET last_active_at = ?')) {
+          const key = params.length >= 4
+            ? this.mappingKey(String(params[1]), String(params[2]), String(params[3]))
+            : this.findMappingKey(String(params[1]), String(params[2]));
           const row = this.mappings.get(key);
           if (row) {
             row.last_active_at = Number(params[0]);
@@ -88,7 +99,16 @@ class FakeDb {
           return;
         }
         if (sql.includes('DELETE FROM im_session_mappings WHERE im_conversation_id = ?')) {
-          this.mappings.delete(this.mappingKey(String(params[0]), String(params[1])));
+          if (params.length >= 3) {
+            this.mappings.delete(this.mappingKey(String(params[0]), String(params[1]), String(params[2])));
+          } else {
+            for (const key of Array.from(this.mappings.keys())) {
+              const row = this.mappings.get(key);
+              if (row?.im_conversation_id === params[0] && row.platform === params[1]) {
+                this.mappings.delete(key);
+              }
+            }
+          }
           this.writeCount++;
           return;
         }
@@ -110,8 +130,15 @@ class FakeDb {
           const value = this.store.get(String(params[0]));
           return value !== undefined ? { value } : undefined;
         }
-        if (sql.includes('FROM im_session_mappings WHERE im_conversation_id = ?')) {
-          return this.mappings.get(this.mappingKey(String(params[0]), String(params[1])));
+        if (sql.includes('FROM im_session_mappings WHERE openclaw_session_key = ?')) {
+          const target = String(params[0]);
+          return Array.from(this.mappings.values()).find(row => row.openclaw_session_key === target);
+        }
+        if (sql.includes('FROM im_session_mappings') && sql.includes('im_conversation_id = ?')) {
+          if (params.length >= 3) {
+            return this.mappings.get(this.mappingKey(String(params[0]), String(params[1]), String(params[2])));
+          }
+          return this.mappings.get(this.findMappingKey(String(params[0]), String(params[1])));
         }
         if (sql.includes('FROM im_session_mappings WHERE cowork_session_id = ?')) {
           const target = String(params[0]);
@@ -131,8 +158,17 @@ class FakeDb {
     };
   }
 
-  private mappingKey(imConversationId: string, platform: string) {
-    return `${platform}\0${imConversationId}`;
+  private mappingKey(imConversationId: string, platform: string, agentId: string) {
+    return `${platform}\0${imConversationId}\0${agentId}`;
+  }
+
+  private findMappingKey(imConversationId: string, platform: string): string {
+    for (const [key, row] of this.mappings.entries()) {
+      if (row.im_conversation_id === imConversationId && row.platform === platform) {
+        return key;
+      }
+    }
+    return this.mappingKey(imConversationId, platform, 'main');
   }
 
   getValue(key: string) {
@@ -208,6 +244,41 @@ test('IMStore persists OpenClaw session keys in IM session mappings', () => {
     coworkSessionId: 'cowork-2',
     agentId: 'agent-2',
     openClawSessionKey: 'agent:agent-2:openclaw-weixin:bot-1:direct:user-1',
+  });
+});
+
+test('IMStore distinguishes the same conversation under different agents', () => {
+  const db = new FakeDb();
+  const store = new IMStore(db as unknown as ConstructorParameters<typeof IMStore>[0]);
+
+  store.createSessionMapping(
+    'group:oc_sanitized',
+    'feishu',
+    'cowork-main',
+    'main',
+    'agent:main:feishu:group:oc_sanitized',
+  );
+  store.createSessionMapping(
+    'group:oc_sanitized',
+    'feishu',
+    'cowork-agent',
+    'agent-2',
+    'agent:agent-2:feishu:group:oc_sanitized',
+  );
+
+  expect(store.getSessionMapping('group:oc_sanitized', 'feishu', 'main')).toMatchObject({
+    coworkSessionId: 'cowork-main',
+    agentId: 'main',
+  });
+  expect(store.getSessionMapping('group:oc_sanitized', 'feishu', 'agent-2')).toMatchObject({
+    coworkSessionId: 'cowork-agent',
+    agentId: 'agent-2',
+  });
+  expect(
+    store.getSessionMappingByOpenClawSessionKey('agent:agent-2:feishu:group:oc_sanitized'),
+  ).toMatchObject({
+    coworkSessionId: 'cowork-agent',
+    agentId: 'agent-2',
   });
 });
 

--- a/src/main/im/imStore.ts
+++ b/src/main/im/imStore.ts
@@ -80,6 +80,18 @@ interface SessionMappingRow {
   last_active_at: number;
 }
 
+function mapSessionMappingRow(row: SessionMappingRow): IMSessionMapping {
+  return {
+    imConversationId: row.im_conversation_id,
+    platform: row.platform as Platform,
+    coworkSessionId: row.cowork_session_id,
+    agentId: row.agent_id || 'main',
+    ...(row.openclaw_session_key ? { openClawSessionKey: row.openclaw_session_key } : {}),
+    createdAt: row.created_at,
+    lastActiveAt: row.last_active_at,
+  };
+}
+
 function deriveNimRuntimeAccountIdForInstance(
   inst: Pick<NimInstanceConfig, 'nimToken' | 'appKey' | 'account'>,
 ): string | null {
@@ -131,10 +143,11 @@ export class IMStore {
         im_conversation_id TEXT NOT NULL,
         platform TEXT NOT NULL,
         cowork_session_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL DEFAULT 'main',
         openclaw_session_key TEXT,
         created_at INTEGER NOT NULL,
         last_active_at INTEGER NOT NULL,
-        PRIMARY KEY (im_conversation_id, platform)
+        PRIMARY KEY (im_conversation_id, platform, agent_id)
       );
     `,
       )
@@ -155,6 +168,77 @@ export class IMStore {
         .prepare('ALTER TABLE im_session_mappings ADD COLUMN openclaw_session_key TEXT')
         .run();
     }
+    this.ensureAgentScopedSessionMappingPrimaryKey(mappingCols);
+    this.db
+      .prepare(
+        'CREATE INDEX IF NOT EXISTS idx_im_session_mappings_openclaw_session_key ON im_session_mappings(openclaw_session_key) WHERE openclaw_session_key IS NOT NULL',
+      )
+      .run();
+  }
+
+  private ensureAgentScopedSessionMappingPrimaryKey(
+    mappingCols: Array<{ name: string; pk?: number }>,
+  ): void {
+    const pkCols = mappingCols
+      .filter(col => typeof col.pk === 'number' && col.pk > 0)
+      .sort((a, b) => (a.pk ?? 0) - (b.pk ?? 0))
+      .map(col => col.name);
+
+    // Test fakes and some old sqlite adapters may not expose pk metadata. In
+    // that case skip the rebuild; real SQLite returns pk ordinals here.
+    if (pkCols.length === 0 || pkCols.includes('agent_id')) {
+      return;
+    }
+
+    const migrate = this.db.transaction(() => {
+      this.db.prepare('DROP TABLE IF EXISTS im_session_mappings_agent_scope_new').run();
+      this.db
+        .prepare(
+          `
+        CREATE TABLE im_session_mappings_agent_scope_new (
+          im_conversation_id TEXT NOT NULL,
+          platform TEXT NOT NULL,
+          cowork_session_id TEXT NOT NULL,
+          agent_id TEXT NOT NULL DEFAULT 'main',
+          openclaw_session_key TEXT,
+          created_at INTEGER NOT NULL,
+          last_active_at INTEGER NOT NULL,
+          PRIMARY KEY (im_conversation_id, platform, agent_id)
+        );
+      `,
+        )
+        .run();
+      this.db
+        .prepare(
+          `
+        INSERT OR REPLACE INTO im_session_mappings_agent_scope_new (
+          im_conversation_id,
+          platform,
+          cowork_session_id,
+          agent_id,
+          openclaw_session_key,
+          created_at,
+          last_active_at
+        )
+        SELECT
+          im_conversation_id,
+          platform,
+          cowork_session_id,
+          COALESCE(NULLIF(agent_id, ''), 'main'),
+          openclaw_session_key,
+          created_at,
+          last_active_at
+        FROM im_session_mappings;
+      `,
+        )
+        .run();
+      this.db.prepare('DROP TABLE im_session_mappings').run();
+      this.db
+        .prepare('ALTER TABLE im_session_mappings_agent_scope_new RENAME TO im_session_mappings')
+        .run();
+    });
+
+    migrate();
   }
 
   /**
@@ -1713,24 +1797,49 @@ export class IMStore {
   // ==================== Session Mapping Operations ====================
 
   /**
-   * Get session mapping by IM conversation ID and platform
+   * Get session mapping by IM conversation ID and platform.
+   *
+   * When agentId is provided, this is an agent-scoped lookup. Calls without
+   * agentId keep legacy behavior and return the most recent mapping for the
+   * conversation, preferring the main agent when timestamps tie.
    */
-  getSessionMapping(imConversationId: string, platform: Platform): IMSessionMapping | null {
+  getSessionMapping(
+    imConversationId: string,
+    platform: Platform,
+    agentId?: string,
+  ): IMSessionMapping | null {
+    const normalizedAgentId = agentId?.trim();
+    const row = normalizedAgentId
+      ? this.db
+        .prepare(
+          'SELECT im_conversation_id, platform, cowork_session_id, agent_id, openclaw_session_key, created_at, last_active_at FROM im_session_mappings WHERE im_conversation_id = ? AND platform = ? AND agent_id = ?',
+        )
+        .get(imConversationId, platform, normalizedAgentId) as SessionMappingRow | undefined
+      : this.db
+        .prepare(
+          `SELECT im_conversation_id, platform, cowork_session_id, agent_id, openclaw_session_key, created_at, last_active_at
+           FROM im_session_mappings
+           WHERE im_conversation_id = ? AND platform = ?
+           ORDER BY last_active_at DESC, CASE WHEN agent_id = 'main' THEN 0 ELSE 1 END
+           LIMIT 1`,
+        )
+        .get(imConversationId, platform) as SessionMappingRow | undefined;
+    return row ? mapSessionMappingRow(row) : null;
+  }
+
+  /**
+   * Find the IM mapping that owns a real OpenClaw channel session key.
+   */
+  getSessionMappingByOpenClawSessionKey(openClawSessionKey: string): IMSessionMapping | null {
+    const normalizedKey = openClawSessionKey.trim();
+    if (!normalizedKey) return null;
+
     const row = this.db
       .prepare(
-        'SELECT im_conversation_id, platform, cowork_session_id, agent_id, openclaw_session_key, created_at, last_active_at FROM im_session_mappings WHERE im_conversation_id = ? AND platform = ?',
+        'SELECT im_conversation_id, platform, cowork_session_id, agent_id, openclaw_session_key, created_at, last_active_at FROM im_session_mappings WHERE openclaw_session_key = ? ORDER BY last_active_at DESC LIMIT 1',
       )
-      .get(imConversationId, platform) as SessionMappingRow | undefined;
-    if (!row) return null;
-    return {
-      imConversationId: row.im_conversation_id,
-      platform: row.platform as Platform,
-      coworkSessionId: row.cowork_session_id,
-      agentId: row.agent_id || 'main',
-      ...(row.openclaw_session_key ? { openClawSessionKey: row.openclaw_session_key } : {}),
-      createdAt: row.created_at,
-      lastActiveAt: row.last_active_at,
-    };
+      .get(normalizedKey) as SessionMappingRow | undefined;
+    return row ? mapSessionMappingRow(row) : null;
   }
 
   /**
@@ -1742,16 +1851,7 @@ export class IMStore {
         'SELECT im_conversation_id, platform, cowork_session_id, agent_id, openclaw_session_key, created_at, last_active_at FROM im_session_mappings WHERE cowork_session_id = ? LIMIT 1',
       )
       .get(coworkSessionId) as SessionMappingRow | undefined;
-    if (!row) return null;
-    return {
-      imConversationId: row.im_conversation_id,
-      platform: row.platform as Platform,
-      coworkSessionId: row.cowork_session_id,
-      agentId: row.agent_id || 'main',
-      ...(row.openclaw_session_key ? { openClawSessionKey: row.openclaw_session_key } : {}),
-      createdAt: row.created_at,
-      lastActiveAt: row.last_active_at,
-    };
+    return row ? mapSessionMappingRow(row) : null;
   }
 
   /**
@@ -1785,11 +1885,27 @@ export class IMStore {
   /**
    * Update last active time for a session mapping
    */
-  updateSessionLastActive(imConversationId: string, platform: Platform): void {
+  updateSessionLastActive(imConversationId: string, platform: Platform, agentId?: string): void {
     const now = Date.now();
+    const normalizedAgentId = agentId?.trim();
+    if (normalizedAgentId) {
+      this.db
+        .prepare(
+          'UPDATE im_session_mappings SET last_active_at = ? WHERE im_conversation_id = ? AND platform = ? AND agent_id = ?',
+        )
+        .run(now, imConversationId, platform, normalizedAgentId);
+      return;
+    }
     this.db
       .prepare(
-        'UPDATE im_session_mappings SET last_active_at = ? WHERE im_conversation_id = ? AND platform = ?',
+        `UPDATE im_session_mappings
+         SET last_active_at = ?
+         WHERE rowid = (
+           SELECT rowid FROM im_session_mappings
+           WHERE im_conversation_id = ? AND platform = ?
+           ORDER BY last_active_at DESC, CASE WHEN agent_id = 'main' THEN 0 ELSE 1 END
+           LIMIT 1
+         )`,
       )
       .run(now, imConversationId, platform);
   }
@@ -1804,12 +1920,37 @@ export class IMStore {
     newCoworkSessionId: string,
     newAgentId: string,
     newOpenClawSessionKey?: string,
+    existingAgentId?: string,
   ): void {
     const now = Date.now();
     const normalizedOpenClawSessionKey = newOpenClawSessionKey?.trim() || null;
+    const normalizedExistingAgentId = existingAgentId?.trim();
+    if (normalizedExistingAgentId) {
+      this.db
+        .prepare(
+          'UPDATE im_session_mappings SET cowork_session_id = ?, agent_id = ?, openclaw_session_key = COALESCE(?, openclaw_session_key), last_active_at = ? WHERE im_conversation_id = ? AND platform = ? AND agent_id = ?',
+        )
+        .run(
+          newCoworkSessionId,
+          newAgentId,
+          normalizedOpenClawSessionKey,
+          now,
+          imConversationId,
+          platform,
+          normalizedExistingAgentId,
+        );
+      return;
+    }
     this.db
       .prepare(
-        'UPDATE im_session_mappings SET cowork_session_id = ?, agent_id = ?, openclaw_session_key = COALESCE(?, openclaw_session_key), last_active_at = ? WHERE im_conversation_id = ? AND platform = ?',
+        `UPDATE im_session_mappings
+         SET cowork_session_id = ?, agent_id = ?, openclaw_session_key = COALESCE(?, openclaw_session_key), last_active_at = ?
+         WHERE rowid = (
+           SELECT rowid FROM im_session_mappings
+           WHERE im_conversation_id = ? AND platform = ?
+           ORDER BY last_active_at DESC, CASE WHEN agent_id = 'main' THEN 0 ELSE 1 END
+           LIMIT 1
+         )`,
       )
       .run(newCoworkSessionId, newAgentId, normalizedOpenClawSessionKey, now, imConversationId, platform);
   }
@@ -1818,15 +1959,32 @@ export class IMStore {
     imConversationId: string,
     platform: Platform,
     openClawSessionKey: string,
+    agentId?: string,
   ): void {
     const normalizedKey = openClawSessionKey.trim();
     if (!normalizedKey) {
       return;
     }
     const now = Date.now();
+    const normalizedAgentId = agentId?.trim();
+    if (normalizedAgentId) {
+      this.db
+        .prepare(
+          'UPDATE im_session_mappings SET openclaw_session_key = ?, last_active_at = ? WHERE im_conversation_id = ? AND platform = ? AND agent_id = ?',
+        )
+        .run(normalizedKey, now, imConversationId, platform, normalizedAgentId);
+      return;
+    }
     this.db
       .prepare(
-        'UPDATE im_session_mappings SET openclaw_session_key = ?, last_active_at = ? WHERE im_conversation_id = ? AND platform = ?',
+        `UPDATE im_session_mappings
+         SET openclaw_session_key = ?, last_active_at = ?
+         WHERE rowid = (
+           SELECT rowid FROM im_session_mappings
+           WHERE im_conversation_id = ? AND platform = ?
+           ORDER BY last_active_at DESC, CASE WHEN agent_id = 'main' THEN 0 ELSE 1 END
+           LIMIT 1
+         )`,
       )
       .run(normalizedKey, now, imConversationId, platform);
   }
@@ -1834,7 +1992,16 @@ export class IMStore {
   /**
    * Delete a session mapping
    */
-  deleteSessionMapping(imConversationId: string, platform: Platform): void {
+  deleteSessionMapping(imConversationId: string, platform: Platform, agentId?: string): void {
+    const normalizedAgentId = agentId?.trim();
+    if (normalizedAgentId) {
+      this.db
+        .prepare(
+          'DELETE FROM im_session_mappings WHERE im_conversation_id = ? AND platform = ? AND agent_id = ?',
+        )
+        .run(imConversationId, platform, normalizedAgentId);
+      return;
+    }
     this.db
       .prepare('DELETE FROM im_session_mappings WHERE im_conversation_id = ? AND platform = ?')
       .run(imConversationId, platform);
@@ -1899,14 +2066,6 @@ export class IMStore {
     }
 
     const rows = this.db.prepare(query).all(...params) as SessionMappingRow[];
-    return rows.map(row => ({
-      imConversationId: row.im_conversation_id,
-      platform: row.platform as Platform,
-      coworkSessionId: row.cowork_session_id,
-      agentId: row.agent_id || 'main',
-      ...(row.openclaw_session_key ? { openClawSessionKey: row.openclaw_session_key } : {}),
-      createdAt: row.created_at,
-      lastActiveAt: row.last_active_at,
-    }));
+    return rows.map(mapSessionMappingRow);
   }
 }

--- a/src/main/ipcHandlers/scheduledTask/helpers.test.ts
+++ b/src/main/ipcHandlers/scheduledTask/helpers.test.ts
@@ -184,4 +184,16 @@ describe('dedupeConversationMappings', () => {
     ]);
     expect(result).toHaveLength(3);
   });
+
+  test('keeps the same peer when mappings belong to different agents', () => {
+    const result = dedupeConversationMappings([
+      { imConversationId: `group:${LOWER_PEER}`, agentId: 'main' },
+      { imConversationId: `group:${LOWER_PEER}`, agentId: 'agent-2' },
+      { imConversationId: `group:${LOWER_PEER}`, agentId: 'agent-2' },
+    ]);
+    expect(result).toEqual([
+      { imConversationId: `group:${LOWER_PEER}`, agentId: 'main' },
+      { imConversationId: `group:${LOWER_PEER}`, agentId: 'agent-2' },
+    ]);
+  });
 });

--- a/src/main/ipcHandlers/scheduledTask/helpers.ts
+++ b/src/main/ipcHandlers/scheduledTask/helpers.ts
@@ -239,7 +239,7 @@ export function resolveConversationAgentIdFromMappings(
  * targets. Input must be sorted by lastActiveAt DESC (listSessionMappings
  * order); the first (most recent) row per peer wins.
  */
-export function dedupeConversationMappings<T extends { imConversationId: string }>(
+export function dedupeConversationMappings<T extends { imConversationId: string; agentId?: string }>(
   mappings: readonly T[],
 ): T[] {
   const seen = new Set<string>();
@@ -247,7 +247,7 @@ export function dedupeConversationMappings<T extends { imConversationId: string 
   for (const mapping of mappings) {
     const parsed = parseImConversationId(mapping.imConversationId);
     if (parsed.peerId.toLowerCase().endsWith(':heartbeat')) continue;
-    const key = `${parsed.peerKind ?? ''}:${parsed.peerId.toLowerCase()}`;
+    const key = `${mapping.agentId ?? ''}:${parsed.peerKind ?? ''}:${parsed.peerId.toLowerCase()}`;
     if (seen.has(key)) continue;
     seen.add(key);
     result.push(mapping);

--- a/src/main/libs/openclawChannelSessionSync.test.ts
+++ b/src/main/libs/openclawChannelSessionSync.test.ts
@@ -425,7 +425,7 @@ test('channel sync backfills the real OpenClaw session key for existing mappings
   const sessionKey = 'agent:main:feishu:dm:ou_123';
 
   expect(sync.resolveOrCreateSession(sessionKey)).toBe('cowork-1');
-  expect(updateSessionOpenClawSessionKey).toHaveBeenCalledWith('dm:ou_123', 'feishu', sessionKey);
+  expect(updateSessionOpenClawSessionKey).toHaveBeenCalledWith('dm:ou_123', 'feishu', sessionKey, 'main');
 });
 
 test('channel sync corrects existing mapping cwd from the current bound agent', () => {
@@ -484,6 +484,137 @@ test('channel sync corrects existing mapping cwd from the current bound agent', 
     { cwd: '/repo/writer' },
     { touchUpdatedAt: false },
   );
+});
+
+test('channel sync creates separate local sessions for the same group under different agents', () => {
+  let nextId = 0;
+  const mappings: Array<{
+    imConversationId: string;
+    platform: 'feishu';
+    coworkSessionId: string;
+    agentId: string;
+    openClawSessionKey?: string;
+    createdAt: number;
+    lastActiveAt: number;
+  }> = [
+    {
+      imConversationId: 'group:oc_sanitized',
+      platform: 'feishu',
+      coworkSessionId: 'cowork-main',
+      agentId: 'main',
+      openClawSessionKey: 'agent:main:feishu:group:oc_sanitized',
+      createdAt: 1,
+      lastActiveAt: 1,
+    },
+  ];
+  const createSession = vi.fn(((
+    title: string,
+    cwd: string,
+    systemPrompt: string,
+    executionMode: 'local',
+    activeSkillIds: string[],
+    agentId: string,
+  ) => ({
+    id: `cowork-${++nextId}`,
+    title,
+    claudeSessionId: null,
+    status: 'idle' as const,
+    pinned: false,
+    cwd,
+    systemPrompt,
+    modelOverride: '',
+    executionMode,
+    activeSkillIds,
+    agentId,
+    messages: [],
+    createdAt: 1,
+    updatedAt: 1,
+  })));
+  const sync = new OpenClawChannelSessionSync({
+    coworkStore: {
+      getSession: (id: string) => (
+        id === 'cowork-main'
+          ? {
+            id,
+            title: '[Feishu] group:oc_sanitized',
+            claudeSessionId: null,
+            status: 'idle',
+            pinned: false,
+            cwd: '/repo/main',
+            systemPrompt: '',
+            modelOverride: '',
+            executionMode: 'local',
+            activeSkillIds: [],
+            agentId: 'main',
+            messages: [],
+            createdAt: 1,
+            updatedAt: 1,
+          }
+          : null
+      ),
+      createSession,
+    },
+    imStore: {
+      getIMSettings: () => ({
+        skillsEnabled: true,
+        platformAgentBindings: {
+          feishu: 'main',
+        },
+      }),
+      getSessionMappingByOpenClawSessionKey: (sessionKey: string) =>
+        mappings.find(mapping => mapping.openClawSessionKey === sessionKey) ?? null,
+      getSessionMapping: (conversationId: string, platform: 'feishu', agentId?: string) =>
+        mappings.find(mapping =>
+          mapping.imConversationId === conversationId
+          && mapping.platform === platform
+          && (!agentId || mapping.agentId === agentId),
+        ) ?? null,
+      updateSessionLastActive: () => {},
+      deleteSessionMapping: () => {},
+      createSessionMapping: (
+        imConversationId: string,
+        platform: 'feishu',
+        coworkSessionId: string,
+        agentId: string,
+        openClawSessionKey: string,
+      ) => {
+        mappings.push({
+          imConversationId,
+          platform,
+          coworkSessionId,
+          agentId,
+          openClawSessionKey,
+          createdAt: 1,
+          lastActiveAt: 1,
+        });
+      },
+    },
+    getDefaultCwd: (agentId?: string) => `/repo/${agentId || 'main'}`,
+  });
+
+  expect(sync.isCurrentBindingKey('agent:agent-2:feishu:group:oc_sanitized')).toBe(true);
+  expect(sync.resolveOrCreateSession('agent:agent-2:feishu:group:oc_sanitized')).toBe('cowork-1');
+
+  expect(createSession).toHaveBeenCalledWith(
+    expect.any(String),
+    '/repo/agent-2',
+    '',
+    'local',
+    [],
+    'agent-2',
+  );
+  expect(mappings).toEqual([
+    expect.objectContaining({
+      coworkSessionId: 'cowork-main',
+      agentId: 'main',
+      openClawSessionKey: 'agent:main:feishu:group:oc_sanitized',
+    }),
+    expect.objectContaining({
+      coworkSessionId: 'cowork-1',
+      agentId: 'agent-2',
+      openClawSessionKey: 'agent:agent-2:feishu:group:oc_sanitized',
+    }),
+  ]);
 });
 
 // --- buildChannelDisplayName ---

--- a/src/main/libs/openclawChannelSessionSync.ts
+++ b/src/main/libs/openclawChannelSessionSync.ts
@@ -394,6 +394,48 @@ export class OpenClawChannelSessionSync {
     );
   }
 
+  private resolveAgentIdForSessionKey(sessionKey: string, platform: Platform): string {
+    const keyAgentId = extractAgentIdFromKey(sessionKey);
+    if (keyAgentId) return keyAgentId;
+
+    const accountId = extractAccountIdFromKey(sessionKey);
+    const imSettings = this.imStore.getIMSettings();
+    return resolveAgentBinding(imSettings.platformAgentBindings, platform, accountId);
+  }
+
+  private getMappingForSessionKey(
+    sessionKey: string,
+    parsed: { platform: Platform; conversationId: string },
+    agentId: string,
+  ) {
+    const exactMapping = this.imStore.getSessionMappingByOpenClawSessionKey?.(sessionKey) ?? null;
+    if (exactMapping) return exactMapping;
+    return this.imStore.getSessionMapping(parsed.conversationId, parsed.platform, agentId);
+  }
+
+  private createChannelSession(
+    parsed: { platform: Platform; conversationId: string },
+    agentId: string,
+  ): CoworkSession {
+    const titlePrefix = getChannelTitlePrefix(parsed.platform);
+    const title = `${titlePrefix} ${buildChannelDisplayName(parsed.conversationId)}`;
+    const cwd = this.getDefaultCwd(agentId);
+    console.log(
+      '[ChannelSessionSync] creating new cowork session: title=',
+      title,
+      'cwd=',
+      cwd,
+      'agentId=',
+      agentId,
+    );
+
+    const session = this.coworkStore.createSession(title, cwd, '', 'local', [], agentId);
+    console.log(
+      `[ChannelSessionSync] Created session for ${parsed.platform} conversation ${parsed.conversationId}: ${session.id}`,
+    );
+    return session;
+  }
+
   /**
    * Check if a gateway session key belongs to the agent currently bound to its platform.
    * When users switch agent bindings, the gateway retains old sessions under the previous
@@ -404,8 +446,9 @@ export class OpenClawChannelSessionSync {
     if (!parsed) return true; // Not a channel key — let other logic handle it
     const keyAgentId = extractAgentIdFromKey(sessionKey);
     if (!keyAgentId) return true; // Legacy key without agentId — allow
-    const imSettings = this.imStore.getIMSettings();
     const accountId = extractAccountIdFromKey(sessionKey);
+    if (!accountId) return true; // Account-less group keys are already scoped by agentId.
+    const imSettings = this.imStore.getIMSettings();
     const currentAgentId = resolveAgentBinding(
       imSettings.platformAgentBindings,
       parsed.platform,
@@ -458,8 +501,16 @@ export class OpenClawChannelSessionSync {
       parsed.conversationId,
     );
 
+    const agentId = this.resolveAgentIdForSessionKey(sessionKey, parsed.platform);
+
     // 4. Check persistent mapping in im_session_mappings
-    const existingMapping = this.imStore.getSessionMapping(parsed.conversationId, parsed.platform);
+    let existingMapping = this.getMappingForSessionKey(sessionKey, parsed, agentId);
+    if (!existingMapping) {
+      const legacyMapping = this.imStore.getSessionMapping(parsed.conversationId, parsed.platform);
+      if (legacyMapping?.agentId === agentId) {
+        existingMapping = legacyMapping;
+      }
+    }
     console.log(
       '[ChannelSessionSync] existing mapping:',
       existingMapping
@@ -470,16 +521,7 @@ export class OpenClawChannelSessionSync {
       // Verify the Cowork session still exists
       const session = this.coworkStore.getSession(existingMapping.coworkSessionId);
       if (session) {
-        // Check if the agent binding has changed since this mapping was created.
-        // When platformAgentBindings changes, the mapping's agentId becomes stale.
-        // Create a new session for the new agent and update the mapping.
-        const imSettings = this.imStore.getIMSettings();
-        const accountId = extractAccountIdFromKey(sessionKey);
-        const currentAgentId = resolveAgentBinding(
-          imSettings.platformAgentBindings,
-          parsed.platform,
-          accountId,
-        );
+        const currentAgentId = agentId;
         if (existingMapping.agentId !== currentAgentId) {
           console.log(
             '[ChannelSessionSync] agent binding changed:',
@@ -506,6 +548,7 @@ export class OpenClawChannelSessionSync {
             newSession.id,
             currentAgentId,
             sessionKey,
+            existingMapping.agentId,
           );
           this.syncedSessionKeys.set(sessionKey, newSession.id);
           // Mark so pollChannelSessions skips full history sync for this session —
@@ -520,37 +563,27 @@ export class OpenClawChannelSessionSync {
         );
         this.syncedSessionKeys.set(sessionKey, existingMapping.coworkSessionId);
         if (existingMapping.openClawSessionKey !== sessionKey) {
-          this.imStore.updateSessionOpenClawSessionKey(parsed.conversationId, parsed.platform, sessionKey);
+          this.imStore.updateSessionOpenClawSessionKey(
+            parsed.conversationId,
+            parsed.platform,
+            sessionKey,
+            existingMapping.agentId,
+          );
         }
-        this.imStore.updateSessionLastActive(parsed.conversationId, parsed.platform);
+        this.imStore.updateSessionLastActive(
+          parsed.conversationId,
+          parsed.platform,
+          existingMapping.agentId,
+        );
         return existingMapping.coworkSessionId;
       }
       // Session was deleted, remove stale mapping
       console.log('[ChannelSessionSync] cowork session deleted, removing stale mapping');
-      this.imStore.deleteSessionMapping(parsed.conversationId, parsed.platform);
+      this.imStore.deleteSessionMapping(parsed.conversationId, parsed.platform, existingMapping.agentId);
     }
 
     // 5. Create new Cowork session
-    const titlePrefix = getChannelTitlePrefix(parsed.platform);
-    const title = `${titlePrefix} ${buildChannelDisplayName(parsed.conversationId)}`;
-    // Look up the per-platform agent binding so the session is filed under the correct agent.
-    const imSettings = this.imStore.getIMSettings();
-    const accountId = extractAccountIdFromKey(sessionKey);
-    const agentId = resolveAgentBinding(imSettings.platformAgentBindings, parsed.platform, accountId);
-    const cwd = this.getDefaultCwd(agentId);
-    console.log(
-      '[ChannelSessionSync] creating new cowork session: title=',
-      title,
-      'cwd=',
-      cwd,
-      'agentId=',
-      agentId,
-    );
-
-    const session = this.coworkStore.createSession(title, cwd, '', 'local', [], agentId);
-    console.log(
-      `[ChannelSessionSync] Created session for ${parsed.platform} conversation ${parsed.conversationId}: ${session.id}`,
-    );
+    const session = this.createChannelSession(parsed, agentId);
 
     // 6. Persist mapping
     this.imStore.createSessionMapping(parsed.conversationId, parsed.platform, session.id, agentId, sessionKey);
@@ -593,20 +626,33 @@ export class OpenClawChannelSessionSync {
       return null;
     }
 
+    const agentId = this.resolveAgentIdForSessionKey(sessionKey, parsed.platform);
+
     // Check persistent mapping
-    const existingMapping = this.imStore.getSessionMapping(parsed.conversationId, parsed.platform);
+    let existingMapping = this.getMappingForSessionKey(sessionKey, parsed, agentId);
+    if (!existingMapping) {
+      const legacyMapping = this.imStore.getSessionMapping(parsed.conversationId, parsed.platform);
+      if (legacyMapping?.agentId === agentId) {
+        existingMapping = legacyMapping;
+      }
+    }
     if (existingMapping) {
       const session = this.coworkStore.getSession(existingMapping.coworkSessionId);
       if (session) {
         this.updateLocalSessionCwdIfNeeded(session, existingMapping.agentId);
         this.syncedSessionKeys.set(sessionKey, existingMapping.coworkSessionId);
         if (existingMapping.openClawSessionKey !== sessionKey) {
-          this.imStore.updateSessionOpenClawSessionKey(parsed.conversationId, parsed.platform, sessionKey);
+          this.imStore.updateSessionOpenClawSessionKey(
+            parsed.conversationId,
+            parsed.platform,
+            sessionKey,
+            existingMapping.agentId,
+          );
         }
         return existingMapping.coworkSessionId;
       }
       // Stale mapping, clean up
-      this.imStore.deleteSessionMapping(parsed.conversationId, parsed.platform);
+      this.imStore.deleteSessionMapping(parsed.conversationId, parsed.platform, existingMapping.agentId);
     }
 
     return null;


### PR DESCRIPTION
## Summary
- scope IM session mappings by `(im_conversation_id, platform, agent_id)` while preserving legacy lookups
- prefer exact `openclaw_session_key` mapping before agent-scoped conversation lookup
- keep scheduled-task IM conversation dedupe from collapsing the same peer across different agents
- document the fix with sanitized real session key examples under `specs/bugfixes`

## Verification
- `npm test -- openclawChannelSessionSync imStore scheduledTask/helpers`
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/im/imStore.ts src/main/libs/openclawChannelSessionSync.ts src/main/ipcHandlers/scheduledTask/helpers.ts src/main/libs/openclawChannelSessionSync.test.ts src/main/im/imStore.test.ts src/main/ipcHandlers/scheduledTask/helpers.test.ts`
- `npm run compile:electron`
- `npm test`