### PR TITLE
fix(cowork): sync subagent child tool history

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -466,6 +466,13 @@ export interface CoworkConversationReplacementEntry {
   timestamp?: number;
 }
 
+export interface CoworkMessageReplacementEntry {
+  type: CoworkMessageType;
+  content: string;
+  metadata?: Record<string, unknown>;
+  timestamp?: number;
+}
+
 export interface CoworkSession {
   id: string;
   title: string;
@@ -1983,6 +1990,55 @@ export class CoworkStore {
       // Reconciliation runs repeatedly for channel-synced sessions: assistant
       // output must not reorder the session list, and updated_at never moves
       // backwards. Only a newer user message may advance it.
+      if (lastUserMessageAt != null) {
+        this.db
+          .prepare('UPDATE cowork_sessions SET updated_at = MAX(updated_at, ?) WHERE id = ?')
+          .run(lastUserMessageAt, sessionId);
+      }
+    })();
+  }
+
+  replaceSessionMessages(
+    sessionId: string,
+    messages: CoworkMessageReplacementEntry[],
+  ): void {
+    const now = Date.now();
+
+    this.db.transaction(() => {
+      this.db
+        .prepare(
+          "DELETE FROM cowork_messages WHERE session_id = ? AND type IN ('user', 'assistant', 'tool_use', 'tool_result')",
+        )
+        .run(sessionId);
+
+      const insert = this.db.prepare(`
+        INSERT INTO cowork_messages (id, session_id, type, content, metadata, created_at, sequence)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `);
+
+      const seqRow = this.db
+        .prepare(
+          'SELECT COALESCE(MAX(sequence), 0) as max_seq FROM cowork_messages WHERE session_id = ?',
+        )
+        .get(sessionId) as { max_seq: number } | undefined;
+      let sequence = (seqRow?.max_seq ?? 0) + 1;
+      let lastUserMessageAt: number | null = null;
+      for (const message of messages) {
+        const messageTimestamp = normalizeMessageTimestamp(message.timestamp) ?? now;
+        if (message.type === 'user') {
+          lastUserMessageAt = Math.max(lastUserMessageAt ?? 0, messageTimestamp);
+        }
+        insert.run(
+          uuidv4(),
+          sessionId,
+          message.type,
+          message.content,
+          message.metadata ? JSON.stringify(message.metadata) : null,
+          messageTimestamp,
+          sequence++,
+        );
+      }
+
       if (lastUserMessageAt != null) {
         this.db
           .prepare('UPDATE cowork_sessions SET updated_at = MAX(updated_at, ?) WHERE id = ?')

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -1967,6 +1967,8 @@ function createReconcileStore(
   let nextId = session.messages.length + 1;
   let replaceCallCount = 0;
   let lastReplaceArgs: { sessionId: string; authoritative: Array<Record<string, unknown>> } | null = null;
+  let replaceSessionCallCount = 0;
+  let lastReplaceSessionArgs: { sessionId: string; messages: Array<Record<string, unknown>> } | null = null;
   const updateSessionCalls: Array<{
     sessionId: string;
     patch: Record<string, unknown>;
@@ -1977,6 +1979,8 @@ function createReconcileStore(
     session,
     getReplaceCallCount: () => replaceCallCount,
     getLastReplaceArgs: () => lastReplaceArgs,
+    getReplaceSessionCallCount: () => replaceSessionCallCount,
+    getLastReplaceSessionArgs: () => lastReplaceSessionArgs,
     getUpdateSessionCalls: () => updateSessionCalls,
     store: {
       getSession: (sessionId: string) => (sessionId === session.id ? session : null),
@@ -2022,6 +2026,38 @@ function createReconcileStore(
             type: entry.role,
             content: entry.text,
             metadata: { isStreaming: false, isFinal: true, ...(entry.metadata ?? {}) },
+            timestamp: typeof entry.timestamp === 'number' ? entry.timestamp : nextId,
+          });
+        }
+      },
+      replaceSessionMessages: (sessionId: string, messages: Array<Record<string, unknown>>) => {
+        replaceSessionCallCount++;
+        lastReplaceSessionArgs = { sessionId, messages };
+        lastReplaceArgs = {
+          sessionId,
+          authoritative: messages
+            .filter((entry) => entry.type === 'user' || entry.type === 'assistant')
+            .map((entry) => {
+              const authoritative: Record<string, unknown> = {
+                role: entry.type,
+                text: entry.content,
+              };
+              if (typeof entry.timestamp === 'number') {
+                authoritative.timestamp = entry.timestamp;
+              }
+              if (entry.type === 'user' && entry.metadata !== undefined) {
+                authoritative.metadata = entry.metadata;
+              }
+              return authoritative;
+            }),
+        };
+        session.messages = session.messages.filter((m) => m.type === 'system');
+        for (const entry of messages) {
+          session.messages.push({
+            id: `msg-${nextId++}`,
+            type: entry.type,
+            content: entry.content,
+            metadata: entry.metadata,
             timestamp: typeof entry.timestamp === 'number' ? entry.timestamp : nextId,
           });
         }

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -8891,7 +8891,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         return;
       }
 
-      this.store.replaceConversationMessages(
+      this.store.replaceSessionMessages(
         sessionId,
         plan.entriesToStore,
       );

--- a/src/main/libs/agentEngine/subagent/childHistorySync.test.ts
+++ b/src/main/libs/agentEngine/subagent/childHistorySync.test.ts
@@ -39,8 +39,78 @@ rewrite the intro`;
     expect(plan.changed).toBe(true);
     expect(plan.cursor).toBe(2);
     expect(plan.entriesToStore).toEqual([
-      { role: 'user', text: 'rewrite the intro', timestamp: 1, metadata: {} },
-      { role: 'assistant', text: 'new intro', timestamp: 20 },
+      { type: 'user', content: 'rewrite the intro', timestamp: 1, metadata: {} },
+      {
+        type: 'assistant',
+        content: 'new intro',
+        timestamp: expect.any(Number),
+        metadata: { isStreaming: false, isFinal: true },
+      },
+    ]);
+  });
+
+  test('includes subagent tool calls and results in child session history', () => {
+    const localMessages: CoworkMessage[] = [
+      { id: 'msg-1', type: 'user', content: 'run tests', timestamp: 1, metadata: {} },
+    ] as CoworkMessage[];
+
+    const plan = buildSubagentChildHistorySyncPlan(localMessages, [
+      { role: 'user', content: 'run tests' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'I will run the tests.' },
+          {
+            type: 'toolCall',
+            id: 'call-1',
+            name: 'Bash',
+            arguments: { command: 'npm test' },
+          },
+        ],
+      },
+      {
+        role: 'tool_result',
+        tool_use_id: 'call-1',
+        content: '24 tests passed',
+      },
+      { role: 'assistant', content: 'All tests passed.' },
+    ]);
+
+    expect(plan.changed).toBe(true);
+    expect(plan.entriesToStore).toEqual([
+      { type: 'user', content: 'run tests', timestamp: 1, metadata: {} },
+      {
+        type: 'assistant',
+        content: 'I will run the tests.',
+        timestamp: expect.any(Number),
+        metadata: { isStreaming: false, isFinal: true },
+      },
+      {
+        type: 'tool_use',
+        content: '',
+        timestamp: expect.any(Number),
+        metadata: {
+          toolName: 'Bash',
+          toolInput: { command: 'npm test' },
+          toolUseId: 'call-1',
+        },
+      },
+      {
+        type: 'tool_result',
+        content: '24 tests passed',
+        timestamp: expect.any(Number),
+        metadata: {
+          toolName: undefined,
+          toolResult: '24 tests passed',
+          toolUseId: 'call-1',
+        },
+      },
+      {
+        type: 'assistant',
+        content: 'All tests passed.',
+        timestamp: expect.any(Number),
+        metadata: { isStreaming: false, isFinal: true },
+      },
     ]);
   });
 });

--- a/src/main/libs/agentEngine/subagent/childHistorySync.test.ts
+++ b/src/main/libs/agentEngine/subagent/childHistorySync.test.ts
@@ -43,7 +43,7 @@ rewrite the intro`;
       {
         type: 'assistant',
         content: 'new intro',
-        timestamp: expect.any(Number),
+        timestamp: 20,
         metadata: { isStreaming: false, isFinal: true },
       },
     ]);

--- a/src/main/libs/agentEngine/subagent/childHistorySync.ts
+++ b/src/main/libs/agentEngine/subagent/childHistorySync.ts
@@ -1,24 +1,119 @@
 import type { CoworkMessage } from '../../../coworkStore';
-import {
-  extractGatewayHistoryEntries,
-  shouldSuppressHeartbeatText,
-} from '../../openclawHistory';
-import {
-  applyLocalTimestampsToEntries,
-  isSameReconciledEntry,
-  type ReconciledConversationEntry,
-} from '../openclawConversationReconciliation';
+import { shouldSuppressHeartbeatText } from '../../openclawHistory';
+import { parseSubagentGatewayHistoryMessages } from './historyParser';
 
 export type SubagentChildHistorySyncPlan = {
   changed: boolean;
   cursor: number;
-  entriesToStore: ReconciledConversationEntry[];
-  localEntries: Array<{
-    role: 'user' | 'assistant';
-    text: string;
-    timestamp?: number;
-    metadata?: Record<string, unknown>;
-  }>;
+  entriesToStore: SubagentChildHistoryEntry[];
+  localEntries: SubagentChildHistoryEntry[];
+};
+
+export type SubagentChildHistoryEntry = {
+  type: CoworkMessage['type'];
+  content: string;
+  metadata?: Record<string, unknown>;
+  timestamp?: number;
+};
+
+const normalizeMetadata = (metadata: CoworkMessage['metadata']): Record<string, unknown> | undefined => (
+  metadata ? { ...metadata } : undefined
+);
+
+const sortForStableJson = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(sortForStableJson);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    sorted[key] = sortForStableJson((value as Record<string, unknown>)[key]);
+  }
+  return sorted;
+};
+
+const stableJson = (value: unknown): string => JSON.stringify(sortForStableJson(value));
+
+const isSameHistoryMessage = (
+  left: SubagentChildHistoryEntry,
+  right: SubagentChildHistoryEntry,
+): boolean => (
+  left.type === right.type
+  && left.content === right.content
+  && stableJson(left.metadata ?? null) === stableJson(right.metadata ?? null)
+);
+
+const buildLocalEntries = (localMessages: CoworkMessage[]): {
+  entries: SubagentChildHistoryEntry[];
+  normalizedLocalUserContent: boolean;
+} => {
+  let normalizedLocalUserContent = false;
+  const entries = localMessages
+    .filter((message) => message.type !== 'system')
+    .map((message) => {
+      const content = message.type === 'user'
+        ? normalizeSubagentVisibleUserText(message.content)
+        : message.content;
+      if (message.type === 'user' && content !== message.content) {
+        normalizedLocalUserContent = true;
+      }
+      return {
+        type: message.type,
+        content,
+        timestamp: message.timestamp,
+        metadata: normalizeMetadata(message.metadata),
+      };
+    })
+    .filter((entry) => entry.type === 'tool_use' || entry.content.trim());
+
+  return { entries, normalizedLocalUserContent };
+};
+
+const toStoredEntry = (message: CoworkMessage): SubagentChildHistoryEntry | null => {
+  if (message.type !== 'tool_use' && !message.content.trim()) {
+    return null;
+  }
+
+  if (message.type === 'user') {
+    const content = normalizeSubagentVisibleUserText(message.content).trim();
+    if (!content || shouldSuppressHeartbeatText('user', content)) {
+      return null;
+    }
+    return {
+      type: 'user',
+      content,
+      timestamp: message.timestamp,
+      metadata: normalizeMetadata(message.metadata),
+    };
+  }
+
+  if (message.type === 'assistant') {
+    const content = message.content.trim();
+    if (!content || shouldSuppressHeartbeatText('assistant', content)) {
+      return null;
+    }
+    return {
+      type: 'assistant',
+      content,
+      timestamp: message.timestamp,
+      metadata: {
+        isStreaming: false,
+        isFinal: true,
+        ...(message.metadata ?? {}),
+      },
+    };
+  }
+
+  if (message.type === 'system') return null;
+
+  return {
+    type: message.type,
+    content: message.content,
+    timestamp: message.timestamp,
+    metadata: normalizeMetadata(message.metadata),
+  };
 };
 
 export const normalizeSubagentVisibleUserText = (text: string): string => {
@@ -46,68 +141,32 @@ export const buildSubagentChildHistorySyncPlan = (
   localMessages: CoworkMessage[],
   historyMessages: unknown[],
 ): SubagentChildHistorySyncPlan => {
-  let normalizedLocalUserContent = false;
-  const localEntries = localMessages
-    .filter((message) => message.type === 'user' || message.type === 'assistant')
-    .map((message) => {
-      const text = message.type === 'user'
-        ? normalizeSubagentVisibleUserText(message.content)
-        : message.content;
-      if (message.type === 'user' && text !== message.content) {
-        normalizedLocalUserContent = true;
-      }
-      return {
-        role: message.type as 'user' | 'assistant',
-        text,
-        timestamp: message.timestamp,
-        metadata: message.metadata,
-      };
-    })
-    .filter((entry) => entry.text.trim());
-  const localUsers = localEntries.filter((entry) => entry.role === 'user');
+  const { entries: localEntries, normalizedLocalUserContent } = buildLocalEntries(localMessages);
+  const localUsers = localEntries.filter((entry) => entry.type === 'user');
   let localUserIndex = 0;
-  const mergedEntries: ReconciledConversationEntry[] = [];
+  const mergedEntries: SubagentChildHistoryEntry[] = [];
 
-  for (const entry of extractGatewayHistoryEntries(historyMessages)) {
-    if (entry.role === 'user') {
+  for (const message of parseSubagentGatewayHistoryMessages(historyMessages)) {
+    if (message.type === 'user') {
       const localUser = localUsers[localUserIndex++];
       if (localUser) {
         mergedEntries.push(localUser);
         continue;
       }
-      const visibleText = normalizeSubagentVisibleUserText(entry.text).trim();
+      const visibleText = normalizeSubagentVisibleUserText(message.content).trim();
       if (visibleText && !shouldSuppressHeartbeatText('user', visibleText)) {
         mergedEntries.push({
-          role: 'user',
-          text: visibleText,
-          ...(entry.timestamp != null && { timestamp: entry.timestamp }),
+          type: 'user',
+          content: visibleText,
+          timestamp: message.timestamp,
+          metadata: normalizeMetadata(message.metadata),
         });
       }
       continue;
     }
 
-    if (entry.role !== 'assistant') continue;
-    const text = entry.text.trim();
-    if (!text || shouldSuppressHeartbeatText('assistant', text)) continue;
-    let metadata: Record<string, unknown> | undefined;
-    if (entry.usage || entry.model) {
-      metadata = {};
-      if (entry.usage) {
-        metadata.usage = {
-          ...(entry.usage.input != null && { inputTokens: entry.usage.input }),
-          ...(entry.usage.output != null && { outputTokens: entry.usage.output }),
-        };
-      }
-      if (entry.model) {
-        metadata.model = entry.model;
-      }
-    }
-    mergedEntries.push({
-      role: 'assistant',
-      text,
-      ...(metadata && { metadata }),
-      ...(entry.timestamp != null && { timestamp: entry.timestamp }),
-    });
+    const storedEntry = toStoredEntry(message);
+    if (storedEntry) mergedEntries.push(storedEntry);
   }
 
   for (; localUserIndex < localUsers.length; localUserIndex += 1) {
@@ -126,17 +185,13 @@ export const buildSubagentChildHistorySyncPlan = (
   const isInSync = !normalizedLocalUserContent
     && localEntries.length === mergedEntries.length
     && localEntries.every((entry, index) =>
-      entry.role === mergedEntries[index].role
-      && entry.text === mergedEntries[index].text
-      && isSameReconciledEntry(entry, mergedEntries[index]),
+      isSameHistoryMessage(entry, mergedEntries[index]),
     );
 
   return {
     changed: !isInSync,
     cursor: mergedEntries.length,
-    entriesToStore: isInSync
-      ? mergedEntries
-      : applyLocalTimestampsToEntries(mergedEntries, localEntries),
+    entriesToStore: mergedEntries,
     localEntries,
   };
 };

--- a/src/main/libs/agentEngine/subagent/historyParser.test.ts
+++ b/src/main/libs/agentEngine/subagent/historyParser.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'vitest';
+
+import { parseSubagentGatewayHistoryMessages } from './historyParser';
+
+const deterministicIds = (): (() => string) => {
+  let index = 0;
+  return () => `msg-${++index}`;
+};
+
+describe('subagent history parser', () => {
+  test('reads assistant top-level toolCalls', () => {
+    const messages = parseSubagentGatewayHistoryMessages([
+      {
+        role: 'assistant',
+        content: 'prepare workspace',
+        toolCalls: [{
+          id: 'call-mkdir',
+          name: 'exec',
+          arguments: { command: 'mkdir -p D:\\cus_sk' },
+        }],
+      },
+      {
+        role: 'toolResult',
+        toolCallId: 'call-mkdir',
+        name: 'exec',
+        content: 'ok',
+      },
+    ], { createId: deterministicIds(), startTimestamp: 1000 });
+
+    expect(messages).toEqual([
+      { id: 'msg-1', type: 'assistant', content: 'prepare workspace', timestamp: 1000 },
+      {
+        id: 'msg-2',
+        type: 'tool_use',
+        content: '',
+        timestamp: 1001,
+        metadata: {
+          toolName: 'exec',
+          toolInput: { command: 'mkdir -p D:\\cus_sk' },
+          toolUseId: 'call-mkdir',
+        },
+      },
+      {
+        id: 'msg-3',
+        type: 'tool_result',
+        content: 'ok',
+        timestamp: 1002,
+        metadata: { toolName: 'exec', toolResult: 'ok', toolUseId: 'call-mkdir' },
+      },
+    ]);
+  });
+
+  test('synthesizes missing exec tool use from PowerShell error output', () => {
+    const messages = parseSubagentGatewayHistoryMessages([
+      {
+        role: 'toolResult',
+        toolCallId: 'call-mkdir',
+        name: 'exec',
+        content: [
+          'mkdir : 具有指定名称 D:\\cus_sk 的项已存在。',
+          '所在位置 行:1 字符: 1',
+          '+ mkdir -p D:\\cus_sk',
+          '+ ~~~~~~~~~~~~~~~~~~',
+          '(Command exited with code 1)',
+        ].join('\r\n'),
+      },
+    ], { createId: deterministicIds(), startTimestamp: 1000 });
+
+    expect(messages).toEqual([
+      {
+        id: 'msg-2',
+        type: 'tool_use',
+        content: '',
+        timestamp: 1000,
+        metadata: {
+          toolName: 'exec',
+          toolInput: { command: 'mkdir -p D:\\cus_sk' },
+          toolUseId: 'call-mkdir',
+          inferredFromResult: true,
+        },
+      },
+      {
+        id: 'msg-1',
+        type: 'tool_result',
+        content: [
+          'mkdir : 具有指定名称 D:\\cus_sk 的项已存在。',
+          '所在位置 行:1 字符: 1',
+          '+ mkdir -p D:\\cus_sk',
+          '+ ~~~~~~~~~~~~~~~~~~',
+          '(Command exited with code 1)',
+        ].join('\r\n'),
+        timestamp: 1000,
+        metadata: {
+          toolName: 'exec',
+          toolResult: [
+            'mkdir : 具有指定名称 D:\\cus_sk 的项已存在。',
+            '所在位置 行:1 字符: 1',
+            '+ mkdir -p D:\\cus_sk',
+            '+ ~~~~~~~~~~~~~~~~~~',
+            '(Command exited with code 1)',
+          ].join('\r\n'),
+          toolUseId: 'call-mkdir',
+        },
+      },
+    ]);
+  });
+});

--- a/src/main/libs/agentEngine/subagent/historyParser.ts
+++ b/src/main/libs/agentEngine/subagent/historyParser.ts
@@ -17,6 +17,41 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 };
 
+const getStringField = (
+  value: Record<string, unknown>,
+  keys: string[],
+): string => {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return '';
+};
+
+const getToolCallId = (value: Record<string, unknown>): string | null => (
+  getStringField(value, ['id', 'toolCallId', 'tool_call_id', 'toolUseId', 'tool_use_id']) || null
+);
+
+const getToolName = (value: Record<string, unknown>): string => {
+  const direct = getStringField(value, ['name', 'toolName', 'tool_name']);
+  if (direct) return direct;
+  if (isRecord(value.function)) {
+    return getStringField(value.function, ['name']);
+  }
+  return '';
+};
+
+const isToolCallBlock = (value: Record<string, unknown>): boolean => {
+  const blockType = typeof value.type === 'string' ? value.type.trim() : '';
+  return blockType === 'tool_use'
+    || blockType === 'tool_call'
+    || blockType === 'toolCall'
+    || blockType === 'function_call'
+    || Boolean(getToolName(value) && getToolCallId(value));
+};
+
 /**
  * Resolve tool input from a tool_use block, handling multiple field names and formats.
  * The gateway can return tool arguments as:
@@ -28,6 +63,10 @@ const resolveToolInput = (block: Record<string, unknown>): Record<string, unknow
   if (isRecord(block.input)) return block.input;
   if (isRecord(block.args)) return block.args;
   if (isRecord(block.arguments)) return block.arguments;
+  if (isRecord(block.function)) {
+    const functionArguments = resolveToolInput(block.function);
+    if (Object.keys(functionArguments).length > 0) return functionArguments;
+  }
   if (typeof block.arguments === 'string') {
     try {
       const parsed = JSON.parse(block.arguments);
@@ -47,6 +86,111 @@ const resolveToolInput = (block: Record<string, unknown>): Record<string, unknow
   return {};
 };
 
+const collectToolCallBlocks = (message: Record<string, unknown>): Record<string, unknown>[] => {
+  const blocks: Record<string, unknown>[] = [];
+  const seen = new Set<string>();
+
+  const collect = (value: unknown): void => {
+    if (!value) return;
+    if (Array.isArray(value)) {
+      for (const item of value) collect(item);
+      return;
+    }
+    if (!isRecord(value) || !isToolCallBlock(value)) return;
+    const key = getToolCallId(value) ?? `${getToolName(value)}:${blocks.length}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    blocks.push(value);
+  };
+
+  collect(message.content);
+  collect(message.toolCalls);
+  collect(message.tool_calls);
+  collect(message.toolCall);
+  collect(message.tool_call);
+  collect(message.function_call);
+
+  return blocks;
+};
+
+const createToolUseMessage = (
+  block: Record<string, unknown>,
+  createId: () => string,
+  timestamp: number,
+): SubagentCoworkMessage => ({
+  id: createId(),
+  type: 'tool_use',
+  content: '',
+  timestamp,
+  metadata: {
+    toolName: getToolName(block) || 'tool',
+    toolInput: resolveToolInput(block),
+    toolUseId: getToolCallId(block),
+  },
+});
+
+const inferExecCommandFromToolResult = (resultText: string): string | null => {
+  const lines = resultText.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const trimmed = lines[index].trim();
+    if (!trimmed.startsWith('+')) continue;
+    const command = trimmed.replace(/^\+\s*/, '').trim();
+    if (command && !/^~+$/.test(command)) {
+      return command;
+    }
+  }
+  return null;
+};
+
+const synthesizeMissingToolUses = (
+  messages: SubagentCoworkMessage[],
+  createId: () => string,
+): SubagentCoworkMessage[] => {
+  const seenToolUseIds = new Set<string>();
+  const output: SubagentCoworkMessage[] = [];
+
+  for (const message of messages) {
+    if (message.type === 'tool_use') {
+      const toolUseId = message.metadata?.toolUseId;
+      if (typeof toolUseId === 'string' && toolUseId.trim()) {
+        seenToolUseIds.add(toolUseId);
+      }
+      output.push(message);
+      continue;
+    }
+
+    if (message.type === 'tool_result') {
+      const toolUseId = message.metadata?.toolUseId;
+      if (typeof toolUseId === 'string' && toolUseId.trim() && !seenToolUseIds.has(toolUseId)) {
+        const toolName = typeof message.metadata?.toolName === 'string'
+          ? message.metadata.toolName
+          : 'tool';
+        const command = toolName.toLowerCase() === 'exec'
+          ? inferExecCommandFromToolResult(message.content)
+          : null;
+        const toolUse: SubagentCoworkMessage = {
+          id: createId(),
+          type: 'tool_use',
+          content: '',
+          timestamp: message.timestamp,
+          metadata: {
+            toolName,
+            toolInput: command ? { command } : {},
+            toolUseId,
+            inferredFromResult: true,
+          },
+        };
+        seenToolUseIds.add(toolUseId);
+        output.push(toolUse);
+      }
+    }
+
+    output.push(message);
+  }
+
+  return output;
+};
+
 export const parseSubagentGatewayHistoryMessages = (
   historyMessages: unknown[],
   options: ParseSubagentGatewayHistoryOptions = {},
@@ -62,7 +206,7 @@ export const parseSubagentGatewayHistoryMessages = (
     if (role === 'user' || role === 'assistant' || role === 'system') {
       const text = extractGatewayMessageText(raw).trim();
 
-      if (role === 'assistant' && Array.isArray(raw.content)) {
+      if (role === 'assistant') {
         if (text && !shouldSuppressHeartbeatText(role, text)) {
           messages.push({
             id: createId(),
@@ -71,21 +215,8 @@ export const parseSubagentGatewayHistoryMessages = (
             timestamp: timestamp++,
           });
         }
-        for (const block of raw.content as unknown[]) {
-          if (!isRecord(block)) continue;
-          const blockType = typeof block.type === 'string' ? block.type : '';
-          if (blockType === 'tool_use' || blockType === 'tool_call' || blockType === 'toolCall') {
-            const toolName = typeof block.name === 'string' ? block.name : 'tool';
-            const toolInput = resolveToolInput(block);
-            const toolUseId = typeof block.id === 'string' ? block.id : null;
-            messages.push({
-              id: createId(),
-              type: 'tool_use',
-              content: '',
-              timestamp: timestamp++,
-              metadata: { toolName, toolInput, toolUseId },
-            });
-          }
+        for (const block of collectToolCallBlocks(raw)) {
+          messages.push(createToolUseMessage(block, createId, timestamp++));
         }
       } else if (role === 'user' && Array.isArray(raw.content)) {
         for (const block of raw.content as unknown[]) {
@@ -95,7 +226,7 @@ export const parseSubagentGatewayHistoryMessages = (
             const resultText = typeof block.content === 'string'
               ? block.content
               : extractGatewayMessageText(block).trim();
-            const toolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : null;
+            const toolUseId = getToolCallId(block);
             const isError = block.is_error === true;
             if (resultText) {
               messages.push({
@@ -133,11 +264,8 @@ export const parseSubagentGatewayHistoryMessages = (
 
     if (role === 'tool_result' || role === 'toolresult' || role === 'tool' || role === 'function') {
       const text = extractGatewayMessageText(raw).trim();
-      const toolName = typeof raw.toolName === 'string' ? raw.toolName
-        : typeof raw.tool_name === 'string' ? raw.tool_name
-          : typeof raw.name === 'string' ? raw.name : '';
-      const toolUseId = typeof raw.tool_use_id === 'string' ? raw.tool_use_id
-        : typeof raw.toolCallId === 'string' ? raw.toolCallId : null;
+      const toolName = getToolName(raw);
+      const toolUseId = getToolCallId(raw);
       if (text) {
         messages.push({
           id: createId(),
@@ -154,17 +282,8 @@ export const parseSubagentGatewayHistoryMessages = (
       for (const block of raw.content as unknown[]) {
         if (!isRecord(block)) continue;
         const blockType = typeof block.type === 'string' ? block.type : '';
-        if (blockType === 'tool_use' || blockType === 'tool_call' || blockType === 'toolCall') {
-          const toolName = typeof block.name === 'string' ? block.name : 'tool';
-          const toolInput = resolveToolInput(block);
-          const toolUseId = typeof block.id === 'string' ? block.id : null;
-          messages.push({
-            id: createId(),
-            type: 'tool_use',
-            content: '',
-            timestamp: timestamp++,
-            metadata: { toolName, toolInput, toolUseId },
-          });
+        if (isToolCallBlock(block)) {
+          messages.push(createToolUseMessage(block, createId, timestamp++));
         } else if (blockType === 'text' && typeof block.text === 'string' && block.text.trim()) {
           messages.push({
             id: createId(),
@@ -177,5 +296,5 @@ export const parseSubagentGatewayHistoryMessages = (
     }
   }
 
-  return messages;
+  return synthesizeMissingToolUses(messages, createId);
 };

--- a/src/main/libs/agentEngine/subagent/historyParser.ts
+++ b/src/main/libs/agentEngine/subagent/historyParser.ts
@@ -1,0 +1,181 @@
+import crypto from 'node:crypto';
+
+import type { CoworkMessage } from '../../../coworkStore';
+import {
+  extractGatewayMessageText,
+  shouldSuppressHeartbeatText,
+} from '../../openclawHistory';
+
+export type SubagentCoworkMessage = CoworkMessage;
+
+export interface ParseSubagentGatewayHistoryOptions {
+  createId?: () => string;
+  startTimestamp?: number;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+};
+
+/**
+ * Resolve tool input from a tool_use block, handling multiple field names and formats.
+ * The gateway can return tool arguments as:
+ *  - `input` (Anthropic format, object)
+ *  - `args` (OpenClaw format, object)
+ *  - `arguments` (OpenAI format, may be a JSON string)
+ */
+const resolveToolInput = (block: Record<string, unknown>): Record<string, unknown> => {
+  if (isRecord(block.input)) return block.input;
+  if (isRecord(block.args)) return block.args;
+  if (isRecord(block.arguments)) return block.arguments;
+  if (typeof block.arguments === 'string') {
+    try {
+      const parsed = JSON.parse(block.arguments);
+      if (isRecord(parsed)) return parsed;
+    } catch {
+      // Ignore malformed tool input payloads from gateway history.
+    }
+  }
+  if (typeof block.input === 'string') {
+    try {
+      const parsed = JSON.parse(block.input);
+      if (isRecord(parsed)) return parsed;
+    } catch {
+      // Ignore malformed tool input payloads from gateway history.
+    }
+  }
+  return {};
+};
+
+export const parseSubagentGatewayHistoryMessages = (
+  historyMessages: unknown[],
+  options: ParseSubagentGatewayHistoryOptions = {},
+): SubagentCoworkMessage[] => {
+  const createId = options.createId ?? (() => crypto.randomUUID());
+  let timestamp = options.startTimestamp ?? Date.now() - historyMessages.length * 1000;
+  const messages: SubagentCoworkMessage[] = [];
+
+  for (const raw of historyMessages) {
+    if (!isRecord(raw)) continue;
+    const role = typeof raw.role === 'string' ? raw.role.trim().toLowerCase() : '';
+
+    if (role === 'user' || role === 'assistant' || role === 'system') {
+      const text = extractGatewayMessageText(raw).trim();
+
+      if (role === 'assistant' && Array.isArray(raw.content)) {
+        if (text && !shouldSuppressHeartbeatText(role, text)) {
+          messages.push({
+            id: createId(),
+            type: 'assistant',
+            content: text,
+            timestamp: timestamp++,
+          });
+        }
+        for (const block of raw.content as unknown[]) {
+          if (!isRecord(block)) continue;
+          const blockType = typeof block.type === 'string' ? block.type : '';
+          if (blockType === 'tool_use' || blockType === 'tool_call' || blockType === 'toolCall') {
+            const toolName = typeof block.name === 'string' ? block.name : 'tool';
+            const toolInput = resolveToolInput(block);
+            const toolUseId = typeof block.id === 'string' ? block.id : null;
+            messages.push({
+              id: createId(),
+              type: 'tool_use',
+              content: '',
+              timestamp: timestamp++,
+              metadata: { toolName, toolInput, toolUseId },
+            });
+          }
+        }
+      } else if (role === 'user' && Array.isArray(raw.content)) {
+        for (const block of raw.content as unknown[]) {
+          if (!isRecord(block)) continue;
+          const blockType = typeof block.type === 'string' ? block.type : '';
+          if (blockType === 'tool_result') {
+            const resultText = typeof block.content === 'string'
+              ? block.content
+              : extractGatewayMessageText(block).trim();
+            const toolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : null;
+            const isError = block.is_error === true;
+            if (resultText) {
+              messages.push({
+                id: createId(),
+                type: 'tool_result',
+                content: resultText,
+                timestamp: timestamp++,
+                metadata: {
+                  toolResult: resultText,
+                  toolUseId,
+                  isError: isError || undefined,
+                },
+              });
+            }
+          }
+        }
+        if (text && !shouldSuppressHeartbeatText('user', text)) {
+          messages.push({
+            id: createId(),
+            type: 'user',
+            content: text,
+            timestamp: timestamp++,
+          });
+        }
+      } else if (text && !shouldSuppressHeartbeatText(role as 'user' | 'assistant' | 'system', text)) {
+        messages.push({
+          id: createId(),
+          type: role === 'system' ? 'system' : role as 'user' | 'assistant',
+          content: text,
+          timestamp: timestamp++,
+        });
+      }
+      continue;
+    }
+
+    if (role === 'tool_result' || role === 'toolresult' || role === 'tool' || role === 'function') {
+      const text = extractGatewayMessageText(raw).trim();
+      const toolName = typeof raw.toolName === 'string' ? raw.toolName
+        : typeof raw.tool_name === 'string' ? raw.tool_name
+          : typeof raw.name === 'string' ? raw.name : '';
+      const toolUseId = typeof raw.tool_use_id === 'string' ? raw.tool_use_id
+        : typeof raw.toolCallId === 'string' ? raw.toolCallId : null;
+      if (text) {
+        messages.push({
+          id: createId(),
+          type: 'tool_result',
+          content: text,
+          timestamp: timestamp++,
+          metadata: { toolName: toolName || undefined, toolResult: text, toolUseId },
+        });
+      }
+      continue;
+    }
+
+    if (!role && Array.isArray(raw.content)) {
+      for (const block of raw.content as unknown[]) {
+        if (!isRecord(block)) continue;
+        const blockType = typeof block.type === 'string' ? block.type : '';
+        if (blockType === 'tool_use' || blockType === 'tool_call' || blockType === 'toolCall') {
+          const toolName = typeof block.name === 'string' ? block.name : 'tool';
+          const toolInput = resolveToolInput(block);
+          const toolUseId = typeof block.id === 'string' ? block.id : null;
+          messages.push({
+            id: createId(),
+            type: 'tool_use',
+            content: '',
+            timestamp: timestamp++,
+            metadata: { toolName, toolInput, toolUseId },
+          });
+        } else if (blockType === 'text' && typeof block.text === 'string' && block.text.trim()) {
+          messages.push({
+            id: createId(),
+            type: 'assistant',
+            content: block.text.trim(),
+            timestamp: timestamp++,
+          });
+        }
+      }
+    }
+  }
+
+  return messages;
+};

--- a/src/main/libs/agentEngine/subagent/historyParser.ts
+++ b/src/main/libs/agentEngine/subagent/historyParser.ts
@@ -43,6 +43,28 @@ const getToolName = (value: Record<string, unknown>): string => {
   return '';
 };
 
+const parseHistoryTimestamp = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  if (typeof value !== 'string' || !value.trim()) {
+    return undefined;
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric) && numeric > 0) {
+    return numeric;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+};
+
+const getHistoryMessageTimestamp = (value: Record<string, unknown>): number | undefined => (
+  parseHistoryTimestamp(value.timestamp)
+  ?? parseHistoryTimestamp(value.createdAt)
+  ?? parseHistoryTimestamp(value.created_at)
+  ?? parseHistoryTimestamp(value.time)
+);
+
 const isToolCallBlock = (value: Record<string, unknown>): boolean => {
   const blockType = typeof value.type === 'string' ? value.type.trim() : '';
   return blockType === 'tool_use'
@@ -198,6 +220,18 @@ export const parseSubagentGatewayHistoryMessages = (
   const createId = options.createId ?? (() => crypto.randomUUID());
   let timestamp = options.startTimestamp ?? Date.now() - historyMessages.length * 1000;
   const messages: SubagentCoworkMessage[] = [];
+  const rawTimestampOffsets = new WeakMap<Record<string, unknown>, number>();
+  const nextTimestamp = (raw?: Record<string, unknown>): number => {
+    const parsed = raw ? getHistoryMessageTimestamp(raw) : undefined;
+    if (parsed != null) {
+      const offset = rawTimestampOffsets.get(raw) ?? 0;
+      rawTimestampOffsets.set(raw, offset + 1);
+      const value = parsed + offset;
+      timestamp = Math.max(timestamp, value + 1);
+      return value;
+    }
+    return timestamp++;
+  };
 
   for (const raw of historyMessages) {
     if (!isRecord(raw)) continue;
@@ -212,11 +246,11 @@ export const parseSubagentGatewayHistoryMessages = (
             id: createId(),
             type: 'assistant',
             content: text,
-            timestamp: timestamp++,
+            timestamp: nextTimestamp(raw),
           });
         }
         for (const block of collectToolCallBlocks(raw)) {
-          messages.push(createToolUseMessage(block, createId, timestamp++));
+          messages.push(createToolUseMessage(block, createId, nextTimestamp(raw)));
         }
       } else if (role === 'user' && Array.isArray(raw.content)) {
         for (const block of raw.content as unknown[]) {
@@ -233,7 +267,7 @@ export const parseSubagentGatewayHistoryMessages = (
                 id: createId(),
                 type: 'tool_result',
                 content: resultText,
-                timestamp: timestamp++,
+                timestamp: nextTimestamp(raw),
                 metadata: {
                   toolResult: resultText,
                   toolUseId,
@@ -248,7 +282,7 @@ export const parseSubagentGatewayHistoryMessages = (
             id: createId(),
             type: 'user',
             content: text,
-            timestamp: timestamp++,
+            timestamp: nextTimestamp(raw),
           });
         }
       } else if (text && !shouldSuppressHeartbeatText(role as 'user' | 'assistant' | 'system', text)) {
@@ -256,7 +290,7 @@ export const parseSubagentGatewayHistoryMessages = (
           id: createId(),
           type: role === 'system' ? 'system' : role as 'user' | 'assistant',
           content: text,
-          timestamp: timestamp++,
+          timestamp: nextTimestamp(raw),
         });
       }
       continue;
@@ -271,7 +305,7 @@ export const parseSubagentGatewayHistoryMessages = (
           id: createId(),
           type: 'tool_result',
           content: text,
-          timestamp: timestamp++,
+          timestamp: nextTimestamp(raw),
           metadata: { toolName: toolName || undefined, toolResult: text, toolUseId },
         });
       }
@@ -283,13 +317,13 @@ export const parseSubagentGatewayHistoryMessages = (
         if (!isRecord(block)) continue;
         const blockType = typeof block.type === 'string' ? block.type : '';
         if (isToolCallBlock(block)) {
-          messages.push(createToolUseMessage(block, createId, timestamp++));
+          messages.push(createToolUseMessage(block, createId, nextTimestamp(raw)));
         } else if (blockType === 'text' && typeof block.text === 'string' && block.text.trim()) {
           messages.push({
             id: createId(),
             type: 'assistant',
             content: block.text.trim(),
-            timestamp: timestamp++,
+            timestamp: nextTimestamp(raw),
           });
         }
       }

--- a/src/main/libs/agentEngine/subagent/tracker.ts
+++ b/src/main/libs/agentEngine/subagent/tracker.ts
@@ -3,40 +3,9 @@ import crypto from 'node:crypto';
 import type { SubagentMessageStore } from '../../../subagentMessageStore';
 import type { SubagentRunStore, SubagentRunWithParent } from '../../../subagentRunStore';
 import {
-  extractGatewayMessageText,
-  shouldSuppressHeartbeatText,
-} from '../../openclawHistory';
-
-const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
-};
-
-/**
- * Resolve tool input from a tool_use block, handling multiple field names and formats.
- * The gateway can return tool arguments as:
- *  - `input` (Anthropic format, object)
- *  - `args` (OpenClaw format, object)
- *  - `arguments` (OpenAI format, may be a JSON string)
- */
-const resolveToolInput = (block: Record<string, unknown>): Record<string, unknown> => {
-  if (isRecord(block.input)) return block.input;
-  if (isRecord(block.args)) return block.args;
-  if (isRecord(block.arguments)) return block.arguments;
-  // arguments may be a JSON string (OpenAI format)
-  if (typeof block.arguments === 'string') {
-    try {
-      const parsed = JSON.parse(block.arguments);
-      if (isRecord(parsed)) return parsed;
-    } catch { /* ignore parse errors */ }
-  }
-  if (typeof block.input === 'string') {
-    try {
-      const parsed = JSON.parse(block.input);
-      if (isRecord(parsed)) return parsed;
-    } catch { /* ignore parse errors */ }
-  }
-  return {};
-};
+  parseSubagentGatewayHistoryMessages,
+  type SubagentCoworkMessage,
+} from './historyParser';
 
 const resolveSpawnDisplayLabel = (...sources: Array<Record<string, unknown> | null | undefined>): string | null => {
   for (const source of sources) {
@@ -47,22 +16,6 @@ const resolveSpawnDisplayLabel = (...sources: Array<Record<string, unknown> | nu
   }
   return null;
 };
-
-/** Message format compatible with renderer CoworkMessage interface */
-export interface SubagentCoworkMessage {
-  id: string;
-  type: 'user' | 'assistant' | 'tool_use' | 'tool_result' | 'system';
-  content: string;
-  timestamp: number;
-  metadata?: {
-    toolName?: string;
-    toolInput?: Record<string, unknown>;
-    toolResult?: string;
-    toolUseId?: string | null;
-    isError?: boolean;
-    [key: string]: unknown;
-  };
-}
 
 export type GatewayClientLike = {
   request: <T = Record<string, unknown>>(
@@ -786,148 +739,7 @@ export class SubagentTracker {
 
       console.log('[SubagentTracker] fetchSubagentHistory: got', history.messages.length, 'raw messages for key:', sessionKey);
 
-      const messages: SubagentCoworkMessage[] = [];
-      let ts = Date.now() - history.messages.length * 1000; // synthetic timestamps
-
-      for (const raw of history.messages) {
-        if (!isRecord(raw)) continue;
-        const role = typeof raw.role === 'string' ? raw.role.trim().toLowerCase() : '';
-
-        // Handle standard user/assistant/system messages
-        if (role === 'user' || role === 'assistant' || role === 'system') {
-          const text = extractGatewayMessageText(raw).trim();
-
-          // For assistant messages with content array containing tool_use blocks
-          if (role === 'assistant' && Array.isArray(raw.content)) {
-            // Extract text parts first
-            if (text && !shouldSuppressHeartbeatText(role, text)) {
-              messages.push({
-                id: crypto.randomUUID(),
-                type: 'assistant',
-                content: text,
-                timestamp: ts++,
-              });
-            }
-            // Extract tool_use blocks
-            for (const block of raw.content as unknown[]) {
-              if (!isRecord(block)) continue;
-              const blockType = typeof block.type === 'string' ? block.type : '';
-              if (blockType === 'tool_use' || blockType === 'tool_call' || blockType === 'toolCall') {
-                const toolName = typeof block.name === 'string' ? block.name : 'tool';
-                const toolInput = resolveToolInput(block);
-                const toolUseId = typeof block.id === 'string' ? block.id : null;
-                messages.push({
-                  id: crypto.randomUUID(),
-                  type: 'tool_use',
-                  content: '',
-                  timestamp: ts++,
-                  metadata: { toolName, toolInput, toolUseId },
-                });
-              }
-            }
-          } else if (role === 'user' && Array.isArray(raw.content)) {
-            // User messages may contain tool_result blocks (Anthropic API format)
-            let hasToolResult = false;
-            for (const block of raw.content as unknown[]) {
-              if (!isRecord(block)) continue;
-              const blockType = typeof block.type === 'string' ? block.type : '';
-              if (blockType === 'tool_result') {
-                hasToolResult = true;
-                const resultText = typeof block.content === 'string'
-                  ? block.content
-                  : extractGatewayMessageText(block).trim();
-                const toolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : null;
-                const isError = block.is_error === true;
-                if (resultText) {
-                  messages.push({
-                    id: crypto.randomUUID(),
-                    type: 'tool_result',
-                    content: resultText,
-                    timestamp: ts++,
-                    metadata: { toolResult: resultText, toolUseId, isError: isError || undefined },
-                  });
-                }
-              }
-            }
-            // If there was also text content alongside tool results, emit it
-            if (text && !shouldSuppressHeartbeatText('user', text)) {
-              messages.push({
-                id: crypto.randomUUID(),
-                type: 'user',
-                content: text,
-                timestamp: ts++,
-              });
-            }
-            if (!hasToolResult && !text) {
-              console.log('[SubagentTracker] dropped user message with empty text, keys:', Object.keys(raw).join(','));
-            }
-          } else if (text && !shouldSuppressHeartbeatText(role as 'user' | 'assistant' | 'system', text)) {
-            const type = role === 'system' ? 'system' : role as 'user' | 'assistant';
-            messages.push({
-              id: crypto.randomUUID(),
-              type,
-              content: text,
-              timestamp: ts++,
-            });
-          } else if (!text) {
-            console.log('[SubagentTracker] dropped message with empty text, role:', role, 'keys:', Object.keys(raw).join(','));
-          }
-          continue;
-        }
-
-        // Handle tool result messages
-        if (role === 'tool_result' || role === 'toolresult' || role === 'tool' || role === 'function') {
-          const text = extractGatewayMessageText(raw).trim();
-          const toolName = typeof raw.toolName === 'string' ? raw.toolName
-            : typeof raw.tool_name === 'string' ? raw.tool_name
-              : typeof raw.name === 'string' ? raw.name : '';
-          const toolUseId = typeof raw.tool_use_id === 'string' ? raw.tool_use_id
-            : typeof raw.toolCallId === 'string' ? raw.toolCallId : null;
-          if (text) {
-            messages.push({
-              id: crypto.randomUUID(),
-              type: 'tool_result',
-              content: text,
-              timestamp: ts++,
-              metadata: { toolName: toolName || undefined, toolResult: text, toolUseId },
-            });
-          } else {
-            console.log('[SubagentTracker] dropped tool result with empty text, role:', role);
-          }
-          continue;
-        }
-
-        // Handle messages with content arrays that contain tool_use blocks (no role field)
-        if (!role && Array.isArray(raw.content)) {
-          for (const block of raw.content as unknown[]) {
-            if (!isRecord(block)) continue;
-            const blockType = typeof block.type === 'string' ? block.type : '';
-            if (blockType === 'tool_use' || blockType === 'tool_call' || blockType === 'toolCall') {
-              const toolName = typeof block.name === 'string' ? block.name : 'tool';
-              const toolInput = resolveToolInput(block);
-              const toolUseId = typeof block.id === 'string' ? block.id : null;
-              messages.push({
-                id: crypto.randomUUID(),
-                type: 'tool_use',
-                content: '',
-                timestamp: ts++,
-                metadata: { toolName, toolInput, toolUseId },
-              });
-            } else if (blockType === 'text' && typeof block.text === 'string' && block.text.trim()) {
-              messages.push({
-                id: crypto.randomUUID(),
-                type: 'assistant',
-                content: block.text.trim(),
-                timestamp: ts++,
-              });
-            }
-          }
-          continue;
-        }
-
-        // Log completely unhandled messages
-        console.log('[SubagentTracker] unhandled message, role:', role || '(empty)', 'keys:', Object.keys(raw).join(','));
-      }
+      const messages = parseSubagentGatewayHistoryMessages(history.messages);
 
       // Cache locally
       this.subagentMessages.set(runId, messages);


### PR DESCRIPTION
## Summary
- extract subagent gateway history parsing into a shared helper
- reuse the parser when syncing materialized subagent child sessions so tool calls/results appear on the child session page
- recover orphan subagent tool results by recognizing broader tool-call history shapes and synthesizing a matching tool_use when needed

## Verification
- npx vitest run src/main/libs/agentEngine/subagent/historyParser.test.ts src/main/libs/agentEngine/subagent/childHistorySync.test.ts
- npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/agentEngine/subagent/historyParser.ts src/main/libs/agentEngine/subagent/historyParser.test.ts src/main/libs/agentEngine/subagent/childHistorySync.ts src/main/libs/agentEngine/subagent/childHistorySync.test.ts src/main/libs/agentEngine/subagent/tracker.ts src/main/libs/agentEngine/openclawRuntimeAdapter.ts src/main/coworkStore.ts
- npx tsc --project electron-tsconfig.json

## Notes
- Full tracker Vitest coverage was not rerun after the final parser-only patch; earlier it was blocked locally by better-sqlite3 Node ABI mismatch.