### PR TITLE
fix(openclaw): explicitly disable memory dreaming

### DIFF
--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -1202,6 +1202,97 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(config.plugins.allow).toContain('xai');
   });
 
+  test('keeps memory-core selected and explicitly disables dreaming when dreaming is off', async () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        entries: {
+          'memory-core': {
+            enabled: true,
+            config: {
+              retention: {
+                shortTermDays: 14,
+              },
+              dreaming: {
+                enabled: true,
+                frequency: '0 3 * * *',
+              },
+            },
+          },
+        },
+      },
+    }, null, 2));
+
+    const sync = await createSync({
+      getCoworkConfig: () => ({
+        workingDirectory: tmpDir,
+        systemPrompt: '',
+        executionMode: 'local',
+        agentEngine: 'openclaw',
+        memoryEnabled: false,
+        memoryImplicitUpdateEnabled: false,
+        memoryLlmJudgeEnabled: false,
+        memoryGuardLevel: 'balanced',
+        memoryUserMemoriesMaxItems: 100,
+        skipMissedJobs: false,
+        dreamingEnabled: false,
+        dreamingFrequency: '0 3 * * *',
+      }),
+    });
+
+    const result = sync.sync('dreaming-disabled-cleanup');
+    expect(result.ok).toBe(true);
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.plugins.slots.memory).toBe('memory-core');
+    expect(config.plugins.allow).toContain('memory-core');
+    expect(config.plugins.entries['memory-core']).toEqual({
+      enabled: true,
+      config: {
+        retention: {
+          shortTermDays: 14,
+        },
+        dreaming: {
+          enabled: false,
+        },
+      },
+    });
+  });
+
+  test('writes enabled memory-core dreaming config when dreaming is on', async () => {
+    const sync = await createSync({
+      getCoworkConfig: () => ({
+        workingDirectory: tmpDir,
+        systemPrompt: '',
+        executionMode: 'local',
+        agentEngine: 'openclaw',
+        memoryEnabled: false,
+        memoryImplicitUpdateEnabled: false,
+        memoryLlmJudgeEnabled: false,
+        memoryGuardLevel: 'balanced',
+        memoryUserMemoriesMaxItems: 100,
+        skipMissedJobs: false,
+        dreamingEnabled: true,
+        dreamingFrequency: '0 4 * * *',
+      }),
+    });
+
+    const result = sync.sync('dreaming-enabled');
+    expect(result.ok).toBe(true);
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.plugins.slots.memory).toBe('memory-core');
+    expect(config.plugins.allow).toContain('memory-core');
+    expect(config.plugins.entries['memory-core']).toEqual({
+      enabled: true,
+      config: {
+        dreaming: {
+          enabled: true,
+          frequency: '0 4 * * *',
+        },
+      },
+    });
+  });
+
   test('maps OpenAI OAuth mode to the ChatGPT Responses provider', async () => {
     const { AuthType, OpenClawApi, OpenClawProviderId, ProviderName } = await import('../../shared/providers');
     const { buildProviderSelection } = await import('./openclawConfigSync');

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -91,6 +91,7 @@ export const OPENCLAW_AGENT_TIMEOUT_SECONDS = 3600;
 export const OPENCLAW_HEARTBEAT_EVERY_ENABLED = '1h';
 export const OPENCLAW_HEARTBEAT_EVERY_DISABLED = '0m';
 const DINGTALK_OPENCLAW_CHANNEL = 'dingtalk-connector';
+const OPENCLAW_MEMORY_CORE_PLUGIN_ID = 'memory-core';
 export const OPENCLAW_BINDING_ANY_ACCOUNT_ID = '*';
 const OPENCLAW_DEFAULT_MODEL_MAX_TOKENS = 8192;
 const CHROME_PROXY_SERVER_ARG_PREFIX = '--proxy-server=';
@@ -2009,6 +2010,7 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
         const trustedPluginAllow = Array.from(new Set([
           ...existingAllow,
           BUNDLED_BROWSER_PLUGIN_ID,
+          OPENCLAW_MEMORY_CORE_PLUGIN_ID,
           // A non-empty plugins.allow is a strict allowlist in OpenClaw
           // (manifest-owner-policy "not-in-allowlist"), so runtime-bundled
           // plugins we rely on must be listed here explicitly or they never
@@ -2042,6 +2044,10 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
                 // a removed plugin causes "Config invalid: plugin not found" errors.
                 allow: trustedPluginAllow,
                 deny: [],
+                slots: {
+                  ...((existingPlugins as Record<string, unknown>).slots as Record<string, unknown> | undefined),
+                  memory: OPENCLAW_MEMORY_CORE_PLUGIN_ID,
+                },
                 entries: pluginEntries,
               },
             }
@@ -2092,11 +2098,12 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
     if (managedConfig.plugins) {
       const plugins = managedConfig.plugins as Record<string, unknown>;
       const entries = plugins.entries as Record<string, Record<string, unknown>>;
-      const existingMemoryCore = entries['memory-core'] ?? {};
+      const existingMemoryCore = entries[OPENCLAW_MEMORY_CORE_PLUGIN_ID] ?? {};
       const existingMemoryCoreConfig = (existingMemoryCore as Record<string, unknown>).config as Record<string, unknown> | undefined;
       if (coworkConfig.dreamingEnabled) {
-        entries['memory-core'] = {
+        entries[OPENCLAW_MEMORY_CORE_PLUGIN_ID] = {
           ...existingMemoryCore,
+          enabled: true,
           config: {
             ...existingMemoryCoreConfig,
             dreaming: {
@@ -2105,12 +2112,16 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
             },
           },
         };
-      } else if (existingMemoryCoreConfig?.dreaming) {
-        // Remove dreaming config when disabled
-        const { dreaming: _, ...restConfig } = existingMemoryCoreConfig;
-        entries['memory-core'] = {
+      } else {
+        entries[OPENCLAW_MEMORY_CORE_PLUGIN_ID] = {
           ...existingMemoryCore,
-          config: Object.keys(restConfig).length > 0 ? restConfig : undefined,
+          enabled: true,
+          config: {
+            ...existingMemoryCoreConfig,
+            dreaming: {
+              enabled: false,
+            },
+          },
         };
       }
     }


### PR DESCRIPTION
## Summary
- keep memory-core selected and allowlisted in generated OpenClaw config
- explicitly write `dreaming.enabled=false` when LobsterAI dreaming is off so OpenClaw can reconcile and remove stale managed dream cron jobs
- add runtime config tests for dreaming on/off output

## Verification
- Confirmed live `openclaw.json` contains `plugins.allow` with `memory-core`, `plugins.slots.memory=memory-core`, and `plugins.entries.memory-core.config.dreaming.enabled=false`
- `npx vitest run src/main/libs/openclawConfigSync.runtime.test.ts`
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/openclawConfigSync.ts src/main/libs/openclawConfigSync.runtime.test.ts`
- `npm run compile:electron` passed before launching Lobster AI; rerunning `npm test` while the app was open failed in `pretest` because Windows locked `better_sqlite3.node`, not because of test failures