### PR TITLE
fix(openclaw): support agent-scoped local tools

### DIFF
--- a/openclaw-extensions/ask-user-question/index.ts
+++ b/openclaw-extensions/ask-user-question/index.ts
@@ -1,6 +1,8 @@
 import { Type } from '@sinclair/typebox';
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
 
+import { isAskUserQuestionCandidateSessionKey } from './sessionKey';
+
 /**
  * AskUserQuestion plugin for OpenClaw.
  *
@@ -139,15 +141,14 @@ const plugin = {
       return;
     }
 
-    // Use a factory so the tool is only available for desktop (webchat) sessions.
+    // Use a factory so the tool is only available for LobsterAI local-session candidates.
     // IM channel sessions (qqbot, dingtalk, weixin, feishu, etc.) get null → tool hidden.
     api.registerTool((ctx) => {
-      // Only enable for LobsterAI desktop sessions (sessionKey starts with 'agent:main:lobsterai:').
+      // Enable for LobsterAI desktop sessions across agents and delegated child sessions.
       // IM channel sessions (dingtalk, qqbot, weixin, feishu, wecom, etc.) should not have this tool
       // so the model executes delete commands directly without confirmation on IM.
       const sessionKey = ctx.sessionKey ?? '';
-      const isLocalDesktop = sessionKey.startsWith('agent:main:lobsterai:');
-      if (!isLocalDesktop) {
+      if (!isAskUserQuestionCandidateSessionKey(sessionKey)) {
         return null;
       }
 

--- a/openclaw-extensions/ask-user-question/sessionKey.ts
+++ b/openclaw-extensions/ask-user-question/sessionKey.ts
@@ -3,7 +3,7 @@ const AGENT_SESSION_PREFIX = 'agent:';
 const LOBSTERAI_SESSION_MARKER = 'lobsterai';
 const SUBAGENT_SESSION_MARKER = 'subagent';
 
-export function isLobsterAiDesktopSessionKey(sessionKey: string | undefined | null): boolean {
+export function isAskUserQuestionCandidateSessionKey(sessionKey: string | undefined | null): boolean {
   const raw = (sessionKey ?? '').trim();
   if (!raw) return false;
 
@@ -22,8 +22,10 @@ export function isLobsterAiDesktopSessionKey(sessionKey: string | undefined | nu
 
   const agentId = parts[1]?.trim() ?? '';
   const source = parts[2]?.trim() ?? '';
-  const sessionId = parts.slice(3).join(':').trim();
-  return agentId.length > 0
-    && sessionId.length > 0
-    && (source === LOBSTERAI_SESSION_MARKER || source === SUBAGENT_SESSION_MARKER);
+  const rest = parts.slice(3).join(':').trim();
+  if (!agentId || !rest) {
+    return false;
+  }
+
+  return source === LOBSTERAI_SESSION_MARKER || source === SUBAGENT_SESSION_MARKER;
 }

--- a/specs/bugfixes/agent-scoped-local-tools/2026-07-09-agent-scoped-local-tools-design.md
+++ b/specs/bugfixes/agent-scoped-local-tools/2026-07-09-agent-scoped-local-tools-design.md
@@ -1,0 +1,209 @@
+# Agent 本地工具作用域修复设计文档
+
+## 1. 概述
+
+### 1.1 问题
+
+PR #2285 引入指定 `agentId` 启用 subagent 后，QA 反馈 child session 中不支持调用 `AskUserQuestion`。进一步验证发现问题不只发生在 child session：
+
+- main agent 普通桌面会话可以正常调用 `AskUserQuestion` 并弹出 LobsterAI 桌面选择窗口。
+- 非 main agent 普通桌面会话无法看到 LobsterAI 的 `AskUserQuestion`，模型会误用飞书插件的 `feishu_ask_user_question`。
+- 非 main agent 的 child session 同样无法使用 `AskUserQuestion`。
+- LobsterAI 自注册的 `lobsterai_image_generate` / `lobsterai_video_generate` 已支持非 main 普通桌面会话，但不支持 child session。
+
+用户期望是：
+
+1. 桌面端普通 agent 会话和桌面端 child session 都可以使用 LobsterAI 本地交互工具。
+2. IM 会话继续不出现桌面弹窗，保持原设计。
+3. 图片/视频生成在 child session 中也能继承父会话的媒体模型选择。
+
+### 1.2 根因
+
+`ask-user-question` 插件最初设计于 2026-03-26，当时通过 `sessionKey` 区分桌面端和 IM 端：
+
+```text
+agent:main:lobsterai:* -> 桌面端
+其他 -> IM 端
+```
+
+该设计的目标是避免 IM 端触发桌面弹窗，而不是刻意限制 main agent。但随着多 Agent 桌面会话和 delegated subagent child session 引入，桌面端 sessionKey 已扩展为：
+
+```text
+agent:<agentId>:lobsterai:<sessionId>
+agent:<agentId>:subagent:<...>
+```
+
+`ask-user-question` 仍只判断 `agent:main:lobsterai:*`，因此非 main 桌面会话无法注册 `AskUserQuestion`。
+
+媒体生成插件使用了较宽的桌面会话判断，已经允许 `agent:<agentId>:lobsterai:<sessionId>`，但未允许 `agent:<agentId>:subagent:<...>`。同时主进程媒体回调只通过 `parseManagedSessionKey()` 解析 sessionId，无法把 subagent key 映射回本地 child Cowork session。
+
+## 2. 用户场景
+
+### 场景 1：非 main agent 普通桌面会话询问用户
+
+**Given** 用户在 `qa-reviewer` 等非 main agent 下新建桌面会话
+
+**When** 模型需要结构化询问用户，例如单选、多选或删除确认
+
+**Then** 工具列表中应包含 LobsterAI `AskUserQuestion`，并弹出桌面端交互窗口。
+
+### 场景 2：桌面 child session 询问用户
+
+**Given** 桌面主会话委派出非 main agent child session
+
+**When** child session 需要结构化询问用户
+
+**Then** `AskUserQuestion` 请求应归属到 materialized child Cowork session，不应落到 `__askuser__` 或错误会话。
+
+### 场景 3：IM 会话及其子会话
+
+**Given** 会话来自飞书、钉钉、微信、QQ、Telegram、Discord、企微、NIM、POPO 或 email 等 IM channel
+
+**When** 模型需要用户确认或选择
+
+**Then** 不应弹出 LobsterAI 桌面窗口。IM 会话仍按原设计走文本交互或平台插件自己的交互能力。
+
+### 场景 4：child session 媒体生成
+
+**Given** 用户在父桌面会话中选择了 LobsterAI 图片或视频模型
+
+**When** child session 调用 `lobsterai_image_generate` 或 `lobsterai_video_generate`
+
+**Then** 工具应可见，主进程回调应能解析 child session，并在 child 没有独立选择时继承父会话的媒体模型选择。
+
+## 3. 功能需求
+
+### 3.1 AskUserQuestion 支持所有本地桌面 agent
+
+`AskUserQuestion` 插件应允许：
+
+- legacy `lobsterai:<sessionId>`
+- `agent:<agentId>:lobsterai:<sessionId>`
+- `agent:<agentId>:subagent:<...>`
+
+插件仍应拒绝 IM channel key，例如：
+
+- `agent:<agentId>:feishu:...`
+- `agent:<agentId>:dingtalk-connector:...`
+- `agent:<agentId>:openclaw-weixin:...`
+- 其他非 `lobsterai` / `subagent` 来源。
+
+### 3.2 主进程必须保留 IM 保护
+
+插件侧只根据 sessionKey 字符串做候选判断，不能作为最终安全边界。主进程收到 AskUser HTTP callback 后必须：
+
+1. 根据 `agent:<agentId>:lobsterai:<sessionId>` 解析本地 Cowork session。
+2. 根据 `cowork_sessions.claude_session_id` 反查 materialized child session。
+3. 检查当前 session 及其 parent 链是否绑定在 `im_session_mappings`。
+4. 如果无法解析为本地桌面 Cowork session，或属于 IM 会话链路，直接 deny，不发桌面弹窗事件。
+
+### 3.3 媒体生成支持 child session
+
+`lobsterai_image_generate` / `lobsterai_video_generate` 插件应允许 `agent:<agentId>:subagent:<...>`。
+
+主进程媒体回调应支持：
+
+- 通过 managed key 解析普通桌面会话。
+- 通过 `cowork_sessions.claude_session_id` 反查 child session。
+- child session 没有媒体选择时，向 parent session 回退查找媒体选择。
+
+### 3.4 不调整 subagent 工具 deny 策略
+
+当前 subagent 工具策略裁剪的是 `agents_list`、`sessions_spawn`、`subagents`、`cron`、`gateway` 等委派/网关/定时任务工具，不包含 AskUser 和媒体生成。本修复不调整 subagent deny list。
+
+### 3.5 不处理 Feishu AskUser 暴露问题
+
+`feishu_ask_user_question` 在桌面会话中仍可见是误用诱因之一，但不是本次修复范围。本次只确保 LobsterAI 桌面 AskUser 在正确会话中可见，并保留 IM 不弹桌面窗的约束。
+
+## 4. 实现方案
+
+### 4.1 AskUserQuestion 插件 sessionKey 判定
+
+在 `openclaw-extensions/ask-user-question/` 下新增独立 sessionKey helper，避免继续 hardcode `agent:main:lobsterai:*`。
+
+候选会话判断只允许：
+
+```text
+lobsterai:*
+agent:*:lobsterai:*
+agent:*:subagent:*
+```
+
+该 helper 只负责工具注册可见性，不负责最终桌面/IM 判定。
+
+### 4.2 本地 Cowork session 反查
+
+在主进程新增本地 OpenClaw sessionKey resolver：
+
+- managed key：使用 `parseManagedSessionKey()` 取出 sessionId，并确认 `cowork_sessions` 中存在该 session。
+- child key：使用 `cowork_sessions.claude_session_id = sessionKey` 反查 materialized child session。
+- IM 判断：从当前 session 沿 `parent_session_id` 向上查找，如果任一 session 存在 `im_session_mappings.cowork_session_id`，视为 IM 会话链路。
+
+AskUser callback 使用 desktop resolver。无法解析或属于 IM 链路时返回 `{ behavior: 'deny' }`，避免 HTTP callback 挂起。
+
+### 4.3 媒体生成 child session 支持
+
+媒体插件的 `isLobsterAiDesktopSessionKey()` 增加 `agent:*:subagent:*` 支持。
+
+媒体回调中的 sessionId 提取从 `parseManagedSessionKey()` 切换为本地 resolver，使 child key 能映射到 materialized child Cowork session。
+
+媒体模型选择按以下顺序解析：
+
+1. child session 自己的 `mediaSelectionBySession`。
+2. parent session 的 `mediaSelectionBySession`。
+3. 继续向上查找，最多 16 层，防止异常循环。
+
+### 4.4 UI 弹窗策略
+
+本次采用低风险处理：
+
+- AskUser permission 仍按 resolved sessionId 派发。
+- child session 触发的 AskUser 归属到 child session。
+- 不把 child AskUser 改成全局弹窗，也不强制映射到 parent session。
+
+这保持现有 UI selector 行为，避免扩大弹窗展示范围。
+
+## 5. 边界情况
+
+| 场景 | 处理方式 |
+|------|---------|
+| 非 main 普通桌面会话 | 注册 `AskUserQuestion`，回调解析到该 session |
+| 桌面 child session 已 materialized | 注册 `AskUserQuestion`，通过 `claude_session_id` 反查 child session |
+| 桌面 child session 尚未 materialized | 主进程解析失败并 deny，避免挂起或弹错会话 |
+| IM 普通会话 | 插件层通常不注册；即使误传 callback，主进程 IM mapping 检查后 deny |
+| IM 派生 child session | 如果 parent 在 IM mapping 中，主进程沿 parent 链识别并 deny |
+| child 媒体生成没有独立模型选择 | 继承 parent 的媒体模型选择 |
+| parent 链异常循环 | 最多查找 16 层，超过后停止 |
+
+## 6. 涉及文件
+
+### 新增
+
+| 文件 | 说明 |
+|------|------|
+| `openclaw-extensions/ask-user-question/sessionKey.ts` | AskUser 插件 sessionKey 候选判断 |
+| `src/main/libs/openclawLocalSessionResolver.ts` | 主进程 OpenClaw sessionKey 到 Cowork session 的本地解析与 IM 保护 |
+| `tests/openclaw-extensions/ask-user-question/sessionKey.test.ts` | AskUser sessionKey 判定测试 |
+| `src/main/libs/openclawLocalSessionResolver.test.ts` | 本地 session resolver 测试 |
+
+### 修改
+
+| 文件 | 改动 |
+|------|------|
+| `openclaw-extensions/ask-user-question/index.ts` | 使用新的 sessionKey helper，支持非 main 桌面 agent 和 subagent candidate |
+| `openclaw-extensions/lobster-media-generation/sessionKey.ts` | 允许 `agent:*:subagent:*` |
+| `src/main/mcp/mcpRuntime.ts` | AskUser callback 使用本地桌面 session resolver，并对非桌面/未知会话 deny |
+| `src/main/main.ts` | 媒体 callback 使用本地 session resolver，并支持 parent media selection 回退 |
+| `tests/openclaw-extensions/lobster-media-generation/sessionKey.test.ts` | 增加 subagent sessionKey 覆盖 |
+
+## 7. 验收标准
+
+1. main agent 普通桌面会话继续可以调用 `AskUserQuestion` 并弹窗。
+2. 非 main agent 普通桌面会话可以调用 `AskUserQuestion`，不再误用飞书 AskUser。
+3. 桌面 child session 的 `AskUserQuestion` callback 能映射到 materialized child Cowork session。
+4. IM 会话及其 child 链路不会触发 LobsterAI 桌面弹窗。
+5. 普通非 main agent 继续可以使用 `lobsterai_image_generate` / `lobsterai_video_generate`。
+6. 桌面 child session 可以看到 LobsterAI 图片/视频生成工具。
+7. child session 媒体生成在没有独立选择时继承 parent 的媒体模型选择。
+8. 不修改 `vendor/openclaw-runtime/current` 作为最终状态。
+9. 相关 Vitest、touched-file ESLint 和 Electron 主进程编译通过。

--- a/src/main/libs/openclawLocalSessionResolver.test.ts
+++ b/src/main/libs/openclawLocalSessionResolver.test.ts
@@ -1,0 +1,80 @@
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import {
+  getCoworkParentSessionId,
+  isCoworkSessionBoundToIm,
+  resolveCoworkSessionIdByOpenClawSessionKey,
+  resolveLocalDesktopCoworkSessionIdByOpenClawSessionKey,
+} from './openclawLocalSessionResolver';
+
+const dbs: Database.Database[] = [];
+
+const createDb = (): Database.Database => {
+  const db = new Database(':memory:');
+  dbs.push(db);
+  db.exec(`
+    CREATE TABLE cowork_sessions (
+      id TEXT PRIMARY KEY,
+      claude_session_id TEXT,
+      parent_session_id TEXT
+    );
+    CREATE TABLE im_session_mappings (
+      cowork_session_id TEXT
+    );
+  `);
+  return db;
+};
+
+const insertSession = (
+  db: Database.Database,
+  id: string,
+  claudeSessionId: string | null = null,
+  parentSessionId: string | null = null,
+) => {
+  db.prepare('INSERT INTO cowork_sessions (id, claude_session_id, parent_session_id) VALUES (?, ?, ?)')
+    .run(id, claudeSessionId, parentSessionId);
+};
+
+afterEach(() => {
+  while (dbs.length > 0) {
+    dbs.pop()?.close();
+  }
+});
+
+describe('openclaw local session resolver', () => {
+  test('resolves managed desktop session keys across agents', () => {
+    const db = createDb();
+    insertSession(db, 'session-1');
+
+    expect(resolveCoworkSessionIdByOpenClawSessionKey(
+      db,
+      'agent:qa-reviewer:lobsterai:session-1',
+    )).toBe('session-1');
+  });
+
+  test('resolves materialized subagent child session keys', () => {
+    const db = createDb();
+    insertSession(db, 'parent-1');
+    insertSession(db, 'child-1', 'agent:qa-reviewer:subagent:run-1', 'parent-1');
+
+    expect(resolveCoworkSessionIdByOpenClawSessionKey(
+      db,
+      'agent:qa-reviewer:subagent:run-1',
+    )).toBe('child-1');
+    expect(getCoworkParentSessionId(db, 'child-1')).toBe('parent-1');
+  });
+
+  test('rejects IM-bound sessions and descendants for desktop callbacks', () => {
+    const db = createDb();
+    insertSession(db, 'im-parent');
+    insertSession(db, 'im-child', 'agent:qa-reviewer:subagent:run-2', 'im-parent');
+    db.prepare('INSERT INTO im_session_mappings (cowork_session_id) VALUES (?)').run('im-parent');
+
+    expect(isCoworkSessionBoundToIm(db, 'im-child')).toBe(true);
+    expect(resolveLocalDesktopCoworkSessionIdByOpenClawSessionKey(
+      db,
+      'agent:qa-reviewer:subagent:run-2',
+    )).toBe(null);
+  });
+});

--- a/src/main/libs/openclawLocalSessionResolver.ts
+++ b/src/main/libs/openclawLocalSessionResolver.ts
@@ -1,0 +1,86 @@
+import type Database from 'better-sqlite3';
+
+import { parseManagedSessionKey } from './openclawChannelSessionSync';
+
+const MAX_PARENT_LOOKUP_DEPTH = 16;
+
+const getSessionRowById = (
+  db: Database.Database,
+  sessionId: string,
+): { id: string; parent_session_id: string | null } | null => {
+  const normalized = sessionId.trim();
+  if (!normalized) return null;
+  const row = db
+    .prepare('SELECT id, parent_session_id FROM cowork_sessions WHERE id = ? LIMIT 1')
+    .get(normalized) as { id: string; parent_session_id: string | null } | undefined;
+  return row ?? null;
+};
+
+const getSessionRowByClaudeSessionId = (
+  db: Database.Database,
+  sessionKey: string,
+): { id: string; parent_session_id: string | null } | null => {
+  const normalized = sessionKey.trim();
+  if (!normalized) return null;
+  const row = db
+    .prepare('SELECT id, parent_session_id FROM cowork_sessions WHERE claude_session_id = ? LIMIT 1')
+    .get(normalized) as { id: string; parent_session_id: string | null } | undefined;
+  return row ?? null;
+};
+
+export function resolveCoworkSessionIdByOpenClawSessionKey(
+  db: Database.Database,
+  sessionKey: string | undefined | null,
+): string | null {
+  const normalized = (sessionKey ?? '').trim();
+  if (!normalized) return null;
+
+  const persisted = getSessionRowByClaudeSessionId(db, normalized);
+  if (persisted) return persisted.id;
+
+  const managed = parseManagedSessionKey(normalized);
+  if (!managed) return null;
+
+  const session = getSessionRowById(db, managed.sessionId);
+  return session?.id ?? null;
+}
+
+export function getCoworkParentSessionId(
+  db: Database.Database,
+  sessionId: string | undefined | null,
+): string | null {
+  const normalized = (sessionId ?? '').trim();
+  if (!normalized) return null;
+  return getSessionRowById(db, normalized)?.parent_session_id ?? null;
+}
+
+export function isCoworkSessionBoundToIm(
+  db: Database.Database,
+  sessionId: string,
+): boolean {
+  let current: string | null = sessionId.trim();
+  const seen = new Set<string>();
+
+  for (let depth = 0; current && depth < MAX_PARENT_LOOKUP_DEPTH; depth++) {
+    if (seen.has(current)) return false;
+    seen.add(current);
+
+    const mapping = db
+      .prepare('SELECT 1 FROM im_session_mappings WHERE cowork_session_id = ? LIMIT 1')
+      .get(current) as { 1: number } | undefined;
+    if (mapping) return true;
+
+    current = getCoworkParentSessionId(db, current);
+  }
+
+  return false;
+}
+
+export function resolveLocalDesktopCoworkSessionIdByOpenClawSessionKey(
+  db: Database.Database,
+  sessionKey: string | undefined | null,
+): string | null {
+  const sessionId = resolveCoworkSessionIdByOpenClawSessionKey(db, sessionKey);
+  if (!sessionId) return null;
+  return isCoworkSessionBoundToIm(db, sessionId) ? null : sessionId;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -253,7 +253,6 @@ import {
   buildManagedSessionKey,
   DEFAULT_MANAGED_AGENT_ID,
   OpenClawChannelSessionSync,
-  parseManagedSessionKey,
 } from './libs/openclawChannelSessionSync';
 import {
   classifyAppConfigChange,
@@ -270,6 +269,10 @@ import {
   backupOpenClawConfig,
   getOpenClawGatewayRepairBusyError,
 } from './libs/openclawGatewayRepair';
+import {
+  getCoworkParentSessionId,
+  resolveCoworkSessionIdByOpenClawSessionKey,
+} from './libs/openclawLocalSessionResolver';
 import {
   addMemoryEntry,
   deleteMemoryEntry,
@@ -3144,6 +3147,30 @@ const normalizeMediaSelectionState = (selection?: MediaSelectionState): MediaSel
   return normalized;
 };
 
+const resolveMediaSelectionForSession = (sessionId: string | null): MediaSelectionState | undefined => {
+  let current = sessionId?.trim() || null;
+  const seen = new Set<string>();
+
+  for (let depth = 0; current && depth < 16; depth++) {
+    if (seen.has(current)) return undefined;
+    seen.add(current);
+
+    const selection = normalizeMediaSelectionState(mediaSelectionBySession.get(current));
+    if (selection && selection.mode !== 'none') {
+      return selection;
+    }
+
+    try {
+      current = getCoworkParentSessionId(getStore().getDatabase(), current);
+    } catch (error) {
+      console.warn('[MediaGeneration] failed to resolve parent media selection:', error);
+      return undefined;
+    }
+  }
+
+  return undefined;
+};
+
 const mediaModelIdForOutput = (model: unknown, fallback?: string): string => {
   const rawModel = typeof model === 'string' && model.trim() ? model : fallback;
   return mediaModelDisplayName(rawModel, rawModel) || 'default';
@@ -3943,7 +3970,7 @@ if (!gotTheLock) {
   };
 
   const extractSessionIdFromKey = (sessionKey: string): string | null =>
-    parseManagedSessionKey(sessionKey)?.sessionId ?? null;
+    resolveCoworkSessionIdByOpenClawSessionKey(getStore().getDatabase(), sessionKey);
 
   /**
    * Handle media generation tool callbacks from the OpenClaw plugin.
@@ -3957,7 +3984,7 @@ if (!gotTheLock) {
     const action = (args.action as string) || 'generate';
     const serverBaseUrl = getServerApiBaseUrl();
     const sessionId = extractSessionIdFromKey(request.context.sessionKey);
-    const selection = normalizeMediaSelectionState(sessionId ? mediaSelectionBySession.get(sessionId) : undefined);
+    const selection = resolveMediaSelectionForSession(sessionId);
     const prompt = typeof args.prompt === 'string' ? args.prompt : '';
     const explicitModel = canonicalizeMediaModelId(typeof args.model === 'string' ? args.model : '');
     const resolvedModelFromSelection = tool === MediaGenerationTool.Image

--- a/src/main/mcp/mcpRuntime.ts
+++ b/src/main/mcp/mcpRuntime.ts
@@ -14,9 +14,9 @@ import {
   type MediaGenerationRequest,
   type MediaGenerationResponse,
 } from '../libs/mcpBridgeServer';
-import { parseManagedSessionKey } from '../libs/openclawChannelSessionSync';
 import { OpenClawConfigImpact } from '../libs/openclawConfigImpact';
 import type { ResolvedMcpServer } from '../libs/openclawConfigSync';
+import { resolveLocalDesktopCoworkSessionIdByOpenClawSessionKey } from '../libs/openclawLocalSessionResolver';
 import { resolveStdioCommand } from '../libs/resolveStdioCommand';
 import type { SqliteStore } from '../sqliteStore';
 import { createMcpLaunchSourceFingerprint, McpLaunchResolutionStatus } from './mcpLaunchResolution';
@@ -118,8 +118,16 @@ export class McpRuntime {
 
     this.bridgeServer.onAskUser(request => {
       const sessionId = request.sessionKey
-        ? parseManagedSessionKey(request.sessionKey)?.sessionId ?? '__askuser__'
+        ? resolveLocalDesktopCoworkSessionIdByOpenClawSessionKey(
+            this.deps.getStore().getDatabase(),
+            request.sessionKey,
+          )
         : '__askuser__';
+      if (!sessionId) {
+        console.warn('[AskUser] denied request for non-desktop or unknown session:', request.sessionKey);
+        this.resolveAskUser(request.requestId, { behavior: 'deny' });
+        return;
+      }
       const windows = BrowserWindow.getAllWindows();
       windows.forEach(win => {
         if (win.isDestroyed()) return;

--- a/tests/openclaw-extensions/ask-user-question/sessionKey.test.ts
+++ b/tests/openclaw-extensions/ask-user-question/sessionKey.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+
+import { isAskUserQuestionCandidateSessionKey } from '../../../openclaw-extensions/ask-user-question/sessionKey';
+
+describe('ask-user-question session key gating', () => {
+  test('allows desktop sessions across agents', () => {
+    expect(isAskUserQuestionCandidateSessionKey('agent:main:lobsterai:session-1')).toBe(true);
+    expect(isAskUserQuestionCandidateSessionKey('agent:qa-reviewer:lobsterai:session-2')).toBe(true);
+  });
+
+  test('allows materialized subagent session candidates', () => {
+    expect(isAskUserQuestionCandidateSessionKey('agent:qa-reviewer:subagent:run-1')).toBe(true);
+  });
+
+  test('allows legacy desktop sessions', () => {
+    expect(isAskUserQuestionCandidateSessionKey('lobsterai:session-3')).toBe(true);
+  });
+
+  test('rejects channel and malformed session keys', () => {
+    expect(isAskUserQuestionCandidateSessionKey('agent:qa-reviewer:feishu:direct:user-1')).toBe(false);
+    expect(isAskUserQuestionCandidateSessionKey('agent:qa-reviewer:dingtalk-connector:direct:user-1')).toBe(false);
+    expect(isAskUserQuestionCandidateSessionKey('agent::lobsterai:session-4')).toBe(false);
+    expect(isAskUserQuestionCandidateSessionKey('agent:qa-reviewer:lobsterai:')).toBe(false);
+    expect(isAskUserQuestionCandidateSessionKey('')).toBe(false);
+  });
+});

--- a/tests/openclaw-extensions/lobster-media-generation/sessionKey.test.ts
+++ b/tests/openclaw-extensions/lobster-media-generation/sessionKey.test.ts
@@ -11,6 +11,10 @@ describe('lobster-media-generation session key gating', () => {
     expect(isLobsterAiDesktopSessionKey('agent:creative-agent:lobsterai:session-2')).toBe(true);
   });
 
+  test('allows materialized subagent child sessions', () => {
+    expect(isLobsterAiDesktopSessionKey('agent:creative-agent:subagent:run-1')).toBe(true);
+  });
+
   test('allows legacy desktop sessions', () => {
     expect(isLobsterAiDesktopSessionKey('lobsterai:session-3')).toBe(true);
   });


### PR DESCRIPTION
## Summary
- allow LobsterAI AskUserQuestion for non-main desktop agents and delegated child-session candidates
- resolve AskUser/media callbacks back to local Cowork sessions, while denying IM-bound sessions and descendants
- allow LobsterAI image/video generation tools in child sessions and inherit parent media selection when needed
- document the bugfix under specs/bugfixes/agent-scoped-local-tools

## Validation
- npm test -- tests/openclaw-extensions/ask-user-question/sessionKey.test.ts tests/openclaw-extensions/lobster-media-generation/sessionKey.test.ts src/main/libs/openclawLocalSessionResolver.test.ts
- npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 <touched files>
- npm run compile:electron