### PR TITLE
fix(cowork): prefer agent display names for subagents

### DIFF
--- a/src/main/libs/openclawAgentModels.test.ts
+++ b/src/main/libs/openclawAgentModels.test.ts
@@ -170,6 +170,34 @@ describe('buildAgentEntry', () => {
     expect(identity.emoji).toBeUndefined();
   });
 
+  test('emits display name both as top-level name and identity name', () => {
+    const result = buildAgentEntry({
+      id: 'writer',
+      name: '写作助手',
+      description: '',
+      systemPrompt: '',
+      identity: '',
+      model: '',
+      workingDirectory: '',
+      icon: '',
+      skillIds: [],
+      enabled: true,
+      isDefault: false,
+      source: 'custom',
+      presetId: '',
+      createdAt: 0,
+      updatedAt: 0,
+    }, 'anthropic/claude-sonnet-4');
+
+    expect(result).toMatchObject({
+      id: 'writer',
+      name: '写作助手',
+      identity: {
+        name: '写作助手',
+      },
+    });
+  });
+
   test('emits subagent allowAgents for configured agent delegation', () => {
     const result = buildAgentEntry({
       id: 'main',

--- a/src/main/libs/openclawAgentModels.ts
+++ b/src/main/libs/openclawAgentModels.ts
@@ -223,6 +223,7 @@ export function buildAgentEntry(
   return {
     id: agent.id,
     ...(agent.isDefault ? { default: true } : {}),
+    ...(agent.name ? { name: agent.name } : {}),
     ...(agent.name || legacyIcon ? {
       identity: {
         ...(agent.name ? { name: agent.name } : {}),

--- a/src/renderer/components/artifacts/SubagentPanelContent.tsx
+++ b/src/renderer/components/artifacts/SubagentPanelContent.tsx
@@ -1,8 +1,11 @@
 import { ArrowLeftIcon } from '@heroicons/react/20/solid';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import { i18nService } from '@/services/i18n';
+import type { RootState } from '@/store';
 import type { CoworkMessage, SubagentSessionSummary } from '@/types/cowork';
+import { getSubagentDisplayInitial, getSubagentDisplayName } from '@/utils/subagentDisplay';
 
 import ConversationTurnsView from '../cowork/ConversationTurnsView';
 
@@ -28,17 +31,6 @@ const formatDuration = (createdAt: number, endedAt: number | null): string => {
   return `${days}d`;
 };
 
-const getSubagentDisplayName = (subagent: SubagentSessionSummary): string => (
-  subagent.label?.trim()
-    || subagent.agentId?.trim()
-    || i18nService.t('subagentUnnamed')
-);
-
-const getSubagentInitial = (subagent: SubagentSessionSummary): string => {
-  const displayName = getSubagentDisplayName(subagent).trim();
-  return displayName.slice(0, 1).toUpperCase() || 'S';
-};
-
 const getSubagentStatusLabel = (status: SubagentSessionSummary['status']): string => {
   if (status === 'done') return i18nService.t('subagentCompleted');
   if (status === 'error') return i18nService.t('subagentError');
@@ -59,9 +51,10 @@ const SubagentStatusDot: React.FC<{ status: SubagentSessionSummary['status'] }> 
 
 const SubagentPanelRow: React.FC<{
   subagent: SubagentSessionSummary;
+  agents: RootState['agent']['agents'];
   onSelectSubagent: (subagent: SubagentSessionSummary) => void;
-}> = ({ subagent, onSelectSubagent }) => {
-  const displayName = getSubagentDisplayName(subagent);
+}> = ({ subagent, agents, onSelectSubagent }) => {
+  const displayName = getSubagentDisplayName(subagent, agents);
   const duration = formatDuration(
     subagent.createdAt,
     subagent.status === 'running' ? null : subagent.endedAt,
@@ -74,7 +67,7 @@ const SubagentPanelRow: React.FC<{
       className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-surface"
     >
       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
-        {getSubagentInitial(subagent)}
+        {getSubagentDisplayInitial(subagent, agents)}
       </span>
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-center gap-2">
@@ -96,8 +89,9 @@ const SubagentPanelRow: React.FC<{
 
 const SubagentDetailContent: React.FC<{
   subagent: SubagentSessionSummary;
+  agents: RootState['agent']['agents'];
   onBack: () => void;
-}> = ({ subagent, onBack }) => {
+}> = ({ subagent, agents, onBack }) => {
   const [messages, setMessages] = useState<CoworkMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [status, setStatus] = useState<SubagentSessionSummary['status']>(subagent.status);
@@ -171,7 +165,7 @@ const SubagentDetailContent: React.FC<{
     }] as CoworkMessage[];
   }, [messages, subagent.createdAt, subagent.task]);
 
-  const displayName = getSubagentDisplayName(subagent);
+  const displayName = getSubagentDisplayName(subagent, agents);
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
@@ -185,7 +179,7 @@ const SubagentDetailContent: React.FC<{
           <ArrowLeftIcon className="h-4 w-4" />
         </button>
         <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
-          {getSubagentInitial(subagent)}
+          {getSubagentDisplayInitial(subagent, agents)}
         </span>
         <div className="min-w-0 flex-1">
           <div className="truncate text-sm font-medium text-foreground">{displayName}</div>
@@ -219,8 +213,9 @@ const SubagentDetailContent: React.FC<{
 const SubagentSection: React.FC<{
   title: string;
   subagents: SubagentSessionSummary[];
+  agents: RootState['agent']['agents'];
   onSelectSubagent: (subagent: SubagentSessionSummary) => void;
-}> = ({ title, subagents, onSelectSubagent }) => {
+}> = ({ title, subagents, agents, onSelectSubagent }) => {
   if (subagents.length === 0) return null;
 
   return (
@@ -235,6 +230,7 @@ const SubagentSection: React.FC<{
           <SubagentPanelRow
             key={subagent.id}
             subagent={subagent}
+            agents={agents}
             onSelectSubagent={onSelectSubagent}
           />
         ))}
@@ -250,6 +246,7 @@ const SubagentPanelContent: React.FC<SubagentPanelContentProps> = ({
   onBackToList,
   onSelectSubagent,
 }) => {
+  const agents = useSelector((state: RootState) => state.agent.agents);
   const grouped = useMemo(() => ({
     running: subagents.filter(subagent => subagent.status === 'running'),
     done: subagents.filter(subagent => subagent.status === 'done'),
@@ -260,6 +257,7 @@ const SubagentPanelContent: React.FC<SubagentPanelContentProps> = ({
     return (
       <SubagentDetailContent
         subagent={selectedSubagent}
+        agents={agents}
         onBack={onBackToList ?? (() => undefined)}
       />
     );
@@ -292,16 +290,19 @@ const SubagentPanelContent: React.FC<SubagentPanelContentProps> = ({
         <SubagentSection
           title={i18nService.t('subagentPanelRunning')}
           subagents={grouped.running}
+          agents={agents}
           onSelectSubagent={onSelectSubagent}
         />
         <SubagentSection
           title={i18nService.t('subagentPanelCompleted')}
           subagents={grouped.done}
+          agents={agents}
           onSelectSubagent={onSelectSubagent}
         />
         <SubagentSection
           title={i18nService.t('subagentPanelFailed')}
           subagents={grouped.error}
+          agents={agents}
           onSelectSubagent={onSelectSubagent}
         />
       </div>

--- a/src/renderer/components/cowork/SubagentSessionDetail.tsx
+++ b/src/renderer/components/cowork/SubagentSessionDetail.tsx
@@ -1,8 +1,11 @@
 import { ArrowLeftIcon } from '@heroicons/react/20/solid';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import { i18nService } from '../../services/i18n';
+import type { RootState } from '../../store';
 import type { CoworkMessage, SubagentSessionSummary } from '../../types/cowork';
+import { getSubagentDisplayName } from '../../utils/subagentDisplay';
 import ComposeIcon from '../icons/ComposeIcon';
 import SidebarToggleIcon from '../icons/SidebarToggleIcon';
 import ConversationTurnsView from './ConversationTurnsView';
@@ -24,6 +27,7 @@ const SubagentSessionDetail: React.FC<SubagentSessionDetailProps> = ({ subagent,
   const [status, setStatus] = useState<'running' | 'done' | 'error'>(subagent.status);
   const contentRef = useRef<HTMLDivElement>(null);
   const prevMessageCountRef = useRef(0);
+  const agents = useSelector((state: RootState) => state.agent.agents);
 
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
@@ -76,7 +80,9 @@ const SubagentSessionDetail: React.FC<SubagentSessionDetailProps> = ({ subagent,
   }, [fetchHistory, fetchStatus, status]);
 
   // Use agent name as title to avoid duplicating the task content shown in conversation
-  const displayTitle = subagent.agentId ?? subagent.label ?? 'Subagent';
+  const displayTitle = useMemo(() => {
+    return getSubagentDisplayName(subagent, agents);
+  }, [agents, subagent]);
 
   // When messages are empty but task exists, synthesize a user message so
   // the view shows the initial prompt instead of "暂无对话记录"

--- a/src/renderer/components/cowork/SubagentTurnLinks.tsx
+++ b/src/renderer/components/cowork/SubagentTurnLinks.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 
-import { i18nService } from '@/services/i18n';
+import type { RootState } from '@/store';
 import type { SubagentSessionSummary } from '@/types/cowork';
+import { getSubagentDisplayName } from '@/utils/subagentDisplay';
 
 import {
   COWORK_DETAIL_CONTENT_CLASS,
@@ -14,41 +16,40 @@ interface SubagentTurnLinksProps {
   onSelectSubagent: (subagent: SubagentSessionSummary) => void;
 }
 
-const getDisplayName = (subagent: SubagentSessionSummary): string => (
-  subagent.label?.trim()
-    || subagent.agentId?.trim()
-    || i18nService.t('subagentUnnamed')
-);
-
 const SubagentTurnLinks: React.FC<SubagentTurnLinksProps> = ({
   subagents,
   variant = 'turn',
   onSelectSubagent,
 }) => {
+  const agents = useSelector((state: RootState) => state.agent.agents);
+
   if (subagents.length === 0) return null;
 
   const links = (
     <div className="flex flex-wrap items-center gap-2">
-      {subagents.map(subagent => (
-        <button
-          key={subagent.id}
-          type="button"
-          onClick={() => onSelectSubagent(subagent)}
-          className="inline-flex h-8 max-w-full items-center gap-2 rounded-full border border-border bg-background px-3 text-sm text-secondary shadow-sm transition-colors hover:border-primary/40 hover:text-foreground"
-          aria-label={getDisplayName(subagent)}
-        >
-          <span
-            className={`h-2 w-2 shrink-0 rounded-full ${
-              subagent.status === 'running'
-                ? 'animate-pulse bg-blue-500'
-                : subagent.status === 'error'
-                  ? 'bg-red-500'
-                  : 'bg-green-500'
-            }`}
-          />
-          <span className="truncate">{getDisplayName(subagent)}</span>
-        </button>
-      ))}
+      {subagents.map((subagent) => {
+        const displayName = getSubagentDisplayName(subagent, agents);
+        return (
+          <button
+            key={subagent.id}
+            type="button"
+            onClick={() => onSelectSubagent(subagent)}
+            className="inline-flex h-8 max-w-full items-center gap-2 rounded-full border border-border bg-background px-3 text-sm text-secondary shadow-sm transition-colors hover:border-primary/40 hover:text-foreground"
+            aria-label={displayName}
+          >
+            <span
+              className={`h-2 w-2 shrink-0 rounded-full ${
+                subagent.status === 'running'
+                  ? 'animate-pulse bg-blue-500'
+                  : subagent.status === 'error'
+                    ? 'bg-red-500'
+                    : 'bg-green-500'
+              }`}
+            />
+            <span className="truncate">{displayName}</span>
+          </button>
+        );
+      })}
     </div>
   );
 

--- a/src/renderer/utils/subagentDisplay.ts
+++ b/src/renderer/utils/subagentDisplay.ts
@@ -1,0 +1,29 @@
+import { i18nService } from '../services/i18n';
+import type { SubagentSessionSummary } from '../types/cowork';
+import { getAgentDisplayNameById } from './agentDisplay';
+
+interface SubagentAgentDisplaySource {
+  id: string;
+  name?: string;
+}
+
+export const getSubagentDisplayName = (
+  subagent: Pick<SubagentSessionSummary, 'label' | 'agentId'>,
+  agents: Array<Pick<SubagentAgentDisplaySource, 'id' | 'name'>>,
+): string => {
+  const label = subagent.label?.trim();
+  if (label) return label;
+
+  const agentId = subagent.agentId?.trim();
+  if (!agentId) return i18nService.t('subagentUnnamed');
+
+  return getAgentDisplayNameById(agentId, agents) ?? agentId;
+};
+
+export const getSubagentDisplayInitial = (
+  subagent: Pick<SubagentSessionSummary, 'label' | 'agentId'>,
+  agents: Array<Pick<SubagentAgentDisplaySource, 'id' | 'name'>>,
+): string => {
+  const displayName = getSubagentDisplayName(subagent, agents).trim();
+  return displayName.slice(0, 1).toUpperCase() || 'S';
+};


### PR DESCRIPTION
## Summary
- sync LobsterAI agent display names into OpenClaw agent entries
- use a shared subagent display helper for chips, the subagent detail title, and the artifact panel list/detail
- add coverage for top-level OpenClaw agent names

## Verification
- npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/openclawAgentModels.ts src/main/libs/openclawAgentModels.test.ts src/renderer/components/cowork/SubagentTurnLinks.tsx src/renderer/components/cowork/SubagentSessionDetail.tsx src/renderer/components/artifacts/SubagentPanelContent.tsx src/renderer/utils/subagentDisplay.ts
- npx vitest run openclawAgentModels