### PR TITLE
fix(cowork): refine prompt modes and steer follow-up handling

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -11,6 +11,7 @@ import { ArrowUpIcon, FolderIcon } from '@heroicons/react/24/solid';
 import { AuthSubscriptionStatus } from '@shared/auth/constants';
 import { ProviderName } from '@shared/providers';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -390,6 +391,7 @@ interface CoworkPromptInputProps {
   contextUsageControl?: React.ReactNode;
   goal?: CoworkGoal | null;
   onGoalCommand?: (command: string) => boolean | void | Promise<boolean | void>;
+  goalStatusBarPortalTarget?: HTMLElement | null;
   canSteer?: boolean;
   /** When true, hides attachment/skill buttons but keeps the input box visible (disabled) */
   remoteManaged?: boolean;
@@ -422,6 +424,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       contextUsageControl,
       goal,
       onGoalCommand,
+      goalStatusBarPortalTarget,
       canSteer = false,
       remoteManaged = false,
     } = props;
@@ -3096,7 +3099,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   ) : null;
 
   const goalActionsDisabled = disabled || voiceInputLocksEditing || !onGoalCommand;
-  const sessionGoalStatusBar = goal && !goalInputActive ? (() => {
+  const shouldUseExternalGoalStatusBar = goalStatusBarPortalTarget !== undefined;
+  const sessionGoalStatusBarNode = goal && !goalInputActive ? (() => {
     const summary = getGoalSummary(goal);
     const detail = goal.lastStatusNote
       ? `${summary}: ${goal.objective} - ${goal.lastStatusNote}`
@@ -3107,12 +3111,16 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       ? i18nService.t('coworkGoalPause')
       : i18nService.t('coworkGoalResume');
     return (
-      <div className={`${isCompact ? 'px-3 pt-2' : 'px-4 pt-3'}`}>
+      <div className={shouldUseExternalGoalStatusBar ? '' : `${isCompact ? 'px-3 pt-2' : 'px-4 pt-3'}`}>
         <div
           role="status"
           title={detail}
           aria-label={detail}
-          className="flex min-w-0 items-center gap-2 rounded-lg border border-border bg-surface-raised/70 px-2.5 py-1.5 text-xs text-secondary"
+          className={`flex min-w-0 items-center gap-2 border border-border bg-surface-raised/60 px-2.5 py-1.5 text-xs text-secondary ${
+            shouldUseExternalGoalStatusBar
+              ? `${isCompact ? 'mx-3' : 'mx-5'} rounded-t-2xl rounded-b-none border-b-0`
+              : 'rounded-xl shadow-subtle'
+          }`}
         >
           <GoalIcon className={`h-4 w-4 shrink-0 ${
             goal.status === CoworkGoalStatus.Active
@@ -3163,6 +3171,11 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       </div>
     );
   })() : null;
+  const sessionGoalStatusBar = sessionGoalStatusBarNode
+    ? goalStatusBarPortalTarget
+      ? createPortal(sessionGoalStatusBarNode, goalStatusBarPortalTarget)
+      : shouldUseExternalGoalStatusBar ? null : sessionGoalStatusBarNode
+    : null;
 
   const planModeBadge = isPlanMode ? (
     <button

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -164,6 +164,42 @@ const summarizePromptShape = (prompt: string): string => {
   return `chars=${prompt.length}, lines=${lines.length}, blankLines=${blankLines}, orderedListLines=${orderedListLines}`;
 };
 
+const SteerQueueStatusIcon: React.FC<React.SVGProps<SVGSVGElement>> = ({ className, ...props }) => (
+  <svg
+    className={className}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.45"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M3.75 3.5v6.7c0 .86.7 1.55 1.55 1.55h6.45" />
+    <path d="m10.15 10.1 1.65 1.65-1.65 1.65" />
+    <path d="M5.75 5.6h4" />
+    <path d="M5.75 7.9h3" />
+  </svg>
+);
+
+const SteerQueueIcon: React.FC<React.SVGProps<SVGSVGElement>> = ({ className, ...props }) => (
+  <svg
+    className={className}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.6"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M3.5 3.5v3.25c0 1.52 1.23 2.75 2.75 2.75h6" />
+    <path d="m10.25 7.75 1.75 1.75-1.75 1.75" />
+  </svg>
+);
+
 const getModelAnalyticsSource = (model: Model, selectorGroup: ModelSelectorChangeMeta['group']): string => {
   if (model.isServerModel || model.providerKey === ProviderName.LobsteraiServer || selectorGroup === ModelSelectorGroup.Server) {
     return 'package';
@@ -3059,7 +3095,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       >
         {isRejected
           ? <ExclamationTriangleIcon className="h-4 w-4 shrink-0 text-warning" />
-          : <ArrowTurnDownRightIcon className="h-4 w-4 shrink-0" />}
+          : <SteerQueueStatusIcon className="h-4 w-4 shrink-0" />}
         <span className={`shrink-0 font-medium ${isRejected ? 'text-warning' : 'text-foreground'}`}>
           {isRejected ? i18nService.t('coworkSteerRejected') : i18nService.t('coworkSteerQueued')}
         </span>
@@ -3076,7 +3112,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
               title={i18nService.t('coworkSteerInterruptTooltip')}
               aria-label={i18nService.t('coworkSteerInterruptTooltip')}
             >
-              <ArrowTurnDownRightIcon className="h-3.5 w-3.5" />
+              <SteerQueueIcon className="h-3.5 w-3.5" />
               <span>{i18nService.t('coworkSteer')}</span>
             </button>
           )}

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -92,9 +92,9 @@ import {
 } from '../common/activeContextBadgeStyles';
 import Modal from '../common/Modal';
 import DefaultAgentIcon from '../icons/DefaultAgentIcon';
+import EditIcon from '../icons/EditIcon';
 import GoalIcon from '../icons/GoalIcon';
 import PaperClipIcon from '../icons/PaperClipIcon';
-import PencilIcon from '../icons/PencilIcon';
 import PlanModeIcon from '../icons/PlanModeIcon';
 import PromptAddIcon from '../icons/PromptAddIcon';
 import SkillIcon from '../icons/SkillIcon';
@@ -3123,7 +3123,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
             title={i18nService.t('edit')}
             aria-label={i18nService.t('edit')}
           >
-            <PencilIcon className="h-3.5 w-3.5" />
+            <EditIcon className="h-3.5 w-3.5" />
           </button>
           <button
             type="button"
@@ -3202,7 +3202,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
               title={i18nService.t('coworkGoalEdit')}
               aria-label={i18nService.t('coworkGoalEdit')}
             >
-              <PencilIcon className="h-3.5 w-3.5" />
+              <EditIcon className="h-3.5 w-3.5" />
             </button>
             {canTogglePause && (
               <button

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -2380,6 +2380,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
 
   const handleTogglePlanMode = useCallback(() => {
     const nextMode = isPlanMode ? CoworkCollaborationMode.Default : CoworkCollaborationMode.Plan;
+    handleCloseSkillsPopover();
+    setShowAddMenu(false);
     logPromptModelSelection('debug', `plan mode ${nextMode === CoworkCollaborationMode.Plan ? 'enabled' : 'disabled'} for draft ${draftKey}`);
     reportPromptControl(nextMode === CoworkCollaborationMode.Plan ? 'plan_mode_enabled' : 'plan_mode_disabled', {
       entry: LogReporterEntry.PromptToolsMenu,
@@ -2404,7 +2406,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         entry: LogReporterEntry.PromptToolsMenu,
       });
     }
-  }, [dispatch, draftKey, goalInputActive, isPlanMode, planConfirmation?.messageId, planConfirmation?.state, reportPromptControl, resetGoalInput]);
+  }, [dispatch, draftKey, goalInputActive, handleCloseSkillsPopover, isPlanMode, planConfirmation?.messageId, planConfirmation?.state, reportPromptControl, resetGoalInput]);
 
   const handleEnableGoalInput = useCallback((mode: GoalInputMode = 'start', initialValue?: string) => {
     if (disabled || voiceInputLocksEditing || !onGoalCommand) return;

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -2842,18 +2842,6 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
           >
             <PlanModeIcon className="h-5 w-5 shrink-0 text-secondary" />
             <span className="min-w-0 flex-1 truncate">{i18nService.t('coworkPlanMode')}</span>
-            <span
-              className={`relative h-5 w-9 rounded-full transition-colors ${
-                isPlanMode ? 'bg-primary' : 'bg-neutral-200 dark:bg-neutral-700'
-              }`}
-              aria-hidden="true"
-            >
-              <span
-                className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
-                  isPlanMode ? 'translate-x-4' : 'translate-x-0.5'
-                }`}
-              />
-            </span>
           </button>
 
           <SkillsPopover

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -392,6 +392,8 @@ interface CoworkPromptInputProps {
   goal?: CoworkGoal | null;
   onGoalCommand?: (command: string) => boolean | void | Promise<boolean | void>;
   goalStatusBarPortalTarget?: HTMLElement | null;
+  goalStatusBarAttached?: boolean;
+  steerPreviewPortalTarget?: HTMLElement | null;
   canSteer?: boolean;
   /** When true, hides attachment/skill buttons but keeps the input box visible (disabled) */
   remoteManaged?: boolean;
@@ -425,6 +427,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       goal,
       onGoalCommand,
       goalStatusBarPortalTarget,
+      goalStatusBarAttached = true,
+      steerPreviewPortalTarget,
       canSteer = false,
       remoteManaged = false,
     } = props;
@@ -3027,19 +3031,29 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     });
   };
 
-  const renderSteerQueueItem = (steer: CoworkPendingSteer, source: 'pending' | 'rejected') => {
+  const shouldUseExternalSteerPreview = steerPreviewPortalTarget !== undefined;
+  const renderSteerQueueItem = (
+    steer: CoworkPendingSteer,
+    source: 'pending' | 'rejected',
+    options: { external?: boolean; separated?: boolean } = {},
+  ) => {
     const isRejected = source === 'rejected';
     const displayText = steer.text || steer.attachments?.map(attachment => attachment.name).join(', ') || '';
     const title = isRejected && steer.error
       ? `${i18nService.t('coworkSteerRejected')}: ${steer.error}`
       : `${i18nService.t('coworkSteerQueued')}: ${displayText}`;
+    const shapeClass = options.external
+      ? ''
+      : 'rounded-lg';
+    const surfaceClass = options.external ? 'bg-transparent' : 'border border-border bg-surface-raised/70';
+    const dividerClass = options.separated ? 'border-t border-border' : '';
     return (
       <div
         key={steer.id}
         role="status"
         title={title}
         aria-label={title}
-        className={`flex min-w-0 items-center gap-2 rounded-lg border border-border bg-surface-raised/70 px-2.5 py-1.5 text-xs ${
+        className={`flex min-w-0 items-center gap-2 px-2.5 py-1.5 text-xs ${shapeClass} ${surfaceClass} ${dividerClass} ${
           isRejected ? 'text-warning' : 'text-secondary'
         }`}
       >
@@ -3089,14 +3103,26 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     );
   };
 
-  const steerPreview = pendingSteers.length > 0 || rejectedSteers.length > 0 ? (
-    <div className={`${isCompact ? 'px-3 pt-2' : 'px-4 pt-3'}`}>
-      <div className="space-y-1.5">
-        {pendingSteers.map(steer => renderSteerQueueItem(steer, 'pending'))}
-        {rejectedSteers.map(steer => renderSteerQueueItem(steer, 'rejected'))}
+  const steerPreviewItems = [
+    ...pendingSteers.map(steer => ({ steer, source: 'pending' as const })),
+    ...rejectedSteers.map(steer => ({ steer, source: 'rejected' as const })),
+  ];
+  const externalSteerPreviewClass = `${isCompact ? 'mx-3' : 'mx-5'} max-h-[156px] overflow-y-auto rounded-t-2xl rounded-b-none border border-b-0 border-border bg-surface-raised/60`;
+  const steerPreviewNode = steerPreviewItems.length > 0 ? (
+    <div className={shouldUseExternalSteerPreview ? externalSteerPreviewClass : `${isCompact ? 'px-3 pt-2' : 'px-4 pt-3'}`}>
+      <div className={shouldUseExternalSteerPreview ? '' : 'space-y-1.5'}>
+        {steerPreviewItems.map(({ steer, source }, index) => renderSteerQueueItem(steer, source, {
+          external: shouldUseExternalSteerPreview,
+          separated: shouldUseExternalSteerPreview && index > 0,
+        }))}
       </div>
     </div>
   ) : null;
+  const steerPreview = steerPreviewNode
+    ? steerPreviewPortalTarget
+      ? createPortal(steerPreviewNode, steerPreviewPortalTarget)
+      : shouldUseExternalSteerPreview ? null : steerPreviewNode
+    : null;
 
   const goalActionsDisabled = disabled || voiceInputLocksEditing || !onGoalCommand;
   const shouldUseExternalGoalStatusBar = goalStatusBarPortalTarget !== undefined;
@@ -3118,7 +3144,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
           aria-label={detail}
           className={`flex min-w-0 items-center gap-2 border border-border bg-surface-raised/60 px-2.5 py-1.5 text-xs text-secondary ${
             shouldUseExternalGoalStatusBar
-              ? `${isCompact ? 'mx-3' : 'mx-5'} rounded-t-2xl rounded-b-none border-b-0`
+              ? `${isCompact ? 'mx-3' : 'mx-5'} ${goalStatusBarAttached ? 'rounded-t-2xl rounded-b-none border-b-0' : 'rounded-xl'}`
               : 'rounded-xl shadow-subtle'
           }`}
         >

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -538,6 +538,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const inputSourceOverrideRef = useRef<'template' | null>(null);
     const wasStreamingRef = useRef(isStreaming);
     const autoSubmittingQueuedSteerRef = useRef<string | null>(null);
+    const queuedFollowUpTurnStartingRef = useRef(false);
     const interruptingQueuedSteerIdRef = useRef<string | null>(null);
     const suppressQueuedSteerAfterStopRef = useRef(false);
 
@@ -1351,29 +1352,42 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   ]);
 
   const submitQueuedFollowUp = useCallback((
-    queuedSteer: CoworkPendingSteer,
+    queuedSteerOrBatch: CoworkPendingSteer | CoworkPendingSteer[],
     trigger: 'completed' | 'interrupted' | 'idle_click' | 'idle_recovery',
   ) => {
     if (!sessionId || remoteManaged || disabled) return;
-    if (autoSubmittingQueuedSteerRef.current === queuedSteer.id) {
+    const queuedSteers = Array.isArray(queuedSteerOrBatch) ? queuedSteerOrBatch : [queuedSteerOrBatch];
+    const primarySteer = queuedSteers[0];
+    if (!primarySteer) return;
+    const queuedSteerIds = queuedSteers.map(steer => steer.id);
+    if (autoSubmittingQueuedSteerRef.current || queuedFollowUpTurnStartingRef.current) {
       console.debug(
-        `[CoworkSteer] skipped duplicate queued follow-up submit for session ${sessionId}; `
-        + `id=${queuedSteer.id}; trigger=${trigger}.`,
+        `[CoworkSteer] skipped queued follow-up submit while another queued follow-up is starting; `
+        + `session=${sessionId}; activeId=${autoSubmittingQueuedSteerRef.current ?? 'turn_starting'}; `
+        + `ids=${queuedSteerIds.join(',')}; trigger=${trigger}.`,
       );
       return;
     }
 
-    autoSubmittingQueuedSteerRef.current = queuedSteer.id;
+    const basePrompt = queuedSteers
+      .map(steer => steer.text.trim())
+      .filter(Boolean)
+      .join('\n\n');
+    const mergedAttachments = queuedSteers.flatMap(steer => steer.attachments ?? []);
+    const mergedSelectedTextSnippets = queuedSteers.flatMap(steer => steer.selectedTextSnippets ?? []);
+
+    autoSubmittingQueuedSteerRef.current = primarySteer.id;
     console.debug(
       `[CoworkSteer] preparing queued follow-up for session ${sessionId}; `
-      + `id=${queuedSteer.id}; trigger=${trigger}; chars=${queuedSteer.text.length}; `
-      + `attachments=${queuedSteer.attachments?.length ?? 0}.`,
+      + `ids=${queuedSteerIds.join(',')}; trigger=${trigger}; `
+      + `count=${queuedSteers.length}; chars=${basePrompt.length}; `
+      + `attachments=${mergedAttachments.length}.`,
     );
 
     void preparePromptPayload({
-      basePrompt: queuedSteer.text,
-      attachments: queuedSteer.attachments ?? [],
-      selectedTextSnippets: queuedSteer.selectedTextSnippets ?? [],
+      basePrompt,
+      attachments: mergedAttachments,
+      selectedTextSnippets: mergedSelectedTextSnippets,
       submitMethod: 'button',
     })
       .then((payload) => {
@@ -1382,7 +1396,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         }
         console.debug(
           `[CoworkSteer] submitting queued follow-up for session ${sessionId}; `
-          + `id=${queuedSteer.id}; trigger=${trigger}; chars=${payload.finalPrompt.length}; `
+          + `ids=${queuedSteerIds.join(',')}; trigger=${trigger}; chars=${payload.finalPrompt.length}; `
           + `imageAttachments=${payload.imageAttachments?.length ?? 0}; `
           + `mediaReferences=${payload.mediaReferences?.length ?? 0}.`,
         );
@@ -1399,16 +1413,19 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         if (result === false) {
           console.warn(
             `[CoworkSteer] queued follow-up was rejected by normal continue flow for session ${sessionId}; `
-            + `id=${queuedSteer.id}; trigger=${trigger}.`,
+            + `ids=${queuedSteerIds.join(',')}; trigger=${trigger}.`,
           );
           return;
         }
-        dispatch(removePendingSteer({ sessionId, steerId: queuedSteer.id }));
+        queuedFollowUpTurnStartingRef.current = true;
+        queuedSteers.forEach((steer) => {
+          dispatch(removePendingSteer({ sessionId, steerId: steer.id }));
+        });
       })
       .catch((error) => {
         console.error(
           `[CoworkSteer] failed to submit queued follow-up for session ${sessionId}; `
-          + `id=${queuedSteer.id}; trigger=${trigger}.`,
+          + `ids=${queuedSteerIds.join(',')}; trigger=${trigger}.`,
           error,
         );
       })
@@ -1420,7 +1437,18 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   useEffect(() => {
     const wasStreaming = wasStreamingRef.current;
     wasStreamingRef.current = isStreaming;
-    if (isStreaming || !sessionId || remoteManaged || disabled) {
+    if (isStreaming) {
+      queuedFollowUpTurnStartingRef.current = false;
+      return;
+    }
+    if (!sessionId || remoteManaged || disabled) {
+      return;
+    }
+    if (queuedFollowUpTurnStartingRef.current) {
+      console.debug(
+        `[CoworkSteer] waiting for queued follow-up turn to enter streaming before submitting more; `
+        + `session=${sessionId}; queued=${pendingSteers.length}.`,
+      );
       return;
     }
 
@@ -1444,15 +1472,17 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     }
 
     const trigger = interruptingQueuedSteerId ? 'interrupted' : wasStreaming ? 'completed' : 'idle_recovery';
+    const queuedBatch = interruptingQueuedSteerId ? pendingSteers : [nextQueuedSteer];
     interruptingQueuedSteerIdRef.current = null;
     console.debug(
       `[CoworkSteer] queued follow-up trigger=${trigger}; `
       + `session=${sessionId}; `
-      + `id=${nextQueuedSteer.id}; chars=${nextQueuedSteer.text.length}; `
+      + `ids=${queuedBatch.map(steer => steer.id).join(',')}; count=${queuedBatch.length}; `
+      + `chars=${queuedBatch.reduce((total, steer) => total + steer.text.length, 0)}; `
       + `streamTransition=${wasStreaming ? 'yes' : 'no'}; `
-      + `attachments=${nextQueuedSteer.attachments?.length ?? 0}.`,
+      + `attachments=${queuedBatch.reduce((total, steer) => total + (steer.attachments?.length ?? 0), 0)}.`,
     );
-    submitQueuedFollowUp(nextQueuedSteer, trigger);
+    submitQueuedFollowUp(queuedBatch, trigger);
   }, [disabled, isStreaming, pendingSteers, remoteManaged, sessionId, submitQueuedFollowUp]);
 
   const handleSubmit = useCallback(async (submitMethod: 'button' | 'keyboard' | 'voice' = 'button') => {
@@ -3064,12 +3094,14 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
 
   const handleSteerQueuedInput = (steer: CoworkPendingSteer) => {
     if (!sessionId || remoteManaged || disabled) return;
+    const queuedBatch = pendingSteers.length > 0 ? pendingSteers : [steer];
     if (!isStreaming) {
       console.debug(
         `[CoworkSteer] submitting queued follow-up from idle click; `
-        + `session=${sessionId}; id=${steer.id}; chars=${steer.text.length}.`,
+        + `session=${sessionId}; ids=${queuedBatch.map(item => item.id).join(',')}; `
+        + `count=${queuedBatch.length}.`,
       );
-      submitQueuedFollowUp(steer, 'idle_click');
+      submitQueuedFollowUp(queuedBatch, 'idle_click');
       return;
     }
     if (!onStop) {
@@ -3083,7 +3115,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     interruptingQueuedSteerIdRef.current = steer.id;
     console.debug(
       `[CoworkSteer] interrupting active turn for queued steer follow-up; `
-      + `session=${sessionId}; id=${steer.id}; chars=${steer.text.length}.`,
+      + `session=${sessionId}; ids=${queuedBatch.map(item => item.id).join(',')}; `
+      + `count=${queuedBatch.length}.`,
     );
     void Promise.resolve(onStop()).catch((error) => {
       interruptingQueuedSteerIdRef.current = null;

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1350,10 +1350,77 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     reportPromptControl,
   ]);
 
+  const submitQueuedFollowUp = useCallback((
+    queuedSteer: CoworkPendingSteer,
+    trigger: 'completed' | 'interrupted' | 'idle_click' | 'idle_recovery',
+  ) => {
+    if (!sessionId || remoteManaged || disabled) return;
+    if (autoSubmittingQueuedSteerRef.current === queuedSteer.id) {
+      console.debug(
+        `[CoworkSteer] skipped duplicate queued follow-up submit for session ${sessionId}; `
+        + `id=${queuedSteer.id}; trigger=${trigger}.`,
+      );
+      return;
+    }
+
+    autoSubmittingQueuedSteerRef.current = queuedSteer.id;
+    console.debug(
+      `[CoworkSteer] preparing queued follow-up for session ${sessionId}; `
+      + `id=${queuedSteer.id}; trigger=${trigger}; chars=${queuedSteer.text.length}; `
+      + `attachments=${queuedSteer.attachments?.length ?? 0}.`,
+    );
+
+    void preparePromptPayload({
+      basePrompt: queuedSteer.text,
+      attachments: queuedSteer.attachments ?? [],
+      selectedTextSnippets: queuedSteer.selectedTextSnippets ?? [],
+      submitMethod: 'button',
+    })
+      .then((payload) => {
+        if (!payload) {
+          return false;
+        }
+        console.debug(
+          `[CoworkSteer] submitting queued follow-up for session ${sessionId}; `
+          + `id=${queuedSteer.id}; trigger=${trigger}; chars=${payload.finalPrompt.length}; `
+          + `imageAttachments=${payload.imageAttachments?.length ?? 0}; `
+          + `mediaReferences=${payload.mediaReferences?.length ?? 0}.`,
+        );
+        return onSubmit(
+          payload.finalPrompt,
+          undefined,
+          payload.imageAttachments,
+          payload.mediaReferences,
+          payload.selectedTextSnippets,
+          CoworkCollaborationMode.Default,
+        );
+      })
+      .then((result) => {
+        if (result === false) {
+          console.warn(
+            `[CoworkSteer] queued follow-up was rejected by normal continue flow for session ${sessionId}; `
+            + `id=${queuedSteer.id}; trigger=${trigger}.`,
+          );
+          return;
+        }
+        dispatch(removePendingSteer({ sessionId, steerId: queuedSteer.id }));
+      })
+      .catch((error) => {
+        console.error(
+          `[CoworkSteer] failed to submit queued follow-up for session ${sessionId}; `
+          + `id=${queuedSteer.id}; trigger=${trigger}.`,
+          error,
+        );
+      })
+      .finally(() => {
+        autoSubmittingQueuedSteerRef.current = null;
+      });
+  }, [disabled, dispatch, onSubmit, preparePromptPayload, remoteManaged, sessionId]);
+
   useEffect(() => {
     const wasStreaming = wasStreamingRef.current;
     wasStreamingRef.current = isStreaming;
-    if (isStreaming || !wasStreaming || !sessionId || remoteManaged || disabled) {
+    if (isStreaming || !sessionId || remoteManaged || disabled) {
       return;
     }
 
@@ -1375,65 +1442,18 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       interruptingQueuedSteerIdRef.current = null;
       return;
     }
-    if (autoSubmittingQueuedSteerRef.current === nextQueuedSteer.id) {
-      return;
-    }
 
-    autoSubmittingQueuedSteerRef.current = nextQueuedSteer.id;
+    const trigger = interruptingQueuedSteerId ? 'interrupted' : wasStreaming ? 'completed' : 'idle_recovery';
     interruptingQueuedSteerIdRef.current = null;
     console.debug(
-      `[CoworkSteer] active turn ${interruptingQueuedSteerId ? 'interrupted' : 'completed'}; `
-      + `preparing queued follow-up for session ${sessionId}; `
+      `[CoworkSteer] queued follow-up trigger=${trigger}; `
+      + `session=${sessionId}; `
       + `id=${nextQueuedSteer.id}; chars=${nextQueuedSteer.text.length}; `
+      + `streamTransition=${wasStreaming ? 'yes' : 'no'}; `
       + `attachments=${nextQueuedSteer.attachments?.length ?? 0}.`,
     );
-
-    void preparePromptPayload({
-      basePrompt: nextQueuedSteer.text,
-      attachments: nextQueuedSteer.attachments ?? [],
-      selectedTextSnippets: nextQueuedSteer.selectedTextSnippets ?? [],
-      submitMethod: 'button',
-    })
-      .then((payload) => {
-        if (!payload) {
-          return false;
-        }
-        console.debug(
-          `[CoworkSteer] submitting queued follow-up for session ${sessionId}; `
-          + `id=${nextQueuedSteer.id}; chars=${payload.finalPrompt.length}; `
-          + `imageAttachments=${payload.imageAttachments?.length ?? 0}; `
-          + `mediaReferences=${payload.mediaReferences?.length ?? 0}.`,
-        );
-        return onSubmit(
-          payload.finalPrompt,
-          undefined,
-          payload.imageAttachments,
-          payload.mediaReferences,
-          payload.selectedTextSnippets,
-          CoworkCollaborationMode.Default,
-        );
-      })
-      .then((result) => {
-        if (result === false) {
-          console.warn(
-            `[CoworkSteer] queued follow-up was rejected by normal continue flow for session ${sessionId}; `
-            + `id=${nextQueuedSteer.id}.`,
-          );
-          return;
-        }
-        dispatch(removePendingSteer({ sessionId, steerId: nextQueuedSteer.id }));
-      })
-      .catch((error) => {
-        console.error(
-          `[CoworkSteer] failed to submit queued follow-up for session ${sessionId}; `
-          + `id=${nextQueuedSteer.id}.`,
-          error,
-        );
-      })
-      .finally(() => {
-        autoSubmittingQueuedSteerRef.current = null;
-      });
-  }, [disabled, dispatch, isStreaming, onSubmit, pendingSteers, preparePromptPayload, remoteManaged, sessionId]);
+    submitQueuedFollowUp(nextQueuedSteer, trigger);
+  }, [disabled, isStreaming, pendingSteers, remoteManaged, sessionId, submitQueuedFollowUp]);
 
   const handleSubmit = useCallback(async (submitMethod: 'button' | 'keyboard' | 'voice' = 'button') => {
     let effectiveSubmitMethod = submitMethod;
@@ -3043,12 +3063,20 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   };
 
   const handleSteerQueuedInput = (steer: CoworkPendingSteer) => {
-    if (!sessionId || remoteManaged) return;
-    if (!isStreaming || !onStop) {
+    if (!sessionId || remoteManaged || disabled) return;
+    if (!isStreaming) {
+      console.debug(
+        `[CoworkSteer] submitting queued follow-up from idle click; `
+        + `session=${sessionId}; id=${steer.id}; chars=${steer.text.length}.`,
+      );
+      submitQueuedFollowUp(steer, 'idle_click');
+      return;
+    }
+    if (!onStop) {
       console.debug(
         `[CoworkSteer] queued follow-up remains scheduled without interrupting active turn; `
         + `session=${sessionId}; id=${steer.id}; chars=${steer.text.length}; `
-        + `reason=${!isStreaming ? 'not_streaming' : 'missing_stop_handler'}.`,
+        + 'reason=missing_stop_handler.',
       );
       return;
     }

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1683,6 +1683,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const [isArtifactPanelExpanded, setIsArtifactPanelExpanded] = useState(false);
   const [isExpandedPromptInputHidden, setIsExpandedPromptInputHidden] = useState(false);
   const [isExpandedConversationPreviewOpen, setIsExpandedConversationPreviewOpen] = useState(false);
+  const [goalStatusBarPortalTarget, setGoalStatusBarPortalTarget] = useState<HTMLDivElement | null>(null);
   const previousArtifactPanelOpenRef = useRef(isPanelOpen);
   const fileListPreviewTabOpenBySessionRef = useRef<Record<string, boolean>>({});
   const browserPreviewTabOpenBySessionRef = useRef<Record<string, boolean>>({});
@@ -4261,6 +4262,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const artifactPanelOverlayBottom = artifactPanelIsOverlay && !isExpandedPromptInputHidden
     ? promptInputAreaHeight
     : 0;
+  const showExternalGoalStatusBar = Boolean(
+    currentSession.goal
+    && !remoteManaged
+    && !(isArtifactPanelExpanded && isExpandedPromptInputHidden)
+  );
   const artifactPanelInnerWidth = artifactPanelIsOverlay ? '100%' : artifactPanelFrameWidth;
   const shouldShowTurnNavigationRail = railItems.length > 1 && isScrollable;
   const shouldShowScrollToBottom = isScrollable && !shouldAutoScroll;
@@ -5123,6 +5129,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
           </div>
         )}
         <div className={COWORK_DETAIL_CONTENT_CLASS}>
+          {showExternalGoalStatusBar && (
+            <div className="relative z-10 -mb-px">
+              <div ref={setGoalStatusBarPortalTarget} />
+            </div>
+          )}
           <CoworkPromptInput
             ref={promptInputRef}
             onSubmit={onContinue}
@@ -5143,6 +5154,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             sessionId={currentSession?.id}
             goal={!remoteManaged ? currentSession?.goal : null}
             onGoalCommand={!remoteManaged && currentSession?.id ? handleGoalCommand : undefined}
+            goalStatusBarPortalTarget={showExternalGoalStatusBar ? goalStatusBarPortalTarget : null}
             contextUsageControl={(
               <div className="flex min-w-0 items-center gap-2">
                 <div ref={compactConfirmRef} className="relative inline-flex flex-shrink-0">

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1159,6 +1159,13 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const planConfirmation = useSelector((state: RootState) =>
     currentSession?.id ? state.cowork.planConfirmations[currentSession.id] : undefined
   );
+  const queuedSteerCount = useSelector((state: RootState) => {
+    if (!currentSession?.id) return 0;
+    return (
+      (state.cowork.pendingSteers[currentSession.id]?.length ?? 0)
+      + (state.cowork.rejectedSteers[currentSession.id]?.length ?? 0)
+    );
+  });
   const messageRailIndex = useSelector((state: RootState) =>
     currentSession?.id ? state.cowork.messageRailIndexBySessionId[currentSession.id] ?? [] : []
   );
@@ -1684,6 +1691,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const [isExpandedPromptInputHidden, setIsExpandedPromptInputHidden] = useState(false);
   const [isExpandedConversationPreviewOpen, setIsExpandedConversationPreviewOpen] = useState(false);
   const [goalStatusBarPortalTarget, setGoalStatusBarPortalTarget] = useState<HTMLDivElement | null>(null);
+  const [steerPreviewPortalTarget, setSteerPreviewPortalTarget] = useState<HTMLDivElement | null>(null);
   const previousArtifactPanelOpenRef = useRef(isPanelOpen);
   const fileListPreviewTabOpenBySessionRef = useRef<Record<string, boolean>>({});
   const browserPreviewTabOpenBySessionRef = useRef<Record<string, boolean>>({});
@@ -4262,11 +4270,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const artifactPanelOverlayBottom = artifactPanelIsOverlay && !isExpandedPromptInputHidden
     ? promptInputAreaHeight
     : 0;
-  const showExternalGoalStatusBar = Boolean(
-    currentSession.goal
-    && !remoteManaged
-    && !(isArtifactPanelExpanded && isExpandedPromptInputHidden)
-  );
+  const showPromptAuxiliaryBars = !remoteManaged && !(isArtifactPanelExpanded && isExpandedPromptInputHidden);
+  const showExternalGoalStatusBar = Boolean(currentSession.goal && showPromptAuxiliaryBars);
+  const showExternalSteerPreview = queuedSteerCount > 0 && showPromptAuxiliaryBars;
   const artifactPanelInnerWidth = artifactPanelIsOverlay ? '100%' : artifactPanelFrameWidth;
   const shouldShowTurnNavigationRail = railItems.length > 1 && isScrollable;
   const shouldShowScrollToBottom = isScrollable && !shouldAutoScroll;
@@ -5130,8 +5136,13 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         )}
         <div className={COWORK_DETAIL_CONTENT_CLASS}>
           {showExternalGoalStatusBar && (
-            <div className="relative z-10 -mb-px">
+            <div className={`relative z-10 ${showExternalSteerPreview ? 'mb-1.5' : '-mb-px'}`}>
               <div ref={setGoalStatusBarPortalTarget} />
+            </div>
+          )}
+          {showExternalSteerPreview && (
+            <div className="relative z-10 -mb-px">
+              <div ref={setSteerPreviewPortalTarget} />
             </div>
           )}
           <CoworkPromptInput
@@ -5155,6 +5166,8 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             goal={!remoteManaged ? currentSession?.goal : null}
             onGoalCommand={!remoteManaged && currentSession?.id ? handleGoalCommand : undefined}
             goalStatusBarPortalTarget={showExternalGoalStatusBar ? goalStatusBarPortalTarget : null}
+            goalStatusBarAttached={!showExternalSteerPreview}
+            steerPreviewPortalTarget={showExternalSteerPreview ? steerPreviewPortalTarget : null}
             contextUsageControl={(
               <div className="flex min-w-0 items-center gap-2">
                 <div ref={compactConfirmRef} className="relative inline-flex flex-shrink-0">


### PR DESCRIPTION
## Summary

- Remove the Plan Mode switch from the prompt menu and close the menu after toggling.
- Move Goal and Steer status bars above the prompt input with Codex-like attached styling.
- Refine Steer queue icons and reuse the shared edit icon for Goal and Steer actions.
- Fix queued Steer follow-ups so idle clicks submit correctly.
- Merge pending Steer follow-ups when interrupting a running turn and prevent duplicate submissions while the next turn starts.

## Testing

- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/renderer/components/cowork/CoworkPromptInput.tsx`
- `git diff --check`
- `npm run build`