### PR TITLE
fix(cowork): strip null bytes from prompts before openclaw gateway send

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -1742,6 +1742,23 @@ test('normal conversation does not receive plan mode instructions', async () => 
   expect(chatSendRequests[0].params.message).not.toContain('[Plan Mode recovery instruction]');
 });
 
+test('continueSession strips NUL characters from the persisted message and chat.send payload', async () => {
+  const nul = String.fromCharCode(0);
+  const { adapter, requests, session } = createRunTurnAdapter();
+
+  await adapter.continueSession('session-1', `请分析${nul}这段${nul}${nul}文本`);
+
+  const chatSendRequests = requests.filter((request) => request.method === 'chat.send');
+  expect(chatSendRequests).toHaveLength(1);
+  const outbound = chatSendRequests[0].params.message as string;
+  expect(outbound).not.toContain(nul);
+  expect(outbound).toContain('请分析这段文本');
+
+  const userMessages = session.messages.filter((message) => message.type === 'user');
+  expect(userMessages).toHaveLength(1);
+  expect(userMessages[0].content).toBe('请分析这段文本');
+});
+
 test('continueSession patches a session override before chat.send even when the model cache matches', async () => {
   const model = 'lobsterai-server/qwen3.6-plus-YoudaoInner';
   const { adapter, requests } = createRunTurnAdapter({

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -36,6 +36,7 @@ import {
   type CoworkSteerResponse,
   CoworkSteerStatus,
 } from '../../../shared/cowork/steer';
+import { stripNullChars } from '../../../shared/cowork/text';
 import type {
   KitReference,
   ResolvedKitCapabilities,
@@ -3899,7 +3900,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   async startSession(sessionId: string, prompt: string, options: CoworkStartOptions = {}): Promise<void> {
-    await this.runTurn(sessionId, prompt, {
+    await this.runTurn(sessionId, stripNullChars(prompt), {
       skipInitialUserMessage: options.skipInitialUserMessage,
       skillIds: options.skillIds,
       messageSkillIds: options.messageSkillIds,
@@ -3917,7 +3918,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   }
 
   async continueSession(sessionId: string, prompt: string, options: CoworkContinueOptions = {}): Promise<void> {
-    await this.runTurn(sessionId, prompt, {
+    await this.runTurn(sessionId, stripNullChars(prompt), {
       skipInitialUserMessage: options.skipInitialUserMessage ?? false,
       systemPrompt: options.systemPrompt,
       skillIds: options.skillIds,
@@ -3937,7 +3938,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     text: string,
     clientSteerId: string,
   ): Promise<CoworkSteerResponse> {
-    const trimmedText = text.trim();
+    const trimmedText = stripNullChars(text).trim();
     if (!trimmedText) {
       return {
         success: false,
@@ -4598,7 +4599,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
 
     firstResponseTiming.promptBuildStartedAtMs = Date.now();
-    const outboundMessage = await this.buildOutboundPrompt(
+    // Strip NUL at the final outbound boundary so bridge content rebuilt from
+    // already-poisoned local history cannot trigger the gateway rejection.
+    const outboundMessage = stripNullChars(await this.buildOutboundPrompt(
       sessionId,
       effectivePrompt,
       outboundSystemPrompt,
@@ -4606,7 +4609,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       options.mediaReferences,
       options.selectedTextSnippets,
       firstResponseTiming,
-    );
+    ));
     if (this.cancelTurnStartupIfStopped(sessionId, 'outbound prompt built')) {
       return;
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -71,6 +71,7 @@ import {
   CoworkSteerRejectReason,
   CoworkSteerStatus,
 } from '../shared/cowork/steer';
+import { stripNullChars } from '../shared/cowork/text';
 import {
   DataMigrationIpc,
   type DataMigrationLastRestoreResult,
@@ -6304,8 +6305,11 @@ if (!gotTheLock) {
           };
         }
 
+        // Strip NUL before this handler persists the message itself; the
+        // runtime adapter sanitizes again at the outbound boundary.
+        const prompt = stripNullChars(options.prompt);
         const fallbackTitle = buildSessionTitleFromInput(
-          options.prompt,
+          prompt,
           t('coworkDefaultSessionTitle'),
         );
         const title = options.title?.trim() || fallbackTitle;
@@ -6362,7 +6366,7 @@ if (!gotTheLock) {
         }
         const imageAttachmentPreviews = buildCoworkImageAttachmentPreviews(options.imageAttachments);
         const messageMetadata = buildCoworkUserSelectionMetadata({
-          prompt: options.prompt,
+          prompt,
           skillIds: options.activeSkillIds,
           kitIds: options.kitIds,
           kitReferences: options.kitReferences,
@@ -6372,7 +6376,7 @@ if (!gotTheLock) {
         });
         coworkStoreInstance.addMessage(session.id, {
           type: 'user',
-          content: options.prompt,
+          content: prompt,
           metadata: messageMetadata,
         });
 
@@ -6385,7 +6389,7 @@ if (!gotTheLock) {
           `Elapsed ${Date.now() - ipcStartedAtMs}ms.`,
         );
         runtime
-          .startSession(session.id, options.prompt, {
+          .startSession(session.id, prompt, {
             skipInitialUserMessage: true,
             systemPrompt,
             skillIds: runtimeSkillIds,

--- a/src/shared/cowork/selectedText.test.ts
+++ b/src/shared/cowork/selectedText.test.ts
@@ -66,6 +66,26 @@ test('rejects selected text snippet limits', () => {
   });
 });
 
+test('strips NUL characters from selected text snippets', () => {
+  const nul = String.fromCharCode(0);
+  expect(normalizeCoworkSelectedTextSnippets([
+    createSnippet(`quo${nul}ted${nul}`, { id: 'nul-text' }),
+  ])).toEqual({
+    success: true,
+    snippets: [
+      {
+        id: 'nul-text',
+        text: 'quoted',
+        sourceMessageId: 'assistant-1',
+        sourceMessageType: CoworkSelectedTextSource.AssistantMessage,
+        sourceId: 'assistant-1',
+        sourceType: CoworkSelectedTextSource.AssistantMessage,
+        createdAt: 1,
+      },
+    ],
+  });
+});
+
 test('rejects duplicate selected text snippets from the same source', () => {
   expect(normalizeCoworkSelectedTextSnippets([
     createSnippet('same', { id: 'one' }),

--- a/src/shared/cowork/selectedText.ts
+++ b/src/shared/cowork/selectedText.ts
@@ -1,3 +1,5 @@
+import { stripNullChars } from './text';
+
 export const CoworkSelectedTextSource = {
   AssistantMessage: 'assistant',
   ArtifactMarkdown: 'artifact_markdown',
@@ -52,7 +54,7 @@ const normalizeOptionalOffset = (value: unknown): number | undefined => (
 
 const normalizeOptionalText = (value: unknown, maxLength = 512): string | undefined => {
   if (typeof value !== 'string') return undefined;
-  const text = value.trim();
+  const text = stripNullChars(value).trim();
   if (!text) return undefined;
   return text.slice(0, maxLength);
 };
@@ -60,7 +62,7 @@ const normalizeOptionalText = (value: unknown, maxLength = 512): string | undefi
 const normalizeSnippet = (value: unknown): CoworkSelectedTextSnippet | null => {
   if (!isRecord(value)) return null;
   const id = typeof value.id === 'string' ? value.id.trim() : '';
-  const text = typeof value.text === 'string' ? value.text.trim() : '';
+  const text = typeof value.text === 'string' ? stripNullChars(value.text).trim() : '';
   const sourceMessageId = typeof value.sourceMessageId === 'string'
     ? value.sourceMessageId.trim()
     : '';

--- a/src/shared/cowork/text.test.ts
+++ b/src/shared/cowork/text.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+
+import { stripNullChars } from './text';
+
+const nul = String.fromCharCode(0);
+
+describe('stripNullChars', () => {
+  test('removes every NUL character', () => {
+    expect(stripNullChars(`a${nul}b${nul}${nul}c`)).toBe('abc');
+  });
+
+  test('returns clean strings unchanged', () => {
+    const value = 'line1\nline2\ttab 中文';
+    expect(stripNullChars(value)).toBe(value);
+  });
+
+  test('keeps other control and whitespace characters', () => {
+    expect(stripNullChars(`\r\n\t ${nul}`)).toBe('\r\n\t ');
+  });
+
+  test('handles the empty string', () => {
+    expect(stripNullChars('')).toBe('');
+  });
+});

--- a/src/shared/cowork/text.ts
+++ b/src/shared/cowork/text.ts
@@ -1,0 +1,8 @@
+// The OpenClaw gateway hard-rejects chat.send messages containing U+0000
+// ("message must not contain null bytes"), and NUL persisted in session
+// history re-enters later outbound prompts through the continuity capsule
+// and retrieved-evidence bridges. Strip it at ingestion and outbound
+// boundaries; other control characters are stripped by the gateway itself.
+export const stripNullChars = (value: string): string => (
+  value.includes('\u0000') ? value.replaceAll('\u0000', '') : value
+);


### PR DESCRIPTION
OpenClaw gateway hard-rejects chat.send payloads containing U+0000, and persisted NUL can re-enter later outbound prompts via continuity capsule and evidence bridges. Sanitize at ingestion (session start/continue/steer) and at the final outbound boundary.

## Summary
<!-- Provide a brief summary of the changes in this PR -->

## Related Issue
<!-- Link to the related issue(s) if applicable -->
Fixes #(issue number)

## Changes Made
<!-- Describe the changes you've made -->
- 
- 
- 

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you've performed -->
- [ ] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
<!-- Mark the completed items with [x] -->
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes
<!-- If your PR includes Electron-specific changes, describe them here -->
- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes
<!-- Any additional information that reviewers should know -->
