### PR TITLE
fix(build): keep null-byte stripping ES2020-compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           filters: |
             renderer:
               - 'src/renderer/**'
+              - 'src/shared/**'
               - 'vite.config.ts'
               - 'tsconfig.json'
               - 'tailwind.config.js'
@@ -37,6 +38,7 @@ jobs:
             main:
               - 'src/main/**'
               - 'src/common/**'
+              - 'src/shared/**'
               - 'electron-tsconfig.json'
               - 'src/main/preload.ts'
             skills:

--- a/src/shared/cowork/text.ts
+++ b/src/shared/cowork/text.ts
@@ -4,5 +4,5 @@
 // and retrieved-evidence bridges. Strip it at ingestion and outbound
 // boundaries; other control characters are stripped by the gateway itself.
 export const stripNullChars = (value: string): string => (
-  value.includes('\u0000') ? value.replaceAll('\u0000', '') : value
+  value.includes('\u0000') ? value.replace(/\u0000/g, '') : value
 );


### PR DESCRIPTION
## Summary

- replace `String.replaceAll` with an ES2020-compatible global regex for null-byte stripping
- run renderer and main CI builds when shared TypeScript changes

## Verification

- `npm run build`
- `npm run compile:electron`
- `npm test -- src/shared/cowork/text.test.ts`
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/shared/cowork/text.ts`
- full `npm run dist:win` rerun passed the previous TypeScript failure point, then was stopped on request