### PR TITLE
feat(cowork): add folder context attachments

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9294,7 +9294,7 @@ if (!gotTheLock) {
 
   ipcMain.handle(
     DialogIpc.StatFile,
-    async (_event, filePath?: string): Promise<{ success: boolean; isFile?: boolean; size?: number; mtimeMs?: number; error?: string }> => {
+    async (_event, filePath?: string): Promise<{ success: boolean; isFile?: boolean; isDirectory?: boolean; size?: number; mtimeMs?: number; error?: string }> => {
       try {
         if (typeof filePath !== 'string' || !filePath.trim()) {
           return { success: false, error: 'Missing file path' };
@@ -9303,6 +9303,7 @@ if (!gotTheLock) {
         return {
           success: true,
           isFile: stat.isFile(),
+          isDirectory: stat.isDirectory(),
           size: stat.size,
           mtimeMs: stat.mtimeMs,
         };

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, webUtils } from 'electron';
 
 import { IpcChannel as ScheduledTaskIpc } from '../scheduledTask/constants';
 import { AgentIpcChannel, AgentLegacyIdentityCleanupStatus } from '../shared/agent/constants';
@@ -610,6 +610,7 @@ contextBridge.exposeInMainWorld('electron', {
       title?: string;
       filters?: { name: string; extensions: string[] }[];
     }) => ipcRenderer.invoke('dialog:selectFiles', options),
+    getPathForFile: (file: File) => webUtils.getPathForFile(file),
     saveInlineFile: (options: {
       dataBase64: string;
       fileName?: string;

--- a/src/renderer/components/cowork/AttachmentCard.tsx
+++ b/src/renderer/components/cowork/AttachmentCard.tsx
@@ -1,3 +1,4 @@
+import { FolderIcon } from '@heroicons/react/24/solid';
 import React, { useEffect, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
@@ -114,6 +115,7 @@ const ImageCard: React.FC<AttachmentCardProps> = ({ attachment, onRemove, label 
 
 const FileCard: React.FC<AttachmentCardProps> = ({ attachment, onRemove, label }) => {
   const { label: typeLabel } = getFileTypeInfo(attachment.name);
+  const displayTypeLabel = attachment.isDirectory ? i18nService.t('folderAttachmentType') : typeLabel;
 
   return (
     <div
@@ -122,7 +124,11 @@ const FileCard: React.FC<AttachmentCardProps> = ({ attachment, onRemove, label }
     >
       {/* File type icon */}
       <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl bg-black/[0.04] dark:bg-white/[0.08]">
-        <FileTypeIcon fileName={attachment.name} className="h-7 w-7 flex-shrink-0" />
+        {attachment.isDirectory ? (
+          <FolderIcon className="h-7 w-7 flex-shrink-0 text-amber-500" />
+        ) : (
+          <FileTypeIcon fileName={attachment.name} className="h-7 w-7 flex-shrink-0" />
+        )}
       </div>
 
       {/* File name + type label */}
@@ -131,7 +137,7 @@ const FileCard: React.FC<AttachmentCardProps> = ({ attachment, onRemove, label }
           {label ? `${label} · ${attachment.name}` : attachment.name}
         </span>
         <span className="mt-0.5 text-xs text-secondary">
-          {typeLabel}
+          {displayTypeLabel}
         </span>
       </div>
 

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -308,6 +308,35 @@ const getFileNameFromPath = (path: string): string => {
   return parts[parts.length - 1] || path;
 };
 
+const normalizeClipboardFileUrlPath = (rawPath: string): string | null => {
+  const trimmed = rawPath.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'file:') return null;
+    let pathname = decodeURIComponent(url.pathname);
+    if (/^\/[A-Za-z]:/.test(pathname)) {
+      pathname = pathname.slice(1);
+    }
+    return pathname || null;
+  } catch {
+    return null;
+  }
+};
+
+const getClipboardFileUrlPath = (clipboardData: DataTransfer | null): string | null => {
+  const uriList = clipboardData?.getData('text/uri-list') ?? '';
+  const uriCandidate = uriList
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .find(line => line && !line.startsWith('#'));
+  if (uriCandidate) {
+    return normalizeClipboardFileUrlPath(uriCandidate);
+  }
+  const plainText = clipboardData?.getData('text/plain') ?? '';
+  return normalizeClipboardFileUrlPath(plainText);
+};
+
 const SEND_SHORTCUT_OPTIONS = [
   { value: 'Enter', label: 'Enter', labelMac: 'Enter' },
   { value: 'Shift+Enter', label: 'Shift+Enter', labelMac: 'Shift+Enter' },
@@ -1312,7 +1341,12 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
 
     const attachmentLines = sourceAttachments
       .filter((a) => !a.path.startsWith('inline:') && !(a.isImage && imageAttachmentPathsWithPayload.has(a.path)))
-      .map((attachment) => `${i18nService.t('inputFileLabel')}: ${attachment.path}`)
+      .map((attachment) => {
+        const label = attachment.isDirectory
+          ? i18nService.t('inputFolderLabel')
+          : i18nService.t('inputFileLabel');
+        return `${label}: ${attachment.path}`;
+      })
       .join('\n');
     const finalPrompt = basePrompt
       ? (attachmentLines ? `${basePrompt}\n\n${attachmentLines}` : basePrompt)
@@ -2137,15 +2171,16 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     }
   }, [reportPromptControl, workingDirectory]);
 
-  const addAttachment = useCallback((filePath: string, imageInfo?: { isImage: boolean; dataUrl?: string }) => {
+  const addAttachment = useCallback((filePath: string, options?: { isImage?: boolean; isDirectory?: boolean; dataUrl?: string }) => {
     if (!filePath) return;
     dispatch(addDraftAttachment({
       draftKey,
       attachment: {
         path: filePath,
         name: getFileNameFromPath(filePath),
-        isImage: imageInfo?.isImage,
-        dataUrl: imageInfo?.dataUrl,
+        isImage: options?.isImage,
+        isDirectory: options?.isDirectory,
+        dataUrl: options?.dataUrl,
       },
     }));
   }, [dispatch, draftKey]);
@@ -2198,11 +2233,35 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   }, []);
 
   const getNativeFilePath = useCallback((file: File): string | null => {
+    const bridgePath = window.electron.dialog.getPathForFile?.(file);
+    if (typeof bridgePath === 'string' && bridgePath.trim()) {
+      return bridgePath;
+    }
     const maybePath = (file as File & { path?: string }).path;
     if (typeof maybePath === 'string' && maybePath.trim()) {
       return maybePath;
     }
     return null;
+  }, []);
+
+  const statNativePath = useCallback(async (filePath: string): Promise<{ isFile: boolean; isDirectory: boolean } | null> => {
+    try {
+      const result = await window.electron.dialog.statFile(filePath);
+      if (!result.success) {
+        console.debug('[CoworkPromptInput] stat dropped/pasted path returned unsuccessful result:', {
+          path: filePath,
+          error: result.error,
+        });
+        return null;
+      }
+      return {
+        isFile: result.isFile === true,
+        isDirectory: result.isDirectory === true,
+      };
+    } catch (error) {
+      console.warn('[CoworkPromptInput] failed to stat dropped/pasted path:', error);
+      return null;
+    }
   }, []);
 
   const saveInlineFile = useCallback(async (file: File): Promise<string | null> => {
@@ -2222,7 +2281,16 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       }
       return null;
     } catch (error) {
-      console.error('Failed to save inline file:', error);
+      const errorName = error instanceof DOMException ? error.name : '';
+      if (errorName === 'NotFoundError') {
+        console.debug('[CoworkPromptInput] skipped inline file save because the source was unavailable to FileReader:', {
+          name: file.name,
+          type: file.type,
+          size: file.size,
+        });
+      } else {
+        console.error('Failed to save inline file:', error);
+      }
       return null;
     }
   }, [fileToBase64, workingDirectory]);
@@ -2247,6 +2315,17 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     }));
     for (const file of files) {
       const nativePath = getNativeFilePath(file);
+      const nativeStat = nativePath ? await statNativePath(nativePath) : null;
+
+      if (nativePath && nativeStat?.isDirectory) {
+        console.debug('[CoworkPromptInput] handleIncomingFiles: directory attachment added', {
+          source,
+          path: nativePath,
+          name: file.name,
+        });
+        addAttachment(nativePath, { isDirectory: true });
+        continue;
+      }
 
       // Check if this is an image file and model supports images
       const fileIsImage = nativePath
@@ -2340,7 +2419,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       hasImageWithoutVision,
       ...getAttachmentAnalyticsParams(incomingAttachments),
     });
-  }, [addAttachment, addImageAttachmentFromDataUrl, disabled, effectiveSelectedModel, fileToDataUrl, getNativeFilePath, modelSupportsImage, reportPromptControl, saveInlineFile, voiceInputLocksEditing]);
+  }, [addAttachment, addImageAttachmentFromDataUrl, disabled, effectiveSelectedModel, fileToDataUrl, getNativeFilePath, modelSupportsImage, reportPromptControl, saveInlineFile, statNativePath, voiceInputLocksEditing]);
 
   const handleAddFile = useCallback(async () => {
     if (isAddingFile || disabled || voiceInputLocksEditing) {
@@ -2695,10 +2774,41 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   const handlePaste = useCallback((event: React.ClipboardEvent<HTMLTextAreaElement>) => {
     if (disabled || voiceInputLocksEditing) return;
     const files = Array.from(event.clipboardData?.files ?? []);
-    if (files.length === 0) return;
+    if (files.length > 0) {
+      event.preventDefault();
+      void handleIncomingFiles(files, 'paste');
+      return;
+    }
+
+    const clipboardPath = getClipboardFileUrlPath(event.clipboardData);
+    if (!clipboardPath) return;
     event.preventDefault();
-    void handleIncomingFiles(files, 'paste');
-  }, [disabled, handleIncomingFiles, voiceInputLocksEditing]);
+    void (async () => {
+      const stat = await statNativePath(clipboardPath);
+      if (!stat?.isDirectory && !stat?.isFile) {
+        console.debug('[CoworkPromptInput] pasted file URL did not resolve to a file or directory', {
+          path: clipboardPath,
+        });
+        return;
+      }
+
+      console.debug('[CoworkPromptInput] handlePaste: file URL attachment added', {
+        path: clipboardPath,
+        isDirectory: stat.isDirectory,
+      });
+      addAttachment(clipboardPath, { isDirectory: stat.isDirectory });
+      reportPromptControl('attachment_add_success', {
+        source: 'paste',
+        modelSupportsImage,
+        hasImageWithoutVision: false,
+        ...getAttachmentAnalyticsParams([{
+          path: clipboardPath,
+          name: getFileNameFromPath(clipboardPath),
+          isImage: false,
+        }]),
+      });
+    })();
+  }, [addAttachment, disabled, handleIncomingFiles, modelSupportsImage, reportPromptControl, statNativePath, voiceInputLocksEditing]);
 
   const canSubmit = !disabled
     && !isVoiceRecognizing

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -134,6 +134,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelSuffixSecure: '（安全）',
     codingPlanSubscriptionBadge: '订阅套餐',
     inputFileLabel: '输入文件',
+    inputFolderLabel: '输入文件夹',
+    folderAttachmentType: '文件夹',
     imageVisionHint:
       '当前模型未启用图片输入，图片将以文件路径形式发送。若该模型本身支持图片理解，可在模型配置中开启图片输入选项。',
     copied: '已复制',
@@ -2888,6 +2890,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelSuffixSecure: '(Secure)',
     codingPlanSubscriptionBadge: 'Subscription',
     inputFileLabel: 'Input Files',
+    inputFolderLabel: 'Input Folder',
+    folderAttachmentType: 'Folder',
     imageVisionHint:
       'Image input is not enabled for the current model. Images will be sent as file paths. If the model supports vision, you can enable image input in the model configuration.',
     copied: 'Copied',

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -31,6 +31,7 @@ export interface DraftAttachment {
   path: string;
   name: string;
   isImage?: boolean;
+  isDirectory?: boolean;
   dataUrl?: string;
 }
 

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1012,6 +1012,7 @@ interface IElectronAPI {
       title?: string;
       filters?: { name: string; extensions: string[] }[];
     }) => Promise<{ success: boolean; paths: string[] }>;
+    getPathForFile?: (file: File) => string;
     saveInlineFile: (options: {
       dataBase64: string;
       fileName?: string;
@@ -1023,7 +1024,7 @@ interface IElectronAPI {
     ) => Promise<{ success: boolean; dataUrl?: string; error?: string }>;
     statFile: (
       filePath: string,
-    ) => Promise<{ success: boolean; isFile?: boolean; size?: number; mtimeMs?: number; error?: string }>;
+    ) => Promise<{ success: boolean; isFile?: boolean; isDirectory?: boolean; size?: number; mtimeMs?: number; error?: string }>;
     readTextFile: (
       filePath: string,
     ) => Promise<{


### PR DESCRIPTION
## Summary
- Show pasted or dropped local folders as removable prompt attachments.
- Send folder attachments to OpenClaw as folder path context instead of uploading directory contents.
- Use Electron native path resolution and stat metadata to reliably detect directories.

## Validation
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/preload.ts src/renderer/store/slices/coworkSlice.ts src/main/main.ts src/renderer/types/electron.d.ts src/renderer/services/i18n.ts src/renderer/components/cowork/AttachmentCard.tsx src/renderer/components/cowork/CoworkPromptInput.tsx`
- `npm run compile:electron`

## Notes
- No database or migration changes.
- `npm run build` was not used for final validation because it currently fails on unrelated missing `@dnd-kit/*` dependencies.