### PR TITLE
fix(memory): migrate fts-only indexes for all agents

### DIFF
--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -19,7 +19,7 @@ import {
 import { getCodexHomeDir } from './openaiCodexAuth';
 import { migrateLegacyCronStorageWithDoctor } from './openclawCronLegacyMigration';
 import { cleanupStaleThirdPartyPluginsFromBundledDir, listLocalOpenClawExtensionIds,syncLocalOpenClawExtensionsIntoRuntime } from './openclawLocalExtensions';
-import { migrateMainFtsOnlyMemoryIndex } from './openclawMemoryIndexMigration';
+import { migrateAllFtsOnlyMemoryIndexes } from './openclawMemoryIndexMigration';
 import { ensureOpenClawWorkerShims } from './openclawWorkerShims';
 import { appendPythonRuntimeToEnv } from './pythonRuntime';
 
@@ -600,7 +600,7 @@ export class OpenClawEngineManager extends EventEmitter {
       env,
     });
 
-    await migrateMainFtsOnlyMemoryIndex({
+    await migrateAllFtsOnlyMemoryIndexes({
       stateDir: this.stateDir,
       configPath: this.configPath,
       runtimeRoot: runtime.root,

--- a/src/main/libs/openclawMemoryIndexMigration.test.ts
+++ b/src/main/libs/openclawMemoryIndexMigration.test.ts
@@ -6,16 +6,21 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
   type MemoryIndexMigrationRunner,
-  migrateMainFtsOnlyMemoryIndex,
-  resolveMainMemoryIndexMigrationNeed,
+  migrateAllFtsOnlyMemoryIndexes,
+  resolveFtsOnlyMemoryIndexMigrationNeed,
 } from './openclawMemoryIndexMigration';
 
 let tmpDir = '';
 let stateDir = '';
 let runtimeRoot = '';
 let configPath = '';
-let dbPath = '';
 let electronNodeRuntimePath = '';
+
+type TestAgentEntry = {
+  id: string;
+  default?: boolean;
+  memorySearch?: Record<string, unknown>;
+};
 
 function mkdirp(dir: string): void {
   fs.mkdirSync(dir, { recursive: true });
@@ -26,11 +31,10 @@ function writeFile(filePath: string, content: string): void {
   fs.writeFileSync(filePath, content, 'utf8');
 }
 
-function writeConfig(memorySearch: Record<string, unknown>, agentMemorySearch?: Record<string, unknown>): void {
-  const mainAgent: Record<string, unknown> = { id: 'main', default: true };
-  if (agentMemorySearch) {
-    mainAgent.memorySearch = agentMemorySearch;
-  }
+function writeConfig(
+  memorySearch: Record<string, unknown>,
+  agents: TestAgentEntry[] = [{ id: 'main', default: true }],
+): void {
   writeFile(
     configPath,
     `${JSON.stringify({
@@ -40,15 +44,19 @@ function writeConfig(memorySearch: Record<string, unknown>, agentMemorySearch?: 
           workspace: path.join(stateDir, 'workspace-main'),
           memorySearch,
         },
-        list: [mainAgent],
+        list: agents,
       },
     }, null, 2)}\n`,
   );
 }
 
-function writeIndexMeta(meta: Record<string, unknown> | null): void {
-  mkdirp(path.dirname(dbPath));
-  const db = new Database(dbPath);
+function defaultIndexPath(agentId: string): string {
+  return path.join(stateDir, 'memory', `${agentId}.sqlite`);
+}
+
+function writeIndexMetaAtPath(filePath: string, meta: Record<string, unknown> | null): void {
+  mkdirp(path.dirname(filePath));
+  const db = new Database(filePath);
   try {
     db.exec('CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)');
     if (meta) {
@@ -61,22 +69,57 @@ function writeIndexMeta(meta: Record<string, unknown> | null): void {
   }
 }
 
-function writeEmptySqlite(): void {
-  mkdirp(path.dirname(dbPath));
-  const db = new Database(dbPath);
+function writeIndexMeta(agentId: string, meta: Record<string, unknown> | null): void {
+  writeIndexMetaAtPath(defaultIndexPath(agentId), meta);
+}
+
+function writeEmptySqlite(agentId: string): void {
+  const filePath = defaultIndexPath(agentId);
+  mkdirp(path.dirname(filePath));
+  const db = new Database(filePath);
   db.close();
 }
 
-function ftsOnlyMemorySearch(): Record<string, unknown> {
+function currentIndexMeta(): Record<string, unknown> {
+  return {
+    model: 'fts-only',
+    provider: 'none',
+    ftsTokenizer: 'trigram',
+  };
+}
+
+function oldIndexMeta(): Record<string, unknown> {
+  return {
+    model: 'gemini-embedding-001',
+    provider: 'gemini',
+    ftsTokenizer: 'unicode61',
+  };
+}
+
+function ftsOnlyMemorySearch(storePath?: string): Record<string, unknown> {
   return {
     enabled: true,
     provider: 'none',
     fallback: 'none',
     store: {
+      ...(storePath ? { path: storePath } : {}),
       fts: { tokenizer: 'trigram' },
       vector: { enabled: false },
     },
   };
+}
+
+function successfulRunner(updatedIndexPaths: string[]): ReturnType<typeof vi.fn<MemoryIndexMigrationRunner>> {
+  return vi.fn<MemoryIndexMigrationRunner>().mockImplementation(async () => {
+    for (const indexPath of updatedIndexPaths) {
+      writeIndexMetaAtPath(indexPath, currentIndexMeta());
+    }
+    return {
+      code: 0,
+      stdout: 'updated',
+      stderr: '',
+    };
+  });
 }
 
 describe('openclawMemoryIndexMigration', () => {
@@ -85,7 +128,6 @@ describe('openclawMemoryIndexMigration', () => {
     stateDir = path.join(tmpDir, 'openclaw', 'state');
     runtimeRoot = path.join(tmpDir, 'runtime');
     configPath = path.join(stateDir, 'openclaw.json');
-    dbPath = path.join(stateDir, 'memory', 'main.sqlite');
     electronNodeRuntimePath = process.execPath;
     mkdirp(runtimeRoot);
     writeFile(path.join(runtimeRoot, 'openclaw.mjs'), 'console.log("openclaw");\n');
@@ -105,14 +147,10 @@ describe('openclawMemoryIndexMigration', () => {
       model: 'gemini-embedding-001',
       store: { fts: { tokenizer: 'trigram' } },
     });
-    writeIndexMeta({
-      model: 'gemini-embedding-001',
-      provider: 'gemini',
-      ftsTokenizer: 'trigram',
-    });
+    writeIndexMeta('main', oldIndexMeta());
     const runner = vi.fn<MemoryIndexMigrationRunner>();
 
-    const result = await migrateMainFtsOnlyMemoryIndex({
+    const result = await migrateAllFtsOnlyMemoryIndexes({
       stateDir,
       configPath,
       runtimeRoot,
@@ -125,35 +163,36 @@ describe('openclawMemoryIndexMigration', () => {
     expect(runner).not.toHaveBeenCalled();
   });
 
-  test('skips when main agent overrides defaults with an embedding provider', async () => {
-    writeConfig(ftsOnlyMemorySearch(), {
-      enabled: true,
-      provider: 'gemini',
-      model: 'gemini-embedding-001',
-      store: { fts: { tokenizer: 'trigram' } },
-    });
-    writeIndexMeta({
-      model: 'gemini-embedding-001',
-      provider: 'gemini',
-      ftsTokenizer: 'trigram',
-    });
+  test('skips all-agent reindex when an agent overrides defaults with an embedding provider', () => {
+    writeConfig(ftsOnlyMemorySearch(), [
+      { id: 'main', default: true },
+      {
+        id: 'custom-agent',
+        memorySearch: {
+          provider: 'gemini',
+          model: 'gemini-embedding-001',
+        },
+      },
+    ]);
+    writeIndexMeta('main', currentIndexMeta());
+    writeIndexMeta('custom-agent', oldIndexMeta());
 
-    expect(resolveMainMemoryIndexMigrationNeed({ configPath, stateDir })).toEqual({
+    expect(resolveFtsOnlyMemoryIndexMigrationNeed({ configPath, stateDir })).toEqual({
       shouldMigrate: false,
       reason: 'not-fts-only-config',
     });
   });
 
-  test('skips when FTS-only index metadata is current', async () => {
-    writeConfig(ftsOnlyMemorySearch());
-    writeIndexMeta({
-      model: 'fts-only',
-      provider: 'none',
-      ftsTokenizer: 'trigram',
-    });
+  test('skips when every configured index metadata is current', async () => {
+    writeConfig(ftsOnlyMemorySearch(), [
+      { id: 'main', default: true },
+      { id: 'custom-agent' },
+    ]);
+    writeIndexMeta('main', currentIndexMeta());
+    writeIndexMeta('custom-agent', currentIndexMeta());
     const runner = vi.fn<MemoryIndexMigrationRunner>();
 
-    const result = await migrateMainFtsOnlyMemoryIndex({
+    const result = await migrateAllFtsOnlyMemoryIndexes({
       stateDir,
       configPath,
       runtimeRoot,
@@ -166,20 +205,22 @@ describe('openclawMemoryIndexMigration', () => {
     expect(runner).not.toHaveBeenCalled();
   });
 
-  test('runs official forced reindex when old embedding metadata exists under FTS-only config', async () => {
-    writeConfig(ftsOnlyMemorySearch());
-    writeIndexMeta({
-      model: 'gemini-embedding-001',
-      provider: 'gemini',
-      ftsTokenizer: 'unicode61',
-    });
-    const runner = vi.fn<MemoryIndexMigrationRunner>().mockResolvedValue({
-      code: 0,
-      stdout: 'updated',
-      stderr: '',
+  test('runs one official all-agent reindex when only a custom agent has old metadata', async () => {
+    writeConfig(ftsOnlyMemorySearch(), [
+      { id: 'main', default: true },
+      { id: 'custom-agent' },
+    ]);
+    writeIndexMeta('main', currentIndexMeta());
+    writeIndexMeta('custom-agent', oldIndexMeta());
+    const runner = successfulRunner([defaultIndexPath('custom-agent')]);
+
+    const need = resolveFtsOnlyMemoryIndexMigrationNeed({ configPath, stateDir });
+    expect(need).toMatchObject({
+      shouldMigrate: true,
+      targets: [{ agentId: 'custom-agent', dbPath: defaultIndexPath('custom-agent') }],
     });
 
-    const result = await migrateMainFtsOnlyMemoryIndex({
+    const result = await migrateAllFtsOnlyMemoryIndexes({
       stateDir,
       configPath,
       runtimeRoot,
@@ -197,8 +238,6 @@ describe('openclawMemoryIndexMigration', () => {
       'memory',
       'index',
       '--force',
-      '--agent',
-      'main',
     ]);
     expect(options.cwd).toBe(runtimeRoot);
     expect(options.timeoutMs).toBeGreaterThan(0);
@@ -209,39 +248,119 @@ describe('openclawMemoryIndexMigration', () => {
     expect(options.env.ELECTRON_RUN_AS_NODE).toBe('1');
   });
 
-  test('runs forced reindex when metadata is missing', async () => {
-    writeConfig(ftsOnlyMemorySearch());
-    writeIndexMeta(null);
+  test('collects every stale configured agent before running one reindex', async () => {
+    writeConfig(ftsOnlyMemorySearch(), [
+      { id: 'main', default: true },
+      { id: 'custom-one' },
+      { id: 'custom-two' },
+    ]);
+    writeIndexMeta('main', oldIndexMeta());
+    writeIndexMeta('custom-one', oldIndexMeta());
+    writeIndexMeta('custom-two', currentIndexMeta());
+    const runner = successfulRunner([
+      defaultIndexPath('main'),
+      defaultIndexPath('custom-one'),
+    ]);
 
-    expect(resolveMainMemoryIndexMigrationNeed({ configPath, stateDir })).toMatchObject({
+    const need = resolveFtsOnlyMemoryIndexMigrationNeed({ configPath, stateDir });
+    expect(need.shouldMigrate).toBe(true);
+    if (need.shouldMigrate) {
+      expect(need.targets.map((target) => target.agentId)).toEqual(['main', 'custom-one']);
+    }
+
+    const result = await migrateAllFtsOnlyMemoryIndexes({
+      stateDir,
+      configPath,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: {},
+      runner,
+    });
+
+    expect(result.status).toBe('migrated');
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  test('detects missing metadata and a missing sqlite meta table', () => {
+    writeConfig(ftsOnlyMemorySearch(), [
+      { id: 'main', default: true },
+      { id: 'custom-agent' },
+    ]);
+    writeIndexMeta('main', null);
+    writeEmptySqlite('custom-agent');
+
+    const need = resolveFtsOnlyMemoryIndexMigrationNeed({ configPath, stateDir });
+    expect(need.shouldMigrate).toBe(true);
+    if (need.shouldMigrate) {
+      expect(need.targets.map((target) => target.agentId)).toEqual(['main', 'custom-agent']);
+      expect(need.targets.every((target) => target.reason === 'index metadata is missing')).toBe(true);
+    }
+  });
+
+  test('ignores orphan indexes until the agent is configured again', async () => {
+    writeConfig(ftsOnlyMemorySearch());
+    writeIndexMeta('main', currentIndexMeta());
+    writeIndexMeta('deleted-agent', oldIndexMeta());
+    const runner = vi.fn<MemoryIndexMigrationRunner>();
+
+    const result = await migrateAllFtsOnlyMemoryIndexes({
+      stateDir,
+      configPath,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: {},
+      runner,
+    });
+
+    expect(result).toEqual({ status: 'skipped', reason: 'index-meta-current' });
+    expect(runner).not.toHaveBeenCalled();
+
+    writeConfig(ftsOnlyMemorySearch(), [
+      { id: 'main', default: true },
+      { id: 'deleted-agent' },
+    ]);
+    const reenabledNeed = resolveFtsOnlyMemoryIndexMigrationNeed({ configPath, stateDir });
+    expect(reenabledNeed).toMatchObject({
       shouldMigrate: true,
-      dbPath,
-      reason: 'index metadata is missing',
+      targets: [{ agentId: 'deleted-agent', dbPath: defaultIndexPath('deleted-agent') }],
     });
   });
 
-  test('runs forced reindex when sqlite meta table is missing', async () => {
-    writeConfig(ftsOnlyMemorySearch());
-    writeEmptySqlite();
+  test('skips when no configured agent has an index database', () => {
+    writeConfig(ftsOnlyMemorySearch(), [
+      { id: 'main', default: true },
+      { id: 'custom-agent' },
+    ]);
 
-    expect(resolveMainMemoryIndexMigrationNeed({ configPath, stateDir })).toMatchObject({
+    expect(resolveFtsOnlyMemoryIndexMigrationNeed({ configPath, stateDir })).toEqual({
+      shouldMigrate: false,
+      reason: 'no-index-db',
+    });
+  });
+
+  test('resolves the configured index path separately for each agent', () => {
+    const storePath = path.join(stateDir, 'custom-memory', '{agentId}.sqlite');
+    writeConfig(ftsOnlyMemorySearch(storePath), [
+      { id: 'main', default: true },
+      { id: 'custom-agent' },
+    ]);
+    const customIndexPath = path.join(stateDir, 'custom-memory', 'custom-agent.sqlite');
+    writeIndexMetaAtPath(customIndexPath, oldIndexMeta());
+
+    const need = resolveFtsOnlyMemoryIndexMigrationNeed({ configPath, stateDir });
+    expect(need).toMatchObject({
       shouldMigrate: true,
-      dbPath,
-      reason: 'index metadata is missing',
+      targets: [{ agentId: 'custom-agent', dbPath: customIndexPath }],
     });
   });
 
   test('skips when bundled OpenClaw CLI is missing', async () => {
     fs.rmSync(path.join(runtimeRoot, 'openclaw.mjs'), { force: true });
     writeConfig(ftsOnlyMemorySearch());
-    writeIndexMeta({
-      model: 'gemini-embedding-001',
-      provider: 'gemini',
-      ftsTokenizer: 'unicode61',
-    });
+    writeIndexMeta('main', oldIndexMeta());
     const runner = vi.fn<MemoryIndexMigrationRunner>();
 
-    const result = await migrateMainFtsOnlyMemoryIndex({
+    const result = await migrateAllFtsOnlyMemoryIndexes({
       stateDir,
       configPath,
       runtimeRoot,
@@ -254,20 +373,16 @@ describe('openclawMemoryIndexMigration', () => {
     expect(runner).not.toHaveBeenCalled();
   });
 
-  test('returns failed when forced reindex exits non-zero', async () => {
+  test('returns failed when all-agent reindex exits non-zero', async () => {
     writeConfig(ftsOnlyMemorySearch());
-    writeIndexMeta({
-      model: 'gemini-embedding-001',
-      provider: 'gemini',
-      ftsTokenizer: 'unicode61',
-    });
+    writeIndexMeta('main', oldIndexMeta());
     const runner = vi.fn<MemoryIndexMigrationRunner>().mockResolvedValue({
       code: 2,
       stdout: '',
       stderr: 'failed',
     });
 
-    const result = await migrateMainFtsOnlyMemoryIndex({
+    const result = await migrateAllFtsOnlyMemoryIndexes({
       stateDir,
       configPath,
       runtimeRoot,
@@ -277,5 +392,30 @@ describe('openclawMemoryIndexMigration', () => {
     });
 
     expect(result).toEqual({ status: 'failed', code: 2 });
+  });
+
+  test('returns failed when successful CLI exit leaves a stale target index', async () => {
+    writeConfig(ftsOnlyMemorySearch());
+    writeIndexMeta('main', oldIndexMeta());
+    const runner = vi.fn<MemoryIndexMigrationRunner>().mockResolvedValue({
+      code: 0,
+      stdout: 'updated',
+      stderr: '',
+    });
+
+    const result = await migrateAllFtsOnlyMemoryIndexes({
+      stateDir,
+      configPath,
+      runtimeRoot,
+      electronNodeRuntimePath,
+      env: {},
+      runner,
+    });
+
+    expect(result).toEqual({
+      status: 'failed',
+      code: 0,
+      error: 'post-reindex verification failed for agents ["main"]',
+    });
   });
 });

--- a/src/main/libs/openclawMemoryIndexMigration.ts
+++ b/src/main/libs/openclawMemoryIndexMigration.ts
@@ -7,7 +7,7 @@ import path from 'path';
 const MEMORY_INDEX_REBUILD_TIMEOUT_MS = 180_000;
 const LOG_TAIL_LIMIT = 4_000;
 const MEMORY_INDEX_META_KEY = 'memory_index_meta_v1';
-const MAIN_AGENT_ID = 'main';
+const DEFAULT_AGENT_ID = 'main';
 
 export type MemoryIndexMigrationRunResult = {
   code: number | null;
@@ -49,9 +49,16 @@ type MemoryIndexMeta = {
   ftsTokenizer?: string;
 };
 
+export type MemoryIndexMigrationTarget = {
+  agentId: string;
+  dbPath: string;
+  expectedTokenizer?: string;
+  reason: string;
+};
+
 export type MemoryIndexMigrationNeed =
   | { shouldMigrate: false; reason: MemoryIndexMigrationSkippedReason }
-  | { shouldMigrate: true; dbPath: string; reason: string };
+  | { shouldMigrate: true; targets: MemoryIndexMigrationTarget[]; reason: string };
 
 function isRecord(value: unknown): value is JsonRecord {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -66,27 +73,45 @@ function readJsonFile(filePath: string): JsonRecord | null {
   }
 }
 
-function findAgentEntry(config: JsonRecord, agentId: string): JsonRecord | null {
+function resolveConfiguredAgentEntries(config: JsonRecord): JsonRecord[] {
   const agents = isRecord(config.agents) ? config.agents : null;
   const list = Array.isArray(agents?.list) ? agents.list : [];
-  for (const entry of list) {
-    if (!isRecord(entry)) {
-      continue;
-    }
-    if (entry.id === agentId) {
-      return entry;
-    }
-  }
-  return null;
+  const entries = list.filter((entry): entry is JsonRecord => (
+    isRecord(entry) && typeof entry.id === 'string' && Boolean(entry.id.trim())
+  ));
+  return entries.length > 0 ? entries : [{ id: DEFAULT_AGENT_ID }];
 }
 
-function resolveMainMemorySearchConfig(config: JsonRecord): JsonRecord | null {
+function resolveDefaultMemorySearchConfig(config: JsonRecord): JsonRecord | null {
   const agents = isRecord(config.agents) ? config.agents : null;
   const defaults = isRecord(agents?.defaults) ? agents.defaults : null;
-  const defaultMemorySearch = isRecord(defaults?.memorySearch) ? defaults.memorySearch : null;
-  const mainAgent = findAgentEntry(config, MAIN_AGENT_ID);
-  const mainMemorySearch = isRecord(mainAgent?.memorySearch) ? mainAgent.memorySearch : null;
-  return mainMemorySearch ?? defaultMemorySearch;
+  return isRecord(defaults?.memorySearch) ? defaults.memorySearch : null;
+}
+
+function mergeMemorySearchConfig(
+  defaults: JsonRecord | null,
+  agentEntry: JsonRecord,
+): JsonRecord | null {
+  const overrides = isRecord(agentEntry.memorySearch) ? agentEntry.memorySearch : null;
+  if (!overrides) {
+    return defaults;
+  }
+  const defaultStore = isRecord(defaults?.store) ? defaults.store : {};
+  const overrideStore = isRecord(overrides.store) ? overrides.store : {};
+  const defaultFts = isRecord(defaultStore.fts) ? defaultStore.fts : {};
+  const overrideFts = isRecord(overrideStore.fts) ? overrideStore.fts : {};
+  const defaultVector = isRecord(defaultStore.vector) ? defaultStore.vector : {};
+  const overrideVector = isRecord(overrideStore.vector) ? overrideStore.vector : {};
+  return {
+    ...(defaults ?? {}),
+    ...overrides,
+    store: {
+      ...defaultStore,
+      ...overrideStore,
+      fts: { ...defaultFts, ...overrideFts },
+      vector: { ...defaultVector, ...overrideVector },
+    },
+  };
 }
 
 function isFtsOnlyMemorySearch(memorySearch: JsonRecord | null): boolean {
@@ -116,18 +141,19 @@ function resolveUserPath(filePath: string): string {
   return path.resolve(filePath);
 }
 
-export function resolveMainMemoryIndexPath(params: {
+export function resolveMemoryIndexPath(params: {
+  agentId: string;
   memorySearch: JsonRecord;
   stateDir: string;
 }): string {
   const store = isRecord(params.memorySearch.store) ? params.memorySearch.store : {};
   const configuredPath = typeof store.path === 'string' && store.path.trim()
-    ? store.path.trim().replace(/\{agentId\}/g, MAIN_AGENT_ID)
+    ? store.path.trim().replace(/\{agentId\}/g, params.agentId)
     : null;
   if (configuredPath) {
     return resolveUserPath(configuredPath);
   }
-  return path.join(params.stateDir, 'memory', `${MAIN_AGENT_ID}.sqlite`);
+  return path.join(params.stateDir, 'memory', `${params.agentId}.sqlite`);
 }
 
 function readMemoryIndexMeta(dbPath: string): MemoryIndexMeta | null {
@@ -155,7 +181,31 @@ function readMemoryIndexMeta(dbPath: string): MemoryIndexMeta | null {
   }
 }
 
-export function resolveMainMemoryIndexMigrationNeed(params: {
+function isMemoryIndexMetaCurrent(
+  meta: MemoryIndexMeta | null,
+  expectedTokenizer?: string,
+): boolean {
+  return Boolean(
+    meta?.model === 'fts-only' &&
+    meta.provider === 'none' &&
+    (!expectedTokenizer || meta.ftsTokenizer === expectedTokenizer),
+  );
+}
+
+function describeMemoryIndexMismatch(
+  meta: MemoryIndexMeta | null,
+  expectedTokenizer?: string,
+): string {
+  return meta
+    ? `index meta is ${JSON.stringify({
+        model: meta.model,
+        provider: meta.provider,
+        ftsTokenizer: meta.ftsTokenizer,
+      })}, expected fts-only/${expectedTokenizer ?? 'default'}`
+    : 'index metadata is missing';
+}
+
+export function resolveFtsOnlyMemoryIndexMigrationNeed(params: {
   configPath: string;
   stateDir: string;
 }): MemoryIndexMigrationNeed {
@@ -168,37 +218,55 @@ export function resolveMainMemoryIndexMigrationNeed(params: {
     return { shouldMigrate: false, reason: 'invalid-config' };
   }
 
-  const memorySearch = resolveMainMemorySearchConfig(config);
-  if (!isFtsOnlyMemorySearch(memorySearch)) {
+  const defaultMemorySearch = resolveDefaultMemorySearchConfig(config);
+  const agentEntries = resolveConfiguredAgentEntries(config);
+  const resolvedAgents = agentEntries.map((entry) => ({
+    agentId: String(entry.id).trim(),
+    memorySearch: mergeMemorySearchConfig(defaultMemorySearch, entry),
+  }));
+  if (resolvedAgents.some(({ memorySearch }) => !isFtsOnlyMemorySearch(memorySearch))) {
     return { shouldMigrate: false, reason: 'not-fts-only-config' };
   }
 
-  const dbPath = resolveMainMemoryIndexPath({
-    memorySearch,
-    stateDir: params.stateDir,
-  });
-  if (!fs.existsSync(dbPath)) {
-    return { shouldMigrate: false, reason: 'no-index-db' };
+  let existingIndexCount = 0;
+  const targets: MemoryIndexMigrationTarget[] = [];
+  for (const { agentId, memorySearch } of resolvedAgents) {
+    if (!memorySearch) {
+      continue;
+    }
+    const dbPath = resolveMemoryIndexPath({
+      agentId,
+      memorySearch,
+      stateDir: params.stateDir,
+    });
+    if (!fs.existsSync(dbPath)) {
+      continue;
+    }
+    existingIndexCount += 1;
+    const expectedTokenizer = resolveFtsTokenizer(memorySearch);
+    const meta = readMemoryIndexMeta(dbPath);
+    if (isMemoryIndexMetaCurrent(meta, expectedTokenizer)) {
+      continue;
+    }
+    targets.push({
+      agentId,
+      dbPath,
+      expectedTokenizer,
+      reason: describeMemoryIndexMismatch(meta, expectedTokenizer),
+    });
   }
 
-  const expectedTokenizer = resolveFtsTokenizer(memorySearch);
-  const meta = readMemoryIndexMeta(dbPath);
-  if (
-    meta?.model === 'fts-only' &&
-    meta.provider === 'none' &&
-    (!expectedTokenizer || meta.ftsTokenizer === expectedTokenizer)
-  ) {
-    return { shouldMigrate: false, reason: 'index-meta-current' };
+  if (targets.length === 0) {
+    return {
+      shouldMigrate: false,
+      reason: existingIndexCount === 0 ? 'no-index-db' : 'index-meta-current',
+    };
   }
 
-  const reason = meta
-    ? `index meta is ${JSON.stringify({
-        model: meta.model,
-        provider: meta.provider,
-        ftsTokenizer: meta.ftsTokenizer,
-      })}, expected fts-only/${expectedTokenizer ?? 'default'}`
-    : 'index metadata is missing';
-  return { shouldMigrate: true, dbPath, reason };
+  const reason = targets
+    .map((target) => `${target.agentId}: ${target.reason}`)
+    .join('; ');
+  return { shouldMigrate: true, targets, reason };
 }
 
 function tailLog(text: string): string {
@@ -250,7 +318,19 @@ export function runProcess(
   });
 }
 
-export async function migrateMainFtsOnlyMemoryIndex(params: {
+function findStaleTargets(targets: MemoryIndexMigrationTarget[]): MemoryIndexMigrationTarget[] {
+  return targets.filter((target) => {
+    if (!fs.existsSync(target.dbPath)) {
+      return true;
+    }
+    return !isMemoryIndexMetaCurrent(
+      readMemoryIndexMeta(target.dbPath),
+      target.expectedTokenizer,
+    );
+  });
+}
+
+export async function migrateAllFtsOnlyMemoryIndexes(params: {
   stateDir: string;
   configPath: string;
   runtimeRoot: string;
@@ -260,7 +340,7 @@ export async function migrateMainFtsOnlyMemoryIndex(params: {
 }): Promise<MemoryIndexMigrationResult> {
   let need: MemoryIndexMigrationNeed;
   try {
-    need = resolveMainMemoryIndexMigrationNeed({
+    need = resolveFtsOnlyMemoryIndexMigrationNeed({
       configPath: params.configPath,
       stateDir: params.stateDir,
     });
@@ -288,10 +368,11 @@ export async function migrateMainFtsOnlyMemoryIndex(params: {
     OPENCLAW_CONFIG_PATH: params.configPath,
     ELECTRON_RUN_AS_NODE: '1',
   };
-  const args = [openclawCliPath, 'memory', 'index', '--force', '--agent', MAIN_AGENT_ID];
+  const args = [openclawCliPath, 'memory', 'index', '--force'];
+  const targetAgentIds = need.targets.map((target) => target.agentId);
 
   console.log(
-    `[OpenClaw] FTS-only memory index migration needed for ${need.dbPath}; running official reindex: ${JSON.stringify(args.slice(1))}`,
+    `[OpenClaw] FTS-only memory index migration needed for agents ${JSON.stringify(targetAgentIds)}; running official all-agent reindex: ${JSON.stringify(args.slice(1))}`,
   );
   try {
     const result = await runner(params.electronNodeRuntimePath, args, {
@@ -301,6 +382,13 @@ export async function migrateMainFtsOnlyMemoryIndex(params: {
     });
 
     if (result.code === 0) {
+      const staleTargets = findStaleTargets(need.targets);
+      if (staleTargets.length > 0) {
+        const staleAgentIds = staleTargets.map((target) => target.agentId);
+        const error = `post-reindex verification failed for agents ${JSON.stringify(staleAgentIds)}`;
+        console.warn(`[OpenClaw] FTS-only memory index migration ${error}.`);
+        return { status: 'failed', code: result.code, error };
+      }
       console.log(`[OpenClaw] FTS-only memory index migration completed: ${need.reason}`);
       return { status: 'migrated', code: result.code, reason: need.reason };
     }


### PR DESCRIPTION
## Summary
- inspect FTS-only memory index metadata for every configured OpenClaw agent
- invoke the official all-agent `memory index --force` flow once when any stale index is found
- verify migrated indexes after reindex and retry safely on a later startup when migration fails
- ignore orphan indexes until their agent is configured again and guard against non-uniform per-agent embedding overrides

## Root cause
The previous upgrade migration only inspected `memory/main.sqlite` and invoked OpenClaw with `--agent main`. Existing custom agents could therefore retain `gemini-embedding-001` metadata while the global configuration expected FTS-only search.

## Electron/OpenClaw behavior
The migration still runs before Gateway startup, remains bounded by the existing timeout, and uses OpenClaw's official atomic reindex implementation. A failed migration is reported without preventing the subsequent Gateway startup.

## Verification
- `npm test -- openclawMemoryIndexMigration` (12 tests passed)
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/openclawMemoryIndexMigration.ts src/main/libs/openclawMemoryIndexMigration.test.ts src/main/libs/openclawEngineManager.ts`
- `npm run compile:electron`
- `git diff --check`