### PR TITLE
fix(scheduled-task): preserve WeCom and DingTalk group ID casing

### DIFF
--- a/scripts/openclaw-plugin-patches/dingtalk.cjs
+++ b/scripts/openclaw-plugin-patches/dingtalk.cjs
@@ -52,6 +52,45 @@ function findDingtalkDistMessageHandlers(pluginDir) {
     .map(entry => path.join(distDir, entry.name));
 }
 
+function findDingtalkDistRuntimeBundles(pluginDir) {
+  const distDir = path.join(pluginDir, 'dist');
+  if (!fs.existsSync(distDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(distDir, { withFileTypes: true })
+    .filter(entry => entry.isFile() && /^runtime-.*\.mjs$/.test(entry.name))
+    .map(entry => path.join(distDir, entry.name));
+}
+
+function patchDingtalkOutboundErrorPropagation(channelPath, label, log) {
+  if (!fs.existsSync(channelPath)) {
+    return;
+  }
+
+  let src = fs.readFileSync(channelPath, 'utf8');
+  const patchMarker = 'dingtalk_outbound_error_propagation_patch';
+  if (src.includes(patchMarker)) {
+    log(`${label} outbound error propagation patch already applied, skipping`);
+    return;
+  }
+
+  const pattern = /(const result = await sendTextToDingTalk\(\{[\s\S]*?\n\s*\}\);\r?\n)([ \t]*)(?=return \{\r?\n[ \t]*channel: CHANNEL_ID,)/;
+  if (!pattern.test(src)) {
+    log(`${label}: sendText outbound pattern not found, skipping error propagation patch`);
+    return;
+  }
+
+  src = src.replace(pattern, (_match, sendCall, indent) => (
+    `${sendCall}${indent}if (!result.ok) {\n` +
+    `${indent}  throw new Error(/* ${patchMarker} */ result.error || 'DingTalk outbound send failed');\n` +
+    `${indent}}\n${indent}`
+  ));
+  fs.writeFileSync(channelPath, src);
+  log(`Patched ${label}: outbound text sends now propagate DingTalk API failures`);
+}
+
 function patchDingtalkAgentWorkspaceResolver(resolverPath, label, log) {
   if (!fs.existsSync(resolverPath)) {
     return;
@@ -197,9 +236,23 @@ function patchDingtalk({ runtimeExtensionsDir, log }) {
       log
     );
   }
+
+  patchDingtalkOutboundErrorPropagation(
+    path.join(pluginDir, 'src', 'channel.ts'),
+    'dingtalk-connector/src/channel.ts',
+    log
+  );
+  for (const runtimeBundlePath of findDingtalkDistRuntimeBundles(pluginDir)) {
+    patchDingtalkOutboundErrorPropagation(
+      runtimeBundlePath,
+      `dingtalk-connector/dist/${path.basename(runtimeBundlePath)}`,
+      log
+    );
+  }
 }
 
 module.exports = {
   findDingtalkDistMessageHandlers,
+  findDingtalkDistRuntimeBundles,
   patchDingtalk,
 };

--- a/specs/bugfixes/im-agent-scoped-session-mapping/2026-07-10-dingtalk-scheduled-task-group-id-casing-fix-design.md
+++ b/specs/bugfixes/im-agent-scoped-session-mapping/2026-07-10-dingtalk-scheduled-task-group-id-casing-fix-design.md
@@ -1,0 +1,120 @@
+# 钉钉定时任务群聊 ID 大小写与投递结果修复设计文档
+
+## 1. 概述
+
+### 1.1 背景
+
+PR #2306 修复了定时任务选择 IM 群聊作为通知目标时的账号过滤、Agent 绑定和历史数据规范化问题。企微回测随后发现，OpenClaw session key 会把通道原生群 ID 转为小写，而部分平台要求主动投递时保留原始大小写。企微兼容方案已在同一主题目录下单独记录。
+
+QA 继续回测钉钉时发现：普通群聊回复正常，但选择同一群聊作为定时任务通知目标后收不到消息，任务运行记录却显示投递成功。本次修复仍属于 #2306 的平台兼容补充，因此继续放在 `im-agent-scoped-session-mapping` 主题目录中，以新的独立文档记录；已有文档保留，不移动或覆盖。
+
+### 1.2 问题现象
+
+日志中创建任务时使用了钉钉返回的原始 `openConversationId`：
+
+```text
+cid+wQbmjFBusv8Bld+Du9t1w==
+```
+
+任务在手动执行或启动迁移时，`delivery.to` 被基于 session 映射规范成全小写：
+
+```text
+cid+wqbmjfbusv8bld+du9t1w==
+```
+
+同一日志中，普通群聊回复使用原始大小写 ID 可以成功；定时任务使用全小写 ID 时没有到达群聊，但 cron 结果仍记录为 `delivered=true`。
+
+### 1.3 根因
+
+故障由两个独立问题叠加而成：
+
+1. OpenClaw 为统一 session key，会将钉钉群 peer ID 规范成小写；LobsterAI 的定时任务历史规范化又把该内部索引值写回 `delivery.to`。钉钉 `openConversationId` 是不应改写的通道原生不透明标识，主动投递必须使用入站元数据中的原始值。
+2. 钉钉连接器的 outbound text 适配层虽然能从 `sendTextToDingTalk` 收到 `{ ok: false, error }`，却没有检查 `ok`，而是继续返回占位 `messageId`。上层因此把 API 失败误记为投递成功，日志中也丢失了真实错误。
+
+普通群聊回复不受第一个问题影响，因为它沿用当前入站消息中的原始会话标识，不需要从小写 session key 反向构造投递目标。
+
+## 2. 修复目标与约束
+
+### 2.1 目标
+
+- 新建或编辑钉钉群通知任务时，保存原始大小写的 `openConversationId`。
+- 已保存全小写群 ID 的历史任务，在启动迁移或手动执行前，能从唯一匹配的 gateway session origin 恢复原始大小写。
+- 已保存为正确原始大小写的任务保持不变。
+- 钉钉文本主动投递失败时向上层抛出真实错误，不再产生假成功结果。
+- 复用企微已验证的安全恢复规则，同时保持其他平台、私聊、账号选择、Agent 绑定和任务 payload 的既有行为。
+
+### 2.2 非目标
+
+- 不修改 OpenClaw session key 的小写规范。
+- 不猜测或合成钉钉群 ID。
+- 不从历史 session 推断、补充或改变任务的 `accountId`。
+- 不修改钉钉私聊目标、普通入站回复或媒体发送行为。
+- 不直接修改 `vendor/openclaw-runtime/current` 下的生成产物。
+
+## 3. 实现方案
+
+### 3.1 通用化群聊原生目标恢复
+
+将企微专用的 session origin 恢复 helper 收敛为可指定平台的群聊 helper，并保留企微包装函数以兼容已有调用和测试。恢复规则保持严格：
+
+1. 只读取 `sessions.list` 返回的 `origin`。
+2. 只接受指定平台且 `origin.chatType=group` 的记录。
+3. 任务已有 `accountId` 时，要求 `origin.accountId` 精确匹配。
+4. 去掉可识别的平台通道前缀后，以不区分大小写的方式匹配当前 peer。
+5. 只有全部匹配记录对应唯一原生目标时才恢复；存在冲突时保持原值。
+
+该 helper 只将已经存在于通道入站元数据中的原始 ID 写回任务，不根据 session key 猜测大小写。
+
+### 3.2 钉钉任务规范化与历史兼容
+
+把钉钉和企微列为需要保护群聊原生目标大小写的平台：
+
+- 对已经是裸原生 ID 的目标，规范化阶段不再用小写 session mapping 覆盖。
+- 新建或编辑任务时，可以从唯一匹配的 session origin 恢复原始大小写。
+- 启动迁移和手动执行前，仅当现有目标是全小写时尝试历史恢复。
+- 历史恢复采用 `casingOnly` 模式，只允许改变 `delivery.to` 的大小写，不得补充或改变账号及其他投递字段。
+- gateway 不可用、无匹配或存在冲突时保持原值，不阻断任务管理流程。
+
+### 3.3 传播钉钉文本发送失败
+
+通过仓库既有的 `scripts/openclaw-plugin-patches/dingtalk.cjs` 对固定版本钉钉插件应用小范围补丁：
+
+- `sendTextToDingTalk` 返回后检查 `result.ok`。
+- `ok=false` 时使用连接器提供的 `result.error` 抛出异常；缺少错误文本时使用稳定的兜底消息。
+- 只修改 outbound text 适配层，不改变请求参数、成功返回值和媒体发送路径。
+- 同时处理插件源码 `src/channel.ts` 与实际运行使用的哈希 `dist/runtime-*.mjs`，并使用标记保证补丁可重复执行。
+
+这样 cron 只有在连接器确认成功后才会记录投递成功；API 拒绝投递时，上层能够记录失败及真实原因。
+
+## 4. 边界情况
+
+| 场景 | 处理方式 |
+|------|---------|
+| 钉钉群 origin、账号和 peer 唯一匹配 | 恢复原始大小写群 ID |
+| 同一账号存在多个仅大小写不同的原生群 ID | 视为冲突，不修改 |
+| 任务已保存正确的混合大小写 ID | 原样保留，不为历史修复连接 gateway |
+| 历史任务缺少账号 | 仅可按唯一群 origin 恢复大小写，不补账号 |
+| origin 为钉钉私聊 | 忽略，保持私聊既有行为 |
+| origin 来自其他 IM 平台 | 忽略 |
+| gateway 未就绪或 `sessions.list` 失败 | 保持原值并记录警告 |
+| 钉钉 API 返回 `ok=false` | outbound 抛出错误，cron 不得记录为成功 |
+| 钉钉文本发送成功 | 保持原有 message ID 和 conversation ID 返回行为 |
+
+## 5. 涉及文件
+
+- `src/main/ipcHandlers/scheduledTask/helpers.ts`
+- `src/main/ipcHandlers/scheduledTask/helpers.test.ts`
+- `src/main/ipcHandlers/scheduledTask/handlers.ts`
+- `src/main/ipcHandlers/scheduledTask/handlers.test.ts`
+- `scripts/openclaw-plugin-patches/dingtalk.cjs`
+- `tests/openclaw-plugin-patches-dingtalk.test.ts`
+
+## 6. 验收标准
+
+- 混合大小写钉钉群 ID 经 session key 小写化后，新建、编辑的定时任务仍保存原始 ID。
+- 已有全小写钉钉群任务可在迁移或手动执行前恢复原始大小写。
+- 历史兼容只改变目标大小写，不推断账号，不改变 Agent 绑定或其他任务字段。
+- 正确的混合大小写目标、钉钉私聊和其他 IM 平台保持原行为。
+- 钉钉连接器文本 API 失败时，任务结果为失败并保留错误信息；成功路径保持不变。
+- 定时任务 helper/handler 与钉钉插件补丁定向测试通过。
+- 变更文件 ESLint、Electron TypeScript 编译、补丁脚本语法检查和 `git diff --check` 通过。

--- a/specs/bugfixes/im-agent-scoped-session-mapping/2026-07-10-wecom-scheduled-task-group-id-casing-fix-design.md
+++ b/specs/bugfixes/im-agent-scoped-session-mapping/2026-07-10-wecom-scheduled-task-group-id-casing-fix-design.md
@@ -1,0 +1,145 @@
+# 企微定时任务群聊 ID 大小写兼容修复设计文档
+
+## 1. 概述
+
+### 1.1 背景
+
+PR #2306 修复了定时任务选择 IM 群聊作为通知目标时的账号过滤、Agent 绑定和历史数据规范化问题。该方案主要以飞书回测，企微回测后发现：普通群聊可以正常收发，但相同群聊被选为定时任务通知目标时，企微返回 `93006 invalid chatid`。
+
+本次修复是 #2306 的企微兼容补充，因此继续放在 `im-agent-scoped-session-mapping` 主题目录中，以新的日期文档记录迭代。按照 `specs/README.md` 的约定，保留此前文档，不移动或覆盖历史设计。
+
+### 1.2 问题现象
+
+企微入站消息携带的真实群聊 ID 包含大小写，例如：
+
+```text
+wrrQeUDgAAeLCVE2WB3A39jXRlrSVEyA
+```
+
+OpenClaw 为统一 session key，会把其中的会话标识规范成小写：
+
+```text
+agent:<agentId>:wecom:group:wrrqeudgaaelcve2wb3a39jxrlrsveya
+```
+
+LobsterAI 的 `im_session_mappings` 来自该 session key。定时任务选择器在 #2306 后会正确选中企微账号和群聊，但保存到 `delivery.to` 的仍是小写群 ID。企微 Bot WebSocket 主动发送时把 `delivery.to` 直接作为 `chatid`，最终返回：
+
+```text
+93006 invalid chatid
+```
+
+### 1.3 根因
+
+这是“会话索引”和“通道原生投递目标”语义混用造成的：
+
+- session key 是内部索引，允许统一小写，以便稳定匹配会话；
+- 企微群 `chatid` 是通道原生投递目标，必须保留入站消息中的原始大小写；
+- 企微插件对私聊会写入 `lastTo` / `deliveryContext`，但对群聊明确设置 `updateLastRoute: undefined`；
+- 因此通用的 session delivery hint 恢复逻辑无法从企微群 session 的 `lastTo` 找回原始大小写；
+- 企微 session 的 `origin.to` 仍保留原始群 ID，可作为定时任务的恢复来源。
+
+## 2. 私聊与普通群聊排查结论
+
+### 2.1 私聊也存在大小写混合，但本次故障只在群聊复现
+
+QA 日志中的企微私聊用户 ID 为 `YangShan`，对应 session key 同样被规范成 `direct:yangshan`，所以“私聊没有大小写混合”并不成立。
+
+但同一批日志中，定时任务使用小写 `delivery.to=yangshan` 可以成功投递；所有 `93006` 均发生在任务切换为小写群 ID 后。结合企微插件行为，私聊与群聊存在两个差异：
+
+- 私聊入站会额外记录 `lastRoute`，主动投递可复用最近路由信息；
+- QA 使用的私聊用户 ID 即使以小写发送，也被企微接受；群 `chatid` 则不能改变大小写。
+
+因此本次不修改私聊目标，不把企微所有 ID 一概改写，只恢复已确认有问题的群 `chatid`。
+
+### 2.2 常规企微群聊回复不受影响
+
+常规群聊的标准链路是“收到企微消息后回复该消息”。企微插件在这条链路中保留原始入站 frame：
+
+- 普通消息使用 `replyStream(frame, ...)` 被动回复；
+- 事件回调需要主动发送时，也从 `frame.body.chatid` 读取原始群 ID；
+- session key 虽然为小写，但不参与本次回复的目标解析。
+
+QA 日志也验证了这一点：混合大小写群 ID 的入站消息对应小写 session key，但普通回复收到 ack 并完成；相同群聊只有在 cron 主动投递使用小写 `delivery.to` 时失败。
+
+### 2.3 其他主动发送仍需区分
+
+企微插件的通用 outbound 最终会把调用方传入的 `to` 直接交给 `sendMessage(chatId, ...)`。因此，任何脱离入站 frame 的主动发送，只要其群目标来自小写 session key，都存在同类风险。
+
+当前 LobsterAI 的常规企微群聊回复不走该路径，`IMGatewayManager.sendNotification` 也尚未为企微实现主动通知。本次只处理已经确认的定时任务创建、更新、手动执行和历史任务迁移，不修改企微插件、普通 IM 回复或通用 message tool 行为。若后续为常规 IM 增加主动群发能力，应单独复用“保留通道原生目标”的原则并补充测试。
+
+## 3. 修复目标与约束
+
+### 3.1 目标
+
+- 新建或编辑企微群通知任务时，把小写 session peer 恢复为原始大小写群 `chatid`；
+- 已保存小写群 ID 的历史企微任务，在启动迁移或手动执行前得到兼容修复；
+- 已经保存为正确原始大小写的任务保持不变；
+- 私聊及其他 IM 平台行为保持不变。
+
+### 3.2 非目标
+
+- 不改变 OpenClaw session key 的小写规范；
+- 不修改企微插件或 OpenClaw runtime；
+- 不改变群聊账号过滤、Agent 绑定、任务 payload、session target 等 #2306 既有行为；
+- 不从不确定的历史 session 猜测账号或群 ID；
+- 不扩展到普通 IM 回复和通用主动发送能力。
+
+## 4. 实现方案
+
+### 4.1 从 session origin 恢复企微群原生目标
+
+在定时任务 helper 中增加企微群目标解析：
+
+1. 只读取 `sessions.list` 返回的 `origin`；
+2. 只接受 platform 为企微、`origin.chatType` 为 `group` 的记录；
+3. 若任务已有 `accountId`，要求 `origin.accountId` 精确匹配；
+4. 去除 `wecom:` 通道前缀后，以不区分大小写的方式匹配当前 peer；
+5. 只有匹配结果对应唯一的原始群 ID 时才恢复；存在冲突则不修改。
+
+这里不从 session key 生成大小写，也不采用“最新一条优先”的猜测策略。
+
+### 4.2 新建与编辑任务
+
+定时任务的本地规范化完成后，通过 gateway `sessions.list` 获取 origin 元数据。如果当前平台是企微且命中唯一群 origin，则将 `delivery.to` 替换为原始大小写群 ID。
+
+对于已经是裸原生 ID 的企微目标，规范化阶段不再用小写 mapping 覆盖它，避免正确历史数据被降级。
+
+### 4.3 历史任务兼容
+
+启动迁移和手动执行前的单任务迁移只对“全小写企微目标”查询 gateway 并尝试恢复：
+
+- 仅允许修改 `delivery.to` 的大小写；
+- 不补充或修改 `accountId`；
+- 不修改 Agent 绑定及其他任务字段；
+- gateway 不可用、无匹配或存在冲突时保持原值，等待用户后续编辑选择，不做猜测。
+
+## 5. 边界情况
+
+| 场景 | 处理方式 |
+|------|---------|
+| 企微群 origin 与任务账号、peer 均匹配且目标唯一 | 恢复原始大小写群 ID |
+| 同一账号出现多个仅大小写不同的原始群 ID | 视为冲突，不修改 |
+| origin 是企微私聊 | 忽略，保持既有私聊行为 |
+| origin 来自其他 IM 平台 | 忽略 |
+| 任务已保存正确的混合大小写裸 ID | 原样保留，不连接 gateway 做历史修复 |
+| 历史任务缺少账号 | 可以按唯一群 origin 恢复大小写，但不得补账号 |
+| gateway 未就绪或 `sessions.list` 失败 | 保持原值，记录警告，不阻断任务管理 |
+
+## 6. 涉及文件
+
+- `src/main/ipcHandlers/scheduledTask/helpers.ts`
+- `src/main/ipcHandlers/scheduledTask/helpers.test.ts`
+- `src/main/ipcHandlers/scheduledTask/handlers.ts`
+- `src/main/ipcHandlers/scheduledTask/handlers.test.ts`
+
+不修改 `src/main/im/`、企微插件和 OpenClaw runtime。
+
+## 7. 验收标准
+
+- 企微混合大小写群 ID 经 session key 小写化后，新建/编辑定时任务仍保存原始群 ID；
+- 已有全小写企微群任务可在迁移或手动执行前恢复原始大小写；
+- 历史兼容只改变目标大小写，不推断账号，不改变其他任务行为；
+- 正确的混合大小写目标、企微私聊、其他 IM 平台均保持原行为；
+- 普通企微群聊回复继续复用入站 frame，不受本次修改影响；
+- helper、handler 的定向测试及 scheduled task 全量测试通过；
+- 变更文件 ESLint、Electron TypeScript 编译和 `git diff --check` 通过。

--- a/src/main/ipcHandlers/scheduledTask/handlers.test.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.test.ts
@@ -203,6 +203,50 @@ describe('registerScheduledTaskHandlers', () => {
     });
   });
 
+  test('restores a DingTalk group id from case-preserving origin metadata on create', async () => {
+    const nativeConversationId = 'cid+wQbmjFBusv8Bld+Du9t1w==';
+    const request = vi.fn(async () => ({
+      sessions: [
+        {
+          origin: {
+            provider: 'dingtalk-connector',
+            chatType: 'group',
+            to: nativeConversationId,
+            accountId: 'dingtalk-bot-1',
+          },
+        },
+      ],
+    }));
+    const { cronJobService, deps } = makeDeps(OpenClawEnginePhase.Running, {
+      gatewayClient: { request },
+    });
+    registerScheduledTaskHandlers(deps);
+
+    const handler = registeredHandlers.get(ScheduledTaskIpc.Create);
+    await handler?.(undefined, {
+      name: 'dingtalk group',
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 13 * * *' },
+      payload: { kind: PayloadKind.AgentTurn, message: 'hi' },
+      delivery: {
+        mode: DeliveryMode.Announce,
+        channel: 'dingtalk-connector',
+        to: `group:${nativeConversationId.toLowerCase()}`,
+        accountId: 'dingtalk-bot-1',
+      },
+    });
+
+    const input = cronJobService.addJob.mock.calls[0][0] as {
+      delivery: Record<string, unknown>;
+    };
+    expect(input.delivery).toEqual({
+      mode: DeliveryMode.Announce,
+      channel: 'dingtalk-connector',
+      to: nativeConversationId,
+      accountId: 'dingtalk-bot-1',
+    });
+  });
+
   test('repairs only the casing of an existing WeCom group target', async () => {
     const nativeGroupId = 'wrrQeUDgAAeLCVE2WB3A39jXRlrSVEyA';
     const request = vi.fn(async () => ({
@@ -282,6 +326,94 @@ describe('registerScheduledTaskHandlers', () => {
         state: {},
         createdAt: '2026-07-09T00:00:00.000Z',
         updatedAt: '2026-07-09T00:00:00.000Z',
+      },
+    ]);
+
+    const result = await migrateScheduledTaskAnnounceJobs(deps);
+
+    expect(result).toEqual({ checked: 1, updated: 0 });
+    expect(cronJobService.updateJob).not.toHaveBeenCalled();
+    expect(adapter.connectGatewayIfNeeded).not.toHaveBeenCalled();
+  });
+
+  test('repairs only the casing of an existing DingTalk group target', async () => {
+    const nativeConversationId = 'cid+wQbmjFBusv8Bld+Du9t1w==';
+    const request = vi.fn(async () => ({
+      sessions: [
+        {
+          origin: {
+            provider: 'dingtalk-connector',
+            chatType: 'group',
+            to: nativeConversationId,
+            accountId: 'dingtalk-bot-1',
+          },
+        },
+      ],
+    }));
+    const { cronJobService, deps } = makeDeps(OpenClawEnginePhase.Running, {
+      gatewayClient: { request },
+    });
+    cronJobService.listJobs.mockResolvedValue([
+      {
+        id: 'legacy-dingtalk-job',
+        name: 'legacy dingtalk group',
+        description: '',
+        enabled: true,
+        schedule: { kind: 'cron', expr: '0 13 * * *' },
+        sessionTarget: SessionTarget.Isolated,
+        wakeMode: WakeMode.Now,
+        payload: { kind: PayloadKind.AgentTurn, message: 'hi' },
+        delivery: {
+          mode: DeliveryMode.Announce,
+          channel: 'dingtalk-connector',
+          to: nativeConversationId.toLowerCase(),
+          accountId: 'dingtalk-bot-1',
+        },
+        agentId: 'agent-dingtalk-bot-1',
+        sessionKey: null,
+        state: {},
+        createdAt: '2026-07-10T00:00:00.000Z',
+        updatedAt: '2026-07-10T00:00:00.000Z',
+      },
+    ]);
+
+    const result = await migrateScheduledTaskAnnounceJobs(deps);
+
+    expect(result).toEqual({ checked: 1, updated: 1 });
+    expect(cronJobService.updateJob).toHaveBeenCalledWith('legacy-dingtalk-job', {
+      delivery: {
+        mode: DeliveryMode.Announce,
+        channel: 'dingtalk-connector',
+        to: nativeConversationId,
+        accountId: 'dingtalk-bot-1',
+      },
+    });
+  });
+
+  test('preserves an existing native-case DingTalk group target', async () => {
+    const nativeConversationId = 'cid+wQbmjFBusv8Bld+Du9t1w==';
+    const { adapter, cronJobService, deps } = makeDeps(OpenClawEnginePhase.Starting);
+    cronJobService.listJobs.mockResolvedValue([
+      {
+        id: 'native-dingtalk-job',
+        name: 'native dingtalk group',
+        description: '',
+        enabled: true,
+        schedule: { kind: 'cron', expr: '0 13 * * *' },
+        sessionTarget: SessionTarget.Isolated,
+        wakeMode: WakeMode.Now,
+        payload: { kind: PayloadKind.AgentTurn, message: 'hi' },
+        delivery: {
+          mode: DeliveryMode.Announce,
+          channel: 'dingtalk-connector',
+          to: nativeConversationId,
+          accountId: 'dingtalk-bot-1',
+        },
+        agentId: 'agent-dingtalk-bot-1',
+        sessionKey: null,
+        state: {},
+        createdAt: '2026-07-10T00:00:00.000Z',
+        updatedAt: '2026-07-10T00:00:00.000Z',
       },
     ]);
 

--- a/src/main/ipcHandlers/scheduledTask/handlers.test.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.test.ts
@@ -21,7 +21,11 @@ import {
 } from '../../../scheduledTask/constants';
 import type { CronJobService } from '../../../scheduledTask/cronJobService';
 import { OpenClawEnginePhase } from '../../../shared/openclawEngine/constants';
-import { registerScheduledTaskHandlers, type ScheduledTaskHandlerDeps } from './handlers';
+import {
+  migrateScheduledTaskAnnounceJobs,
+  registerScheduledTaskHandlers,
+  type ScheduledTaskHandlerDeps,
+} from './handlers';
 
 function makeDeps(
   enginePhase: OpenClawEnginePhase = OpenClawEnginePhase.Running,
@@ -151,6 +155,141 @@ describe('registerScheduledTaskHandlers', () => {
       accountId: 'weixin-bot-1',
     });
     expect(result).toEqual({ success: true, task: { id: 'job-1', name: '科技早报' } });
+  });
+
+  test('restores a WeCom group chat id from case-preserving origin metadata on create', async () => {
+    const nativeGroupId = 'wrrQeUDgAAeLCVE2WB3A39jXRlrSVEyA';
+    const request = vi.fn(async () => ({
+      sessions: [
+        {
+          updatedAt: 2_000,
+          origin: {
+            provider: 'wecom',
+            surface: 'wecom',
+            chatType: 'group',
+            to: `wecom:${nativeGroupId}`,
+            accountId: 'wecom-bot-1',
+          },
+        },
+      ],
+    }));
+    const { cronJobService, deps } = makeDeps(OpenClawEnginePhase.Running, {
+      gatewayClient: { request },
+    });
+    registerScheduledTaskHandlers(deps);
+
+    const handler = registeredHandlers.get(ScheduledTaskIpc.Create);
+    await handler?.(undefined, {
+      name: 'wecom group',
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 13 * * *' },
+      payload: { kind: PayloadKind.AgentTurn, message: 'hi' },
+      delivery: {
+        mode: DeliveryMode.Announce,
+        channel: 'wecom',
+        to: `group:${nativeGroupId.toLowerCase()}`,
+        accountId: 'wecom-bot-1',
+      },
+    });
+
+    const input = cronJobService.addJob.mock.calls[0][0] as {
+      delivery: Record<string, unknown>;
+    };
+    expect(input.delivery).toEqual({
+      mode: DeliveryMode.Announce,
+      channel: 'wecom',
+      to: nativeGroupId,
+      accountId: 'wecom-bot-1',
+    });
+  });
+
+  test('repairs only the casing of an existing WeCom group target', async () => {
+    const nativeGroupId = 'wrrQeUDgAAeLCVE2WB3A39jXRlrSVEyA';
+    const request = vi.fn(async () => ({
+      sessions: [
+        {
+          lastChannel: 'wecom',
+          lastTo: nativeGroupId.toLowerCase(),
+          lastAccountId: 'inferred-account-must-not-be-added',
+          origin: {
+            provider: 'wecom',
+            chatType: 'group',
+            to: `wecom:${nativeGroupId}`,
+            accountId: 'wecom-bot-1',
+          },
+        },
+      ],
+    }));
+    const { cronJobService, deps } = makeDeps(OpenClawEnginePhase.Running, {
+      gatewayClient: { request },
+    });
+    cronJobService.listJobs.mockResolvedValue([
+      {
+        id: 'legacy-wecom-job',
+        name: 'legacy wecom group',
+        description: '',
+        enabled: true,
+        schedule: { kind: 'cron', expr: '0 13 * * *' },
+        sessionTarget: SessionTarget.Isolated,
+        wakeMode: WakeMode.Now,
+        payload: { kind: PayloadKind.AgentTurn, message: 'hi' },
+        delivery: {
+          mode: DeliveryMode.Announce,
+          channel: 'wecom',
+          to: nativeGroupId.toLowerCase(),
+        },
+        agentId: 'agent-wecom-bot-1',
+        sessionKey: null,
+        state: {},
+        createdAt: '2026-07-09T00:00:00.000Z',
+        updatedAt: '2026-07-09T00:00:00.000Z',
+      },
+    ]);
+
+    const result = await migrateScheduledTaskAnnounceJobs(deps);
+
+    expect(result).toEqual({ checked: 1, updated: 1 });
+    expect(cronJobService.updateJob).toHaveBeenCalledWith('legacy-wecom-job', {
+      delivery: {
+        mode: DeliveryMode.Announce,
+        channel: 'wecom',
+        to: nativeGroupId,
+      },
+    });
+  });
+
+  test('preserves an existing native-case WeCom target when gateway hints are unavailable', async () => {
+    const nativeGroupId = 'wrrQeUDgAAeLCVE2WB3A39jXRlrSVEyA';
+    const { adapter, cronJobService, deps } = makeDeps(OpenClawEnginePhase.Starting);
+    cronJobService.listJobs.mockResolvedValue([
+      {
+        id: 'native-wecom-job',
+        name: 'native wecom group',
+        description: '',
+        enabled: true,
+        schedule: { kind: 'cron', expr: '0 13 * * *' },
+        sessionTarget: SessionTarget.Isolated,
+        wakeMode: WakeMode.Now,
+        payload: { kind: PayloadKind.AgentTurn, message: 'hi' },
+        delivery: {
+          mode: DeliveryMode.Announce,
+          channel: 'wecom',
+          to: nativeGroupId,
+          accountId: 'wecom-bot-1',
+        },
+        agentId: 'agent-wecom-bot-1',
+        sessionKey: null,
+        state: {},
+        createdAt: '2026-07-09T00:00:00.000Z',
+        updatedAt: '2026-07-09T00:00:00.000Z',
+      },
+    ]);
+
+    const result = await migrateScheduledTaskAnnounceJobs(deps);
+
+    expect(result).toEqual({ checked: 1, updated: 0 });
+    expect(cronJobService.updateJob).not.toHaveBeenCalled();
+    expect(adapter.connectGatewayIfNeeded).not.toHaveBeenCalled();
   });
 
   test('binds the job to the conversation agent for agent-bound IM targets', async () => {

--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -29,10 +29,12 @@ import {
   listScheduledTaskChannels,
   resolveConversationAgentIdFromMappings,
   resolveImDeliveryHintsFromSessions,
+  resolveWecomGroupDeliveryTargetFromSessions,
 } from './helpers';
 
 /** Matches auto-generated channel session titles, e.g. "[TG] group:123". */
 const AUTO_CHANNEL_TITLE_RE = /^\[[^\]]*\]\s/;
+const WECOM_PLATFORM: Platform = 'wecom';
 
 type ConversationMappingForList = {
   imConversationId: string;
@@ -51,6 +53,7 @@ type AnnounceNormalizationContext = {
 function normalizeImAnnounceDeliveryTo(
   rawTo: string,
   mappings: readonly ConversationMappingForList[],
+  platform: Platform,
 ): string {
   const parsed = parseImConversationId(rawTo);
   if (
@@ -59,6 +62,12 @@ function normalizeImAnnounceDeliveryTo(
     parsed.peerKind === ImPeerKind.Channel
   ) {
     return parsed.peerId;
+  }
+
+  // A bare WeCom target is already the provider-native id. Do not replace its
+  // case from a lowercased OpenClaw session mapping during legacy migration.
+  if (platform === WECOM_PLATFORM && !rawTo.includes(':')) {
+    return rawTo;
   }
 
   const peer = parsed.peerId.trim().toLowerCase();
@@ -243,7 +252,7 @@ function applyLocalAnnounceDeliveryNormalization(
   // marker (group:oc_xxx).
   const rawTo: string = delivery.to;
   const parsedConversation = parseImConversationId(rawTo);
-  delivery.to = normalizeImAnnounceDeliveryTo(rawTo, mappings);
+  delivery.to = normalizeImAnnounceDeliveryTo(rawTo, mappings, platform);
   if (delivery.to !== rawTo) {
     console.debug(
       '[ScheduledTask] normalized IM delivery.to:',
@@ -290,6 +299,7 @@ async function restoreAnnounceDeliveryHintsFromGateway(
   normalizedInput: Record<string, any>,
   context: AnnounceNormalizationContext,
   deps: Pick<ScheduledTaskHandlerDeps, 'getOpenClawRuntimeAdapter'>,
+  options?: { wecomCasingOnly?: boolean },
 ): Promise<void> {
   const { getOpenClawRuntimeAdapter } = deps;
   const delivery = normalizedInput.delivery;
@@ -311,24 +321,47 @@ async function restoreAnnounceDeliveryHintsFromGateway(
           { includeGlobal: true, includeUnknown: true, limit: 500 },
           { timeoutMs: 10_000 },
         );
-        const hints = resolveImDeliveryHintsFromSessions({
-          sessions: Array.isArray(result?.sessions) ? result.sessions : [],
-          channel: delivery.channel,
-          peerId: delivery.to,
-          preferredAccountId: context.parsedConversation.accountId,
-        });
-        if (hints) {
-          if (hints.to !== delivery.to) {
+        const sessions = Array.isArray(result?.sessions) ? result.sessions : [];
+        const selectedAccountId = typeof delivery.accountId === 'string'
+          ? delivery.accountId
+          : undefined;
+        if (!options?.wecomCasingOnly) {
+          const hints = resolveImDeliveryHintsFromSessions({
+            sessions,
+            channel: delivery.channel,
+            peerId: delivery.to,
+            preferredAccountId: context.parsedConversation.accountId,
+          });
+          if (hints) {
+            if (hints.to !== delivery.to) {
+              console.log(
+                '[ScheduledTask] restored delivery.to casing from gateway session:',
+                delivery.to,
+                '->',
+                hints.to,
+              );
+              delivery.to = hints.to;
+            }
+            if (!delivery.accountId && hints.accountId) {
+              delivery.accountId = hints.accountId;
+            }
+          }
+        }
+
+        if (context.platform === WECOM_PLATFORM) {
+          const nativeGroupTarget = resolveWecomGroupDeliveryTargetFromSessions({
+            sessions,
+            peerId: delivery.to,
+            preferredAccountId: selectedAccountId,
+          });
+          if (nativeGroupTarget && nativeGroupTarget !== delivery.to) {
             console.log(
-              '[ScheduledTask] restored delivery.to casing from gateway session:',
+              '[ScheduledTask] restored WeCom group delivery.to casing from gateway origin:',
               delivery.to,
               '->',
-              hints.to,
+              nativeGroupTarget,
             );
-            delivery.to = hints.to;
-          }
-          if (!delivery.accountId && hints.accountId) {
-            delivery.accountId = hints.accountId;
+            delivery.to = nativeGroupTarget;
           }
         }
       }
@@ -385,10 +418,13 @@ function stableJson(value: unknown): string {
   return JSON.stringify(value);
 }
 
-function buildLocalAnnounceNormalizationPatch(
+async function buildAnnounceNormalizationPatch(
   task: ScheduledTask,
-  deps: Pick<ScheduledTaskHandlerDeps, 'getIMGatewayManager'>,
-): Partial<ScheduledTaskInput> | null {
+  deps: Pick<
+    ScheduledTaskHandlerDeps,
+    'getIMGatewayManager' | 'getOpenClawRuntimeAdapter'
+  >,
+): Promise<Partial<ScheduledTaskInput> | null> {
   const normalizedInput: Record<string, any> = {
     sessionTarget: task.sessionTarget,
     payload: clonePayload(task.payload),
@@ -398,6 +434,20 @@ function buildLocalAnnounceNormalizationPatch(
   };
   const context = applyLocalAnnounceDeliveryNormalization(normalizedInput, deps);
   if (!context) return null;
+  const normalizedTo = typeof normalizedInput.delivery?.to === 'string'
+    ? normalizedInput.delivery.to.trim()
+    : '';
+  if (
+    context.platform === WECOM_PLATFORM &&
+    normalizedTo &&
+    normalizedTo === normalizedTo.toLowerCase()
+  ) {
+    // Historical repair must only restore the case-sensitive WeCom group id;
+    // it must not infer or change account routing from gateway metadata.
+    await restoreAnnounceDeliveryHintsFromGateway(normalizedInput, context, deps, {
+      wecomCasingOnly: true,
+    });
+  }
 
   const patch: Partial<ScheduledTaskInput> = {};
   if (normalizedInput.sessionTarget !== task.sessionTarget) {
@@ -427,9 +477,12 @@ function buildLocalAnnounceNormalizationPatch(
 
 async function migrateScheduledTaskAnnounceJob(
   task: ScheduledTask,
-  deps: Pick<ScheduledTaskHandlerDeps, 'getCronJobService' | 'getIMGatewayManager'>,
+  deps: Pick<
+    ScheduledTaskHandlerDeps,
+    'getCronJobService' | 'getIMGatewayManager' | 'getOpenClawRuntimeAdapter'
+  >,
 ): Promise<boolean> {
-  const patch = buildLocalAnnounceNormalizationPatch(task, deps);
+  const patch = await buildAnnounceNormalizationPatch(task, deps);
   if (!patch) return false;
   await deps.getCronJobService().updateJob(task.id, patch);
   console.log(
@@ -445,7 +498,10 @@ async function migrateScheduledTaskAnnounceJob(
 }
 
 export async function migrateScheduledTaskAnnounceJobs(
-  deps: Pick<ScheduledTaskHandlerDeps, 'getCronJobService' | 'getIMGatewayManager'>,
+  deps: Pick<
+    ScheduledTaskHandlerDeps,
+    'getCronJobService' | 'getIMGatewayManager' | 'getOpenClawRuntimeAdapter'
+  >,
 ): Promise<{ checked: number; updated: number }> {
   const tasks = await deps.getCronJobService().listJobs();
   let updated = 0;
@@ -585,6 +641,7 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
         await migrateScheduledTaskAnnounceJob(task, {
           getCronJobService,
           getIMGatewayManager,
+          getOpenClawRuntimeAdapter,
         });
       }
       await cronJobService.runJob(id);

--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -28,13 +28,18 @@ import {
   filterConversationMappingsForSelectedAccount,
   listScheduledTaskChannels,
   resolveConversationAgentIdFromMappings,
+  resolveGroupDeliveryTargetFromSessions,
   resolveImDeliveryHintsFromSessions,
-  resolveWecomGroupDeliveryTargetFromSessions,
 } from './helpers';
 
 /** Matches auto-generated channel session titles, e.g. "[TG] group:123". */
 const AUTO_CHANNEL_TITLE_RE = /^\[[^\]]*\]\s/;
+const DINGTALK_PLATFORM: Platform = 'dingtalk';
 const WECOM_PLATFORM: Platform = 'wecom';
+const CASE_SENSITIVE_GROUP_TARGET_PLATFORMS = new Set<Platform>([
+  DINGTALK_PLATFORM,
+  WECOM_PLATFORM,
+]);
 
 type ConversationMappingForList = {
   imConversationId: string;
@@ -64,9 +69,9 @@ function normalizeImAnnounceDeliveryTo(
     return parsed.peerId;
   }
 
-  // A bare WeCom target is already the provider-native id. Do not replace its
-  // case from a lowercased OpenClaw session mapping during legacy migration.
-  if (platform === WECOM_PLATFORM && !rawTo.includes(':')) {
+  // Bare targets for case-sensitive group-id providers are already native ids.
+  // Do not replace their case from a lowercased OpenClaw session mapping.
+  if (CASE_SENSITIVE_GROUP_TARGET_PLATFORMS.has(platform) && !rawTo.includes(':')) {
     return rawTo;
   }
 
@@ -299,7 +304,7 @@ async function restoreAnnounceDeliveryHintsFromGateway(
   normalizedInput: Record<string, any>,
   context: AnnounceNormalizationContext,
   deps: Pick<ScheduledTaskHandlerDeps, 'getOpenClawRuntimeAdapter'>,
-  options?: { wecomCasingOnly?: boolean },
+  options?: { casingOnly?: boolean },
 ): Promise<void> {
   const { getOpenClawRuntimeAdapter } = deps;
   const delivery = normalizedInput.delivery;
@@ -325,7 +330,7 @@ async function restoreAnnounceDeliveryHintsFromGateway(
         const selectedAccountId = typeof delivery.accountId === 'string'
           ? delivery.accountId
           : undefined;
-        if (!options?.wecomCasingOnly) {
+        if (!options?.casingOnly) {
           const hints = resolveImDeliveryHintsFromSessions({
             sessions,
             channel: delivery.channel,
@@ -348,15 +353,16 @@ async function restoreAnnounceDeliveryHintsFromGateway(
           }
         }
 
-        if (context.platform === WECOM_PLATFORM) {
-          const nativeGroupTarget = resolveWecomGroupDeliveryTargetFromSessions({
+        if (CASE_SENSITIVE_GROUP_TARGET_PLATFORMS.has(context.platform)) {
+          const nativeGroupTarget = resolveGroupDeliveryTargetFromSessions({
             sessions,
+            platform: context.platform,
             peerId: delivery.to,
             preferredAccountId: selectedAccountId,
           });
           if (nativeGroupTarget && nativeGroupTarget !== delivery.to) {
             console.log(
-              '[ScheduledTask] restored WeCom group delivery.to casing from gateway origin:',
+              `[ScheduledTask] restored ${context.platform} group delivery.to casing from gateway origin:`,
               delivery.to,
               '->',
               nativeGroupTarget,
@@ -438,14 +444,14 @@ async function buildAnnounceNormalizationPatch(
     ? normalizedInput.delivery.to.trim()
     : '';
   if (
-    context.platform === WECOM_PLATFORM &&
+    CASE_SENSITIVE_GROUP_TARGET_PLATFORMS.has(context.platform) &&
     normalizedTo &&
     normalizedTo === normalizedTo.toLowerCase()
   ) {
-    // Historical repair must only restore the case-sensitive WeCom group id;
+    // Historical repair must only restore the case-sensitive native group id;
     // it must not infer or change account routing from gateway metadata.
     await restoreAnnounceDeliveryHintsFromGateway(normalizedInput, context, deps, {
-      wecomCasingOnly: true,
+      casingOnly: true,
     });
   }
 

--- a/src/main/ipcHandlers/scheduledTask/helpers.test.ts
+++ b/src/main/ipcHandlers/scheduledTask/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   filterConversationMappingsForSelectedAccount,
   resolveConversationAgentIdFromMappings,
   resolveImDeliveryHintsFromSessions,
+  resolveWecomGroupDeliveryTargetFromSessions,
 } from './helpers';
 
 const TRUE_CASE_PEER = 'WxId_ZhangSan@im.wechat';
@@ -122,6 +123,77 @@ describe('resolveImDeliveryHintsFromSessions', () => {
       peerId: 'userid-abc',
     });
     expect(hints).toEqual({ to: 'UserId-ABC' });
+  });
+});
+
+describe('resolveWecomGroupDeliveryTargetFromSessions', () => {
+  const nativeGroupId = 'wrrQeUDgAAeLCVE2WB3A39jXRlrSVEyA';
+  const lowerGroupId = nativeGroupId.toLowerCase();
+
+  function wecomGroupOrigin(
+    accountId: string,
+    to = `wecom:${nativeGroupId}`,
+    overrides: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return {
+      origin: {
+        provider: 'wecom',
+        surface: 'wecom',
+        chatType: 'group',
+        to,
+        accountId,
+        ...overrides,
+      },
+    };
+  }
+
+  test('restores the native group id from WeCom origin metadata', () => {
+    expect(
+      resolveWecomGroupDeliveryTargetFromSessions({
+        sessions: [wecomGroupOrigin('bot-1')],
+        peerId: lowerGroupId,
+        preferredAccountId: 'bot-1',
+      }),
+    ).toBe(nativeGroupId);
+  });
+
+  test('requires the selected bot account to match when one is provided', () => {
+    expect(
+      resolveWecomGroupDeliveryTargetFromSessions({
+        sessions: [
+          wecomGroupOrigin('other-bot', `wecom:${lowerGroupId}`),
+          wecomGroupOrigin('bot-1'),
+        ],
+        peerId: lowerGroupId,
+        preferredAccountId: 'bot-1',
+      }),
+    ).toBe(nativeGroupId);
+  });
+
+  test('rejects conflicting native ids instead of guessing', () => {
+    expect(
+      resolveWecomGroupDeliveryTargetFromSessions({
+        sessions: [
+          wecomGroupOrigin('bot-1'),
+          wecomGroupOrigin('bot-1', `wecom:${lowerGroupId}`),
+        ],
+        peerId: lowerGroupId,
+        preferredAccountId: 'bot-1',
+      }),
+    ).toBeNull();
+  });
+
+  test('ignores direct chats and non-WeCom origins', () => {
+    expect(
+      resolveWecomGroupDeliveryTargetFromSessions({
+        sessions: [
+          wecomGroupOrigin('bot-1', `wecom:${nativeGroupId}`, { chatType: 'direct' }),
+          wecomGroupOrigin('bot-1', `feishu:${nativeGroupId}`, { provider: 'feishu' }),
+        ],
+        peerId: lowerGroupId,
+        preferredAccountId: 'bot-1',
+      }),
+    ).toBeNull();
   });
 });
 

--- a/src/main/ipcHandlers/scheduledTask/helpers.test.ts
+++ b/src/main/ipcHandlers/scheduledTask/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   dedupeConversationMappings,
   filterConversationMappingsForSelectedAccount,
   resolveConversationAgentIdFromMappings,
+  resolveGroupDeliveryTargetFromSessions,
   resolveImDeliveryHintsFromSessions,
   resolveWecomGroupDeliveryTargetFromSessions,
 } from './helpers';
@@ -194,6 +195,27 @@ describe('resolveWecomGroupDeliveryTargetFromSessions', () => {
         preferredAccountId: 'bot-1',
       }),
     ).toBeNull();
+  });
+
+  test('restores a DingTalk openConversationId through the generic group resolver', () => {
+    const nativeConversationId = 'cid+wQbmjFBusv8Bld+Du9t1w==';
+    expect(
+      resolveGroupDeliveryTargetFromSessions({
+        sessions: [
+          {
+            origin: {
+              provider: 'dingtalk-connector',
+              chatType: 'group',
+              to: nativeConversationId,
+              accountId: 'dingtalk-bot-1',
+            },
+          },
+        ],
+        platform: 'dingtalk',
+        peerId: nativeConversationId.toLowerCase(),
+        preferredAccountId: 'dingtalk-bot-1',
+      }),
+    ).toBe(nativeConversationId);
   });
 });
 

--- a/src/main/ipcHandlers/scheduledTask/helpers.ts
+++ b/src/main/ipcHandlers/scheduledTask/helpers.ts
@@ -228,16 +228,17 @@ export function resolveImDeliveryHintsFromSessions(params: {
 }
 
 /**
- * Restores a WeCom group's case-sensitive native chat id from inbound session
- * origin metadata. WeCom group sessions intentionally do not update
- * `lastTo`/`deliveryContext`, while OpenClaw lowercases their session keys.
+ * Restores a case-sensitive native group id from inbound session origin
+ * metadata. OpenClaw lowercases channel peer ids in session keys, but providers
+ * such as WeCom and DingTalk require their opaque group ids unchanged.
  *
  * This is deliberately narrower than `resolveImDeliveryHintsFromSessions`:
- * only WeCom group origins are considered, an explicitly selected account must
- * match, and conflicting native ids are rejected instead of picking one.
+ * only group origins from the requested platform are considered, an explicitly
+ * selected account must match, and conflicting native ids are rejected.
  */
-export function resolveWecomGroupDeliveryTargetFromSessions(params: {
+export function resolveGroupDeliveryTargetFromSessions(params: {
   sessions: readonly unknown[];
+  platform: Platform;
   peerId: string;
   preferredAccountId?: string;
 }): string | null {
@@ -252,7 +253,7 @@ export function resolveWecomGroupDeliveryTargetFromSessions(params: {
     if (!origin || origin.chatType !== ImPeerKind.Group) continue;
 
     const originChannel = asNonEmptyString(origin.provider) ?? asNonEmptyString(origin.surface);
-    if (!originChannel || PlatformRegistry.platformOfChannel(originChannel) !== WECOM_PLATFORM) {
+    if (!originChannel || PlatformRegistry.platformOfChannel(originChannel) !== params.platform) {
       continue;
     }
 
@@ -263,7 +264,7 @@ export function resolveWecomGroupDeliveryTargetFromSessions(params: {
     if (!originTo) continue;
     const colonIndex = originTo.indexOf(':');
     const prefix = colonIndex > 0 ? originTo.slice(0, colonIndex) : '';
-    const withoutChannel = prefix && PlatformRegistry.platformOfChannel(prefix) === WECOM_PLATFORM
+    const withoutChannel = prefix && PlatformRegistry.platformOfChannel(prefix) === params.platform
       ? originTo.slice(colonIndex + 1)
       : originTo;
     const parsedTarget = parseImConversationId(withoutChannel);
@@ -274,6 +275,18 @@ export function resolveWecomGroupDeliveryTargetFromSessions(params: {
   }
 
   return nativeTargets.size === 1 ? [...nativeTargets][0] : null;
+}
+
+/** Backward-compatible WeCom wrapper for existing callers and tests. */
+export function resolveWecomGroupDeliveryTargetFromSessions(params: {
+  sessions: readonly unknown[];
+  peerId: string;
+  preferredAccountId?: string;
+}): string | null {
+  return resolveGroupDeliveryTargetFromSessions({
+    ...params,
+    platform: WECOM_PLATFORM,
+  });
 }
 
 /**

--- a/src/main/ipcHandlers/scheduledTask/helpers.ts
+++ b/src/main/ipcHandlers/scheduledTask/helpers.ts
@@ -10,6 +10,8 @@ export interface ScheduledTaskHelperDeps {
 
 let deps: ScheduledTaskHelperDeps | null = null;
 
+const WECOM_PLATFORM: Platform = 'wecom';
+
 export function initScheduledTaskHelpers(d: ScheduledTaskHelperDeps): void {
   deps = d;
 }
@@ -133,6 +135,13 @@ interface GatewaySessionRowLike {
   lastTo?: unknown;
   lastAccountId?: unknown;
   deliveryContext?: { channel?: unknown; to?: unknown; accountId?: unknown } | null;
+  origin?: {
+    provider?: unknown;
+    surface?: unknown;
+    chatType?: unknown;
+    to?: unknown;
+    accountId?: unknown;
+  } | null;
 }
 
 export interface ImDeliveryHints {
@@ -216,6 +225,55 @@ export function resolveImDeliveryHintsFromSessions(params: {
   pool.sort((a, b) => b.updatedAt - a.updatedAt);
   const best = pool[0];
   return { to: best.to, ...(best.accountId ? { accountId: best.accountId } : {}) };
+}
+
+/**
+ * Restores a WeCom group's case-sensitive native chat id from inbound session
+ * origin metadata. WeCom group sessions intentionally do not update
+ * `lastTo`/`deliveryContext`, while OpenClaw lowercases their session keys.
+ *
+ * This is deliberately narrower than `resolveImDeliveryHintsFromSessions`:
+ * only WeCom group origins are considered, an explicitly selected account must
+ * match, and conflicting native ids are rejected instead of picking one.
+ */
+export function resolveWecomGroupDeliveryTargetFromSessions(params: {
+  sessions: readonly unknown[];
+  peerId: string;
+  preferredAccountId?: string;
+}): string | null {
+  const requestedPeer = parseImConversationId(params.peerId).peerId.trim().toLowerCase();
+  const preferredAccountId = params.preferredAccountId?.trim();
+  if (!requestedPeer) return null;
+
+  const nativeTargets = new Set<string>();
+  for (const row of params.sessions) {
+    if (!row || typeof row !== 'object') continue;
+    const origin = (row as GatewaySessionRowLike).origin;
+    if (!origin || origin.chatType !== ImPeerKind.Group) continue;
+
+    const originChannel = asNonEmptyString(origin.provider) ?? asNonEmptyString(origin.surface);
+    if (!originChannel || PlatformRegistry.platformOfChannel(originChannel) !== WECOM_PLATFORM) {
+      continue;
+    }
+
+    const originAccountId = asNonEmptyString(origin.accountId);
+    if (preferredAccountId && originAccountId !== preferredAccountId) continue;
+
+    const originTo = asNonEmptyString(origin.to);
+    if (!originTo) continue;
+    const colonIndex = originTo.indexOf(':');
+    const prefix = colonIndex > 0 ? originTo.slice(0, colonIndex) : '';
+    const withoutChannel = prefix && PlatformRegistry.platformOfChannel(prefix) === WECOM_PLATFORM
+      ? originTo.slice(colonIndex + 1)
+      : originTo;
+    const parsedTarget = parseImConversationId(withoutChannel);
+    if (parsedTarget.peerKind && parsedTarget.peerKind !== ImPeerKind.Group) continue;
+    const nativePeer = parsedTarget.peerId.trim();
+    if (!nativePeer || nativePeer.toLowerCase() !== requestedPeer) continue;
+    nativeTargets.add(nativePeer);
+  }
+
+  return nativeTargets.size === 1 ? [...nativeTargets][0] : null;
 }
 
 /**

--- a/tests/openclaw-plugin-patches-dingtalk.test.ts
+++ b/tests/openclaw-plugin-patches-dingtalk.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from 'vitest';
 
 const {
   findDingtalkDistMessageHandlers,
+  findDingtalkDistRuntimeBundles,
   patchDingtalk,
 } = require('../scripts/openclaw-plugin-patches/dingtalk.cjs');
 
@@ -52,6 +53,58 @@ describe('openclaw DingTalk plugin patches', () => {
     expect(findDingtalkDistMessageHandlers(pluginDir)).toEqual([
       path.join(distDir, 'message-handler-abc123.mjs'),
     ]);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('finds hashed dist runtime bundles', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dingtalk-plugin-patch-'));
+    const pluginDir = path.join(tempDir, 'dingtalk-connector');
+    const distDir = path.join(pluginDir, 'dist');
+    fs.mkdirSync(distDir, { recursive: true });
+    fs.writeFileSync(path.join(distDir, 'runtime-abc123.mjs'), 'export {};\n');
+    fs.writeFileSync(path.join(distDir, 'runtime-abc123.d.mts'), 'export {};\n');
+    fs.writeFileSync(path.join(distDir, 'message-handler-abc123.mjs'), 'export {};\n');
+
+    expect(findDingtalkDistRuntimeBundles(pluginDir)).toEqual([
+      path.join(distDir, 'runtime-abc123.mjs'),
+    ]);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('propagates failed outbound text sends from source and dist channel runtimes', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dingtalk-plugin-patch-'));
+    const pluginDir = path.join(tempDir, 'dingtalk-connector');
+    const sourceChannel = path.join(pluginDir, 'src', 'channel.ts');
+    const distRuntime = path.join(pluginDir, 'dist', 'runtime-test.mjs');
+    fs.mkdirSync(path.dirname(sourceChannel), { recursive: true });
+    fs.mkdirSync(path.dirname(distRuntime), { recursive: true });
+    const outboundSource = [
+      'const result = await sendTextToDingTalk({',
+      '  config: resolvedConfig,',
+      '  target: to,',
+      '  text,',
+      '  replyToId,',
+      '});',
+      'return {',
+      '  channel: CHANNEL_ID,',
+      '  messageId: result.processQueryKey ?? result.cardInstanceId ?? "unknown",',
+      '};',
+    ].join('\n');
+    fs.writeFileSync(sourceChannel, outboundSource);
+    fs.writeFileSync(distRuntime, outboundSource);
+
+    patchDingtalk({ runtimeExtensionsDir: tempDir, log: () => {} });
+    patchDingtalk({ runtimeExtensionsDir: tempDir, log: () => {} });
+
+    for (const patchedPath of [sourceChannel, distRuntime]) {
+      const patched = fs.readFileSync(patchedPath, 'utf-8');
+      expect(patched).toContain('dingtalk_outbound_error_propagation_patch');
+      expect(patched.match(/dingtalk_outbound_error_propagation_patch/g)).toHaveLength(1);
+      expect(patched).toContain("result.error || 'DingTalk outbound send failed'");
+      expect(patched.indexOf('if (!result.ok)')).toBeLessThan(patched.indexOf('return {'));
+    }
 
     fs.rmSync(tempDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## 背景

这是 #2306 的 IM 群聊定时任务兼容补充。QA 回测发现，OpenClaw session key 会将企微和钉钉的群聊原生 ID 转为小写，而两类群 ID 在主动投递时需要保留通道返回的原始大小写；钉钉连接器还会吞掉文本 API 的失败结果，导致 cron 误报 `delivered=true`。

## 改动

- 从 gateway session origin 恢复企微、钉钉群聊原生 ID 的大小写。
- 兼容已经保存为全小写目标的历史定时任务，只修复 `delivery.to` 大小写，不推断账号、不改变 Agent 绑定或其他任务字段。
- 保留已经正确保存的原生大小写目标，不连接 gateway 做无意义覆盖。
- 通过现有钉钉插件补丁机制检查 outbound text 的 `result.ok`；失败时向上层传播真实错误，避免假成功。
- 保留钉钉文本发送成功路径、私聊、普通入站回复和其他 IM 平台的既有行为。
- 按 `specs/README.md` 在 #2306 同主题目录补充企微、钉钉两份迭代设计文档。

## OpenClaw / Electron 影响

- 未直接修改 `vendor/openclaw-runtime/current` 生成物。
- 钉钉第三方连接器补丁会应用到 `src/channel.ts` 和实际运行的哈希 `dist/runtime-*.mjs`。
- 连接器成功返回行为不变；仅原先 `ok=false` 但被误报成功的文本主动发送改为正确失败。

## 验证

- `npx vitest run src/main/ipcHandlers/scheduledTask/helpers.test.ts src/main/ipcHandlers/scheduledTask/handlers.test.ts tests/openclaw-plugin-patches-dingtalk.test.ts`：45 tests passed
- 变更 TypeScript 文件 ESLint：通过
- `npx tsc --project electron-tsconfig.json --noEmit`：通过
- 钉钉补丁脚本语法、幂等性及当前真实插件源码/runtime 命中验证：通过
- `git diff --check`：通过
- `npm run compile:electron` 的 native dependency 预处理被本机正在运行的 Electron 锁定 `better_sqlite3.node` 阻断；独立 Electron TypeScript 编译已通过