### PR TITLE
fix(renderer): prevent Windows title bar logo compression

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -522,8 +522,16 @@ const App: React.FC = () => {
 
   const handleOpenUpdateModal = useCallback(() => {
     if (!updateInfo) return;
+
+    const message = `update modal requested status=${appUpdateState.status} source=${appUpdateState.source ?? 'none'} version=${updateInfo.latestVersion}`;
+    console.debug(`[AppUpdate] ${message}`);
+    try {
+      window.electron?.log?.fromRenderer?.('debug', 'AppUpdate', message);
+    } catch {
+      // Best-effort diagnostic only.
+    }
     setShowUpdateModal(true);
-  }, [updateInfo]);
+  }, [appUpdateState.source, appUpdateState.status, updateInfo]);
 
   const handleUpdateFound = useCallback((_info: AppUpdateInfo) => {
     setShowUpdateModal(true);

--- a/src/renderer/components/window/WindowsAppTitleBar.test.ts
+++ b/src/renderer/components/window/WindowsAppTitleBar.test.ts
@@ -1,0 +1,59 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import WindowsAppTitleBar from './WindowsAppTitleBar';
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+afterEach(() => {
+  if (originalWindowDescriptor) {
+    Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+    return;
+  }
+  Reflect.deleteProperty(globalThis, 'window');
+});
+
+const renderTitleBar = (
+  platform: string,
+  props: Partial<React.ComponentProps<typeof WindowsAppTitleBar>> = {},
+) => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { electron: { platform } },
+  });
+
+  return renderToStaticMarkup(React.createElement(WindowsAppTitleBar, {
+    onToggleSidebar: () => undefined,
+    ...props,
+  }));
+};
+
+describe('WindowsAppTitleBar', () => {
+  test('keeps the logo at a fixed size and lets collapsed actions use their content width', () => {
+    const html = renderTitleBar('win32', {
+      isSidebarCollapsed: true,
+      onNewChat: () => undefined,
+      updateBadge: React.createElement('button', null, 'Restart to update'),
+    });
+
+    expect(html).toContain('class="h-4 w-4 max-w-none shrink-0"');
+    expect(html).toContain('class="hidden text-sm font-medium text-foreground"');
+    expect(html).not.toContain('style="width:220px"');
+  });
+
+  test.each([
+    { sidebarWidth: 220, titleBarWidth: 196 },
+    { sidebarWidth: 244, titleBarWidth: 220 },
+    { sidebarWidth: 420, titleBarWidth: 396 },
+  ])('keeps the expanded title bar aligned at sidebar width $sidebarWidth', ({ sidebarWidth, titleBarWidth }) => {
+    const html = renderTitleBar('win32', { sidebarWidth });
+
+    expect(html).toContain(`style="width:${titleBarWidth}px"`);
+    expect(html).toContain('class="truncate text-sm font-medium text-foreground"');
+  });
+
+  test('does not render on macOS', () => {
+    expect(renderTitleBar('darwin')).toBe('');
+  });
+});

--- a/src/renderer/components/window/WindowsAppTitleBar.tsx
+++ b/src/renderer/components/window/WindowsAppTitleBar.tsx
@@ -55,17 +55,17 @@ const WindowsAppTitleBar: React.FC<WindowsAppTitleBarProps> = ({
   return (
     <div className="draggable flex h-9 shrink-0 items-center justify-between border-b border-border bg-surface-raised px-3">
       <div
-        className="flex h-full shrink-0 items-center justify-between"
-        style={{ width: Math.max(0, sidebarWidth - 24) }}
+        className={`flex h-full shrink-0 items-center ${isSidebarCollapsed ? 'gap-1' : 'justify-between'}`}
+        style={isSidebarCollapsed ? undefined : { width: Math.max(0, sidebarWidth - 24) }}
       >
-        <div className="flex min-w-0 items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <img
             src="logo.png"
             alt=""
             draggable={false}
-            className="h-4 w-4 shrink-0"
+            className="h-4 w-4 max-w-none shrink-0"
           />
-          <span className="truncate text-sm font-medium text-foreground">
+          <span className={`${isSidebarCollapsed ? 'hidden' : 'truncate'} text-sm font-medium text-foreground`}>
             LobsterAI
           </span>
         </div>


### PR DESCRIPTION
Keep the logo fixed when the sidebar is collapsed with an update badge. Preserve expanded sidebar alignment and macOS behavior.
