### PR TITLE
feat(build): add opt-in Windows web installer target

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "dist:mac:universal": "npm run build && npm run compile:electron && npm run build:skills && electron-builder --mac --universal --config scripts/electron-builder-config.cjs",
     "predist:win": "npm run openclaw:runtime:win-x64",
     "dist:win": "npm run setup:python-runtime && npm run build && npm run compile:electron && npm run build:skills && electron-builder --win --x64 --config scripts/electron-builder-config.cjs",
+    "dist:win:web": "cross-env LOBSTERAI_WEB_INSTALLER=1 npm run dist:win",
     "predist:linux": "npm run openclaw:runtime:linux-x64",
     "dist:linux": "npm run build && npm run compile:electron && npm run build:skills && electron-builder --linux --config scripts/electron-builder-config.cjs",
     "clean:release": "rimraf release",

--- a/patches/app-builder-lib+24.13.3.patch
+++ b/patches/app-builder-lib+24.13.3.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/app-builder-lib/out/targets/nsis/WebInstallerTarget.js b/node_modules/app-builder-lib/out/targets/nsis/WebInstallerTarget.js
+index 9b75baa..e018ea7 100644
+--- a/node_modules/app-builder-lib/out/targets/nsis/WebInstallerTarget.js
++++ b/node_modules/app-builder-lib/out/targets/nsis/WebInstallerTarget.js
+@@ -23,8 +23,11 @@ class WebInstallerTarget extends NsisTarget_1.NsisTarget {
+                 throw new Error("Cannot compute app package download URL");
+             }
+             appPackageUrl = (0, PublishManager_1.computeDownloadUrl)(publishConfigs[0], null, packager);
++            // Computed URLs point at a directory, so the NSIS template appends the
++            // package file name. An explicit appPackageUrl is used verbatim, as the
++            // option documentation states ("it is full URL").
++            defines.APP_PACKAGE_URL_IS_INCOMPLETE = null;
+         }
+-        defines.APP_PACKAGE_URL_IS_INCOMPLETE = null;
+         defines.APP_PACKAGE_URL = appPackageUrl;
+     }
+     get installerFilenamePattern() {

--- a/scripts/build-keyfrom.cjs
+++ b/scripts/build-keyfrom.cjs
@@ -1,0 +1,39 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_KEYFROM = 'official';
+const KEYFROM_PATTERN = /^[a-z0-9_-]{1,64}$/;
+
+function normalizeKeyfrom(value) {
+  if (typeof value !== 'string') return DEFAULT_KEYFROM;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return DEFAULT_KEYFROM;
+  if (!KEYFROM_PATTERN.test(normalized)) return DEFAULT_KEYFROM;
+  return normalized;
+}
+
+function readBuildKeyfrom() {
+  if (process.env.KEYFROM !== undefined) {
+    return normalizeKeyfrom(process.env.KEYFROM);
+  }
+
+  const buildInfoPath = path.join(__dirname, '..', '.keyfrom-build', 'keyfrom.json');
+  try {
+    if (!fs.existsSync(buildInfoPath)) {
+      return DEFAULT_KEYFROM;
+    }
+    const parsed = JSON.parse(fs.readFileSync(buildInfoPath, 'utf8'));
+    return normalizeKeyfrom(parsed?.keyfrom);
+  } catch (error) {
+    console.warn('[Keyfrom] failed to read build keyfrom for artifact names, using official:', error);
+    return DEFAULT_KEYFROM;
+  }
+}
+
+module.exports = {
+  DEFAULT_KEYFROM,
+  normalizeKeyfrom,
+  readBuildKeyfrom,
+};

--- a/scripts/electron-builder-config.cjs
+++ b/scripts/electron-builder-config.cjs
@@ -1,37 +1,58 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-
 const config = require('../electron-builder.json');
+const { readBuildKeyfrom } = require('./build-keyfrom.cjs');
 
-const DEFAULT_KEYFROM = 'official';
-const KEYFROM_PATTERN = /^[a-z0-9_-]{1,64}$/;
+// Opt-in web installer (small NSIS stub that downloads the app package from a
+// CDN at install time). Default builds are full offline installers; nothing
+// changes unless LOBSTERAI_WEB_INSTALLER=1 is set explicitly.
+const WEB_INSTALLER_ENV = 'LOBSTERAI_WEB_INSTALLER';
+const WEB_PKG_BASE_URL_ENV = 'LOBSTERAI_WEB_PKG_BASE_URL';
+const WEB_PKG_URL_ENV = 'LOBSTERAI_WEB_PKG_URL';
 
-function normalizeKeyfrom(value) {
-  if (typeof value !== 'string') return DEFAULT_KEYFROM;
-  const normalized = value.trim().toLowerCase();
-  if (!normalized) return DEFAULT_KEYFROM;
-  if (!KEYFROM_PATTERN.test(normalized)) return DEFAULT_KEYFROM;
-  return normalized;
+function isWebInstallerEnabled() {
+  const value = (process.env[WEB_INSTALLER_ENV] || '').trim().toLowerCase();
+  return value === '1' || value === 'true';
 }
 
-function readBuildKeyfrom() {
-  if (process.env.KEYFROM !== undefined) {
-    return normalizeKeyfrom(process.env.KEYFROM);
+// Name of the .nsis.7z app package that electron-builder produces; fixed as
+// <productName>-<version>-x64.nsis.7z.
+function expectedPackageFileName() {
+  const version = require('../package.json').version;
+  return `${config.productName}-${version}-x64.nsis.7z`;
+}
+
+// Returns the complete package download URL baked into the web installer.
+// Requires the app-builder-lib patch (patches/app-builder-lib+*.patch) that
+// makes an explicit appPackageUrl be used verbatim instead of being treated
+// as a directory to which the package file name is appended.
+function resolveWebPackageUrl(keyfrom) {
+  // Mode 1: exact package URL, for upload-first flows where object storage
+  // assigns a random path/name (e.g. NOS). Used verbatim; must be a permanent
+  // public link.
+  const fullUrl = (process.env[WEB_PKG_URL_ENV] || '').trim().replace(/\/+$/, '');
+  if (fullUrl) {
+    if (fullUrl.includes('?')) {
+      throw new Error(
+        `[WebInstaller] ${WEB_PKG_URL_ENV} must be a permanent public URL without query parameters; ` +
+          'signed/expiring links cannot be baked into the installer.',
+      );
+    }
+    return fullUrl;
   }
 
-  const buildInfoPath = path.join(__dirname, '..', '.keyfrom-build', 'keyfrom.json');
-  try {
-    if (!fs.existsSync(buildInfoPath)) {
-      return DEFAULT_KEYFROM;
-    }
-    const parsed = JSON.parse(fs.readFileSync(buildInfoPath, 'utf8'));
-    return normalizeKeyfrom(parsed?.keyfrom);
-  } catch (error) {
-    console.warn('[Keyfrom] failed to read build keyfrom for artifact names, using official:', error);
-    return DEFAULT_KEYFROM;
+  // Mode 2: pre-agreed CDN directory. The keyfrom marker is baked into the app
+  // package (extraResources), so each channel gets its own subdirectory, and
+  // the fixed package file name completes the URL.
+  const raw = (process.env[WEB_PKG_BASE_URL_ENV] || '').trim().replace(/\/+$/, '');
+  if (!raw) {
+    throw new Error(
+      `[WebInstaller] either ${WEB_PKG_URL_ENV} (exact package URL from object storage) or ` +
+        `${WEB_PKG_BASE_URL_ENV} (CDN base directory, e.g. https://cdn.example.com/lobsterai/win) ` +
+        `is required when ${WEB_INSTALLER_ENV}=1.`,
+    );
   }
+  return `${raw}/${keyfrom}/${expectedPackageFileName()}`;
 }
 
 function asArray(value) {
@@ -82,6 +103,21 @@ config.nsis = {
   ...(config.nsis || {}),
   artifactName: `LobsterAI-Setup-\${arch}-\${version}-${keyfrom}.\${ext}`,
 };
+
+if (isWebInstallerEnabled()) {
+  // Build the web installer alongside the full one: both targets share the
+  // same intermediate .nsis.7z app package, so the extra cost is one more
+  // makensis run. nsisWeb inherits every option from the nsis block.
+  config.win = {
+    ...config.win,
+    target: ['nsis', 'nsis-web'],
+  };
+  config.nsisWeb = {
+    appPackageUrl: resolveWebPackageUrl(keyfrom),
+    artifactName: `LobsterAI-WebSetup-\${arch}-\${version}-${keyfrom}.\${ext}`,
+  };
+  console.log(`[WebInstaller] nsis-web target enabled, app package url: ${config.nsisWeb.appPackageUrl}`);
+}
 
 console.log(`[Keyfrom] configured artifact keyfrom as ${keyfrom}`);
 


### PR DESCRIPTION
Extract keyfrom reading into scripts/build-keyfrom.cjs and add a LOBSTERAI_WEB_INSTALLER-gated nsis-web target that downloads the app package from a CDN at install time, backed by an app-builder-lib patch for verbatim appPackageUrl support.
