### PR TITLE
fix(installer): self-heal interrupted win-resources.tar extraction

### DIFF
--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -10,8 +10,12 @@
 ; which electron-builder inserts inside the install section -- right after
 ; the user clicks Install and, critically, *before* uninstallOldVersion.
 
+; Note: clobbers $0 (nsExec exit status). Callers that need a previous exit
+; code after this macro must copy it to another register first ($R2 by
+; convention below). [Console]::Out.Write emits no trailing newline, so the
+; timestamp can be embedded mid-line in log writes.
 !macro GetTimestamp OUTVAR
-  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "[DateTime]::Now.ToString(\"yyyy-MM-dd HH:mm:ss.fff\")"'
+  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "[Console]::Out.Write([DateTime]::Now.ToString(\"yyyy-MM-dd HH:mm:ss.fff\"))"'
   Pop $0
   Pop ${OUTVAR}
   StrCmp $0 "0" +2
@@ -54,12 +58,14 @@
       Start-Sleep -Milliseconds 500;\
     }"'
   Pop $0
+  StrCpy $R2 $0
   System::Call 'kernel32::GetTickCount()i .r6'
   IntOp $5 $6 - $7
   CreateDirectory "$APPDATA\LobsterAI"
   FileOpen $9 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $9 0 END
   !insertmacro GetTimestamp $8
-  FileWrite $9 "$8 phase=process-stop-complete exit=$0 elapsed_ms=$5$\r$\n"
+  FileWrite $9 "$8 phase=process-stop-complete exit=$R2 elapsed_ms=$5$\r$\n"
   FileClose $9
 !macroend
 
@@ -123,18 +129,20 @@
       }"'
     Pop $0
     Pop $1
+    StrCpy $R2 $0
     System::Call 'kernel32::GetTickCount()i .r6'
     IntOp $5 $6 - $7
 
     StrCmp $R0 "" BackupSkipCloseLog
       !insertmacro GetTimestamp $8
-      FileWrite $R0 "$8 phase=backup-end exit=$0 elapsed_ms=$5$\r$\n"
+      FileWrite $R0 "$8 phase=backup-end exit=$R2 elapsed_ms=$5$\r$\n"
       FileWrite $R0 "$8 phase=backup-output text=$1$\r$\n"
       FileClose $R0
     BackupSkipCloseLog:
     FileOpen $9 "$APPDATA\LobsterAI\install-timing.log" a
+    FileSeek $9 0 END
     !insertmacro GetTimestamp $8
-    FileWrite $9 "$8 phase=skill-backup-complete exit=$0 elapsed_ms=$5$\r$\n"
+    FileWrite $9 "$8 phase=skill-backup-complete exit=$R2 elapsed_ms=$5$\r$\n"
     FileClose $9
 
     ; -- Remove old installation directory --
@@ -168,6 +176,7 @@
     System::Call 'kernel32::GetTickCount()i .r6'
     IntOp $5 $6 - $7
     FileOpen $9 "$APPDATA\LobsterAI\install-timing.log" a
+    FileSeek $9 0 END
     !insertmacro GetTimestamp $8
     FileWrite $9 "$8 phase=old-install-cleanup-complete elapsed_ms=$5 renamed_path=$3 cleanup_mode=async$\r$\n"
     FileClose $9
@@ -181,6 +190,7 @@
 
   CreateDirectory "$APPDATA\LobsterAI"
   FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $2 0 END
   !insertmacro GetTimestamp $8
   FileWrite $2 "$8 phase=nsis-extract-complete$\r$\n"
   FileClose $2
@@ -200,69 +210,154 @@
   DetailPrint "[Installer] Preparing resource directories"
   DetailPrint "[Installer] Adding Windows Defender exclusions before extraction"
   FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $2 0 END
   !insertmacro GetTimestamp $8
   FileWrite $2 "$8 phase=defender-exclusion-start$\r$\n"
   FileClose $2
   System::Call 'kernel32::GetTickCount()i .r7'
   nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "try { Add-MpPreference -ExclusionPath $\"$INSTDIR\resources\cfmind$\",$\"$INSTDIR\resources\python-win$\",$\"$INSTDIR\resources\SKILLs$\",$\"$INSTDIR\resources\app.asar.unpacked$\" -ErrorAction Stop; Write-Output \"[Installer] Windows Defender exclusions added\" } catch { Write-Output (\"[Installer] Windows Defender exclusions skipped: \" + $$_.Exception.Message) }"'
   Pop $0
+  StrCpy $R2 $0
   System::Call 'kernel32::GetTickCount()i .r6'
   IntOp $5 $6 - $7
   FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $2 0 END
   !insertmacro GetTimestamp $8
-  FileWrite $2 "$8 phase=defender-exclusion-complete exit=$0 elapsed_ms=$5$\r$\n"
+  FileWrite $2 "$8 phase=defender-exclusion-complete exit=$R2 elapsed_ms=$5$\r$\n"
   FileClose $2
 
   System::Call 'Kernel32::SetEnvironmentVariable(t "ELECTRON_RUN_AS_NODE", t "1")i'
 
-  DetailPrint "[Installer] Launching bundled extractor"
   DetailPrint "[Installer] Extracting bundled resources"
+  ; $R2 = current extractor exit code, $R3 = extractor id for logs.
+  ; ($R2 survives GetTimestamp, which clobbers $0 -- see the macro note.)
+  StrCpy $R2 ""
+  StrCpy $R3 "none"
+
+  ; -- Attempt 1: Windows built-in bsdtar (Win10 1803+) --
+  ; Runs a trusted system binary instead of the freshly written app exe,
+  ; which security software tends to freeze for cloud analysis on its first
+  ; execution (the root cause of installers hanging at this phase).
+  IfFileExists "$SYSDIR\tar.exe" 0 TarExtractElectron
+  StrCpy $R3 "system-tar"
   FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $2 0 END
   !insertmacro GetTimestamp $8
-  FileWrite $2 "$8 phase=tar-extract-start tar=$INSTDIR\resources\win-resources.tar dest=$INSTDIR\resources$\r$\n"
+  FileWrite $2 "$8 phase=tar-extract-start extractor=system-tar tar=$INSTDIR\resources\win-resources.tar dest=$INSTDIR\resources$\r$\n"
+  FileClose $2
+  System::Call 'kernel32::GetTickCount()i .r7'
+  nsExec::ExecToLog '"$SYSDIR\tar.exe" -xf "$INSTDIR\resources\win-resources.tar" -C "$INSTDIR\resources"'
+  Pop $0
+  StrCpy $R2 $0
+  System::Call 'kernel32::GetTickCount()i .r6'
+  IntOp $5 $6 - $7
+  FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $2 0 END
+  !insertmacro GetTimestamp $8
+  FileWrite $2 "$8 phase=tar-extract-exit extractor=system-tar exit=$R2 elapsed_ms=$5$\r$\n"
+  FileClose $2
+  StrCmp $R2 "error" TarExtractElectron
+  IntCmp $R2 0 TarExtractVerify TarExtractElectron TarExtractElectron
+
+  TarExtractElectron:
+  ; -- Attempt 2: bundled Electron Node runtime --
+  ; Wrapped in a 10-minute watchdog: if security software freezes the child
+  ; before it can run, the installer must fail visibly instead of hanging
+  ; forever (a killed installer leaves a half-installed app behind).
+  StrCpy $R3 "electron"
+  DetailPrint "[Installer] Launching bundled extractor"
+  FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $2 0 END
+  !insertmacro GetTimestamp $8
+  FileWrite $2 "$8 phase=tar-extract-start extractor=electron tar=$INSTDIR\resources\win-resources.tar dest=$INSTDIR\resources$\r$\n"
   FileClose $2
   System::Call 'kernel32::GetTickCount()i .r7'
 
-  nsExec::ExecToLog '"$INSTDIR\${APP_EXECUTABLE_FILENAME}" "$INSTDIR\resources\unpack-cfmind.cjs" "$INSTDIR\resources\win-resources.tar" "$INSTDIR\resources" "$APPDATA\LobsterAI\install-timing.log"'
+  nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "$$p = Start-Process -FilePath \"$INSTDIR\${APP_EXECUTABLE_FILENAME}\" -ArgumentList \"`\"$INSTDIR\resources\unpack-cfmind.cjs`\" `\"$INSTDIR\resources\win-resources.tar`\" `\"$INSTDIR\resources`\" `\"$APPDATA\LobsterAI\install-timing.log`\"\" -NoNewWindow -PassThru; if ($$p.WaitForExit(600000)) { $$p.WaitForExit(); if ($$p.ExitCode -eq $$null) { exit 125 }; exit $$p.ExitCode } else { Stop-Process -Id $$p.Id -Force -ErrorAction SilentlyContinue; exit 124 }"'
   Pop $0
+  StrCpy $R2 $0
   System::Call 'kernel32::GetTickCount()i .r6'
   IntOp $5 $6 - $7
-
-  ; Diagnostic: log raw exit code with brackets to reveal trailing whitespace
-  StrLen $4 $0
   FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $2 0 END
   !insertmacro GetTimestamp $8
-  FileWrite $2 "$8 phase=tar-extract-raw-exit exit_raw=[$0] exit_len=$4$\r$\n"
+  FileWrite $2 "$8 phase=tar-extract-exit extractor=electron exit=$R2 elapsed_ms=$5$\r$\n"
   FileClose $2
 
-  ; "error" = nsExec couldn't start the process (check before IntCmp, which
+  ; "error" = nsExec couldn't start powershell (check before IntCmp, which
   ; converts non-numeric strings to 0 and would misidentify "error" as success)
-  StrCmp $0 "error" TarExtractProcessFailed
+  StrCmp $R2 "error" TarExtractProcessFailed
+  StrCmp $R2 "124" TarExtractTimeout
   ; IntCmp tolerates trailing whitespace/CR that StrCmp would reject
-  IntCmp $0 0 TarExtractOK TarExtractNonZero TarExtractNonZero
+  IntCmp $R2 0 TarExtractVerify TarExtractNonZero TarExtractNonZero
+
+  TarExtractVerify:
+  ; Success requires the OpenClaw runtime entry to actually exist -- an exit
+  ; code alone must never trigger deletion of the only recovery source.
+  IfFileExists "$INSTDIR\resources\cfmind\gateway-bundle.mjs" TarExtractSucceeded
+  IfFileExists "$INSTDIR\resources\cfmind\openclaw.mjs" TarExtractSucceeded
+  FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $2 0 END
+  !insertmacro GetTimestamp $8
+  FileWrite $2 "$8 phase=tar-extract-error extractor=$R3 exit=$R2 reason=entry-missing-after-extract$\r$\n"
+  FileClose $2
+  ; A bogus system-tar success still gets a shot at the bundled extractor.
+  StrCmp $R3 "system-tar" TarExtractElectron
+  MessageBox MB_OK|MB_ICONEXCLAMATION "Resource extraction finished but the AI runtime files are still missing. LobsterAI will retry the extraction automatically on first launch. If the app still reports missing runtime files, add the install directory to your antivirus allowlist and reinstall. Details: $APPDATA\LobsterAI\install-timing.log"
+  Goto TarExtractFailed
 
   TarExtractProcessFailed:
     FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+    FileSeek $2 0 END
     !insertmacro GetTimestamp $8
-    FileWrite $2 "$8 phase=tar-extract-error exit=$0 elapsed_ms=$5 reason=process-start-failed$\r$\n"
+    FileWrite $2 "$8 phase=tar-extract-error extractor=$R3 exit=$R2 elapsed_ms=$5 reason=process-start-failed$\r$\n"
     FileClose $2
-    MessageBox MB_OK|MB_ICONEXCLAMATION "Resource extraction failed: could not start extractor process (exit=$0). This may be caused by antivirus software. See %APPDATA%\LobsterAI\install-timing.log for details."
-    Goto TarExtractOK
+    MessageBox MB_OK|MB_ICONEXCLAMATION "Resource extraction failed: could not start the extractor process (exit=$R2). This is usually caused by antivirus software. LobsterAI will retry the extraction automatically on first launch; if that fails too, add the install directory to your antivirus allowlist and reinstall. Details: $APPDATA\LobsterAI\install-timing.log"
+    Goto TarExtractFailed
+
+  TarExtractTimeout:
+    FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+    FileSeek $2 0 END
+    !insertmacro GetTimestamp $8
+    FileWrite $2 "$8 phase=tar-extract-error extractor=$R3 exit=$R2 elapsed_ms=$5 reason=timeout$\r$\n"
+    FileClose $2
+    MessageBox MB_OK|MB_ICONEXCLAMATION "Resource extraction timed out after 10 minutes -- the extractor process appears to be blocked, usually by antivirus software. LobsterAI will retry the extraction automatically on first launch; if that fails too, add the install directory to your antivirus allowlist and reinstall. Details: $APPDATA\LobsterAI\install-timing.log"
+    Goto TarExtractFailed
 
   TarExtractNonZero:
     FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+    FileSeek $2 0 END
     !insertmacro GetTimestamp $8
-    FileWrite $2 "$8 phase=tar-extract-error exit=$0 elapsed_ms=$5 reason=nonzero-exit$\r$\n"
+    FileWrite $2 "$8 phase=tar-extract-error extractor=$R3 exit=$R2 elapsed_ms=$5 reason=nonzero-exit$\r$\n"
     FileClose $2
-    MessageBox MB_OK|MB_ICONEXCLAMATION "Resource extraction failed (exit code $0). See %APPDATA%\LobsterAI\install-timing.log for details."
-  TarExtractOK:
+    MessageBox MB_OK|MB_ICONEXCLAMATION "Resource extraction failed (exit code $R2). LobsterAI will retry the extraction automatically on first launch; if that fails too, add the install directory to your antivirus allowlist and reinstall. Details: $APPDATA\LobsterAI\install-timing.log"
+    Goto TarExtractFailed
 
+  TarExtractSucceeded:
   FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $2 0 END
   !insertmacro GetTimestamp $8
-  FileWrite $2 "$8 phase=tar-extract-complete exit=$0 elapsed_ms=$5$\r$\n"
+  FileWrite $2 "$8 phase=tar-extract-complete extractor=$R3 exit=$R2$\r$\n"
+  FileClose $2
+  ; Completion marker, read by the app for install-integrity diagnostics.
+  FileOpen $2 "$INSTDIR\resources\.win-resources-extracted" w
+  !insertmacro GetTimestamp $8
+  FileWrite $2 "$8 source=installer extractor=$R3$\r$\n"
   FileClose $2
   DetailPrint "[Installer] Bundled resources extraction complete"
+  ; Only a verified success may delete these: the preserved archive is what
+  ; lets the app finish an interrupted extraction at first launch.
   Delete "$INSTDIR\resources\win-resources.tar"
+  Delete "$INSTDIR\resources\unpack-cfmind.cjs"
+  Goto TarExtractDone
+
+  TarExtractFailed:
+  FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $2 0 END
+  !insertmacro GetTimestamp $8
+  FileWrite $2 "$8 phase=tar-extract-failed-archive-preserved extractor=$R3 exit=$R2$\r$\n"
+  FileClose $2
+  TarExtractDone:
 
   ; -- Restore user-created skills from AppData backup --
   ; The backup was created in customCheckAppRunning before extraction began.
@@ -271,6 +366,7 @@
   IfFileExists "$APPDATA\LobsterAI\skills-backup\*.*" 0 SkipSkillRestore
     DetailPrint "[Installer] Restoring user-created skills"
     FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+    FileSeek $2 0 END
     !insertmacro GetTimestamp $8
     FileWrite $2 "$8 phase=skill-restore-start$\r$\n"
     FileClose $2
@@ -288,22 +384,24 @@
       Remove-Item -Path $$backup -Recurse -Force -ErrorAction SilentlyContinue"'
     Pop $0
     Pop $1
+    StrCpy $R2 $0
     System::Call 'kernel32::GetTickCount()i .r6'
     IntOp $5 $6 - $7
     FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+    FileSeek $2 0 END
     !insertmacro GetTimestamp $8
-    FileWrite $2 "$8 phase=skill-restore-complete exit=$0 elapsed_ms=$5$\r$\n"
+    FileWrite $2 "$8 phase=skill-restore-complete exit=$R2 elapsed_ms=$5$\r$\n"
     FileWrite $2 "$8 phase=skill-restore-output text=$1$\r$\n"
     FileClose $2
   SkipSkillRestore:
 
   System::Call 'Kernel32::SetEnvironmentVariable(t "ELECTRON_RUN_AS_NODE", t "")i'
 
-  ; Clean up the unpack script -- no longer needed after installation
-  DetailPrint "[Installer] Cleaning up temporary installer files"
-  Delete "$INSTDIR\resources\unpack-cfmind.cjs"
+  ; The unpack script is deleted in TarExtractSucceeded above; after a failed
+  ; extraction it is intentionally kept alongside win-resources.tar.
 
   FileOpen $2 "$APPDATA\LobsterAI\install-timing.log" a
+  FileSeek $2 0 END
   !insertmacro GetTimestamp $8
   FileWrite $2 "$8 phase=install-complete$\r$\n"
   FileClose $2

--- a/src/main/libs/installerResourceRecovery.test.ts
+++ b/src/main/libs/installerResourceRecovery.test.ts
@@ -1,0 +1,121 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as tar from 'tar';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  hasBundledRuntimeEntry,
+  INSTALLER_RESOURCES_MARKER,
+  INSTALLER_RESOURCES_TAR,
+  recoverInstallerResourcesFromTar,
+} from './installerResourceRecovery';
+
+describe('installerResourceRecovery', () => {
+  let workDir: string;
+  let resourcesDir: string;
+
+  const tarPath = () => path.join(resourcesDir, INSTALLER_RESOURCES_TAR);
+  const markerPath = () => path.join(resourcesDir, INSTALLER_RESOURCES_MARKER);
+  const entryPath = () => path.join(resourcesDir, 'cfmind', 'gateway-bundle.mjs');
+
+  const createInstallerTar = async (): Promise<void> => {
+    const stagingDir = path.join(workDir, 'staging');
+    fs.mkdirSync(path.join(stagingDir, 'cfmind'), { recursive: true });
+    fs.mkdirSync(path.join(stagingDir, 'python-win'), { recursive: true });
+    fs.writeFileSync(path.join(stagingDir, 'cfmind', 'gateway-bundle.mjs'), 'export const ok = true;\n');
+    fs.writeFileSync(path.join(stagingDir, 'python-win', 'python.exe'), 'fake-binary');
+    await tar.create({ file: tarPath(), cwd: stagingDir }, ['cfmind', 'python-win']);
+  };
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'installer-recovery-'));
+    resourcesDir = path.join(workDir, 'resources');
+    // The installer pre-creates cfmind as an empty directory before extraction
+    // starts, so a broken install has the directory but no entry file.
+    fs.mkdirSync(path.join(resourcesDir, 'cfmind'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test('recovers the runtime from a leftover installer tar and cleans up', async () => {
+    await createInstallerTar();
+    expect(hasBundledRuntimeEntry(resourcesDir)).toBe(false);
+
+    const progressCalls: number[] = [];
+    const result = await recoverInstallerResourcesFromTar(resourcesDir, 'test', (progress) => {
+      progressCalls.push(progress.bytes);
+    });
+
+    expect(result.attempted).toBe(true);
+    expect(result.success).toBe(true);
+    expect(result.entries).toBeGreaterThan(0);
+    expect(hasBundledRuntimeEntry(resourcesDir)).toBe(true);
+    expect(fs.existsSync(entryPath())).toBe(true);
+    expect(fs.existsSync(path.join(resourcesDir, 'python-win', 'python.exe'))).toBe(true);
+    // Mirrors the installer success path: marker stamped, archive removed.
+    expect(fs.existsSync(markerPath())).toBe(true);
+    expect(fs.existsSync(tarPath())).toBe(false);
+    // Initial progress callback fires so callers can surface an installing state.
+    expect(progressCalls[0]).toBe(0);
+  });
+
+  test('is a no-op when the runtime entry is already present', async () => {
+    await createInstallerTar();
+    fs.writeFileSync(entryPath(), 'export const ok = true;\n');
+
+    const result = await recoverInstallerResourcesFromTar(resourcesDir, 'test');
+
+    expect(result.attempted).toBe(false);
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(tarPath())).toBe(true);
+  });
+
+  test('reports failure when no tar is left to recover from', async () => {
+    const result = await recoverInstallerResourcesFromTar(resourcesDir, 'test');
+
+    expect(result.attempted).toBe(false);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  test('keeps the tar when extraction fails so it can be retried', async () => {
+    fs.writeFileSync(tarPath(), 'this is not a tar archive');
+
+    const result = await recoverInstallerResourcesFromTar(resourcesDir, 'test');
+
+    expect(result.attempted).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+    expect(fs.existsSync(tarPath())).toBe(true);
+    expect(fs.existsSync(markerPath())).toBe(false);
+  });
+
+  test('keeps the tar when the archive does not contain the runtime entry', async () => {
+    const stagingDir = path.join(workDir, 'staging');
+    fs.mkdirSync(path.join(stagingDir, 'SKILLs'), { recursive: true });
+    fs.writeFileSync(path.join(stagingDir, 'SKILLs', 'readme.txt'), 'no runtime here');
+    await tar.create({ file: tarPath(), cwd: stagingDir }, ['SKILLs']);
+
+    const result = await recoverInstallerResourcesFromTar(resourcesDir, 'test');
+
+    expect(result.attempted).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('still missing');
+    expect(fs.existsSync(tarPath())).toBe(true);
+  });
+
+  test('concurrent callers share a single in-flight recovery', async () => {
+    await createInstallerTar();
+
+    const first = recoverInstallerResourcesFromTar(resourcesDir, 'test-a');
+    const second = recoverInstallerResourcesFromTar(resourcesDir, 'test-b');
+
+    expect(second).toBe(first);
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(firstResult.success).toBe(true);
+    expect(secondResult).toBe(firstResult);
+  });
+});

--- a/src/main/libs/installerResourceRecovery.ts
+++ b/src/main/libs/installerResourceRecovery.ts
@@ -1,0 +1,183 @@
+import fs from 'fs';
+import path from 'path';
+import * as tar from 'tar';
+
+/**
+ * Recovery for Windows installs where the NSIS installer stopped (killed by
+ * the user, or its extractor child was frozen by security software) after the
+ * main app files were extracted but before win-resources.tar was unpacked.
+ * In that state the app launches, but resources/cfmind, python-win and SKILLs
+ * are empty directories; the tar preserved next to them is the only local
+ * source of the OpenClaw runtime. The installer only deletes the tar after a
+ * successful extraction, so we can finish its job here.
+ */
+
+export const INSTALLER_RESOURCES_TAR = 'win-resources.tar';
+/** Written after a successful extraction, by the installer or by this module. */
+export const INSTALLER_RESOURCES_MARKER = '.win-resources-extracted';
+
+// Any of these marks the OpenClaw runtime as present. Mirrors the entry
+// candidates of OpenClawEngineManager.resolveOpenClawEntry.
+const RUNTIME_ENTRY_CANDIDATES = [
+  path.join('cfmind', 'gateway-bundle.mjs'),
+  path.join('cfmind', 'openclaw.mjs'),
+  path.join('cfmind', 'dist', 'entry.js'),
+  path.join('cfmind', 'gateway.asar'),
+];
+
+const PROGRESS_LOG_STEP_BYTES = 50 * 1024 * 1024;
+
+export interface InstallerResourceRecoveryProgress {
+  entries: number;
+  bytes: number;
+  totalBytes: number;
+}
+
+export interface InstallerResourceRecoveryResult {
+  /** True when an extraction was actually started. */
+  attempted: boolean;
+  /** True when the runtime entry is present (recovered now, or already intact). */
+  success: boolean;
+  tarPath: string;
+  entries?: number;
+  elapsedMs?: number;
+  error?: string;
+}
+
+export const hasBundledRuntimeEntry = (resourcesDir: string): boolean =>
+  RUNTIME_ENTRY_CANDIDATES.some((candidate) => fs.existsSync(path.join(resourcesDir, candidate)));
+
+const stringifyError = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  return String(error);
+};
+
+const doRecover = async (
+  resourcesDir: string,
+  reason: string,
+  onProgress?: (progress: InstallerResourceRecoveryProgress) => void,
+): Promise<InstallerResourceRecoveryResult> => {
+  const tarPath = path.join(resourcesDir, INSTALLER_RESOURCES_TAR);
+  const markerPath = path.join(resourcesDir, INSTALLER_RESOURCES_MARKER);
+
+  if (hasBundledRuntimeEntry(resourcesDir)) {
+    return { attempted: false, success: true, tarPath };
+  }
+
+  if (!fs.existsSync(tarPath)) {
+    console.warn(
+      `[InstallerRecovery] runtime entry is missing and no installer tar is left to recover from ` +
+        `(reason=${reason}, extractedMarker=${fs.existsSync(markerPath)}, dir=${resourcesDir})`,
+    );
+    return { attempted: false, success: false, tarPath, error: 'installer resource tar not found' };
+  }
+
+  let totalBytes = 0;
+  try {
+    totalBytes = fs.statSync(tarPath).size;
+  } catch {
+    // Progress percentages become unavailable; extraction can still proceed.
+  }
+
+  const t0 = Date.now();
+  let entries = 0;
+  let bytes = 0;
+  let nextProgressBytes = PROGRESS_LOG_STEP_BYTES;
+  console.log(
+    `[InstallerRecovery] runtime entry is missing, extracting ${tarPath} -> ${resourcesDir} ` +
+      `(reason=${reason}, tarBytes=${totalBytes})`,
+  );
+  onProgress?.({ entries: 0, bytes: 0, totalBytes });
+
+  try {
+    await tar.extract({
+      file: tarPath,
+      cwd: resourcesDir,
+      onReadEntry: (entry) => {
+        entries += 1;
+        bytes += Number(entry.size ?? 0);
+        if (bytes >= nextProgressBytes) {
+          while (bytes >= nextProgressBytes) {
+            nextProgressBytes += PROGRESS_LOG_STEP_BYTES;
+          }
+          console.log(
+            `[InstallerRecovery] extract progress: entries=${entries} ` +
+              `mb=${(bytes / (1024 * 1024)).toFixed(0)} elapsedMs=${Date.now() - t0}`,
+          );
+          onProgress?.({ entries, bytes, totalBytes });
+        }
+      },
+    });
+  } catch (error) {
+    console.error(
+      `[InstallerRecovery] extraction failed after ${Date.now() - t0}ms (entries=${entries}), ` +
+        `keeping ${tarPath} for a later retry:`,
+      error,
+    );
+    return {
+      attempted: true,
+      success: false,
+      tarPath,
+      entries,
+      elapsedMs: Date.now() - t0,
+      error: stringifyError(error),
+    };
+  }
+
+  const elapsedMs = Date.now() - t0;
+  if (!hasBundledRuntimeEntry(resourcesDir)) {
+    console.error(
+      `[InstallerRecovery] extraction finished (entries=${entries}, elapsedMs=${elapsedMs}) ` +
+        `but the runtime entry is still missing, keeping ${tarPath}`,
+    );
+    return {
+      attempted: true,
+      success: false,
+      tarPath,
+      entries,
+      elapsedMs,
+      error: 'runtime entry still missing after extraction',
+    };
+  }
+
+  // Mirror the installer's success path: stamp the marker, drop the archive.
+  try {
+    fs.writeFileSync(markerPath, `${new Date().toISOString()} source=app-recovery reason=${reason}\n`);
+  } catch (error) {
+    console.warn('[InstallerRecovery] failed to write extraction marker:', error);
+  }
+  try {
+    fs.rmSync(tarPath);
+  } catch (error) {
+    console.warn(`[InstallerRecovery] recovered, but failed to remove ${tarPath}:`, error);
+  }
+
+  console.log(`[InstallerRecovery] runtime recovered from installer tar (entries=${entries}, elapsedMs=${elapsedMs})`);
+  return { attempted: true, success: true, tarPath, entries, elapsedMs };
+};
+
+let inflightRecovery: Promise<InstallerResourceRecoveryResult> | null = null;
+
+/**
+ * Extract win-resources.tar back into the resources directory if (and only
+ * if) the OpenClaw runtime entry is missing. The tar is deleted only after
+ * the runtime entry is confirmed present, so a failed attempt (e.g. security
+ * software still holding files) can be retried later. Concurrent calls share
+ * one extraction. Cheap no-op when the runtime is intact.
+ */
+export const recoverInstallerResourcesFromTar = (
+  resourcesDir: string,
+  reason: string,
+  onProgress?: (progress: InstallerResourceRecoveryProgress) => void,
+): Promise<InstallerResourceRecoveryResult> => {
+  if (inflightRecovery) {
+    return inflightRecovery;
+  }
+  const promise = doRecover(resourcesDir, reason, onProgress).finally(() => {
+    if (inflightRecovery === promise) {
+      inflightRecovery = null;
+    }
+  });
+  inflightRecovery = promise;
+  return promise;
+};

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -7,7 +7,7 @@ import net from 'net';
 import os from 'os';
 import path from 'path';
 
-import type { OpenClawEnginePhase } from '../../shared/openclawEngine/constants';
+import { OpenClawEngineErrorCode, type OpenClawEnginePhase } from '../../shared/openclawEngine/constants';
 import { ensureElectronNodeShim, getElectronNodeRuntimePath, getSkillsRoot } from './coworkUtil';
 import {
   formatGatewayLogDateKey,
@@ -16,6 +16,7 @@ import {
   getRecentGatewayLogEntries,
   pruneGatewayLogs,
 } from './gatewayLogRotation';
+import { recoverInstallerResourcesFromTar } from './installerResourceRecovery';
 import { getCodexHomeDir } from './openaiCodexAuth';
 import { migrateLegacyCronStorageWithDoctor } from './openclawCronLegacyMigration';
 import { cleanupStaleThirdPartyPluginsFromBundledDir, listLocalOpenClawExtensionIds,syncLocalOpenClawExtensionsIntoRuntime } from './openclawLocalExtensions';
@@ -61,6 +62,7 @@ export interface OpenClawEngineStatus {
   version: string | null;
   progressPercent?: number;
   message?: string;
+  errorCode?: OpenClawEngineErrorCode;
   gatewayPort?: number | null;
   gatewayHttpUrl?: string | null;
   canRetry: boolean;
@@ -430,6 +432,12 @@ export class OpenClawEngineManager extends EventEmitter {
     const t0 = Date.now();
     const elapsed = () => `${Date.now() - t0}ms`;
 
+    // Heal installs where the installer's win-resources.tar extraction never
+    // finished (killed or frozen by security software): the runtime entry is
+    // missing but the preserved archive can restore it. Cheap no-op when the
+    // runtime is intact.
+    await this.maybeRecoverInstallerResources('gateway-start');
+
     const ensured = await this.ensureReady();
     console.log(`[OpenClaw] startGateway: ensureReady done (${elapsed()}), phase=${ensured.phase}`);
     if (ensured.phase !== 'ready' && ensured.phase !== 'running') {
@@ -483,6 +491,7 @@ export class OpenClawEngineManager extends EventEmitter {
         phase: 'error',
         version: runtime.version,
         message: `OpenClaw entry file is missing in runtime: ${runtime.root}.`,
+        errorCode: OpenClawEngineErrorCode.RuntimeEntryMissing,
         canRetry: true,
       });
       return this.getStatus();
@@ -741,6 +750,57 @@ export class OpenClawEngineManager extends EventEmitter {
       gatewayPort: port,
       gatewayHttpUrl: this.buildGatewayHttpUrl(port),
     };
+  }
+
+  /**
+   * Finish an interrupted installation on packaged Windows builds: when the
+   * NSIS installer was stopped before unpacking win-resources.tar, the app
+   * ships with empty cfmind/python-win/SKILLs directories while the archive
+   * still sits next to them. Extracting it restores the runtime in place;
+   * the archive is preserved on failure so the next attempt can retry.
+   */
+  private async maybeRecoverInstallerResources(reason: string): Promise<void> {
+    if (process.platform !== 'win32' || !app.isPackaged) {
+      return;
+    }
+
+    const statusBeforeRecovery = this.status;
+    let statusTouched = false;
+    try {
+      const result = await recoverInstallerResourcesFromTar(
+        process.resourcesPath,
+        reason,
+        ({ bytes, totalBytes }) => {
+          statusTouched = true;
+          this.setStatus({
+            phase: 'installing',
+            version: this.status.version,
+            progressPercent: totalBytes > 0 ? Math.min(99, Math.floor((bytes / totalBytes) * 100)) : undefined,
+            message: 'Recovering bundled resources from the installer archive...',
+            canRetry: false,
+          });
+        },
+      );
+
+      if (result.attempted && result.success) {
+        // Runtime version metadata was unreadable while the files were missing.
+        const runtime = this.resolveRuntimeMetadata();
+        this.desiredVersion = runtime.version || this.desiredVersion;
+        this.setStatus({
+          phase: 'ready',
+          version: this.desiredVersion,
+          message: 'OpenClaw runtime was recovered from installer resources.',
+          canRetry: false,
+        });
+      } else if (statusTouched) {
+        this.setStatus(statusBeforeRecovery);
+      }
+    } catch (error) {
+      console.error('[OpenClaw] installer resource recovery attempt failed:', error);
+      if (statusTouched) {
+        this.setStatus(statusBeforeRecovery);
+      }
+    }
   }
 
   private resolveRuntimeMetadata(): RuntimeMetadata {

--- a/src/renderer/components/cowork/EngineFailureOverlay.tsx
+++ b/src/renderer/components/cowork/EngineFailureOverlay.tsx
@@ -1,7 +1,7 @@
 import { ArrowPathIcon, ChevronDownIcon, ExclamationTriangleIcon, WrenchScrewdriverIcon } from '@heroicons/react/24/outline';
 import React, { useEffect, useState } from 'react';
 
-import { OpenClawGatewayRepairErrorCode } from '../../../shared/openclawEngine/constants';
+import { OpenClawEngineErrorCode, OpenClawGatewayRepairErrorCode } from '../../../shared/openclawEngine/constants';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { LogReporterAction, reportYdAnalyzer } from '../../services/logReporter';
@@ -107,6 +107,11 @@ const EngineFailureOverlay: React.FC<EngineFailureOverlayProps> = ({
     return null;
   }
 
+  // Incomplete installation (runtime files missing): rebuilding the OpenClaw
+  // config cannot help. Quick repair still retries recovery from leftover
+  // installer resources, but the honest fix is allowlist + reinstall.
+  const isRuntimeMissing = status.errorCode === OpenClawEngineErrorCode.RuntimeEntryMissing;
+
   if (isDeferred) {
     return (
       <div className="pointer-events-none fixed inset-x-0 top-4 z-[90] flex justify-center px-4">
@@ -151,11 +156,16 @@ const EngineFailureOverlay: React.FC<EngineFailureOverlayProps> = ({
             <ExclamationTriangleIcon className="h-6 w-6" />
           </span>
           <h3 id="openclaw-gateway-failure-title" className="mt-3 text-base font-semibold text-foreground">
-            {i18nService.t('coworkOpenClawError')}
+            {i18nService.t(isRuntimeMissing ? 'coworkOpenClawRuntimeMissingError' : 'coworkOpenClawError')}
           </h3>
           <p className="mt-2 text-[13px] leading-5 text-secondary">
-            {i18nService.t('coworkOpenClawErrorRepairHint')}
+            {i18nService.t(isRuntimeMissing ? 'coworkOpenClawRuntimeMissingRepairHint' : 'coworkOpenClawErrorRepairHint')}
           </p>
+          {isRuntimeMissing && status.message && (
+            <p className="mt-2 max-w-full break-all text-xs leading-4 text-secondary/80">
+              {status.message}
+            </p>
+          )}
           {gatewayRepairError && (
             <p className="mt-2 text-[13px] leading-5 text-red-600 dark:text-red-400">
               {gatewayRepairError}

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -851,6 +851,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkOpenClawQuickRepair: '一键修复',
     coworkOpenClawErrorRepairHint:
       '推荐使用一键修复：自动备份并重建 OpenClaw 配置后重新启动网关，可解决大多数启动失败问题；不会删除聊天记录、模型配置、技能或工作区文件。',
+    coworkOpenClawRuntimeMissingError: 'AI 引擎运行时文件缺失，安装未完成。',
+    coworkOpenClawRuntimeMissingRepairHint:
+      '常见原因是安装过程被安全软件拦截或中途退出。可先尝试一键修复（会从安装包残留资源自动恢复运行时）；若修复无效，请将安装目录加入安全软件信任区后，重新下载安装包覆盖安装。聊天记录、模型配置与工作区文件不会丢失。',
     coworkOpenClawErrorShort: '网关启动失败',
     coworkOpenClawErrorDefer: '稍后处理',
     openClawMaintenanceTitle: '运行维护',
@@ -3673,6 +3676,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkOpenClawQuickRepair: 'Quick Repair',
     coworkOpenClawErrorRepairHint:
       'Quick Repair backs up and rebuilds the OpenClaw config, then restarts the gateway. It resolves most startup failures and keeps chats, model settings, skills, and workspace files.',
+    coworkOpenClawRuntimeMissingError: 'AI engine runtime files are missing — the installation did not complete.',
+    coworkOpenClawRuntimeMissingRepairHint:
+      'This usually happens when security software blocks the installer or it exits early. Try Quick Repair first — it restores the runtime from leftover installer resources. If that fails, add the install directory to your security software allowlist, then download the installer again and reinstall. Chats, model settings, and workspace files are preserved.',
     coworkOpenClawErrorShort: 'Gateway failed to start',
     coworkOpenClawErrorDefer: 'Later',
     openClawMaintenanceTitle: 'Run Maintenance',

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -14,6 +14,7 @@ import type {
   ResolvedKitCapabilities,
 } from '../../shared/kit/constants';
 import type {
+  OpenClawEngineErrorCode,
   OpenClawEnginePhase as SharedOpenClawEnginePhase,
   OpenClawGatewayRepairErrorCode,
 } from '../../shared/openclawEngine/constants';
@@ -246,6 +247,7 @@ export interface OpenClawEngineStatus {
   version: string | null;
   progressPercent?: number;
   message?: string;
+  errorCode?: OpenClawEngineErrorCode;
   gatewayPort?: number | null;
   gatewayHttpUrl?: string | null;
   canRetry: boolean;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -37,6 +37,7 @@ import type {
   LocalWebService,
 } from '../../shared/localWebServices/constants';
 import type {
+  OpenClawEngineErrorCode,
   OpenClawEnginePhase as SharedOpenClawEnginePhase,
   OpenClawGatewayRepairErrorCode,
 } from '../../shared/openclawEngine/constants';
@@ -246,6 +247,7 @@ interface OpenClawEngineStatus {
   version: string | null;
   progressPercent?: number;
   message?: string;
+  errorCode?: OpenClawEngineErrorCode;
   gatewayPort?: number | null;
   gatewayHttpUrl?: string | null;
   canRetry: boolean;

--- a/src/shared/openclawEngine/constants.ts
+++ b/src/shared/openclawEngine/constants.ts
@@ -29,3 +29,16 @@ export const OpenClawGatewayRepairErrorCode = {
 
 export type OpenClawGatewayRepairErrorCode =
   typeof OpenClawGatewayRepairErrorCode[keyof typeof OpenClawGatewayRepairErrorCode];
+
+export const OpenClawEngineErrorCode = {
+  /**
+   * resources/cfmind has no runtime entry file. On packaged Windows builds
+   * this means the installer never finished unpacking win-resources.tar
+   * (typically killed or frozen by security software) and automatic recovery
+   * from the leftover archive was not possible.
+   */
+  RuntimeEntryMissing: 'runtime_entry_missing',
+} as const;
+
+export type OpenClawEngineErrorCode =
+  typeof OpenClawEngineErrorCode[keyof typeof OpenClawEngineErrorCode];


### PR DESCRIPTION
Security software freezing the freshly-written extractor exe on first execution was hanging installs (and killed installs left cfmind empty with no way to recover). The NSIS installer now tries the trusted system tar.exe first, falls back to the bundled electron extractor under a 10-minute watchdog, and verifies the runtime entry actually exists before deleting the archive. If extraction still fails, the archive is preserved and the gateway manager retries it via installerResourceRecovery on next launch, surfacing a dedicated runtime-missing error state in the UI when recovery isn't possible.