### PR TITLE
fix(build): sign Windows app binary through internal signing service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Copy to .env (gitignored) and fill in real values.
+# Values here are read by packaging scripts only; process env always wins.
+
+# -- macOS code signing & notarization (scripts/notarize.js) --
+APPLE_ID=your-apple-id@example.com
+APPLE_APP_SPECIFIC_PASSWORD=xxxx-xxxx-xxxx-xxxx
+APPLE_TEAM_ID=XXXXXXXXXX
+
+# -- Windows code signing (scripts/win-sign.cjs) --
+# Ask the signing service team for the internal service URL and a CI/app
+# credential; do not use a personal account. All four values are required.
+# Without them, Windows builds are produced UNSIGNED (dev-only).
+# URL is the service root; pasting the full /api/sign endpoint also works.
+YD_SIGN_SERVICE_URL=
+YD_SIGN_APP_KEY=
+YD_SIGN_APP_SECRET=
+YD_SIGN_USERNAME=

--- a/scripts/electron-builder-config.cjs
+++ b/scripts/electron-builder-config.cjs
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require('path');
+
 const config = require('../electron-builder.json');
 const { readBuildKeyfrom } = require('./build-keyfrom.cjs');
 
@@ -91,6 +93,16 @@ const keyfrom = readBuildKeyfrom();
 for (const platformName of ['mac', 'win', 'linux']) {
   mergeExtraResources(platformName);
 }
+
+// Sign every Windows binary electron-builder produces (LobsterAI.exe, the
+// uninstaller, the installer) through the internal Youdao signing service,
+// not just the final Setup.exe: the unsigned inner exe is what security
+// software freezes on first execution. The hook skips with a warning when
+// YD_SIGN_* credentials are absent, so local packaging still works.
+config.win = {
+  ...config.win,
+  sign: path.join(__dirname, 'win-sign.cjs'),
+};
 
 delete config.extraResources;
 

--- a/scripts/electron-builder-hooks.cjs
+++ b/scripts/electron-builder-hooks.cjs
@@ -599,6 +599,11 @@ async function afterPack(context) {
       console.warn(`[electron-builder-hooks] App not found at ${appPath}, skipping icon fix`);
     }
   }
+
+  // Windows binaries need no extra handling here: with win.sign configured,
+  // electron-builder routes the app exe, uninstaller and installer through
+  // scripts/win-sign.cjs, and the NSIS target's CopyElevateHelper signs
+  // resources/elevate.exe itself (see app-builder-lib nsisUtil.js).
 }
 
 module.exports = {

--- a/scripts/win-sign.cjs
+++ b/scripts/win-sign.cjs
@@ -1,0 +1,291 @@
+'use strict';
+
+/**
+ * electron-builder custom Windows code-signing hook.
+ *
+ * Uploads each binary produced by the build (app exe, uninstaller, installer)
+ * to the internal Youdao signing service and replaces the local file with the
+ * signed result. This closes the "signed installer shell, unsigned payload"
+ * gap: security software freezes the unsigned LobsterAI.exe on first
+ * execution, which is what hung installations in the field.
+ *
+ * Service API (per the official signing-service doc):
+ *   POST /api/sign
+ *     headers: x-app-key, x-app-secret, x-username
+ *     body:    multipart, files=<binary> (application/octet-stream)
+ *     ->       {results: [{originalName, downloadUrl, ...}]}
+ *   GET <downloadUrl>   same auth headers, returns the signed file
+ *
+ * NEVER call the service's /api/cleanup from automation: it deletes every
+ * file on the shared server, including other teams' in-flight jobs.
+ *
+ * Credentials (process env wins; missing keys are filled from the repo-root
+ * .env file, same convention as the Apple notarization credentials). The
+ * service URL is internal infrastructure and is deliberately NOT hardcoded
+ * here -- ask the signing service team for all four values:
+ *   YD_SIGN_SERVICE_URL   signing service base URL
+ *   YD_SIGN_APP_KEY       service app key
+ *   YD_SIGN_APP_SECRET    service app secret
+ *   YD_SIGN_USERNAME      requesting user (shown in the service's audit log)
+ *
+ * Missing values -> the hook logs one warning and skips, so local dev
+ * packaging keeps producing (unsigned) artifacts. See .env.example.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SERVICE_URL_ENV = 'YD_SIGN_SERVICE_URL';
+const APP_KEY_ENV = 'YD_SIGN_APP_KEY';
+const APP_SECRET_ENV = 'YD_SIGN_APP_SECRET';
+const USERNAME_ENV = 'YD_SIGN_USERNAME';
+
+const REQUEST_TIMEOUT_MS = 15 * 60 * 1000;
+const MAX_ATTEMPTS = 2;
+
+let warnedAboutMissingCredentials = false;
+const signedThisRun = new Set();
+
+/**
+ * Minimal dependency-free .env loader (KEY=VALUE lines, # comments,
+ * optional surrounding quotes). Existing process.env values always win,
+ * matching dotenv semantics. Values are never logged.
+ */
+function loadDotEnv(envPath = path.join(__dirname, '..', '.env')) {
+  let content;
+  try {
+    content = fs.readFileSync(envPath, 'utf8');
+  } catch {
+    return;
+  }
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/.exec(line);
+    if (!match) continue;
+    const key = match[1];
+    let value = match[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+loadDotEnv();
+
+/**
+ * Read the PE Attribute Certificate Table (data directory #4) entry.
+ * Returns {offset, size} when the file carries an Authenticode signature,
+ * null when it is a valid PE without one. Throws for non-PE files.
+ */
+function readPeCertTable(filePath) {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const header = Buffer.alloc(4096);
+    const bytesRead = fs.readSync(fd, header, 0, header.length, 0);
+    if (bytesRead < 0x40 || header.toString('latin1', 0, 2) !== 'MZ') {
+      throw new Error(`${filePath} is not a PE file (missing MZ header)`);
+    }
+    const eLfanew = header.readUInt32LE(0x3c);
+    if (eLfanew + 24 > bytesRead || header.toString('latin1', eLfanew, eLfanew + 4) !== 'PE\0\0') {
+      throw new Error(`${filePath} is not a PE file (missing PE signature)`);
+    }
+    const optOff = eLfanew + 4 + 20;
+    const magic = header.readUInt16LE(optOff);
+    let ddOff;
+    if (magic === 0x10b) {
+      ddOff = optOff + 96; // PE32
+    } else if (magic === 0x20b) {
+      ddOff = optOff + 112; // PE32+
+    } else {
+      throw new Error(`${filePath} has unknown optional header magic 0x${magic.toString(16)}`);
+    }
+    const certEntryOff = ddOff + 4 * 8;
+    if (certEntryOff + 8 > bytesRead) {
+      throw new Error(`${filePath} PE header is truncated`);
+    }
+    const offset = header.readUInt32LE(certEntryOff);
+    const size = header.readUInt32LE(certEntryOff + 4);
+    if (offset === 0 || size === 0) {
+      return null;
+    }
+    return { offset, size };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/**
+ * People paste whatever URL is at hand -- the doc's full /api/sign endpoint
+ * or the manual upload page. Normalize all of them to the service root
+ * (a raw endpoint would otherwise double up into /api/sign/api/sign).
+ */
+function normalizeServiceUrl(rawUrl) {
+  return rawUrl
+    .replace(/\/+$/, '')
+    .replace(/\/sign\.html$/i, '')
+    .replace(/\/api\/sign$/i, '')
+    .replace(/\/+$/, '');
+}
+
+function resolveServiceConfig() {
+  const serviceUrl = (process.env[SERVICE_URL_ENV] || '').trim();
+  const appKey = (process.env[APP_KEY_ENV] || '').trim();
+  const appSecret = (process.env[APP_SECRET_ENV] || '').trim();
+  const username = (process.env[USERNAME_ENV] || '').trim();
+  if (!serviceUrl || !appKey || !appSecret || !username) {
+    return null;
+  }
+  const baseUrl = normalizeServiceUrl(serviceUrl);
+  return {
+    baseUrl,
+    headers: {
+      'x-app-key': appKey,
+      'x-app-secret': appSecret,
+      'x-username': username,
+    },
+  };
+}
+
+async function safeText(response) {
+  try {
+    return (await response.text()).slice(0, 300);
+  } catch {
+    return '';
+  }
+}
+
+async function fileToBlob(filePath) {
+  if (typeof fs.openAsBlob === 'function') {
+    return fs.openAsBlob(filePath, { type: 'application/octet-stream' });
+  }
+  return new Blob([await fs.promises.readFile(filePath)], { type: 'application/octet-stream' });
+}
+
+async function signOnce(serviceConfig, filePath) {
+  const fileName = path.basename(filePath);
+
+  const formData = new FormData();
+  formData.append('files', await fileToBlob(filePath), fileName);
+
+  const signResponse = await fetch(`${serviceConfig.baseUrl}/api/sign`, {
+    method: 'POST',
+    headers: serviceConfig.headers,
+    body: formData,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!signResponse.ok) {
+    throw new Error(`[WinSign] sign request failed: HTTP ${signResponse.status} ${await safeText(signResponse)}`);
+  }
+
+  const payload = await signResponse.json();
+  const result = Array.isArray(payload?.results) ? payload.results[0] : null;
+  if (!result?.downloadUrl) {
+    throw new Error(`[WinSign] unexpected sign response: ${JSON.stringify(payload).slice(0, 300)}`);
+  }
+
+  const downloadUrl = new URL(result.downloadUrl, `${serviceConfig.baseUrl}/`).toString();
+  const downloadResponse = await fetch(downloadUrl, {
+    headers: serviceConfig.headers,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!downloadResponse.ok) {
+    throw new Error(`[WinSign] download failed: HTTP ${downloadResponse.status} ${await safeText(downloadResponse)}`);
+  }
+  const signedBytes = Buffer.from(await downloadResponse.arrayBuffer());
+
+  const originalSize = fs.statSync(filePath).size;
+  if (signedBytes.length < originalSize) {
+    throw new Error(
+      `[WinSign] signed file is smaller than the original (${signedBytes.length} < ${originalSize} bytes), refusing to replace ${fileName}`,
+    );
+  }
+
+  const tmpPath = `${filePath}.ydsign.tmp`;
+  fs.writeFileSync(tmpPath, signedBytes);
+  try {
+    const certTable = readPeCertTable(tmpPath);
+    if (!certTable) {
+      throw new Error(`[WinSign] service returned ${fileName} without an Authenticode signature`);
+    }
+    fs.renameSync(tmpPath, filePath);
+  } catch (error) {
+    fs.rmSync(tmpPath, { force: true });
+    throw error;
+  }
+}
+
+/**
+ * Sign one binary in place through the internal service.
+ * Returns true when the file ends up signed, false when signing was skipped
+ * (no credentials, or the file already carries a signature).
+ */
+async function signFile(filePath) {
+  const serviceConfig = resolveServiceConfig();
+  if (!serviceConfig) {
+    if (!warnedAboutMissingCredentials) {
+      warnedAboutMissingCredentials = true;
+      console.warn(
+        `[WinSign] ${SERVICE_URL_ENV}/${APP_KEY_ENV}/${APP_SECRET_ENV}/${USERNAME_ENV} are not fully set (env or .env) -- `
+        + 'Windows binaries will NOT be signed. This is fine for local dev builds and must never happen on release CI. '
+        + 'See .env.example.',
+      );
+    }
+    return false;
+  }
+
+  const normalizedPath = path.resolve(filePath);
+  if (signedThisRun.has(normalizedPath)) {
+    return true;
+  }
+  if (readPeCertTable(normalizedPath)) {
+    console.log(`[WinSign] ${path.basename(normalizedPath)} already carries a signature, skipping`);
+    signedThisRun.add(normalizedPath);
+    return false;
+  }
+
+  const sizeMb = (fs.statSync(normalizedPath).size / (1024 * 1024)).toFixed(1);
+  console.log(`[WinSign] signing ${path.basename(normalizedPath)} (${sizeMb} MB) via ${serviceConfig.baseUrl}`);
+  const t0 = Date.now();
+
+  let lastError = null;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await signOnce(serviceConfig, normalizedPath);
+      signedThisRun.add(normalizedPath);
+      console.log(`[WinSign] signed ${path.basename(normalizedPath)} in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+      return true;
+    } catch (error) {
+      lastError = error;
+      console.warn(`[WinSign] attempt ${attempt}/${MAX_ATTEMPTS} failed for ${path.basename(normalizedPath)}:`, error.message);
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * electron-builder `win.sign` entry point. Called once per binary that needs
+ * a signature (app exe, uninstaller, installer; some versions also pass
+ * hash variants for the same file -- deduplicated via signedThisRun).
+ */
+async function signWindowsBinary(configuration) {
+  await signFile(configuration.path);
+}
+
+function _resetForTests() {
+  warnedAboutMissingCredentials = false;
+  signedThisRun.clear();
+}
+
+module.exports = signWindowsBinary;
+module.exports.default = signWindowsBinary;
+module.exports.signFile = signFile;
+module.exports.readPeCertTable = readPeCertTable;
+module.exports.loadDotEnv = loadDotEnv;
+module.exports._resetForTests = _resetForTests;

--- a/tests/winSign.test.ts
+++ b/tests/winSign.test.ts
@@ -1,9 +1,10 @@
+import fs from 'node:fs';
 import http from 'node:http';
 import { createRequire } from 'node:module';
 import { AddressInfo } from 'node:net';
-import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
 const require = createRequire(import.meta.url);

--- a/tests/winSign.test.ts
+++ b/tests/winSign.test.ts
@@ -1,0 +1,265 @@
+import http from 'node:http';
+import { createRequire } from 'node:module';
+import { AddressInfo } from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { signFile, readPeCertTable, loadDotEnv, _resetForTests } = require('../scripts/win-sign.cjs');
+
+const PE_BODY_MARKER = 'FAKE-PE-BODY-FOR-WIN-SIGN-TEST';
+const SIGN_ENV_KEYS = ['YD_SIGN_SERVICE_URL', 'YD_SIGN_APP_KEY', 'YD_SIGN_APP_SECRET', 'YD_SIGN_USERNAME'] as const;
+
+/** Build a minimal but structurally valid PE32+ image. */
+function buildMinimalPe(options: { signed: boolean }): Buffer {
+  const headerSize = 0x148; // MZ stub (0x40) + PE sig (4) + COFF (20) + optional header (240)
+  const bodyEnd = 0x200;
+  const cert = Buffer.from('FAKE-AUTHENTICODE-PKCS7-BLOB');
+  const certRecordLength = 8 + cert.length;
+  const total = options.signed ? bodyEnd + certRecordLength : bodyEnd;
+
+  const pe = Buffer.alloc(total);
+  pe.write('MZ', 0, 'latin1');
+  pe.writeUInt32LE(0x40, 0x3c); // e_lfanew
+  pe.write('PE\0\0', 0x40, 'latin1');
+
+  const coff = 0x44;
+  pe.writeUInt16LE(0x8664, coff); // machine: x64
+  pe.writeUInt16LE(0, coff + 2); // sections
+  pe.writeUInt16LE(240, coff + 16); // sizeOfOptionalHeader
+  pe.writeUInt16LE(0x22, coff + 18); // characteristics
+
+  const opt = 0x58;
+  pe.writeUInt16LE(0x20b, opt); // PE32+
+  pe.writeUInt32LE(16, opt + 108); // numberOfRvaAndSizes
+
+  if (options.signed) {
+    const certEntry = opt + 112 + 4 * 8; // data directory #4
+    pe.writeUInt32LE(bodyEnd, certEntry);
+    pe.writeUInt32LE(certRecordLength, certEntry + 4);
+    pe.writeUInt32LE(certRecordLength, bodyEnd); // WIN_CERTIFICATE.dwLength
+    pe.writeUInt16LE(0x0200, bodyEnd + 4); // wRevision
+    pe.writeUInt16LE(2, bodyEnd + 6); // wCertificateType
+    cert.copy(pe, bodyEnd + 8);
+  }
+
+  pe.write(PE_BODY_MARKER, headerSize, 'latin1');
+  return pe;
+}
+
+interface MockSignServer {
+  baseUrl: string;
+  requests: string[];
+  mode: 'ok' | 'sign-500';
+  lastUploadBody: Buffer | null;
+  close: () => Promise<void>;
+}
+
+function hasValidAuthHeaders(req: http.IncomingMessage): boolean {
+  return (
+    req.headers['x-app-key'] === 'test-app-key' &&
+    req.headers['x-app-secret'] === 'test-app-secret' &&
+    req.headers['x-username'] === 'ci-bot'
+  );
+}
+
+function startMockSignServer(): Promise<MockSignServer> {
+  const state: Omit<MockSignServer, 'baseUrl' | 'close'> = {
+    requests: [],
+    mode: 'ok',
+    lastUploadBody: null,
+  };
+
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks);
+      state.requests.push(`${req.method} ${req.url}`);
+
+      if (!hasValidAuthHeaders(req)) {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'invalid app credentials' }));
+        return;
+      }
+
+      if (req.method === 'POST' && req.url === '/api/sign') {
+        if (state.mode === 'sign-500') {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'signer exploded' }));
+          return;
+        }
+        state.lastUploadBody = body;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        // Relative downloadUrl on purpose: the hook must resolve it against the base URL.
+        res.end(JSON.stringify({ results: [{ originalName: 'target.exe', downloadUrl: 'api/download/target.exe' }] }));
+        return;
+      }
+
+      if (req.method === 'GET' && req.url === '/api/download/target.exe') {
+        res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+        res.end(buildMinimalPe({ signed: true }));
+        return;
+      }
+
+      res.writeHead(404);
+      res.end();
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        get requests() { return state.requests; },
+        get mode() { return state.mode; },
+        set mode(value) { state.mode = value; },
+        get lastUploadBody() { return state.lastUploadBody; },
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((done) => server.close(() => done())),
+      });
+    });
+  });
+}
+
+describe('win-sign hook', () => {
+  let server: MockSignServer;
+  let workDir: string;
+  let targetPath: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    server = await startMockSignServer();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  beforeEach(() => {
+    for (const key of SIGN_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.YD_SIGN_SERVICE_URL = server.baseUrl;
+    process.env.YD_SIGN_APP_KEY = 'test-app-key';
+    process.env.YD_SIGN_APP_SECRET = 'test-app-secret';
+    process.env.YD_SIGN_USERNAME = 'ci-bot';
+    server.mode = 'ok';
+    server.requests.length = 0;
+    _resetForTests();
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'win-sign-'));
+    targetPath = path.join(workDir, 'target.exe');
+    fs.writeFileSync(targetPath, buildMinimalPe({ signed: false }));
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test('parses signed and unsigned PE certificate tables', () => {
+    expect(readPeCertTable(targetPath)).toBeNull();
+    fs.writeFileSync(targetPath, buildMinimalPe({ signed: true }));
+    expect(readPeCertTable(targetPath)).toMatchObject({ offset: 0x200 });
+    fs.writeFileSync(targetPath, Buffer.from('not a pe file'));
+    expect(() => readPeCertTable(targetPath)).toThrow(/not a PE file/);
+  });
+
+  test('signs a binary end-to-end: upload with auth headers, download, replace', async () => {
+    const result = await signFile(targetPath);
+
+    expect(result).toBe(true);
+    expect(readPeCertTable(targetPath)).not.toBeNull();
+    expect(server.requests).toEqual([
+      'POST /api/sign',
+      'GET /api/download/target.exe',
+    ]);
+    // The multipart upload must contain the actual binary content.
+    expect(server.lastUploadBody?.includes(Buffer.from(PE_BODY_MARKER))).toBe(true);
+    expect(fs.existsSync(`${targetPath}.ydsign.tmp`)).toBe(false);
+  });
+
+  test.each([
+    ['service root', ''],
+    ['full /api/sign endpoint', '/api/sign'],
+    ['manual upload page', '/sign.html'],
+    ['trailing slash', '/'],
+  ])('accepts the %s form of YD_SIGN_SERVICE_URL', async (_label, suffix) => {
+    process.env.YD_SIGN_SERVICE_URL = `${server.baseUrl}${suffix}`;
+
+    const result = await signFile(targetPath);
+
+    expect(result).toBe(true);
+    expect(readPeCertTable(targetPath)).not.toBeNull();
+    expect(server.requests[0]).toBe('POST /api/sign');
+  });
+
+  test('rejects with the service error when credentials are wrong', async () => {
+    process.env.YD_SIGN_APP_SECRET = 'wrong-secret';
+    const before = fs.readFileSync(targetPath);
+
+    await expect(signFile(targetPath)).rejects.toThrow(/HTTP 401/);
+    expect(fs.readFileSync(targetPath).equals(before)).toBe(true);
+  });
+
+  test('skips when any credential (incl. service URL) is missing and leaves the file untouched', async () => {
+    const before = fs.readFileSync(targetPath);
+
+    for (const key of SIGN_ENV_KEYS) {
+      const saved = process.env[key];
+      delete process.env[key];
+
+      const result = await signFile(targetPath);
+
+      expect(result, `expected skip when ${key} is missing`).toBe(false);
+      process.env[key] = saved;
+    }
+
+    expect(fs.readFileSync(targetPath).equals(before)).toBe(true);
+    expect(server.requests).toHaveLength(0);
+  });
+
+  test('skips files that already carry a signature without contacting the service', async () => {
+    fs.writeFileSync(targetPath, buildMinimalPe({ signed: true }));
+
+    const result = await signFile(targetPath);
+
+    expect(result).toBe(false);
+    expect(server.requests).toHaveLength(0);
+  });
+
+  test('keeps the original file intact when the service fails', async () => {
+    server.mode = 'sign-500';
+    const before = fs.readFileSync(targetPath);
+
+    await expect(signFile(targetPath)).rejects.toThrow(/HTTP 500/);
+    expect(fs.readFileSync(targetPath).equals(before)).toBe(true);
+    expect(fs.existsSync(`${targetPath}.ydsign.tmp`)).toBe(false);
+  });
+
+  test('loadDotEnv fills missing vars from a .env file without overriding process.env', () => {
+    const envPath = path.join(workDir, '.env');
+    fs.writeFileSync(envPath, [
+      '# signing credentials',
+      'YD_SIGN_APP_KEY="from-dotenv-key"',
+      "YD_SIGN_APP_SECRET='from-dotenv-secret'",
+      'export YD_SIGN_USERNAME=dotenv-bot',
+      'MALFORMED LINE IGNORED',
+    ].join('\n'));
+
+    delete process.env.YD_SIGN_APP_KEY;
+    delete process.env.YD_SIGN_APP_SECRET;
+    process.env.YD_SIGN_USERNAME = 'env-wins';
+
+    loadDotEnv(envPath);
+
+    expect(process.env.YD_SIGN_APP_KEY).toBe('from-dotenv-key');
+    expect(process.env.YD_SIGN_APP_SECRET).toBe('from-dotenv-secret');
+    expect(process.env.YD_SIGN_USERNAME).toBe('env-wins');
+  });
+});


### PR DESCRIPTION
electron-builder only signed the NSIS installer shell, leaving the inner LobsterAI.exe unsigned. Security software freezes on the unsigned exe during first execution, hanging installs in the field. win-sign.cjs now signs every Windows binary (app exe, uninstaller, installer) via the internal Youdao signing service, with credentials sourced from env or .env and a warn-and-skip fallback for local dev builds.
