### PR TITLE
fix(openclaw): terminate critical tool loops

### DIFF
--- a/scripts/apply-openclaw-patches.cjs
+++ b/scripts/apply-openclaw-patches.cjs
@@ -63,6 +63,46 @@ if (patchFiles.length === 0) {
 console.log(`[apply-openclaw-patches] Applying patches for openclaw ${openclawVersion} (${patchFiles.length} file(s))`);
 
 const strongPatchValidators = {
+  'openclaw-terminate-run-on-critical-tool-loop.patch': [
+    {
+      file: 'packages/agent-core/src/agent.ts',
+      snippets: [
+        'ShouldStopAfterTurnContext',
+        'this.shouldStopAfterTurn = options.shouldStopAfterTurn',
+        'shouldStopAfterTurn: this.shouldStopAfterTurn',
+      ],
+    },
+    {
+      file: 'src/agents/agent-tools.before-tool-call.ts',
+      snippets: [
+        'const terminateRun = deniedReason === "tool-loop"',
+        '...(terminateRun ? { terminate: true } : {})',
+      ],
+    },
+    {
+      file: 'src/agents/sessions/sdk.ts',
+      snippets: [
+        'shouldStopAfterTurn: (context) => {',
+        'details?.deniedReason === "tool-loop"',
+      ],
+    },
+    {
+      file: 'packages/agent-core/src/agent.critical-tool-loop.test.ts',
+      snippets: [
+        'stops a mixed parallel batch after normal sibling tools finish',
+        'expect(providerTurns).toBe(1)',
+        'expect(shouldStopCalls).toBe(1)',
+      ],
+    },
+    {
+      file: 'src/agents/agent-tools.before-tool-call.blocked-result.test.ts',
+      snippets: [
+        'terminates critical tool-loop vetoes',
+        'keeps %s vetoes non-terminating',
+        'expect(result.terminate).toBe(true)',
+      ],
+    },
+  ],
   'openclaw-stop-loop-after-aborted-tool-run.patch': [
     {
       file: 'packages/agent-core/src/agent-loop.ts',

--- a/scripts/patches/v2026.6.1/openclaw-terminate-run-on-critical-tool-loop.patch
+++ b/scripts/patches/v2026.6.1/openclaw-terminate-run-on-critical-tool-loop.patch
@@ -1,0 +1,316 @@
+diff --git a/packages/agent-core/src/agent.critical-tool-loop.test.ts b/packages/agent-core/src/agent.critical-tool-loop.test.ts
+new file mode 100644
+--- /dev/null
++++ b/packages/agent-core/src/agent.critical-tool-loop.test.ts
+@@ -0,0 +1,174 @@
++import { Type } from "typebox";
++import { describe, expect, it } from "vitest";
++import { agentLoop } from "./agent-loop.js";
++import { Agent } from "./agent.js";
++import {
++  type AssistantMessage,
++  createAssistantMessageEventStream,
++  type Message,
++  type Model,
++} from "./llm.js";
++import type { AgentEvent, AgentLoopConfig, AgentTool, StreamFn } from "./types.js";
++
++const model: Model = {
++  id: "test-model",
++  name: "Test Model",
++  api: "test-api",
++  provider: "test-provider",
++  baseUrl: "https://example.test",
++  reasoning: false,
++  input: ["text"],
++  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
++  contextWindow: 1000,
++  maxTokens: 1000,
++};
++
++const config: AgentLoopConfig = {
++  model,
++  convertToLlm: (messages) => messages as Message[],
++};
++
++function makeAssistantMessage(content: AssistantMessage["content"]): AssistantMessage {
++  return {
++    role: "assistant",
++    content,
++    api: model.api,
++    provider: model.provider,
++    model: model.id,
++    usage: {
++      input: 0,
++      output: 0,
++      cacheRead: 0,
++      cacheWrite: 0,
++      totalTokens: 0,
++      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
++    },
++    stopReason: content.some((item) => item.type === "toolCall") ? "toolUse" : "stop",
++    timestamp: 1,
++  };
++}
++
++function createCriticalTool(name: string): AgentTool {
++  return {
++    name,
++    label: name,
++    description: "critical loop veto",
++    parameters: Type.Object({}, { additionalProperties: false }),
++    execute: async () => ({
++      content: [{ type: "text", text: "CRITICAL: tool loop" }],
++      details: {
++        status: "blocked",
++        deniedReason: "tool-loop",
++        reason: "CRITICAL: tool loop",
++      },
++      terminate: true,
++    }),
++  };
++}
++
++function shouldStopOnCriticalToolLoop(context: {
++  toolResults: Array<{ details?: unknown }>;
++}): boolean {
++  return context.toolResults.some((message) => {
++    const details = message.details as { deniedReason?: string } | undefined;
++    return details?.deniedReason === "tool-loop";
++  });
++}
++
++describe("critical tool-loop termination", () => {
++  it("stops a mixed parallel batch after normal sibling tools finish", async () => {
++    const executed: string[] = [];
++    let providerTurns = 0;
++    const streamFn: StreamFn = () => {
++      providerTurns += 1;
++      const stream = createAssistantMessageEventStream();
++      queueMicrotask(() => {
++        const message =
++          providerTurns === 1
++            ? makeAssistantMessage([
++                { type: "toolCall", id: "call-veto", name: "veto_tool", arguments: {} },
++                { type: "toolCall", id: "call-normal", name: "normal_tool", arguments: {} },
++              ])
++            : makeAssistantMessage([{ type: "text", text: "should not reach" }]);
++        stream.push({
++          type: "done",
++          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
++          message,
++        });
++        stream.end();
++      });
++      return stream;
++    };
++    const normalTool: AgentTool = {
++      name: "normal_tool",
++      label: "normal_tool",
++      description: "normal tool",
++      parameters: Type.Object({}, { additionalProperties: false }),
++      execute: async () => {
++        executed.push("normal_tool");
++        return { content: [{ type: "text", text: "ok" }], details: { status: "ok" } };
++      },
++    };
++
++    const stream = agentLoop(
++      [{ role: "user", content: "run", timestamp: 1 }],
++      { systemPrompt: "", messages: [], tools: [createCriticalTool("veto_tool"), normalTool] },
++      { ...config, shouldStopAfterTurn: shouldStopOnCriticalToolLoop },
++      undefined,
++      streamFn,
++    );
++    const events: AgentEvent[] = [];
++    for await (const event of stream) {
++      events.push(event);
++    }
++
++    expect(providerTurns).toBe(1);
++    expect(executed).toEqual(["normal_tool"]);
++    expect(events.filter((event) => event.type === "agent_end")).toHaveLength(1);
++  });
++
++  it("forwards Agent.shouldStopAfterTurn and prevents a second provider turn", async () => {
++    let providerTurns = 0;
++    let shouldStopCalls = 0;
++    const streamFn: StreamFn = () => {
++      providerTurns += 1;
++      const stream = createAssistantMessageEventStream();
++      queueMicrotask(() => {
++        const message =
++          providerTurns === 1
++            ? makeAssistantMessage([
++                { type: "toolCall", id: "call-loop", name: "loop_tool", arguments: {} },
++              ])
++            : makeAssistantMessage([{ type: "text", text: "should not reach" }]);
++        stream.push({
++          type: "done",
++          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
++          message,
++        });
++        stream.end();
++      });
++      return stream;
++    };
++    const agent = new Agent({
++      initialState: { model, tools: [createCriticalTool("loop_tool")] },
++      streamFn,
++      shouldStopAfterTurn: (context) => {
++        shouldStopCalls += 1;
++        return shouldStopOnCriticalToolLoop(context);
++      },
++    });
++    let agentEndCount = 0;
++    agent.subscribe((event) => {
++      if (event.type === "agent_end") {
++        agentEndCount += 1;
++      }
++    });
++
++    await agent.prompt("trigger");
++    await agent.waitForIdle();
++
++    expect(providerTurns).toBe(1);
++    expect(shouldStopCalls).toBe(1);
++    expect(agentEndCount).toBe(1);
++  });
++});
+diff --git a/packages/agent-core/src/agent.ts b/packages/agent-core/src/agent.ts
+--- a/packages/agent-core/src/agent.ts
++++ b/packages/agent-core/src/agent.ts
+@@ -22,6 +22,7 @@ import type {
+   BeforeToolCallContext,
+   BeforeToolCallResult,
+   QueueMode,
++  ShouldStopAfterTurnContext,
+   StreamFn,
+   ToolExecutionMode,
+ } from "./types.js";
+@@ -128,6 +129,8 @@ export interface AgentOptions {
+     context: AfterToolCallContext,
+     signal?: AbortSignal,
+   ) => Promise<AfterToolCallResult | undefined>;
++  /** Hook that may stop the agent loop after a turn completes. */
++  shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
+   /** Hook that may update model, reasoning, or context after a turn. */
+   prepareNextTurn?: (
+     signal?: AbortSignal,
+@@ -223,6 +226,7 @@ export class Agent {
+     context: AfterToolCallContext,
+     signal?: AbortSignal,
+   ) => Promise<AfterToolCallResult | undefined>;
++  public shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
+   public prepareNextTurn?: (
+     signal?: AbortSignal,
+   ) => Promise<AgentLoopTurnUpdate | undefined> | AgentLoopTurnUpdate | undefined;
+@@ -249,6 +253,7 @@ export class Agent {
+     this.onResponse = options.onResponse;
+     this.beforeToolCall = options.beforeToolCall;
+     this.afterToolCall = options.afterToolCall;
++    this.shouldStopAfterTurn = options.shouldStopAfterTurn;
+     this.prepareNextTurn = options.prepareNextTurn;
+     this.steeringQueue = new PendingMessageQueue(options.steeringMode ?? "one-at-a-time");
+     this.followUpQueue = new PendingMessageQueue(options.followUpMode ?? "one-at-a-time");
+@@ -480,6 +485,7 @@ export class Agent {
+       toolExecution: this.toolExecution,
+       beforeToolCall: this.beforeToolCall,
+       afterToolCall: this.afterToolCall,
++      shouldStopAfterTurn: this.shouldStopAfterTurn,
+       prepareNextTurn: this.prepareNextTurn
+         ? async () => await this.prepareNextTurn?.(this.signal)
+         : undefined,
+diff --git a/src/agents/agent-tools.before-tool-call.blocked-result.test.ts b/src/agents/agent-tools.before-tool-call.blocked-result.test.ts
+new file mode 100644
+--- /dev/null
++++ b/src/agents/agent-tools.before-tool-call.blocked-result.test.ts
+@@ -0,0 +1,34 @@
++import { describe, expect, it } from "vitest";
++import { buildBlockedToolResult } from "./agent-tools.before-tool-call.js";
++
++describe("buildBlockedToolResult", () => {
++  it("terminates critical tool-loop vetoes", () => {
++    const result = buildBlockedToolResult({
++      reason: "CRITICAL: repeated tool call detected",
++      deniedReason: "tool-loop",
++    });
++
++    expect(result.details).toMatchObject({
++      status: "blocked",
++      deniedReason: "tool-loop",
++    });
++    expect(result.terminate).toBe(true);
++  });
++
++  it.each(["plugin-before-tool-call", "plugin-approval"] as const)(
++    "keeps %s vetoes non-terminating",
++    (deniedReason) => {
++      const result = buildBlockedToolResult({ reason: "denied", deniedReason });
++
++      expect(result.details.deniedReason).toBe(deniedReason);
++      expect(result.terminate).toBeUndefined();
++    },
++  );
++
++  it("keeps the default plugin veto non-terminating", () => {
++    const result = buildBlockedToolResult({ reason: "denied" });
++
++    expect(result.details.deniedReason).toBe("plugin-before-tool-call");
++    expect(result.terminate).toBeUndefined();
++  });
++});
+diff --git a/src/agents/agent-tools.before-tool-call.e2e.test.ts b/src/agents/agent-tools.before-tool-call.e2e.test.ts
+--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
++++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
+@@ -220,4 +220,5 @@ describe("before_tool_call loop detection behavior", () => {
+     expect(details.status).toBe("blocked");
+     expect(details.deniedReason).toBe("tool-loop");
+     expect(String(details.reason)).toContain(expectedReason);
++    expect(record.terminate).toBe(true);
+   }
+diff --git a/src/agents/agent-tools.before-tool-call.ts b/src/agents/agent-tools.before-tool-call.ts
+--- a/src/agents/agent-tools.before-tool-call.ts
++++ b/src/agents/agent-tools.before-tool-call.ts
+@@ -678,12 +678,18 @@ export function buildBlockedToolResult(params: {
+   reason: string;
+   deniedReason?: HookBlockedReason;
+ }) {
++  const deniedReason = params.deniedReason ?? "plugin-before-tool-call";
++  // Critical loop vetoes must end the run instead of inviting another provider
++  // turn. A post-turn hook separately covers mixed batches where a successful
++  // sibling prevents immediate batch termination.
++  const terminateRun = deniedReason === "tool-loop";
+   return {
+     content: [{ type: "text" as const, text: params.reason }],
+     details: {
+       status: "blocked",
+-      deniedReason: params.deniedReason ?? "plugin-before-tool-call",
++      deniedReason,
+       reason: params.reason,
+     },
++    ...(terminateRun ? { terminate: true } : {}),
+   };
+ }
+diff --git a/src/agents/sessions/sdk.ts b/src/agents/sessions/sdk.ts
+--- a/src/agents/sessions/sdk.ts
++++ b/src/agents/sessions/sdk.ts
+@@ -390,6 +390,18 @@ export async function createAgentSession(
+           }),
+       );
+     },
++    shouldStopAfterTurn: (context) => {
++      // Agent-core only ends a tool batch immediately when every result has
++      // terminate: true. A post-turn check also covers a critical loop veto
++      // emitted beside a normal result in a mixed parallel batch.
++      for (const message of context.toolResults) {
++        const details = message.details as { deniedReason?: string } | undefined;
++        if (details?.deniedReason === "tool-loop") {
++          return true;
++        }
++      }
++      return false;
++    },
+     sessionId: sessionManager.getSessionId(),
+     transformContext: async (messages) => {
+       const runner = extensionRunnerRef.current;

--- a/specs/bugfixes/openclaw-critical-tool-loop-termination/2026-07-14-openclaw-critical-tool-loop-termination-design.md
+++ b/specs/bugfixes/openclaw-critical-tool-loop-termination/2026-07-14-openclaw-critical-tool-loop-termination-design.md
@@ -1,0 +1,155 @@
+# OpenClaw Critical 工具循环终止 Agent Run 修复设计
+
+## 1. 问题与根因
+
+LobsterAI 当前固定使用 OpenClaw `v2026.6.1`。该版本已经具备原生工具循环检测：当重复调用达到 critical 阈值时，`before_tool_call` 返回 `deniedReason: "tool-loop"`，并记录类似 `Session execution blocked` 的日志。
+
+问题在于，这个 critical 分支只阻止当前工具调用。被阻止的调用仍以普通 tool result 返回给模型，Agent run 本身没有进入终止态。模型可以在下一轮继续调用工具，再次触发相同 veto，造成 provider request 和 token 消耗持续增长。因此，日志宣称 session 已 blocked，而实际只 blocked 了一次 tool call。
+
+直接原因可以概括为：
+
+```text
+critical loop detected
+  -> current tool call vetoed
+  -> veto returned as an ordinary tool result
+  -> Agent starts another provider turn
+  -> model calls a tool again
+  -> repeat
+```
+
+本修复不调整 OpenClaw 的 loop detector、阈值、工具签名或 outcome hash。正常任务需要依次 `web_fetch` 100 个不同网址时，是否构成 loop 仍完全由 OpenClaw 原生检测器判断；只有原生检测器已经给出 critical `tool-loop` veto 后，本修复才负责终止当前 run。
+
+## 2. 用户场景
+
+### 场景 1：单个工具触发 critical loop
+
+- **Given** OpenClaw 原生循环检测已判定某次工具调用为 critical
+- **When** before-tool-call hook 返回 `deniedReason: "tool-loop"`
+- **Then** 当前 tool result 必须携带 run 终止标记
+- **And** 当前 turn 结束后不得再次请求模型
+
+### 场景 2：混合并行工具批次
+
+- **Given** 同一 assistant message 同时发起一个 critical loop 工具和一个正常工具
+- **When** 两个工具并行执行
+- **Then** 正常工具允许完成并记录结果
+- **And** 整个 turn 完成后终止 Agent run
+- **And** 不得因为正常结果没有 `terminate` 而进入下一轮模型请求
+
+### 场景 3：普通插件 veto
+
+- **Given** 工具被 `plugin-before-tool-call` 或 `plugin-approval` 拒绝
+- **When** 该拒绝不是 OpenClaw critical loop
+- **Then** 继续保持原有非终止语义
+- **And** 模型仍可改用其他工具或方案完成任务
+
+### 场景 4：合法的大批量抓取
+
+- **Given** 用户任务确实需要访问大量不同网址
+- **When** OpenClaw 原生 detector 没有输出 critical `tool-loop`
+- **Then** 本修复不参与判断，也不限制工具调用总数
+
+## 3. 功能需求
+
+1. 只有 `deniedReason === "tool-loop"` 的 blocked result 才增加 `terminate: true`。
+2. `plugin-before-tool-call`、`plugin-approval` 及默认 veto 不增加 `terminate`。
+3. 单工具和全部结果均为 critical veto 的批次，应通过 agent-core 现有 `shouldTerminateToolBatch()` 结束。
+4. 混合批次中，只要任一已完成 tool result 是 critical `tool-loop` veto，就应在 turn 边界结束，不再发起 provider request。
+5. 混合批次中的正常 sibling 工具必须完成，不能通过全局 abort 粗暴中断。
+6. Agent wrapper 必须把 agent-core 已有的 `shouldStopAfterTurn` 能力暴露并转发给 loop config。
+7. 本修复不得修改原生循环检测算法、阈值或 `web_fetch` 的业务行为。
+8. 本修复不得替代用户主动停止场景的 `openclaw-stop-loop-after-aborted-tool-run.patch`；两者分别处理 critical loop 和 abort boundary。
+
+## 4. 实现方案
+
+新增版本补丁：
+
+```text
+scripts/patches/v2026.6.1/openclaw-terminate-run-on-critical-tool-loop.patch
+```
+
+补丁采用两层终止机制：
+
+1. 结果级终止
+   - `buildBlockedToolResult()` 先归一化 `deniedReason`。
+   - critical `tool-loop` veto 返回 `terminate: true`。
+   - 该层覆盖单工具和全部结果均终止的批次。
+2. turn 级终止
+   - `AgentOptions` 和 `Agent` 暴露并转发 agent-core 已存在的 `shouldStopAfterTurn` hook。
+   - `createAgentSession()` 在 turn 完成后检查所有 tool result；任一结果的 `details.deniedReason` 为 `tool-loop` 即返回 `true`。
+   - 该层覆盖“critical veto + 正常结果”的混合并行批次。
+
+不直接把 `shouldTerminateToolBatch()` 从 `every()` 改为 `some()`，因为 `terminate` 是通用 agent-core 结果字段，改变其全局批处理语义可能影响其他调用方。不在 detector 或 before-tool-call hook 中调用 `AbortController.abort()`，因为这会把安全熔断混同为用户取消，并可能中断同批次的正常工具结果及事件收尾。
+
+LobsterAI 同时增加：
+
+- patch 强校验，避免应用状态被误判；
+- patch 内容契约测试，固定双层终止和非 critical veto 的兼容边界；
+- OpenClaw 行为测试，断言混合批次的正常 sibling 完成、provider 仅调用一次且只产生一个 `agent_end`。
+
+## 5. 边界与兼容性
+
+| 场景 | 预期行为 |
+|---|---|
+| 单个 critical loop veto | 当前 turn 收尾后结束 run，不再调用模型 |
+| 同批次全部为 critical loop veto | 通过结果级 `terminate` 结束 |
+| critical veto 与正常工具混合 | 正常工具完成；turn 级 hook 随后结束 run |
+| 普通插件策略拒绝 | 不终止，保留模型恢复能力 |
+| 100 个不同 URL 的合法抓取 | detector 未判 critical 时不受本补丁限制 |
+| 用户主动 `/stop` | 继续由 abort boundary 补丁负责 |
+| 已排队 steering/follow-up | 不注入已判定异常的旧 run；队列本身不在本补丁中清空 |
+
+本补丁结束的是当前 Agent run，不删除 session，也不改变已有 transcript。用户之后仍可在同一会话发起新的正常任务。
+
+## 6. 上游依据与补丁生命周期
+
+上游关联项（核查日期：2026-07-14）：
+
+- Issue [#106231](https://github.com/openclaw/openclaw/issues/106231)：`Loop detection blocks exec but does not terminate stuck agent run`，当前为 open。
+- 参考 PR [#106297](https://github.com/openclaw/openclaw/pull/106297)：`fix(agents): terminate agent run on critical loop detection instead of continuing indefinitely`，当前为 open、未合并，核查 head SHA 为 `59977a726886274d04a036be59c7392972d67db9`。
+
+本补丁参考 #106297 的双层方案并适配 OpenClaw `v2026.6.1`，但不能因为 PR 已存在就认定固定版本已经修复。未来升级 OpenClaw 时，应根据目标稳定 tag 的实际代码决定是否去除补丁：
+
+1. 确认 #106297 已合并且目标稳定 tag 包含其合并提交，或目标 tag 已包含语义等价实现；仅 PR 关闭、issue 关闭或 main 分支存在代码都不足以作为移除依据。
+2. 核对目标代码同时覆盖结果级终止和混合批次的 turn 级终止，不能只确认其中一层。
+3. 在目标 tag 上验证：单 critical veto、全部 veto、混合并行批次、普通插件 veto、steering/follow-up 队列和用户主动 stop。
+4. 确认第一次 critical loop 后不再出现同一 run 的后续 provider request，并确认正常 sibling 工具和事件生命周期完整收尾。
+5. 验证通过后，不要把本 patch 迁移到新版本目录；删除或调整 `criticalToolLoopTerminationPatch.test.ts`，并移除 `apply-openclaw-patches.cjs` 中对应强校验。
+
+若上游最终采用与 #106297 不同的实现，应按上述行为标准做语义审计，而不是机械地保留或删除补丁。
+
+## 7. 验收标准
+
+1. 新 patch 能与 LobsterAI 其余 `v2026.6.1` patches 一起从干净 tag 顺序应用。
+2. critical `tool-loop` blocked result 包含 `terminate: true`。
+3. 普通插件 veto 的 `terminate` 仍为 `undefined`。
+4. 混合并行批次中正常 sibling 工具执行完成。
+5. 单 critical 和混合批次的 provider turn 均不超过 1 次，且只发出一次 `agent_end`。
+6. OpenClaw 原生 loop detection E2E 中所有 critical 分支均验证 `terminate: true`。
+7. LobsterAI patch 内容测试和强校验通过。
+8. 现场日志中首次 critical `Session execution blocked` 后，不再出现同一 run 的下一次 provider request。
+
+## 8. 验证计划
+
+OpenClaw focused tests：
+
+```bash
+node scripts/run-vitest.mjs \
+  packages/agent-core/src/agent.critical-tool-loop.test.ts \
+  src/agents/agent-tools.before-tool-call.blocked-result.test.ts
+
+node scripts/run-vitest.mjs run \
+  --config test/vitest/vitest.e2e.config.ts \
+  src/agents/agent-tools.before-tool-call.e2e.test.ts \
+  --testNamePattern "loop detection behavior"
+```
+
+LobsterAI 验证：
+
+```bash
+npm run openclaw:patch
+npm test -- src/main/libs/openclawPatches/criticalToolLoopTerminationPatch.test.ts
+npm run compile:electron
+```
+
+手工回放时，使用可控的 fake tool 或测试模型反复请求同一参数并返回相同无进展结果；观察 critical 日志后的 provider request 次数。不要使用真实第三方 URL 批量请求作为回归手段，以免产生额外费用。

--- a/src/main/libs/openclawPatches/criticalToolLoopTerminationPatch.test.ts
+++ b/src/main/libs/openclawPatches/criticalToolLoopTerminationPatch.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from 'vitest';
+
+import { expectPatchContains } from './patchTestUtils';
+
+describe('OpenClaw critical tool-loop termination patch', () => {
+  test('backports the dual-layer termination from upstream #106297', () => {
+    expectPatchContains('openclaw-terminate-run-on-critical-tool-loop.patch', [
+      'const terminateRun = deniedReason === "tool-loop";',
+      '...(terminateRun ? { terminate: true } : {})',
+      'shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext)',
+      'shouldStopAfterTurn: this.shouldStopAfterTurn',
+      'details?.deniedReason === "tool-loop"',
+      'stops a mixed parallel batch after normal sibling tools finish',
+      'expect(providerTurns).toBe(1)',
+      'keeps %s vetoes non-terminating',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- backport a dual-layer OpenClaw v2026.6.1 fix so a critical `tool-loop` veto terminates the current Agent run
- preserve normal plugin veto behavior and allow normal sibling tools in mixed parallel batches to finish before stopping
- add strong patch validation, focused regression coverage, and a bugfix design spec
- document the upstream reference PR and the audit/removal procedure for a future OpenClaw upgrade

## Runtime behavior

This changes the bundled OpenClaw runtime source during `openclaw:patch`. It does not change Electron IPC, storage, renderer UI, or loop-detection thresholds. The patch only terminates a run after OpenClaw's native detector has already emitted a critical `deniedReason: "tool-loop"` result.

Upstream references:

- https://github.com/openclaw/openclaw/issues/106231
- https://github.com/openclaw/openclaw/pull/106297

## Verification

- `npm run openclaw:patch` ? all 23 v2026.6.1 patches applied from a clean baseline
- `npm test -- src/main/libs/openclawPatches/criticalToolLoopTerminationPatch.test.ts`
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/libs/openclawPatches/criticalToolLoopTerminationPatch.test.ts`
- `npm run compile:electron`
- OpenClaw focused tests: 6 passed
- OpenClaw loop-detection E2E focus: 22 passed, 28 skipped
- OpenClaw formatting and narrow oxlint: passed
- `pnpm tsgo:test:packages`: passed

Known verification gaps:

- `pnpm tsgo:core` reports two pre-existing unused-symbol errors in patched files outside this change
- `pnpm tsgo:test:src` exceeded the five-minute local timeout
- the full runtime bundle was not rebuilt and no live provider replay was run
