### PR TITLE
feat(providers): add GPT-5.6 and Grok 4.5 default models

### DIFF
--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -3,6 +3,8 @@ import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { ProviderName } from '../../shared/providers';
+
 vi.mock('electron', () => ({
   app: {
     isPackaged: false,
@@ -1388,6 +1390,35 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(selection.providerConfig.api).toBe(OpenClawApi.OpenAIResponses);
     expect(selection.providerConfig.auth).toBe(AuthType.ApiKey);
     expect(selection.providerConfig.apiKey).toBe('${LOBSTER_APIKEY_XAI}');
+  });
+
+  test.each([
+    [ProviderName.OpenAI, 'gpt-5.6-sol', 'https://api.openai.com/v1', 1_050_000],
+    [ProviderName.OpenAI, 'gpt-5.6-terra', 'https://api.openai.com/v1', 1_050_000],
+    [ProviderName.OpenAI, 'gpt-5.6-luna', 'https://api.openai.com/v1', 1_050_000],
+    [ProviderName.Xai, 'grok-4.5', 'https://api.x.ai/v1', 500_000],
+  ])('writes official context metadata for %s/%s', async (providerName, modelId, baseURL, contextWindow) => {
+    const { buildProviderSelection } = await import('./openclawConfigSync');
+
+    const selection = buildProviderSelection({
+      apiKey: 'test-key',
+      baseURL,
+      modelId,
+      apiType: 'openai',
+      providerName,
+      authType: 'apikey',
+      codingPlanEnabled: false,
+      supportsImage: false,
+      supportsThinking: false,
+      modelName: modelId,
+    });
+
+    expect(selection.providerConfig.models[0]).toMatchObject({
+      id: modelId,
+      input: ['text', 'image'],
+      reasoning: true,
+      contextWindow,
+    });
   });
 
   test('keeps MiniMax API key mode on the standard MiniMax provider', async () => {

--- a/src/renderer/services/config.test.ts
+++ b/src/renderer/services/config.test.ts
@@ -349,6 +349,119 @@ describe('configService provider migrations', () => {
     });
   });
 
+  test('keeps an equivalent user GPT-5.6 Sol model while adding the other GPT-5.6 defaults', async () => {
+    const storedConfig: AppConfig = {
+      ...defaultConfig,
+      providerModelMigrationVersions: {
+        [ProviderName.OpenAI]: 1,
+      },
+      providers: {
+        ...defaultConfig.providers,
+        [ProviderName.OpenAI]: {
+          ...defaultConfig.providers![ProviderName.OpenAI],
+          enabled: true,
+          apiKey: 'sk-openai',
+          models: [
+            {
+              id: 'gpt5.6sol',
+              name: 'My GPT 5.6 Sol',
+              supportsImage: false,
+              customParams: { service_tier: 'priority' },
+            },
+            { id: 'gpt-5.5', name: 'GPT-5.5', supportsImage: true, supportsThinking: true },
+          ],
+        },
+      },
+    };
+    const { configService, storeData } = await loadConfigServiceWithStoredConfig(storedConfig);
+
+    await configService.init();
+
+    const savedConfig = storeData[CONFIG_KEYS.APP_CONFIG] as AppConfig;
+    const models = savedConfig.providers?.[ProviderName.OpenAI].models ?? [];
+    const solModels = models.filter(
+      model => model.id.toLowerCase().replace(/[^a-z0-9]/g, '') === 'gpt56sol',
+    );
+    expect(solModels).toHaveLength(1);
+    expect(solModels[0]).toMatchObject({
+      id: 'gpt5.6sol',
+      name: 'My GPT 5.6 Sol',
+      supportsImage: true,
+      supportsThinking: true,
+      contextWindow: 1_050_000,
+      customParams: { service_tier: 'priority' },
+    });
+    expect(models.map(model => model.id)).toEqual([
+      'gpt5.6sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.5',
+    ]);
+    expect(savedConfig.providerModelMigrationVersions?.[ProviderName.OpenAI]).toBe(2);
+  });
+
+  test('keeps an equivalent user Grok 4.5 model without adding the canonical duplicate', async () => {
+    const storedConfig: AppConfig = {
+      ...defaultConfig,
+      providerModelMigrationVersions: undefined,
+      providers: {
+        ...defaultConfig.providers,
+        [ProviderName.Xai]: {
+          ...defaultConfig.providers![ProviderName.Xai],
+          enabled: true,
+          apiKey: 'xai-key',
+          models: [
+            { id: 'grok4.5', name: 'My Grok 4.5', supportsImage: false },
+            { id: 'grok-4.3', name: 'Grok 4.3', supportsImage: true, supportsThinking: true, contextWindow: 1_000_000 },
+          ],
+        },
+      },
+    };
+    const { configService, storeData } = await loadConfigServiceWithStoredConfig(storedConfig);
+
+    await configService.init();
+
+    const savedConfig = storeData[CONFIG_KEYS.APP_CONFIG] as AppConfig;
+    const models = savedConfig.providers?.[ProviderName.Xai].models ?? [];
+    expect(models.filter(
+      model => model.id.toLowerCase().replace(/[^a-z0-9]/g, '') === 'grok45',
+    )).toEqual([
+      {
+        id: 'grok4.5',
+        name: 'My Grok 4.5',
+        supportsImage: true,
+        supportsThinking: true,
+        contextWindow: 500_000,
+      },
+    ]);
+    expect(savedConfig.providerModelMigrationVersions?.[ProviderName.Xai]).toBe(1);
+  });
+
+  test('does not re-inject a deleted GPT-5.6 model after migration v2 is applied', async () => {
+    const storedConfig: AppConfig = {
+      ...defaultConfig,
+      providerModelMigrationVersions: {
+        [ProviderName.OpenAI]: 2,
+      },
+      providers: {
+        ...defaultConfig.providers,
+        [ProviderName.OpenAI]: {
+          ...defaultConfig.providers![ProviderName.OpenAI],
+          models: defaultConfig.providers![ProviderName.OpenAI].models?.filter(
+            model => model.id !== 'gpt-5.6-terra',
+          ),
+        },
+      },
+    };
+    const { configService, storeData } = await loadConfigServiceWithStoredConfig(storedConfig);
+
+    await configService.init();
+
+    const savedConfig = storeData[CONFIG_KEYS.APP_CONFIG] as AppConfig;
+    expect(savedConfig.providers?.[ProviderName.OpenAI].models?.map(model => model.id)).not.toContain('gpt-5.6-terra');
+    expect(savedConfig.providerModelMigrationVersions?.[ProviderName.OpenAI]).toBe(2);
+  });
+
   test.each(addedProviderMigrationCases)(
     'does not re-inject a deleted $providerName model after migration is applied',
     async ({ providerName, deletedModelId }) => {

--- a/src/renderer/services/config.ts
+++ b/src/renderer/services/config.ts
@@ -16,6 +16,21 @@ import { localStore } from './store';
 
 type ProviderModel = NonNullable<ProviderConfig['models']>[number];
 
+const getProviderModelIdentity = (modelId: string): string =>
+  modelId.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+
+const getCanonicalProviderModelId = (providerKey: string, modelId: string): string => {
+  const identity = getProviderModelIdentity(modelId);
+  if (!identity) {
+    return modelId;
+  }
+
+  const canonicalModel = ProviderRegistry.get(providerKey)?.defaultModels.find(
+    model => getProviderModelIdentity(model.id) === identity,
+  );
+  return canonicalModel?.id ?? modelId;
+};
+
 const getFixedProviderApiFormat = (providerKey: string): ApiFormat | null => {
   const def = ProviderRegistry.get(providerKey);
   if (def && !def.switchableBaseUrls) {
@@ -70,21 +85,22 @@ const normalizeProviderModels = (
   providerKey: string,
   models: ProviderConfig['models'],
 ): ProviderConfig['models'] => models?.map(model => {
+  const canonicalModelId = getCanonicalProviderModelId(providerKey, model.id);
   const contextWindow = ProviderRegistry.resolveModelContextWindow(
     providerKey,
-    model.id,
+    canonicalModelId,
     model.contextWindow,
   );
   const supportsThinking = ProviderRegistry.resolveModelSupportsThinking(
     providerKey,
-    model.id,
+    canonicalModelId,
     model.supportsThinking,
   );
   return {
     ...model,
     supportsImage: ProviderRegistry.resolveModelSupportsImage(
       providerKey,
-      model.id,
+      canonicalModelId,
       model.supportsImage,
     ),
     ...(supportsThinking ? { supportsThinking } : {}),
@@ -325,6 +341,31 @@ const ADDED_PROVIDER_MODELS: Record<string, { models: ProviderModel[]; position:
   },
 };
 
+// Model batches added after the original v1 migration. Keep these separate so
+// upgrading does not re-add older defaults that a user intentionally removed.
+const RECENT_PROVIDER_MODEL_MIGRATIONS: Record<string, {
+  version: number;
+  models: ProviderModel[];
+  position: 'start' | 'end';
+}> = {
+  [ProviderName.OpenAI]: {
+    version: 2,
+    models: [
+      { id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', supportsImage: true, supportsThinking: true, contextWindow: 1_050_000 },
+      { id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra', supportsImage: true, supportsThinking: true, contextWindow: 1_050_000 },
+      { id: 'gpt-5.6-luna', name: 'GPT-5.6 Luna', supportsImage: true, supportsThinking: true, contextWindow: 1_050_000 },
+    ],
+    position: 'start',
+  },
+  [ProviderName.Xai]: {
+    version: 1,
+    models: [
+      { id: 'grok-4.5', name: 'Grok 4.5', supportsImage: true, supportsThinking: true, contextWindow: 500_000 },
+    ],
+    position: 'start',
+  },
+};
+
 const markCurrentProviderModelMigrationsApplied = (
   versions: AppConfig['providerModelMigrationVersions'],
 ): NonNullable<AppConfig['providerModelMigrationVersions']> => {
@@ -335,16 +376,25 @@ const markCurrentProviderModelMigrationsApplied = (
       ADDED_PROVIDER_MODELS_MIGRATION_VERSION,
     );
   });
+  Object.entries(RECENT_PROVIDER_MODEL_MIGRATIONS).forEach(([providerKey, migration]) => {
+    nextVersions[providerKey] = Math.max(
+      nextVersions[providerKey] ?? 0,
+      migration.version,
+    );
+  });
   return nextVersions;
 };
 
 const getNewlyAppliedProviderModelMigrations = (
   previousVersions: AppConfig['providerModelMigrationVersions'],
   nextVersions: AppConfig['providerModelMigrationVersions'],
-): string[] => Object.keys(ADDED_PROVIDER_MODELS).filter(
-  providerKey => (previousVersions?.[providerKey] ?? 0) < ADDED_PROVIDER_MODELS_MIGRATION_VERSION
-    && (nextVersions?.[providerKey] ?? 0) >= ADDED_PROVIDER_MODELS_MIGRATION_VERSION
-);
+): string[] => {
+  const latestVersions = markCurrentProviderModelMigrationsApplied(undefined);
+  return Object.entries(latestVersions)
+    .filter(([providerKey, version]) => (previousVersions?.[providerKey] ?? 0) < version
+      && (nextVersions?.[providerKey] ?? 0) >= version)
+    .map(([providerKey]) => providerKey);
+};
 
 const PROVIDER_MODEL_CONTEXT_WINDOW_OVERRIDES: Record<string, Record<string, number>> = {
   [ProviderName.Minimax]: {
@@ -401,10 +451,12 @@ const alignProviderModelOrder = (
     return models;
   }
 
-  const defaultOrder = new Map(defaultModels.map((model, index) => [model.id, index]));
+  const defaultOrder = new Map(
+    defaultModels.map((model, index) => [getProviderModelIdentity(model.id), index]),
+  );
   return [...models].sort((a, b) => {
-    const aOrder = defaultOrder.get(a.id);
-    const bOrder = defaultOrder.get(b.id);
+    const aOrder = defaultOrder.get(getProviderModelIdentity(a.id));
+    const bOrder = defaultOrder.get(getProviderModelIdentity(b.id));
     if (aOrder === undefined && bOrder === undefined) return 0;
     if (aOrder === undefined) return 1;
     if (bOrder === undefined) return -1;
@@ -446,14 +498,19 @@ const hydrateStoredConfig = (storedConfig: AppConfig): AppConfig => {
             // Inject added models (for existing users who already have saved config)
             const addedConfig = ADDED_PROVIDER_MODELS[providerKey];
             const existingIds = new Set(
-              (mergedProvider.models as Array<{ id: string }> | undefined)?.map(model => model.id) ?? []
+              (mergedProvider.models as Array<{ id: string }> | undefined)
+                ?.map(model => getProviderModelIdentity(model.id)) ?? []
             );
-            const hasAnyAddedModel = addedConfig?.models.some(model => existingIds.has(model.id)) ?? false;
+            const hasAnyAddedModel = addedConfig?.models.some(
+              model => existingIds.has(getProviderModelIdentity(model.id)),
+            ) ?? false;
             const hasAppliedAddedModelsMigration =
               (providerModelMigrationVersions[providerKey] ?? 0) >= ADDED_PROVIDER_MODELS_MIGRATION_VERSION
               || hasAnyAddedModel;
             if (addedConfig && mergedProvider.models && !hasAppliedAddedModelsMigration) {
-              const newModels = addedConfig.models.filter(m => !existingIds.has(m.id));
+              const newModels = addedConfig.models.filter(
+                model => !existingIds.has(getProviderModelIdentity(model.id)),
+              );
               if (newModels.length > 0) {
                 mergedProvider.models = addedConfig.position === 'start'
                   ? [...newModels, ...mergedProvider.models]
@@ -461,7 +518,32 @@ const hydrateStoredConfig = (storedConfig: AppConfig): AppConfig => {
               }
             }
             if (addedConfig && mergedProvider.models) {
-              providerModelMigrationVersions[providerKey] = ADDED_PROVIDER_MODELS_MIGRATION_VERSION;
+              providerModelMigrationVersions[providerKey] = Math.max(
+                providerModelMigrationVersions[providerKey] ?? 0,
+                ADDED_PROVIDER_MODELS_MIGRATION_VERSION,
+              );
+            }
+            const recentMigration = RECENT_PROVIDER_MODEL_MIGRATIONS[providerKey];
+            const hasAppliedRecentMigration = recentMigration
+              && (providerModelMigrationVersions[providerKey] ?? 0) >= recentMigration.version;
+            if (recentMigration && mergedProvider.models && !hasAppliedRecentMigration) {
+              const recentExistingIds = new Set(
+                (mergedProvider.models as Array<{ id: string }>).map(
+                  model => getProviderModelIdentity(model.id),
+                ),
+              );
+              const newModels = recentMigration.models.filter(
+                model => !recentExistingIds.has(getProviderModelIdentity(model.id)),
+              );
+              if (newModels.length > 0) {
+                mergedProvider.models = recentMigration.position === 'start'
+                  ? [...newModels, ...mergedProvider.models]
+                  : [...mergedProvider.models, ...newModels];
+              }
+              providerModelMigrationVersions[providerKey] = Math.max(
+                providerModelMigrationVersions[providerKey] ?? 0,
+                recentMigration.version,
+              );
             }
             if (mergedProvider.models) {
               mergedProvider.models = applyProviderModelContextWindowOverrides(

--- a/src/shared/providers/constants.test.ts
+++ b/src/shared/providers/constants.test.ts
@@ -67,6 +67,25 @@ describe('ProviderRegistry', () => {
     ]);
   });
 
+  test('OpenAI defaults include the GPT-5.6 family with official context windows', () => {
+    const openai = ProviderRegistry.get(ProviderName.OpenAI);
+    expect(openai?.defaultModels.slice(0, 3)).toEqual([
+      { id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', supportsImage: true, supportsThinking: true, contextWindow: 1_050_000 },
+      { id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra', supportsImage: true, supportsThinking: true, contextWindow: 1_050_000 },
+      { id: 'gpt-5.6-luna', name: 'GPT-5.6 Luna', supportsImage: true, supportsThinking: true, contextWindow: 1_050_000 },
+    ]);
+  });
+
+  test('xAI defaults include Grok 4.5 with its official context window', () => {
+    expect(ProviderRegistry.get(ProviderName.Xai)?.defaultModels[0]).toEqual({
+      id: 'grok-4.5',
+      name: 'Grok 4.5',
+      supportsImage: true,
+      supportsThinking: true,
+      contextWindow: 500_000,
+    });
+  });
+
   test('get returns undefined for unknown provider', () => {
     expect(ProviderRegistry.get('nonexistent')).toBeUndefined();
     expect(ProviderRegistry.get(ProviderName.Custom)).toBeUndefined();
@@ -117,6 +136,10 @@ describe('ProviderRegistry', () => {
       [ProviderName.Xiaomi, 'mimo-v2.5'],
       [ProviderName.OpenAI, 'gpt-5.4'],
       [ProviderName.OpenAI, 'gpt-5.5'],
+      [ProviderName.OpenAI, 'gpt-5.6-sol'],
+      [ProviderName.OpenAI, 'gpt-5.6-terra'],
+      [ProviderName.OpenAI, 'gpt-5.6-luna'],
+      [ProviderName.Xai, 'grok-4.5'],
       [ProviderName.Gemini, 'gemini-3.1-pro-preview'],
       [ProviderName.Anthropic, 'claude-opus-4-7'],
       [ProviderName.OpenRouter, 'openai/gpt-5.5'],
@@ -140,6 +163,8 @@ describe('ProviderRegistry', () => {
     expect(ProviderRegistry.resolveModelContextWindow(ProviderName.DeepSeek, 'deepseek-v4-flash')).toBe(1_000_000);
     expect(ProviderRegistry.resolveModelContextWindow('custom_0', 'deepseek-v4-pro')).toBe(1_000_000);
     expect(ProviderRegistry.resolveModelContextWindow(ProviderName.DeepSeek, 'deepseek-v4-pro', 200_000)).toBe(200_000);
+    expect(ProviderRegistry.resolveModelContextWindow(ProviderName.OpenAI, 'gpt-5.6-sol')).toBe(1_050_000);
+    expect(ProviderRegistry.resolveModelContextWindow(ProviderName.Xai, 'grok-4.5')).toBe(500_000);
   });
 
   test('supportsCodingPlan is true for moonshot, qwen, zhipu, volcengine, qianfan, xiaomi', () => {

--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -487,8 +487,11 @@ const PROVIDER_DEFINITIONS = [
     region: 'global',
     enPriority: 1,
     defaultModels: [
-      { id: 'gpt-5.4', name: 'GPT-5.4', supportsImage: true, supportsThinking: true },
+      { id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', supportsImage: true, supportsThinking: true, contextWindow: 1_050_000 },
+      { id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra', supportsImage: true, supportsThinking: true, contextWindow: 1_050_000 },
+      { id: 'gpt-5.6-luna', name: 'GPT-5.6 Luna', supportsImage: true, supportsThinking: true, contextWindow: 1_050_000 },
       { id: 'gpt-5.5', name: 'GPT-5.5', supportsImage: true, supportsThinking: true },
+      { id: 'gpt-5.4', name: 'GPT-5.4', supportsImage: true, supportsThinking: true },
     ],
   },
   {
@@ -519,10 +522,10 @@ const PROVIDER_DEFINITIONS = [
     codingPlanSupported: false,
     region: 'global',
     enPriority: 4,
-    // Model IDs must stay within the pinned OpenClaw xai extension's selectable
-    // catalog (extensions/xai/model-definitions.ts); retired IDs are pruned by
-    // the runtime on config sync.
+    // The pinned OpenClaw xai extension forward-resolves new grok-4.* IDs even
+    // before they enter its built-in catalog; retired IDs are still pruned.
     defaultModels: [
+      { id: 'grok-4.5', name: 'Grok 4.5', supportsImage: true, supportsThinking: true, contextWindow: 500_000 },
       { id: 'grok-4.3', name: 'Grok 4.3', supportsImage: true, supportsThinking: true, contextWindow: 1_000_000 },
       { id: 'grok-build-0.1', name: 'Grok Build 0.1', supportsImage: true, supportsThinking: true, contextWindow: 256_000 },
     ],


### PR DESCRIPTION
Introduce a versioned model migration path that matches existing user models by normalized ID so upgrades don't duplicate an equivalent model a user already customized.