### PR TITLE
fix(cowork): restore IM session loading state

### DIFF
--- a/src/main/libs/agentEngine/channelSessionRunStatus.ts
+++ b/src/main/libs/agentEngine/channelSessionRunStatus.ts
@@ -1,5 +1,18 @@
 import type { CoworkSessionStatus } from '../../coworkStore';
 
+export function resolveChannelSessionTerminalStatus(rawStatus: string): CoworkSessionStatus | null {
+  if (
+    rawStatus === 'failed' ||
+    rawStatus === 'killed' ||
+    rawStatus === 'timeout' ||
+    rawStatus === 'error'
+  ) {
+    return 'error';
+  }
+  if (rawStatus === 'done' || rawStatus === 'completed') return 'completed';
+  return null;
+}
+
 /**
  * Decides the next local status for a channel-synced session from a gateway
  * `sessions.list` row.
@@ -21,15 +34,8 @@ export function resolveChannelSessionNextStatus(input: {
   const { hasActiveRun, rawStatus, currentStatus } = input;
 
   if (hasActiveRun === true) return 'running';
-  if (
-    rawStatus === 'failed' ||
-    rawStatus === 'killed' ||
-    rawStatus === 'timeout' ||
-    rawStatus === 'error'
-  ) {
-    return 'error';
-  }
-  if (rawStatus === 'done' || rawStatus === 'completed') return 'completed';
+  const terminalStatus = resolveChannelSessionTerminalStatus(rawStatus);
+  if (terminalStatus) return terminalStatus;
   if (hasActiveRun === false) {
     return currentStatus === 'running' ? 'completed' : null;
   }

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -1556,6 +1556,288 @@ test('pollChannelSessions does not complete a channel session while a local acti
   expect(statusEvents).toEqual([]);
 });
 
+test('sessions.changed drives IM loading status without creating a local active turn', () => {
+  const sessionKey = 'agent:main:feishu:dm:ou_123';
+  const { session, store, getUpdateSessionCalls } = createReconcileStore([], {
+    sessionId: 'session-1',
+  });
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const statusEvents: Array<{ sessionId: string; status: string }> = [];
+  adapter.on('sessionStatus', (sessionId: string, status: string) => {
+    statusEvents.push({ sessionId, status });
+  });
+  adapter.channelSessionSync = {
+    isCurrentBindingKey: () => true,
+    resolveOrCreateSession: () => session.id,
+  };
+
+  adapter.handleGatewayEvent({
+    event: 'sessions.changed',
+    payload: {
+      sessionKey,
+      runId: 'im-run-1',
+      phase: 'start',
+      status: 'running',
+    },
+  });
+
+  expect(session.status).toBe('running');
+  expect(adapter.activeTurns.has(session.id)).toBe(false);
+  expect(adapter.knownChannelSessionIds.has(session.id)).toBe(false);
+  expect(adapter.channelLifecycleRunBySessionKey.get(sessionKey)?.runId).toBe('im-run-1');
+
+  adapter.handleGatewayEvent({
+    event: 'sessions.changed',
+    payload: {
+      sessionKey,
+      runId: 'im-run-1',
+      phase: 'end',
+      status: 'done',
+    },
+  });
+
+  expect(session.status).toBe('completed');
+  expect(adapter.channelLifecycleRunBySessionKey.has(sessionKey)).toBe(false);
+  expect(getUpdateSessionCalls().filter((call) => 'status' in call.patch)).toEqual([
+    {
+      sessionId: session.id,
+      patch: { status: 'running' },
+      options: undefined,
+    },
+    {
+      sessionId: session.id,
+      patch: { status: 'completed' },
+      options: undefined,
+    },
+  ]);
+  expect(statusEvents).toEqual([
+    { sessionId: session.id, status: 'running' },
+    { sessionId: session.id, status: 'completed' },
+  ]);
+});
+
+test('sessions.changed IM status handling excludes desktop, cron, main, subagent, and stale bindings', () => {
+  const validSessionKey = 'agent:main:feishu:dm:ou_123';
+  const { session, store, getUpdateSessionCalls } = createReconcileStore([], {
+    sessionId: 'session-1',
+  });
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const resolveOrCreateSession = vi.fn(() => session.id);
+  adapter.channelSessionSync = {
+    isCurrentBindingKey: (key: string) => key !== validSessionKey,
+    resolveOrCreateSession,
+  };
+
+  for (const sessionKey of [
+    `agent:main:lobsterai:${session.id}`,
+    'agent:main:cron:job-1:run:run-1',
+    'agent:main:main',
+    'agent:main:subagent:run-1',
+    validSessionKey,
+  ]) {
+    adapter.handleGatewayEvent({
+      event: 'sessions.changed',
+      payload: {
+        sessionKey,
+        runId: 'run-ignored',
+        phase: 'start',
+        status: 'running',
+      },
+    });
+  }
+
+  expect(session.status).toBe('completed');
+  expect(resolveOrCreateSession).not.toHaveBeenCalled();
+  expect(getUpdateSessionCalls().some((call) => 'status' in call.patch)).toBe(false);
+});
+
+test('explicit IM lifecycle start prevents polling from clearing loading mid-run', async () => {
+  const sessionKey = 'agent:main:feishu:dm:ou_123';
+  const { session, store, getUpdateSessionCalls } = createReconcileStore([], {
+    sessionId: 'session-1',
+  });
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  adapter.channelSessionSync = {
+    isChannelSessionKey: (key: string) => key === sessionKey,
+    isCurrentBindingKey: () => true,
+    resolveOrCreateSession: () => session.id,
+  };
+  adapter.gatewayClient = {
+    start: () => {},
+    stop: () => {},
+    request: async () => ({
+      sessions: [{
+        key: sessionKey,
+        hasActiveRun: false,
+        status: 'running',
+      }],
+    }),
+  };
+
+  adapter.handleGatewayEvent({
+    event: 'sessions.changed',
+    payload: {
+      sessionKey,
+      runId: 'im-run-1',
+      phase: 'start',
+      status: 'running',
+    },
+  });
+  await adapter.pollChannelSessions();
+
+  expect(session.status).toBe('running');
+  expect(getUpdateSessionCalls().filter((call) => 'status' in call.patch)).toEqual([
+    {
+      sessionId: session.id,
+      patch: { status: 'running' },
+      options: undefined,
+    },
+  ]);
+});
+
+test('polling terminal status recovers when an IM lifecycle terminal event is missed', async () => {
+  const sessionKey = 'agent:main:feishu:dm:ou_123';
+  const { session, store } = createReconcileStore([], {
+    sessionId: 'session-1',
+  });
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  adapter.channelSessionSync = {
+    isChannelSessionKey: (key: string) => key === sessionKey,
+    isCurrentBindingKey: () => true,
+    resolveOrCreateSession: () => session.id,
+  };
+  adapter.gatewayClient = {
+    start: () => {},
+    stop: () => {},
+    request: async () => ({
+      sessions: [{
+        key: sessionKey,
+        hasActiveRun: false,
+        status: 'done',
+      }],
+    }),
+  };
+
+  adapter.handleGatewayEvent({
+    event: 'sessions.changed',
+    payload: {
+      sessionKey,
+      runId: 'im-run-1',
+      phase: 'start',
+      status: 'running',
+    },
+  });
+  await adapter.pollChannelSessions();
+
+  expect(session.status).toBe('completed');
+  expect(adapter.channelLifecycleRunBySessionKey.has(sessionKey)).toBe(false);
+});
+
+test('a stale IM terminal event cannot clear a newer run loading state', () => {
+  const sessionKey = 'agent:main:feishu:dm:ou_123';
+  const { session, store } = createReconcileStore([], {
+    sessionId: 'session-1',
+  });
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  adapter.channelSessionSync = {
+    isCurrentBindingKey: () => true,
+    resolveOrCreateSession: () => session.id,
+  };
+
+  adapter.handleGatewayEvent({
+    event: 'sessions.changed',
+    payload: {
+      sessionKey,
+      runId: 'im-run-new',
+      phase: 'start',
+      status: 'running',
+    },
+  });
+  adapter.handleGatewayEvent({
+    event: 'sessions.changed',
+    payload: {
+      sessionKey,
+      runId: 'im-run-old',
+      phase: 'end',
+      status: 'done',
+    },
+  });
+
+  expect(session.status).toBe('running');
+  expect(adapter.channelLifecycleRunBySessionKey.get(sessionKey)?.runId).toBe('im-run-new');
+});
+
+test('gateway session lifecycle subscription uses the existing sessions.subscribe RPC', async () => {
+  const adapter = new OpenClawRuntimeAdapter({} as never, {} as never);
+  const request = vi.fn().mockResolvedValue({ subscribed: true });
+
+  adapter.subscribeToGatewaySessionEvents({
+    start: () => {},
+    stop: () => {},
+    request,
+  });
+
+  await vi.waitFor(() => {
+    expect(request).toHaveBeenCalledWith(
+      'sessions.subscribe',
+      {},
+      { timeoutMs: 5_000 },
+    );
+  });
+});
+
+test('stale IM lifecycle markers are pruned without allocating per-run timers', () => {
+  const adapter = new OpenClawRuntimeAdapter({} as never, {} as never);
+  const sessionKey = 'agent:main:feishu:dm:ou_123';
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    adapter.agentTimeoutSeconds = 1;
+    adapter.channelLifecycleRunBySessionKey.set(sessionKey, {
+      runId: 'lost-terminal-run',
+      observedAtMs: Date.now() - 61_001,
+    });
+
+    adapter.pruneStaleChannelLifecycleRuns();
+
+    expect(adapter.channelLifecycleRunBySessionKey.has(sessionKey)).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      '[ChannelSync] discarded stale IM lifecycle run marker.',
+      `SessionKey ${sessionKey}.`,
+      'Run lost-terminal-run.',
+    );
+  } finally {
+    warn.mockRestore();
+  }
+});
+
+test('malformed IM lifecycle mapping errors stay isolated from the gateway event loop', () => {
+  const adapter = new OpenClawRuntimeAdapter({} as never, {} as never);
+  const mappingError = new Error('mapping unavailable');
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  adapter.channelSessionSync = {
+    isCurrentBindingKey: () => {
+      throw mappingError;
+    },
+  };
+  try {
+    expect(() => adapter.handleGatewayEvent({
+      event: 'sessions.changed',
+      payload: {
+        sessionKey: 'agent:main:feishu:dm:ou_123',
+        runId: 'im-run-1',
+        phase: 'start',
+        status: 'running',
+      },
+    })).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      '[ChannelSync] failed to process gateway session lifecycle event:',
+      mappingError,
+    );
+  } finally {
+    warn.mockRestore();
+  }
+});
+
 function createRunTurnAdapter(options: {
   sessionModelOverride?: string;
   agentModel?: string;

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -56,6 +56,7 @@ import {
   isCronSessionKey,
   isManagedSessionKey,
   type OpenClawChannelSessionSync,
+  parseChannelSessionKey,
   parseManagedSessionKey,
 } from '../openclawChannelSessionSync';
 import { OPENCLAW_AGENT_TIMEOUT_SECONDS } from '../openclawConfigSync';
@@ -82,7 +83,10 @@ import {
   findReusableCommittedAssistantMessageId,
   findReusableFinalAssistantMessageId,
 } from './assistantMessageReconciliation';
-import { resolveChannelSessionNextStatus } from './channelSessionRunStatus';
+import {
+  resolveChannelSessionNextStatus,
+  resolveChannelSessionTerminalStatus,
+} from './channelSessionRunStatus';
 import { AgentLifecyclePhase, type AgentLifecyclePhase as AgentLifecyclePhaseValue } from './constants';
 import {
   buildCoworkContinuityCapsule,
@@ -155,6 +159,12 @@ import type {
 } from './types';
 
 const OPENCLAW_GATEWAY_TOOL_EVENTS_CAP = 'tool-events';
+const OpenClawGatewayEvent = {
+  SessionsChanged: 'sessions.changed',
+} as const;
+const OpenClawGatewayMethod = {
+  SessionsSubscribe: 'sessions.subscribe',
+} as const;
 const BRIDGE_MAX_MESSAGES = 20;
 const BRIDGE_MAX_MESSAGE_CHARS = 1200;
 const FORK_COMPACTION_SUMMARY_MAX_CHARS = 40_000;
@@ -402,6 +412,11 @@ type GatewayClientLike = {
 };
 
 type GatewayClientCtor = new (options: Record<string, unknown>) => GatewayClientLike;
+
+type ChannelSessionLifecycleRun = {
+  runId: string;
+  observedAtMs: number;
+};
 
 type OpenClawRuntimeAdapterOptions = {
   normalizeModelRef?: (modelRef: string) => string;
@@ -2162,9 +2177,17 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private readonly manuallyStoppedSessions = new Set<string>();
   /** Session keys whose origin is "heartbeat" — discovered via polling, used to filter real-time events. */
   private readonly heartbeatSessionKeys = new Set<string>();
+  /**
+   * Native IM runs are not represented by the gateway's `hasActiveRun` flag.
+   * Track explicit `sessions.changed` lifecycle starts so the polling fallback
+   * cannot immediately overwrite their loading state with `completed`.
+   */
+  private readonly channelLifecycleRunBySessionKey = new Map<string, ChannelSessionLifecycleRun>();
   private channelPollingTimer: ReturnType<typeof setInterval> | null = null;
 
   private static readonly CHANNEL_POLL_INTERVAL_MS = 10_000;
+  private static readonly CHANNEL_LIFECYCLE_RUN_GRACE_MS = 60_000;
+  private static readonly GATEWAY_SESSION_SUBSCRIBE_TIMEOUT_MS = 5_000;
   /** Delay before pulling a cron delivery mirror into the mapped conversation,
    *  giving the gateway time to flush the transcript append. */
   private static readonly CRON_DELIVERY_SYNC_DELAY_MS = 2_000;
@@ -3435,13 +3458,27 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     const session = this.store.getSession(coworkSessionId);
     if (!session) return false;
 
+    const rawStatus = typeof row.status === 'string' ? row.status.trim().toLowerCase() : '';
+    const terminalStatus = resolveChannelSessionTerminalStatus(rawStatus);
+
+    // A native IM run is announced by `sessions.changed`, but does not appear
+    // in OpenClaw's chat-specific `hasActiveRun` tracker. Keep that explicit
+    // lifecycle signal authoritative while it is fresh; otherwise the 10s
+    // polling fallback would turn the loading state off mid-run. A persisted
+    // terminal row still wins if the matching terminal event was dropped.
+    if (this.getFreshChannelLifecycleRun(openClawSessionKey) && !terminalStatus) {
+      return false;
+    }
+    if (terminalStatus) {
+      this.channelLifecycleRunBySessionKey.delete(openClawSessionKey);
+    }
+
     const hasActiveRun =
       row.hasActiveRun === true
         ? true
         : row.hasActiveRun === false
           ? false
           : null;
-    const rawStatus = typeof row.status === 'string' ? row.status.trim().toLowerCase() : '';
     const nextStatus = resolveChannelSessionNextStatus({
       hasActiveRun,
       rawStatus,
@@ -3465,6 +3502,33 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     return true;
   }
 
+  private getFreshChannelLifecycleRun(sessionKey: string): ChannelSessionLifecycleRun | null {
+    const activeRun = this.channelLifecycleRunBySessionKey.get(sessionKey);
+    if (!activeRun) return null;
+
+    const configuredTimeoutMs = Number.isFinite(this.agentTimeoutSeconds)
+      ? Math.max(1, this.agentTimeoutSeconds) * 1_000
+      : OPENCLAW_AGENT_TIMEOUT_SECONDS * 1_000;
+    const maxAgeMs = configuredTimeoutMs + OpenClawRuntimeAdapter.CHANNEL_LIFECYCLE_RUN_GRACE_MS;
+    if (Date.now() - activeRun.observedAtMs <= maxAgeMs) {
+      return activeRun;
+    }
+
+    this.channelLifecycleRunBySessionKey.delete(sessionKey);
+    console.warn(
+      '[ChannelSync] discarded stale IM lifecycle run marker.',
+      `SessionKey ${sessionKey}.`,
+      `Run ${activeRun.runId || 'unknown'}.`,
+    );
+    return null;
+  }
+
+  private pruneStaleChannelLifecycleRuns(): void {
+    for (const sessionKey of this.channelLifecycleRunBySessionKey.keys()) {
+      this.getFreshChannelLifecycleRun(sessionKey);
+    }
+  }
+
   setChannelSessionSync(sync: OpenClawChannelSessionSync): void {
     this.channelSessionSync = sync;
   }
@@ -3475,6 +3539,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
 
     this.channelSessionSync.clearCache();
+    this.channelLifecycleRunBySessionKey.clear();
     for (const [sessionKey] of this.sessionIdBySessionKey.entries()) {
       if (this.channelSessionSync.isChannelSessionKey(sessionKey)) {
         this.sessionIdBySessionKey.delete(sessionKey);
@@ -3812,6 +3877,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       console.warn('[ChannelSync] pollChannelSessions: skipped — gatewayClient:', !!this.gatewayClient, 'channelSessionSync:', !!this.channelSessionSync);
       return;
     }
+    // Reuse the existing poll cadence for marker cleanup instead of creating
+    // one timer per IM run. This bounds memory even if both a terminal event
+    // and the corresponding terminal sessions.list row are lost.
+    this.pruneStaleChannelLifecycleRuns();
     if (this.isGatewayRpcDegraded()) {
       console.debug('[ChannelSync] skipped channel session polling because gateway session RPCs are degraded.');
       return;
@@ -5102,6 +5171,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         this.gatewayClientVersion = connection.version;
         this.gatewayClientEntryPath = connection.clientEntryPath;
         this.resetGatewayRpcHealth();
+        this.subscribeToGatewaySessionEvents(client);
         settleResolve();
         try {
           this.options.onGatewayClientReady?.();
@@ -5179,6 +5249,24 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     client.start();
   }
 
+  private subscribeToGatewaySessionEvents(client: GatewayClientLike): void {
+    void client.request<{ subscribed?: boolean }>(
+      OpenClawGatewayMethod.SessionsSubscribe,
+      {},
+      { timeoutMs: OpenClawRuntimeAdapter.GATEWAY_SESSION_SUBSCRIBE_TIMEOUT_MS },
+    ).then((result) => {
+      if (result?.subscribed !== true) {
+        console.warn('[ChannelSync] gateway session event subscription was not confirmed.');
+        return;
+      }
+      console.log('[ChannelSync] subscribed to gateway session lifecycle events.');
+    }).catch((error) => {
+      // Polling remains available as a compatibility fallback if an older or
+      // temporarily degraded gateway cannot establish the subscription.
+      console.warn('[ChannelSync] failed to subscribe to gateway session lifecycle events:', error);
+    });
+  }
+
   private stopGatewayClient(): void {
     this.gatewayStoppingIntentionally = true;
     this.stopChannelPolling();
@@ -5212,6 +5300,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     this.resetGatewayRpcHealth();
     this.knownChannelSessionIds.clear();
     this.heartbeatSessionKeys.clear();
+    this.channelLifecycleRunBySessionKey.clear();
     this.stoppedSessions.clear();
     this.recentlyClosedRunIds.clear();
     this.browserPrewarmAttempted = false;
@@ -5961,6 +6050,18 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       return;
     }
 
+    if (event.event === OpenClawGatewayEvent.SessionsChanged) {
+      try {
+        this.handleChannelSessionLifecycleEvent(event.payload);
+      } catch (error) {
+        // Channel parsing and mapping may touch plugin-provided identifiers and
+        // local persistence. Keep a malformed event isolated from the gateway
+        // client's event loop; polling remains the fallback.
+        console.warn('[ChannelSync] failed to process gateway session lifecycle event:', error);
+      }
+      return;
+    }
+
     if (event.event === 'chat') {
       this.handleChatEvent(event.payload, event.seq);
       return;
@@ -6000,6 +6101,106 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (event.event === 'cron') {
       console.debug('[OpenClawRuntime] received cron event:', JSON.stringify(event));
       this.scheduleImConversationSyncAfterCronDelivery(event.payload);
+    }
+  }
+
+  private handleChannelSessionLifecycleEvent(payload: unknown): void {
+    if (!this.channelSessionSync || !isRecord(payload)) return;
+
+    const sessionKey = typeof payload.sessionKey === 'string' ? payload.sessionKey.trim() : '';
+    const phase = normalizeAgentLifecyclePhase(payload.phase);
+    if (
+      !sessionKey
+      || !parseChannelSessionKey(sessionKey)
+      || !this.channelSessionSync.isCurrentBindingKey(sessionKey)
+      || (
+        phase !== AgentLifecyclePhase.Start
+        && phase !== AgentLifecyclePhase.End
+        && phase !== AgentLifecyclePhase.Error
+      )
+    ) {
+      return;
+    }
+
+    // A deleted conversation may only be re-created by a genuine new IM run,
+    // never by a delayed terminal event from the run that was deleted.
+    if (this.deletedChannelKeys.has(sessionKey) && phase !== AgentLifecyclePhase.Start) {
+      return;
+    }
+
+    const runId = typeof payload.runId === 'string' ? payload.runId.trim() : '';
+    const trackedRun = this.getFreshChannelLifecycleRun(sessionKey);
+    if (
+      phase !== AgentLifecyclePhase.Start
+      && trackedRun?.runId
+      && runId
+      && trackedRun.runId !== runId
+    ) {
+      console.debug('[ChannelSync] ignored stale IM lifecycle terminal event for a superseded run.');
+      return;
+    }
+
+    const sessionId = this.resolveSessionIdBySessionKey(sessionKey)
+      ?? this.channelSessionSync.resolveOrCreateSession(sessionKey);
+    if (!sessionId) return;
+
+    const activeTurn = this.activeTurns.get(sessionId);
+    if (
+      phase !== AgentLifecyclePhase.Start
+      && activeTurn
+      && runId
+      && activeTurn.runId !== runId
+      && !activeTurn.knownRunIds.has(runId)
+    ) {
+      console.debug('[ChannelSync] ignored IM lifecycle terminal event for a non-current local turn.');
+      return;
+    }
+
+    if (phase === AgentLifecyclePhase.Start) {
+      this.channelLifecycleRunBySessionKey.set(sessionKey, {
+        runId,
+        observedAtMs: Date.now(),
+      });
+      if (this.deletedChannelKeys.delete(sessionKey)) {
+        this.fullySyncedSessions.add(sessionId);
+        this.reCreatedChannelSessionIds.add(sessionId);
+      }
+    } else {
+      this.channelLifecycleRunBySessionKey.delete(sessionKey);
+    }
+
+    this.rememberSessionKey(sessionId, sessionKey);
+    const isNewlyKnownSession = !this.knownChannelSessionIds.has(sessionId);
+    // Leave discovery ownership to pollChannelSessions. Marking the session as
+    // known here would prevent that poll from scheduling its initial full
+    // history sync for a conversation first seen through this lifecycle event.
+
+    const session = this.store.getSession(sessionId);
+    if (!session) return;
+    const rawStatus = typeof payload.status === 'string' ? payload.status.trim().toLowerCase() : '';
+    const nextStatus: CoworkSessionStatus = phase === AgentLifecyclePhase.Start
+      ? 'running'
+      : phase === AgentLifecyclePhase.Error
+        ? 'error'
+        : resolveChannelSessionNextStatus({
+          hasActiveRun: false,
+          rawStatus,
+          currentStatus: session.status,
+        }) ?? 'completed';
+
+    if (session.status !== nextStatus) {
+      const previousStatus = session.status;
+      this.store.updateSession(sessionId, { status: nextStatus });
+      this.emitSessionStatus(sessionId, nextStatus);
+      console.debug(
+        '[ChannelSync] synced IM session lifecycle status.',
+        `Session ${sessionId}.`,
+        `Status ${previousStatus} -> ${nextStatus}.`,
+        `Phase ${phase}.`,
+      );
+    }
+    if (isNewlyKnownSession) {
+      this.notifySessionsChanged();
     }
   }
 
@@ -9932,6 +10133,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     // Only real-time events (new IM messages) will re-create the session.
     for (const key of removedChannelKeys) {
       this.deletedChannelKeys.add(key);
+      this.channelLifecycleRunBySessionKey.delete(key);
     }
 
     if (removedKeys.length > 0) {

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -282,6 +282,15 @@ class CoworkService {
     }
 
     const sessionStatusCleanup = cowork.onStreamSessionStatus?.(({ sessionId, status }) => {
+      const coworkState = store.getState().cowork;
+      const previousStatus = coworkState.sessions.find(session => session.id === sessionId)?.status
+        ?? (coworkState.currentSession?.id === sessionId ? coworkState.currentSession.status : undefined);
+      if (previousStatus !== status) {
+        this.logDiagnostic(
+          'debug',
+          `received session status transition: session=${sessionId}; ${previousStatus ?? 'unknown'} -> ${status}.`,
+        );
+      }
       store.dispatch(updateSessionStatus({ sessionId, status }));
       this.setCurrentSessionStreaming(sessionId, status === 'running', `stream_status_${status}`);
       if (status === CoworkSessionStatusValue.Running) {


### PR DESCRIPTION
Subscribe to gateway session lifecycle events and keep polling as a safe fallback. Prevent cron, desktop, and stale run events from affecting IM loading state.