### PR TITLE
feat(cowork): surface structured run failure details in error UI

### DIFF
--- a/scripts/patches/v2026.6.1/openclaw-run-failure-detail.patch
+++ b/scripts/patches/v2026.6.1/openclaw-run-failure-detail.patch
@@ -1,0 +1,91 @@
+diff --git a/src/auto-reply/reply/agent-runner-execution.test.ts b/src/auto-reply/reply/agent-runner-execution.test.ts
+index 4b0bf4592..788616073 100644
+--- a/src/auto-reply/reply/agent-runner-execution.test.ts
++++ b/src/auto-reply/reply/agent-runner-execution.test.ts
+@@ -43,6 +43,11 @@ const state = vi.hoisted(() => ({
+ const GENERIC_RUN_FAILURE_TEXT =
+   "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.";
+ 
++// LobsterAI patch: raw runner failures now always forward the sanitized detail
++// instead of collapsing to GENERIC_RUN_FAILURE_TEXT when verbose is off.
++const FORWARDED_INCOMPLETE_TERMINAL_FAILURE_TEXT =
++  "⚠️ Agent failed before reply: openai/gpt-5.5 ended with an incomplete terminal response. Please try again, or use /new to start a fresh session.";
++
+ describe("resolveSessionRuntimeOverrideForProvider", () => {
+   it("ignores unsupported session runtime pins", () => {
+     expect(
+@@ -4948,7 +4953,7 @@ describe("runAgentTurnWithFallback", () => {
+     expect(failMock).not.toHaveBeenCalled();
+   });
+ 
+-  it("uses compact generic copy for raw external chat errors when verbose is off", async () => {
++  it("forwards sanitized failure detail for raw external chat errors even when verbose is off", async () => {
+     state.runEmbeddedAgentMock.mockRejectedValueOnce(
+       new Error("INVALID_ARGUMENT: some other failure"),
+     );
+@@ -4979,7 +4984,9 @@ describe("runAgentTurnWithFallback", () => {
+ 
+     expect(result.kind).toBe("final");
+     if (result.kind === "final") {
+-      expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
++      expect(result.payload.text).toBe(
++        "⚠️ Agent failed before reply: INVALID_ARGUMENT: some other failure. Please try again, or use /new to start a fresh session.",
++      );
+     }
+   });
+ 
+@@ -5180,7 +5187,7 @@ describe("runAgentTurnWithFallback", () => {
+       expect(result.kind).toBe("final");
+       if (result.kind === "final") {
+         expect(result.payload.text).not.toBe(SILENT_REPLY_TOKEN);
+-        expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
++        expect(result.payload.text).toBe(FORWARDED_INCOMPLETE_TERMINAL_FAILURE_TEXT);
+       }
+     },
+   );
+@@ -5221,7 +5228,7 @@ describe("runAgentTurnWithFallback", () => {
+ 
+     expect(result.kind).toBe("final");
+     if (result.kind === "final") {
+-      expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
++      expect(result.payload.text).toBe(FORWARDED_INCOMPLETE_TERMINAL_FAILURE_TEXT);
+     }
+   });
+ 
+@@ -5349,7 +5356,7 @@ describe("runAgentTurnWithFallback", () => {
+     }
+   });
+ 
+-  it("uses compact generic copy for raw runner failures in normal Discord direct chats", async () => {
++  it("forwards sanitized failure detail for raw runner failures in normal Discord direct chats", async () => {
+     state.runEmbeddedAgentMock.mockRejectedValueOnce(
+       new Error("openai/gpt-5.5 ended with an incomplete terminal response"),
+     );
+@@ -5368,7 +5375,7 @@ describe("runAgentTurnWithFallback", () => {
+ 
+     expect(result.kind).toBe("final");
+     if (result.kind === "final") {
+-      expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
++      expect(result.payload.text).toBe(FORWARDED_INCOMPLETE_TERMINAL_FAILURE_TEXT);
+     }
+   });
+ 
+diff --git a/src/auto-reply/reply/agent-runner-execution.ts b/src/auto-reply/reply/agent-runner-execution.ts
+index 7d13bf369..03698016f 100644
+--- a/src/auto-reply/reply/agent-runner-execution.ts
++++ b/src/auto-reply/reply/agent-runner-execution.ts
+@@ -841,10 +841,11 @@ function buildExternalRunFailureReply(
+   if (codexAppServerFailure) {
+     return { text: codexAppServerFailure, isGenericRunnerFailure: false };
+   }
++  // LobsterAI patch: always forward the sanitized failure detail (redacted and
++  // truncated by formatForwardedExternalRunFailureText) so non-webchat surfaces
++  // (cron, IM direct chats) see the real reason instead of the generic copy.
+   return {
+-    text: options?.includeDetails
+-      ? formatForwardedExternalRunFailureText(normalizedMessage)
+-      : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
++    text: formatForwardedExternalRunFailureText(normalizedMessage),
+     isGenericRunnerFailure: true,
+   };
+ }

--- a/scripts/patches/v2026.6.1/openclaw-safe-error-metadata.patch
+++ b/scripts/patches/v2026.6.1/openclaw-safe-error-metadata.patch
@@ -1,6 +1,8 @@
+diff --git a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+index 91fc8c6a4..6b5e10190 100644
 --- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
 +++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
-@@ -52,6 +52,7 @@
+@@ -52,6 +52,7 @@ export function handleAgentEnd(
    const lastAssistant = ctx.state.lastAssistant;
    const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";
    let lifecycleErrorText: string | undefined;
@@ -8,7 +10,7 @@
    const hasAssistantVisibleText =
      Array.isArray(ctx.state.assistantTexts) &&
      ctx.state.assistantTexts.some((text) => hasAssistantVisibleReply({ text }));
-@@ -101,6 +102,12 @@
+@@ -101,6 +102,12 @@ export function handleAgentEnd(
          provider: lastAssistant.provider,
        }).textPreview ?? GENERIC_ASSISTANT_ERROR_TEXT;
      lifecycleErrorText = safeErrorText;
@@ -21,7 +23,7 @@
      const safeRunId = sanitizeForConsole(ctx.params.runId) ?? "-";
      const safeModel = sanitizeForConsole(lastAssistant.model) ?? "unknown";
      const safeProvider = sanitizeForConsole(lastAssistant.provider) ?? "unknown";
-@@ -143,6 +150,7 @@
+@@ -143,6 +150,7 @@ export function handleAgentEnd(
            phase: "error",
            error: lifecycleErrorText ?? GENERIC_ASSISTANT_ERROR_TEXT,
            ...terminalMeta,
@@ -29,7 +31,7 @@
            ...(livenessState ? { livenessState } : {}),
            ...(replayInvalid ? { replayInvalid } : {}),
            endedAt: Date.now(),
-@@ -154,6 +162,7 @@
+@@ -154,6 +162,7 @@ export function handleAgentEnd(
            phase: "error",
            error: lifecycleErrorText ?? GENERIC_ASSISTANT_ERROR_TEXT,
            ...terminalMeta,
@@ -37,19 +39,22 @@
            ...(livenessState ? { livenessState } : {}),
            ...(replayInvalid ? { replayInvalid } : {}),
          },
+diff --git a/src/gateway/server-chat.ts b/src/gateway/server-chat.ts
+index fec53fd3c..7fa2e0188 100644
 --- a/src/gateway/server-chat.ts
 +++ b/src/gateway/server-chat.ts
-@@ -45,7 +45,34 @@
-   SessionMessageSubscriberRegistry,
+@@ -46,6 +46,35 @@ export type {
    ToolEventRecipientRegistry,
  } from "./server-chat-state.js";
-+
+ 
 +const SAFE_CHAT_ERROR_METADATA_KEYS = [
 +  "provider",
 +  "model",
 +  "failoverReason",
 +  "providerRuntimeFailureKind",
 +  "providerErrorType",
++  "httpCode",
++  "providerErrorMessagePreview",
 +  "rawErrorPreview",
 +  "rawErrorHash",
 +] as const;
@@ -67,14 +72,14 @@
 +      metadata[key] = value;
 +    }
 +  }
- 
++
 +  return Object.keys(metadata).length > 0 ? metadata : undefined;
 +}
 +
  function projectToolSearchCodeEventForChannelPayload<T extends { data?: unknown }>(payload: T): T {
    const data = payload.data;
    if (!data || typeof data !== "object") {
-@@ -478,6 +505,7 @@
+@@ -478,6 +507,7 @@ export function createAgentEventHandler({
            typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
          const evtErrorKind =
            readChatErrorKind(evt.data?.errorKind) ?? detectErrorKind(evt.data?.error);
@@ -82,7 +87,7 @@
          if (chatLink) {
            const finished = chatRunState.registry.shift(evt.runId);
            if (!finished) {
-@@ -494,6 +522,7 @@
+@@ -494,6 +524,7 @@ export function createAgentEventHandler({
                evt.data?.error,
                evtStopReason,
                evtErrorKind,
@@ -90,7 +95,7 @@
                { agentId: finished.agentId, controlUiVisible: isControlUiVisible },
              );
            }
-@@ -507,6 +536,7 @@
+@@ -507,6 +538,7 @@ export function createAgentEventHandler({
              evt.data?.error,
              evtStopReason,
              evtErrorKind,
@@ -98,7 +103,7 @@
              { agentId: sessionAgentId, controlUiVisible: isControlUiVisible },
            );
          }
-@@ -738,6 +768,7 @@
+@@ -738,6 +770,7 @@ export function createAgentEventHandler({
      error?: unknown,
      stopReason?: string,
      errorKind?: ErrorKind,
@@ -106,7 +111,7 @@
      opts?: { agentId?: string; controlUiVisible?: boolean },
    ) => {
      const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId, {
-@@ -781,6 +812,7 @@
+@@ -781,6 +814,7 @@ export function createAgentEventHandler({
        errorMessage: error ? formatForLog(error) : undefined,
        message: buildChatErrorMessage(error),
        ...(errorKind && { errorKind }),

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -14,6 +14,7 @@ import {
   CoworkForkMode,
   type CoworkForkMode as CoworkForkModeType,
 } from '../shared/cowork/constants';
+import type { CoworkErrorDetail } from '../shared/cowork/errorDetail';
 import {
   type CoworkGoal,
   normalizeCoworkGoal,
@@ -428,6 +429,7 @@ export interface CoworkMessageMetadata {
   toolResult?: string;
   toolUseId?: string | null;
   error?: string;
+  errorDetail?: CoworkErrorDetail;
   isError?: boolean;
   isStreaming?: boolean;
   isFinal?: boolean;

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -24,6 +24,7 @@ import {
 import { ContinuityCapsuleSource } from './coworkContinuityCapsule';
 import {
   buildOpenClawChatSendPayloadTooLargeError,
+  buildOpenClawRuntimeErrorDetail,
   ensurePlanModeProposedPlanBlock,
   estimateOpenClawChatSendFrameBytes,
   isPlanModeResponseComplete,
@@ -312,6 +313,83 @@ test('resolveOpenClawRuntimeErrorMessage keeps generic error when safe metadata 
     providerRuntimeFailureKind: 'unclassified',
     rawErrorPreview: 'provider returned a surprising response',
   })).toBe('LLM request failed.');
+});
+
+test('buildOpenClawRuntimeErrorDetail preserves safe metadata behind the normalized copy', () => {
+  const metadata = {
+    provider: 'anthropic',
+    model: 'claude-sonnet-5',
+    failoverReason: 'rate_limit',
+    providerRuntimeFailureKind: 'rate_limit',
+    providerErrorType: 'rate_limit_error',
+    httpCode: '429',
+    providerErrorMessagePreview: 'Number of request tokens has exceeded your per-minute rate limit',
+    rawErrorPreview: '429 {"type":"error","error":{"type":"rate_limit_error"}}',
+    rawErrorHash: 'abc123hash',
+  };
+  const displayMessage = resolveOpenClawRuntimeErrorMessage('LLM request failed.', metadata);
+  const detail = buildOpenClawRuntimeErrorDetail('LLM request failed.', displayMessage, metadata);
+
+  expect(detail).toEqual({
+    rawErrorMessage: 'LLM request failed.',
+    provider: 'anthropic',
+    model: 'claude-sonnet-5',
+    failoverReason: 'rate_limit',
+    providerRuntimeFailureKind: 'rate_limit',
+    providerErrorType: 'rate_limit_error',
+    httpCode: '429',
+    providerErrorMessagePreview: 'Number of request tokens has exceeded your per-minute rate limit',
+    rawErrorPreview: '429 {"type":"error","error":{"type":"rate_limit_error"}}',
+  });
+});
+
+test('buildOpenClawRuntimeErrorDetail returns undefined when the error passed through unchanged', () => {
+  expect(buildOpenClawRuntimeErrorDetail(
+    'session file locked (timeout after 10000ms)',
+    'session file locked (timeout after 10000ms)',
+    undefined,
+  )).toBeUndefined();
+});
+
+test('buildOpenClawRuntimeErrorDetail annotates the model source from gateway provider metadata', () => {
+  const detail = buildOpenClawRuntimeErrorDetail(
+    'LLM request failed.',
+    '请求过于频繁，请稍后再试。',
+    { provider: 'custom', model: 'kimi-k2.5', httpCode: '429' },
+    {
+      resolveModelSource: (providerId) => (providerId === 'custom'
+        ? { source: 'custom-provider', providerName: 'custom', providerDisplayName: '我的中转' }
+        : undefined),
+    },
+  );
+
+  expect(detail).toMatchObject({
+    provider: 'custom',
+    model: 'kimi-k2.5',
+    modelSource: 'custom-provider',
+    providerDisplayName: '我的中转',
+  });
+});
+
+test('buildOpenClawRuntimeErrorDetail falls back to the turn model ref when metadata lacks provider info', () => {
+  const detail = buildOpenClawRuntimeErrorDetail(
+    'Agent failed before reply: something broke.',
+    '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
+    undefined,
+    {
+      fallbackModelRef: 'zai/glm-5',
+      resolveModelSource: (providerId) => (providerId === 'zai'
+        ? { source: 'coding-plan', providerName: 'zhipu' }
+        : undefined),
+    },
+  );
+
+  expect(detail).toMatchObject({
+    provider: 'zai',
+    model: 'glm-5',
+    modelSource: 'coding-plan',
+  });
+  expect(detail?.providerDisplayName).toBeUndefined();
 });
 
 test('estimateOpenClawChatSendFrameBytes measures the full RPC frame as UTF-8 JSON', () => {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -17,6 +17,10 @@ import {
 } from '../../../common/openclawSession';
 import { CoworkIpcChannel } from '../../../shared/cowork/constants';
 import {
+  buildCoworkErrorDetail,
+  type CoworkErrorDetail,
+} from '../../../shared/cowork/errorDetail';
+import {
   type CoworkGoal,
   normalizeCoworkGoal,
 } from '../../../shared/cowork/goal';
@@ -59,7 +63,11 @@ import {
   parseChannelSessionKey,
   parseManagedSessionKey,
 } from '../openclawChannelSessionSync';
-import { OPENCLAW_AGENT_TIMEOUT_SECONDS } from '../openclawConfigSync';
+import {
+  OPENCLAW_AGENT_TIMEOUT_SECONDS,
+  type OpenClawProviderModelSource,
+  resolveModelSourceForOpenClawProvider,
+} from '../openclawConfigSync';
 import {
   OpenClawEngineManager,
   type OpenClawEngineStatus,
@@ -517,6 +525,8 @@ type ChatEventPayload = {
   failoverReason?: string;
   providerRuntimeFailureKind?: string;
   providerErrorType?: string;
+  httpCode?: string;
+  providerErrorMessagePreview?: string;
   rawErrorPreview?: string;
   rawErrorHash?: string;
 };
@@ -546,6 +556,10 @@ const OPENCLAW_GENERIC_LLM_REQUEST_FAILED = 'LLM request failed.';
 const OpenClawFailureFinalText = {
   AgentFailedBeforeReply: 'Agent failed before reply:',
   SessionFileLocked: 'session file locked (timeout',
+  // OpenClaw's generic external-run failure copy (verbose off, e.g. cron/IM
+  // sessions). Detect it so the session surfaces an error instead of a
+  // normal-looking assistant reply.
+  GenericRunFailure: 'Something went wrong while processing your request',
 } as const;
 
 const OpenClawHistoryRole = {
@@ -920,7 +934,8 @@ export function isPlanModeResponseComplete(text: string): boolean {
 function isOpenClawFailureFinalText(text: string): boolean {
   const trimmed = text.trim();
   return trimmed.includes(OpenClawFailureFinalText.AgentFailedBeforeReply)
-    || trimmed.includes(OpenClawFailureFinalText.SessionFileLocked);
+    || trimmed.includes(OpenClawFailureFinalText.SessionFileLocked)
+    || trimmed.includes(OpenClawFailureFinalText.GenericRunFailure);
 }
 
 export function isSignificantAssistantStreamReset(previousLength: number, nextLength: number): boolean {
@@ -1368,6 +1383,8 @@ export type OpenClawSafeRuntimeErrorMetadata = {
   failoverReason?: string;
   providerRuntimeFailureKind?: string;
   providerErrorType?: string;
+  httpCode?: string;
+  providerErrorMessagePreview?: string;
   rawErrorPreview?: string;
   rawErrorHash?: string;
 };
@@ -1419,6 +1436,8 @@ function normalizeOpenClawSafeRuntimeErrorMetadata(
     'failoverReason',
     'providerRuntimeFailureKind',
     'providerErrorType',
+    'httpCode',
+    'providerErrorMessagePreview',
     'rawErrorPreview',
     'rawErrorHash',
   ] as const) {
@@ -1484,6 +1503,48 @@ export function resolveOpenClawRuntimeErrorMessage(
   }
 
   return normalized;
+}
+
+export type OpenClawRuntimeErrorDetailOptions = {
+  /** Turn model reference ("providerId/modelId") used when gateway metadata lacks provider/model. */
+  fallbackModelRef?: string;
+  /** Classifies an OpenClaw provider id back to its LobsterAI Settings entry. */
+  resolveModelSource?: (openclawProviderId: string) => OpenClawProviderModelSource | undefined;
+};
+
+const splitModelRef = (modelRef: string | undefined): { provider?: string; model?: string } => {
+  const trimmed = modelRef?.trim();
+  if (!trimmed) return {};
+  const slashIndex = trimmed.indexOf('/');
+  if (slashIndex <= 0) return { model: trimmed };
+  return {
+    provider: trimmed.slice(0, slashIndex),
+    model: trimmed.slice(slashIndex + 1) || undefined,
+  };
+};
+
+/**
+ * Preserves the redacted technical detail of a runtime error next to the
+ * normalized display copy, so the UI can offer a "technical details"
+ * disclosure. Returns undefined when there is nothing beyond the display copy.
+ */
+export function buildOpenClawRuntimeErrorDetail(
+  rawErrorMessage: string,
+  displayMessage: string,
+  metadata?: OpenClawSafeRuntimeErrorMetadata,
+  options?: OpenClawRuntimeErrorDetailOptions,
+): CoworkErrorDetail | undefined {
+  const fallbackRef = splitModelRef(options?.fallbackModelRef);
+  const provider = metadata?.provider?.trim() || fallbackRef.provider;
+  const model = metadata?.model?.trim() || fallbackRef.model;
+  const sourceInfo = provider ? options?.resolveModelSource?.(provider) : undefined;
+  return buildCoworkErrorDetail({
+    rawErrorMessage,
+    displayMessage,
+    metadata: { ...metadata, provider, model },
+    modelSource: sourceInfo?.source,
+    providerDisplayName: sourceInfo?.providerDisplayName,
+  });
 }
 
 const extractTextBlocksAndSignals = (
@@ -5509,6 +5570,28 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     return this.normalizeModelRef(rawCurrentModel);
   }
 
+  /** Builds the persisted error detail, annotated with the failing model's LobsterAI source. */
+  private buildTurnErrorDetail(
+    sessionId: string,
+    turn: ActiveTurn | undefined,
+    rawErrorMessage: string,
+    displayMessage: string,
+    metadata: OpenClawSafeRuntimeErrorMetadata | undefined,
+  ): CoworkErrorDetail | undefined {
+    let fallbackModelRef = turn?.model?.trim() || '';
+    if (!fallbackModelRef) {
+      try {
+        fallbackModelRef = this.resolveCurrentModelForSession(sessionId);
+      } catch {
+        fallbackModelRef = '';
+      }
+    }
+    return buildOpenClawRuntimeErrorDetail(rawErrorMessage, displayMessage, metadata, {
+      fallbackModelRef: fallbackModelRef || undefined,
+      resolveModelSource: resolveModelSourceForOpenClawProvider,
+    });
+  }
+
   private finalizeStoppedStreamingMessage(
     sessionId: string,
     messageId: string | null,
@@ -6881,6 +6964,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         // If a different run started while the fallback was pending, leave it alone.
         if (errorRunId && !turn.knownRunIds.has(errorRunId)) return;
         const errorMessage = resolveOpenClawRuntimeErrorMessage(rawErrorMessage, errorMetadata);
+        const errorDetail = this.buildTurnErrorDetail(sessionId, turn, rawErrorMessage, errorMessage, errorMetadata);
         console.log(`[OpenClawRuntime] lifecycle error fallback surfaced an error after waiting for the gateway chat error event in session ${sessionId}: ${errorMessage}`);
         // Abort the retrying run on the gateway so the session is freed for new messages.
         // Without this, the gateway continues retrying indefinitely and rejects subsequent chat.send requests.
@@ -6899,7 +6983,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         const errorMsg = this.store.addMessage(sessionId, {
           type: 'system',
           content: errorMessage,
-          metadata: { error: errorMessage },
+          metadata: { error: errorMessage, ...(errorDetail ? { errorDetail } : {}) },
         });
         this.emit('message', sessionId, errorMsg);
         this.emit('error', sessionId, errorMessage);
@@ -8022,16 +8106,16 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       return;
     }
     if (finalTextIsOpenClawFailure) {
-      const errorMessage = resolveOpenClawRuntimeErrorMessage(
-        finalText.trim() || 'OpenClaw run failed',
-        normalizeOpenClawSafeRuntimeErrorMetadata(payload),
-      );
+      const rawErrorMessage = finalText.trim() || 'OpenClaw run failed';
+      const errorMetadata = normalizeOpenClawSafeRuntimeErrorMetadata(payload);
+      const errorMessage = resolveOpenClawRuntimeErrorMessage(rawErrorMessage, errorMetadata);
+      const errorDetail = this.buildTurnErrorDetail(sessionId, turn, rawErrorMessage, errorMessage, errorMetadata);
       const erroredSessionKey = turn.sessionKey;
       this.store.updateSession(sessionId, { status: 'error' });
       const errorMsg = this.store.addMessage(sessionId, {
         type: 'system',
         content: errorMessage,
-        metadata: { error: errorMessage },
+        metadata: { error: errorMessage, ...(errorDetail ? { errorDetail } : {}) },
       });
       this.emit('message', sessionId, errorMsg);
       this.emit('error', sessionId, errorMessage);
@@ -8184,16 +8268,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       const rawErrorMessage = payload.errorMessage?.trim()
         || errorMessageFromMessage?.trim()
         || 'OpenClaw run failed';
-      const errorMessage = resolveOpenClawRuntimeErrorMessage(
-        rawErrorMessage,
-        normalizeOpenClawSafeRuntimeErrorMetadata(payload),
-      );
+      const errorMetadata = normalizeOpenClawSafeRuntimeErrorMetadata(payload);
+      const errorMessage = resolveOpenClawRuntimeErrorMessage(rawErrorMessage, errorMetadata);
+      const errorDetail = this.buildTurnErrorDetail(sessionId, turn, rawErrorMessage, errorMessage, errorMetadata);
       const erroredSessionKey = turn.sessionKey;
       this.store.updateSession(sessionId, { status: 'error' });
       const errorMsg = this.store.addMessage(sessionId, {
         type: 'system',
         content: errorMessage,
-        metadata: { error: errorMessage },
+        metadata: { error: errorMessage, ...(errorDetail ? { errorDetail } : {}) },
       });
       this.emit('message', sessionId, errorMsg);
       this.emit('error', sessionId, errorMessage);
@@ -8838,10 +8921,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private handleChatError(sessionId: string, turn: ActiveTurn, payload: ChatEventPayload): void {
     console.log('[OpenClawRuntime] handleChatError payload:', JSON.stringify(payload).slice(0, 1000));
     const rawErrorMessage = payload.errorMessage?.trim() || 'OpenClaw run failed';
-    let errorMessage = resolveOpenClawRuntimeErrorMessage(
-      rawErrorMessage,
-      normalizeOpenClawSafeRuntimeErrorMetadata(payload),
-    );
+    const errorMetadata = normalizeOpenClawSafeRuntimeErrorMetadata(payload);
+    let errorMessage = resolveOpenClawRuntimeErrorMessage(rawErrorMessage, errorMetadata);
 
     // Detect model API errors that are likely caused by unsupported image content
     // in tool results (e.g., Read tool returning image blocks for non-vision models).
@@ -8850,6 +8931,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (/^400\b/.test(errorMessage)) {
       errorMessage += '\n\n[Hint: If the model attempted to read an image file, this may be because the model does not support image input. Consider using a vision-capable model or avoid sending image files.]';
     }
+    const errorDetail = this.buildTurnErrorDetail(sessionId, turn, rawErrorMessage, errorMessage, errorMetadata);
 
     const erroredSessionKey = turn.sessionKey;
     this.clearContextMaintenanceState(sessionId, turn, 'chat error');
@@ -8858,7 +8940,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     const errorMsg = this.store.addMessage(sessionId, {
       type: 'system',
       content: errorMessage,
-      metadata: { error: errorMessage },
+      metadata: { error: errorMessage, ...(errorDetail ? { errorDetail } : {}) },
     });
     this.emit('message', sessionId, errorMsg);
     this.emit('error', sessionId, errorMessage);

--- a/src/main/libs/claudeSettings.ts
+++ b/src/main/libs/claudeSettings.ts
@@ -681,6 +681,35 @@ export type ProviderRawConfig = {
   models: ProviderModelConfig[];
 };
 
+export type ProviderSourceEntry = {
+  providerName: string;
+  codingPlanEnabled: boolean;
+  authType?: ProviderConfig['authType'];
+  displayName?: string;
+};
+
+/**
+ * Lightweight view of every configured provider (enabled or not) for
+ * classifying which Settings entry a runtime error's provider id belongs to.
+ */
+export function listProviderSourceEntries(): ProviderSourceEntry[] {
+  const sqliteStore = getStore();
+  const appConfig = sqliteStore?.get<AppConfig>('app_config');
+  if (!appConfig?.providers) return [];
+
+  const entries: ProviderSourceEntry[] = [];
+  for (const [providerName, providerConfig] of Object.entries(appConfig.providers)) {
+    if (!providerConfig) continue;
+    entries.push({
+      providerName,
+      codingPlanEnabled: !!providerConfig.codingPlanEnabled,
+      authType: providerConfig.authType,
+      displayName: providerConfig.displayName?.trim() || undefined,
+    });
+  }
+  return entries;
+}
+
 export function resolveAllEnabledProviderConfigs(): ProviderRawConfig[] {
   const sqliteStore = getStore();
   if (!sqliteStore) return [];

--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -44,6 +44,12 @@ const mockRuntimeState = vi.hoisted(() => ({
       customParams?: Record<string, unknown>;
     }>;
   }>,
+  providerSourceEntries: [] as Array<{
+    providerName: string;
+    codingPlanEnabled: boolean;
+    authType?: 'apikey' | 'oauth';
+    displayName?: string;
+  }>,
   rawApiConfig: {
     config: {
       baseURL: 'https://api.openai.com/v1',
@@ -62,6 +68,7 @@ const mockRuntimeState = vi.hoisted(() => ({
 
 vi.mock('./claudeSettings', () => ({
   getAllServerModelMetadata: () => mockRuntimeState.serverModels,
+  listProviderSourceEntries: () => mockRuntimeState.providerSourceEntries,
   resolveAllEnabledProviderConfigs: () => mockRuntimeState.enabledProviders,
   resolveAllProviderApiKeys: () => ({}),
   resolveRawApiConfig: () => mockRuntimeState.rawApiConfig,
@@ -95,6 +102,7 @@ describe('OpenClawConfigSync runtime config output', () => {
     mockRuntimeState.proxyPort = null;
     mockRuntimeState.serverModels = [];
     mockRuntimeState.enabledProviders = [];
+    mockRuntimeState.providerSourceEntries = [];
     mockRuntimeState.rawApiConfig = {
       config: {
         baseURL: 'https://api.openai.com/v1',
@@ -2416,5 +2424,72 @@ describe('OpenClawConfigSync runtime config output', () => {
         'x-client-id': 'client-456',
       },
     });
+  });
+});
+
+describe('resolveModelSourceForOpenClawProvider', () => {
+  beforeEach(() => {
+    mockRuntimeState.providerSourceEntries = [];
+  });
+
+  test('classifies the LobsterAI plan without any Settings entry', async () => {
+    const { resolveModelSourceForOpenClawProvider } = await import('./openclawConfigSync');
+    expect(resolveModelSourceForOpenClawProvider('lobsterai-server')).toEqual({
+      source: 'lobsterai-plan',
+      providerName: ProviderName.LobsteraiServer,
+    });
+  });
+
+  test('classifies a custom provider with its display name', async () => {
+    mockRuntimeState.providerSourceEntries = [
+      { providerName: ProviderName.Custom, codingPlanEnabled: false, displayName: '我的中转' },
+    ];
+    const { resolveModelSourceForOpenClawProvider } = await import('./openclawConfigSync');
+    expect(resolveModelSourceForOpenClawProvider('custom')).toEqual({
+      source: 'custom-provider',
+      providerName: ProviderName.Custom,
+      providerDisplayName: '我的中转',
+    });
+  });
+
+  test('classifies a vendor coding plan through the descriptor provider id', async () => {
+    mockRuntimeState.providerSourceEntries = [
+      { providerName: ProviderName.Zhipu, codingPlanEnabled: true },
+    ];
+    const { resolveModelSourceForOpenClawProvider } = await import('./openclawConfigSync');
+    // Zhipu maps to the OpenClaw provider id "zai".
+    expect(resolveModelSourceForOpenClawProvider('zai')).toEqual({
+      source: 'coding-plan',
+      providerName: ProviderName.Zhipu,
+      providerDisplayName: 'Zhipu',
+    });
+  });
+
+  test('classifies OAuth-mode builtin providers via their oauth descriptor id', async () => {
+    mockRuntimeState.providerSourceEntries = [
+      { providerName: ProviderName.Minimax, codingPlanEnabled: false, authType: 'oauth' },
+    ];
+    const { resolveModelSourceForOpenClawProvider } = await import('./openclawConfigSync');
+    expect(resolveModelSourceForOpenClawProvider('minimax-portal')).toEqual({
+      source: 'builtin-oauth',
+      providerName: ProviderName.Minimax,
+      providerDisplayName: 'MiniMax',
+    });
+    // The api-key descriptor id no longer matches while OAuth mode is active.
+    expect(resolveModelSourceForOpenClawProvider('minimax')).toBeUndefined();
+  });
+
+  test('classifies plain builtin providers and unknown ids', async () => {
+    mockRuntimeState.providerSourceEntries = [
+      { providerName: ProviderName.DeepSeek, codingPlanEnabled: false },
+    ];
+    const { resolveModelSourceForOpenClawProvider } = await import('./openclawConfigSync');
+    expect(resolveModelSourceForOpenClawProvider('deepseek')).toEqual({
+      source: 'builtin-provider',
+      providerName: ProviderName.DeepSeek,
+      providerDisplayName: 'DeepSeek',
+    });
+    expect(resolveModelSourceForOpenClawProvider('never-configured')).toBeUndefined();
+    expect(resolveModelSourceForOpenClawProvider('')).toBeUndefined();
   });
 });

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -13,6 +13,7 @@ import {
   normalizeBrowserWebAccessConfig,
 } from '../../shared/browserWebAccess/constants';
 import { COWORK_TEMP_DIR_NAME } from '../../shared/cowork/constants';
+import { CoworkErrorModelSource } from '../../shared/cowork/errorDetail';
 import { normalizeMcpServerUrlInput } from '../../shared/mcp/url';
 import {
   AuthType,
@@ -28,6 +29,7 @@ import { OpenClawSessionKeepAlive } from '../openclawSessionPolicy/constants';
 import { buildOpenClawSessionConfig } from '../openclawSessionPolicy/store';
 import {
   getAllServerModelMetadata,
+  listProviderSourceEntries,
   resolveAllEnabledProviderConfigs,
   resolveAllProviderApiKeys,
   resolveRawApiConfig,
@@ -1070,6 +1072,69 @@ export const buildProviderSelection = (options: {
     },
   };
 };
+
+export type OpenClawProviderModelSource = {
+  source: CoworkErrorModelSource;
+  providerName?: string;
+  providerDisplayName?: string;
+};
+
+/**
+ * Classifies an OpenClaw provider id (as reported in gateway error metadata)
+ * back to the LobsterAI Settings entry it was generated from, so runtime
+ * errors can tell the user whether the failing model is the LobsterAI plan,
+ * a vendor coding plan, or their own custom provider.
+ */
+export function resolveModelSourceForOpenClawProvider(
+  openclawProviderId: string,
+): OpenClawProviderModelSource | undefined {
+  const providerId = openclawProviderId?.trim();
+  if (!providerId) return undefined;
+
+  if (providerId === OpenClawProviderId.LobsteraiServer) {
+    return {
+      source: CoworkErrorModelSource.LobsterAIPlan,
+      providerName: ProviderName.LobsteraiServer,
+    };
+  }
+
+  for (const entry of listProviderSourceEntries()) {
+    const descriptor = resolveDescriptor(
+      entry.providerName,
+      entry.codingPlanEnabled,
+      entry.authType,
+    );
+    if (descriptor.providerId !== providerId) continue;
+
+    if (entry.providerName === ProviderName.Custom) {
+      return {
+        source: CoworkErrorModelSource.CustomProvider,
+        providerName: entry.providerName,
+        providerDisplayName: entry.displayName,
+      };
+    }
+    // Built-in providers rarely carry a user displayName; fall back to the
+    // registry label ("DeepSeek", "Zhipu", ...) so the error card can name them.
+    const providerDisplayName =
+      entry.displayName || ProviderRegistry.get(entry.providerName)?.label || undefined;
+    if (entry.codingPlanEnabled) {
+      return {
+        source: CoworkErrorModelSource.CodingPlan,
+        providerName: entry.providerName,
+        providerDisplayName,
+      };
+    }
+    return {
+      source: entry.authType === 'oauth'
+        ? CoworkErrorModelSource.BuiltinOAuth
+        : CoworkErrorModelSource.BuiltinProvider,
+      providerName: entry.providerName,
+      providerDisplayName,
+    };
+  }
+
+  return undefined;
+}
 
 const buildProviderModelCatalog = (
   providers: Record<string, OpenClawProviderSelection['providerConfig']>,

--- a/src/renderer/components/cowork/AssistantTurnBlock.tsx
+++ b/src/renderer/components/cowork/AssistantTurnBlock.tsx
@@ -4,6 +4,12 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { classifyErrorKey } from '../../../common/coworkErrorClassify';
 import { ContextCompactionStatus } from '../../../common/coworkSystemMessages';
 import { getScheduledReminderDisplayText } from '../../../scheduledTask/reminderText';
+import {
+  type CoworkErrorDetail,
+  CoworkErrorModelSource,
+  formatCoworkErrorDetailText,
+  parseCoworkErrorDetail,
+} from '../../../shared/cowork/errorDetail';
 import type { CoworkGoal } from '../../../shared/cowork/goal';
 import { dedupeArtifactsForDisplay } from '../../services/artifactParser';
 import { i18nService } from '../../services/i18n';
@@ -16,6 +22,7 @@ import InformationCircleIcon from '../icons/InformationCircleIcon';
 import MarkdownContent from '../MarkdownContent';
 import AssistantMessageItem from './AssistantMessageItem';
 import MediaPollingIndicator from './MediaPollingIndicator';
+import { MessageCopyButton } from './MessageActionButton';
 import {
   collectMediaPollCounts,
   consolidateMediaPolling,
@@ -133,6 +140,76 @@ const getSystemMessageDisplayContent = (message: CoworkMessage, content: string)
 
   const key = classifyErrorKey(errorText) ?? classifyErrorKey(content);
   return key ? i18nService.t(key) : content;
+};
+
+// ── SystemErrorTechnicalDetail ───────────────────────────────────────────────
+
+/**
+ * User-facing model source label. Users only need two buckets — the LobsterAI
+ * plan vs. a model they configured themselves; finer detail (provider name,
+ * Coding Plan, OAuth) goes into the parenthesized qualifier.
+ */
+const buildErrorModelSourceLabel = (detail: CoworkErrorDetail): string | null => {
+  if (!detail.modelSource) return null;
+  if (detail.modelSource === CoworkErrorModelSource.LobsterAIPlan) {
+    return i18nService.t('coworkErrorModelSourceLobsterAIPlan');
+  }
+
+  const qualifiers: string[] = [];
+  if (detail.providerDisplayName) qualifiers.push(detail.providerDisplayName);
+  if (detail.modelSource === CoworkErrorModelSource.CodingPlan) qualifiers.push('Coding Plan');
+  if (detail.modelSource === CoworkErrorModelSource.BuiltinOAuth) qualifiers.push('OAuth');
+
+  const base = i18nService.t('coworkErrorModelSourceCustomModel');
+  return qualifiers.length > 0 ? `${base} (${qualifiers.join(' · ')})` : base;
+};
+
+/** "Model: glm-5 · Custom model (Zhipu · Coding Plan)" line shown without expanding details. */
+const buildErrorModelLine = (detail: CoworkErrorDetail): string | null => {
+  const sourceLabel = buildErrorModelSourceLabel(detail);
+  if (!detail.model && !sourceLabel) return null;
+
+  const parts: string[] = [];
+  if (detail.model) {
+    parts.push(`${i18nService.t('coworkErrorModelLabel')}: ${detail.model}`);
+  }
+  if (sourceLabel) {
+    parts.push(sourceLabel);
+  }
+  return parts.join(' · ');
+};
+
+const SystemErrorTechnicalDetail: React.FC<{ detail: CoworkErrorDetail }> = ({ detail }) => {
+  const [expanded, setExpanded] = useState(false);
+  const detailText = useMemo(() => formatCoworkErrorDetailText(detail), [detail]);
+  if (!detailText) return null;
+
+  return (
+    <div className="mt-1.5 pl-6">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="flex items-center gap-1 text-xs text-muted transition-colors hover:text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded"
+        aria-expanded={expanded}
+      >
+        {expanded
+          ? <ChevronUpIcon className="h-3 w-3 flex-shrink-0" />
+          : <ChevronDownIcon className="h-3 w-3 flex-shrink-0" />
+        }
+        <span>{i18nService.t('coworkErrorTechnicalDetails')}</span>
+      </button>
+      {expanded && (
+        <div className="relative mt-1.5 rounded-md bg-surface-raised px-3 py-2">
+          <div className="absolute right-1 top-1">
+            <MessageCopyButton content={detailText} />
+          </div>
+          <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap break-words pr-8 font-mono text-code text-secondary">
+            {detailText}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
 };
 
 // ── VideoArtifactPathList ────────────────────────────────────────────────────
@@ -294,6 +371,9 @@ const AssistantTurnBlock: React.FC<{
       );
     }
 
+    const errorDetail = parseCoworkErrorDetail(message.metadata?.errorDetail);
+    const errorModelLine = errorDetail ? buildErrorModelLine(errorDetail) : null;
+
     return (
       <div className="rounded-lg border border-border bg-background px-3 py-2">
         <div className="flex items-center gap-2">
@@ -308,6 +388,10 @@ const AssistantTurnBlock: React.FC<{
             />
           </div>
         </div>
+        {errorModelLine && (
+          <div className="mt-1 pl-6 text-xs text-muted">{errorModelLine}</div>
+        )}
+        {errorDetail && <SystemErrorTechnicalDetail detail={errorDetail} />}
       </div>
     );
   };

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1518,6 +1518,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkModelSwitchFailed: '模型切换失败，请稍后重试。',
     coworkErrorEngineNotReady: 'AI 引擎正在启动中，请稍等几秒后重试。',
     coworkErrorUnknown: '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
+    coworkErrorTechnicalDetails: '技术详情',
+    coworkErrorModelLabel: '模型',
+    coworkErrorModelSourceLobsterAIPlan: 'LobsterAI 套餐',
+    coworkErrorModelSourceCustomModel: '自定义模型',
 
     // Media Generation
     mediaGeneration: '媒体生成',
@@ -4408,6 +4412,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorEngineNotReady: 'AI engine is starting up. Please wait a few seconds and try again.',
     coworkErrorUnknown:
       'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
+    coworkErrorTechnicalDetails: 'Technical details',
+    coworkErrorModelLabel: 'Model',
+    coworkErrorModelSourceLobsterAIPlan: 'LobsterAI plan',
+    coworkErrorModelSourceCustomModel: 'Custom model',
 
     // Media Generation
     mediaGeneration: 'Media Generation',

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -3,6 +3,7 @@ import type {
   CoworkContextUsageSource,
   CoworkForkMode,
 } from '../../shared/cowork/constants';
+import type { CoworkErrorDetail } from '../../shared/cowork/errorDetail';
 import type { CoworkGoal } from '../../shared/cowork/goal';
 import type {
   CoworkImageAttachmentPayload,
@@ -69,6 +70,7 @@ export interface CoworkMessageMetadata {
   toolResult?: string;
   toolUseId?: string | null;
   error?: string;
+  errorDetail?: CoworkErrorDetail;
   isError?: boolean;
   isStreaming?: boolean;
   isFinal?: boolean;

--- a/src/shared/cowork/errorDetail.test.ts
+++ b/src/shared/cowork/errorDetail.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  buildCoworkErrorDetail,
+  CoworkErrorModelSource,
+  formatCoworkErrorDetailText,
+  parseCoworkErrorDetail,
+} from './errorDetail';
+
+describe('buildCoworkErrorDetail', () => {
+  test('keeps redacted provider metadata for a rate-limit error', () => {
+    const detail = buildCoworkErrorDetail({
+      rawErrorMessage: 'LLM request failed.',
+      displayMessage: '请求过于频繁，请稍后再试。',
+      metadata: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-5',
+        httpCode: '429',
+        providerErrorType: 'rate_limit_error',
+        providerErrorMessagePreview: 'Number of request tokens has exceeded your per-minute rate limit',
+        rawErrorPreview: '429 {"type":"error","error":{"type":"rate_limit_error","message":"..."}}',
+        failoverReason: 'rate_limit',
+        providerRuntimeFailureKind: 'rate_limit',
+      },
+    });
+
+    expect(detail).toEqual({
+      rawErrorMessage: 'LLM request failed.',
+      provider: 'anthropic',
+      model: 'claude-sonnet-5',
+      httpCode: '429',
+      providerErrorType: 'rate_limit_error',
+      providerErrorMessagePreview: 'Number of request tokens has exceeded your per-minute rate limit',
+      rawErrorPreview: '429 {"type":"error","error":{"type":"rate_limit_error","message":"..."}}',
+      failoverReason: 'rate_limit',
+      providerRuntimeFailureKind: 'rate_limit',
+    });
+  });
+
+  test('keeps the raw message when i18n normalization rewrote the display copy', () => {
+    const detail = buildCoworkErrorDetail({
+      rawErrorMessage: '401 authentication_error: invalid x-api-key',
+      displayMessage: 'API 密钥无效或已过期，请在设置中检查并更新您的 API 密钥。',
+    });
+
+    expect(detail).toEqual({
+      rawErrorMessage: '401 authentication_error: invalid x-api-key',
+    });
+  });
+
+  test('returns undefined when there is nothing beyond the display copy', () => {
+    expect(buildCoworkErrorDetail({
+      rawErrorMessage: 'OpenClaw run failed',
+      displayMessage: 'OpenClaw run failed',
+    })).toBeUndefined();
+
+    expect(buildCoworkErrorDetail({
+      rawErrorMessage: '  ',
+      displayMessage: 'anything',
+    })).toBeUndefined();
+  });
+
+  test('drops empty and whitespace-only metadata fields', () => {
+    const detail = buildCoworkErrorDetail({
+      rawErrorMessage: 'LLM request failed.',
+      displayMessage: 'LLM request failed.',
+      metadata: {
+        provider: '  ',
+        httpCode: '500',
+        rawErrorPreview: '',
+      },
+    });
+
+    expect(detail).toEqual({ httpCode: '500' });
+  });
+
+  test('keeps the model source annotation even without other metadata', () => {
+    const detail = buildCoworkErrorDetail({
+      rawErrorMessage: 'LLM request failed.',
+      displayMessage: 'LLM request failed.',
+      modelSource: CoworkErrorModelSource.CustomProvider,
+      providerDisplayName: '我的中转',
+    });
+
+    expect(detail).toEqual({
+      modelSource: 'custom-provider',
+      providerDisplayName: '我的中转',
+    });
+  });
+
+  test('rejects unknown model source values', () => {
+    expect(buildCoworkErrorDetail({
+      rawErrorMessage: 'x',
+      displayMessage: 'x',
+      modelSource: 'made-up' as never,
+    })).toBeUndefined();
+  });
+});
+
+describe('formatCoworkErrorDetailText', () => {
+  test('renders key/value lines in display order', () => {
+    const text = formatCoworkErrorDetailText({
+      rawErrorMessage: 'LLM request failed.',
+      provider: 'anthropic',
+      httpCode: '429',
+      providerErrorType: 'rate_limit_error',
+    });
+
+    expect(text).toBe([
+      'provider: anthropic',
+      'httpCode: 429',
+      'providerErrorType: rate_limit_error',
+      'rawErrorMessage: LLM request failed.',
+    ].join('\n'));
+  });
+
+  test('includes model source annotations after the model', () => {
+    const text = formatCoworkErrorDetailText({
+      provider: 'custom',
+      providerDisplayName: 'my-relay',
+      model: 'kimi-k2.5',
+      modelSource: CoworkErrorModelSource.CustomProvider,
+    });
+
+    expect(text).toBe([
+      'provider: custom',
+      'providerDisplayName: my-relay',
+      'model: kimi-k2.5',
+      'modelSource: custom-provider',
+    ].join('\n'));
+  });
+
+  test('returns empty string for an empty detail', () => {
+    expect(formatCoworkErrorDetailText({})).toBe('');
+  });
+});
+
+describe('parseCoworkErrorDetail', () => {
+  test('round-trips a detail restored from persisted JSON metadata', () => {
+    const persisted = JSON.parse(JSON.stringify({
+      provider: 'openai',
+      httpCode: '500',
+      rawErrorMessage: 'Internal server error',
+      unexpected: 123,
+    }));
+
+    expect(parseCoworkErrorDetail(persisted)).toEqual({
+      provider: 'openai',
+      httpCode: '500',
+      rawErrorMessage: 'Internal server error',
+    });
+  });
+
+  test('rejects non-object and empty values', () => {
+    expect(parseCoworkErrorDetail(null)).toBeNull();
+    expect(parseCoworkErrorDetail('error')).toBeNull();
+    expect(parseCoworkErrorDetail([])).toBeNull();
+    expect(parseCoworkErrorDetail({ provider: '  ' })).toBeNull();
+    expect(parseCoworkErrorDetail({ provider: 42 })).toBeNull();
+  });
+
+  test('keeps valid model sources and drops corrupted ones', () => {
+    expect(parseCoworkErrorDetail({
+      model: 'glm-5',
+      modelSource: 'coding-plan',
+    })).toEqual({ model: 'glm-5', modelSource: 'coding-plan' });
+
+    expect(parseCoworkErrorDetail({
+      model: 'glm-5',
+      modelSource: 'not-a-source',
+    })).toEqual({ model: 'glm-5' });
+  });
+});

--- a/src/shared/cowork/errorDetail.ts
+++ b/src/shared/cowork/errorDetail.ts
@@ -1,0 +1,150 @@
+/**
+ * Where the failing model comes from in LobsterAI terms, so users can tell at
+ * a glance whether an error concerns the LobsterAI plan, a vendor coding plan
+ * they configured, or their own custom provider.
+ */
+export const CoworkErrorModelSource = {
+  LobsterAIPlan: 'lobsterai-plan',
+  CodingPlan: 'coding-plan',
+  CustomProvider: 'custom-provider',
+  BuiltinOAuth: 'builtin-oauth',
+  BuiltinProvider: 'builtin-provider',
+} as const;
+export type CoworkErrorModelSource = typeof CoworkErrorModelSource[keyof typeof CoworkErrorModelSource];
+
+const COWORK_ERROR_MODEL_SOURCE_VALUES = new Set<string>(Object.values(CoworkErrorModelSource));
+
+export function isCoworkErrorModelSource(value: unknown): value is CoworkErrorModelSource {
+  return typeof value === 'string' && COWORK_ERROR_MODEL_SOURCE_VALUES.has(value);
+}
+
+/**
+ * Technical detail of an underlying provider/API error, preserved alongside the
+ * normalized user-facing error copy so the UI can offer a "technical details"
+ * disclosure without weakening the friendly primary message.
+ *
+ * Every preview field originates from OpenClaw's redacted observation pipeline
+ * (rawErrorPreview ≤ 400 chars, providerErrorMessagePreview ≤ 200 chars, with
+ * API keys / cookies / request ids already redacted). Never place unredacted
+ * provider payloads in this structure.
+ */
+export interface CoworkErrorDetail {
+  /** Runtime error message before LobsterAI i18n normalization. */
+  rawErrorMessage?: string;
+  provider?: string;
+  model?: string;
+  /** LobsterAI-side classification of where the failing model comes from. */
+  modelSource?: CoworkErrorModelSource;
+  /** User-visible provider name from Settings (e.g. a custom provider's displayName). */
+  providerDisplayName?: string;
+  httpCode?: string;
+  providerErrorType?: string;
+  providerErrorMessagePreview?: string;
+  rawErrorPreview?: string;
+  failoverReason?: string;
+  providerRuntimeFailureKind?: string;
+}
+
+const COWORK_ERROR_DETAIL_METADATA_KEYS = [
+  'provider',
+  'model',
+  'httpCode',
+  'providerErrorType',
+  'providerErrorMessagePreview',
+  'rawErrorPreview',
+  'failoverReason',
+  'providerRuntimeFailureKind',
+] as const;
+
+type CoworkErrorDetailMetadataKey = typeof COWORK_ERROR_DETAIL_METADATA_KEYS[number];
+
+export type CoworkErrorDetailSourceMetadata = Partial<
+  Record<CoworkErrorDetailMetadataKey, string | undefined>
+>;
+
+const normalizeField = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+/**
+ * Builds the persisted error detail, or undefined when it would carry no
+ * information beyond the user-facing message (so metadata stays lean and the
+ * UI only offers the disclosure when there is something extra to show).
+ */
+export function buildCoworkErrorDetail(input: {
+  rawErrorMessage?: string;
+  displayMessage?: string;
+  metadata?: CoworkErrorDetailSourceMetadata;
+  modelSource?: CoworkErrorModelSource;
+  providerDisplayName?: string;
+}): CoworkErrorDetail | undefined {
+  const detail: CoworkErrorDetail = {};
+
+  for (const key of COWORK_ERROR_DETAIL_METADATA_KEYS) {
+    const value = normalizeField(input.metadata?.[key]);
+    if (value) detail[key] = value;
+  }
+
+  if (input.modelSource && isCoworkErrorModelSource(input.modelSource)) {
+    detail.modelSource = input.modelSource;
+  }
+  const providerDisplayName = normalizeField(input.providerDisplayName);
+  if (providerDisplayName) {
+    detail.providerDisplayName = providerDisplayName;
+  }
+
+  const rawErrorMessage = normalizeField(input.rawErrorMessage);
+  const displayMessage = normalizeField(input.displayMessage);
+  if (rawErrorMessage && rawErrorMessage !== displayMessage) {
+    detail.rawErrorMessage = rawErrorMessage;
+  }
+
+  return Object.keys(detail).length > 0 ? detail : undefined;
+}
+
+const COWORK_ERROR_DETAIL_DISPLAY_ORDER: Array<keyof CoworkErrorDetail> = [
+  'provider',
+  'providerDisplayName',
+  'model',
+  'modelSource',
+  'httpCode',
+  'providerErrorType',
+  'failoverReason',
+  'providerRuntimeFailureKind',
+  'providerErrorMessagePreview',
+  'rawErrorMessage',
+  'rawErrorPreview',
+];
+
+/**
+ * Multi-line `key: value` text for the technical-details disclosure and its
+ * copy action. Values are already redacted upstream; this is display-only
+ * formatting.
+ */
+export function formatCoworkErrorDetailText(detail: CoworkErrorDetail): string {
+  const lines: string[] = [];
+  for (const key of COWORK_ERROR_DETAIL_DISPLAY_ORDER) {
+    const value = normalizeField(detail[key]);
+    if (value) lines.push(`${key}: ${value}`);
+  }
+  return lines.join('\n');
+}
+
+export function parseCoworkErrorDetail(value: unknown): CoworkErrorDetail | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const detail: CoworkErrorDetail = {};
+  for (const key of COWORK_ERROR_DETAIL_DISPLAY_ORDER) {
+    const raw = record[key];
+    if (typeof raw !== 'string') continue;
+    if (key === 'modelSource') {
+      const normalized = normalizeField(raw);
+      if (normalized && isCoworkErrorModelSource(normalized)) detail.modelSource = normalized;
+      continue;
+    }
+    const normalized = normalizeField(raw);
+    if (normalized) detail[key as Exclude<keyof CoworkErrorDetail, 'modelSource'>] = normalized;
+  }
+  return Object.keys(detail).length > 0 ? detail : null;
+}


### PR DESCRIPTION
Add a redacted CoworkErrorDetail structure (provider, model, http code, error type/preview, failover reason) carried from OpenClaw through the runtime adapter and config sync into the assistant turn UI, so users can expand technical details on a failed run instead of only seeing the normalized message.