### PR TITLE
style(renderer): refine Windows caption icons

### DIFF
--- a/src/renderer/components/window/WindowTitleBar.tsx
+++ b/src/renderer/components/window/WindowTitleBar.tsx
@@ -26,7 +26,7 @@ const WindowControlAction = {
 } as const;
 type WindowControlAction = typeof WindowControlAction[keyof typeof WindowControlAction];
 
-const WINDOW_CAPTION_BUTTON_CLASS_NAME = 'non-draggable inline-flex h-full w-[46px] shrink-0 items-center justify-center text-foreground/90 outline-none transition-colors duration-100 hover:bg-foreground/[0.08] focus-visible:bg-foreground/[0.08] active:bg-foreground/[0.12]';
+const WINDOW_CAPTION_BUTTON_CLASS_NAME = 'non-draggable inline-flex h-full w-[46px] shrink-0 items-center justify-center text-foreground/90 outline-none transition-colors duration-100 hover:bg-foreground/[0.06] focus-visible:bg-foreground/[0.06] active:bg-foreground/[0.09]';
 const WINDOW_CLOSE_CAPTION_BUTTON_CLASS_NAME = 'non-draggable inline-flex h-full w-[46px] shrink-0 items-center justify-center text-foreground/90 outline-none transition-colors duration-100 hover:bg-[#c42b1c] hover:text-white focus-visible:bg-[#c42b1c] focus-visible:text-white active:bg-[#b1261a] active:text-white';
 
 const reportWindowControlAction = (action: WindowControlAction): void => {
@@ -126,8 +126,8 @@ const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
         aria-label="Minimize"
         title="Minimize"
       >
-        <svg aria-hidden="true" viewBox="0 0 10 10" className="h-[10px] w-[10px]" fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round">
-          <path d="M1 5.5h8" />
+        <svg aria-hidden="true" viewBox="0 0 12 12" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round">
+          <path d="M2 6.5h8" />
         </svg>
       </button>
       <button
@@ -138,13 +138,13 @@ const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
         title={state.isMaximized ? 'Restore' : 'Maximize'}
       >
         {state.isMaximized ? (
-          <svg aria-hidden="true" viewBox="0 0 10 10" className="h-[10px] w-[10px]" fill="none" stroke="currentColor" strokeWidth="1" strokeLinejoin="round">
-            <path d="M3.5 1.5h5v5" />
-            <rect x="1.5" y="3.5" width="5" height="5" rx="0.5" />
+          <svg aria-hidden="true" viewBox="0 0 12 12" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="1" strokeLinejoin="round">
+            <path d="M4 1.5h6.5V8H8" />
+            <rect x="1.5" y="4" width="6.5" height="6.5" rx="0.6" />
           </svg>
         ) : (
-          <svg aria-hidden="true" viewBox="0 0 10 10" className="h-[10px] w-[10px]" fill="none" stroke="currentColor" strokeWidth="1">
-            <rect x="1.5" y="1.5" width="7" height="7" rx="0.6" />
+          <svg aria-hidden="true" viewBox="0 0 12 12" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="1">
+            <rect x="2" y="2" width="8" height="8" rx="0.7" />
           </svg>
         )}
       </button>

--- a/src/renderer/components/window/WindowTitleBar.tsx
+++ b/src/renderer/components/window/WindowTitleBar.tsx
@@ -18,6 +18,27 @@ const DEFAULT_STATE: WindowState = {
   isFocused: true,
 };
 
+const WindowControlAction = {
+  Minimize: 'minimize',
+  Maximize: 'maximize',
+  Restore: 'restore',
+  Close: 'close',
+} as const;
+type WindowControlAction = typeof WindowControlAction[keyof typeof WindowControlAction];
+
+const WINDOW_CAPTION_BUTTON_CLASS_NAME = 'non-draggable inline-flex h-full w-[46px] shrink-0 items-center justify-center text-foreground/90 outline-none transition-colors duration-100 hover:bg-foreground/[0.08] focus-visible:bg-foreground/[0.08] active:bg-foreground/[0.12]';
+const WINDOW_CLOSE_CAPTION_BUTTON_CLASS_NAME = 'non-draggable inline-flex h-full w-[46px] shrink-0 items-center justify-center text-foreground/90 outline-none transition-colors duration-100 hover:bg-[#c42b1c] hover:text-white focus-visible:bg-[#c42b1c] focus-visible:text-white active:bg-[#b1261a] active:text-white';
+
+const reportWindowControlAction = (action: WindowControlAction): void => {
+  const message = `window control requested action=${action}`;
+  console.debug(`[WindowTitleBar] ${message}`);
+  try {
+    window.electron?.log?.fromRenderer?.('debug', 'WindowTitleBar', message);
+  } catch {
+    // Window controls must remain available even if diagnostic logging fails.
+  }
+};
+
 const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
   isOverlayActive = false,
   inline = false,
@@ -26,6 +47,8 @@ const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
   const [state, setState] = useState<WindowState>(DEFAULT_STATE);
 
   useEffect(() => {
+    if (window.electron.platform !== 'win32') return;
+
     let disposed = false;
     window.electron.window.isMaximized().then((isMaximized) => {
       if (!disposed) {
@@ -46,14 +69,19 @@ const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
   }, []);
 
   const handleMinimize = () => {
+    reportWindowControlAction(WindowControlAction.Minimize);
     window.electron.window.minimize();
   };
 
   const handleToggleMaximize = () => {
+    reportWindowControlAction(
+      state.isMaximized ? WindowControlAction.Restore : WindowControlAction.Maximize,
+    );
     window.electron.window.toggleMaximize();
   };
 
   const handleClose = () => {
+    reportWindowControlAction(WindowControlAction.Close);
     window.electron.window.close();
   };
 
@@ -76,8 +104,8 @@ const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
   }
 
   const containerClassName = inline
-    ? `window-controls-floating non-draggable flex h-8 items-center gap-0.5 transition-colors ${!state.isFocused ? 'opacity-70' : 'opacity-100'} ${className}`.trim()
-    : `window-controls-floating non-draggable absolute top-0 right-0 z-[55] flex h-full items-center gap-0.5 rounded-bl-xl pl-1 pb-1 pt-0.5 transition-colors ${
+    ? `window-controls-floating non-draggable flex h-full items-stretch transition-opacity ${!state.isFocused ? 'opacity-70' : 'opacity-100'} ${className}`.trim()
+    : `window-controls-floating non-draggable absolute top-0 right-0 z-[55] flex h-9 items-stretch transition-opacity ${
       !state.isFocused ? 'opacity-70' : 'opacity-100'
     } ${
       isOverlayActive
@@ -94,42 +122,42 @@ const WindowTitleBar: React.FC<WindowTitleBarProps> = ({
       <button
         type="button"
         onClick={handleMinimize}
-        className="non-draggable h-8 w-8 inline-flex items-center justify-center rounded-lg transition-colors text-secondary hover:hover:bg-surface-raised"
+        className={WINDOW_CAPTION_BUTTON_CLASS_NAME}
         aria-label="Minimize"
         title="Minimize"
       >
-        <svg viewBox="0 0 12 12" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M2 6h8" />
+        <svg aria-hidden="true" viewBox="0 0 10 10" className="h-[10px] w-[10px]" fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round">
+          <path d="M1 5.5h8" />
         </svg>
       </button>
       <button
         type="button"
         onClick={handleToggleMaximize}
-        className="non-draggable h-8 w-8 inline-flex items-center justify-center rounded-lg transition-colors text-secondary hover:hover:bg-surface-raised"
+        className={WINDOW_CAPTION_BUTTON_CLASS_NAME}
         aria-label={state.isMaximized ? 'Restore' : 'Maximize'}
         title={state.isMaximized ? 'Restore' : 'Maximize'}
       >
         {state.isMaximized ? (
-          <svg viewBox="0 0 12 12" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M4 2h6.5v6.5" />
-            <path d="M1.5 4h7v7h-7z" />
+          <svg aria-hidden="true" viewBox="0 0 10 10" className="h-[10px] w-[10px]" fill="none" stroke="currentColor" strokeWidth="1" strokeLinejoin="round">
+            <path d="M3.5 1.5h5v5" />
+            <rect x="1.5" y="3.5" width="5" height="5" rx="0.5" />
           </svg>
         ) : (
-          <svg viewBox="0 0 12 12" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M2 2h8v8H2z" />
+          <svg aria-hidden="true" viewBox="0 0 10 10" className="h-[10px] w-[10px]" fill="none" stroke="currentColor" strokeWidth="1">
+            <rect x="1.5" y="1.5" width="7" height="7" rx="0.6" />
           </svg>
         )}
       </button>
       <button
         type="button"
         onClick={handleClose}
-        className="non-draggable h-8 w-8 inline-flex items-center justify-center rounded-lg transition-colors text-secondary hover:bg-red-500 hover:text-white dark:hover:bg-red-500"
+        className={WINDOW_CLOSE_CAPTION_BUTTON_CLASS_NAME}
         aria-label="Close"
         title="Close"
       >
-        <svg viewBox="0 0 12 12" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M3 3l6 6" />
-          <path d="M9 3L3 9" />
+        <svg aria-hidden="true" viewBox="0 0 12 12" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round">
+          <path d="M2 2l8 8" />
+          <path d="M10 2L2 10" />
         </svg>
       </button>
     </div>

--- a/src/renderer/components/window/WindowsAppTitleBar.test.ts
+++ b/src/renderer/components/window/WindowsAppTitleBar.test.ts
@@ -57,11 +57,11 @@ describe('WindowsAppTitleBar', () => {
     expect(renderTitleBar(platform)).toBe('');
   });
 
-  test('uses compact Windows caption glyphs with full-size hit targets', () => {
+  test('uses uniform Windows caption glyphs with full-size hit targets', () => {
     const html = renderTitleBar('win32');
 
     expect(html.match(/w-\[46px\]/g)).toHaveLength(3);
-    expect(html.match(/h-\[10px\] w-\[10px\]/g)).toHaveLength(2);
+    expect(html.match(/h-3 w-3/g)).toHaveLength(3);
     expect(html).toContain('aria-label="Minimize"');
     expect(html).toContain('aria-label="Maximize"');
     expect(html).toContain('aria-label="Close"');

--- a/src/renderer/components/window/WindowsAppTitleBar.test.ts
+++ b/src/renderer/components/window/WindowsAppTitleBar.test.ts
@@ -53,7 +53,18 @@ describe('WindowsAppTitleBar', () => {
     expect(html).toContain('class="truncate text-sm font-medium text-foreground"');
   });
 
-  test('does not render on macOS', () => {
-    expect(renderTitleBar('darwin')).toBe('');
+  test.each(['darwin', 'linux'])('does not render on %s', (platform) => {
+    expect(renderTitleBar(platform)).toBe('');
+  });
+
+  test('uses compact Windows caption glyphs with full-size hit targets', () => {
+    const html = renderTitleBar('win32');
+
+    expect(html.match(/w-\[46px\]/g)).toHaveLength(3);
+    expect(html.match(/h-\[10px\] w-\[10px\]/g)).toHaveLength(2);
+    expect(html).toContain('aria-label="Minimize"');
+    expect(html).toContain('aria-label="Maximize"');
+    expect(html).toContain('aria-label="Close"');
+    expect(html).toContain('bg-surface-raised pl-3');
   });
 });

--- a/src/renderer/components/window/WindowsAppTitleBar.tsx
+++ b/src/renderer/components/window/WindowsAppTitleBar.tsx
@@ -53,7 +53,7 @@ const WindowsAppTitleBar: React.FC<WindowsAppTitleBarProps> = ({
   }
 
   return (
-    <div className="draggable flex h-9 shrink-0 items-center justify-between border-b border-border bg-surface-raised px-3">
+    <div className="draggable flex h-9 shrink-0 items-center justify-between border-b border-border bg-surface-raised pl-3">
       <div
         className={`flex h-full shrink-0 items-center ${isSidebarCollapsed ? 'gap-1' : 'justify-between'}`}
         style={isSidebarCollapsed ? undefined : { width: Math.max(0, sidebarWidth - 24) }}


### PR DESCRIPTION
Align window control sizing and hover states with native Windows styling.