### PR TITLE
fix(auth): preserve local callback across login retries

### DIFF
--- a/src/main/libs/authLocalCallbackServer.test.ts
+++ b/src/main/libs/authLocalCallbackServer.test.ts
@@ -67,6 +67,39 @@ describe('startAuthLocalCallback', () => {
     }
   });
 
+  test('reuses the active callback so a repeated login does not invalidate the first page', async () => {
+    const codes: string[] = [];
+    const firstCallback = await startAuthLocalCallback({
+      onCode: code => codes.push(code),
+    });
+    const secondCallback = await startAuthLocalCallback({ onCode: () => {} });
+
+    expect(secondCallback.redirectUri).toBe(firstCallback.redirectUri);
+    expect(secondCallback.state).toBe(firstCallback.state);
+
+    const response = await fetch(
+      `${firstCallback.redirectUri}?code=first-page-code&state=${firstCallback.state}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(codes).toEqual(['first-page-code']);
+  });
+
+  test('coalesces callback servers that start concurrently', async () => {
+    const codes: string[] = [];
+    const [firstCallback, secondCallback] = await Promise.all([
+      startAuthLocalCallback({ onCode: code => codes.push(code) }),
+      startAuthLocalCallback({ onCode: () => {} }),
+    ]);
+
+    try {
+      expect(secondCallback.redirectUri).toBe(firstCallback.redirectUri);
+      expect(secondCallback.state).toBe(firstCallback.state);
+    } finally {
+      await firstCallback.close();
+    }
+  });
+
   test('delivers code when callback path and state are valid', async () => {
     const codes: string[] = [];
     const callback = await startAuthLocalCallback({

--- a/src/main/libs/authLocalCallbackServer.ts
+++ b/src/main/libs/authLocalCallbackServer.ts
@@ -17,7 +17,12 @@ export interface AuthLocalCallback {
   close: () => Promise<void>;
 }
 
-let activeCallback: AuthLocalCallback | null = null;
+interface ActiveAuthLocalCallback extends AuthLocalCallback {
+  refreshTimeout: (timeoutMs: number) => void;
+}
+
+let activeCallback: ActiveAuthLocalCallback | null = null;
+let startingCallback: Promise<ActiveAuthLocalCallback> | null = null;
 
 const escapeHtml = (value: string): string =>
   value.replace(/[<>&"]/g, (char) => {
@@ -136,21 +141,27 @@ function resolveSafeReturnTo(value: string | null): string | null {
   }
 }
 
-export async function startAuthLocalCallback(
+async function createAuthLocalCallback(
   options: AuthLocalCallbackOptions,
-): Promise<AuthLocalCallback> {
-  if (activeCallback) {
-    await activeCallback.close();
-  }
-
+): Promise<ActiveAuthLocalCallback> {
   const state = crypto.randomBytes(24).toString('base64url');
   const server = http.createServer();
   let closed = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
 
-  const callback: AuthLocalCallback = {
+  const callback: ActiveAuthLocalCallback = {
     redirectUri: '',
     state,
+    refreshTimeout: (timeoutMs: number) => {
+      if (closed) return;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => {
+        console.warn(`[AuthLocalCallback] login callback timed out at ${callback.redirectUri}`);
+        void callback.close();
+      }, timeoutMs);
+    },
     close: async () => {
       if (closed) return;
       closed = true;
@@ -162,6 +173,7 @@ export async function startAuthLocalCallback(
         activeCallback = null;
       }
       await closeServer(server);
+      console.debug(`[AuthLocalCallback] closed local callback server at ${callback.redirectUri}`);
     },
   };
 
@@ -236,12 +248,45 @@ export async function startAuthLocalCallback(
 
   callback.redirectUri = `http://${AUTH_LOCAL_CALLBACK_HOST}:${address.port}${AUTH_CALLBACK_PATH}`;
   activeCallback = callback;
+  server.on('error', error => {
+    console.error(`[AuthLocalCallback] local callback server failed at ${callback.redirectUri}:`, error);
+    void callback.close();
+  });
   console.log(`[AuthLocalCallback] started local callback server on ${AUTH_LOCAL_CALLBACK_HOST}:${address.port}`);
 
-  timer = setTimeout(() => {
-    console.warn('[AuthLocalCallback] login callback timed out, closed local server');
-    void callback.close();
-  }, options.timeoutMs ?? AUTH_LOCAL_CALLBACK_TIMEOUT_MS);
+  callback.refreshTimeout(options.timeoutMs ?? AUTH_LOCAL_CALLBACK_TIMEOUT_MS);
 
   return callback;
+}
+
+export async function startAuthLocalCallback(
+  options: AuthLocalCallbackOptions,
+): Promise<AuthLocalCallback> {
+  const timeoutMs = options.timeoutMs ?? AUTH_LOCAL_CALLBACK_TIMEOUT_MS;
+
+  if (activeCallback) {
+    // Existing browser tabs still target this URL, so keep it valid across repeated login clicks.
+    activeCallback.refreshTimeout(timeoutMs);
+    console.log(`[AuthLocalCallback] reusing active local callback server at ${activeCallback.redirectUri}`);
+    return activeCallback;
+  }
+
+  if (startingCallback) {
+    // Coalesce clicks that arrive before the first server has finished binding its port.
+    const callback = await startingCallback;
+    callback.refreshTimeout(timeoutMs);
+    console.log(`[AuthLocalCallback] reusing starting local callback server at ${callback.redirectUri}`);
+    return callback;
+  }
+
+  const callbackPromise = createAuthLocalCallback(options);
+  startingCallback = callbackPromise;
+
+  try {
+    return await callbackPromise;
+  } finally {
+    if (startingCallback === callbackPromise) {
+      startingCallback = null;
+    }
+  }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5264,7 +5264,7 @@ if (!gotTheLock) {
     return quota;
   };
 
-  ipcMain.handle('auth:login', async (_event, { loginUrl }: { loginUrl?: string } = {}) => {
+  ipcMain.handle(AuthIpcChannel.Login, async (_event, { loginUrl }: { loginUrl?: string } = {}) => {
     const baseUrl = loginUrl || `${getServerApiBaseUrl()}/login`;
     const fallbackUrl = appendLoginParams(baseUrl, { source: 'electron' });
     let localCallback: Awaited<ReturnType<typeof startAuthLocalCallback>> | null = null;
@@ -5290,7 +5290,7 @@ if (!gotTheLock) {
       await shell.openExternal(finalUrl);
       return { success: true };
     } catch (error) {
-      await localCallback?.close();
+      // The callback may be shared by another login page and will clean itself up on timeout.
       console.warn('[Auth] local callback login failed, falling back to deep link login:', error);
       try {
         await shell.openExternal(fallbackUrl);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1051,7 +1051,7 @@ contextBridge.exposeInMainWorld('electron', {
     send: (status: 'online' | 'offline') => ipcRenderer.send('network:status-change', status),
   },
   auth: {
-    login: (loginUrl?: string) => ipcRenderer.invoke('auth:login', { loginUrl }),
+    login: (loginUrl?: string) => ipcRenderer.invoke(AuthIpcChannel.Login, { loginUrl }),
     exchange: (code: string) => ipcRenderer.invoke('auth:exchange', { code }),
     getUser: () => ipcRenderer.invoke('auth:getUser'),
     getQuota: () => ipcRenderer.invoke('auth:getQuota'),

--- a/src/renderer/services/auth.test.ts
+++ b/src/renderer/services/auth.test.ts
@@ -1,10 +1,16 @@
 import { ProviderName } from '@shared/providers';
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
+  authService,
   mapPricingCatalogTextModelsToServerModels,
   mapPricingCatalogToPublicServerModels,
 } from './auth';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe('pricing catalog model mapping', () => {
   test('maps public text models to locked server models', () => {
@@ -61,5 +67,68 @@ describe('pricing catalog model mapping', () => {
 
     expect(models.map(model => model.id)).toEqual(['MiniMax-M3']);
     expect(models[0].accessible).toBe(false);
+  });
+});
+
+describe('login diagnostics', () => {
+  test('persists renderer lifecycle logs without including the login URL', async () => {
+    const fromRenderer = vi.fn();
+    const login = vi.fn().mockResolvedValue({ success: true });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.stubGlobal('window', {
+      electron: {
+        api: {
+          fetch: vi.fn().mockResolvedValue({
+            ok: true,
+            data: { data: { value: 'https://lobsterai.youdao.com/portal#/login' } },
+          }),
+        },
+        auth: { login },
+        log: { fromRenderer },
+      },
+    });
+
+    await authService.login();
+
+    expect(login).toHaveBeenCalledWith('https://lobsterai.youdao.com/portal#/login');
+    expect(fromRenderer).toHaveBeenCalledWith(
+      'info',
+      'AuthService',
+      expect.stringMatching(/^login attempt \d+ started$/),
+    );
+    expect(fromRenderer).toHaveBeenCalledWith(
+      'info',
+      'AuthService',
+      expect.stringMatching(/^login attempt \d+ handed off to the system browser$/),
+    );
+    expect(fromRenderer.mock.calls.flat().join(' ')).not.toContain('lobsterai.youdao.com');
+  });
+
+  test('records a warning while preserving the existing non-throwing IPC failure behavior', async () => {
+    const fromRenderer = vi.fn();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.stubGlobal('window', {
+      electron: {
+        api: {
+          fetch: vi.fn().mockResolvedValue({
+            ok: true,
+            data: { data: { value: 'https://lobsterai.youdao.com/portal#/login' } },
+          }),
+        },
+        auth: { login: vi.fn().mockResolvedValue({ success: false, error: 'open failed' }) },
+        log: { fromRenderer },
+      },
+    });
+
+    await expect(authService.login()).resolves.toBeUndefined();
+
+    expect(fromRenderer).toHaveBeenCalledWith(
+      'warn',
+      'AuthService',
+      expect.stringMatching(/^login attempt \d+ could not open the system browser$/),
+    );
   });
 });

--- a/src/renderer/services/auth.ts
+++ b/src/renderer/services/auth.ts
@@ -50,6 +50,32 @@ const readPositiveNumber = (value: unknown): number | undefined => (
     : undefined
 );
 
+type AuthRendererLogLevel = 'debug' | 'info' | 'warn';
+
+const writeAuthRendererLog = (
+  level: AuthRendererLogLevel,
+  message: string,
+  error?: unknown,
+): void => {
+  if (level === 'warn') {
+    if (error === undefined) {
+      console.warn(`[Auth] ${message}`);
+    } else {
+      console.warn(`[Auth] ${message}:`, error);
+    }
+  } else if (level === 'debug') {
+    console.debug(`[Auth] ${message}`);
+  } else {
+    console.log(`[Auth] ${message}`);
+  }
+
+  try {
+    window.electron?.log?.fromRenderer?.(level, 'AuthService', message);
+  } catch {
+    // Logging is best-effort and must never interrupt authentication.
+  }
+};
+
 export function mapPricingCatalogTextModelsToServerModels(
   textModels: PricingCatalogTextModel[],
 ): Model[] {
@@ -93,6 +119,7 @@ class AuthService {
   private unsubQuotaChanged: (() => void) | null = null;
   private unsubWindowState: (() => void) | null = null;
   private lastRefreshTime = 0;
+  private loginAttemptSequence = 0;
 
   /**
    * Initialize: try to restore login state from persisted token.
@@ -148,8 +175,21 @@ class AuthService {
    * Initiate login (opens system browser).
    */
   async login() {
-    const loginUrl = await this.fetchLoginUrl();
-    await window.electron.auth.login(loginUrl);
+    const attemptId = ++this.loginAttemptSequence;
+    writeAuthRendererLog('info', `login attempt ${attemptId} started`);
+
+    try {
+      const loginUrl = await this.fetchLoginUrl();
+      const result = await window.electron.auth.login(loginUrl);
+      if (result.success) {
+        writeAuthRendererLog('info', `login attempt ${attemptId} handed off to the system browser`);
+      } else {
+        writeAuthRendererLog('warn', `login attempt ${attemptId} could not open the system browser`);
+      }
+    } catch (error) {
+      writeAuthRendererLog('warn', `login attempt ${attemptId} failed before browser handoff`, error);
+      throw error;
+    }
   }
 
   /**
@@ -167,16 +207,16 @@ class AuthService {
       if (response.ok && typeof response.data === 'object' && response.data !== null) {
         const value = (response.data as any)?.data?.value;
         if (typeof value === 'string' && value.trim()) {
-          console.log('[Auth] fetched login URL from overmind');
+          writeAuthRendererLog('debug', 'resolved login URL from overmind');
           return value.trim();
         }
       }
     } catch (e) {
-      console.error('[Auth] Failed to fetch login URL from overmind:', e);
+      writeAuthRendererLog('warn', 'failed to resolve login URL from overmind', e);
     }
     // Fallback: use Portal login page directly
     const { getPortalLoginUrl } = await import('./endpoints');
-    console.log('[Auth] using fallback portal login URL');
+    writeAuthRendererLog('info', 'using fallback portal login URL');
     return getPortalLoginUrl();
   }
 
@@ -184,17 +224,20 @@ class AuthService {
    * Handle OAuth callback with auth code.
    */
   async handleCallback(code: string): Promise<boolean> {
+    writeAuthRendererLog('info', 'received login callback; starting token exchange');
     try {
       const result = await window.electron.auth.exchange(code);
       if (result.success) {
+        writeAuthRendererLog('info', 'login callback exchange succeeded');
         store.dispatch(setLoggedIn({ user: result.user, quota: result.quota }));
         await this.loadServerModels();
         void this.fetchProfileSummary();
         this.refreshQuota();
         return true;
       }
+      writeAuthRendererLog('warn', 'login callback exchange was rejected');
     } catch (e) {
-      console.error('Auth callback failed:', e);
+      writeAuthRendererLog('warn', 'login callback exchange failed', e);
     }
     return false;
   }

--- a/src/shared/auth/constants.ts
+++ b/src/shared/auth/constants.ts
@@ -2,6 +2,7 @@ export const AuthIpcChannel = {
   Callback: 'auth:callback',
   GetPricingCatalog: 'auth:getPricingCatalog',
   GetPendingCallback: 'auth:getPendingCallback',
+  Login: 'auth:login',
 } as const;
 
 export type AuthIpcChannel = typeof AuthIpcChannel[keyof typeof AuthIpcChannel];


### PR DESCRIPTION
Reuse the active callback server for repeated and concurrent login attempts. Add safe lifecycle diagnostics and regression coverage.
