### PR TITLE
fix(cowork): prevent periodic IM message flicker

### DIFF
--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -462,6 +462,39 @@ test('replaceConversationMessages ignores assistant-only entries for the updated
   expect(store.getSession(sid)?.updatedAt).toBe(2000);
 });
 
+test('getRecentConversationMessages reads beyond the session page and excludes non-conversation messages', () => {
+  const sid = 'sess-recent-conversation';
+  insertSession(sid);
+
+  for (let index = 1; index <= 31; index += 1) {
+    insertMessage(
+      `msg-${index}`,
+      sid,
+      index % 2 === 0 ? 'assistant' : 'user',
+      `message ${index}`,
+      '{}',
+      index,
+      index,
+    );
+  }
+  insertMessage('tool-32', sid, 'tool_use', 'ignored tool', '{}', 32, 32);
+
+  expect(store.getSession(sid)?.messages).toHaveLength(30);
+  expect(store.getRecentConversationMessages(sid, 50).map(message => message.content)).toEqual(
+    Array.from({ length: 31 }, (_, index) => `message ${index + 1}`),
+  );
+  expect(store.getRecentConversationMessages(sid, 3).map(message => message.content)).toEqual([
+    'message 29',
+    'message 30',
+    'message 31',
+  ]);
+  expect(store.getAllConversationMessages(sid).map(message => message.content)).toEqual(
+    Array.from({ length: 31 }, (_, index) => `message ${index + 1}`),
+  );
+  expect(store.getRecentConversationMessages(sid, 0)).toEqual([]);
+  expect(store.getRecentConversationMessages(sid, Number.POSITIVE_INFINITY)).toEqual([]);
+});
+
 test('getSession returns all messages when ALL have corrupt metadata', () => {
   const sid = 'sess-2';
   insertSession(sid);

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -765,6 +765,28 @@ export class CoworkStore {
     return this.db.prepare(sql).all(...params) as T[];
   }
 
+  private mapConversationMessageRows(sessionId: string, rows: CoworkMessageRow[]): CoworkMessage[] {
+    return rows.map(row => {
+      let metadata: Record<string, unknown> | undefined;
+      if (row.metadata) {
+        try {
+          metadata = JSON.parse(row.metadata);
+        } catch {
+          console.warn(
+            `[CoworkStore] corrupt metadata detected for message ${row.id} in session ${sessionId}, discarding metadata`,
+          );
+        }
+      }
+      return {
+        id: row.id,
+        type: row.type as CoworkMessageType,
+        content: row.content,
+        timestamp: row.created_at,
+        metadata,
+      };
+    });
+  }
+
   private escapeLikePattern(value: string): string {
     return value.replace(/[\\%_]/g, (match) => `\\${match}`);
   }
@@ -1689,6 +1711,51 @@ export class CoworkStore {
       timestamp: row.created_at,
       metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
     }));
+  }
+
+  /**
+   * Read a bounded conversation tail independently from the renderer's mixed-message page.
+   * Channel history reconciliation uses this to compare the same-sized user/assistant window
+   * returned by the gateway without loading an unbounded transcript into memory.
+   */
+  getRecentConversationMessages(sessionId: string, limit: number): CoworkMessage[] {
+    if (!Number.isFinite(limit) || limit <= 0) return [];
+    const boundedLimit = Math.floor(limit);
+
+    const rows = this.getAll<CoworkMessageRow>(
+      `
+      SELECT id, type, content, metadata, created_at, sequence
+      FROM (
+        SELECT id, type, content, metadata, created_at, sequence, ROWID as rowid_
+        FROM cowork_messages
+        WHERE session_id = ? AND type IN ('user', 'assistant')
+        ORDER BY COALESCE(sequence, created_at) DESC, created_at DESC, ROWID DESC
+        LIMIT ?
+      )
+      ORDER BY COALESCE(sequence, created_at) ASC, created_at ASC, rowid_ ASC
+    `,
+      [sessionId, boundedLimit],
+    );
+
+    return this.mapConversationMessageRows(sessionId, rows);
+  }
+
+  /**
+   * Read the complete user/assistant transcript for a rare reconciliation fallback.
+   * Routine polling must use getRecentConversationMessages() to keep reads bounded.
+   */
+  getAllConversationMessages(sessionId: string): CoworkMessage[] {
+    const rows = this.getAll<CoworkMessageRow>(
+      `
+      SELECT id, type, content, metadata, created_at, sequence
+      FROM cowork_messages
+      WHERE session_id = ? AND type IN ('user', 'assistant')
+      ORDER BY COALESCE(sequence, created_at) ASC, created_at ASC, ROWID ASC
+    `,
+      [sessionId],
+    );
+
+    return this.mapConversationMessageRows(sessionId, rows);
   }
 
   getSessionMessageRailIndex(sessionId: string): CoworkMessageRailIndexItem[] {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -2325,7 +2325,7 @@ test('continueSession aborts silently when the session is stopped during the mod
 
 function createReconcileStore(
   messages: Array<Record<string, unknown>>,
-  options: { agentModel?: string; sessionId?: string } = {},
+  options: { agentModel?: string; sessionId?: string; sessionMessageLimit?: number } = {},
 ) {
   const session = {
     id: options.sessionId ?? 'session-1',
@@ -2344,6 +2344,7 @@ function createReconcileStore(
   };
   let nextId = session.messages.length + 1;
   let replaceCallCount = 0;
+  let getAllConversationMessagesCallCount = 0;
   let lastReplaceArgs: { sessionId: string; authoritative: Array<Record<string, unknown>> } | null = null;
   let replaceSessionCallCount = 0;
   let lastReplaceSessionArgs: { sessionId: string; messages: Array<Record<string, unknown>> } | null = null;
@@ -2356,12 +2357,32 @@ function createReconcileStore(
   return {
     session,
     getReplaceCallCount: () => replaceCallCount,
+    getAllConversationMessagesCallCount: () => getAllConversationMessagesCallCount,
     getLastReplaceArgs: () => lastReplaceArgs,
     getReplaceSessionCallCount: () => replaceSessionCallCount,
     getLastReplaceSessionArgs: () => lastReplaceSessionArgs,
     getUpdateSessionCalls: () => updateSessionCalls,
     store: {
-      getSession: (sessionId: string) => (sessionId === session.id ? session : null),
+      getSession: (sessionId: string) => {
+        if (sessionId !== session.id) return null;
+        if (options.sessionMessageLimit == null) return session;
+        return {
+          ...session,
+          messages: session.messages.slice(-options.sessionMessageLimit),
+        };
+      },
+      getRecentConversationMessages: (sessionId: string, limit: number) => {
+        if (sessionId !== session.id) return [];
+        return session.messages
+          .filter((message) => message.type === 'user' || message.type === 'assistant')
+          .slice(-limit);
+      },
+      getAllConversationMessages: (sessionId: string) => {
+        if (sessionId !== session.id) return [];
+        getAllConversationMessagesCallCount += 1;
+        return session.messages
+          .filter((message) => message.type === 'user' || message.type === 'assistant');
+      },
       getAgent: () => ({
         id: session.agentId,
         name: 'Main',
@@ -2832,6 +2853,90 @@ test('reconcileWithHistory: already in sync — skips replace', async () => {
 
   expect(getReplaceCallCount()).toBe(0);
   expect(session.messages.length).toBe(2);
+});
+
+test('reconcileWithHistory: compares beyond the paginated session window', async () => {
+  const messages = Array.from({ length: 31 }, (_, index) => ({
+    id: `msg-${index + 1}`,
+    type: index % 2 === 0 ? 'user' : 'assistant',
+    content: `message ${index + 1}`,
+    timestamp: index + 1,
+    metadata: {},
+  }));
+  const {
+    session,
+    store,
+    getReplaceCallCount,
+    getAllConversationMessagesCallCount,
+  } = createReconcileStore(messages, {
+    sessionMessageLimit: 30,
+  });
+
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  adapter.gatewayClient = {
+    start: () => {},
+    stop: () => {},
+    request: async () => ({
+      messages: messages.map((message) => ({
+        role: message.type,
+        content: message.content,
+      })),
+    }),
+  };
+
+  await adapter.reconcileWithHistory(session.id, 'agent:main:feishu:group:test');
+  await adapter.reconcileWithHistory(session.id, 'agent:main:feishu:group:test');
+
+  expect(getReplaceCallCount()).toBe(0);
+  expect(getAllConversationMessagesCallCount()).toBe(0);
+  expect(session.messages).toHaveLength(31);
+});
+
+test('reconcileWithHistory: preserves history before a repaired 50-message gateway tail', async () => {
+  const messages = Array.from({ length: 60 }, (_, index) => ({
+    id: `msg-${index + 1}`,
+    type: index % 2 === 0 ? 'user' : 'assistant',
+    content: `message ${index + 1}`,
+    timestamp: index + 1,
+    metadata: {},
+  }));
+  const gatewayMessages = messages.slice(-50).map((message) => ({
+    role: message.type,
+    content: message.content,
+  }));
+  gatewayMessages[gatewayMessages.length - 1] = {
+    role: 'assistant',
+    content: 'message 60 updated',
+  };
+
+  const {
+    session,
+    store,
+    getReplaceCallCount,
+    getAllConversationMessagesCallCount,
+    getLastReplaceArgs,
+  } = createReconcileStore(messages);
+  const adapter = new OpenClawRuntimeAdapter(store, {});
+  adapter.gatewayClient = {
+    start: () => {},
+    stop: () => {},
+    request: async () => ({ messages: gatewayMessages }),
+  };
+
+  await adapter.reconcileWithHistory(session.id, 'agent:main:feishu:group:test');
+  await adapter.reconcileWithHistory(session.id, 'agent:main:feishu:group:test');
+
+  expect(getReplaceCallCount()).toBe(1);
+  expect(getAllConversationMessagesCallCount()).toBe(1);
+  const authoritative = getLastReplaceArgs()!.authoritative;
+  expect(authoritative).toHaveLength(60);
+  expect(authoritative.slice(0, 10).map((entry) => entry.text)).toEqual(
+    Array.from({ length: 10 }, (_, index) => `message ${index + 1}`),
+  );
+  expect(authoritative.at(-1)?.text).toBe('message 60 updated');
+  expect(session.messages).toHaveLength(60);
+  expect(session.messages[0]?.content).toBe('message 1');
+  expect(session.messages.at(-1)?.content).toBe('message 60 updated');
 });
 
 test('reconcileWithHistory: missing assistant message — triggers replace', async () => {
@@ -6816,6 +6921,17 @@ function createHistoryStore(messages: Array<Record<string, unknown>>) {
     session,
     store: {
       getSession: (sessionId: string) => (sessionId === session.id ? session : null),
+      getRecentConversationMessages: (sessionId: string, limit: number) => {
+        if (sessionId !== session.id) return [];
+        return session.messages
+          .filter((message) => message.type === 'user' || message.type === 'assistant')
+          .slice(-limit);
+      },
+      getAllConversationMessages: (sessionId: string) => {
+        if (sessionId !== session.id) return [];
+        return session.messages
+          .filter((message) => message.type === 'user' || message.type === 'assistant');
+      },
       addMessage: (sessionId: string, message: Record<string, unknown>) => {
         expect(sessionId).toBe(session.id);
         const created = {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1319,6 +1319,48 @@ const normalizeEntryText = (
   return result;
 };
 
+const buildLocalReconciledEntries = (
+  messages: ReadonlyArray<CoworkMessage>,
+  platformFlags: PlatformFlags,
+): ReconciledConversationEntry[] => {
+  const entries: ReconciledConversationEntry[] = [];
+  for (const message of messages) {
+    if (message.type !== 'user' && message.type !== 'assistant') continue;
+    const text = normalizeEntryText(message.type, message.content, platformFlags);
+    const mediaKey = getLocalMediaAttachmentsKey(message.metadata);
+    if ((!text && !mediaKey) || shouldSuppressHeartbeatText(message.type, text)) continue;
+    entries.push({
+      role: message.type,
+      text,
+      timestamp: message.timestamp,
+      metadata: message.metadata,
+    });
+  }
+  return entries;
+};
+
+const getReconciliationTailState = (
+  localEntries: ReadonlyArray<ReconciledConversationEntry>,
+  authoritativeEntries: ReadonlyArray<ReconciledConversationEntry>,
+  alignment: { localIdx: number; authIdx: number } | null,
+): {
+  authoritativeTail: ReconciledConversationEntry[];
+  localTail: ReconciledConversationEntry[];
+  isInSync: boolean;
+} | null => {
+  if (!alignment || (alignment.localIdx === 0 && alignment.authIdx === 0)) return null;
+  const authoritativeTail = authoritativeEntries.slice(alignment.authIdx);
+  const localTail = localEntries.slice(alignment.localIdx);
+  return {
+    authoritativeTail,
+    localTail,
+    isInSync: localTail.length === authoritativeTail.length
+      && localTail.every((entry, index) =>
+        isSameReconciledEntry(entry, authoritativeTail[index]),
+      ),
+  };
+};
+
 const extractMessageText = extractGatewayMessageText;
 
 const summarizeGatewayMessageShape = (message: unknown): string => {
@@ -9247,10 +9289,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
    * Reconcile local session messages with the authoritative gateway chat.history.
    *
    * This is the single source-of-truth sync method: after a turn completes,
-   * it fetches the full conversation from OpenClaw and overwrites local
-   * user/assistant messages to match exactly.  Tool messages (tool_use,
-   * tool_result, system) are kept as-is because the gateway does not
-   * expose them in chat.history.
+   * it aligns the bounded OpenClaw history window with local user/assistant
+   * messages, preserving any older local prefix outside that window. Tool
+   * messages (tool_use, tool_result, system) are kept as-is because the
+   * gateway does not expose them in chat.history.
    *
    * The reconciliation is idempotent — calling it multiple times produces
    * the same result.
@@ -9376,17 +9418,8 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       // Collect local user/assistant messages for comparison
       // Apply the same normalization as authoritativeEntries so alignment
       // works even when local messages still carry raw platform prefixes.
-      const session = this.store.getSession(sessionId);
-      const localEntries: Array<{ role: 'user' | 'assistant'; text: string; timestamp?: number; metadata?: Record<string, unknown> }> = [];
-      if (session) {
-        for (const msg of session.messages) {
-          if (msg.type !== 'user' && msg.type !== 'assistant') continue;
-          const text = normalizeEntryText(msg.type, msg.content, platformFlags);
-          const mediaKey = getLocalMediaAttachmentsKey(msg.metadata);
-          if ((!text && !mediaKey) || shouldSuppressHeartbeatText(msg.type, text)) continue;
-          localEntries.push({ role: msg.type, text, timestamp: msg.timestamp, metadata: msg.metadata });
-        }
-      }
+      let localMessages = this.store.getRecentConversationMessages(sessionId, limit);
+      let localEntries = buildLocalReconciledEntries(localMessages, platformFlags);
 
       // Fast path: if already in sync, skip
       const isInSync = localEntries.length === authoritativeEntries.length
@@ -9403,32 +9436,48 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       }
 
       // Tail-alignment: find where the gateway window overlaps local history.
-      const alignment = findTailAlignment(localEntries, authoritativeEntries);
+      let alignment = findTailAlignment(localEntries, authoritativeEntries);
+      let tailState = getReconciliationTailState(localEntries, authoritativeEntries, alignment);
+
+      // A bounded tail is enough for every steady-state poll. Only expand the
+      // local transcript when a replacement is already necessary, otherwise a
+      // gateway window of `limit` entries could truncate an older local prefix.
+      if (!tailState?.isInSync && localMessages.length === limit) {
+        const allLocalMessages = this.store.getAllConversationMessages(sessionId);
+        if (allLocalMessages.length > localMessages.length) {
+          console.debug(
+            '[Reconcile] expanding local history before replacement — sessionId:', sessionId,
+            'recent:', localMessages.length, 'all:', allLocalMessages.length,
+          );
+          localMessages = allLocalMessages;
+          localEntries = buildLocalReconciledEntries(localMessages, platformFlags);
+          alignment = findTailAlignment(localEntries, authoritativeEntries);
+          tailState = getReconciliationTailState(localEntries, authoritativeEntries, alignment);
+        }
+      }
 
       let entriesToStore: ReconciledConversationEntry[];
 
-      if (alignment && (alignment.localIdx > 0 || alignment.authIdx > 0)) {
+      if (tailState?.isInSync && alignment) {
+        console.log(
+          '[Reconcile] tail in sync — sessionId:', sessionId,
+          'preserved:', alignment.localIdx, 'tail:', tailState.localTail.length,
+          'authSkipped:', alignment.authIdx,
+        );
+        this.channelSyncCursor.set(sessionId, authoritativeEntries.length);
+        return;
+      }
+
+      if (tailState && alignment) {
         // Gateway covers only the tail — preserve older local messages
-        const authoritativeTail = authoritativeEntries.slice(alignment.authIdx);
-        const tail = localEntries.slice(alignment.localIdx);
-        const tailInSync = tail.length === authoritativeTail.length
-          && tail.every((entry, idx) =>
-            isSameReconciledEntry(entry, authoritativeTail[idx]),
-          );
-        if (tailInSync) {
-          console.log(
-            '[Reconcile] tail in sync — sessionId:', sessionId,
-            'preserved:', alignment.localIdx, 'tail:', tail.length,
-            'authSkipped:', alignment.authIdx,
-          );
-          this.channelSyncCursor.set(sessionId, authoritativeEntries.length);
-          return;
-        }
         // Concat preserved prefix with authoritative tail
-        entriesToStore = [...localEntries.slice(0, alignment.localIdx), ...authoritativeTail];
+        entriesToStore = [
+          ...localEntries.slice(0, alignment.localIdx),
+          ...tailState.authoritativeTail,
+        ];
         console.log(
           '[Reconcile] tail replace — sessionId:', sessionId,
-          'preserved:', alignment.localIdx, 'auth:', authoritativeTail.length,
+          'preserved:', alignment.localIdx, 'auth:', tailState.authoritativeTail.length,
           'authSkipped:', alignment.authIdx,
           'total:', entriesToStore.length,
         );


### PR DESCRIPTION
Compare matching history windows during reconciliation. Preserve older messages when repairing a mismatched gateway tail.


