### PR TITLE
fix(cowork): prevent scroll jumps on session refresh

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -15,7 +15,10 @@ import {
   type OpenClawSessionPatch,
   OpenClawSessionReasoningLevel,
 } from '../../../common/openclawSession';
-import { CoworkIpcChannel } from '../../../shared/cowork/constants';
+import {
+  CoworkIpcChannel,
+  type CoworkSessionsChangedPayload,
+} from '../../../shared/cowork/constants';
 import {
   buildCoworkErrorDetail,
   type CoworkErrorDetail,
@@ -3390,7 +3393,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       store: this.store,
       rememberSessionKey: (sessionId, sessionKey) => this.rememberSessionKey(sessionId, sessionKey),
       markSessionHistoryUnsynced: (sessionId) => this.fullySyncedSessions.delete(sessionId),
-      notifySessionsChanged: () => this.notifySessionsChanged(),
+      notifySessionsChanged: (sessionId) => this.notifySessionsChanged(sessionId),
       emitSessionStatus: (sessionId, status) => this.emitSessionStatus(sessionId, status),
       emitComplete: (sessionId, sessionKey) => this.emit('complete', sessionId, sessionKey),
       emitError: (sessionId, error) => this.emit('error', sessionId, error),
@@ -3417,10 +3420,18 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     return this.options.normalizeModelRef?.(normalized) ?? normalized;
   }
 
-  private notifySessionsChanged(): void {
+  private notifySessionsChanged(sessionIds: string | readonly string[]): void {
+    const normalizedSessionIds = Array.from(new Set(
+      (Array.isArray(sessionIds) ? sessionIds : [sessionIds])
+        .map(sessionId => sessionId.trim())
+        .filter(Boolean),
+    ));
+    if (normalizedSessionIds.length === 0) return;
+
+    const payload: CoworkSessionsChangedPayload = { sessionIds: normalizedSessionIds };
     for (const win of BrowserWindow.getAllWindows()) {
       if (!win.isDestroyed()) {
-        win.webContents.send('cowork:sessions:changed');
+        win.webContents.send(CoworkIpcChannel.SessionsChanged, payload);
       }
     }
   }
@@ -3944,9 +3955,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         console.warn('[ChannelSync] pollChannelSessions: sessions.list returned non-array sessions:', typeof sessions, 'full result keys:', Object.keys(result as Record<string, unknown>));
         return;
       }
-      let hasNew = false;
       let channelCount = 0;
       const newSessionsToSync: Array<{ sessionId: string; sessionKey: string }> = [];
+      const newSessionIds: string[] = [];
       for (const row of sessions) {
         const key = typeof row?.key === 'string' ? row.key : '';
         if (!key) continue;
@@ -3995,22 +4006,16 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         if (sessionId && !this.knownChannelSessionIds.has(sessionId)) {
           this.knownChannelSessionIds.add(sessionId);
           this.rememberSessionKey(sessionId, key);
-          hasNew = true;
+          newSessionIds.push(sessionId);
           // Queue full history sync for newly discovered sessions
           if (!this.fullySyncedSessions.has(sessionId)) {
             newSessionsToSync.push({ sessionId, sessionKey: key });
           }
         }
       }
-      if (hasNew) {
-        let notified = 0;
-        for (const win of BrowserWindow.getAllWindows()) {
-          if (!win.isDestroyed()) {
-            win.webContents.send('cowork:sessions:changed');
-            notified++;
-          }
-        }
-        console.log('[ChannelSync] discovered', channelCount, 'channel sessions, notified', notified, 'windows');
+      if (newSessionIds.length > 0) {
+        this.notifySessionsChanged(newSessionIds);
+        console.log('[ChannelSync] discovered', channelCount, 'channel sessions, including', newSessionIds.length, 'new sessions');
       }
       // Sync full history for newly discovered sessions
       for (const { sessionId, sessionKey } of newSessionsToSync) {
@@ -6277,7 +6282,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       );
     }
     if (isNewlyKnownSession) {
-      this.notifySessionsChanged();
+      this.notifySessionsChanged(sessionId);
     }
   }
 
@@ -6320,11 +6325,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           // deliberately never advance updated_at (streaming reorder guard),
           // so surface the fresh delivery in the session list explicitly.
           this.store.updateSession(conversation.sessionId, {}, { touchUpdatedAt: true });
-          for (const win of BrowserWindow.getAllWindows()) {
-            if (!win.isDestroyed()) {
-              win.webContents.send('cowork:sessions:changed');
-            }
-          }
+          this.notifySessionsChanged(conversation.sessionId);
           console.log(
             '[ChannelSync] synced IM conversation after cron delivery.',
             `Session ${conversation.sessionId}.`,
@@ -7753,11 +7754,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     this.clearPendingStoreUpdate(messageId);
     this.clearPendingMessageUpdate(messageId);
     this.store.deleteMessage(sessionId, messageId);
-    for (const win of BrowserWindow.getAllWindows()) {
-      if (!win.isDestroyed()) {
-        win.webContents.send('cowork:sessions:changed');
-      }
-    }
+    this.notifySessionsChanged(sessionId);
   }
 
   private deleteSilentAssistantMessages(sessionId: string): void {
@@ -9180,7 +9177,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       );
       this.channelSyncCursor.set(sessionId, plan.cursor);
 
-      this.notifySessionsChanged();
+      this.notifySessionsChanged(sessionId);
     } catch (error) {
       console.warn('[SubagentHistorySync] failed - sessionId:', sessionId, 'error:', error);
     }
@@ -9496,11 +9493,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       this.channelSyncCursor.set(sessionId, authoritativeEntries.length);
 
       // Notify renderer to refresh
-      for (const win of BrowserWindow.getAllWindows()) {
-        if (!win.isDestroyed()) {
-          win.webContents.send('cowork:sessions:changed');
-        }
-      }
+      this.notifySessionsChanged(sessionId);
     } catch (error) {
       console.warn('[Reconcile] failed — sessionId:', sessionId, 'error:', error);
     }
@@ -10460,10 +10453,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         const newUserMessages = afterCount - beforeCount;
         console.log('[Debug:prefetch] reconciled (attempt', attempt, ') synced user messages:', newUserMessages, '(before:', beforeCount, 'after:', afterCount, ')');
 
-        // Emit 'message' events for newly added user messages so the renderer
-        // updates the active session view in real-time.  reconcileWithHistory
-        // writes to SQLite and sends cowork:sessions:changed, but that only
-        // refreshes the session list sidebar — not the active conversation.
+        // Emit 'message' events for newly added user messages so the active
+        // conversation updates immediately while the scoped session refresh
+        // reconciles the full persisted view asynchronously.
         if (newUserMessages > 0) {
           const session = this.store.getSession(sessionId);
           if (session) {

--- a/src/main/libs/agentEngine/subagent/sessionMaterializer.test.ts
+++ b/src/main/libs/agentEngine/subagent/sessionMaterializer.test.ts
@@ -76,7 +76,7 @@ describe('SubagentSessionMaterializer', () => {
     }));
     expect(deps.rememberSessionKey).toHaveBeenCalledWith('child-1', 'agent:product-analyst:subagent:child-1');
     expect(deps.markSessionHistoryUnsynced).toHaveBeenCalledWith('child-1');
-    expect(deps.notifySessionsChanged).toHaveBeenCalled();
+    expect(deps.notifySessionsChanged).toHaveBeenCalledWith('child-1');
     await Promise.resolve();
     expect(deps.syncSessionHistory).toHaveBeenCalledWith('child-1', 'agent:product-analyst:subagent:child-1');
   });
@@ -91,6 +91,6 @@ describe('SubagentSessionMaterializer', () => {
     expect(store.updateSession).toHaveBeenCalledWith('child-1', { status: 'completed' });
     expect(deps.emitSessionStatus).toHaveBeenCalledWith('child-1', 'completed');
     expect(deps.emitComplete).toHaveBeenCalledWith('child-1', 'agent:product-analyst:subagent:child-1');
-    expect(deps.notifySessionsChanged).toHaveBeenCalled();
+    expect(deps.notifySessionsChanged).toHaveBeenCalledWith('child-1');
   });
 });

--- a/src/main/libs/agentEngine/subagent/sessionMaterializer.ts
+++ b/src/main/libs/agentEngine/subagent/sessionMaterializer.ts
@@ -15,7 +15,7 @@ export interface SubagentSessionMaterializerDeps {
   store: SubagentSessionMaterializerStore;
   rememberSessionKey: (sessionId: string, sessionKey: string) => void;
   markSessionHistoryUnsynced: (sessionId: string) => void;
-  notifySessionsChanged: () => void;
+  notifySessionsChanged: (sessionId: string) => void;
   emitSessionStatus: (sessionId: string, status: CoworkSessionStatus) => void;
   emitComplete: (sessionId: string, sessionKey: string) => void;
   emitError: (sessionId: string, error: string) => void;
@@ -56,7 +56,7 @@ export class SubagentSessionMaterializer {
       );
       this.deps.rememberSessionKey(session.id, params.childSessionKey);
       this.deps.markSessionHistoryUnsynced(session.id);
-      this.deps.notifySessionsChanged();
+      this.deps.notifySessionsChanged(session.id);
       void this.deps.syncSessionHistory(session.id, params.childSessionKey)
         .catch((error) => {
           console.warn('[OpenClawRuntime] subagent child history sync failed:', error);
@@ -102,7 +102,7 @@ export class SubagentSessionMaterializer {
     } else {
       this.deps.emitError(sessionId, 'Subagent session failed.');
     }
-    this.deps.notifySessionsChanged();
+    this.deps.notifySessionsChanged(sessionId);
     void this.deps.syncSessionHistory(sessionId, sessionKey)
       .catch((error) => {
         console.warn('[OpenClawRuntime] passive subagent final history sync failed:', error);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -13,7 +13,10 @@ import {
 import { AuthIpcChannel } from '../shared/auth/constants';
 import { BrowserIpc, type BrowserRuntimeProfile } from '../shared/browserWebAccess/constants';
 import { ClipboardIpc } from '../shared/clipboard/constants';
-import { CoworkIpcChannel } from '../shared/cowork/constants';
+import {
+  CoworkIpcChannel,
+  type CoworkSessionsChangedPayload,
+} from '../shared/cowork/constants';
 import { DataMigrationIpc } from '../shared/dataMigration/constants';
 import { DialogIpc } from '../shared/dialog/constants';
 import {
@@ -611,10 +614,10 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.on('cowork:stream:error', handler);
       return () => ipcRenderer.removeListener('cowork:stream:error', handler);
     },
-    onSessionsChanged: (callback: () => void) => {
-      const handler = () => callback();
-      ipcRenderer.on('cowork:sessions:changed', handler);
-      return () => ipcRenderer.removeListener('cowork:sessions:changed', handler);
+    onSessionsChanged: (callback: (data?: CoworkSessionsChangedPayload) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data?: CoworkSessionsChangedPayload) => callback(data);
+      ipcRenderer.on(CoworkIpcChannel.SessionsChanged, handler);
+      return () => ipcRenderer.removeListener(CoworkIpcChannel.SessionsChanged, handler);
     },
     onSessionModelOverrideChanged: (
       callback: (data: { sessionId: string; modelOverride: string }) => void,

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -73,6 +73,10 @@ import type {
 } from '../types/cowork';
 import { CoworkSessionStatusValue } from '../types/cowork';
 import { CoworkQueuedFollowUpCoordinator } from './coworkQueuedFollowUpCoordinator';
+import {
+  getPreservedMessageWindow,
+  shouldReloadCurrentSessionForChange,
+} from './coworkSessionRefreshPolicy';
 import { i18nService } from './i18n';
 
 const STREAM_ERROR_DUPLICATE_WINDOW_MS = 10_000;
@@ -407,24 +411,39 @@ class CoworkService {
 
     // Sessions changed listener (new channel sessions discovered by polling,
     // or reconcileWithHistory replaced messages for a channel session)
-    const sessionsChangedCleanup = cowork.onSessionsChanged(() => {
+    const sessionsChangedCleanup = cowork.onSessionsChanged((payload) => {
       const beforeState = store.getState().cowork;
-      console.log('[CoworkService] onSessionsChanged: received IPC event, before sessions:', beforeState.sessions.length, 'sessionIds:', beforeState.sessions.map(s => s.id).slice(0, 5));
+      const changedSessionIds = Array.isArray(payload?.sessionIds) ? payload.sessionIds : [];
+      const changeScope = changedSessionIds.length > 0
+        ? `${changedSessionIds.slice(0, 5).join(',')}${changedSessionIds.length > 5 ? `,+${changedSessionIds.length - 5}` : ''}`
+        : 'unscoped';
+      this.logDiagnostic(
+        'debug',
+        `received sessions change; active=${beforeState.currentSessionId ?? 'none'}; changed=${changeScope}.`,
+      );
       void this.loadSessions().then(() => {
         const state = store.getState().cowork;
-        console.log('[CoworkService] onSessionsChanged: loadSessions complete, total sessions:', state.sessions.length, 'sessionIds:', state.sessions.map(s => s.id).slice(0, 5));
 
-        // Reload the active session's full message list so that messages
-        // replaced by reconcileWithHistory (bulk SQLite replace) are reflected
-        // in the conversation view, not just the sidebar.  Without this,
-        // user messages synced from gateway history would only appear after
-        // the user manually re-enters the conversation.
+        // Reload the active conversation only when that session changed.
+        // Preserve any older history the user already paged in so a scoped
+        // refresh cannot collapse the view back to the default tail window.
         const currentId = state.currentSessionId;
-        if (currentId) {
-          void this.loadSession(currentId);
+        const shouldReloadCurrent = shouldReloadCurrentSessionForChange(currentId, payload);
+        this.logDiagnostic(
+          'debug',
+          `processed sessions change; active=${currentId ?? 'none'}; changed=${changeScope}; reloadActive=${shouldReloadCurrent}.`,
+        );
+        if (currentId && shouldReloadCurrent) {
+          void this.loadSession(currentId, { preserveLoadedRange: true }).catch((error: unknown) => {
+            this.logDiagnostic(
+              'error',
+              `failed to refresh changed active session ${currentId}.`,
+              error,
+            );
+          });
         }
       }).catch((err) => {
-        console.error('[CoworkService] onSessionsChanged: loadSessions FAILED:', err);
+        this.logDiagnostic('error', 'failed to refresh the session list after a sessions change.', err);
       });
     });
     this.streamListenerCleanups.push(sessionsChangedCleanup);
@@ -1266,11 +1285,15 @@ class CoworkService {
     }
   }
 
-  async loadSession(sessionId: string): Promise<CoworkSession | null> {
+  async loadSession(
+    sessionId: string,
+    options: { preserveLoadedRange?: boolean } = {},
+  ): Promise<CoworkSession | null> {
     try {
       const cowork = window.electron?.cowork;
       if (!cowork) return null;
       const requestId = ++this.latestLoadSessionRequestId;
+      const previouslyLoadedSession = store.getState().cowork.currentSession;
 
       const result = await cowork.getSession(sessionId);
       if (result.success && result.session) {
@@ -1283,8 +1306,77 @@ class CoworkService {
           this.logDiagnostic('debug', `ignored stale session load result for session ${sessionId}.`);
           return result.session;
         }
-        store.dispatch(setCurrentSession(result.session));
-        this.setCurrentSessionStreaming(sessionId, result.session.status === 'running', 'load_session_completed');
+        let session = result.session;
+        if (
+          options.preserveLoadedRange
+          && previouslyLoadedSession?.id === sessionId
+          && cowork.getSessionMessages
+        ) {
+          const preservedWindow = getPreservedMessageWindow(
+            previouslyLoadedSession.messagesOffset,
+            session.messagesOffset,
+            session.totalMessages,
+          );
+          if (preservedWindow) {
+            let pageResult;
+            try {
+              pageResult = await cowork.getSessionMessages({
+                sessionId,
+                ...preservedWindow,
+              });
+            } catch (error) {
+              this.logDiagnostic(
+                'warn',
+                `failed to preserve loaded history for session ${sessionId}; keeping the existing view.`,
+                error,
+              );
+              return previouslyLoadedSession;
+            }
+            if (requestId !== this.latestLoadSessionRequestId) {
+              this.logDiagnostic('debug', `ignored stale preserved session load result for session ${sessionId}.`);
+              return session;
+            }
+            if (pageResult.success && pageResult.messages && pageResult.messages.length > 0) {
+              const returnedOffset = pageResult.offset ?? preservedWindow.offset;
+              const returnedEnd = returnedOffset + pageResult.messages.length;
+              const latestLoadedSession = store.getState().cowork.currentSession;
+              const latestLoadedEnd = latestLoadedSession
+                ? latestLoadedSession.messagesOffset + latestLoadedSession.messages.length
+                : 0;
+              if (
+                latestLoadedSession?.id === sessionId
+                && (
+                  latestLoadedSession.messagesOffset < returnedOffset
+                  || latestLoadedEnd > returnedEnd
+                )
+              ) {
+                this.logDiagnostic(
+                  'debug',
+                  `kept a newer in-memory history window for session ${sessionId}; loaded offset=${latestLoadedSession.messagesOffset}, count=${latestLoadedSession.messages.length}; refresh offset=${returnedOffset}, count=${pageResult.messages.length}.`,
+                );
+                return latestLoadedSession;
+              }
+              session = {
+                ...session,
+                messages: pageResult.messages,
+                messagesOffset: returnedOffset,
+                totalMessages: pageResult.total ?? session.totalMessages,
+              };
+              this.logDiagnostic(
+                'debug',
+                `preserved loaded history for session ${sessionId}; returned ${session.messages.length} of ${session.totalMessages} messages from offset ${session.messagesOffset}.`,
+              );
+            } else {
+              this.logDiagnostic(
+                'warn',
+                `failed to preserve loaded history for session ${sessionId}: ${pageResult.error ?? 'empty result'}; keeping the existing view.`,
+              );
+              return previouslyLoadedSession;
+            }
+          }
+        }
+        store.dispatch(setCurrentSession(session));
+        this.setCurrentSessionStreaming(sessionId, session.status === 'running', 'load_session_completed');
         void this.loadSessionMessageRailIndex(sessionId);
         void cowork.markSessionViewed?.(sessionId).catch((error: unknown) => {
           console.warn('[CoworkService] failed to mark session viewed:', error);
@@ -1295,7 +1387,7 @@ class CoworkService {
           store.dispatch(setRemoteManaged(imResult?.remoteManaged ?? false));
         }
 
-        return result.session;
+        return session;
       }
 
       console.error('Failed to load session:', result.error);

--- a/src/renderer/services/coworkLoadSession.test.ts
+++ b/src/renderer/services/coworkLoadSession.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { store } from '../store';
+import { setCurrentSession, setMessageWindow } from '../store/slices/coworkSlice';
+import {
+  type CoworkMessage,
+  type CoworkSession,
+  CoworkSessionStatusValue,
+} from '../types/cowork';
+import { coworkService } from './cowork';
+
+const makeMessages = (count: number): CoworkMessage[] => Array.from(
+  { length: count },
+  (_, index) => ({
+    id: `message-${index}`,
+    type: index % 2 === 0 ? 'user' : 'assistant',
+    content: `message ${index}`,
+    timestamp: index,
+  }),
+);
+
+const makeSession = (
+  messages: CoworkMessage[],
+  messagesOffset: number,
+  totalMessages: number,
+): CoworkSession => ({
+  id: 'session-1',
+  title: 'Session 1',
+  claudeSessionId: null,
+  status: CoworkSessionStatusValue.Completed,
+  pinned: false,
+  pinOrder: null,
+  cwd: '/tmp',
+  systemPrompt: '',
+  modelOverride: '',
+  executionMode: 'local',
+  activeSkillIds: [],
+  agentId: 'main',
+  messages,
+  messagesOffset,
+  totalMessages,
+  createdAt: 1,
+  updatedAt: 1,
+});
+
+beforeEach(() => {
+  coworkService.clearSession();
+});
+
+afterEach(() => {
+  coworkService.clearSession();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('coworkService.loadSession', () => {
+  test('preserves history already loaded before the default 30-message window', async () => {
+    const allMessages = makeMessages(39);
+    const defaultPageSession = makeSession(allMessages.slice(9), 9, 39);
+    store.dispatch(setCurrentSession(makeSession(allMessages, 0, 39)));
+
+    const getSession = vi.fn(async () => ({ success: true, session: defaultPageSession }));
+    const getSessionMessages = vi.fn(async () => ({
+      success: true,
+      messages: allMessages,
+      offset: 0,
+      total: 39,
+    }));
+    vi.stubGlobal('window', {
+      electron: {
+        cowork: {
+          getSession,
+          getSessionMessages,
+          remoteManaged: vi.fn(async () => ({ remoteManaged: false })),
+        },
+      },
+    });
+
+    const result = await coworkService.loadSession('session-1', {
+      preserveLoadedRange: true,
+    });
+
+    expect(getSessionMessages).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      offset: 0,
+      limit: 39,
+    });
+    expect(result?.messages).toHaveLength(39);
+    expect(result?.messagesOffset).toBe(0);
+    expect(store.getState().cowork.currentSession?.messages).toHaveLength(39);
+    expect(store.getState().cowork.currentSession?.messagesOffset).toBe(0);
+  });
+
+  test('does not request another message page when no earlier history was loaded', async () => {
+    const allMessages = makeMessages(39);
+    const defaultPageSession = makeSession(allMessages.slice(9), 9, 39);
+    store.dispatch(setCurrentSession(defaultPageSession));
+
+    const getSessionMessages = vi.fn();
+    vi.stubGlobal('window', {
+      electron: {
+        cowork: {
+          getSession: vi.fn(async () => ({ success: true, session: defaultPageSession })),
+          getSessionMessages,
+          remoteManaged: vi.fn(async () => ({ remoteManaged: false })),
+        },
+      },
+    });
+
+    await coworkService.loadSession('session-1', { preserveLoadedRange: true });
+
+    expect(getSessionMessages).not.toHaveBeenCalled();
+  });
+
+  test('keeps the existing history view when preserving the loaded page fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const allMessages = makeMessages(39);
+    const fullyLoadedSession = makeSession(allMessages, 0, 39);
+    const defaultPageSession = makeSession(allMessages.slice(9), 9, 39);
+    store.dispatch(setCurrentSession(fullyLoadedSession));
+
+    vi.stubGlobal('window', {
+      electron: {
+        cowork: {
+          getSession: vi.fn(async () => ({ success: true, session: defaultPageSession })),
+          getSessionMessages: vi.fn(async () => {
+            throw new Error('message page unavailable');
+          }),
+          remoteManaged: vi.fn(async () => ({ remoteManaged: false })),
+        },
+      },
+    });
+
+    const result = await coworkService.loadSession('session-1', {
+      preserveLoadedRange: true,
+    });
+
+    expect(result).toStrictEqual(fullyLoadedSession);
+    expect(store.getState().cowork.currentSession?.messages).toHaveLength(39);
+    expect(store.getState().cowork.currentSession?.messagesOffset).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('keeping the existing view'),
+      expect.any(Error),
+    );
+  });
+
+  test('does not overwrite history that advances while a preserved page is loading', async () => {
+    const allMessages = makeMessages(39);
+    const messagesWithLiveUpdate = makeMessages(40);
+    const defaultPageSession = makeSession(allMessages.slice(9), 9, 39);
+    store.dispatch(setCurrentSession(makeSession(allMessages, 0, 39)));
+
+    vi.stubGlobal('window', {
+      electron: {
+        cowork: {
+          getSession: vi.fn(async () => ({ success: true, session: defaultPageSession })),
+          getSessionMessages: vi.fn(async () => {
+            store.dispatch(setMessageWindow({
+              sessionId: 'session-1',
+              messages: messagesWithLiveUpdate,
+              messagesOffset: 0,
+              totalMessages: 40,
+            }));
+            return {
+              success: true,
+              messages: allMessages,
+              offset: 0,
+              total: 39,
+            };
+          }),
+          remoteManaged: vi.fn(async () => ({ remoteManaged: false })),
+        },
+      },
+    });
+
+    const result = await coworkService.loadSession('session-1', {
+      preserveLoadedRange: true,
+    });
+
+    expect(result?.messages).toHaveLength(40);
+    expect(result?.totalMessages).toBe(40);
+    expect(store.getState().cowork.currentSession?.messages).toHaveLength(40);
+  });
+});

--- a/src/renderer/services/coworkSessionRefreshPolicy.test.ts
+++ b/src/renderer/services/coworkSessionRefreshPolicy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  getPreservedMessageWindow,
+  shouldReloadCurrentSessionForChange,
+} from './coworkSessionRefreshPolicy';
+
+describe('coworkSessionRefreshPolicy', () => {
+  test('reloads only when the current session is included in a scoped change', () => {
+    expect(shouldReloadCurrentSessionForChange('session-1', {
+      sessionIds: ['session-1'],
+    })).toBe(true);
+    expect(shouldReloadCurrentSessionForChange('session-1', {
+      sessionIds: ['session-2'],
+    })).toBe(false);
+  });
+
+  test('keeps legacy unscoped notifications backward compatible', () => {
+    expect(shouldReloadCurrentSessionForChange('session-1')).toBe(true);
+    expect(shouldReloadCurrentSessionForChange('session-1', { sessionIds: [] })).toBe(true);
+    expect(shouldReloadCurrentSessionForChange(null, { sessionIds: ['session-1'] })).toBe(false);
+  });
+
+  test('preserves a history window that starts before the refreshed default page', () => {
+    expect(getPreservedMessageWindow(0, 9, 39)).toEqual({
+      offset: 0,
+      limit: 39,
+    });
+    expect(getPreservedMessageWindow(14, 15, 45)).toEqual({
+      offset: 14,
+      limit: 31,
+    });
+  });
+
+  test('does not request another page when the refreshed window is already sufficient', () => {
+    expect(getPreservedMessageWindow(9, 9, 39)).toBeNull();
+    expect(getPreservedMessageWindow(10, 9, 39)).toBeNull();
+    expect(getPreservedMessageWindow(0, 0, 39)).toBeNull();
+  });
+});

--- a/src/renderer/services/coworkSessionRefreshPolicy.ts
+++ b/src/renderer/services/coworkSessionRefreshPolicy.ts
@@ -1,0 +1,34 @@
+import type { CoworkSessionsChangedPayload } from '../../shared/cowork/constants';
+
+export interface CoworkPreservedMessageWindow {
+  offset: number;
+  limit: number;
+}
+
+export const shouldReloadCurrentSessionForChange = (
+  currentSessionId: string | null,
+  payload?: CoworkSessionsChangedPayload,
+): boolean => {
+  if (!currentSessionId) return false;
+  if (!payload || !Array.isArray(payload.sessionIds) || payload.sessionIds.length === 0) return true;
+  return payload.sessionIds.includes(currentSessionId);
+};
+
+export const getPreservedMessageWindow = (
+  currentOffset: number,
+  refreshedOffset: number,
+  refreshedTotal: number,
+): CoworkPreservedMessageWindow | null => {
+  const safeCurrentOffset = Math.max(0, Math.floor(currentOffset));
+  const safeRefreshedOffset = Math.max(0, Math.floor(refreshedOffset));
+  const safeRefreshedTotal = Math.max(0, Math.floor(refreshedTotal));
+
+  if (safeCurrentOffset >= safeRefreshedOffset || safeCurrentOffset >= safeRefreshedTotal) {
+    return null;
+  }
+
+  return {
+    offset: safeCurrentOffset,
+    limit: safeRefreshedTotal - safeCurrentOffset,
+  };
+};

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -11,6 +11,7 @@ import type {
 import type {
   CoworkContextUsageFailureReason,
   CoworkContextUsageSource,
+  CoworkSessionsChangedPayload,
 } from '../../shared/cowork/constants';
 import type { CoworkGoal } from '../../shared/cowork/goal';
 import type { CoworkMessageRailIndexItem } from '../../shared/cowork/rail';
@@ -1079,7 +1080,9 @@ interface IElectronAPI {
       callback: (data: { sessionId: string; claudeSessionId: string | null }) => void,
     ) => () => void;
     onStreamError: (callback: (data: { sessionId: string; error: string }) => void) => () => void;
-    onSessionsChanged: (callback: () => void) => () => void;
+    onSessionsChanged: (
+      callback: (data?: CoworkSessionsChangedPayload) => void,
+    ) => () => void;
     onSessionModelOverrideChanged?: (
       callback: (data: { sessionId: string; modelOverride: string }) => void,
     ) => () => void;

--- a/src/shared/cowork/constants.ts
+++ b/src/shared/cowork/constants.ts
@@ -49,6 +49,7 @@ export const CoworkIpcChannel = {
   GoalCommand: 'cowork:session:goalCommand',
   SubmitSteer: 'cowork:session:submitSteer',
   SessionModelOverrideChanged: 'cowork:session:modelOverrideChanged',
+  SessionsChanged: 'cowork:sessions:changed',
   StreamGoal: 'cowork:stream:goal',
   MemoryReadRaw: 'cowork:memory:readRaw',
   MemoryWriteRaw: 'cowork:memory:writeRaw',
@@ -58,6 +59,10 @@ export const CoworkIpcChannel = {
   TempStorageClean: 'cowork:tempStorage:clean',
 } as const;
 export type CoworkIpcChannel = typeof CoworkIpcChannel[keyof typeof CoworkIpcChannel];
+
+export interface CoworkSessionsChangedPayload {
+  sessionIds: string[];
+}
 
 export const CoworkForkMode = {
   None: 'none',


### PR DESCRIPTION
Scope refresh events by session ID and preserve loaded message history.
