### PR TITLE
fix(cowork): sync image attachments with model capability

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -21,6 +21,8 @@ import {
 } from '../../../shared/cowork/goal';
 import {
   formatCoworkImageAttachmentLimit,
+  isCoworkImagePath as isImagePath,
+  shouldShowCoworkImageVisionHint,
 } from '../../../shared/cowork/imageAttachments';
 import { isPlanImplementationApproval } from '../../../shared/cowork/planMode';
 import type { CoworkSelectedTextSnippet } from '../../../shared/cowork/selectedText';
@@ -256,15 +258,6 @@ const reportModelSelected = (
 // CoworkAttachment is aliased from the Redux-persisted DraftAttachment type
 // so that attachment state survives view switches (cowork ↔ skills, etc.)
 type CoworkAttachment = DraftAttachment;
-
-const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg', '.tiff', '.tif', '.ico', '.avif']);
-
-const isImagePath = (filePath: string): boolean => {
-  const dotIndex = filePath.lastIndexOf('.');
-  if (dotIndex === -1) return false;
-  const ext = filePath.slice(dotIndex).toLowerCase();
-  return IMAGE_EXTENSIONS.has(ext);
-};
 
 const isImageMimeType = (mimeType: string): boolean => {
   return mimeType.startsWith('image/');
@@ -671,6 +664,10 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     globalSelectedModel: currentAgentSelectedModel,
   });
   const modelSupportsImage = !!effectiveSelectedModel?.supportsImage;
+  const shouldShowImageVisionHint = shouldShowCoworkImageVisionHint(
+    attachments,
+    modelSupportsImage,
+  );
 
   const resolveSubmitModelAccessPrompt = useCallback((): ModelAccessPromptKind | null => {
     const hasAccessibleUserModel = availableModels.some(
@@ -1058,6 +1055,10 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     draftStartedAnalyticsRef.current = false;
   }, [sessionId]);
 
+  useEffect(() => {
+    setImageVisionHint(shouldShowImageVisionHint);
+  }, [shouldShowImageVisionHint]);
+
   // Sync value from draft when sessionId changes
   useEffect(() => {
     setValue(draftPrompt);
@@ -1065,8 +1066,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     setSteerInputActive(false);
     setIsTemplateHeightLocked(false);
     // Re-derive imageVisionHint from the new session's draft attachments
-    const hasImageWithoutVision = !modelSupportsImage && attachments.some(a => a.isImage || isImagePath(a.path));
-    setImageVisionHint(hasImageWithoutVision);
+    setImageVisionHint(shouldShowImageVisionHint);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftKey]); // intentionally omit other deps to only trigger on session switch
 

--- a/src/renderer/services/coworkPromptPayload.test.ts
+++ b/src/renderer/services/coworkPromptPayload.test.ts
@@ -95,4 +95,29 @@ describe('prepareCoworkPromptPayload', () => {
       },
     });
   });
+
+  test('ignores a stale image data URL after switching to a non-vision model', async () => {
+    const result = await prepareCoworkPromptPayload({
+      basePrompt: 'inspect',
+      attachments: [
+        {
+          path: '/tmp/image.png',
+          name: 'image.png',
+          isImage: true,
+          dataUrl: 'data:image/png;base64,YWJj',
+        },
+      ],
+      selectedTextSnippets: [],
+      modelSupportsImage: false,
+      fileLabel: 'File',
+      folderLabel: 'Folder',
+    });
+
+    expect(result).toEqual({
+      success: true,
+      payload: {
+        finalPrompt: 'inspect\n\nFile: /tmp/image.png',
+      },
+    });
+  });
 });

--- a/src/renderer/services/coworkPromptPayload.ts
+++ b/src/renderer/services/coworkPromptPayload.ts
@@ -117,7 +117,7 @@ export async function prepareCoworkPromptPayload(
       }
     }
 
-    if (!attachment.isImage || !imageDataUrl) continue;
+    if (!options.modelSupportsImage || !attachment.isImage || !imageDataUrl) continue;
     const extracted = extractBase64FromDataUrl(imageDataUrl);
     if (!extracted) continue;
 

--- a/src/shared/cowork/imageAttachments.test.ts
+++ b/src/shared/cowork/imageAttachments.test.ts
@@ -6,6 +6,7 @@ import {
   COWORK_IMAGE_ATTACHMENT_PREVIEW_FALLBACK_MAX_BYTES,
   estimateBase64DecodedBytes,
   formatCoworkImageAttachmentLimit,
+  shouldShowCoworkImageVisionHint,
   validateCoworkImageAttachmentSize,
 } from './imageAttachments';
 
@@ -18,6 +19,14 @@ test('estimateBase64DecodedBytes handles padding and data URL prefixes', () => {
 
 test('formatCoworkImageAttachmentLimit uses a locale-neutral MB label', () => {
   expect(formatCoworkImageAttachmentLimit()).toBe('30MB');
+});
+
+test('shouldShowCoworkImageVisionHint follows the current model capability', () => {
+  const attachments = [{ path: '/tmp/image.png' }];
+
+  expect(shouldShowCoworkImageVisionHint(attachments, false)).toBe(true);
+  expect(shouldShowCoworkImageVisionHint(attachments, true)).toBe(false);
+  expect(shouldShowCoworkImageVisionHint([{ path: '/tmp/notes.txt' }], false)).toBe(false);
 });
 
 test('validateCoworkImageAttachmentSize accepts exactly the 30MB limit', () => {

--- a/src/shared/cowork/imageAttachments.ts
+++ b/src/shared/cowork/imageAttachments.ts
@@ -1,6 +1,36 @@
 export const COWORK_IMAGE_ATTACHMENT_MAX_BYTES = 30 * 1000 * 1000;
 export const COWORK_IMAGE_ATTACHMENT_PREVIEW_FALLBACK_MAX_BYTES = 512 * 1024;
 
+const COWORK_IMAGE_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.svg',
+  '.tiff',
+  '.tif',
+  '.ico',
+  '.avif',
+]);
+
+export function isCoworkImagePath(filePath: string): boolean {
+  const dotIndex = filePath.lastIndexOf('.');
+  if (dotIndex === -1) return false;
+  return COWORK_IMAGE_EXTENSIONS.has(filePath.slice(dotIndex).toLowerCase());
+}
+
+export function shouldShowCoworkImageVisionHint(
+  attachments: Array<{ path: string; isImage?: boolean }>,
+  modelSupportsImage: boolean,
+): boolean {
+  return (
+    !modelSupportsImage &&
+    attachments.some(attachment => attachment.isImage || isCoworkImagePath(attachment.path))
+  );
+}
+
 export type CoworkImageAttachmentPayload = {
   name: string;
   mimeType: string;


### PR DESCRIPTION
## Summary

Keep image attachment behavior in sync with the currently selected model's vision capability.

When a conversation switches from a vision model to a non-vision model, an attachment can still retain its previously prepared `dataUrl`. The prompt builder previously sent that stale image payload, and the vision warning was only recalculated when the session changed. This change makes both paths use the current model capability.

## Related Issue

Fixes #1861

## Changes Made

- Recalculate the image vision warning when attachments or model capability change.
- Prevent stale image data URLs from being sent to non-vision models while preserving the file path in the text prompt.
- Share image-path detection between the prompt component and the warning-state helper.
- Add regression tests for both model-switch behaviors.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

Validation performed with Node.js 24.15.0:

- Full Vitest suite: 229 files passed, 2477 tests passed, 8 skipped.
- TypeScript: `tsc --noEmit` passed.
- ESLint on all changed TypeScript files passed with zero warnings.
- `git diff --check` passed.

## Screenshots (if applicable)

N/A. This corrects capability-driven state and payload preparation without changing the existing UI layout.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

The existing image warning can still be dismissed. It is only reset when the underlying derived condition changes, such as selecting a model with a different vision capability.
