### PR TITLE
fix(cowork): render export modal above sidebar

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -4814,7 +4814,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       )}
 
       {/* Export Options Modal */}
-      {showExportOptions && (
+      {showExportOptions && createPortal(
         <div
           className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
           onClick={() => setShowExportOptions(false)}
@@ -4878,7 +4878,8 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
 
       {/* Content row: chat + artifact panel */}


### PR DESCRIPTION
Mount the export options modal via a body portal to avoid stacking context conflicts.

