### PR TITLE
fix(auth): harden session lifecycle and token refresh

### DIFF
--- a/specs/bugfixes/auth-session-lifecycle/2026-07-23-auth-session-lifecycle-design.md
+++ b/specs/bugfixes/auth-session-lifecycle/2026-07-23-auth-session-lifecycle-design.md
@@ -1,0 +1,213 @@
+# LobsterAI 登录凭证生命周期修复设计文档
+
+## 1. 概述
+
+### 1.1 问题
+
+LobsterAI 桌面端使用 Access Token 与 Refresh Token 访问套餐模型和账号接口。服务端已将新签发的 Access Token、Refresh Token 有效期分别调整为 30 天和 180 天，但端侧仍存在以下问题：
+
+1. 应用启动恢复账号时，断网、请求超时、服务端 5xx 与凭证真正过期都会返回笼统的失败，renderer 可能将临时故障当作退出登录。
+2. 主进程认证接口、OpenClaw Token 代理和 OpenAI 兼容代理存在多条刷新路径，其中兼容代理曾直接调用刷新接口，绕过统一的并发合并。
+3. 多个使用旧 Access Token 的请求可能先后收到 401。首个请求刷新完成后，迟到的 401 仍可能再次刷新。
+4. Refresh Token 被明确拒绝后，没有统一清理本地状态并通知 renderer；套餐模型最终显示的是“API 密钥无效或已过期”，与用户实际使用的登录凭证不符。
+5. 刷新请求没有显式超时，异常网络下所有等待同一次刷新的请求可能长时间挂起。
+6. 端侧缺少“登录态恢复、刷新结果、真正退登”的结构化生命周期事件。
+
+### 1.2 根因
+
+- `auth:getUser` 只返回 `success`，无法表达“无凭证、暂时不可校验、Refresh Token 失效”之间的差异。
+- Token 刷新逻辑散落在 `main.ts` 和本地代理中，缺少统一的刷新结果类型。
+- 原有单飞 Promise 只覆盖正在执行的刷新；刷新完成后才到达的旧 401 无法识别 Token 已经更新。
+- OpenClaw 运行时错误分类只根据通用 401 映射到 API Key 错误，没有结合 `lobsterai-server` provider 元数据。
+- 端侧行为上报使用 rlogs，而 Grafana 中的 Graphite 指标来自服务端 MetricLog，两条链路用途不同。
+
+## 2. 用户场景
+
+### 场景 1：启动时网络暂时不可用
+
+**Given** 本地仍有登录凭证和缓存的用户资料
+
+**When** 应用启动校验账号时发生断网、超时或服务端临时错误
+
+**Then** 保留登录快照，不清理 Token，不将用户标记为真正退出
+
+### 场景 2：Access Token 过期但 Refresh Token 有效
+
+**Given** Access Token 已过期且 Refresh Token 仍有效
+
+**When** 账号接口或套餐模型请求收到 401
+
+**Then** 只执行一次刷新，保存新 Token，并使用新 Access Token 重试原请求
+
+### 场景 3：并发请求收到旧 Token 的 401
+
+**Given** 另一个请求已经完成刷新
+
+**When** 使用旧 Access Token 的迟到响应返回 401
+
+**Then** 先使用当前已保存的新 Access Token 重试，不再次调用刷新接口
+
+### 场景 4：Refresh Token 真正失效
+
+**Given** 刷新接口返回 HTTP 401，或业务码 `40100`/`40101`
+
+**When** 桌面端确认 Refresh Token 已过期或无效
+
+**Then** 清理登录凭证和套餐模型缓存，通知 renderer 进入过期状态，并提示用户重新登录
+
+### 场景 5：刷新请求超时
+
+**Given** 刷新接口在 15 秒内没有响应
+
+**When** 主进程中止本次刷新
+
+**Then** 将结果标记为临时失败，保留登录凭证，等待后续操作再次恢复
+
+## 3. 功能需求
+
+### FR-1：结构化认证状态
+
+统一使用以下状态：
+
+- `authenticated`：服务器已确认登录有效
+- `unauthenticated`：本地没有凭证
+- `temporarily_unavailable`：网络、超时、5xx 或异常响应导致暂时无法确认
+- `expired`：刷新接口明确拒绝 Refresh Token
+
+只有 `expired` 和明确的用户退出操作可以清理本地登录状态。
+
+### FR-2：统一刷新协调器
+
+- 所有 LobsterAI Refresh Token 刷新必须进入同一个协调器。
+- 同时发生的刷新共享同一个 Promise。
+- 收到 401 后先比较请求使用的 Access Token 与当前保存的 Token；若已更新，优先使用新 Token 重试。
+- LobsterAI 套餐请求仅对 HTTP 401 刷新，403 按模型/账号权限错误处理。
+- 若 401 后的刷新因网络、超时或 5xx 临时失败，本地代理返回临时服务错误，不把原始 401 继续包装成“登录已过期”。
+
+### FR-3：终态失效闭环
+
+- Refresh Token 终态失效时只执行一次本地清理。
+- 主进程通过 `auth:sessionChanged` 通知 renderer。
+- Renderer 清理用户、额度和套餐模型状态，并加载公开模型目录。
+- Renderer 通过现有全局 Toast 明确提示登录状态过期，需要重新登录。
+- `lobsterai-server` 的 401 显示“登录状态已过期，请重新登录”，其他自定义供应商仍显示 API Key/OAuth 对应提示。
+
+### FR-4：刷新超时
+
+- 刷新请求超时为 15 秒。
+- 超时属于临时失败，不触发退登。
+- 第一版不增加指数退避或长时间冷却，避免网络恢复后仍被人为阻塞。
+
+### FR-5：认证生命周期事件
+
+端侧通过现有 rlogs 行为分析链路上报低基数事件：
+
+- `auth_restore`
+- `token_refresh`
+- `auth_terminal_expired`
+
+事件只包含结果、刷新原因、失败类型、HTTP 状态、业务错误码、耗时和合并请求数，不包含 Token。
+
+Grafana/Graphite 的运维指标继续以服务端 MetricLog 为准，包括：
+
+- `api.result.auth.refresh`
+- `api.cost.auth.refresh`
+- `api.result.auth.exchange`
+- `api.error_code.TOKEN_EXPIRED`
+- `api.error_code.TOKEN_INVALID`
+
+端侧 rlogs 事件不会自动写入上述 Graphite 数据源；如未来需要在同一 Grafana 面板展示精确客户端状态，应另行设计受限的服务端客户端指标接收接口。
+
+### FR-6：自动化测试
+
+测试至少覆盖：
+
+- 并发刷新只访问一次刷新接口
+- 迟到旧 401 使用已更新 Token 重试
+- 刷新期间退出或重新登录时，迟到响应不覆盖当前会话
+- 403 不刷新
+- 刷新 401 进入终态失效
+- 刷新 5xx、网络失败和超时保留登录态
+- 临时不可用保留 renderer 登录快照
+- 终态失效清理 renderer 状态
+- LobsterAI 套餐 401 与第三方 API Key/OAuth 错误显示不同文案
+
+## 4. 实现方案
+
+### 4.1 共享协议
+
+在 `src/shared/auth/constants.ts` 中集中认证 IPC 名称、会话状态、刷新结果、失败类型、刷新原因和生命周期事件类型，供 main、preload 与 renderer 共同使用。
+
+### 4.2 主进程刷新协调
+
+新增 `AuthSessionManager`，通过依赖注入使用 Token 存储、Electron `net.fetch`、刷新 URL 和事件回调。该模块负责：
+
+- 单飞刷新
+- 15 秒超时
+- 服务端响应分类
+- Token 轮换保存
+- 认证请求 401 重试
+- 旧 Token 迟到 401 保护
+- 生命周期指标事件
+
+`main.ts` 继续负责本地数据清理、OpenClaw 配置同步和 BrowserWindow 事件发送，避免认证协调模块依赖 Electron 窗口与业务缓存。
+
+### 4.3 本地代理
+
+- OpenClaw Token 代理在 401 后先检查 Token 是否已经更新，再决定是否刷新。
+- OpenAI 兼容代理把被拒绝的 Token 传给刷新回调；当前 Token 已更新时直接复用。
+- 两类代理都保留结构化刷新结果；临时刷新失败映射为 503，只有终态失败继续按登录失效处理。
+- LobsterAI Server provider 不再因 403 刷新，Copilot 等具有独立语义的 provider 保持原有行为。
+
+### 4.4 Renderer 状态
+
+Redux auth slice 增加 `sessionStatus`：
+
+- 暂时不可用时保留已有用户、额度和登录标记。
+- 冷启动时若 main 返回缓存用户和仍存在的凭证，可恢复账号展示。
+- 终态过期时清理用户、额度、资料摘要和套餐模型。
+
+### 4.5 错误提示
+
+OpenClaw 错误分类结合 provider、HTTP 状态和 failover 元数据：
+
+- `lobsterai-server` + 401：登录状态过期
+- `lobsterai-server` + HTTP 403：模型访问权限不足
+- 第三方 provider 401：维持 API Key/OAuth 错误
+
+中英文文案同时添加到 main 和 renderer 的 i18n 字典。
+
+## 5. 边界情况
+
+| 场景 | 处理方式 |
+|------|---------|
+| 刷新接口 401 且响应体为空 | 视为 Refresh Token 终态失效 |
+| 刷新接口返回 200 但缺少新 Access Token | 视为临时的无效响应，不清理凭证 |
+| 刷新接口 5xx | 临时失败，不清理凭证 |
+| 刷新过程中断网 | 临时失败，不清理凭证 |
+| 刷新请求超过 15 秒 | 中止请求并标记超时，不清理凭证 |
+| 套餐模型 401 后刷新暂时不可用 | 返回临时服务错误，不提示登录已过期 |
+| 刷新成功后业务接口仍返回 401 | 返回业务响应，不将一次成功刷新反向判定为 Refresh Token 过期 |
+| 刷新期间用户主动退出 | 丢弃迟到的刷新响应，不重新写回已经清理的凭证 |
+| 刷新期间用户完成新登录 | 丢弃旧会话的刷新响应，保留新登录签发的 Token |
+| 多窗口同时存在 | 主进程向所有未销毁窗口广播认证状态事件 |
+| Renderer 尚未订阅终态事件 | 后续 `auth:getUser` 因无本地凭证返回 `unauthenticated`，仍会显示登录入口 |
+
+## 6. 非目标
+
+本次不包含：
+
+- Refresh Token 安全存储和数据迁移策略
+- 到期前 72 小时的主动刷新策略
+- 登录点击、浏览器拉起和回调漏斗统计修正
+- 端侧直接写入 Graphite
+
+## 7. 验收标准
+
+1. 断网、超时和服务端 5xx 不再清理有效登录凭证。
+2. Refresh Token 返回 401/`40100`/`40101` 后，renderer 自动进入过期状态、展示登录入口并通过 Toast 提示重新登录。
+3. 套餐模型认证失败显示登录过期文案，不再显示 API 密钥过期。
+4. 同一时刻多个 401 只触发一次刷新；迟到旧 401 不重复刷新。
+5. LobsterAI 套餐路径的 403 不触发 Token 刷新。
+6. 生命周期事件不包含 Token 或任意高基数字段。
+7. 相关 Vitest、Electron TypeScript 编译、renderer 类型检查和改动文件 ESLint 全部通过。

--- a/src/common/coworkErrorClassify.ts
+++ b/src/common/coworkErrorClassify.ts
@@ -8,6 +8,7 @@ import { OpenClawTranscriptSafetyErrorCode } from '../shared/openclawTranscript/
 
 export const CoworkErrorI18nKey = {
   AuthInvalid: 'coworkErrorAuthInvalid',
+  LobsterAILoginExpired: 'coworkErrorLobsterAILoginExpired',
   OAuthInvalid: 'coworkErrorOAuthInvalid',
   ModelAccessDenied: 'coworkErrorModelAccessDenied',
   QuotaExhausted: 'coworkErrorQuotaExhausted',

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -60,6 +60,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Cowork error messages (shared with renderer via classifyErrorKey)
     coworkErrorAuthInvalid: 'API 密钥无效或已过期，请检查配置。',
+    coworkErrorLobsterAILoginExpired: '登录状态已过期，请重新登录后继续使用 LobsterAI 套餐模型。',
     coworkErrorOAuthInvalid: 'OAuth 授权已失效或权限不足，请重新授权后重试。',
     coworkErrorModelAccessDenied: '当前账号无权访问该模型，请切换模型或检查服务商账号权限。',
     coworkErrorQuotaExhausted:
@@ -356,6 +357,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Cowork error messages
     coworkErrorAuthInvalid: 'Invalid or expired API key. Please check your configuration.',
+    coworkErrorLobsterAILoginExpired:
+      'Your login session has expired. Sign in again to continue using LobsterAI plan models.',
     coworkErrorOAuthInvalid: 'OAuth authorization is invalid or missing required access. Re-authenticate and try again.',
     coworkErrorModelAccessDenied: 'This account is not allowed to access the selected model. Switch models or check provider account permissions.',
     coworkErrorQuotaExhausted:

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -275,6 +275,26 @@ test('resolveOpenClawRuntimeErrorMessage classifies generic error from safe OAut
   })).toContain('OAuth 授权已失效');
 });
 
+test('resolveOpenClawRuntimeErrorMessage identifies expired LobsterAI plan login', () => {
+  expect(resolveOpenClawRuntimeErrorMessage('LLM request failed.', {
+    provider: 'lobsterai-server',
+    model: 'MiniMax-M3',
+    failoverReason: 'auth',
+    httpCode: '401',
+    rawErrorPreview: '401 status code (no body)',
+  })).toContain('登录状态已过期');
+});
+
+test('resolveOpenClawRuntimeErrorMessage keeps LobsterAI HTTP 403 as model access denial', () => {
+  expect(resolveOpenClawRuntimeErrorMessage('LLM request failed.', {
+    provider: 'lobsterai-server',
+    model: 'MiniMax-M3',
+    failoverReason: 'auth',
+    httpCode: '403',
+    rawErrorPreview: '403 Forbidden',
+  })).toContain('无权访问该模型');
+});
+
 test('resolveOpenClawRuntimeErrorMessage classifies generic error from safe model access metadata', () => {
   expect(resolveOpenClawRuntimeErrorMessage('LLM request failed.', {
     provider: 'minimax',

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -57,6 +57,7 @@ import type {
 } from '../../../shared/kit/constants';
 import { OpenClawGatewayFailureKind } from '../../../shared/openclawEngine/constants';
 import { OpenClawTranscriptSafetyStatus } from '../../../shared/openclawTranscript/constants';
+import { ProviderName } from '../../../shared/providers';
 import type { Agent, CoworkExecutionMode, CoworkMessage, CoworkMessageMetadata, CoworkSession, CoworkSessionStatus, CoworkStore } from '../../coworkStore';
 import { t } from '../../i18n';
 import { MediaGenerationTool } from '../../mediaGenerationPolicy';
@@ -1508,6 +1509,13 @@ function classifyOpenClawSafeRuntimeErrorMetadata(
 ): string | null {
   if (!metadata) return null;
 
+  if (
+    metadata.provider?.trim() === ProviderName.LobsteraiServer
+    && metadata.httpCode?.trim() === '403'
+  ) {
+    return CoworkErrorI18nKey.ModelAccessDenied;
+  }
+
   const failureKind = metadata.providerRuntimeFailureKind?.trim();
   if (failureKind && COWORK_ERROR_KEY_BY_OPENCLAW_RUNTIME_FAILURE_KIND[failureKind]) {
     return COWORK_ERROR_KEY_BY_OPENCLAW_RUNTIME_FAILURE_KIND[failureKind];
@@ -1532,6 +1540,18 @@ function classifyOpenClawSafeRuntimeErrorMetadata(
   return null;
 }
 
+function isLobsterAILoginExpiredMetadata(
+  metadata: OpenClawSafeRuntimeErrorMetadata | undefined,
+): boolean {
+  if (metadata?.provider?.trim() !== ProviderName.LobsteraiServer) return false;
+  if (metadata.httpCode?.trim() === '403') return false;
+  if (metadata.providerRuntimeFailureKind?.trim() === 'auth_scope') return false;
+  return metadata.httpCode?.trim() === '401'
+    || metadata.failoverReason?.trim() === 'auth'
+    || metadata.providerRuntimeFailureKind?.trim() === 'auth_refresh'
+    || metadata.providerRuntimeFailureKind?.trim() === 'auth_invalid_token';
+}
+
 export function resolveOpenClawRuntimeErrorMessage(
   errorMessage: string,
   metadata?: OpenClawSafeRuntimeErrorMetadata,
@@ -1540,6 +1560,15 @@ export function resolveOpenClawRuntimeErrorMessage(
   const classifiedKey = classifyErrorKey(normalized);
 
   if (classifiedKey) {
+    if (
+      isLobsterAILoginExpiredMetadata(metadata)
+      && (
+        classifiedKey === CoworkErrorI18nKey.AuthInvalid
+        || classifiedKey === CoworkErrorI18nKey.OAuthInvalid
+      )
+    ) {
+      return t(CoworkErrorI18nKey.LobsterAILoginExpired);
+    }
     if (classifiedKey === CoworkErrorI18nKey.QuotaExhausted) {
       consumeRecentOpenClawTokenProxyQuotaError();
     }
@@ -1547,6 +1576,10 @@ export function resolveOpenClawRuntimeErrorMessage(
   }
 
   if (isOpenClawGenericLlmRequestFailed(normalized)) {
+    if (isLobsterAILoginExpiredMetadata(metadata)) {
+      consumeRecentOpenClawTokenProxyQuotaError();
+      return t(CoworkErrorI18nKey.LobsterAILoginExpired);
+    }
     const metadataClassifiedKey = classifyOpenClawSafeRuntimeErrorMetadata(metadata);
     if (metadataClassifiedKey) {
       consumeRecentOpenClawTokenProxyQuotaError();

--- a/src/main/libs/authSessionManager.test.ts
+++ b/src/main/libs/authSessionManager.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  AuthLifecycleEventType,
+  AuthRefreshFailureKind,
+  AuthRefreshOutcome,
+  AuthSessionStatus,
+} from '../../shared/auth/constants';
+import {
+  AuthSessionManager,
+  AuthSessionRequestError,
+  type AuthTokens,
+} from './authSessionManager';
+
+type TestManagerOptions = {
+  fetch: (url: string, init?: RequestInit) => Promise<Response>;
+  tokens?: AuthTokens | null;
+  timeoutMs?: number;
+};
+
+function createTestManager(options: TestManagerOptions) {
+  let tokens = options.tokens === undefined
+    ? { accessToken: 'access-old', refreshToken: 'refresh-old' }
+    : options.tokens;
+  const saveTokens = vi.fn((nextTokens: AuthTokens) => {
+    tokens = nextTokens;
+  });
+  const onTerminalFailure = vi.fn(() => {
+    tokens = null;
+  });
+  const onLifecycleEvent = vi.fn();
+  const manager = new AuthSessionManager({
+    getTokens: () => tokens,
+    saveTokens,
+    fetch: options.fetch,
+    getRefreshUrl: () => 'https://server.example/api/auth/refresh',
+    buildRefreshRequestBody: refreshToken => JSON.stringify({ refreshToken }),
+    onTerminalFailure,
+    onLifecycleEvent,
+    timeoutMs: options.timeoutMs,
+  });
+
+  return {
+    manager,
+    onLifecycleEvent,
+    onTerminalFailure,
+    saveTokens,
+    setTokens(nextTokens: AuthTokens | null) {
+      tokens = nextTokens;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('AuthSessionManager refresh', () => {
+  test('deduplicates concurrent refreshes and rotates both tokens once', async () => {
+    let resolveFetch: ((response: Response) => void) | null = null;
+    const fetch = vi.fn(() => new Promise<Response>(resolve => {
+      resolveFetch = resolve;
+    }));
+    const testManager = createTestManager({ fetch });
+
+    const first = testManager.manager.refresh('passive');
+    const second = testManager.manager.refresh('openclaw-proxy');
+    resolveFetch?.(new Response(JSON.stringify({
+      code: 0,
+      data: {
+        accessToken: 'access-new',
+        refreshToken: 'refresh-new',
+      },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(testManager.saveTokens).toHaveBeenCalledOnce();
+    expect(firstResult).toMatchObject({
+      outcome: AuthRefreshOutcome.Success,
+      accessToken: 'access-new',
+      joinedRequests: 1,
+      reason: 'passive',
+    });
+    expect(secondResult).toEqual(firstResult);
+    expect(testManager.onLifecycleEvent).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: AuthLifecycleEventType.TokenRefresh,
+      outcome: AuthRefreshOutcome.Success,
+      joinedRequests: 1,
+    }));
+  });
+
+  test('treats refresh HTTP 401 without a body as terminal', async () => {
+    const testManager = createTestManager({
+      fetch: vi.fn(async () => new Response(null, { status: 401 })),
+    });
+
+    const result = await testManager.manager.refresh('passive');
+
+    expect(result).toMatchObject({
+      outcome: AuthRefreshOutcome.TerminalFailure,
+      failureKind: AuthRefreshFailureKind.Rejected,
+      httpStatus: 401,
+    });
+    expect(testManager.onTerminalFailure).toHaveBeenCalledOnce();
+  });
+
+  test('treats an explicit refresh-token business error as terminal', async () => {
+    const testManager = createTestManager({
+      fetch: vi.fn(async () => new Response(JSON.stringify({
+        code: 40101,
+        message: 'refresh token expired',
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })),
+    });
+
+    const result = await testManager.manager.refresh('passive');
+
+    expect(result).toMatchObject({
+      outcome: AuthRefreshOutcome.TerminalFailure,
+      failureKind: AuthRefreshFailureKind.Rejected,
+      errorCode: 40101,
+    });
+    expect(testManager.onTerminalFailure).toHaveBeenCalledOnce();
+  });
+
+  test('keeps credentials for refresh 5xx responses', async () => {
+    const testManager = createTestManager({
+      fetch: vi.fn(async () => new Response(JSON.stringify({
+        code: 50000,
+        message: 'temporary failure',
+      }), {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+      })),
+    });
+
+    const result = await testManager.manager.refresh('passive');
+
+    expect(result).toMatchObject({
+      outcome: AuthRefreshOutcome.TransientFailure,
+      failureKind: AuthRefreshFailureKind.Http,
+      httpStatus: 503,
+    });
+    expect(testManager.onTerminalFailure).not.toHaveBeenCalled();
+  });
+
+  test('times out refresh without marking the session expired', async () => {
+    vi.useFakeTimers();
+    const testManager = createTestManager({
+      timeoutMs: 1_000,
+      fetch: vi.fn((_url, init) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      })),
+    });
+
+    const refresh = testManager.manager.refresh('passive');
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await refresh;
+
+    expect(result).toMatchObject({
+      outcome: AuthRefreshOutcome.TransientFailure,
+      failureKind: AuthRefreshFailureKind.Timeout,
+    });
+    expect(testManager.onTerminalFailure).not.toHaveBeenCalled();
+  });
+
+  test('does not restore credentials when logout completes during refresh', async () => {
+    let resolveFetch: ((response: Response) => void) | null = null;
+    const testManager = createTestManager({
+      fetch: vi.fn(() => new Promise<Response>(resolve => {
+        resolveFetch = resolve;
+      })),
+    });
+
+    const refresh = testManager.manager.refresh('passive');
+    testManager.setTokens(null);
+    resolveFetch?.(new Response(JSON.stringify({
+      code: 0,
+      data: {
+        accessToken: 'access-stale',
+        refreshToken: 'refresh-stale',
+      },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    await expect(refresh).resolves.toMatchObject({
+      outcome: AuthRefreshOutcome.NoTokens,
+    });
+    expect(testManager.saveTokens).not.toHaveBeenCalled();
+  });
+
+  test('does not let an old refresh rejection clear a newly established session', async () => {
+    let resolveFetch: ((response: Response) => void) | null = null;
+    const testManager = createTestManager({
+      fetch: vi.fn(() => new Promise<Response>(resolve => {
+        resolveFetch = resolve;
+      })),
+    });
+
+    const refresh = testManager.manager.refresh('passive');
+    testManager.setTokens({
+      accessToken: 'access-new-login',
+      refreshToken: 'refresh-new-login',
+    });
+    resolveFetch?.(new Response(null, { status: 401 }));
+
+    await expect(refresh).resolves.toMatchObject({
+      outcome: AuthRefreshOutcome.Success,
+      accessToken: 'access-new-login',
+    });
+    expect(testManager.onTerminalFailure).not.toHaveBeenCalled();
+    expect(testManager.saveTokens).not.toHaveBeenCalled();
+  });
+});
+
+describe('AuthSessionManager authenticated fetch', () => {
+  test('recovers concurrent request 401s with one refresh request', async () => {
+    let resolveRefresh: ((response: Response) => void) | null = null;
+    const fetch = vi.fn((url: string, init?: RequestInit): Promise<Response> => {
+      if (url.endsWith('/api/auth/refresh')) {
+        return new Promise<Response>(resolve => {
+          resolveRefresh = resolve;
+        });
+      }
+      const authorization = new Headers(init?.headers).get('Authorization');
+      return Promise.resolve(new Response(null, {
+        status: authorization === 'Bearer access-new' ? 200 : 401,
+      }));
+    });
+    const testManager = createTestManager({ fetch });
+
+    const first = testManager.manager.fetchWithAuth('https://server.example/api/user/profile');
+    const second = testManager.manager.fetchWithAuth('https://server.example/api/user/quota');
+    await vi.waitFor(() => {
+      expect(resolveRefresh).not.toBeNull();
+    });
+    resolveRefresh?.(new Response(JSON.stringify({
+      code: 0,
+      data: {
+        accessToken: 'access-new',
+        refreshToken: 'refresh-new',
+      },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const [firstResponse, secondResponse] = await Promise.all([first, second]);
+    const refreshCalls = fetch.mock.calls.filter(([url]) => url.endsWith('/api/auth/refresh'));
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(refreshCalls).toHaveLength(1);
+  });
+
+  test('retries a stale 401 with a token already refreshed by another request', async () => {
+    const fetch = vi.fn(async (_url: string, init?: RequestInit) => {
+      const authorization = new Headers(init?.headers).get('Authorization');
+      if (authorization === 'Bearer access-old') {
+        testManager.setTokens({
+          accessToken: 'access-new',
+          refreshToken: 'refresh-new',
+        });
+        return new Response(null, { status: 401 });
+      }
+      return new Response('ok', { status: 200 });
+    });
+    const testManager = createTestManager({ fetch });
+
+    const response = await testManager.manager.fetchWithAuth('https://server.example/api/user/profile');
+
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).not.toHaveBeenCalledWith(
+      'https://server.example/api/auth/refresh',
+      expect.anything(),
+    );
+  });
+
+  test('does not refresh on HTTP 403', async () => {
+    const fetch = vi.fn(async () => new Response(null, { status: 403 }));
+    const testManager = createTestManager({ fetch });
+
+    const response = await testManager.manager.fetchWithAuth('https://server.example/api/user/profile');
+
+    expect(response.status).toBe(403);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('surfaces refresh network failures as temporarily unavailable', async () => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url.endsWith('/api/auth/refresh')) {
+        throw new Error('network unavailable');
+      }
+      return new Response(null, { status: 401 });
+    });
+    const testManager = createTestManager({ fetch });
+
+    await expect(
+      testManager.manager.fetchWithAuth('https://server.example/api/user/profile'),
+    ).rejects.toMatchObject<AuthSessionRequestError>({
+      status: AuthSessionStatus.TemporarilyUnavailable,
+      failureKind: AuthRefreshFailureKind.Network,
+    });
+    expect(testManager.onTerminalFailure).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/libs/authSessionManager.ts
+++ b/src/main/libs/authSessionManager.ts
@@ -1,0 +1,371 @@
+import {
+  type AuthLifecycleEvent,
+  AuthLifecycleEventType,
+  AuthRefreshFailureKind,
+  type AuthRefreshFailureKind as AuthRefreshFailureKindValue,
+  AuthRefreshOutcome,
+  type AuthRefreshOutcome as AuthRefreshOutcomeValue,
+  AuthRefreshReason,
+  type AuthRefreshReason as AuthRefreshReasonValue,
+  AuthSessionStatus,
+  type AuthSessionStatus as AuthSessionStatusValue,
+} from '../../shared/auth/constants';
+
+export type AuthTokens = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+export type AuthRefreshResult = {
+  outcome: AuthRefreshOutcomeValue;
+  reason: AuthRefreshReasonValue;
+  durationMs: number;
+  joinedRequests: number;
+  accessToken?: string;
+  failureKind?: AuthRefreshFailureKindValue;
+  httpStatus?: number;
+  errorCode?: number;
+};
+
+type AuthRefreshResultWithoutTiming = Omit<AuthRefreshResult, 'durationMs' | 'joinedRequests'>;
+
+type AuthFetch = (url: string, init?: RequestInit) => Promise<Response>;
+
+type AuthSessionManagerOptions = {
+  getTokens: () => AuthTokens | null;
+  saveTokens: (tokens: AuthTokens) => void;
+  fetch: AuthFetch;
+  getRefreshUrl: () => string;
+  buildRefreshRequestBody: (refreshToken: string) => string;
+  onTerminalFailure: (result: AuthRefreshResultWithoutTiming) => void;
+  onRefreshSuccess?: (result: AuthRefreshResultWithoutTiming) => void;
+  onLifecycleEvent?: (event: AuthLifecycleEvent) => void;
+  timeoutMs?: number;
+  now?: () => number;
+  log?: {
+    info: (message: string) => void;
+    warn: (message: string, error?: unknown) => void;
+  };
+};
+
+type PendingRefresh = {
+  promise: Promise<AuthRefreshResult>;
+  joinedRequests: number;
+};
+
+const DEFAULT_REFRESH_TIMEOUT_MS = 15_000;
+const TERMINAL_REFRESH_ERROR_CODES = new Set([40100, 40101]);
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function readAccessToken(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const accessToken = (value as Record<string, unknown>).accessToken;
+  return typeof accessToken === 'string' && accessToken.trim() ? accessToken : undefined;
+}
+
+function readRefreshToken(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const refreshToken = (value as Record<string, unknown>).refreshToken;
+  return typeof refreshToken === 'string' && refreshToken.trim() ? refreshToken : undefined;
+}
+
+async function readRefreshResponseBody(response: Response): Promise<Record<string, unknown> | null> {
+  try {
+    const value = await response.json();
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+export class AuthSessionRequestError extends Error {
+  readonly status: AuthSessionStatusValue;
+  readonly failureKind?: AuthRefreshFailureKindValue;
+  readonly originalError?: unknown;
+
+  constructor(
+    status: AuthSessionStatusValue,
+    message: string,
+    options: {
+      failureKind?: AuthRefreshFailureKindValue;
+      originalError?: unknown;
+    } = {},
+  ) {
+    super(message);
+    this.name = 'AuthSessionRequestError';
+    this.status = status;
+    this.failureKind = options.failureKind;
+    this.originalError = options.originalError;
+  }
+}
+
+export function resolveAuthSessionStatusFromError(error: unknown): AuthSessionStatusValue {
+  return error instanceof AuthSessionRequestError
+    ? error.status
+    : AuthSessionStatus.TemporarilyUnavailable;
+}
+
+export class AuthSessionManager {
+  private readonly options: Required<Pick<AuthSessionManagerOptions, 'timeoutMs' | 'now'>> &
+    Omit<AuthSessionManagerOptions, 'timeoutMs' | 'now'>;
+  private pendingRefresh: PendingRefresh | null = null;
+
+  constructor(options: AuthSessionManagerOptions) {
+    this.options = {
+      ...options,
+      timeoutMs: options.timeoutMs ?? DEFAULT_REFRESH_TIMEOUT_MS,
+      now: options.now ?? Date.now,
+    };
+  }
+
+  async waitForPendingRefresh(): Promise<void> {
+    await this.pendingRefresh?.promise;
+  }
+
+  refresh(reason: AuthRefreshReasonValue): Promise<AuthRefreshResult> {
+    if (this.pendingRefresh) {
+      this.pendingRefresh.joinedRequests += 1;
+      return this.pendingRefresh.promise;
+    }
+
+    const startedAt = this.options.now();
+    const pending: PendingRefresh = {
+      joinedRequests: 0,
+      promise: Promise.resolve({
+        outcome: AuthRefreshOutcome.NoTokens,
+        reason,
+        durationMs: 0,
+        joinedRequests: 0,
+      }),
+    };
+
+    const promise = this.performRefresh(reason)
+      .then(result => {
+        const completed: AuthRefreshResult = {
+          ...result,
+          durationMs: Math.max(0, this.options.now() - startedAt),
+          joinedRequests: pending.joinedRequests,
+        };
+        this.emitLifecycleEvent(completed);
+        return completed;
+      })
+      .finally(() => {
+        if (this.pendingRefresh?.promise === promise) {
+          this.pendingRefresh = null;
+        }
+      });
+
+    pending.promise = promise;
+    this.pendingRefresh = pending;
+    return promise;
+  }
+
+  async fetchWithAuth(url: string, options?: RequestInit): Promise<Response> {
+    const initialTokens = this.options.getTokens();
+    if (!initialTokens) {
+      throw new AuthSessionRequestError(
+        AuthSessionStatus.Unauthenticated,
+        'No auth tokens are available',
+      );
+    }
+
+    const doFetch = async (accessToken: string): Promise<Response> => {
+      const headers = new Headers(options?.headers);
+      headers.set('Authorization', `Bearer ${accessToken}`);
+      try {
+        return await this.options.fetch(url, {
+          ...options,
+          headers,
+        });
+      } catch (error) {
+        throw new AuthSessionRequestError(
+          AuthSessionStatus.TemporarilyUnavailable,
+          'Authenticated request failed',
+          {
+            failureKind: AuthRefreshFailureKind.Network,
+            originalError: error,
+          },
+        );
+      }
+    };
+
+    let rejectedAccessToken = initialTokens.accessToken;
+    let response = await doFetch(rejectedAccessToken);
+    if (response.status !== 401) {
+      return response;
+    }
+
+    const latestTokens = this.options.getTokens();
+    if (latestTokens?.accessToken && latestTokens.accessToken !== rejectedAccessToken) {
+      rejectedAccessToken = latestTokens.accessToken;
+      response = await doFetch(rejectedAccessToken);
+      if (response.status !== 401) {
+        return response;
+      }
+    }
+
+    const refreshResult = await this.refresh(AuthRefreshReason.Passive);
+    if (refreshResult.outcome === AuthRefreshOutcome.Success && refreshResult.accessToken) {
+      return doFetch(refreshResult.accessToken);
+    }
+    if (refreshResult.outcome === AuthRefreshOutcome.TerminalFailure) {
+      throw new AuthSessionRequestError(
+        AuthSessionStatus.Expired,
+        'Refresh token was rejected',
+        { failureKind: refreshResult.failureKind },
+      );
+    }
+    if (refreshResult.outcome === AuthRefreshOutcome.NoTokens) {
+      throw new AuthSessionRequestError(
+        AuthSessionStatus.Unauthenticated,
+        'Auth tokens were cleared before refresh',
+      );
+    }
+    throw new AuthSessionRequestError(
+      AuthSessionStatus.TemporarilyUnavailable,
+      'Token refresh is temporarily unavailable',
+      { failureKind: refreshResult.failureKind },
+    );
+  }
+
+  private async performRefresh(
+    reason: AuthRefreshReasonValue,
+  ): Promise<AuthRefreshResultWithoutTiming> {
+    const tokens = this.options.getTokens();
+    if (!tokens?.refreshToken) {
+      return {
+        outcome: AuthRefreshOutcome.NoTokens,
+        reason,
+      };
+    }
+
+    const controller = new AbortController();
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, this.options.timeoutMs);
+
+    try {
+      const refreshUrl = this.options.getRefreshUrl();
+      this.options.log?.info(`[Auth] requesting token refresh (reason: ${reason})`);
+      const response = await this.options.fetch(refreshUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: this.options.buildRefreshRequestBody(tokens.refreshToken),
+        signal: controller.signal,
+      });
+      const body = await readRefreshResponseBody(response);
+      const errorCode = readNumber(body?.code);
+      const data = body?.data;
+      const accessToken = readAccessToken(data);
+      const currentTokens = this.options.getTokens();
+
+      if (!currentTokens) {
+        this.options.log?.info(
+          `[Auth] ignored token refresh response after credentials were cleared (reason: ${reason})`,
+        );
+        return {
+          outcome: AuthRefreshOutcome.NoTokens,
+          reason,
+        };
+      }
+      if (currentTokens.refreshToken !== tokens.refreshToken) {
+        this.options.log?.info(
+          `[Auth] ignored token refresh response for a superseded session (reason: ${reason})`,
+        );
+        return {
+          outcome: AuthRefreshOutcome.Success,
+          reason,
+          accessToken: currentTokens.accessToken,
+        };
+      }
+
+      if (response.ok && errorCode === 0 && accessToken) {
+        const nextTokens = {
+          accessToken,
+          refreshToken: readRefreshToken(data) ?? tokens.refreshToken,
+        };
+        this.options.saveTokens(nextTokens);
+        const result: AuthRefreshResultWithoutTiming = {
+          outcome: AuthRefreshOutcome.Success,
+          reason,
+          accessToken,
+          httpStatus: response.status,
+          errorCode,
+        };
+        this.invokeSafely(this.options.onRefreshSuccess, result);
+        this.options.log?.info(`[Auth] token refresh succeeded (reason: ${reason})`);
+        return result;
+      }
+
+      const isTerminalFailure = response.status === 401
+        || (errorCode !== undefined && TERMINAL_REFRESH_ERROR_CODES.has(errorCode));
+      const result: AuthRefreshResultWithoutTiming = {
+        outcome: isTerminalFailure
+          ? AuthRefreshOutcome.TerminalFailure
+          : AuthRefreshOutcome.TransientFailure,
+        reason,
+        failureKind: isTerminalFailure
+          ? AuthRefreshFailureKind.Rejected
+          : response.ok
+            ? AuthRefreshFailureKind.InvalidResponse
+            : AuthRefreshFailureKind.Http,
+        httpStatus: response.status,
+        errorCode,
+      };
+      if (result.outcome === AuthRefreshOutcome.TerminalFailure) {
+        this.invokeSafely(this.options.onTerminalFailure, result);
+      }
+      this.options.log?.warn(
+        `[Auth] token refresh rejected (reason: ${reason}, status: ${response.status}, code: ${errorCode ?? 'unknown'})`,
+      );
+      return result;
+    } catch (error) {
+      const failureKind = timedOut || isAbortError(error)
+        ? AuthRefreshFailureKind.Timeout
+        : AuthRefreshFailureKind.Network;
+      this.options.log?.warn(
+        `[Auth] token refresh failed (reason: ${reason}, kind: ${failureKind})`,
+        error,
+      );
+      return {
+        outcome: AuthRefreshOutcome.TransientFailure,
+        reason,
+        failureKind,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private emitLifecycleEvent(result: AuthRefreshResult): void {
+    this.invokeSafely(this.options.onLifecycleEvent, {
+      eventType: AuthLifecycleEventType.TokenRefresh,
+      outcome: result.outcome,
+      reason: result.reason,
+      durationMs: result.durationMs,
+      failureKind: result.failureKind,
+      httpStatus: result.httpStatus,
+      errorCode: result.errorCode,
+      joinedRequests: result.joinedRequests,
+    });
+  }
+
+  private invokeSafely<T>(callback: ((value: T) => void) | undefined, value: T): void {
+    try {
+      callback?.(value);
+    } catch (error) {
+      this.options.log?.warn('[Auth] lifecycle callback failed', error);
+    }
+  }
+}

--- a/src/main/libs/coworkOpenAICompatProxy.test.ts
+++ b/src/main/libs/coworkOpenAICompatProxy.test.ts
@@ -1,6 +1,9 @@
 import type http from 'http';
 import { describe, expect, test, vi } from 'vitest';
 
+import { AuthRefreshOutcome } from '../../shared/auth/constants';
+import { ProviderName } from '../../shared/providers';
+
 vi.mock('electron', () => ({
   session: { defaultSession: { webRequest: { onBeforeSendHeaders: vi.fn() } } },
 }));
@@ -8,6 +11,27 @@ vi.mock('electron', () => ({
 import { __openAICompatProxyTestUtils, isAllowedProxyHost } from './coworkOpenAICompatProxy';
 
 const testUtils = __openAICompatProxyTestUtils;
+
+test('refreshes LobsterAI credentials only for HTTP 401', () => {
+  expect(testUtils.shouldRefreshProxyToken(401, ProviderName.LobsteraiServer)).toBe(true);
+  expect(testUtils.shouldRefreshProxyToken(403, ProviderName.LobsteraiServer)).toBe(false);
+  expect(testUtils.shouldRefreshProxyToken(403, ProviderName.Copilot)).toBe(true);
+});
+
+test('maps only transient LobsterAI refresh failures to temporary service errors', () => {
+  expect(testUtils.isTemporaryLobsterAIAuthRefreshFailure(
+    ProviderName.LobsteraiServer,
+    { outcome: AuthRefreshOutcome.TransientFailure },
+  )).toBe(true);
+  expect(testUtils.isTemporaryLobsterAIAuthRefreshFailure(
+    ProviderName.LobsteraiServer,
+    { outcome: AuthRefreshOutcome.TerminalFailure },
+  )).toBe(false);
+  expect(testUtils.isTemporaryLobsterAIAuthRefreshFailure(
+    ProviderName.Copilot,
+    { outcome: AuthRefreshOutcome.TransientFailure },
+  )).toBe(false);
+});
 
 function createMockResponse() {
   let output = '';

--- a/src/main/libs/coworkOpenAICompatProxy.ts
+++ b/src/main/libs/coworkOpenAICompatProxy.ts
@@ -3,6 +3,11 @@ import { session } from 'electron';
 import http from 'http';
 
 import {
+  AuthRefreshOutcome,
+  type AuthTokenRefreshResult,
+} from '../../shared/auth/constants';
+import { ProviderName } from '../../shared/providers';
+import {
   anthropicToOpenAI,
   buildOpenAIChatCompletionsURL,
   formatSSEEvent,
@@ -180,7 +185,11 @@ export function isAllowedProxyHost(req: http.IncomingMessage): boolean {
  * with the new token.  Providers register their refresher via
  * {@link registerProxyTokenRefresher}.
  */
-const tokenRefreshers = new Map<string, () => Promise<string | null>>();
+type ProxyTokenRefresher = (
+  rejectedToken?: string,
+) => Promise<AuthTokenRefreshResult>;
+
+const tokenRefreshers = new Map<string, ProxyTokenRefresher>();
 let currentCoworkSessionId: string | null = null;
 const toolCallExtraContentById = new Map<string, unknown>();
 
@@ -230,6 +239,19 @@ function toOptionalObject(value: unknown): Record<string, unknown> | null {
     return value as Record<string, unknown>;
   }
   return null;
+}
+
+function shouldRefreshProxyToken(status: number, provider?: string): boolean {
+  if (status === 401) return true;
+  return status === 403 && provider !== ProviderName.LobsteraiServer;
+}
+
+function isTemporaryLobsterAIAuthRefreshFailure(
+  provider: string | undefined,
+  result: AuthTokenRefreshResult,
+): boolean {
+  return provider === ProviderName.LobsteraiServer
+    && result.outcome === AuthRefreshOutcome.TransientFailure;
 }
 
 function toString(value: unknown): string {
@@ -2520,23 +2542,36 @@ async function handleRequest(
       });
       // Auto-retry once for token expiry using provider-based refresher
       if (
-        (upstreamResponse.status === 401 || upstreamResponse.status === 403)
+        shouldRefreshProxyToken(upstreamResponse.status, upstreamConfig.provider)
         && upstreamConfig.provider
       ) {
         const refresher = tokenRefreshers.get(upstreamConfig.provider);
         if (refresher) {
           console.log(`[CoworkProxy] OpenAI passthrough: ${upstreamConfig.provider} auth error, refreshing token and retrying...`);
           try {
-            const newToken = await refresher();
-            if (newToken) {
-              upstreamConfig.apiKey = newToken;
-              upstreamHeaders.Authorization = `Bearer ${newToken}`;
+            const refreshResult = await refresher(upstreamConfig.apiKey);
+            if (refreshResult.accessToken) {
+              upstreamConfig.apiKey = refreshResult.accessToken;
+              upstreamHeaders.Authorization = `Bearer ${refreshResult.accessToken}`;
               upstreamResponse = await session.defaultSession.fetch(upstreamUrl, {
                 method: 'POST',
                 headers: upstreamHeaders,
                 body,
               });
               console.log(`[CoworkProxy] OpenAI passthrough: retry status=${upstreamResponse.status}`);
+            } else if (isTemporaryLobsterAIAuthRefreshFailure(
+              upstreamConfig.provider,
+              refreshResult,
+            )) {
+              writeJSON(
+                res,
+                503,
+                createAnthropicErrorBody(
+                  'Login verification is temporarily unavailable. Please retry.',
+                  'service_unavailable',
+                ),
+              );
+              return;
             }
           } catch (refreshErr) {
             console.warn(`[CoworkProxy] OpenAI passthrough: ${upstreamConfig.provider} token refresh failed:`, refreshErr);
@@ -2709,26 +2744,39 @@ async function handleRequest(
     // 401/403 likely means the token expired.  Look up the registered
     // refresher for this provider and retry once with a fresh token.
     if (
-      (upstreamResponse.status === 401 || upstreamResponse.status === 403)
+      shouldRefreshProxyToken(upstreamResponse.status, upstreamConfig?.provider)
       && upstreamConfig?.provider
     ) {
       const refresher = tokenRefreshers.get(upstreamConfig.provider);
       if (refresher) {
         console.log(`[CoworkProxy] Got ${upstreamResponse.status} from ${upstreamConfig.provider}, attempting token refresh and retry...`);
         try {
-          const newToken = await refresher();
-          if (newToken) {
+          const refreshResult = await refresher(upstreamConfig.apiKey);
+          if (refreshResult.accessToken) {
             if (isGeminiProvider(upstreamConfig.provider, upstreamConfig.baseURL)) {
-              headers['x-goog-api-key'] = newToken;
+              headers['x-goog-api-key'] = refreshResult.accessToken;
             } else {
-              headers.Authorization = `Bearer ${newToken}`;
+              headers.Authorization = `Bearer ${refreshResult.accessToken}`;
             }
             if (upstreamConfig) {
-              upstreamConfig.apiKey = newToken;
+              upstreamConfig.apiKey = refreshResult.accessToken;
             }
             upstreamResponse = await sendUpstreamRequest(upstreamRequest, currentTargetURL);
             const retryDuration = Date.now() - fetchStartTime;
             console.log(`[CoworkProxy] Token refresh retry: status=${upstreamResponse.status}, ok=${upstreamResponse.ok}, fetchTime=${retryDuration}ms`);
+          } else if (isTemporaryLobsterAIAuthRefreshFailure(
+            upstreamConfig.provider,
+            refreshResult,
+          )) {
+            writeJSON(
+              res,
+              503,
+              createAnthropicErrorBody(
+                'Login verification is temporarily unavailable. Please retry.',
+                'service_unavailable',
+              ),
+            );
+            return;
           }
         } catch (refreshError) {
           console.warn(`[CoworkProxy] Token refresh for ${upstreamConfig.provider} failed:`, refreshError);
@@ -2890,7 +2938,9 @@ export const __openAICompatProxyTestUtils = {
   processResponsesStreamEvent,
   convertChatCompletionsRequestToResponsesRequest,
   filterOpenAIToolsForProvider,
+  isTemporaryLobsterAIAuthRefreshFailure,
   isGeminiProvider,
+  shouldRefreshProxyToken,
 };
 
 export async function startCoworkOpenAICompatProxy(): Promise<void> {
@@ -2963,7 +3013,7 @@ export function configureCoworkOpenAICompatProxy(config: OpenAICompatUpstreamCon
   lastProxyError = null;
 }
 
-export function registerProxyTokenRefresher(provider: string, refresher: () => Promise<string | null>): void {
+export function registerProxyTokenRefresher(provider: string, refresher: ProxyTokenRefresher): void {
   tokenRefreshers.set(provider, refresher);
 }
 

--- a/src/main/libs/openclawTokenProxy.test.ts
+++ b/src/main/libs/openclawTokenProxy.test.ts
@@ -3,6 +3,8 @@ import { PassThrough } from 'node:stream';
 import http from 'http';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { AuthRefreshOutcome } from '../../shared/auth/constants';
+
 vi.mock('electron', () => ({
   net: { fetch: vi.fn() },
 }));
@@ -16,6 +18,20 @@ const testUtils = __openClawTokenProxyTestUtils;
 
 beforeEach(() => {
   consumeRecentOpenClawTokenProxyQuotaError();
+});
+
+test('refreshes LobsterAI credentials for 401 but not 403', () => {
+  expect(testUtils.shouldRefreshLobsterAIToken(401)).toBe(true);
+  expect(testUtils.shouldRefreshLobsterAIToken(403)).toBe(false);
+});
+
+test('turns only transient refresh failures into temporary service errors', () => {
+  expect(testUtils.isTemporaryAuthRefreshFailure({
+    outcome: AuthRefreshOutcome.TransientFailure,
+  })).toBe(true);
+  expect(testUtils.isTemporaryAuthRefreshFailure({
+    outcome: AuthRefreshOutcome.TerminalFailure,
+  })).toBe(false);
 });
 
 type MockProxyResponse = {

--- a/src/main/libs/openclawTokenProxy.ts
+++ b/src/main/libs/openclawTokenProxy.ts
@@ -2,6 +2,12 @@ import { net } from 'electron';
 import http from 'http';
 
 import { isLobsterAIQuotaExhaustedError } from '../../common/coworkErrorClassify';
+import {
+  AuthRefreshOutcome,
+  AuthRefreshReason,
+  type AuthRefreshReason as AuthRefreshReasonValue,
+  type AuthTokenRefreshResult,
+} from '../../shared/auth/constants';
 
 const PROXY_BIND_HOST = '127.0.0.1';
 const RECENT_QUOTA_ERROR_TTL_MS = 30_000;
@@ -13,12 +19,14 @@ let recentQuotaError: OpenClawTokenProxyQuotaError | null = null;
 
 // Injected dependencies
 let tokenGetter: (() => { accessToken: string; refreshToken: string } | null) | null = null;
-let tokenRefresher: ((reason: string) => Promise<string | null>) | null = null;
+let tokenRefresher: (
+  (reason: AuthRefreshReasonValue) => Promise<AuthTokenRefreshResult>
+) | null = null;
 let serverBaseUrlGetter: (() => string) | null = null;
 
 export type OpenClawTokenProxyConfig = {
   getAuthTokens: () => { accessToken: string; refreshToken: string } | null;
-  refreshToken: (reason: string) => Promise<string | null>;
+  refreshToken: (reason: AuthRefreshReasonValue) => Promise<AuthTokenRefreshResult>;
   getServerBaseUrl: () => string;
 };
 
@@ -102,6 +110,28 @@ function collectRequestBody(req: http.IncomingMessage): Promise<Buffer> {
   });
 }
 
+function shouldRefreshLobsterAIToken(status: number): boolean {
+  return status === 401;
+}
+
+function isTemporaryAuthRefreshFailure(result: AuthTokenRefreshResult): boolean {
+  return result.outcome === AuthRefreshOutcome.TransientFailure;
+}
+
+function writeTemporaryAuthRefreshFailure(res: http.ServerResponse): void {
+  res.writeHead(503, {
+    'Content-Type': 'application/json',
+    'Retry-After': '1',
+  });
+  res.end(JSON.stringify({
+    error: {
+      message: 'Login verification is temporarily unavailable. Please retry.',
+      type: 'service_unavailable',
+      code: 'auth_refresh_temporarily_unavailable',
+    },
+  }));
+}
+
 async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
   try {
     const tokens = tokenGetter?.();
@@ -123,14 +153,39 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
     const upstreamPath = `/api/proxy${req.url || '/'}`;
     const upstreamUrl = `${serverBaseUrl}${upstreamPath}`;
 
-    const result = await forwardRequest(upstreamUrl, req.method || 'POST', tokens.accessToken, upstreamBody, req.headers);
+    let result = await forwardRequest(upstreamUrl, req.method || 'POST', tokens.accessToken, upstreamBody, req.headers);
 
-    if ((result.status === 401 || result.status === 403) && tokenRefresher) {
-      console.log(`[OpenClawTokenProxy] received ${result.status}, attempting token refresh`);
-      const newToken = await tokenRefresher('openclaw-proxy');
-      if (newToken) {
-        const retryResult = await forwardRequest(upstreamUrl, req.method || 'POST', newToken, upstreamBody, req.headers);
+    if (shouldRefreshLobsterAIToken(result.status) && tokenRefresher) {
+      const latestAccessToken = tokenGetter?.()?.accessToken;
+      if (latestAccessToken && latestAccessToken !== tokens.accessToken) {
+        result = await forwardRequest(
+          upstreamUrl,
+          req.method || 'POST',
+          latestAccessToken,
+          upstreamBody,
+          req.headers,
+        );
+        if (result.status !== 401) {
+          pipeResponse(result, res);
+          return;
+        }
+      }
+
+      console.log('[OpenClawTokenProxy] received 401, attempting token refresh');
+      const refreshResult = await tokenRefresher(AuthRefreshReason.OpenClawProxy);
+      if (refreshResult.accessToken) {
+        const retryResult = await forwardRequest(
+          upstreamUrl,
+          req.method || 'POST',
+          refreshResult.accessToken,
+          upstreamBody,
+          req.headers,
+        );
         pipeResponse(retryResult, res);
+        return;
+      }
+      if (isTemporaryAuthRefreshFailure(refreshResult)) {
+        writeTemporaryAuthRefreshFailure(res);
         return;
       }
     }
@@ -687,4 +742,6 @@ export const __openClawTokenProxyTestUtils = {
   pipeNodeReadableResponseWithQuotaScan,
   pipeWebReadableResponseWithQuotaScan,
   pipeStreamingResponseWithQuotaScan,
+  isTemporaryAuthRefreshFailure,
+  shouldRefreshLobsterAIToken,
 };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -37,7 +37,16 @@ import { AppIpcChannel } from '../shared/app/constants';
 import { AppSettingsAutoLaunchErrorCode, AppSettingsIpc } from '../shared/appSettings/constants';
 import { AppUpdateIpc } from '../shared/appUpdate/constants';
 import { ArtifactBrowserPartition, ArtifactPreviewIpc, ArtifactPreviewProtocol } from '../shared/artifactPreview/constants';
-import { AuthIpcChannel } from '../shared/auth/constants';
+import {
+  AuthIpcChannel,
+  type AuthLifecycleEvent,
+  AuthLifecycleEventType,
+  AuthRefreshOutcome,
+  AuthRefreshReason,
+  type AuthSessionChangedEvent,
+  AuthSessionChangeReason,
+  AuthSessionStatus,
+} from '../shared/auth/constants';
 import {
   type BrowserDiagnosticResultStep,
   BrowserDiagnosticStatus,
@@ -192,6 +201,10 @@ import {
   appendLoginParams,
   startAuthLocalCallback,
 } from './libs/authLocalCallbackServer';
+import {
+  AuthSessionManager,
+  resolveAuthSessionStatusFromError,
+} from './libs/authSessionManager';
 import type { BrowserAnnotationAssetIdentity, SaveBrowserAnnotationAssetInput } from './libs/browserAnnotationAssetStore';
 import { BrowserAnnotationAssetStore } from './libs/browserAnnotationAssetStore';
 import {
@@ -1952,9 +1965,9 @@ const bootstrapOpenClawEngine = async (
   return promise;
 };
 
-// Module-level handle so ensureOpenClawRunningForCowork can await any in-flight
-// proactive token refresh before syncing config to the gateway.
-let pendingTokenRefresh: Promise<string | null> | null = null;
+// Injected after the auth session manager is created. This keeps gateway startup
+// able to await an in-flight refresh without exposing refresh internals globally.
+let waitForPendingTokenRefresh: () => Promise<void> = async () => {};
 
 const ensureOpenClawRunningForCowork = async () => {
   const configApplyStatus = await waitForOpenClawConfigApply('cowork engine startup');
@@ -1967,10 +1980,7 @@ const ensureOpenClawRunningForCowork = async () => {
   if (status.phase === 'running') {
     // Token proxy handles dynamic token injection — no need to restart
     // the gateway for token changes. Just wait for any in-flight refresh.
-    if (pendingTokenRefresh) {
-      console.log('[OpenClaw] ensureRunning: awaiting pending token refresh before proceeding');
-      await pendingTokenRefresh.catch(() => {});
-    }
+    await waitForPendingTokenRefresh();
     return manager.getStatus();
   }
   if (status.phase === 'starting') {
@@ -1979,10 +1989,7 @@ const ensureOpenClawRunningForCowork = async () => {
 
   // Wait for any in-flight token refresh so that the gateway starts with
   // a fresh token rather than the stale one that triggered the refresh.
-  if (pendingTokenRefresh) {
-    console.log('[OpenClaw] ensureRunning: awaiting pending token refresh before gateway start');
-    await pendingTokenRefresh.catch(() => {});
-  }
+  await waitForPendingTokenRefresh();
 
   // Ensure AskUser server is started and config is synced before launching the gateway,
   // so that mcp.servers config is available in openclaw.json when the gateway loads.
@@ -2828,7 +2835,7 @@ const bindCoworkRuntimeForwarder = (): void => {
         const windows = BrowserWindow.getAllWindows();
         windows.forEach(win => {
           if (win.isDestroyed()) return;
-          win.webContents.send('auth:quotaChanged');
+          win.webContents.send(AuthIpcChannel.QuotaChanged);
         });
       }
     } catch {
@@ -4211,6 +4218,15 @@ if (!gotTheLock) {
     getStore().delete('auth_tokens');
   };
 
+  const getAuthUser = (): Record<string, unknown> | null => {
+    try {
+      return getStore().get<Record<string, unknown>>(AUTH_USER_STORE_KEY) || null;
+    } catch (error) {
+      console.warn('[Auth] failed to read cached auth user:', error);
+      return null;
+    }
+  };
+
   const saveAuthUser = (user: Record<string, unknown>) => {
     try {
       getStore().set(AUTH_USER_STORE_KEY, user);
@@ -4221,7 +4237,7 @@ if (!gotTheLock) {
 
   const getAuthUserId = (): string | null => {
     try {
-      const user = getStore().get<Record<string, unknown>>(AUTH_USER_STORE_KEY);
+      const user = getAuthUser();
       const yid = user?.yid;
       if (typeof yid === 'string' && yid.trim()) return yid;
       const userId = user?.userId;
@@ -4290,77 +4306,56 @@ if (!gotTheLock) {
     return parsed.toString();
   };
 
-  // refreshOnce() is the single entry-point for all token refresh paths
-  // (proactive, proxy 401/403 retry, and main-process authenticated API 401s).
-  // It deduplicates concurrent calls via pendingTokenRefresh so that rolling
-  // refresh tokens are never consumed twice.
-  const refreshOnce = async (reason: string): Promise<string | null> => {
-    if (pendingTokenRefresh) {
-      return pendingTokenRefresh;
+  const emitAuthLifecycleEvent = (event: AuthLifecycleEvent): void => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(AuthIpcChannel.LifecycleEvent, event);
     }
-    let resolvedToken: string | null = null;
-    pendingTokenRefresh = (async () => {
-      try {
-        const tokens = getAuthTokens();
-        if (!tokens?.refreshToken) return null;
-        const serverBaseUrl = getServerApiBaseUrl();
-        const refreshUrl = `${serverBaseUrl}/api/auth/refresh`;
-        console.log(`[Auth] requesting token refresh (reason: ${reason}) at ${refreshUrl}`);
-        const resp = await net.fetch(refreshUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(withKeyfromBody({ refreshToken: tokens.refreshToken })),
-        });
-        if (resp.ok) {
-          const body = await resp.json() as { code: number; data: { accessToken: string; refreshToken?: string } };
-          if (body.code === 0 && body.data) {
-            saveAuthTokens(body.data.accessToken, body.data.refreshToken || tokens.refreshToken);
-            console.log(`[Auth] token refresh succeeded (reason: ${reason})`);
-            resolvedToken = body.data.accessToken;
-            // Token proxy handles fresh tokens dynamically — no need
-            // to restart the gateway on token refresh.
-            syncOpenClawConfig({ reason: `token-refresh:${reason}`, restartGatewayIfRunning: false }).catch((err) => {
-              console.warn('[Auth] post-refresh OpenClaw config sync failed:', err);
-            });
-          }
-        }
-      } catch (err) {
-        console.warn(`[Auth] token refresh failed (reason: ${reason}):`, err);
-      } finally {
-        pendingTokenRefresh = null;
-      }
-      return resolvedToken;
-    })();
-    return pendingTokenRefresh;
   };
 
-  /**
-   * Helper: Fetch with Bearer token, auto-refresh on 401 and retry once.
-   */
-  const fetchWithAuth = async (url: string, options?: RequestInit): Promise<Response> => {
-    const tokens = getAuthTokens();
-    if (!tokens) throw new Error('No auth tokens');
+  const emitAuthSessionChanged = (event: AuthSessionChangedEvent): void => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) {
+        window.webContents.send(AuthIpcChannel.SessionChanged, event);
+      }
+    }
+  };
 
-    const doFetch = (accessToken: string) =>
-      net.fetch(url, {
-        ...options,
-        headers: {
-          ...(options?.headers as Record<string, string>),
-          Authorization: `Bearer ${accessToken}`,
-        },
+  const authSessionManager = new AuthSessionManager({
+    getTokens: getAuthTokens,
+    saveTokens: tokens => saveAuthTokens(tokens.accessToken, tokens.refreshToken),
+    fetch: (url, options) => net.fetch(url, options),
+    getRefreshUrl: () => `${getServerApiBaseUrl()}/api/auth/refresh`,
+    buildRefreshRequestBody: refreshToken => JSON.stringify(withKeyfromBody({ refreshToken })),
+    onTerminalFailure: () => {
+      clearLocalAuthSession({
+        reason: AuthSessionChangeReason.RefreshRejected,
+        notifyRenderer: true,
       });
+    },
+    onRefreshSuccess: result => {
+      syncOpenClawConfig({
+        reason: `token-refresh:${result.reason}`,
+        restartGatewayIfRunning: false,
+      }).catch((error) => {
+        console.warn('[Auth] post-refresh OpenClaw config sync failed:', error);
+      });
+    },
+    onLifecycleEvent: emitAuthLifecycleEvent,
+    log: {
+      info: message => console.log(message),
+      warn: (message, error) => {
+        if (error === undefined) {
+          console.warn(message);
+        } else {
+          console.warn(message, error);
+        }
+      },
+    },
+  });
+  waitForPendingTokenRefresh = () => authSessionManager.waitForPendingRefresh();
 
-    let resp = await doFetch(tokens.accessToken);
-
-    if (resp.status === 401 && tokens.refreshToken) {
-      const refreshedAccessToken = await refreshOnce('passive');
-      if (refreshedAccessToken) {
-        resp = await doFetch(refreshedAccessToken);
-      }
-    }
-
-    return resp;
-  };
+  const fetchWithAuth = (url: string, options?: RequestInit): Promise<Response> =>
+    authSessionManager.fetchWithAuth(url, options);
 
   const extractSessionIdFromKey = (sessionKey: string): string | null =>
     resolveCoworkSessionIdByOpenClawSessionKey(getStore().getDatabase(), sessionKey);
@@ -5118,7 +5113,7 @@ if (!gotTheLock) {
             emitMediaTaskMessage(tracker.sessionId, lines.join('\n'));
           }
           BrowserWindow.getAllWindows().forEach(win => {
-            if (!win.isDestroyed()) win.webContents.send('auth:quotaChanged');
+            if (!win.isDestroyed()) win.webContents.send(AuthIpcChannel.QuotaChanged);
           });
         }
       } catch {
@@ -5287,6 +5282,42 @@ if (!gotTheLock) {
     cachedMediaGenerationEntitled = defaultGateState.mediaGenerationEntitled;
   };
 
+  const clearLocalAuthSession = (options: {
+    reason: AuthSessionChangeReason;
+    notifyRenderer: boolean;
+  }): void => {
+    const previousQuotaGateState = getAuthQuotaGateState();
+    clearAuthTokens();
+    clearAuthUser();
+    clearServerModelMetadata();
+    resetAuthQuotaGateState();
+
+    const quotaGateSyncScheduled = syncOpenClawConfigIfAuthQuotaGateChanged(previousQuotaGateState);
+    if (!quotaGateSyncScheduled) {
+      const syncReason = options.reason === AuthSessionChangeReason.RefreshRejected
+        ? 'auth-session-expired-server-models-cleared'
+        : 'auth-logout-server-models-cleared';
+      syncOpenClawConfig({
+        reason: syncReason,
+        restartGatewayIfRunning: false,
+      }).catch(error => {
+        console.warn('[Auth] failed to sync OpenClaw config after auth cleanup:', error);
+      });
+    }
+
+    if (options.notifyRenderer) {
+      emitAuthSessionChanged({
+        status: AuthSessionStatus.Expired,
+        reason: options.reason,
+      });
+      emitAuthLifecycleEvent({
+        eventType: AuthLifecycleEventType.TerminalExpired,
+        outcome: AuthSessionStatus.Expired,
+        reason: options.reason,
+      });
+    }
+  };
+
   /**
    * Normalize quota data from various server response formats into a unified shape.
    */
@@ -5343,7 +5374,7 @@ if (!gotTheLock) {
     }
   });
 
-  ipcMain.handle('auth:exchange', async (_event, { code }: { code: string }) => {
+  ipcMain.handle(AuthIpcChannel.Exchange, async (_event, { code }: { code: string }) => {
     try {
       const serverBaseUrl = getServerApiBaseUrl();
       const exchangeUrl = `${serverBaseUrl}/api/auth/exchange`;
@@ -5385,19 +5416,39 @@ if (!gotTheLock) {
     }
   });
 
-  ipcMain.handle('auth:getUser', async () => {
+  ipcMain.handle(AuthIpcChannel.GetUser, async () => {
     try {
       const tokens = getAuthTokens();
-      if (!tokens) return { success: false };
+      if (!tokens) {
+        return {
+          success: false,
+          status: AuthSessionStatus.Unauthenticated,
+          hasCredentials: false,
+        };
+      }
       const serverBaseUrl = getServerApiBaseUrl();
       // Fetch user profile
       const profileResp = await fetchWithAuth(`${serverBaseUrl}/api/user/profile`);
-      if (!profileResp.ok) return { success: false };
+      if (!profileResp.ok) {
+        return {
+          success: false,
+          status: AuthSessionStatus.TemporarilyUnavailable,
+          hasCredentials: true,
+          cachedUser: getAuthUser(),
+        };
+      }
       const profileBody = (await profileResp.json()) as {
         code: number;
         data: Record<string, unknown>;
       };
-      if (profileBody.code !== 0 || !profileBody.data) return { success: false };
+      if (profileBody.code !== 0 || !profileBody.data) {
+        return {
+          success: false,
+          status: AuthSessionStatus.TemporarilyUnavailable,
+          hasCredentials: true,
+          cachedUser: getAuthUser(),
+        };
+      }
       saveAuthUser(profileBody.data);
       // Fetch quota separately
       const quotaResp = await fetchWithAuth(`${serverBaseUrl}/api/user/quota`);
@@ -5414,13 +5465,29 @@ if (!gotTheLock) {
         }
       }
       console.log('[Auth] getUser profile data:', JSON.stringify(profileBody.data));
-      return { success: true, user: profileBody.data, quota };
-    } catch {
-      return { success: false };
+      return {
+        success: true,
+        status: AuthSessionStatus.Authenticated,
+        user: profileBody.data,
+        quota,
+      };
+    } catch (error) {
+      const status = resolveAuthSessionStatusFromError(error);
+      if (status === AuthSessionStatus.TemporarilyUnavailable) {
+        console.warn('[Auth] getUser temporarily unavailable:', error);
+      }
+      return {
+        success: false,
+        status,
+        hasCredentials: status !== AuthSessionStatus.Unauthenticated && Boolean(getAuthTokens()),
+        cachedUser: status === AuthSessionStatus.TemporarilyUnavailable
+          ? getAuthUser()
+          : null,
+      };
     }
   });
 
-  ipcMain.handle('auth:getQuota', async () => {
+  ipcMain.handle(AuthIpcChannel.GetQuota, async () => {
     try {
       const tokens = getAuthTokens();
       if (!tokens) return { success: false };
@@ -5438,7 +5505,7 @@ if (!gotTheLock) {
     }
   });
 
-  ipcMain.handle('auth:getProfileSummary', async () => {
+  ipcMain.handle(AuthIpcChannel.GetProfileSummary, async () => {
     try {
       const tokens = getAuthTokens();
       if (!tokens) return { success: false };
@@ -5455,7 +5522,7 @@ if (!gotTheLock) {
     }
   });
 
-  ipcMain.handle('auth:claimCreditsFinalReward', async (_event, payload: { campaignCode?: string }) => {
+  ipcMain.handle(AuthIpcChannel.ClaimCreditsFinalReward, async (_event, payload: { campaignCode?: string }) => {
     try {
       const campaignCode = payload?.campaignCode?.trim();
       if (!campaignCode) return { success: false, error: 'Missing campaign code' };
@@ -5483,7 +5550,7 @@ if (!gotTheLock) {
     }
   });
 
-  ipcMain.handle('auth:getActiveClientBanner', async () => {
+  ipcMain.handle(AuthIpcChannel.GetActiveClientBanner, async () => {
     try {
       const serverBaseUrl = getServerApiBaseUrl();
       const url = appendKeyfromQuery(`${serverBaseUrl}/api/client-banners/active?placement=desktop_sidebar`);
@@ -5497,7 +5564,7 @@ if (!gotTheLock) {
     }
   });
 
-  ipcMain.handle('auth:getActiveClientBanners', async () => {
+  ipcMain.handle(AuthIpcChannel.GetActiveClientBanners, async () => {
     try {
       const serverBaseUrl = getServerApiBaseUrl();
       const url = appendKeyfromQuery(`${serverBaseUrl}/api/client-banners/active-list?placement=desktop_sidebar`);
@@ -5511,7 +5578,7 @@ if (!gotTheLock) {
     }
   });
 
-  ipcMain.handle('auth:logout', async () => {
+  ipcMain.handle(AuthIpcChannel.Logout, async () => {
     try {
       const tokens = getAuthTokens();
       if (tokens) {
@@ -5531,52 +5598,34 @@ if (!gotTheLock) {
             /* best-effort */
           });
       }
-      clearAuthTokens();
-      clearAuthUser();
-      clearServerModelMetadata();
-      const previousQuotaGateState = getAuthQuotaGateState();
-      resetAuthQuotaGateState();
-      const quotaGateSyncScheduled = syncOpenClawConfigIfAuthQuotaGateChanged(previousQuotaGateState);
-      if (!quotaGateSyncScheduled) {
-        syncOpenClawConfig({
-          reason: 'auth-logout-server-models-cleared',
-          restartGatewayIfRunning: false,
-        }).catch((error) => {
-          console.warn('[Auth] failed to sync OpenClaw config after logout:', error);
-        });
-      }
+      clearLocalAuthSession({
+        reason: AuthSessionChangeReason.UserLogout,
+        notifyRenderer: false,
+      });
       console.log('[Auth] cleared login state and scheduled server model config refresh');
       return { success: true };
     } catch (error) {
       console.warn('[Auth] logout cleanup encountered an error; clearing local state anyway:', error);
-      const previousQuotaGateState = getAuthQuotaGateState();
-      clearAuthTokens();
-      clearAuthUser();
-      clearServerModelMetadata();
-      resetAuthQuotaGateState();
-      const quotaGateSyncScheduled = syncOpenClawConfigIfAuthQuotaGateChanged(previousQuotaGateState);
-      if (!quotaGateSyncScheduled) {
-        syncOpenClawConfig({
-          reason: 'auth-logout-server-models-cleared',
-          restartGatewayIfRunning: false,
-        }).catch((syncError) => {
-          console.warn('[Auth] failed to sync OpenClaw config after logout cleanup:', syncError);
-        });
-      }
+      clearLocalAuthSession({
+        reason: AuthSessionChangeReason.UserLogout,
+        notifyRenderer: false,
+      });
       return { success: true };
     }
   });
 
-  ipcMain.handle('auth:refreshToken', async () => {
+  ipcMain.handle(AuthIpcChannel.RefreshToken, async () => {
     try {
-      const accessToken = await refreshOnce('manual');
-      return accessToken ? { success: true, accessToken } : { success: false };
+      const result = await authSessionManager.refresh(AuthRefreshReason.Manual);
+      return result.outcome === AuthRefreshOutcome.Success
+        ? { success: true, accessToken: result.accessToken, outcome: result.outcome }
+        : { success: false, outcome: result.outcome };
     } catch {
       return { success: false };
     }
   });
 
-  ipcMain.handle('auth:getAccessToken', async () => {
+  ipcMain.handle(AuthIpcChannel.GetAccessToken, async () => {
     const tokens = getAuthTokens();
     return tokens?.accessToken || null;
   });
@@ -5622,7 +5671,7 @@ if (!gotTheLock) {
     }
   });
 
-  ipcMain.handle('auth:getModels', async () => {
+  ipcMain.handle(AuthIpcChannel.GetModels, async () => {
     try {
       const tokens = getAuthTokens();
       if (!tokens) {
@@ -11369,7 +11418,7 @@ if (!gotTheLock) {
         );
         const expiresAt = payload.exp * 1000;
         if (expiresAt - Date.now() < 5 * 60 * 1000) {
-          void refreshOnce('proactive'); // fire-and-forget
+          void authSessionManager.refresh(AuthRefreshReason.Proactive); // fire-and-forget
         }
       } catch {
         /* unable to parse JWT, return token as-is */
@@ -11399,43 +11448,28 @@ if (!gotTheLock) {
         });
     }
 
-    registerProxyTokenRefresher('lobsterai-server', async () => {
-      const tokens = getAuthTokens();
-      if (!tokens?.refreshToken) return null;
-      const serverBaseUrl = getServerApiBaseUrl();
-      try {
-        const refreshUrl = `${serverBaseUrl}/api/auth/refresh`;
-        console.log(`[Auth] requesting proxy token refresh at ${refreshUrl}`);
-        const resp = await net.fetch(refreshUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(withKeyfromBody({ refreshToken: tokens.refreshToken })),
-        });
-        if (resp.ok) {
-          const body = (await resp.json()) as {
-            code: number;
-            data: { accessToken: string; refreshToken?: string };
-          };
-          if (body.code === 0 && body.data) {
-            saveAuthTokens(body.data.accessToken, body.data.refreshToken || tokens.refreshToken);
-            console.log('[Auth] proxy token refresh succeeded');
-            return body.data.accessToken;
-          }
-        }
-      } catch (err) {
-        console.warn('[Auth] proxy token refresh failed:', err);
+    registerProxyTokenRefresher(ProviderName.LobsteraiServer, async rejectedToken => {
+      const latestAccessToken = getAuthTokens()?.accessToken;
+      if (latestAccessToken && rejectedToken && latestAccessToken !== rejectedToken) {
+        return {
+          outcome: AuthRefreshOutcome.Success,
+          accessToken: latestAccessToken,
+        };
       }
-      return null;
+      return authSessionManager.refresh(AuthRefreshReason.CompatProxy);
     });
 
-    registerProxyTokenRefresher('github-copilot', async () => {
+    registerProxyTokenRefresher(ProviderName.Copilot, async () => {
       try {
         const { refreshCopilotTokenNow } = await import('./libs/copilotTokenManager');
         const refreshed = await refreshCopilotTokenNow();
-        return refreshed.copilotToken;
+        return {
+          outcome: AuthRefreshOutcome.Success,
+          accessToken: refreshed.copilotToken,
+        };
       } catch (err) {
         console.warn('[Auth] Copilot proxy token refresh failed:', err);
-        return null;
+        return { outcome: AuthRefreshOutcome.TransientFailure };
       }
     });
 
@@ -11445,7 +11479,7 @@ if (!gotTheLock) {
     try {
       await startOpenClawTokenProxy({
         getAuthTokens,
-        refreshToken: refreshOnce,
+        refreshToken: reason => authSessionManager.refresh(reason),
         getServerBaseUrl: getServerApiBaseUrl,
       });
       console.log('[Main] OpenClaw token proxy started');

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -10,7 +10,11 @@ import {
   AsrIpcChannel,
   type AsrRealtimeSessionRequest,
 } from '../shared/asr/constants';
-import { AuthIpcChannel } from '../shared/auth/constants';
+import {
+  AuthIpcChannel,
+  type AuthLifecycleEvent,
+  type AuthSessionChangedEvent,
+} from '../shared/auth/constants';
 import { BrowserIpc, type BrowserRuntimeProfile } from '../shared/browserWebAccess/constants';
 import { ClipboardIpc } from '../shared/clipboard/constants';
 import type { CoworkBrowserAnnotationMessageBatch } from '../shared/cowork/browserAnnotations';
@@ -1071,19 +1075,19 @@ contextBridge.exposeInMainWorld('electron', {
   },
   auth: {
     login: (loginUrl?: string) => ipcRenderer.invoke(AuthIpcChannel.Login, { loginUrl }),
-    exchange: (code: string) => ipcRenderer.invoke('auth:exchange', { code }),
-    getUser: () => ipcRenderer.invoke('auth:getUser'),
-    getQuota: () => ipcRenderer.invoke('auth:getQuota'),
-    logout: () => ipcRenderer.invoke('auth:logout'),
-    refreshToken: () => ipcRenderer.invoke('auth:refreshToken'),
-    getAccessToken: () => ipcRenderer.invoke('auth:getAccessToken'),
-    getModels: () => ipcRenderer.invoke('auth:getModels'),
+    exchange: (code: string) => ipcRenderer.invoke(AuthIpcChannel.Exchange, { code }),
+    getUser: () => ipcRenderer.invoke(AuthIpcChannel.GetUser),
+    getQuota: () => ipcRenderer.invoke(AuthIpcChannel.GetQuota),
+    logout: () => ipcRenderer.invoke(AuthIpcChannel.Logout),
+    refreshToken: () => ipcRenderer.invoke(AuthIpcChannel.RefreshToken),
+    getAccessToken: () => ipcRenderer.invoke(AuthIpcChannel.GetAccessToken),
+    getModels: () => ipcRenderer.invoke(AuthIpcChannel.GetModels),
     getPricingCatalog: () => ipcRenderer.invoke(AuthIpcChannel.GetPricingCatalog),
-    getProfileSummary: () => ipcRenderer.invoke('auth:getProfileSummary'),
+    getProfileSummary: () => ipcRenderer.invoke(AuthIpcChannel.GetProfileSummary),
     claimCreditsFinalReward: (campaignCode: string) =>
-      ipcRenderer.invoke('auth:claimCreditsFinalReward', { campaignCode }),
-    getActiveClientBanner: () => ipcRenderer.invoke('auth:getActiveClientBanner'),
-    getActiveClientBanners: () => ipcRenderer.invoke('auth:getActiveClientBanners'),
+      ipcRenderer.invoke(AuthIpcChannel.ClaimCreditsFinalReward, { campaignCode }),
+    getActiveClientBanner: () => ipcRenderer.invoke(AuthIpcChannel.GetActiveClientBanner),
+    getActiveClientBanners: () => ipcRenderer.invoke(AuthIpcChannel.GetActiveClientBanners),
     getPendingCallback: () => ipcRenderer.invoke(AuthIpcChannel.GetPendingCallback),
     onCallback: (callback: (data: { code: string }) => void) => {
       const handler = (_event: any, data: { code: string }) => callback(data);
@@ -1092,8 +1096,18 @@ contextBridge.exposeInMainWorld('electron', {
     },
     onQuotaChanged: (callback: () => void) => {
       const handler = () => callback();
-      ipcRenderer.on('auth:quotaChanged', handler);
-      return () => ipcRenderer.removeListener('auth:quotaChanged', handler);
+      ipcRenderer.on(AuthIpcChannel.QuotaChanged, handler);
+      return () => ipcRenderer.removeListener(AuthIpcChannel.QuotaChanged, handler);
+    },
+    onSessionChanged: (callback: (event: AuthSessionChangedEvent) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: AuthSessionChangedEvent) => callback(data);
+      ipcRenderer.on(AuthIpcChannel.SessionChanged, handler);
+      return () => ipcRenderer.removeListener(AuthIpcChannel.SessionChanged, handler);
+    },
+    onLifecycleEvent: (callback: (event: AuthLifecycleEvent) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: AuthLifecycleEvent) => callback(data);
+      ipcRenderer.on(AuthIpcChannel.LifecycleEvent, handler);
+      return () => ipcRenderer.removeListener(AuthIpcChannel.LifecycleEvent, handler);
     },
   },
   media: {

--- a/src/renderer/services/auth.test.ts
+++ b/src/renderer/services/auth.test.ts
@@ -1,6 +1,13 @@
+import {
+  type AuthSessionChangedEvent,
+  AuthSessionChangeReason,
+  AuthSessionStatus,
+} from '@shared/auth/constants';
 import { ProviderName } from '@shared/providers';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
+import { store } from '../store';
+import { setLoggedIn } from '../store/slices/authSlice';
 import {
   authService,
   mapPricingCatalogTextModelsToServerModels,
@@ -8,6 +15,7 @@ import {
 } from './auth';
 
 afterEach(() => {
+  authService.destroy();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -130,5 +138,106 @@ describe('login diagnostics', () => {
       'AuthService',
       expect.stringMatching(/^login attempt \d+ could not open the system browser$/),
     );
+  });
+});
+
+describe('auth state restoration', () => {
+  const user = {
+    yid: 'user@example.com',
+    nickname: 'Lobster User',
+    avatarUrl: null,
+  };
+  const quota = {
+    planName: '专业',
+    subscriptionStatus: 'active',
+    creditsLimit: 1_000,
+    creditsUsed: 100,
+    creditsRemaining: 900,
+  };
+
+  test('preserves the current login snapshot for a temporary verification failure', async () => {
+    store.dispatch(setLoggedIn({ user, quota }));
+    vi.stubGlobal('window', {
+      electron: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({
+            success: false,
+            status: AuthSessionStatus.TemporarilyUnavailable,
+            hasCredentials: true,
+            cachedUser: user,
+          }),
+        },
+      },
+    });
+
+    const result = await authService.refreshAuthState({ clearOnFailure: true });
+
+    expect(result.isLoggedIn).toBe(true);
+    expect(store.getState().auth).toMatchObject({
+      isLoggedIn: true,
+      sessionStatus: AuthSessionStatus.TemporarilyUnavailable,
+      user,
+      quota,
+    });
+  });
+
+  test('clears the current login snapshot for terminal expiration', async () => {
+    store.dispatch(setLoggedIn({ user, quota }));
+    vi.stubGlobal('window', {
+      electron: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({
+            success: false,
+            status: AuthSessionStatus.Expired,
+            hasCredentials: false,
+          }),
+          getPricingCatalog: vi.fn().mockResolvedValue({
+            success: true,
+            textModels: [],
+          }),
+        },
+      },
+    });
+
+    const result = await authService.refreshAuthState({ clearOnFailure: true });
+
+    expect(result.isLoggedIn).toBe(false);
+    expect(store.getState().auth).toMatchObject({
+      isLoggedIn: false,
+      sessionStatus: AuthSessionStatus.Expired,
+      user: null,
+      quota: null,
+    });
+  });
+
+  test('shows a re-login toast when the main process reports terminal expiration', async () => {
+    const dispatchEvent = vi.fn();
+    store.dispatch(setLoggedIn({ user, quota }));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('window', {
+      dispatchEvent,
+      electron: {
+        auth: {
+          getPricingCatalog: vi.fn().mockResolvedValue({
+            success: true,
+            textModels: [],
+          }),
+        },
+      },
+    });
+
+    const serviceWithSessionHandler = authService as unknown as {
+      handleSessionChanged: (event: AuthSessionChangedEvent) => Promise<void>;
+    };
+    await serviceWithSessionHandler.handleSessionChanged({
+      status: AuthSessionStatus.Expired,
+      reason: AuthSessionChangeReason.RefreshRejected,
+    });
+
+    expect(store.getState().auth.sessionStatus).toBe(AuthSessionStatus.Expired);
+    expect(dispatchEvent).toHaveBeenCalledOnce();
+    const toastEvent = dispatchEvent.mock.calls[0][0] as CustomEvent<string>;
+    expect(toastEvent.type).toBe('app:showToast');
+    expect(toastEvent.detail).toContain('登录状态已过期');
   });
 });

--- a/src/renderer/services/auth.ts
+++ b/src/renderer/services/auth.ts
@@ -1,8 +1,16 @@
+import {
+  type AuthLifecycleEvent,
+  AuthLifecycleEventType,
+  type AuthSessionChangedEvent,
+  AuthSessionStatus,
+} from '@shared/auth/constants';
 import { ProviderName } from '@shared/providers';
 
 import { store } from '../store';
 import {
+  setAuthExpired,
   setAuthLoading,
+  setAuthTemporarilyUnavailable,
   setLoggedIn,
   setLoggedOut,
   setProfileSummary,
@@ -15,6 +23,8 @@ import {
   clearServerModels,
   setServerModels,
 } from '../store/slices/modelSlice';
+import { i18nService } from './i18n';
+import { LogReporterAction, reportYdAnalyzer } from './logReporter';
 
 interface AuthStateRefreshResult {
   isLoggedIn: boolean;
@@ -76,6 +86,20 @@ const writeAuthRendererLog = (
   }
 };
 
+const reportAuthLifecycleEvent = (event: AuthLifecycleEvent): void => {
+  void reportYdAnalyzer({
+    action: LogReporterAction.AuthLifecycle,
+    event_type: event.eventType,
+    outcome: event.outcome,
+    reason: 'reason' in event ? event.reason : undefined,
+    duration_ms: 'durationMs' in event ? event.durationMs : undefined,
+    failure_kind: 'failureKind' in event ? event.failureKind : undefined,
+    http_status: 'httpStatus' in event ? event.httpStatus : undefined,
+    error_code: 'errorCode' in event ? event.errorCode : undefined,
+    joined_requests: 'joinedRequests' in event ? event.joinedRequests : undefined,
+  });
+};
+
 export function mapPricingCatalogTextModelsToServerModels(
   textModels: PricingCatalogTextModel[],
 ): Model[] {
@@ -116,7 +140,9 @@ export function mapPricingCatalogToPublicServerModels(
 
 class AuthService {
   private unsubCallback: (() => void) | null = null;
+  private unsubLifecycleEvent: (() => void) | null = null;
   private unsubQuotaChanged: (() => void) | null = null;
+  private unsubSessionChanged: (() => void) | null = null;
   private unsubWindowState: (() => void) | null = null;
   private lastRefreshTime = 0;
   private loginAttemptSequence = 0;
@@ -134,6 +160,10 @@ class AuthService {
     this.unsubCallback = window.electron.auth.onCallback(async ({ code }) => {
       await this.handleCallback(code);
     });
+    this.unsubSessionChanged = window.electron.auth.onSessionChanged(event => {
+      void this.handleSessionChanged(event);
+    });
+    this.unsubLifecycleEvent = window.electron.auth.onLifecycleEvent(reportAuthLifecycleEvent);
 
     try {
       const pendingCode = await window.electron.auth.getPendingCallback();
@@ -142,12 +172,17 @@ class AuthService {
         handledPendingCode = await this.handleCallback(pendingCode);
       }
       if (!handledPendingCode) {
-        await this.refreshAuthState({ clearOnFailure: true });
+        await this.refreshAuthState({
+          clearOnFailure: true,
+          reportLifecycle: true,
+        });
       }
     } catch {
-      store.dispatch(setLoggedOut());
-      store.dispatch(clearServerModels());
-      await this.loadPublicPricingCatalogModels();
+      store.dispatch(setAuthTemporarilyUnavailable({ hasCredentials: false }));
+      reportAuthLifecycleEvent({
+        eventType: AuthLifecycleEventType.Restore,
+        outcome: AuthSessionStatus.TemporarilyUnavailable,
+      });
     }
 
     // Listen for quota changes (e.g. after cowork session using server model)
@@ -246,7 +281,10 @@ class AuthService {
    * Refresh the full auth snapshot from persisted tokens.
    */
   async refreshAuthState(
-    options: { clearOnFailure?: boolean } = {},
+    options: {
+      clearOnFailure?: boolean;
+      reportLifecycle?: boolean;
+    } = {},
   ): Promise<AuthStateRefreshResult> {
     try {
       const result = await window.electron.auth.getUser();
@@ -254,16 +292,47 @@ class AuthService {
         store.dispatch(setLoggedIn({ user: result.user, quota: result.quota }));
         await this.loadServerModels();
         void this.fetchProfileSummary();
+        if (options.reportLifecycle) {
+          reportAuthLifecycleEvent({
+            eventType: AuthLifecycleEventType.Restore,
+            outcome: AuthSessionStatus.Authenticated,
+          });
+        }
         return { isLoggedIn: true, user: result.user, quota: result.quota ?? null };
       }
-    } catch {
-      // handled below
-    }
 
-    if (options.clearOnFailure) {
-      store.dispatch(setLoggedOut());
-      store.dispatch(clearServerModels());
-      await this.loadPublicPricingCatalogModels();
+      const status = result.status ?? (
+        result.hasCredentials
+          ? AuthSessionStatus.TemporarilyUnavailable
+          : AuthSessionStatus.Unauthenticated
+      );
+      if (options.reportLifecycle) {
+        reportAuthLifecycleEvent({
+          eventType: AuthLifecycleEventType.Restore,
+          outcome: status,
+        });
+      }
+
+      if (status === AuthSessionStatus.TemporarilyUnavailable) {
+        store.dispatch(setAuthTemporarilyUnavailable({
+          hasCredentials: result.hasCredentials === true,
+          cachedUser: result.cachedUser ?? null,
+        }));
+      } else if (status === AuthSessionStatus.Expired) {
+        await this.applyLoggedOutState(true);
+      } else if (options.clearOnFailure) {
+        await this.applyLoggedOutState(false);
+      }
+    } catch {
+      store.dispatch(setAuthTemporarilyUnavailable({
+        hasCredentials: store.getState().auth.isLoggedIn,
+      }));
+      if (options.reportLifecycle) {
+        reportAuthLifecycleEvent({
+          eventType: AuthLifecycleEventType.Restore,
+          outcome: AuthSessionStatus.TemporarilyUnavailable,
+        });
+      }
     }
 
     const current = store.getState().auth;
@@ -279,9 +348,7 @@ class AuthService {
    */
   async logout() {
     await window.electron.auth.logout();
-    store.dispatch(setLoggedOut());
-    store.dispatch(clearServerModels());
-    await this.loadPublicPricingCatalogModels();
+    await this.applyLoggedOutState(false);
   }
 
   /**
@@ -335,10 +402,42 @@ class AuthService {
   destroy() {
     this.unsubCallback?.();
     this.unsubCallback = null;
+    this.unsubLifecycleEvent?.();
+    this.unsubLifecycleEvent = null;
     this.unsubQuotaChanged?.();
     this.unsubQuotaChanged = null;
+    this.unsubSessionChanged?.();
+    this.unsubSessionChanged = null;
     this.unsubWindowState?.();
     this.unsubWindowState = null;
+  }
+
+  private async handleSessionChanged(event: AuthSessionChangedEvent): Promise<void> {
+    if (event.status !== AuthSessionStatus.Expired) return;
+    writeAuthRendererLog('warn', `login session expired (${event.reason})`);
+    const cleanup = this.applyLoggedOutState(true);
+    window.dispatchEvent(new CustomEvent('app:showToast', {
+      detail: i18nService.t('coworkErrorLobsterAILoginExpired'),
+    }));
+    await cleanup;
+  }
+
+  private async applyLoggedOutState(expired: boolean): Promise<void> {
+    const targetStatus = expired
+      ? AuthSessionStatus.Expired
+      : AuthSessionStatus.Unauthenticated;
+    const current = store.getState().auth;
+    if (
+      !current.isLoggedIn
+      && !current.isLoading
+      && current.sessionStatus === targetStatus
+    ) {
+      return;
+    }
+
+    store.dispatch(expired ? setAuthExpired() : setLoggedOut());
+    store.dispatch(clearServerModels());
+    await this.loadPublicPricingCatalogModels();
   }
 
   /**

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1643,6 +1643,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Cowork 错误消息
     coworkErrorAuthInvalid: 'API 密钥无效或已过期，请在设置中检查并更新您的 API 密钥。',
+    coworkErrorLobsterAILoginExpired: '登录状态已过期，请重新登录后继续使用 LobsterAI 套餐模型。',
     coworkErrorOAuthInvalid: 'OAuth 授权已失效或权限不足，请重新授权后重试。',
     coworkErrorModelAccessDenied: '当前账号无权访问该模型，请切换模型或检查服务商账号权限。',
     coworkErrorQuotaExhausted:
@@ -4687,6 +4688,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Cowork error messages
     coworkErrorAuthInvalid:
       'Invalid or expired API key. Please check and update your API key in settings.',
+    coworkErrorLobsterAILoginExpired:
+      'Your login session has expired. Sign in again to continue using LobsterAI plan models.',
     coworkErrorOAuthInvalid:
       'OAuth authorization is invalid or missing required access. Re-authenticate and try again.',
     coworkErrorModelAccessDenied:

--- a/src/renderer/services/logReporter.ts
+++ b/src/renderer/services/logReporter.ts
@@ -28,6 +28,7 @@ export const LogReporterAction = {
   AppStarted: 'lobsterai_app_started',
   AppearanceSettingChanged: 'lobsterai_appearance_setting_changed',
   ArtifactPreviewAction: 'lobsterai_artifact_preview_action',
+  AuthLifecycle: 'lobsterai_auth_lifecycle',
   BrowserSettingChanged: 'lobsterai_browser_setting_changed',
   CustomModelConnectionTested: 'lobsterai_custom_model_connection_tested',
   CustomModelSettingsSaved: 'lobsterai_custom_model_settings_saved',

--- a/src/renderer/store/slices/authSlice.test.ts
+++ b/src/renderer/store/slices/authSlice.test.ts
@@ -1,0 +1,69 @@
+import { AuthSessionStatus } from '@shared/auth/constants';
+import { describe, expect, test } from 'vitest';
+
+import authReducer, {
+  setAuthExpired,
+  setAuthTemporarilyUnavailable,
+  setLoggedIn,
+} from './authSlice';
+
+const user = {
+  yid: 'user@example.com',
+  nickname: 'Lobster User',
+  avatarUrl: null,
+};
+
+const quota = {
+  planName: '专业',
+  subscriptionStatus: 'active',
+  creditsLimit: 1_000,
+  creditsUsed: 100,
+  creditsRemaining: 900,
+};
+
+describe('auth session status', () => {
+  test('preserves the authenticated snapshot during a temporary verification failure', () => {
+    const loggedIn = authReducer(undefined, setLoggedIn({ user, quota }));
+    const unavailable = authReducer(
+      loggedIn,
+      setAuthTemporarilyUnavailable({ hasCredentials: true }),
+    );
+
+    expect(unavailable).toMatchObject({
+      isLoggedIn: true,
+      isLoading: false,
+      sessionStatus: AuthSessionStatus.TemporarilyUnavailable,
+      user,
+      quota,
+    });
+  });
+
+  test('restores a cached user when startup verification is temporarily unavailable', () => {
+    const unavailable = authReducer(
+      undefined,
+      setAuthTemporarilyUnavailable({
+        hasCredentials: true,
+        cachedUser: user,
+      }),
+    );
+
+    expect(unavailable).toMatchObject({
+      isLoggedIn: true,
+      sessionStatus: AuthSessionStatus.TemporarilyUnavailable,
+      user,
+    });
+  });
+
+  test('clears user and quota after terminal expiration', () => {
+    const loggedIn = authReducer(undefined, setLoggedIn({ user, quota }));
+    const expired = authReducer(loggedIn, setAuthExpired());
+
+    expect(expired).toMatchObject({
+      isLoggedIn: false,
+      isLoading: false,
+      sessionStatus: AuthSessionStatus.Expired,
+      user: null,
+      quota: null,
+    });
+  });
+});

--- a/src/renderer/store/slices/authSlice.ts
+++ b/src/renderer/store/slices/authSlice.ts
@@ -1,4 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import {
+  AuthSessionStatus,
+  type AuthSessionStatus as AuthSessionStatusValue,
+} from '@shared/auth/constants';
 
 export interface UserProfile {
   yid: string;
@@ -85,6 +89,7 @@ export interface ProfileSummary {
 interface AuthState {
   isLoggedIn: boolean;
   isLoading: boolean;
+  sessionStatus: AuthSessionStatusValue;
   user: UserProfile | null;
   quota: UserQuota | null;
   profileSummary: ProfileSummary | null;
@@ -93,6 +98,7 @@ interface AuthState {
 const initialState: AuthState = {
   isLoggedIn: false,
   isLoading: true,
+  sessionStatus: AuthSessionStatus.Unauthenticated,
   user: null,
   quota: null,
   profileSummary: null,
@@ -108,15 +114,41 @@ const authSlice = createSlice({
     setLoggedIn(state, action: PayloadAction<{ user: UserProfile; quota: UserQuota }>) {
       state.isLoggedIn = true;
       state.isLoading = false;
+      state.sessionStatus = AuthSessionStatus.Authenticated;
       state.user = action.payload.user;
       state.quota = action.payload.quota;
     },
     setLoggedOut(state) {
       state.isLoggedIn = false;
       state.isLoading = false;
+      state.sessionStatus = AuthSessionStatus.Unauthenticated;
       state.user = null;
       state.quota = null;
       state.profileSummary = null;
+    },
+    setAuthExpired(state) {
+      state.isLoggedIn = false;
+      state.isLoading = false;
+      state.sessionStatus = AuthSessionStatus.Expired;
+      state.user = null;
+      state.quota = null;
+      state.profileSummary = null;
+    },
+    setAuthTemporarilyUnavailable(
+      state,
+      action: PayloadAction<{
+        hasCredentials: boolean;
+        cachedUser?: UserProfile | null;
+      }>,
+    ) {
+      state.isLoading = false;
+      state.sessionStatus = AuthSessionStatus.TemporarilyUnavailable;
+      if (action.payload.hasCredentials) {
+        state.isLoggedIn = true;
+      }
+      if (action.payload.cachedUser) {
+        state.user = action.payload.cachedUser;
+      }
     },
     updateQuota(state, action: PayloadAction<UserQuota>) {
       state.quota = action.payload;
@@ -127,5 +159,13 @@ const authSlice = createSlice({
   },
 });
 
-export const { setAuthLoading, setLoggedIn, setLoggedOut, updateQuota, setProfileSummary } = authSlice.actions;
+export const {
+  setAuthExpired,
+  setAuthLoading,
+  setAuthTemporarilyUnavailable,
+  setLoggedIn,
+  setLoggedOut,
+  setProfileSummary,
+  updateQuota,
+} = authSlice.actions;
 export default authSlice.reducer;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -5,6 +5,12 @@ import type {
   AsrRealtimeSessionResult,
 } from '../../shared/asr/constants';
 import type {
+  AuthLifecycleEvent,
+  AuthRefreshOutcome,
+  AuthSessionChangedEvent,
+  AuthSessionStatus,
+} from '../../shared/auth/constants';
+import type {
   BrowserDiagnosticResult,
   BrowserRuntimeProfile,
 } from '../../shared/browserWebAccess/constants';
@@ -1690,10 +1696,21 @@ interface IElectronAPI {
     exchange: (
       code: string,
     ) => Promise<{ success: boolean; user?: any; quota?: any; error?: string }>;
-    getUser: () => Promise<{ success: boolean; user?: any; quota?: any }>;
+    getUser: () => Promise<{
+      success: boolean;
+      status?: AuthSessionStatus;
+      hasCredentials?: boolean;
+      cachedUser?: any;
+      user?: any;
+      quota?: any;
+    }>;
     getQuota: () => Promise<{ success: boolean; quota?: any }>;
     logout: () => Promise<{ success: boolean }>;
-    refreshToken: () => Promise<{ success: boolean; accessToken?: string }>;
+    refreshToken: () => Promise<{
+      success: boolean;
+      accessToken?: string;
+      outcome?: AuthRefreshOutcome;
+    }>;
     getAccessToken: () => Promise<string | null>;
     getModels: () => Promise<{
       success: boolean;
@@ -1734,6 +1751,8 @@ interface IElectronAPI {
     getPendingCallback: () => Promise<string | null>;
     onCallback: (callback: (data: { code: string }) => void) => () => void;
     onQuotaChanged: (callback: () => void) => () => void;
+    onSessionChanged: (callback: (event: AuthSessionChangedEvent) => void) => () => void;
+    onLifecycleEvent: (callback: (event: AuthLifecycleEvent) => void) => () => void;
   };
   media: {
     getModels: (type: 'image' | 'video') => Promise<{ success: boolean; models?: Array<{ modelId: string; displayName: string; provider: string; mediaType: string; generationTimeout: number; pricing: Record<string, unknown> }>; error?: string }>;
@@ -1766,6 +1785,9 @@ interface IElectronAPI {
     }>;
     getUser: () => Promise<{
       success: boolean;
+      status?: AuthSessionStatus;
+      hasCredentials?: boolean;
+      cachedUser?: import('../store/slices/authSlice').UserProfile | null;
       user?: import('../store/slices/authSlice').UserProfile;
       quota?: {
         planName: string;
@@ -1786,10 +1808,17 @@ interface IElectronAPI {
       };
     }>;
     logout: () => Promise<{ success: boolean }>;
-    refreshToken: () => Promise<{ success: boolean; accessToken?: string }>;
+    refreshToken: () => Promise<{
+      success: boolean;
+      accessToken?: string;
+      outcome?: AuthRefreshOutcome;
+    }>;
     getAccessToken: () => Promise<string | null>;
     getPendingCallback: () => Promise<string | null>;
     onCallback: (callback: (data: { code: string }) => void) => () => void;
+    onQuotaChanged: (callback: () => void) => () => void;
+    onSessionChanged: (callback: (event: AuthSessionChangedEvent) => void) => () => void;
+    onLifecycleEvent: (callback: (event: AuthLifecycleEvent) => void) => () => void;
   };
   qwen: Record<string, never>;
   feishu: {

--- a/src/shared/auth/constants.ts
+++ b/src/shared/auth/constants.ts
@@ -1,11 +1,112 @@
 export const AuthIpcChannel = {
   Callback: 'auth:callback',
+  ClaimCreditsFinalReward: 'auth:claimCreditsFinalReward',
+  Exchange: 'auth:exchange',
+  GetAccessToken: 'auth:getAccessToken',
+  GetActiveClientBanner: 'auth:getActiveClientBanner',
+  GetActiveClientBanners: 'auth:getActiveClientBanners',
+  GetModels: 'auth:getModels',
   GetPricingCatalog: 'auth:getPricingCatalog',
+  GetProfileSummary: 'auth:getProfileSummary',
   GetPendingCallback: 'auth:getPendingCallback',
+  GetQuota: 'auth:getQuota',
+  GetUser: 'auth:getUser',
+  LifecycleEvent: 'auth:lifecycleEvent',
   Login: 'auth:login',
+  Logout: 'auth:logout',
+  QuotaChanged: 'auth:quotaChanged',
+  RefreshToken: 'auth:refreshToken',
+  SessionChanged: 'auth:sessionChanged',
 } as const;
 
 export type AuthIpcChannel = typeof AuthIpcChannel[keyof typeof AuthIpcChannel];
+
+export const AuthSessionStatus = {
+  Authenticated: 'authenticated',
+  Expired: 'expired',
+  TemporarilyUnavailable: 'temporarily_unavailable',
+  Unauthenticated: 'unauthenticated',
+} as const;
+
+export type AuthSessionStatus = typeof AuthSessionStatus[keyof typeof AuthSessionStatus];
+
+export const AuthSessionChangeReason = {
+  RefreshRejected: 'refresh_rejected',
+  UserLogout: 'user_logout',
+} as const;
+
+export type AuthSessionChangeReason =
+  typeof AuthSessionChangeReason[keyof typeof AuthSessionChangeReason];
+
+export const AuthRefreshOutcome = {
+  NoTokens: 'no_tokens',
+  Success: 'success',
+  TerminalFailure: 'terminal_failure',
+  TransientFailure: 'transient_failure',
+} as const;
+
+export type AuthRefreshOutcome = typeof AuthRefreshOutcome[keyof typeof AuthRefreshOutcome];
+
+export type AuthTokenRefreshResult = {
+  outcome: AuthRefreshOutcome;
+  accessToken?: string;
+};
+
+export const AuthRefreshFailureKind = {
+  Http: 'http_error',
+  InvalidResponse: 'invalid_response',
+  Network: 'network',
+  Rejected: 'rejected',
+  Timeout: 'timeout',
+} as const;
+
+export type AuthRefreshFailureKind =
+  typeof AuthRefreshFailureKind[keyof typeof AuthRefreshFailureKind];
+
+export const AuthRefreshReason = {
+  CompatProxy: 'compat-proxy',
+  Manual: 'manual',
+  OpenClawProxy: 'openclaw-proxy',
+  Passive: 'passive',
+  Proactive: 'proactive',
+} as const;
+
+export type AuthRefreshReason = typeof AuthRefreshReason[keyof typeof AuthRefreshReason];
+
+export const AuthLifecycleEventType = {
+  Restore: 'auth_restore',
+  TerminalExpired: 'auth_terminal_expired',
+  TokenRefresh: 'token_refresh',
+} as const;
+
+export type AuthLifecycleEventType =
+  typeof AuthLifecycleEventType[keyof typeof AuthLifecycleEventType];
+
+export type AuthLifecycleEvent =
+  | {
+      eventType: typeof AuthLifecycleEventType.TokenRefresh;
+      outcome: AuthRefreshOutcome;
+      reason: AuthRefreshReason;
+      durationMs: number;
+      failureKind?: AuthRefreshFailureKind;
+      httpStatus?: number;
+      errorCode?: number;
+      joinedRequests: number;
+    }
+  | {
+      eventType: typeof AuthLifecycleEventType.Restore;
+      outcome: AuthSessionStatus;
+    }
+  | {
+      eventType: typeof AuthLifecycleEventType.TerminalExpired;
+      outcome: typeof AuthSessionStatus.Expired;
+      reason: AuthSessionChangeReason;
+    };
+
+export type AuthSessionChangedEvent = {
+  status: AuthSessionStatus;
+  reason: AuthSessionChangeReason;
+};
 
 export const AuthSubscriptionStatus = {
   Active: 'active',


### PR DESCRIPTION
## 变更概述

- 统一桌面端认证请求、OpenClaw Token Proxy 与兼容代理的 Token 刷新入口。
- 区分临时网络/服务失败与 Refresh Token 终态失效，临时失败保留登录态。
- 增加刷新单飞、迟到 401 重试、15 秒超时和终态失效竞态保护。
- Refresh Token 真正失效时清理凭证和套餐模型缓存，并通知 renderer 展示明确的登录过期提示。
- 补充认证生命周期 rlogs 事件、设计文档与边界测试。

## Electron 行为影响

- 新增主进程认证会话管理器，所有相关入口共享刷新状态。
- Token 刷新后同步 OpenClaw 配置，不要求重启 Gateway。
- 终态失效会更新 renderer 登录状态；临时失败不会误退登。
- 不涉及 SQLite 表结构迁移。

## 验证

- `npm run build` 通过。
- 变更 TypeScript 文件严格 ESLint 通过。
- Renderer/Electron TypeScript 检查通过。
- 定向 Vitest：6 个文件、261 个测试通过。
- 手工冒烟：仅 Access Token 失效时自动刷新并正常完成套餐模型对话。
- 手工冒烟：Access/Refresh Token 同时失效时正确提示登录过期并退出登录态。

## 说明

完整 Vitest 在本机未作为结果依据：当前运行中的 Electron 与 Node `better-sqlite3` ABI 不一致，另有与本变更无关的 installer/static-analyzer 既有失败；本次相关定向测试均已通过。