### PR TITLE
fix(openclaw): enforce runtime/config safety-contract gate to stop false-stop token burn

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "openclaw": {
     "version": "v2026.6.1",
     "repo": "https://github.com/openclaw/openclaw.git",
+    "runSafetyContract": "count-hardcaps-prompt-observe-v1",
     "plugins": [
       {
         "id": "dingtalk-connector",

--- a/scripts/apply-openclaw-patches.cjs
+++ b/scripts/apply-openclaw-patches.cjs
@@ -359,24 +359,44 @@ const strongPatchValidators = {
       snippets: [
         'maxToolCallReservationsPerBudgetScope: 64',
         'maxProviderDispatchesPerBudgetScope: 32',
-        'maxCumulativeEstimatedPromptTokensPerBudgetScope: 2_000_000',
+        'legacyDiagnosticThreshold: 2_000_000',
         'warningRatio: 0.75',
         'reserveToolBatch(params: {',
         'reserveProviderDispatch(params: {',
+        'observeProviderPromptEstimate(params: {',
+        'legacyEstimatedExposureUnitsTotal',
+        'knownEstimateDispatchCount',
+        'estimateUnavailableDispatchCount',
+        'pendingObservationDispatchCount',
+        'legacyDiagnosticThresholdCrossed',
+        'run_prompt_exposure_threshold_crossed',
+        'run_prompt_exposure_estimate_unavailable_observed',
+        'run_safety_scope_summary',
         'containsUnknownRemoteMedia',
         'publishTerminalOnce(reason: RunSafetyTermination): boolean {',
         'if (this.scopeTerminalReasonValue) {',
-        // The prompt-exposure budget is calibrated in tokens; the estimator
-        // must count CJK-aware token equivalents with a bounded per-blob
-        // inline-media estimate, never raw serialized bytes.
+        // Keep the historical estimator algorithm stable for comparable
+        // observe-only telemetry; it is not provider usage or a billing unit.
         'estimateStringChars, estimateTokensFromChars',
         'INLINE_MEDIA_TOKEN_ESTIMATE',
       ],
-      forbiddenSnippets: ['Buffer.byteLength(serialized'],
+      forbiddenSnippets: [
+        'Buffer.byteLength(serialized',
+        'maxCumulativeEstimatedPromptTokensPerBudgetScope',
+        'refineProviderPromptEstimate(',
+        'kind: RunSafetyTerminationKind.RunPromptExposureBudget',
+        'kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable',
+        'continuationClosedReasonValue = RunSafetyTerminationKind.RunPromptExposureBudget',
+      ],
     },
     {
       file: 'src/agents/run-safety-controller.test.ts',
       snippets: [
+        'allows the configured provider dispatches and blocks the next one before dispatch',
+        'keeps prompt observations immutable and idempotent',
+        'observes prompt exposure above the legacy threshold without terminating',
+        'records an unavailable prompt estimate without terminating',
+        'reserves a raw tool batch in declaration order before blocking overflow calls',
         'publishes only the first product terminal outcome',
         'expect(coordinator.publishTerminalOnce(first)).toBe(true)',
         'expect(coordinator.publishTerminalOnce(second)).toBe(false)',
@@ -411,10 +431,15 @@ const strongPatchValidators = {
       snippets: [
         'params.controller.reserveToolBatch({',
         'params.controller.reserveProviderDispatch({',
-        'const finalEstimate = estimateRunSafetyPromptTokens(finalPayload, payloadModel);',
-        'params.controller.refineProviderPromptEstimate({',
+        'estimateRunSafetyPromptObservation(finalPayload, payloadModel)',
+        'params.controller.observeProviderPromptEstimate({',
         'runWithRunSafetyProviderDispatch',
         'maxRetries: 0',
+      ],
+      forbiddenSnippets: [
+        'refineProviderPromptEstimate(',
+        'kind: RunSafetyTerminationKind.RunPromptExposureBudget',
+        'kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable',
       ],
       orderedSnippets: [
         'const safetyDecisions = params.controller.reserveToolBatch({',
@@ -517,9 +542,13 @@ const strongPatchValidators = {
         'runSafety: z',
         'maxToolCallReservationsPerBudgetScope: z.number().int().positive().safe().optional()',
         'maxProviderDispatchesPerBudgetScope: z.number().int().positive().safe().optional()',
-        'maxCumulativeEstimatedPromptTokensPerBudgetScope: z',
+        'promptExposure: z',
+        'legacyDiagnosticThreshold: z',
       ],
-      forbiddenSnippets: ['maxToolCallingRounds'],
+      forbiddenSnippets: [
+        'maxToolCallingRounds',
+        'maxCumulativeEstimatedPromptTokensPerBudgetScope',
+      ],
     },
     {
       file: 'packages/agent-core/src/agent-loop.ts',
@@ -578,7 +607,34 @@ const strongPatchValidators = {
         'Native CLI',
         'tool calls remain opaque to the host',
         'export function reserveCliProviderDispatch',
-        'RunPromptEstimateUnavailable',
+        'observeProviderPromptEstimate({',
+      ],
+      forbiddenSnippets: [
+        'kind: RunSafetyTerminationKind.RunPromptExposureBudget',
+        'kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable',
+      ],
+    },
+    {
+      file: 'src/agents/cli-runner.run-safety.test.ts',
+      snippets: [
+        'spawns after recording unavailable telemetry when the final CLI payload cannot be estimated',
+      ],
+    },
+    {
+      file: 'src/context-engine/run-safety-compaction.ts',
+      snippets: [
+        'reserveProviderDispatch({',
+        'observeProviderPromptEstimate({',
+      ],
+      forbiddenSnippets: [
+        'kind: RunSafetyTerminationKind.RunPromptExposureBudget',
+        'kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable',
+      ],
+    },
+    {
+      file: 'src/context-engine/run-safety-compaction.test.ts',
+      snippets: [
+        'calls compaction transport when final prompt estimation is unavailable',
       ],
     },
     {
@@ -642,7 +698,7 @@ const strongPatchValidators = {
       snippets: [
         'reserves the Anthropic without-thinking recovery as a second provider dispatch',
         'counts the final payload instead of the larger Agent Context and disables SDK retries',
-        'atomically refines concurrent dispatches exactly to the prompt limit',
+        'continues transport when final prompt estimation is unavailable',
         'blocks the next logical dispatch before invoking the provider',
         'blocks raw overflow calls and stops after the allowed sibling settles',
       ],
@@ -893,9 +949,14 @@ const strongPatchValidators = {
         'Unversioned AgentHarness runAttempt is not permitted.',
         'Unversioned AgentHarness compact is not permitted.',
         'runSafety.controller.reserveProviderDispatch({',
-        'estimateRunSafetyPromptTokens(finalPayload, model)',
-        'runSafety.controller.refineProviderPromptEstimate({',
+        'estimateRunSafetyPromptObservation(finalPayload, model)',
+        'runSafety.controller.observeProviderPromptEstimate({',
         'return await transport(finalPayload);',
+      ],
+      forbiddenSnippets: [
+        'refineProviderPromptEstimate(',
+        'kind: RunSafetyTerminationKind.RunPromptExposureBudget',
+        'kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable',
       ],
     },
     {
@@ -948,7 +1009,8 @@ const strongPatchValidators = {
         'counts one normal send as one provider dispatch',
         'creates a new ticket for each recovery send on the shared controller',
         'does not call transport when the dispatch limit is exhausted',
-        'does not call transport when final prompt exposure exceeds the limit',
+        'calls transport when final prompt estimation is unavailable',
+        'calls transport when final prompt exposure exceeds the legacy threshold',
       ],
     },
   ],

--- a/scripts/build-openclaw-runtime.sh
+++ b/scripts/build-openclaw-runtime.sh
@@ -101,12 +101,41 @@ try {
 } catch {}
 READVER
 )
+DESIRED_RUN_SAFETY_CONTRACT=""
+DESIRED_RUN_SAFETY_CONTRACT=$(node - "$ELECTRON_ROOT" <<'READCONTRACT'
+const path = require('path');
+try {
+  const pkg = require(path.join(process.argv[2], 'package.json'));
+  if (pkg.openclaw && pkg.openclaw.runSafetyContract) {
+    console.log(pkg.openclaw.runSafetyContract);
+  }
+} catch {}
+READCONTRACT
+)
+if [[ -z "$DESIRED_VERSION" || -z "$DESIRED_RUN_SAFETY_CONTRACT" ]]; then
+  echo "package.json must declare openclaw.version and openclaw.runSafetyContract." >&2
+  exit 1
+fi
 
 # Compute a fingerprint of version-specific patch files so the build is invalidated when patches change.
 PATCHES_DIR="$ELECTRON_ROOT/scripts/patches/$DESIRED_VERSION"
 PATCH_HASH=""
 if [[ -d "$PATCHES_DIR" ]]; then
-  PATCH_HASH=$(cat "$PATCHES_DIR"/*.patch 2>/dev/null | sha256sum | cut -d' ' -f1)
+  PATCH_HASH=$(node - "$PATCHES_DIR" <<'READPATCHHASH'
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const patchesDir = process.argv[2];
+const patchFiles = fs.readdirSync(patchesDir)
+  .filter((name) => name.endsWith('.patch'))
+  .sort();
+const hash = crypto.createHash('sha256');
+for (const patchFile of patchFiles) {
+  hash.update(fs.readFileSync(path.join(patchesDir, patchFile)));
+}
+console.log(hash.digest('hex'));
+READPATCHHASH
+  )
 fi
 
 if [[ -n "$DESIRED_VERSION" && "${OPENCLAW_FORCE_BUILD:-}" != "1" ]]; then
@@ -126,9 +155,16 @@ try {
 } catch {}
 READPH
     )
-    if [[ "$BUILT_VERSION" == "$DESIRED_VERSION" && "$BUILT_PATCH_HASH" == "$PATCH_HASH" ]]; then
+    BUILT_RUN_SAFETY_CONTRACT=$(node - "$BUILD_INFO" <<'READCONTRACT'
+try {
+  const info = require(process.argv[2]);
+  console.log(info.runSafetyContract || '');
+} catch {}
+READCONTRACT
+    )
+    if [[ "$BUILT_VERSION" == "$DESIRED_VERSION" && "$BUILT_PATCH_HASH" == "$PATCH_HASH" && "$BUILT_RUN_SAFETY_CONTRACT" == "$DESIRED_RUN_SAFETY_CONTRACT" ]]; then
       if [[ -d "$OUT_DIR/node_modules" && -f "$OUT_DIR/gateway.asar" && -f "$OUT_DIR/dist/control-ui/index.html" ]]; then
-        echo "[openclaw-runtime] Already built for $DESIRED_VERSION (target=$TARGET_ID, patchHash=${PATCH_HASH:0:12}…), skipping."
+        echo "[openclaw-runtime] Already built for $DESIRED_VERSION (target=$TARGET_ID, patchHash=${PATCH_HASH:0:12}…, runSafetyContract=$DESIRED_RUN_SAFETY_CONTRACT), skipping."
         echo "[openclaw-runtime] Use OPENCLAW_FORCE_BUILD=1 to force rebuild."
         exit 0
       fi
@@ -136,6 +172,9 @@ READPH
     fi
     if [[ "$BUILT_VERSION" == "$DESIRED_VERSION" && "$BUILT_PATCH_HASH" != "$PATCH_HASH" ]]; then
       echo "[openclaw-runtime] Patches changed (was=${BUILT_PATCH_HASH:0:12}…, now=${PATCH_HASH:0:12}…), rebuilding."
+    fi
+    if [[ "$BUILT_VERSION" == "$DESIRED_VERSION" && "$BUILT_RUN_SAFETY_CONTRACT" != "$DESIRED_RUN_SAFETY_CONTRACT" ]]; then
+      echo "[openclaw-runtime] Run-safety contract changed (was=${BUILT_RUN_SAFETY_CONTRACT:-missing}, now=$DESIRED_RUN_SAFETY_CONTRACT), rebuilding."
     fi
   fi
   echo "[openclaw-runtime] Pinned version: $DESIRED_VERSION (current build: ${BUILT_VERSION:-none})"
@@ -188,7 +227,7 @@ cp -R "$PKG_DIR" "$OUT_DIR"
 
 # Save build metadata for traceability.
 # Use `node -` so stdin is treated as script and the following args remain user args.
-node - "$OUT_DIR" "$OPENCLAW_SRC" "$TARGET_ID" "$ELECTRON_ROOT" "$PATCH_HASH" <<'NODE'
+node - "$OUT_DIR" "$OPENCLAW_SRC" "$TARGET_ID" "$ELECTRON_ROOT" "$PATCH_HASH" "$DESIRED_RUN_SAFETY_CONTRACT" <<'NODE'
 const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
@@ -197,6 +236,7 @@ const src = process.argv[3];
 const target = process.argv[4];
 const electronRoot = process.argv[5];
 const patchHash = process.argv[6] || '';
+const runSafetyContract = process.argv[7] || '';
 
 // Read pinned version from package.json
 let openclawVersion = '';
@@ -222,6 +262,7 @@ const meta = {
   openclawVersion,
   openclawCommit,
   patchHash,
+  runSafetyContract,
 };
 fs.writeFileSync(path.join(outDir, 'runtime-build-info.json'), JSON.stringify(meta, null, 2) + '\n');
 NODE

--- a/scripts/electron-builder-hooks.cjs
+++ b/scripts/electron-builder-hooks.cjs
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const { createHash } = require('crypto');
 const { existsSync, readdirSync, statSync, mkdirSync, readFileSync, rmSync, cpSync, lstatSync } = require('fs');
 const { spawnSync } = require('child_process');
 const asar = require('@electron/asar');
@@ -55,6 +56,81 @@ function readRuntimeBuildInfo(runtimeRoot) {
   } catch {
     return null;
   }
+}
+
+function readExpectedOpenClawRuntimeContract() {
+  const pkgPath = path.join(__dirname, '..', 'package.json');
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  } catch (error) {
+    throw new Error(
+      '[electron-builder-hooks] Failed to read package.json for the OpenClaw runtime contract. '
+      + `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const openclawVersion = pkg?.openclaw?.version;
+  const runSafetyContract = pkg?.openclaw?.runSafetyContract;
+  if (
+    typeof openclawVersion !== 'string'
+    || openclawVersion.length === 0
+    || typeof runSafetyContract !== 'string'
+    || runSafetyContract.length === 0
+  ) {
+    throw new Error(
+      '[electron-builder-hooks] package.json must declare openclaw.version '
+      + 'and openclaw.runSafetyContract before packaging.',
+    );
+  }
+
+  const patchesDir = path.join(__dirname, 'patches', openclawVersion);
+  const patchHash = computeOpenClawPatchHash(patchesDir);
+  return { openclawVersion, runSafetyContract, patchHash };
+}
+
+function computeOpenClawPatchHash(patchesDir) {
+  if (!existsSync(patchesDir)) {
+    return '';
+  }
+
+  const patchFiles = readdirSync(patchesDir)
+    .filter((name) => name.endsWith('.patch'))
+    .sort();
+  const hash = createHash('sha256');
+  for (const patchFile of patchFiles) {
+    hash.update(readFileSync(path.join(patchesDir, patchFile)));
+  }
+  return hash.digest('hex');
+}
+
+function assertOpenClawRuntimeBuildInfoMatchesExpected(buildInfo, expected, buildHint) {
+  const actualVersion = typeof buildInfo?.openclawVersion === 'string'
+    ? buildInfo.openclawVersion
+    : null;
+  const actualContract = typeof buildInfo?.runSafetyContract === 'string'
+    ? buildInfo.runSafetyContract
+    : null;
+  const actualPatchHash = typeof buildInfo?.patchHash === 'string'
+    ? buildInfo.patchHash
+    : null;
+
+  if (
+    actualVersion === expected.openclawVersion
+    && actualContract === expected.runSafetyContract
+    && actualPatchHash === expected.patchHash
+  ) {
+    return;
+  }
+
+  throw new Error(
+    '[electron-builder-hooks] Bundled OpenClaw runtime contract mismatch. '
+    + `Expected version=${expected.openclawVersion}, runSafetyContract=${expected.runSafetyContract}; `
+    + `patchHash=${expected.patchHash || 'missing'}; `
+    + `found version=${actualVersion || 'missing'}, runSafetyContract=${actualContract || 'missing'}, `
+    + `patchHash=${actualPatchHash || 'missing'}. `
+    + `Run \`${buildHint}\` before packaging.`,
+  );
 }
 
 function getOpenClawRuntimeBuildHint(targetId) {
@@ -197,6 +273,11 @@ function ensureBundledLocalExtensions(runtimeRoot, buildHint) {
 function ensureBundledOpenClawRuntime(context) {
   const { runtimeRoot, targetId } = syncCurrentOpenClawRuntimeForTarget(context);
   const buildHint = getOpenClawRuntimeBuildHint(targetId);
+  assertOpenClawRuntimeBuildInfoMatchesExpected(
+    readRuntimeBuildInfo(runtimeRoot),
+    readExpectedOpenClawRuntimeContract(),
+    buildHint,
+  );
 
   ensureBundledLocalExtensions(runtimeRoot, buildHint);
 
@@ -614,4 +695,6 @@ async function afterPack(context) {
 module.exports = {
   beforePack,
   afterPack,
+  assertOpenClawRuntimeBuildInfoMatchesExpected,
+  computeOpenClawPatchHash,
 };

--- a/scripts/patches/v2026.6.1/openclaw-varying-args-no-progress-core.patch
+++ b/scripts/patches/v2026.6.1/openclaw-varying-args-no-progress-core.patch
@@ -11,22 +11,16 @@ diff --git a/extensions/amazon-bedrock-mantle/register.sync.runtime.ts b/extensi
 index 76da1c046..4030e0364 100644
 --- a/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
 +++ b/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
-@@ -62,6 +62,8 @@ export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
-       }),
-     createStreamFn: ({ model }) =>
+@@ -64,2 +64,4 @@ export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
        model.api === "anthropic-messages" ? createMantleAnthropicStreamFn() : undefined,
 +    createAgentStreamFnV1: ({ model }) =>
 +      model.api === "anthropic-messages" ? createMantleAnthropicStreamFn() : undefined,
      matchesContextOverflowError: ({ errorMessage }) =>
-       /context_length_exceeded|max.*tokens.*exceeded/i.test(errorMessage),
-     classifyFailoverReason: ({ errorMessage }) => {
 diff --git a/extensions/amazon-bedrock/index.test.ts b/extensions/amazon-bedrock/index.test.ts
 index f16f79151..6c4424dff 100644
 --- a/extensions/amazon-bedrock/index.test.ts
 +++ b/extensions/amazon-bedrock/index.test.ts
-@@ -1220,6 +1220,76 @@ describe("amazon-bedrock provider plugin", () => {
-       expect(bedrockClientConfigs).toEqual([{ region: "us-east-1" }]);
-     });
+@@ -1222,2 +1222,72 @@ describe("amazon-bedrock provider plugin", () => {
  
 +    it("forces one control-plane attempt despite AWS retry configuration", async () => {
 +      const modelId =
@@ -99,15 +93,11 @@ index f16f79151..6c4424dff 100644
 +    });
 +
      it("omits temperature for opaque application inference profile ARNs that resolve to Opus 4.7", async () => {
-       const modelId =
-         "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/z27qyso459dd";
 diff --git a/extensions/amazon-bedrock/register.sync.runtime.ts b/extensions/amazon-bedrock/register.sync.runtime.ts
 index fa59e5f0b..0459c8397 100644
 --- a/extensions/amazon-bedrock/register.sync.runtime.ts
 +++ b/extensions/amazon-bedrock/register.sync.runtime.ts
-@@ -232,7 +232,12 @@ async function createBedrockControlPlane(region: string | undefined): Promise<Be
-   }
-   await refreshAwsSharedConfigCacheForBedrock();
+@@ -234,3 +234,8 @@ async function createBedrockControlPlane(region: string | undefined): Promise<Be
    const { BedrockClient, GetInferenceProfileCommand } = await import("@aws-sdk/client-bedrock");
 -  const client = new BedrockClient(region ? { region } : {});
 +  const client = new BedrockClient({
@@ -117,11 +107,7 @@ index fa59e5f0b..0459c8397 100644
 +    maxAttempts: 1,
 +  });
    return {
-     getInferenceProfile: async (input) => await client.send(new GetInferenceProfileCommand(input)),
-   };
-@@ -583,8 +588,9 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
-             withAwsCredentialRefreshOnPayload({
-               ...merged,
+@@ -585,4 +590,5 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
                onPayload: async (payload: unknown, payloadModel: unknown) => {
 -                if (payload && typeof payload === "object") {
 -                  const payloadRecord = payload as Record<string, unknown>;
@@ -129,20 +115,12 @@ index fa59e5f0b..0459c8397 100644
 +                if (gatedPayload && typeof gatedPayload === "object") {
 +                  const payloadRecord = gatedPayload as Record<string, unknown>;
                    injectBedrockCachePoints(payloadRecord, cacheRetention);
-                   if (shouldPatchMaxThinking) {
-                     patchOpus47MaxThinkingEffort(payloadRecord);
-@@ -598,7 +604,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
-                     }
-                   }
+@@ -600,3 +606,3 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
                  }
 -                return originalOnPayload?.(payload, payloadModel);
 +                return gatedPayload;
                },
-             }),
-           );
-@@ -612,9 +618,10 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
-           withAwsCredentialRefreshOnPayload({
-             ...merged,
+@@ -614,5 +620,6 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
              onPayload: async (payload: unknown, payloadModel: unknown) => {
 +              const gatedPayload = (await originalOnPayload?.(payload, payloadModel)) ?? payload;
                const traits = await resolveAppProfileTraits(modelId, region);
@@ -151,22 +129,16 @@ index fa59e5f0b..0459c8397 100644
 +              if (gatedPayload && typeof gatedPayload === "object") {
 +                const payloadRecord = gatedPayload as Record<string, unknown>;
                  if (traits.cacheEligible) {
-                   injectBedrockCachePoints(payloadRecord, cacheRetention);
-                 }
-@@ -625,7 +632,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
-                   omitDeprecatedOpus47PayloadTemperature(payloadRecord);
-                 }
+@@ -627,3 +634,3 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
                }
 -              return originalOnPayload?.(payload, payloadModel);
 +              return gatedPayload;
              },
-           }),
-         );
 diff --git a/extensions/amazon-bedrock/stream.runtime.test.ts b/extensions/amazon-bedrock/stream.runtime.test.ts
 index 75e0f2813..497df2c22 100644
 --- a/extensions/amazon-bedrock/stream.runtime.test.ts
 +++ b/extensions/amazon-bedrock/stream.runtime.test.ts
-@@ -1,6 +1,10 @@
+@@ -1,4 +1,8 @@
 -import { describe, expect, it } from "vitest";
 +import { afterEach, describe, expect, it, vi } from "vitest";
  import { testing } from "./stream.runtime.js";
@@ -176,11 +148,7 @@ index 75e0f2813..497df2c22 100644
 +});
 +
  function bedrockModel(overrides: Record<string, unknown>) {
-   return {
-     api: "bedrock-converse-stream",
-@@ -90,6 +94,25 @@ describe("Bedrock profile endpoint resolution", () => {
-   });
- });
+@@ -92,2 +96,21 @@ describe("Bedrock profile endpoint resolution", () => {
  
 +describe("Bedrock run-safety transport attempts", () => {
 +  it("forces one SDK attempt despite default, environment, or profile retry configuration", () => {
@@ -202,15 +170,11 @@ index 75e0f2813..497df2c22 100644
 +});
 +
  describe("Bedrock thinking effort mapping", () => {
-   it("clamps max effort for Claude models without native max support", () => {
-     expect(
 diff --git a/extensions/amazon-bedrock/stream.runtime.ts b/extensions/amazon-bedrock/stream.runtime.ts
 index 5568188c2..b301fba77 100644
 --- a/extensions/amazon-bedrock/stream.runtime.ts
 +++ b/extensions/amazon-bedrock/stream.runtime.ts
-@@ -51,6 +51,16 @@ import { supportsBedrockPromptCaching, type BedrockOptions } from "./bedrock-opt
- 
- type Block = (TextContent | ThinkingContent | ToolCall) & { index?: number; partialJson?: string };
+@@ -53,2 +53,12 @@ type Block = (TextContent | ThinkingContent | ToolCall) & { index?: number; part
  
 +function buildBedrockRuntimeClientConfig(options: BedrockOptions): BedrockRuntimeClientConfig {
 +  return {
@@ -223,34 +187,22 @@ index 5568188c2..b301fba77 100644
 +}
 +
  export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> = (
-   model: Model<"bedrock-converse-stream">,
-   context: Context,
-@@ -79,9 +89,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
- 
-     const blocks = output.content as Block[];
+@@ -81,5 +91,3 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
  
 -    const config: BedrockRuntimeClientConfig = {
 -      profile: options.profile,
 -    };
 +    const config = buildBedrockRuntimeClientConfig(options);
      const configuredRegion = getConfiguredBedrockRegion(options);
-     const hasConfiguredProfile = hasConfiguredBedrockProfile(options);
-     const endpointRegion = getStandardBedrockEndpointRegion(model.baseUrl);
-@@ -949,6 +957,7 @@ function createImageBlock(mimeType: string, data: string) {
- }
- 
+@@ -951,2 +959,3 @@ function createImageBlock(mimeType: string, data: string) {
  export const testing = {
 +  buildBedrockRuntimeClientConfig,
    convertMessages,
-   getConfiguredBedrockRegion,
-   hasConfiguredBedrockProfile,
 diff --git a/extensions/google/provider-registration.ts b/extensions/google/provider-registration.ts
 index 63225b1d3..5432eba72 100644
 --- a/extensions/google/provider-registration.ts
 +++ b/extensions/google/provider-registration.ts
-@@ -95,6 +95,19 @@ export function buildGoogleProvider(): ProviderPlugin {
-       }
-       return undefined;
+@@ -97,2 +97,15 @@ export function buildGoogleProvider(): ProviderPlugin {
      },
 +    createAgentStreamFnV1: ({ model }) => {
 +      if (
@@ -266,31 +218,19 @@ index 63225b1d3..5432eba72 100644
 +      return undefined;
 +    },
      ...GOOGLE_GEMINI_PROVIDER_HOOKS,
-     // Gemini 2.5+ delivers reasoning via native thinkingParts (thinkingConfig.includeThoughts).
-     // Tagged mode simultaneously injects <think>/<final> which the model opens before a tool
 diff --git a/extensions/google/transport-stream.test.ts b/extensions/google/transport-stream.test.ts
 index 7f569044f..a44db7cc7 100644
 --- a/extensions/google/transport-stream.test.ts
 +++ b/extensions/google/transport-stream.test.ts
-@@ -9,6 +9,7 @@ const {
-   guardedFetchMock,
-   googleAuthGetAccessTokenMock,
+@@ -11,2 +11,3 @@ const {
    googleAuthMock,
 +  runSafetyDispatchState,
  } = vi.hoisted(() => {
-   const googleAuthGetAccessTokenMockLocal = vi.fn();
-   return {
-@@ -20,6 +21,7 @@ const {
-         getAccessToken: googleAuthGetAccessTokenMockLocal,
-       };
+@@ -22,2 +23,3 @@ const {
      }),
 +    runSafetyDispatchState: { active: false },
    };
- });
- 
-@@ -32,6 +34,11 @@ vi.mock("google-auth-library", () => ({
-   GoogleAuth: googleAuthMock,
- }));
+@@ -34,2 +36,7 @@ vi.mock("google-auth-library", () => ({
  
 +vi.mock("openclaw/plugin-sdk/provider-model-shared", async (importOriginal) => ({
 +  ...(await importOriginal()),
@@ -298,27 +238,15 @@ index 7f569044f..a44db7cc7 100644
 +}));
 +
  let buildGoogleGenerativeAiParams: typeof import("./transport-stream.js").buildGoogleGenerativeAiParams;
- let buildGoogleGemini3FirstResponseRetryParams: typeof import("./transport-stream.js").buildGoogleGemini3FirstResponseRetryParams;
- let createGoogleGenerativeAiTransportStreamFn: typeof import("./transport-stream.js").createGoogleGenerativeAiTransportStreamFn;
-@@ -299,6 +306,7 @@ describe("google transport stream", () => {
-   });
- 
+@@ -301,2 +308,3 @@ describe("google transport stream", () => {
    beforeEach(() => {
 +    runSafetyDispatchState.active = false;
      buildGuardedModelFetchMock.mockReset();
-     guardedFetchMock.mockReset();
-     googleAuthGetAccessTokenMock.mockReset();
-@@ -314,6 +322,7 @@ describe("google transport stream", () => {
- 
-   afterAll(() => {
+@@ -316,2 +324,3 @@ describe("google transport stream", () => {
      vi.doUnmock("openclaw/plugin-sdk/provider-transport-runtime");
 +    vi.doUnmock("openclaw/plugin-sdk/provider-model-shared");
      vi.doUnmock("google-auth-library");
-     vi.resetModules();
-   });
-@@ -700,6 +709,38 @@ describe("google transport stream", () => {
-     expect(retryBody.tools).toEqual(firstBody.tools);
-   });
+@@ -702,2 +711,34 @@ describe("google transport stream", () => {
  
 +  it("does not retry a Gemini 3 first-response timeout inside one host dispatch", async () => {
 +    vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "10");
@@ -353,23 +281,15 @@ index 7f569044f..a44db7cc7 100644
 +  });
 +
    it("keeps streaming after the first Gemini 3 chunk arrives before the retry deadline", async () => {
-     vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "10");
-     guardedFetchMock.mockResolvedValueOnce(
 diff --git a/extensions/google/transport-stream.ts b/extensions/google/transport-stream.ts
 index c2e1816bf..e5428caf0 100644
 --- a/extensions/google/transport-stream.ts
 +++ b/extensions/google/transport-stream.ts
-@@ -9,6 +9,7 @@ import {
- } from "openclaw/plugin-sdk/llm";
- import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
+@@ -11,2 +11,3 @@ import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtim
  import { createProviderHttpError } from "openclaw/plugin-sdk/provider-http";
 +import { shouldDisableInternalProviderTransportRetries } from "openclaw/plugin-sdk/provider-model-shared";
  import {
-   buildGuardedModelFetch,
-   coerceTransportToolCallArguments,
-@@ -1058,6 +1059,11 @@ async function openGoogleSseChunks(params: {
-   if (firstAttempt.type === "ready") {
-     return firstAttempt;
+@@ -1060,2 +1061,7 @@ async function openGoogleSseChunks(params: {
    }
 +  if (shouldDisableInternalProviderTransportRetries()) {
 +    throw new Error(
@@ -377,23 +297,15 @@ index c2e1816bf..e5428caf0 100644
 +    );
 +  }
  
-   const retryAttempt = await openGoogleSseAttempt({
-     guardedFetch: params.guardedFetch,
 diff --git a/extensions/lmstudio/src/stream.test.ts b/extensions/lmstudio/src/stream.test.ts
 index b0de39698..0bfcaa072 100644
 --- a/extensions/lmstudio/src/stream.test.ts
 +++ b/extensions/lmstudio/src/stream.test.ts
-@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vites
- import { resetLmstudioPreloadCooldownForTest, wrapLmstudioInferencePreload } from "./stream.js";
- 
+@@ -6,2 +6,3 @@ import { resetLmstudioPreloadCooldownForTest, wrapLmstudioInferencePreload } fro
  const ensureLmstudioModelLoadedMock = vi.hoisted(() => vi.fn());
 +const runSafetyDispatchState = vi.hoisted(() => ({ active: false }));
  const resolveLmstudioProviderHeadersMock = vi.hoisted(() =>
-   vi.fn(async (_params?: unknown) => undefined),
- );
-@@ -28,9 +29,15 @@ vi.mock("./runtime.js", async (importOriginal) => {
-   };
- });
+@@ -30,2 +31,7 @@ vi.mock("./runtime.js", async (importOriginal) => {
  
 +vi.mock("openclaw/plugin-sdk/provider-model-shared", async (importOriginal) => ({
 +  ...(await importOriginal()),
@@ -401,23 +313,15 @@ index b0de39698..0bfcaa072 100644
 +}));
 +
  afterAll(() => {
-   vi.doUnmock("./models.fetch.js");
+@@ -33,2 +39,3 @@ afterAll(() => {
    vi.doUnmock("./runtime.js");
 +  vi.doUnmock("openclaw/plugin-sdk/provider-model-shared");
    vi.resetModules();
- });
- 
-@@ -163,6 +170,7 @@ function runWrappedLmstudioStream(
- 
- describe("lmstudio stream wrapper", () => {
+@@ -165,2 +172,3 @@ describe("lmstudio stream wrapper", () => {
    beforeEach(() => {
 +    runSafetyDispatchState.active = false;
      resetLmstudioPreloadCooldownForTest();
-   });
- 
-@@ -324,6 +332,20 @@ describe("lmstudio stream wrapper", () => {
-     });
-   });
+@@ -326,2 +334,16 @@ describe("lmstudio stream wrapper", () => {
  
 +  it("skips best-effort preload inside a host run-safety provider dispatch", async () => {
 +    const baseStream = buildDoneStreamFn();
@@ -434,23 +338,15 @@ index b0de39698..0bfcaa072 100644
 +  });
 +
    it("dedupes concurrent preload requests for the same model and context", async () => {
-     let resolvePreload: (() => void) | undefined;
-     ensureLmstudioModelLoadedMock.mockImplementationOnce(
 diff --git a/extensions/lmstudio/src/stream.ts b/extensions/lmstudio/src/stream.ts
 index 270e4f0cf..7ff7d15c1 100644
 --- a/extensions/lmstudio/src/stream.ts
 +++ b/extensions/lmstudio/src/stream.ts
-@@ -2,6 +2,7 @@ import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
- import { streamSimple } from "openclaw/plugin-sdk/llm";
- import { createSubsystemLogger } from "openclaw/plugin-sdk/logging-core";
+@@ -4,2 +4,3 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/logging-core";
  import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 +import { shouldDisableInternalProviderTransportRetries } from "openclaw/plugin-sdk/provider-model-shared";
  import { createPlainTextToolCallCompatWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
- import { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "openclaw/plugin-sdk/ssrf-runtime";
- import { asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
-@@ -184,7 +185,10 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext):
-       return underlying(model, context, options);
-     }
+@@ -186,3 +187,6 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext):
      const providerConfig = ctx.config?.models?.providers?.[LMSTUDIO_PROVIDER_ID];
 -    if (!shouldPreloadLmstudioModels(providerConfig)) {
 +    if (
@@ -458,15 +354,11 @@ index 270e4f0cf..7ff7d15c1 100644
 +      !shouldPreloadLmstudioModels(providerConfig)
 +    ) {
        return streamWithPlainTextToolCalls(withLmstudioUsageCompat(model), context, options);
-     }
-     const providerBaseUrl = providerConfig?.baseUrl;
 diff --git a/extensions/ollama/index.ts b/extensions/ollama/index.ts
 index 1acc895da..8c9089341 100644
 --- a/extensions/ollama/index.ts
 +++ b/extensions/ollama/index.ts
-@@ -218,6 +218,15 @@ export default definePluginEntry({
-             ) ?? OLLAMA_CLOUD_BASE_URL,
-         });
+@@ -220,2 +220,11 @@ export default definePluginEntry({
        },
 +      createAgentStreamFnV1: ({ config, model, provider }) => {
 +        return createConfiguredOllamaStreamFn({
@@ -478,11 +370,7 @@ index 1acc895da..8c9089341 100644
 +        });
 +      },
        ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
-       buildReplayPolicy: (ctx) =>
-         ctx.modelApi === "ollama"
-@@ -330,6 +339,14 @@ export default definePluginEntry({
-           ),
-         });
+@@ -332,2 +341,10 @@ export default definePluginEntry({
        },
 +      createAgentStreamFnV1: ({ config, model, provider }) => {
 +        return createConfiguredOllamaStreamFn({
@@ -493,15 +381,11 @@ index 1acc895da..8c9089341 100644
 +        });
 +      },
        ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
-       buildReplayPolicy: (ctx) =>
-         ctx.modelApi === "ollama"
 diff --git a/extensions/ollama/src/stream-runtime.test.ts b/extensions/ollama/src/stream-runtime.test.ts
 index 47985afb4..215e451f1 100644
 --- a/extensions/ollama/src/stream-runtime.test.ts
 +++ b/extensions/ollama/src/stream-runtime.test.ts
-@@ -651,6 +651,54 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
-   });
- });
+@@ -653,2 +653,50 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
  
 +describe("Ollama run-safety payload gate", () => {
 +  it("awaits the final payload gate and sends its replacement before fetch", async () => {
@@ -552,24 +436,16 @@ index 47985afb4..215e451f1 100644
 +});
 +
  describe("convertToOllamaMessages", () => {
-   it("converts user text messages", () => {
-     const messages = [{ role: "user", content: "hello" }];
 diff --git a/extensions/ollama/src/stream.ts b/extensions/ollama/src/stream.ts
 index d376f654a..c3446907e 100644
 --- a/extensions/ollama/src/stream.ts
 +++ b/extensions/ollama/src/stream.ts
-@@ -1163,7 +1163,7 @@ function createRawOllamaStreamFn(
-         }
-         normalizeOllamaGreedySamplingOptions(ollamaOptions);
+@@ -1165,3 +1165,3 @@ function createRawOllamaStreamFn(
  
 -        const body = buildOllamaChatRequest({
 +        let body = buildOllamaChatRequest({
            modelId: model.id,
-           providerId: model.provider,
-           messages: ollamaMessages,
-@@ -1172,7 +1172,10 @@ function createRawOllamaStreamFn(
-           options: ollamaOptions,
-           requestParams: resolveOllamaTopLevelParams(model),
+@@ -1174,3 +1174,6 @@ function createRawOllamaStreamFn(
          });
 -        options?.onPayload?.(body, model);
 +        const nextBody = await options?.onPayload?.(body, model);
@@ -577,23 +453,15 @@ index d376f654a..c3446907e 100644
 +          body = nextBody as typeof body;
 +        }
          const headers: Record<string, string> = {
-           "Content-Type": "application/json",
-           ...defaultHeaders,
 diff --git a/packages/agent-core/src/agent-loop.ts b/packages/agent-core/src/agent-loop.ts
 index 7409b4f2a..ce6159a17 100644
 --- a/packages/agent-core/src/agent-loop.ts
 +++ b/packages/agent-core/src/agent-loop.ts
-@@ -17,6 +17,7 @@ import type {
-   AgentTool,
-   AgentToolCall,
+@@ -19,2 +19,3 @@ import type {
    AgentToolResult,
 +  BeforeToolCallBatchDecision,
    StreamFn,
- } from "./types.js";
- import { validateToolArguments } from "./validation.js";
-@@ -331,6 +332,11 @@ async function runLoop(
-         context: currentContext,
-         newMessages,
+@@ -333,2 +334,7 @@ async function runLoop(
        };
 +      if (await config.shouldStopAfterTurn?.(nextTurnContext)) {
 +        await emit({ type: "agent_end", messages: newMessages });
@@ -601,11 +469,7 @@ index 7409b4f2a..ce6159a17 100644
 +      }
 +
        const nextTurnSnapshot = await config.prepareNextTurn?.(nextTurnContext);
-       if (nextTurnSnapshot) {
-         currentContext = nextTurnSnapshot.context ?? currentContext;
-@@ -348,18 +354,6 @@ async function runLoop(
-         return;
-       }
+@@ -350,14 +356,2 @@ async function runLoop(
  
 -      if (
 -        await config.shouldStopAfterTurn?.({
@@ -620,11 +484,7 @@ index 7409b4f2a..ce6159a17 100644
 -      }
 -
        pendingMessages = (await config.getSteeringMessages?.()) || [];
-       if (await stopIfAborted()) {
-         return;
-@@ -495,27 +489,44 @@ async function executeToolCalls(
-   emit: AgentEventSink,
- ): Promise<ExecutedToolCallBatch> {
+@@ -497,10 +491,33 @@ async function executeToolCalls(
    const toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall");
 -  const hasSequentialToolCall = toolCalls.some(
 -    (tc) => currentContext.tools?.find((t) => t.name === tc.name)?.executionMode === "sequential",
@@ -664,8 +524,7 @@ index 7409b4f2a..ce6159a17 100644
 -      toolCalls,
 +      rawCalls,
        config,
-       signal,
-       emit,
+@@ -509,11 +526,5 @@ async function executeToolCalls(
      );
 +  } finally {
 +    await config.afterToolCallBatch?.({ ...batchContext, decisions }, signal);
@@ -679,11 +538,7 @@ index 7409b4f2a..ce6159a17 100644
 -    emit,
 -  );
  }
- 
- type ExecutedToolCallBatch = {
-@@ -523,10 +534,15 @@ type ExecutedToolCallBatch = {
-   terminate: boolean;
- };
+@@ -525,2 +536,7 @@ type ExecutedToolCallBatch = {
  
 +type RawToolCall = {
 +  toolCall: AgentToolCall;
@@ -691,60 +546,37 @@ index 7409b4f2a..ce6159a17 100644
 +};
 +
  async function executeToolCallsSequential(
-   currentContext: AgentContext,
+@@ -528,3 +544,3 @@ async function executeToolCallsSequential(
    assistantMessage: AssistantMessage,
 -  toolCalls: AgentToolCall[],
 +  rawCalls: RawToolCall[],
    config: AgentLoopConfig,
-   signal: AbortSignal | undefined,
-   emit: AgentEventSink,
-@@ -534,7 +550,8 @@ async function executeToolCallsSequential(
-   const finalizedCalls: FinalizedToolCallOutcome[] = [];
-   const messages: ToolResultMessage[] = [];
+@@ -536,3 +552,4 @@ async function executeToolCallsSequential(
  
 -  for (const toolCall of toolCalls) {
 +  for (const rawCall of rawCalls) {
 +    const { toolCall } = rawCall;
      await emit({
-       type: "tool_execution_start",
-       toolCallId: toolCall.id,
-@@ -548,6 +565,7 @@ async function executeToolCallsSequential(
-       toolCall,
-       config,
+@@ -550,2 +567,3 @@ async function executeToolCallsSequential(
        signal,
 +      rawCall.decision,
      );
-     let finalized: FinalizedToolCallOutcome;
-     if (preparation.kind === "immediate") {
-@@ -588,14 +606,15 @@ async function executeToolCallsSequential(
- async function executeToolCallsParallel(
-   currentContext: AgentContext,
+@@ -590,3 +608,3 @@ async function executeToolCallsParallel(
    assistantMessage: AssistantMessage,
 -  toolCalls: AgentToolCall[],
 +  rawCalls: RawToolCall[],
    config: AgentLoopConfig,
-   signal: AbortSignal | undefined,
-   emit: AgentEventSink,
- ): Promise<ExecutedToolCallBatch> {
-   const finalizedCalls: FinalizedToolCallEntry[] = [];
+@@ -597,3 +615,4 @@ async function executeToolCallsParallel(
  
 -  for (const toolCall of toolCalls) {
 +  for (const rawCall of rawCalls) {
 +    const { toolCall } = rawCall;
      await emit({
-       type: "tool_execution_start",
-       toolCallId: toolCall.id,
-@@ -609,6 +628,7 @@ async function executeToolCallsParallel(
-       toolCall,
-       config,
+@@ -611,2 +630,3 @@ async function executeToolCallsParallel(
        signal,
 +      rawCall.decision,
      );
-     if (preparation.kind === "immediate") {
-       const finalized = {
-@@ -711,7 +731,19 @@ async function prepareToolCall(
-   toolCall: AgentToolCall,
-   config: AgentLoopConfig,
+@@ -713,3 +733,15 @@ async function prepareToolCall(
    signal: AbortSignal | undefined,
 +  batchDecision?: BeforeToolCallBatchDecision,
  ): Promise<PreparedToolCall | ImmediateToolCallOutcome> {
@@ -760,11 +592,7 @@ index 7409b4f2a..ce6159a17 100644
 +    };
 +  }
    const tool = currentContext.tools?.find((t) => t.name === toolCall.name);
-   if (!tool) {
-     return {
-@@ -853,10 +885,15 @@ async function finalizeExecutedToolCall(
-   };
- }
+@@ -855,6 +887,11 @@ async function finalizeExecutedToolCall(
  
 -function createErrorToolResult(message: string): AgentToolResult<unknown> {
 +function createErrorToolResult(
@@ -778,8 +606,6 @@ index 7409b4f2a..ce6159a17 100644
 +    details,
 +    ...(terminate === undefined ? {} : { terminate }),
    };
- }
- 
 diff --git a/packages/agent-core/src/agent.run-safety-tool-budget.test.ts b/packages/agent-core/src/agent.run-safety-tool-budget.test.ts
 new file mode 100644
 index 000000000..a0973fc35
@@ -1000,26 +826,16 @@ diff --git a/packages/agent-core/src/agent.ts b/packages/agent-core/src/agent.ts
 index 08de46e32..0efb6426c 100644
 --- a/packages/agent-core/src/agent.ts
 +++ b/packages/agent-core/src/agent.ts
-@@ -12,6 +12,7 @@ import { type AgentCoreStreamRuntimeDeps, resolveAgentCoreStreamFn } from "./run
- import type {
-   AfterToolCallContext,
+@@ -14,2 +14,3 @@ import type {
    AfterToolCallResult,
 +  AfterToolCallBatchContext,
    AgentContext,
-   AgentEvent,
-   AgentLoopConfig,
-@@ -20,6 +21,8 @@ import type {
-   AgentState,
-   AgentTool,
+@@ -22,2 +23,4 @@ import type {
    BeforeToolCallContext,
 +  BeforeToolCallBatchContext,
 +  BeforeToolCallBatchDecision,
    BeforeToolCallResult,
-   QueueMode,
-   ShouldStopAfterTurnContext,
-@@ -119,6 +122,16 @@ export interface AgentOptions {
-   onPayload?: SimpleStreamOptions["onPayload"];
-   /** Inspect the provider response after it returns. */
+@@ -121,2 +124,12 @@ export interface AgentOptions {
    onResponse?: SimpleStreamOptions["onResponse"];
 +  /** Reserve or block a raw provider tool-call batch before any tool-specific processing. */
 +  beforeToolCallBatch?: (
@@ -1032,11 +848,7 @@ index 08de46e32..0efb6426c 100644
 +    signal?: AbortSignal,
 +  ) => void | Promise<void>;
    /** Hook that may short-circuit or alter a tool call before execution. */
-   beforeToolCall?: (
-     context: BeforeToolCallContext,
-@@ -218,6 +231,14 @@ export class Agent {
-   public getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
-   public onPayload?: SimpleStreamOptions["onPayload"];
+@@ -220,2 +233,10 @@ export class Agent {
    public onResponse?: SimpleStreamOptions["onResponse"];
 +  public beforeToolCallBatch?: (
 +    context: BeforeToolCallBatchContext,
@@ -1047,33 +859,21 @@ index 08de46e32..0efb6426c 100644
 +    signal?: AbortSignal,
 +  ) => void | Promise<void>;
    public beforeToolCall?: (
-     context: BeforeToolCallContext,
-     signal?: AbortSignal,
-@@ -251,6 +272,8 @@ export class Agent {
-     this.getApiKey = options.getApiKey;
-     this.onPayload = options.onPayload;
+@@ -253,2 +274,4 @@ export class Agent {
      this.onResponse = options.onResponse;
 +    this.beforeToolCallBatch = options.beforeToolCallBatch;
 +    this.afterToolCallBatch = options.afterToolCallBatch;
      this.beforeToolCall = options.beforeToolCall;
-     this.afterToolCall = options.afterToolCall;
-     this.shouldStopAfterTurn = options.shouldStopAfterTurn;
-@@ -483,6 +506,8 @@ export class Agent {
-       thinkingBudgets: this.thinkingBudgets,
-       maxRetryDelayMs: this.maxRetryDelayMs,
+@@ -485,2 +508,4 @@ export class Agent {
        toolExecution: this.toolExecution,
 +      beforeToolCallBatch: this.beforeToolCallBatch,
 +      afterToolCallBatch: this.afterToolCallBatch,
        beforeToolCall: this.beforeToolCall,
-       afterToolCall: this.afterToolCall,
-       shouldStopAfterTurn: this.shouldStopAfterTurn,
 diff --git a/packages/agent-core/src/types.ts b/packages/agent-core/src/types.ts
 index 7baf77299..74e580ab1 100644
 --- a/packages/agent-core/src/types.ts
 +++ b/packages/agent-core/src/types.ts
-@@ -55,6 +55,34 @@ export interface BeforeToolCallResult {
-   reason?: string;
- }
+@@ -57,2 +57,30 @@ export interface BeforeToolCallResult {
  
 +/** One raw tool-call reservation decision made before lookup or validation. */
 +export interface BeforeToolCallBatchDecision {
@@ -1104,11 +904,7 @@ index 7baf77299..74e580ab1 100644
 +}
 +
  /**
-  * Partial override returned from `afterToolCall`.
-  *
-@@ -251,6 +279,21 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
-    */
-   toolExecution?: ToolExecutionMode;
+@@ -253,2 +281,17 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
  
 +  /**
 +   * Called once for the raw provider tool-call batch before tool lookup, argument
@@ -1126,15 +922,11 @@ index 7baf77299..74e580ab1 100644
 +  ) => void | Promise<void>;
 +
    /**
-    * Called before a tool is executed, after arguments have been validated.
-    *
 diff --git a/packages/gateway-protocol/src/schema/agent.test.ts b/packages/gateway-protocol/src/schema/agent.test.ts
 index dac19a785..04a6b1611 100644
 --- a/packages/gateway-protocol/src/schema/agent.test.ts
 +++ b/packages/gateway-protocol/src/schema/agent.test.ts
-@@ -72,4 +72,29 @@ describe("AgentParamsSchema", () => {
- 
-     expect(Value.Check(AgentParamsSchema, params)).toBe(false);
+@@ -74,2 +74,27 @@ describe("AgentParamsSchema", () => {
    });
 +
 +  it("accepts only opaque run-safety claim fields", () => {
@@ -1166,9 +958,7 @@ diff --git a/packages/gateway-protocol/src/schema/agent.ts b/packages/gateway-pr
 index 768893147..db3844ad2 100644
 --- a/packages/gateway-protocol/src/schema/agent.ts
 +++ b/packages/gateway-protocol/src/schema/agent.ts
-@@ -43,6 +43,15 @@ export const AgentInternalEventSchema = Type.Object(
-   { additionalProperties: false },
- );
+@@ -45,2 +45,11 @@ export const AgentInternalEventSchema = Type.Object(
  
 +export const AgentRunSafetyClaimSchema = Type.Object(
 +  {
@@ -1180,44 +970,28 @@ index 768893147..db3844ad2 100644
 +);
 +
  export const AgentEventSchema = Type.Object(
-   {
-     runId: NonEmptyString,
-@@ -197,6 +206,8 @@ export const AgentParamsSchema = Type.Object(
-     ),
-     acpTurnSource: Type.Optional(Type.Literal("manual_spawn")),
+@@ -199,2 +208,4 @@ export const AgentParamsSchema = Type.Object(
      internalRuntimeHandoffId: Type.Optional(NonEmptyString),
 +    /** Internal-only opaque claim for a pre-registered inherited safety scope. */
 +    runSafety: Type.Optional(AgentRunSafetyClaimSchema),
      internalEvents: Type.Optional(Type.Array(AgentInternalEventSchema)),
-     inputProvenance: Type.Optional(InputProvenanceSchema),
-     suppressPromptPersistence: Type.Optional(Type.Boolean()),
 diff --git a/src/agents/acp-spawn.test.ts b/src/agents/acp-spawn.test.ts
 index 7596d208a..64881cb89 100644
 --- a/src/agents/acp-spawn.test.ts
 +++ b/src/agents/acp-spawn.test.ts
-@@ -167,6 +167,7 @@ vi.mock("../tasks/runtime-internal.js", () => ({
- }));
- 
+@@ -169,2 +169,3 @@ vi.mock("../tasks/runtime-internal.js", () => ({
  const { isSpawnAcpAcceptedResult, spawnAcpDirect } = await import("./acp-spawn.js");
 +const { runSafetyRegistry } = await import("./run-safety-registry.js");
  type SpawnRequest = Parameters<typeof spawnAcpDirect>[0];
- type SpawnContext = Parameters<typeof spawnAcpDirect>[1];
- type SpawnResult = Awaited<ReturnType<typeof spawnAcpDirect>>;
-@@ -615,6 +616,7 @@ function enableTelegramCurrentConversationBindings(): void {
- 
- describe("spawnAcpDirect", () => {
+@@ -617,2 +618,3 @@ describe("spawnAcpDirect", () => {
    beforeEach(() => {
 +    runSafetyRegistry.resetForTests();
      replaceSpawnConfig(createDefaultSpawnConfig());
-     hoisted.areHeartbeatsEnabledMock.mockReset().mockReturnValue(true);
-     hoisted.getChannelPluginMock.mockReset().mockReturnValue(undefined);
-@@ -760,9 +762,73 @@ describe("spawnAcpDirect", () => {
-   });
- 
+@@ -762,2 +764,3 @@ describe("spawnAcpDirect", () => {
    afterEach(() => {
 +    runSafetyRegistry.resetForTests();
      sessionBindingServiceTesting.resetSessionBindingAdaptersForTests();
-   });
+@@ -765,2 +768,65 @@ describe("spawnAcpDirect", () => {
  
 +  it("fails closed before gateway transport when ACP spawn lost its run identity", async () => {
 +    const result = await spawnAcpDirect(createSpawnRequest(), {
@@ -1283,15 +1057,11 @@ index 7596d208a..64881cb89 100644
 +  });
 +
    it("spawns ACP session, binds a new thread, and dispatches initial task", async () => {
-     const result = await spawnAcpDirect(
-       {
 diff --git a/src/agents/acp-spawn.ts b/src/agents/acp-spawn.ts
 index f4ab1b207..6d48033a4 100644
 --- a/src/agents/acp-spawn.ts
 +++ b/src/agents/acp-spawn.ts
-@@ -88,6 +88,11 @@ import {
-   resolveConfiguredSubagentSpawnModelSelection,
-   resolveThinkingDefault,
+@@ -90,2 +90,7 @@ import {
  } from "./model-selection.js";
 +import type { RunSafetyContext, RunSafetyTermination } from "./run-safety-controller.js";
 +import {
@@ -1299,11 +1069,7 @@ index f4ab1b207..6d48033a4 100644
 +  runSafetyRegistry,
 +} from "./run-safety-registry.js";
  import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
- import { resolveRequesterOriginForChild } from "./spawn-requester-origin.js";
- import { resolveSpawnedWorkspaceInheritance } from "./spawned-context.js";
-@@ -174,6 +179,12 @@ export type SpawnAcpContext = {
-   sandboxed?: boolean;
-   inheritedToolAllowlist?: string[];
+@@ -176,2 +181,8 @@ export type SpawnAcpContext = {
    inheritedToolDenylist?: string[];
 +  runId?: string;
 +  /**
@@ -1312,36 +1078,21 @@ index f4ab1b207..6d48033a4 100644
 +   */
 +  runSafety?: RunSafetyContext | null;
  };
- 
- export const ACP_SPAWN_ERROR_CODES = [
-@@ -201,6 +212,7 @@ type SpawnAcpResultFields = {
-   inlineDelivery?: boolean;
-   streamLogPath?: string;
+@@ -203,2 +214,3 @@ type SpawnAcpResultFields = {
    note?: string;
 +  terminationReason?: RunSafetyTermination;
  };
- 
- type SpawnAcpAcceptedResult = SpawnAcpResultFields & {
-@@ -546,12 +558,16 @@ function createAcpSpawnFailure(params: {
-   errorCode: SpawnAcpErrorCode;
-   error: string;
+@@ -548,2 +560,4 @@ function createAcpSpawnFailure(params: {
    childSessionKey?: string;
 +  runId?: string;
 +  terminationReason?: RunSafetyTermination;
  }): SpawnAcpFailedResult {
-   return {
-     status: params.status,
-     errorCode: params.errorCode,
-     error: params.error,
+@@ -554,2 +568,4 @@ function createAcpSpawnFailure(params: {
      ...(params.childSessionKey ? { childSessionKey: params.childSessionKey } : {}),
 +    ...(params.runId ? { runId: params.runId } : {}),
 +    ...(params.terminationReason ? { terminationReason: params.terminationReason } : {}),
    };
- }
- 
-@@ -1464,6 +1480,22 @@ export async function spawnAcpDirect(
-     preparedBinding = prepared.binding;
-   }
+@@ -1466,2 +1482,18 @@ export async function spawnAcpDirect(
  
 +  const childIdem = crypto.randomUUID();
 +  if (ctx.runSafety === null || (ctx.runSafety && !ctx.runId)) {
@@ -1360,19 +1111,11 @@ index f4ab1b207..6d48033a4 100644
 +  }
 +
    let binding: SessionBindingRecord | null = null;
-   let sessionCreated = false;
-   let initializedRuntime: AcpSpawnRuntimeCloseHandle | undefined;
-@@ -1525,7 +1557,6 @@ export async function spawnAcpDirect(
-     requester: requesterState,
-     binding,
+@@ -1527,3 +1559,2 @@ export async function spawnAcpDirect(
    });
 -  const childIdem = crypto.randomUUID();
    let childRunId: string = childIdem;
-   const streamLogPath =
-     effectiveStreamToParent && parentSessionKey
-@@ -1566,6 +1597,32 @@ export async function spawnAcpDirect(
-     });
-   }
+@@ -1568,2 +1599,28 @@ export async function spawnAcpDirect(
    const gatewayAttachments = toGatewayImageAttachments(params.attachments);
 +  const runSafetyClaim = ctx.runSafety
 +    ? runSafetyRegistry.claimSubagent({
@@ -1401,19 +1144,11 @@ index f4ab1b207..6d48033a4 100644
 +    });
 +  }
    try {
-     const response = await callGateway({
-       method: "agent",
-@@ -1582,6 +1639,7 @@ export async function spawnAcpDirect(
-         acpTurnSource: "manual_spawn",
-         timeout: runTimeoutSeconds,
+@@ -1584,2 +1641,3 @@ export async function spawnAcpDirect(
          label: params.label || undefined,
 +        ...(runSafetyClaim?.ok ? { runSafety: runSafetyClaim.identity } : {}),
          ...(gatewayAttachments ? { attachments: gatewayAttachments } : {}),
-       },
-       timeoutMs: 10_000,
-@@ -1591,6 +1649,12 @@ export async function spawnAcpDirect(
-       childRunId = responseRunId;
-     }
+@@ -1593,2 +1651,8 @@ export async function spawnAcpDirect(
    } catch (err) {
 +    if (runSafetyClaim?.ok) {
 +      runSafetyRegistry.cancelInheritedClaim({
@@ -1422,24 +1157,16 @@ index f4ab1b207..6d48033a4 100644
 +      });
 +    }
      parentRelay?.dispose();
-     await cleanupFailedAcpSpawn({
-       cfg,
 diff --git a/src/agents/agent-command.ts b/src/agents/agent-command.ts
 index a03834ef6..df5d44013 100644
 --- a/src/agents/agent-command.ts
 +++ b/src/agents/agent-command.ts
-@@ -121,6 +121,8 @@ import {
- } from "./model-visibility-policy.js";
- import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-routing.js";
+@@ -123,2 +123,4 @@ import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-routing.
  import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 +import type { RunSafetyContext } from "./run-safety-controller.js";
 +import { runSafetyRegistry } from "./run-safety-registry.js";
  import { normalizeSpawnedRunMetadata } from "./spawned-context.js";
- import { resolveAgentTimeoutMs } from "./timeout.js";
- import { ensureAgentWorkspace } from "./workspace.js";
-@@ -841,6 +843,101 @@ async function agentCommandInternal(
-   let sessionEntry = prepared.sessionEntry;
-   let trackedRestartRecoveryDeliveryContext = false;
+@@ -843,2 +845,97 @@ async function agentCommandInternal(
    let currentRunDeliveryContext: DeliveryContext | undefined;
 +  let ownedRunSafety: RunSafetyContext | undefined;
 +  let runSafety = opts.runSafety;
@@ -1537,11 +1264,7 @@ index a03834ef6..df5d44013 100644
 +    opts = { ...opts, runSafety };
 +  }
  
-   try {
-     if (opts.deliver === true) {
-@@ -1621,7 +1718,10 @@ async function agentCommandInternal(
-         return;
-       }
+@@ -1623,3 +1720,6 @@ async function agentCommandInternal(
        attemptLifecycleState.lifecycleEnded = true;
 -      const stopReason = runResult.meta.stopReason;
 +      // Inherited child/recovery runs only signal the shared controller. The
@@ -1549,11 +1272,7 @@ index a03834ef6..df5d44013 100644
 +      const terminationReason = ownedRunSafety ? runResult.meta.terminationReason : undefined;
 +      const stopReason = terminationReason ? "run_safety" : runResult.meta.stopReason;
        if (stopReason && stopReason !== "end_turn") {
-         console.error(`[agent] run ${runId} ended with stopReason=${stopReason}`);
-       }
-@@ -1634,6 +1734,12 @@ async function agentCommandInternal(
-           endedAt: Date.now(),
-           aborted: runResult.meta.aborted ?? false,
+@@ -1636,2 +1736,8 @@ async function agentCommandInternal(
            stopReason,
 +          ...(terminationReason
 +            ? {
@@ -1562,19 +1281,11 @@ index a03834ef6..df5d44013 100644
 +              }
 +            : {}),
          },
-       });
-     };
-@@ -1776,6 +1882,7 @@ async function agentCommandInternal(
-               }).enabled,
-               timeoutMs,
+@@ -1778,2 +1884,3 @@ async function agentCommandInternal(
                runId,
 +              runSafety,
                opts,
-               runContext,
-               spawnedBy,
-@@ -2211,6 +2318,12 @@ async function agentCommandInternal(
-         );
-       }
+@@ -2213,2 +2320,8 @@ async function agentCommandInternal(
      }
 +    if (ownedRunSafety) {
 +      runSafetyRegistry.releaseRun({
@@ -1583,43 +1294,27 @@ index a03834ef6..df5d44013 100644
 +      });
 +    }
      clearAgentRunContext(runId);
-   }
- }
 diff --git a/src/agents/agent-tools.before-tool-call.runtime.ts b/src/agents/agent-tools.before-tool-call.runtime.ts
 index 95126670e..be76932fc 100644
 --- a/src/agents/agent-tools.before-tool-call.runtime.ts
 +++ b/src/agents/agent-tools.before-tool-call.runtime.ts
-@@ -2,6 +2,7 @@ import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.j
- import { logToolLoopAction } from "../logging/diagnostic.js";
- import {
+@@ -4,2 +4,3 @@ import {
    detectToolCallLoop,
 +  detectVariantNoProgressLoop,
    recordToolCall,
-   recordToolCallOutcome,
- } from "./tool-loop-detection.js";
-@@ -10,6 +11,7 @@ export const beforeToolCallRuntime = {
-   getDiagnosticSessionState,
-   logToolLoopAction,
+@@ -12,2 +13,3 @@ export const beforeToolCallRuntime = {
    detectToolCallLoop,
 +  detectVariantNoProgressLoop,
    recordToolCall,
-   recordToolCallOutcome,
- };
 diff --git a/src/agents/agent-tools.before-tool-call.ts b/src/agents/agent-tools.before-tool-call.ts
 index 47026d650..c4e023e91 100644
 --- a/src/agents/agent-tools.before-tool-call.ts
 +++ b/src/agents/agent-tools.before-tool-call.ts
-@@ -56,6 +56,7 @@ import {
-   reconcileCodeModeExecBeforeHookParams,
- } from "./code-mode-control-tools.js";
+@@ -58,2 +58,3 @@ import {
  import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 +import { createToolOutcomeFingerprint } from "./tool-loop-detection.js";
  import { normalizeToolName } from "./tool-policy.js";
- import type { AnyAgentTool } from "./tools/common.js";
- import { callGatewayTool } from "./tools/gateway.js";
-@@ -63,7 +64,14 @@ import { callGatewayTool } from "./tools/gateway.js";
- export type ToolOutcomeObservation = {
-   toolName: string;
+@@ -65,3 +66,10 @@ export type ToolOutcomeObservation = {
    argsHash: string;
 +  familyHash?: string;
    resultHash: string;
@@ -1630,11 +1325,7 @@ index 47026d650..c4e023e91 100644
 +    message: string;
 +  };
  };
- 
- export type ToolOutcomeObserver = (observation: ToolOutcomeObservation) => void;
-@@ -746,12 +754,21 @@ async function recordLoopOutcome(args: {
-   result?: unknown;
-   error?: unknown;
+@@ -748,2 +756,11 @@ async function recordLoopOutcome(args: {
  }): Promise<void> {
 +  const recordedOutcome: ToolOutcomeObservation | undefined = createToolOutcomeFingerprint({
 +    toolName: args.toolName,
@@ -1646,7 +1337,7 @@ index 47026d650..c4e023e91 100644
 +    args.ctx?.onToolOutcome?.(recordedOutcome);
 +  }
    if (!args.ctx?.sessionKey && !args.ctx?.sessionId) {
-     return;
+@@ -751,5 +768,5 @@ async function recordLoopOutcome(args: {
    }
 -  let recordedOutcome: ToolOutcomeObservation | undefined;
    try {
@@ -1654,11 +1345,7 @@ index 47026d650..c4e023e91 100644
 +    const { detectVariantNoProgressLoop, getDiagnosticSessionState, recordToolCallOutcome } =
 +      await loadBeforeToolCallRuntime();
      const sessionState = getDiagnosticSessionState({
-       sessionKey: args.ctx.sessionKey,
-       sessionId: args.ctx.sessionId,
-@@ -765,19 +782,25 @@ async function recordLoopOutcome(args: {
-       config: args.ctx.loopDetection,
-       ...(args.ctx.runId && { runId: args.ctx.runId }),
+@@ -767,8 +784,17 @@ async function recordLoopOutcome(args: {
      });
 -    if (record?.resultHash && args.ctx.onToolOutcome) {
 -      recordedOutcome = {
@@ -1682,15 +1369,12 @@ index 47026d650..c4e023e91 100644
 +        };
 +      }
      }
-   } catch (err) {
-     log.warn(`tool loop outcome tracking failed: tool=${args.toolName} error=${String(err)}`);
+@@ -777,5 +803,2 @@ async function recordLoopOutcome(args: {
    }
 -  if (recordedOutcome) {
 -    args.ctx.onToolOutcome?.(recordedOutcome);
 -  }
  }
- 
- export async function runBeforeToolCallHook(args: {
 diff --git a/src/agents/agent-tools.before-tool-call.variant-no-progress.test.ts b/src/agents/agent-tools.before-tool-call.variant-no-progress.test.ts
 new file mode 100644
 index 000000000..d6e1d0f2f
@@ -1817,57 +1501,37 @@ diff --git a/src/agents/agent-tools.ts b/src/agents/agent-tools.ts
 index 22ee934a4..604b8f63d 100644
 --- a/src/agents/agent-tools.ts
 +++ b/src/agents/agent-tools.ts
-@@ -70,6 +70,7 @@ import {
- import type { ModelAuthMode } from "./model-auth.js";
- import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
+@@ -72,2 +72,3 @@ import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js
  import { createOpenClawTools } from "./openclaw-tools.js";
 +import type { RunSafetyContext } from "./run-safety-controller.js";
  import type { SandboxContext } from "./sandbox.js";
- import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./sandbox/constants.js";
- import { resolveSenderToolPolicy } from "./sender-tool-policy.js";
-@@ -518,6 +519,8 @@ export function createOpenClawCodingTools(options?: {
-   toolPolicyAuditLogLevel?: "info" | "debug";
-   /** Live observer called after wrapped tool outcomes are recorded. */
+@@ -520,2 +521,4 @@ export function createOpenClawCodingTools(options?: {
    onToolOutcome?: ToolOutcomeObserver;
 +  /** Trusted host-owned safety scope shared with spawned subagents. */
 +  runSafety?: RunSafetyContext;
    /** Runtime-only resolved skill paths that the read tool may load under workspaceOnly. */
-   skillsSnapshot?: SkillSnapshot;
- }): AnyAgentTool[] {
-@@ -1026,6 +1029,7 @@ export function createOpenClawCodingTools(options?: {
-           senderIsOwner: options?.senderIsOwner,
-           authProfileStore: options?.authProfileStore,
+@@ -1028,2 +1031,3 @@ export function createOpenClawCodingTools(options?: {
            sessionId: options?.sessionId,
 +          runSafety: options?.runSafety,
            inheritedToolAllowlist,
-           inheritedToolDenylist,
-           onYield: options?.onYield,
 diff --git a/src/agents/btw.ts b/src/agents/btw.ts
 index 933d09c64..fbaf867ec 100644
 --- a/src/agents/btw.ts
 +++ b/src/agents/btw.ts
-@@ -36,6 +36,7 @@ import {
- } from "./model-auth.js";
- import { ensureOpenClawModelsJson } from "./models-config.js";
+@@ -38,2 +38,3 @@ import { ensureOpenClawModelsJson } from "./models-config.js";
  import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-routing.js";
 +import { ProviderStreamPurpose } from "./provider-run-safety-contract.js";
  import { registerProviderStreamForModel } from "./provider-stream.js";
- import { stripToolResultDetails } from "./session-transcript-repair.js";
- import { sanitizeImageBlocks } from "./tool-images.js";
-@@ -499,6 +500,7 @@ export async function runBtwSideQuestion(
-     agentDir: params.agentDir,
-     workspaceDir,
+@@ -501,2 +502,3 @@ export async function runBtwSideQuestion(
      env: process.env,
 +    purpose: ProviderStreamPurpose.Utility,
    });
-   const streamFn = resolveEmbeddedAgentStreamFn({
-     currentStreamFn: streamSimple,
 diff --git a/src/agents/cli-runner.run-safety.test.ts b/src/agents/cli-runner.run-safety.test.ts
 new file mode 100644
-index 000000000..f26a680e1
+index 000000000..abd0e2130
 --- /dev/null
 +++ b/src/agents/cli-runner.run-safety.test.ts
-@@ -0,0 +1,226 @@
+@@ -0,0 +1,238 @@
 +import { beforeEach, describe, expect, it } from "vitest";
 +import { runPreparedCliAgent } from "./cli-runner.js";
 +import { createManagedRun, supervisorSpawnMock } from "./cli-runner.test-support.js";
@@ -1888,7 +1552,6 @@ index 000000000..f26a680e1
 +    rootRunId: "run-cli-safety",
 +    limits: {
 +      maxProviderDispatchesPerBudgetScope: maxProviderDispatches,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 1_000_000,
 +    },
 +    onDrained: (reason) => {
 +      coordinator.publishTerminalOnce(reason);
@@ -1980,7 +1643,6 @@ index 000000000..f26a680e1
 +    const prior = runSafety.controller.reserveProviderDispatch({
 +      runId: "run-cli-safety",
 +      providerDispatchId: priorDispatchId,
-+      estimatedPromptTokens: 10,
 +    });
 +    expect(prior.allowed).toBe(true);
 +    runSafety.controller.completeProviderDispatch(priorDispatchId);
@@ -2068,8 +1730,20 @@ index 000000000..f26a680e1
 +    );
 +  });
 +
-+  it("fails closed before spawn when the final CLI payload cannot be estimated", async () => {
++  it("spawns after recording unavailable telemetry when the final CLI payload cannot be estimated", async () => {
 +    const runSafety = createRunSafety(2);
++    supervisorSpawnMock.mockResolvedValueOnce(
++      createManagedRun({
++        reason: "exit",
++        exitCode: 0,
++        exitSignal: null,
++        durationMs: 5,
++        stdout: "ok",
++        stderr: "",
++        timedOut: false,
++        noOutputTimedOut: false,
++      }),
++    );
 +    const opaqueImage = new Proxy(
 +      {
 +        type: "image",
@@ -2087,20 +1761,20 @@ index 000000000..f26a680e1
 +
 +    const result = await runPreparedCliAgent(context);
 +
-+    expect(supervisorSpawnMock).not.toHaveBeenCalled();
-+    expect(result.meta.stopReason).toBe("run_safety");
-+    expect(result.meta.terminationReason?.kind).toBe(
-+      RunSafetyTerminationKind.RunPromptEstimateUnavailable,
-+    );
++    expect(supervisorSpawnMock).toHaveBeenCalledOnce();
++    expect(result.meta.stopReason).not.toBe("run_safety");
++    expect(runSafety.controller.terminationReason).toBeUndefined();
++    expect(runSafety.controller.snapshot().promptExposure).toMatchObject({
++      estimateUnavailableDispatchCount: 1,
++      pendingObservationDispatchCount: 0,
++    });
 +  });
 +});
 diff --git a/src/agents/cli-runner.ts b/src/agents/cli-runner.ts
 index 2d8827d72..8b1403d22 100644
 --- a/src/agents/cli-runner.ts
 +++ b/src/agents/cli-runner.ts
-@@ -6,6 +6,11 @@ import { buildAgentHookContextChannelFields } from "../plugins/hook-agent-contex
- import { resolveBlockMessage } from "../plugins/hook-decision-types.js";
- import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+@@ -8,2 +8,7 @@ import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
  import { cliBackendLog, formatCliBackendOutputDigest } from "./cli-runner/log.js";
 +import {
 +  buildCliRunSafetyBlockedResult,
@@ -2108,30 +1782,18 @@ index 2d8827d72..8b1403d22 100644
 +  isCliRunSafetyGateError,
 +} from "./cli-runner/run-safety.js";
  import {
-   loadCliSessionContextEngineMessages,
-   loadCliSessionHistoryMessages,
-@@ -30,6 +35,7 @@ import {
-   runAgentHarnessLlmInputHook,
-   runAgentHarnessLlmOutputHook,
+@@ -32,2 +37,3 @@ import {
  } from "./harness/lifecycle-hook-helpers.js";
 +import { runSafetyRegistry } from "./run-safety-registry.js";
  import type { AgentMessage } from "./runtime/index.js";
- import { SessionManager } from "./sessions/session-manager.js";
- 
-@@ -281,7 +287,9 @@ async function finalizeCliContextEngineTurn(params: {
-   }
- }
+@@ -283,3 +289,5 @@ async function finalizeCliContextEngineTurn(params: {
  
 -export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
 +async function runCliAgentWithSafetyContext(
 +  params: RunCliAgentParams,
 +): Promise<EmbeddedAgentRunResult> {
    // Cron gate must fire before prepareCliRunContext — that call allocates
-   // backend resources released only by runPreparedCliAgent's try…finally.
-   params.onExecutionStarted?.();
-@@ -351,7 +359,39 @@ export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedAg
-   }
- }
+@@ -353,3 +361,35 @@ export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedAg
  
 -export async function runPreparedCliAgent(
 +export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
@@ -2168,11 +1830,7 @@ index 2d8827d72..8b1403d22 100644
 +
 +async function runPreparedCliAgentWithSafetyContext(
    context: PreparedCliRunContext,
- ): Promise<EmbeddedAgentRunResult> {
-   const { executePreparedCliRun } = await import("./cli-runner/execute.runtime.js");
-@@ -791,6 +831,18 @@ export async function runPreparedCliAgent(
-         context.reusableCliSession.sessionId,
-       );
+@@ -793,2 +833,14 @@ export async function runPreparedCliAgent(
      } catch (err) {
 +      if (isCliRunSafetyGateError(err)) {
 +        params.runSafety?.coordinator.publishTerminalOnce(err.terminationReason);
@@ -2187,11 +1845,7 @@ index 2d8827d72..8b1403d22 100644
 +        });
 +      }
        if (isFailoverError(err)) {
-         const retryableSessionId = context.reusableCliSession.sessionId;
-         if (
-@@ -821,6 +873,18 @@ export async function runPreparedCliAgent(
-             );
-             return await finishCliAttempt(await executeCliAttempt(undefined, retryTimeoutMs));
+@@ -823,2 +875,14 @@ export async function runPreparedCliAgent(
            } catch (retryErr) {
 +            if (isCliRunSafetyGateError(retryErr)) {
 +              params.runSafety?.coordinator.publishTerminalOnce(retryErr.terminationReason);
@@ -2206,11 +1860,7 @@ index 2d8827d72..8b1403d22 100644
 +              });
 +            }
              const retryMessage = formatErrorMessage(retryErr);
-             await runCliAgentEndHook(params, {
-               event: buildFailedAgentEndEvent(retryMessage),
-@@ -850,6 +914,47 @@ export async function runPreparedCliAgent(
-   }
- }
+@@ -852,2 +916,43 @@ export async function runPreparedCliAgent(
  
 +export async function runPreparedCliAgent(
 +  context: PreparedCliRunContext,
@@ -2254,39 +1904,23 @@ index 2d8827d72..8b1403d22 100644
 +}
 +
  export type RunClaudeCliAgentParams = Omit<RunCliAgentParams, "provider" | "cliSessionId"> & {
-   provider?: string;
-   claudeSessionId?: string;
-@@ -872,6 +977,7 @@ export function buildRunClaudeCliAgentParams(params: RunClaudeCliAgentParams): R
-     thinkLevel: params.thinkLevel,
-     timeoutMs: params.timeoutMs,
+@@ -874,2 +979,3 @@ export function buildRunClaudeCliAgentParams(params: RunClaudeCliAgentParams): R
      runId: params.runId,
 +    runSafety: params.runSafety,
      jobId: params.jobId,
-     extraSystemPrompt: params.extraSystemPrompt,
-     inputProvenance: params.inputProvenance,
 diff --git a/src/agents/cli-runner/execute.ts b/src/agents/cli-runner/execute.ts
 index fe061d3fb..7d18bf0ba 100644
 --- a/src/agents/cli-runner/execute.ts
 +++ b/src/agents/cli-runner/execute.ts
-@@ -23,6 +23,7 @@ import { classifyFailoverReason } from "../embedded-agent-helpers.js";
- import { sanitizeToolArgs, sanitizeToolResult } from "../embedded-agent-subscribe.tools.js";
- import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
+@@ -25,2 +25,3 @@ import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
  import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 +import { runSafetyRegistry } from "../run-safety-registry.js";
  import { runClaudeLiveSessionTurn, shouldUseClaudeLiveSession } from "./claude-live-session.js";
- import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
- import {
-@@ -43,6 +44,7 @@ import {
-   formatCliBackendOutputDigest,
-   LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV,
+@@ -45,2 +46,3 @@ import {
  } from "./log.js";
 +import { CliRunSafetyGateError, reserveCliProviderDispatch } from "./run-safety.js";
  import type { PreparedCliRunContext } from "./types.js";
- 
- const executeDeps = {
-@@ -269,6 +271,35 @@ export async function executePreparedCliRun(
-   context: PreparedCliRunContext,
-   cliSessionIdToUse?: string,
+@@ -271,2 +273,31 @@ export async function executePreparedCliRun(
  ): Promise<CliOutput> {
 +  if (!context.params.runSafety) {
 +    const loopDetectionConfig = context.params.config?.tools?.loopDetection;
@@ -2318,19 +1952,11 @@ index fe061d3fb..7d18bf0ba 100644
 +    }
 +  }
    const params = context.params;
-   if (params.abortSignal?.aborted) {
-     throw createCliAbortError();
-@@ -376,6 +407,7 @@ export async function executePreparedCliRun(
-             config: params.config,
-           })
+@@ -378,2 +409,3 @@ export async function executePreparedCliRun(
          : undefined;
 +      let runSafetyReservation: ReturnType<typeof reserveCliProviderDispatch> | undefined;
        try {
-         cliBackendLog.info(
-           buildCliExecLogLine({
-@@ -486,6 +518,13 @@ export async function executePreparedCliRun(
-             },
-           });
+@@ -488,2 +520,9 @@ export async function executePreparedCliRun(
          };
 +        runSafetyReservation = reserveCliProviderDispatch({
 +          context,
@@ -2340,25 +1966,19 @@ index fe061d3fb..7d18bf0ba 100644
 +          useResume,
 +        });
          if (shouldUseClaudeLiveSession(context)) {
-           if (!hasJsonlOutput) {
-             throw new Error("Claude live session requires JSONL streaming parser");
-@@ -826,6 +865,7 @@ export async function executePreparedCliRun(
-           ),
-         };
+@@ -828,2 +867,3 @@ export async function executePreparedCliRun(
        } finally {
 +        runSafetyReservation?.complete();
          restoreSkillEnv?.();
-       }
-     });
 diff --git a/src/agents/cli-runner/run-safety.ts b/src/agents/cli-runner/run-safety.ts
 new file mode 100644
-index 000000000..c8f0d9e48
+index 000000000..4c4410bfe
 --- /dev/null
 +++ b/src/agents/cli-runner/run-safety.ts
-@@ -0,0 +1,196 @@
+@@ -0,0 +1,191 @@
 +import type { EmbeddedAgentRunResult } from "../embedded-agent-runner/types.js";
 +import {
-+  estimateRunSafetyPromptTokens,
++  estimateRunSafetyPromptObservation,
 +  type RunSafetyTermination,
 +  RunSafetyTerminationKind,
 +} from "../run-safety-controller.js";
@@ -2389,7 +2009,7 @@ index 000000000..c8f0d9e48
 + * The prompt is supplied after CLI input transforms and image materialization,
 + * immediately before the live-session turn or child-process spawn. Native CLI
 + * tool calls remain opaque to the host, so this gate intentionally covers only
-+ * provider dispatch count and prompt exposure, not raw tool reservations.
++ * provider dispatch count and prompt observation, not raw tool reservations.
 + */
 +export function reserveCliProviderDispatch(params: {
 +  context: PreparedCliRunContext;
@@ -2409,7 +2029,22 @@ index 000000000..c8f0d9e48
 +  }
 +
 +  const providerDispatchId = runSafety.controller.createProviderDispatchId(runParams.runId);
-+  const estimate = estimateRunSafetyPromptTokens(
++  const reservation = runSafety.controller.reserveProviderDispatch({
++    runId: runParams.runId,
++    providerDispatchId,
++  });
++  if (!reservation.allowed) {
++    const reason =
++      reservation.reason ??
++      runSafety.controller.tryTerminate({
++        kind: RunSafetyTerminationKind.RunSafetyStateUnavailable,
++        runId: runParams.runId,
++      });
++    runSafety.coordinator.publishTerminalOnce(reason);
++    throw new CliRunSafetyGateError(reason);
++  }
++
++  const observation = estimateRunSafetyPromptObservation(
 +    {
 +      harness: "cli",
 +      provider: runParams.provider,
@@ -2424,30 +2059,10 @@ index 000000000..c8f0d9e48
 +      ? { contextWindow: params.context.contextWindowInfo.tokens }
 +      : undefined,
 +  );
-+  if (!estimate.ok) {
-+    const reason = runSafety.controller.tryTerminate({
-+      kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable,
-+      runId: runParams.runId,
-+    });
-+    runSafety.coordinator.publishTerminalOnce(reason);
-+    throw new CliRunSafetyGateError(reason);
-+  }
-+
-+  const reservation = runSafety.controller.reserveProviderDispatch({
-+    runId: runParams.runId,
++  runSafety.controller.observeProviderPromptEstimate({
 +    providerDispatchId,
-+    estimatedPromptTokens: estimate.estimatedPromptTokens,
++    observation,
 +  });
-+  if (!reservation.allowed) {
-+    const reason =
-+      reservation.reason ??
-+      runSafety.controller.tryTerminate({
-+        kind: RunSafetyTerminationKind.RunSafetyStateUnavailable,
-+        runId: runParams.runId,
-+      });
-+    runSafety.coordinator.publishTerminalOnce(reason);
-+    throw new CliRunSafetyGateError(reason);
-+  }
 +
 +  let completed = false;
 +  return {
@@ -2556,17 +2171,11 @@ diff --git a/src/agents/cli-runner/types.ts b/src/agents/cli-runner/types.ts
 index ec28d4631..3c87feabc 100644
 --- a/src/agents/cli-runner/types.ts
 +++ b/src/agents/cli-runner/types.ts
-@@ -24,6 +24,7 @@ import type {
-   CurrentInboundPromptContext,
-   EmbeddedRunTrigger,
+@@ -26,2 +26,3 @@ import type {
  } from "../embedded-agent-runner/run/params.js";
 +import type { RunSafetyContext } from "../run-safety-controller.js";
  import type { SilentReplyPromptMode } from "../system-prompt.types.js";
- 
- export type RunCliAgentParams = {
-@@ -50,6 +51,11 @@ export type RunCliAgentParams = {
-   thinkLevel?: ThinkLevel;
-   timeoutMs: number;
+@@ -52,2 +53,7 @@ export type RunCliAgentParams = {
    runId: string;
 +  /**
 +   * Host-owned invocation safety state. All CLI recovery/model fallback
@@ -2574,74 +2183,46 @@ index ec28d4631..3c87feabc 100644
 +   */
 +  runSafety?: RunSafetyContext;
    lane?: string;
-   jobId?: string;
-   extraSystemPrompt?: string;
 diff --git a/src/agents/command/attempt-execution.ts b/src/agents/command/attempt-execution.ts
 index b8abaae96..75a7e76f0 100644
 --- a/src/agents/command/attempt-execution.ts
 +++ b/src/agents/command/attempt-execution.ts
-@@ -40,6 +40,7 @@ import { resolveAvailableAgentHarnessPolicy } from "../harness/selection.js";
- import { resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js";
- import { isCliProvider } from "../model-selection.js";
+@@ -42,2 +42,3 @@ import { isCliProvider } from "../model-selection.js";
  import { resolveOpenAIRuntimeProvider } from "../openai-routing.js";
 +import type { RunSafetyContext } from "../run-safety-controller.js";
  import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
- import type { AgentMessage } from "../runtime/index.js";
- import { acquireSessionWriteLock, resolveSessionWriteLockOptions } from "../session-write-lock.js";
-@@ -412,6 +413,7 @@ export function runAgentAttempt(params: {
-   fastMode?: boolean;
-   timeoutMs: number;
+@@ -414,2 +415,3 @@ export function runAgentAttempt(params: {
    runId: string;
 +  runSafety?: RunSafetyContext;
    opts: AgentCommandOpts;
-   runContext: ReturnType<typeof resolveAgentRunContext>;
-   spawnedBy: string | undefined;
-@@ -582,6 +584,7 @@ export function runAgentAttempt(params: {
-         thinkLevel: params.resolvedThinkLevel,
-         timeoutMs: params.timeoutMs,
+@@ -584,2 +586,3 @@ export function runAgentAttempt(params: {
          runId: params.runId,
 +        runSafety: params.runSafety,
          extraSystemPrompt: params.opts.extraSystemPrompt,
-         inputProvenance: params.opts.inputProvenance,
-         cliSessionId: nextCliSessionId,
-@@ -694,6 +697,7 @@ export function runAgentAttempt(params: {
-     bashElevated: params.opts.bashElevated,
-     timeoutMs: params.timeoutMs,
+@@ -696,2 +699,3 @@ export function runAgentAttempt(params: {
      runId: params.runId,
 +    runSafety: params.runSafety,
      lane: params.opts.lane,
-     abortSignal: params.opts.abortSignal,
-     extraSystemPrompt: params.opts.extraSystemPrompt,
 diff --git a/src/agents/command/types.ts b/src/agents/command/types.ts
 index d9b1b8ad6..8f8c3f29e 100644
 --- a/src/agents/command/types.ts
 +++ b/src/agents/command/types.ts
-@@ -6,6 +6,7 @@ import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.pub
- import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
- import type { InputProvenance } from "../../sessions/input-provenance.js";
+@@ -8,2 +8,3 @@ import type { InputProvenance } from "../../sessions/input-provenance.js";
  import type { ExecElevatedDefaults } from "../bash-tools.exec-types.js";
 +import type { RunSafetyContext, RunSafetyTermination } from "../run-safety-controller.js";
  import type { AgentStreamParams, ClientToolDefinition } from "./shared-types.js";
- 
- /** Image content block for Claude API multimodal messages. */
-@@ -100,6 +101,10 @@ export type AgentCommandOpts = {
-   abortSignal?: AbortSignal;
-   lane?: string;
+@@ -102,2 +103,6 @@ export type AgentCommandOpts = {
    runId?: string;
 +  /** Trusted inherited safety scope for gateway-backed child/recovery runs. */
 +  runSafety?: RunSafetyContext;
 +  /** Delivery-owned route retained for a terminal raised after the root stack returns. */
 +  onRunSafetyTerminal?: (reason: RunSafetyTermination) => Promise<void> | void;
    extraSystemPrompt?: string;
-   /** Bootstrap workspace context injection mode for this run. */
-   bootstrapContextMode?: "full" | "lightweight";
 diff --git a/src/agents/custom-api-registry.test.ts b/src/agents/custom-api-registry.test.ts
 index f1bee168a..a370924b5 100644
 --- a/src/agents/custom-api-registry.test.ts
 +++ b/src/agents/custom-api-registry.test.ts
-@@ -11,6 +11,11 @@ import {
- } from "../llm/providers/register-builtins.js";
- import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
+@@ -13,2 +13,7 @@ import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js"
  import { ensureCustomApiRegistered, getCustomApiRegistrySourceId } from "./custom-api-registry.js";
 +import {
 +  createProviderRunSafetyStreamFnV1,
@@ -2649,11 +2230,7 @@ index f1bee168a..a370924b5 100644
 +  ProviderStreamPurpose,
 +} from "./provider-run-safety-contract.js";
  
- function getRegisteredTestProvider() {
-   const provider = getApiProvider("test-custom-api");
-@@ -75,4 +80,45 @@ describe("ensureCustomApiRegistered", () => {
- 
-     unregisterApiProviders(sourceId);
+@@ -77,2 +82,43 @@ describe("ensureCustomApiRegistered", () => {
    });
 +
 +  it("rejects an unversioned Agent stream before it can be registered or invoked", () => {
@@ -2701,8 +2278,7 @@ diff --git a/src/agents/custom-api-registry.ts b/src/agents/custom-api-registry.
 index 04085e27d..e1d2e7a6c 100644
 --- a/src/agents/custom-api-registry.ts
 +++ b/src/agents/custom-api-registry.ts
-@@ -1,31 +1,96 @@
- import { getApiProvider, registerApiProvider } from "../llm/api-registry.js";
+@@ -2,2 +2,8 @@ import { getApiProvider, registerApiProvider } from "../llm/api-registry.js";
  import type { Api, StreamOptions } from "../llm/types.js";
 +import {
 +  isProviderRunSafetyStreamFnV1,
@@ -2711,8 +2287,7 @@ index 04085e27d..e1d2e7a6c 100644
 +  unwrapProviderRunSafetyStreamFnV1,
 +} from "./provider-run-safety-contract.js";
  import type { StreamFn } from "./runtime/index.js";
- 
- const CUSTOM_API_SOURCE_PREFIX = "openclaw-custom-api:";
+@@ -6,2 +12,9 @@ const CUSTOM_API_SOURCE_PREFIX = "openclaw-custom-api:";
  
 +type CustomApiRegistration = {
 +  agentStreamFn?: StreamFn;
@@ -2722,8 +2297,7 @@ index 04085e27d..e1d2e7a6c 100644
 +const customApiRegistrations = new Map<Api, CustomApiRegistration>();
 +
  export function getCustomApiRegistrySourceId(api: Api): string {
-   return `${CUSTOM_API_SOURCE_PREFIX}${api}`;
- }
+@@ -10,7 +23,4 @@ export function getCustomApiRegistrySourceId(api: Api): string {
  
 -export function ensureCustomApiRegistered(api: Api, streamFn: StreamFn): boolean {
 -  if (getApiProvider(api)) {
@@ -2733,13 +2307,12 @@ index 04085e27d..e1d2e7a6c 100644
 +function registerCustomApi(api: Api, registration: CustomApiRegistration): void {
 +  const agentStreamFn = registration.agentStreamFn ?? registration.utilityStreamFn;
    registerApiProvider(
-     {
-       api,
+@@ -19,3 +29,3 @@ export function ensureCustomApiRegistered(api: Api, streamFn: StreamFn): boolean
        stream: (model, context, options) =>
 -        streamFn(model, context, options) as unknown as ReturnType<
 +        agentStreamFn(model, context, options) as unknown as ReturnType<
            NonNullable<ReturnType<typeof getApiProvider>>["stream"]
-         >,
+@@ -23,5 +33,7 @@ export function ensureCustomApiRegistered(api: Api, streamFn: StreamFn): boolean
        streamSimple: (model, context, options) =>
 -        streamFn(model, context, options as StreamOptions) as unknown as ReturnType<
 -          NonNullable<ReturnType<typeof getApiProvider>>["stream"]
@@ -2750,7 +2323,7 @@ index 04085e27d..e1d2e7a6c 100644
 +          options as StreamOptions,
 +        ) as unknown as ReturnType<NonNullable<ReturnType<typeof getApiProvider>>["stream"]>,
      },
-     getCustomApiRegistrySourceId(api),
+@@ -29,2 +41,55 @@ export function ensureCustomApiRegistered(api: Api, streamFn: StreamFn): boolean
    );
 +}
 +
@@ -2806,22 +2379,15 @@ index 04085e27d..e1d2e7a6c 100644
 +  customApiRegistrations.set(api, registration);
 +  registerCustomApi(api, registration);
    return true;
- }
 diff --git a/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts b/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
 index 2d7d820ec..6516fbac1 100644
 --- a/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
 +++ b/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
-@@ -6,6 +6,7 @@ import {
-   EMBEDDED_COMPACTION_TIMEOUT_MS,
-   resolveCompactionTimeoutMs,
+@@ -8,2 +8,3 @@ import {
  } from "./embedded-agent-runner/compaction-safety-timeout.js";
 +import { RunSafetyController, RunSafetyRootCoordinator } from "./run-safety-controller.js";
  
- describe("compactWithSafetyTimeout", () => {
-   beforeEach(() => {
-@@ -289,4 +290,119 @@ describe("compactContextEngineWithSafetyTimeout", () => {
-       error,
-     );
+@@ -291,2 +292,117 @@ describe("compactContextEngineWithSafetyTimeout", () => {
    });
 +
 +  it("rejects an unversioned compaction owner before calling plugin compact()", async () => {
@@ -2940,10 +2506,10 @@ index 2d7d820ec..6516fbac1 100644
 +  });
  });
 diff --git a/src/agents/embedded-agent-runner/compact.hooks.test.ts b/src/agents/embedded-agent-runner/compact.hooks.test.ts
-index 6a898ec79..95e927315 100644
+index 6a898ec79..e7aa12ea0 100644
 --- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
 +++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
-@@ -1,5 +1,15 @@
+@@ -1,3 +1,13 @@
  import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 +import {
 +  createAssistantMessageEventStream,
@@ -2957,11 +2523,7 @@ index 6a898ec79..95e927315 100644
 +  RunSafetyTerminationKind,
 +} from "../run-safety-controller.js";
  import {
-   applyExtraParamsToAgentMock,
-   applyAgentCompactionSettingsFromConfigMock,
-@@ -336,6 +346,11 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
-   });
- 
+@@ -338,2 +348,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
    it("routes compaction through shared stream resolution and extra params", () => {
 +    const coordinator = new RunSafetyRootCoordinator("root-compaction-resolution");
 +    const controller = new RunSafetyController({
@@ -2969,31 +2531,19 @@ index 6a898ec79..95e927315 100644
 +      rootRunId: "run-compaction-resolution",
 +    });
      const resolvedStreamFn = vi.fn();
-     resolveEmbeddedAgentStreamFnMock.mockReturnValue(resolvedStreamFn);
-     applyExtraParamsToAgentMock.mockReturnValue({
-@@ -363,6 +378,8 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
-       sessionAgentId: "main",
-       effectiveWorkspace: "/tmp/workspace",
+@@ -365,2 +380,4 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
        agentDir: "/tmp/workspace",
 +      runId: "run-compaction-resolution",
 +      runSafety: { coordinator, controller },
        runtimePlan: {
-         auth: { forwardedAuthProfileId: "openai:profile-1" },
-         transport: { resolveExtraParams: vi.fn(() => undefined) },
-@@ -374,7 +391,9 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
-     expect(streamArg.sessionId).toBe("session-1");
-     expect(streamArg.authProfileId).toBe("openai:profile-1");
+@@ -376,3 +393,5 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
      expect(applyExtraParamsToAgentMock).toHaveBeenCalledWith(
 -      expectRecordFields(mockCallArg(applyExtraParamsToAgentMock), { streamFn: resolvedStreamFn }),
 +      expectRecordFields(mockCallArg(applyExtraParamsToAgentMock), {
 +        streamFn: expect.any(Function),
 +      }),
        undefined,
-       "openai",
-       "gpt-5.4",
-@@ -393,6 +412,106 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
-     );
-   });
+@@ -395,2 +414,101 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
  
 +  it("shares the run-safety provider budget with compaction stream calls", async () => {
 +    const coordinator = new RunSafetyRootCoordinator("root-compaction");
@@ -3002,7 +2552,6 @@ index 6a898ec79..95e927315 100644
 +      rootRunId: "run-compaction",
 +      limits: {
 +        maxProviderDispatchesPerBudgetScope: 1,
-+        maxCumulativeEstimatedPromptTokensPerBudgetScope: 10_000,
 +      },
 +    });
 +    const resolvedStreamFn = vi.fn(
@@ -3096,23 +2645,15 @@ index 6a898ec79..95e927315 100644
 +  });
 +
    it("preserves full sender identity when building compaction tools", async () => {
-     await compactEmbeddedAgentSessionDirect({
-       sessionId: "session-1",
 diff --git a/src/agents/embedded-agent-runner/compact.queued.ts b/src/agents/embedded-agent-runner/compact.queued.ts
 index e0e836cd9..2026ceb47 100644
 --- a/src/agents/embedded-agent-runner/compact.queued.ts
 +++ b/src/agents/embedded-agent-runner/compact.queued.ts
-@@ -27,6 +27,7 @@ import { maybeCompactAgentHarnessSession } from "../harness/compaction.js";
- import { resolveAgentHarnessPolicy } from "../harness/policy.js";
- import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
+@@ -29,2 +29,3 @@ import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
  import { isOpenAIProvider } from "../openai-routing.js";
 +import { runSafetyRegistry } from "../run-safety-registry.js";
  import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
- import { DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON } from "./compact-reasons.js";
- import type { CompactEmbeddedAgentSessionParams } from "./compact.types.js";
-@@ -153,6 +154,39 @@ async function deferOwningContextEngineBudgetCompaction(params: {
- export async function compactEmbeddedAgentSession(
-   params: CompactEmbeddedAgentSessionParams,
+@@ -155,2 +156,35 @@ export async function compactEmbeddedAgentSession(
  ): Promise<EmbeddedAgentCompactResult> {
 +  if (!params.runSafety) {
 +    const runId = params.runId ?? params.sessionId;
@@ -3148,50 +2689,30 @@ index e0e836cd9..2026ceb47 100644
 +    }
 +  }
    ensureRuntimePluginsLoaded({
-     config: params.config,
-     workspaceDir: params.workspaceDir,
 diff --git a/src/agents/embedded-agent-runner/compact.ts b/src/agents/embedded-agent-runner/compact.ts
 index d12ad028a..e693e8317 100644
 --- a/src/agents/embedded-agent-runner/compact.ts
 +++ b/src/agents/embedded-agent-runner/compact.ts
-@@ -95,6 +95,8 @@ import { ensureOpenClawModelsJson } from "../models-config.js";
- import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
- import { resolveAgentPromptSurfaceForSessionKey } from "../prompt-surface.js";
+@@ -97,2 +97,4 @@ import { resolveAgentPromptSurfaceForSessionKey } from "../prompt-surface.js";
  import { registerProviderStreamForModel } from "../provider-stream.js";
 +import type { RunSafetyContext } from "../run-safety-controller.js";
 +import { runSafetyRegistry } from "../run-safety-registry.js";
  import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
- import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
- import type { AgentRuntimePlan } from "../runtime-plan/types.js";
-@@ -156,6 +158,7 @@ import { resolveModelAsync } from "./model.js";
- import { sanitizeSessionHistory, validateReplayTurns } from "./replay-history.js";
- import { createEmbeddedAgentResourceLoader } from "./resource-loader.js";
+@@ -158,2 +160,3 @@ import { createEmbeddedAgentResourceLoader } from "./resource-loader.js";
  import { resolveAttemptSpawnWorkspaceDir } from "./run/attempt.thread-helpers.js";
 +import { wrapStreamFnWithRunSafety } from "./run/run-safety-gate.js";
  import { buildEmbeddedSandboxInfo, resolveEmbeddedSandboxInfoExecPolicy } from "./sandbox-info.js";
- import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
- import {
-@@ -203,6 +206,8 @@ function prepareCompactionSessionAgent(params: {
-   effectiveWorkspace: string;
-   agentDir: string;
+@@ -205,2 +208,4 @@ function prepareCompactionSessionAgent(params: {
    runtimePlan?: AgentRuntimePlan;
 +  runId?: string;
 +  runSafety: RunSafetyContext;
  }) {
-   params.session.agent.streamFn = resolveEmbeddedAgentStreamFn({
-     currentStreamFn: resolveEmbeddedAgentBaseStreamFn({ session: params.session as never }),
-@@ -233,7 +238,7 @@ function prepareCompactionSessionAgent(params: {
-     workspaceDir: params.effectiveWorkspace,
-     model: params.effectiveModel,
+@@ -235,3 +240,3 @@ function prepareCompactionSessionAgent(params: {
    });
 -  return applyExtraParamsToAgent(
 +  const appliedExtraParams = applyExtraParamsToAgent(
      params.session.agent as never,
-     params.config,
-     params.provider,
-@@ -247,6 +252,13 @@ function prepareCompactionSessionAgent(params: {
-     undefined,
-     preparedRuntimeExtraParams ? { preparedExtraParams: preparedRuntimeExtraParams } : undefined,
+@@ -249,2 +254,9 @@ function prepareCompactionSessionAgent(params: {
    );
 +  const runId = params.runId ?? params.sessionId;
 +  params.session.agent.streamFn = wrapStreamFnWithRunSafety({
@@ -3201,33 +2722,21 @@ index d12ad028a..e693e8317 100644
 +  });
 +  return appliedExtraParams;
  }
- 
- function resolveCompactionProviderStream(params: {
-@@ -416,8 +428,8 @@ function fallbackFailureToCompactionResult(err: unknown): EmbeddedAgentCompactRe
-  * Core compaction logic without lane queueing.
-  * Use this when already inside a session/global lane to avoid deadlocks.
+@@ -418,4 +430,4 @@ function fallbackFailureToCompactionResult(err: unknown): EmbeddedAgentCompactRe
   */
 -export async function compactEmbeddedAgentSessionDirect(
 -  params: CompactEmbeddedAgentSessionParams,
 +async function compactEmbeddedAgentSessionDirectWithSafetyContext(
 +  params: CompactEmbeddedAgentSessionParams & { runSafety: RunSafetyContext },
  ): Promise<EmbeddedAgentCompactResult> {
-   if (hasExplicitCompactionModel(params) || !hasCompactionModelFallbackCandidates(params)) {
-     return await compactEmbeddedAgentSessionDirectOnce(params);
-@@ -463,7 +475,9 @@ export async function compactEmbeddedAgentSessionDirect(
-       },
-       fallbacksOverride,
+@@ -465,3 +477,5 @@ export async function compactEmbeddedAgentSessionDirect(
        classifyResult: ({ result, provider, model }) =>
 -        classifyCompactionFallbackResult(result, provider, model),
 +        params.runSafety.controller.terminationReason
 +          ? null
 +          : classifyCompactionFallbackResult(result, provider, model),
        run: async (provider, model) => {
-         const preservesPrimaryAuth =
-           provider === primaryProvider || provider === requestedPrimaryProvider;
-@@ -482,8 +496,49 @@ export async function compactEmbeddedAgentSessionDirect(
-   }
- }
+@@ -484,4 +498,45 @@ export async function compactEmbeddedAgentSessionDirect(
  
 -async function compactEmbeddedAgentSessionDirectOnce(
 +export async function compactEmbeddedAgentSessionDirect(
@@ -3274,42 +2783,29 @@ index d12ad028a..e693e8317 100644
 +async function compactEmbeddedAgentSessionDirectOnce(
 +  params: CompactEmbeddedAgentSessionParams & { runSafety: RunSafetyContext },
  ): Promise<EmbeddedAgentCompactResult> {
-   const startedAt = Date.now();
-   const diagId = params.diagId?.trim() || createCompactionDiagId();
-@@ -1235,6 +1290,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
-             effectiveWorkspace,
-             agentDir,
+@@ -1237,2 +1292,4 @@ async function compactEmbeddedAgentSessionDirectOnce(
              runtimePlan,
 +            runId,
 +            runSafety: params.runSafety,
            });
- 
-           const prior = await sanitizeSessionHistory({
 diff --git a/src/agents/embedded-agent-runner/compact.types.ts b/src/agents/embedded-agent-runner/compact.types.ts
 index 7dad8233a..82b2c477e 100644
 --- a/src/agents/embedded-agent-runner/compact.types.ts
 +++ b/src/agents/embedded-agent-runner/compact.types.ts
-@@ -5,11 +5,14 @@ import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-e
- import type { CommandQueueEnqueueFn } from "../../process/command-queue.types.js";
- import type { SkillSnapshot } from "../../skills/types.js";
+@@ -7,2 +7,3 @@ import type { SkillSnapshot } from "../../skills/types.js";
  import type { ExecElevatedDefaults, ExecToolDefaults } from "../bash-tools.exec-types.js";
 +import type { RunSafetyContext } from "../run-safety-controller.js";
  import type { AgentRuntimePlan } from "../runtime-plan/types.js";
- 
- export type CompactEmbeddedAgentSessionParams = {
-   sessionId: string;
+@@ -12,2 +13,4 @@ export type CompactEmbeddedAgentSessionParams = {
    runId?: string;
 +  /** Trusted host-owned safety scope shared with the parent run or compaction fallbacks. */
 +  runSafety?: RunSafetyContext;
    sessionKey?: string;
-   /** Caller-resolved owner agent for global session aliases. */
-   agentId?: string;
 diff --git a/src/agents/embedded-agent-runner/compaction-safety-timeout.ts b/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
 index 24060db03..c2ed83bf0 100644
 --- a/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
 +++ b/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
-@@ -1,6 +1,15 @@
- import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
+@@ -2,3 +2,12 @@ import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-co
  import type { OpenClawConfig } from "../../config/types.openclaw.js";
 -import type { CompactResult, ContextEngine } from "../../context-engine/types.js";
 +import {
@@ -3323,11 +2819,7 @@ index 24060db03..c2ed83bf0 100644
 +  ContextEngineCompactParams,
 +} from "../../context-engine/types.js";
  import { withTimeout } from "../../node-host/with-timeout.js";
- 
- export const EMBEDDED_COMPACTION_TIMEOUT_MS = 900_000;
-@@ -133,8 +142,9 @@ export async function compactWithSafetyTimeout<T>(
-   );
- }
+@@ -135,4 +144,5 @@ export async function compactWithSafetyTimeout<T>(
  
 -/** Parameters for a single {@link ContextEngine.compact} invocation. */
 -export type ContextEngineCompactParams = Parameters<ContextEngine["compact"]>[0];
@@ -3335,17 +2827,12 @@ index 24060db03..c2ed83bf0 100644
 +type BoundedContextEngine = Pick<ContextEngine, "compact"> &
 +  Partial<Pick<ContextEngine, "info" | "runSafetyCompactionV1">>;
  
- /**
-  * Invoke a plugin-owned {@link ContextEngine.compact} bounded by the same
-@@ -157,11 +167,41 @@ export type ContextEngineCompactParams = Parameters<ContextEngine["compact"]>[0]
-  * thrown error, never a silent hang.
-  */
+@@ -159,3 +169,3 @@ export type ContextEngineCompactParams = Parameters<ContextEngine["compact"]>[0]
  export function compactContextEngineWithSafetyTimeout(
 -  contextEngine: Pick<ContextEngine, "compact">,
 +  contextEngine: BoundedContextEngine,
    params: ContextEngineCompactParams,
-   timeoutMs: number = EMBEDDED_COMPACTION_TIMEOUT_MS,
-   abortSignal?: AbortSignal,
+@@ -164,2 +174,32 @@ export function compactContextEngineWithSafetyTimeout(
  ): Promise<CompactResult> {
 +  const ownerContract =
 +    contextEngine.info?.ownsCompaction === true ? contextEngine.runSafetyCompactionV1 : undefined;
@@ -3378,15 +2865,11 @@ index 24060db03..c2ed83bf0 100644
 +    );
 +  }
    return compactWithSafetyTimeout(
-     (compactAbortSignal) =>
-       contextEngine.compact(
 diff --git a/src/agents/embedded-agent-runner/google-prompt-cache.test.ts b/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
 index f9b87ac8b..1de840d88 100644
 --- a/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
 +++ b/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
-@@ -144,6 +144,36 @@ function preparePromptCacheStream(params: {
- }
- 
+@@ -146,2 +146,32 @@ function preparePromptCacheStream(params: {
  describe("google prompt cache", () => {
 +  it("disables managed cache network side effects for run-safety Agent scopes", async () => {
 +    const fetchMock = createCacheFetchMock({
@@ -3419,43 +2902,29 @@ index f9b87ac8b..1de840d88 100644
 +  });
 +
    it("creates cached content from the system prompt and strips that prompt from live requests", async () => {
-     const now = 1_000_000;
-     const expireTime = new Date(now + 3_600_000).toISOString();
 diff --git a/src/agents/embedded-agent-runner/google-prompt-cache.ts b/src/agents/embedded-agent-runner/google-prompt-cache.ts
 index f3d7871a7..78c26f8c6 100644
 --- a/src/agents/embedded-agent-runner/google-prompt-cache.ts
 +++ b/src/agents/embedded-agent-runner/google-prompt-cache.ts
-@@ -63,6 +63,7 @@ type GooglePromptCacheEntry = {
- );
- 
+@@ -65,2 +65,3 @@ type GooglePromptCacheEntry = {
  type PrepareGooglePromptCacheStreamFnParams = {
 +  allowManagedSideEffects?: boolean;
    apiKey?: string;
-   extraParams?: Record<string, unknown>;
-   model: GooglePromptCacheModel;
-@@ -459,6 +460,9 @@ export async function prepareGooglePromptCacheStreamFn(
-   if (!params.streamFn) {
-     return undefined;
+@@ -461,2 +462,5 @@ export async function prepareGooglePromptCacheStreamFn(
    }
 +  if (params.allowManagedSideEffects === false) {
 +    return undefined;
 +  }
    if (resolveExplicitCachedContent(params.extraParams)) {
-     return undefined;
-   }
 diff --git a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
 index e0c51525f..bc635fef6 100644
 --- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
 +++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
-@@ -1,4 +1,5 @@
+@@ -1,2 +1,3 @@
  import { describe, expect, it } from "vitest";
 +import { RunSafetyTerminationKind } from "../run-safety-controller.js";
  import { classifyEmbeddedAgentRunResultForModelFallback } from "./result-fallback-classifier.js";
- 
- describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
-@@ -70,6 +71,27 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
-     expect(result).toBeNull();
-   });
+@@ -72,2 +73,23 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
  
 +  it("never falls back after a typed local run-safety terminal", () => {
 +    const result = classifyEmbeddedAgentRunResultForModelFallback({
@@ -3479,22 +2948,16 @@ index e0c51525f..bc635fef6 100644
 +  });
 +
    it("uses provider-scoped failover matching for business-denial payloads", () => {
-     const result = classifyEmbeddedAgentRunResultForModelFallback({
-       provider: "openrouter",
 diff --git a/src/agents/embedded-agent-runner/result-fallback-classifier.ts b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
 index 6fc29cf19..728184473 100644
 --- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
 +++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
-@@ -85,6 +85,9 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
-   if (!isEmbeddedAgentRunResult(params.result)) {
-     return null;
+@@ -87,2 +87,5 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
    }
 +  if (params.result.meta.terminationReason) {
 +    return null;
 +  }
    if (
-     params.result.meta.aborted ||
-     params.hasDirectlySentBlockReply === true ||
 diff --git a/src/agents/embedded-agent-runner/run.run-safety.test.ts b/src/agents/embedded-agent-runner/run.run-safety.test.ts
 new file mode 100644
 index 000000000..d2d1cbaed
@@ -3575,9 +3038,7 @@ diff --git a/src/agents/embedded-agent-runner/run.ts b/src/agents/embedded-agent
 index ebdf0f90f..a0bc6f070 100644
 --- a/src/agents/embedded-agent-runner/run.ts
 +++ b/src/agents/embedded-agent-runner/run.ts
-@@ -11,7 +11,11 @@ import {
-   resolveContextEngine,
-   resolveContextEngineOwnerPluginId,
+@@ -13,3 +13,7 @@ import {
  } from "../../context-engine/registry.js";
 -import { emitAgentPlanEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 +import {
@@ -3586,37 +3047,21 @@ index ebdf0f90f..a0bc6f070 100644
 +  registerAgentRunContext,
 +} from "../../infra/agent-events.js";
  import { sleepWithAbort } from "../../infra/backoff.js";
- import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
- import { formatErrorMessage } from "../../infra/errors.js";
-@@ -33,6 +37,7 @@ import {
-   resolveSessionAgentIds,
-   resolveAgentWorkspaceDir,
+@@ -35,2 +39,3 @@ import {
  } from "../agent-scope.js";
 +import type { ToolOutcomeObservation } from "../agent-tools.before-tool-call.js";
  import { resolveProcessToolScopeKey } from "../agent-tools.js";
- import {
-   type AuthProfileFailureReason,
-@@ -94,6 +99,8 @@ import {
- } from "../openai-routing.js";
- import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
+@@ -96,2 +101,4 @@ import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
  import { runAgentCleanupStep } from "../run-cleanup-timeout.js";
 +import type { RunSafetyTermination } from "../run-safety-controller.js";
 +import { runSafetyRegistry } from "../run-safety-registry.js";
  import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
- import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
- import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
-@@ -177,7 +184,7 @@ import {
-   shouldRetryMissingAssistantTurn,
-   shouldTreatEmptyAssistantReplyAsSilent,
+@@ -179,3 +186,3 @@ import {
  } from "./run/incomplete-turn.js";
 -import type { RunEmbeddedAgentParams } from "./run/params.js";
 +import type { RunEmbeddedAgentParams, RunSafetyContext } from "./run/params.js";
  import { buildEmbeddedRunPayloads } from "./run/payloads.js";
- import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
- import {
-@@ -462,10 +469,10 @@ function buildHandledReplyPayloads(reply?: ReplyPayload) {
-   ];
- }
+@@ -464,6 +471,6 @@ function buildHandledReplyPayloads(reply?: ReplyPayload) {
  
 -export async function runEmbeddedAgent(
 -  paramsInput: RunEmbeddedAgentParams,
@@ -3626,11 +3071,7 @@ index ebdf0f90f..a0bc6f070 100644
 -  let params = paramsInput;
 +  let params: RunEmbeddedAgentParams & { runSafety: RunSafetyContext } = paramsInput;
    // Resolve sessionKey early so all downstream consumers (hooks, LCM, compaction)
-   // receive a non-null key even when callers omit it. See #60552.
-   const effectiveSessionKey = backfillSessionKey({
-@@ -1210,6 +1217,16 @@ export async function runEmbeddedAgent(
-           postCompactionAbortController?.abort(postCompactionAbortError);
-         }
+@@ -1212,2 +1219,12 @@ export async function runEmbeddedAgent(
        };
 +      const observeToolOutcome = (observation: ToolOutcomeObservation): void => {
 +        params.runSafety?.controller.recordToolOutcome({
@@ -3643,28 +3084,16 @@ index ebdf0f90f..a0bc6f070 100644
 +        observePostCompactionToolOutcome(observation);
 +      };
        let lastRetryFailoverReason: FailoverReason | null = null;
-       let planningOnlyRetryInstruction: string | null = null;
-       let reasoningOnlyRetryInstruction: string | null = null;
-@@ -1583,6 +1600,7 @@ export async function runEmbeddedAgent(
-             cwd: params.cwd,
-             agentDir,
+@@ -1585,2 +1602,3 @@ export async function runEmbeddedAgent(
              config: params.config,
 +            runSafety: params.runSafety,
              allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-             contextEngine,
-             contextTokenBudget: ctxInfo.tokens,
-@@ -1633,7 +1651,7 @@ export async function runEmbeddedAgent(
-             agentId: workspaceResolution.agentId,
-             beforeAgentStartResult,
+@@ -1635,3 +1653,3 @@ export async function runEmbeddedAgent(
              thinkLevel,
 -            onToolOutcome: observePostCompactionToolOutcome,
 +            onToolOutcome: observeToolOutcome,
              onRunProgress: notifyRunProgress,
-             fastMode: params.fastMode,
-             verboseLevel: params.verboseLevel,
-@@ -1845,6 +1863,52 @@ export async function runEmbeddedAgent(
-             sessionAssistantForCandidate?.stopReason === "error"
-               ? sessionAssistantForCandidate.errorMessage?.trim() || formattedAssistantErrorText
+@@ -1847,2 +1865,48 @@ export async function runEmbeddedAgent(
                : undefined;
 +          const runSafetyTermination = params.runSafety?.controller.terminationReason;
 +          if (runSafetyTermination) {
@@ -3713,27 +3142,15 @@ index ebdf0f90f..a0bc6f070 100644
 +            };
 +          }
            const canRestartForLiveSwitch =
-             !hasOutboundDeliveryEvidence(attempt) &&
-             !attempt.didSendDeterministicApprovalPrompt &&
-@@ -1954,6 +2018,7 @@ export async function runEmbeddedAgent(
-                   onCompactionHookMessages,
-                   ...(attempt.promptCache ? { promptCache: attempt.promptCache } : {}),
+@@ -1956,2 +2020,3 @@ export async function runEmbeddedAgent(
                    runId: params.runId,
 +                  runSafety: params.runSafety,
                    trigger: "timeout_recovery",
-                   diagId: timeoutDiagId,
-                   attempt: timeoutCompactionAttempts,
-@@ -2145,6 +2210,7 @@ export async function runEmbeddedAgent(
-                   onCompactionHookMessages,
-                   ...(attempt.promptCache ? { promptCache: attempt.promptCache } : {}),
+@@ -2147,2 +2212,3 @@ export async function runEmbeddedAgent(
                    runId: params.runId,
 +                  runSafety: params.runSafety,
                    trigger: "overflow",
-                   ...(overflowTokenCountForCompaction !== undefined
-                     ? { currentTokenCount: overflowTokenCountForCompaction }
-@@ -3678,6 +3744,88 @@ export async function runEmbeddedAgent(
-   });
- }
+@@ -3680,2 +3746,84 @@ export async function runEmbeddedAgent(
  
 +const RUN_SAFETY_BOOTSTRAP_BLOCK_MESSAGE =
 +  "Agent run was blocked because local run-safety state is unavailable.";
@@ -3818,31 +3235,19 @@ index ebdf0f90f..a0bc6f070 100644
 +}
 +
  function resolveAuthProfileStateProvider(
-   store: AuthProfileStore,
-   profileId: string,
 diff --git a/src/agents/embedded-agent-runner/run/attempt.ts b/src/agents/embedded-agent-runner/run/attempt.ts
 index bf7938c04..c5bfbc182 100644
 --- a/src/agents/embedded-agent-runner/run/attempt.ts
 +++ b/src/agents/embedded-agent-runner/run/attempt.ts
-@@ -453,6 +453,7 @@ import {
-   formatPrePromptPrecheckLog,
-   shouldPreemptivelyCompactBeforePrompt,
+@@ -455,2 +455,3 @@ import {
  } from "./preemptive-compaction.js";
 +import { installRunSafetyAgentHooks, wrapStreamFnWithRunSafety } from "./run-safety-gate.js";
  import {
-   buildCurrentInboundPrompt,
-   buildRuntimeContextCustomMessage,
-@@ -1195,6 +1196,7 @@ export async function runEmbeddedAttempt(
-                 : undefined,
-             sessionId: params.sessionId,
+@@ -1197,2 +1198,3 @@ export async function runEmbeddedAttempt(
              runId: params.runId,
 +            runSafety: params.runSafety,
              toolSearchCatalogRef,
-             agentDir,
-             cwd: effectiveCwd,
-@@ -2261,6 +2263,13 @@ export async function runEmbeddedAttempt(
-         agent: activeSession.agent,
-         sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+@@ -2263,2 +2265,9 @@ export async function runEmbeddedAttempt(
        });
 +      if (params.runSafety) {
 +        installRunSafetyAgentHooks({
@@ -3852,11 +3257,7 @@ index bf7938c04..c5bfbc182 100644
 +        });
 +      }
        prepStages.mark("agent-session");
-       if (isRawModelRun) {
-         // Raw model probes should measure exactly the requested prompt against
-@@ -2656,6 +2665,13 @@ export async function runEmbeddedAttempt(
-           },
-         );
+@@ -2658,2 +2667,9 @@ export async function runEmbeddedAttempt(
        }
 +      if (params.runSafety) {
 +        activeSession.agent.streamFn = wrapStreamFnWithRunSafety({
@@ -3866,19 +3267,11 @@ index bf7938c04..c5bfbc182 100644
 +        });
 +      }
        if (
-         transcriptPolicy.preserveSignatures ||
-         transcriptPolicy.dropThinkingBlocks ||
-@@ -2832,7 +2848,6 @@ export async function runEmbeddedAttempt(
-           },
-         },
+@@ -2834,3 +2850,2 @@ export async function runEmbeddedAttempt(
        );
 -
        try {
-         if (isRawModelRun) {
-           activeSession.agent.reset();
-@@ -3222,6 +3237,14 @@ export async function runEmbeddedAttempt(
-           onExecutionPhase: params.onExecutionPhase,
-           onAgentEvent: params.onAgentEvent,
+@@ -3224,2 +3239,10 @@ export async function runEmbeddedAttempt(
            terminalLifecyclePhase: params.deferTerminalLifecycleEnd ? "finishing" : "end",
 +          getRunSafetyTerminationReason: () => params.runSafety?.controller.terminationReason,
 +          getRunSafetyScopeIdentity: () =>
@@ -3889,54 +3282,36 @@ index bf7938c04..c5bfbc182 100644
 +                }
 +              : undefined,
            onBeforeLifecycleTerminal: () => {
-             if (
-               requiresCompletionRequiredAsyncTaskWait({
-@@ -3970,6 +3993,7 @@ export async function runEmbeddedAttempt(
- 
-           if (!skipPromptSubmission) {
+@@ -3972,2 +3995,3 @@ export async function runEmbeddedAttempt(
              const googlePromptCacheStreamFn = await prepareGooglePromptCacheStreamFn({
 +              allowManagedSideEffects: !params.runSafety,
                apiKey: await resolveEmbeddedAgentApiKey({
-                 provider: params.provider,
-                 resolvedApiKey: params.resolvedApiKey,
 diff --git a/src/agents/embedded-agent-runner/run/params.ts b/src/agents/embedded-agent-runner/run/params.ts
 index 3572d9e13..7292ca3ee 100644
 --- a/src/agents/embedded-agent-runner/run/params.ts
 +++ b/src/agents/embedded-agent-runner/run/params.ts
-@@ -22,6 +22,7 @@ import type {
-   ToolResultFormat,
- } from "../../embedded-agent-subscribe.shared-types.js";
+@@ -24,2 +24,3 @@ import type {
  import type { AgentInternalEvent } from "../../internal-events.js";
 +import type { RunSafetyContext, RunSafetyTermination } from "../../run-safety-controller.js";
  import type { AgentMessage } from "../../runtime/index.js";
- import type { SilentReplyPromptMode } from "../../system-prompt.types.js";
- import type { PromptMode } from "../../system-prompt.types.js";
-@@ -37,6 +38,8 @@ export type CurrentInboundPromptContext = {
-   promptJoiner?: "\n\n" | "\n" | " ";
- };
+@@ -39,2 +40,4 @@ export type CurrentInboundPromptContext = {
  
 +export type { RunSafetyContext } from "../../run-safety-controller.js";
 +
  export type RunEmbeddedAgentParams = {
-   sessionId: string;
-   sessionKey?: string;
-@@ -167,6 +170,10 @@ export type RunEmbeddedAgentParams = {
-    */
-   runTimeoutOverrideMs?: number;
+@@ -169,2 +172,6 @@ export type RunEmbeddedAgentParams = {
    runId: string;
 +  /** Trusted host-owned safety scope shared across fallback attempts. */
 +  runSafety?: RunSafetyContext;
 +  /** Delivery-owned callback retained when a standalone root outlives its stack. */
 +  onRunSafetyTerminal?: (reason: RunSafetyTermination) => Promise<void> | void;
    abortSignal?: AbortSignal;
-   onExecutionStarted?: () => void;
-   onExecutionPhase?: (info: {
 diff --git a/src/agents/embedded-agent-runner/run/run-safety-gate.test.ts b/src/agents/embedded-agent-runner/run/run-safety-gate.test.ts
 new file mode 100644
-index 000000000..5a554f94b
+index 000000000..d567f7423
 --- /dev/null
 +++ b/src/agents/embedded-agent-runner/run/run-safety-gate.test.ts
-@@ -0,0 +1,363 @@
+@@ -0,0 +1,436 @@
 +import {
 +  createAssistantMessageEventStream,
 +  type AssistantMessage,
@@ -4032,7 +3407,6 @@ index 000000000..5a554f94b
 +  it("reserves the Anthropic without-thinking recovery as a second provider dispatch", async () => {
 +    const controller = createController({
 +      maxProviderDispatchesPerBudgetScope: 1,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 10_000,
 +    });
 +    const model = createModel();
 +    const thinkingError = new Error(
@@ -4067,7 +3441,6 @@ index 000000000..5a554f94b
 +  it("counts the final payload instead of the larger Agent Context and disables SDK retries", async () => {
 +    const controller = createController({
 +      maxProviderDispatchesPerBudgetScope: 2,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 10_000,
 +    });
 +    const model = createModel();
 +    const finalPayload = {
@@ -4082,7 +3455,7 @@ index 000000000..5a554f94b
 +    const inner: StreamFn = async (modelValue, _context, options) => {
 +      expect(shouldDisableInternalProviderTransportRetries()).toBe(true);
 +      capturedOptions = options;
-+      expect(controller.snapshot().cumulativeEstimatedPromptTokens).toBe(1);
++      expect(controller.snapshot().promptExposure.pendingObservationDispatchCount).toBe(1);
 +      expect(await options?.onPayload?.(rawPayload, modelValue)).toBe(finalPayload);
 +      const stream = createAssistantMessageEventStream();
 +      stream.push({
@@ -4105,30 +3478,87 @@ index 000000000..5a554f94b
 +
 +    expect(capturedOptions?.maxRetries).toBe(0);
 +    expect(controller.snapshot()).toMatchObject({
-+      cumulativeEstimatedPromptTokens: finalEstimate,
 +      providerDispatchCount: 1,
 +      status: "active",
++      promptExposure: {
++        legacyEstimatedExposureUnitsTotal: finalEstimate,
++        knownEstimateDispatchCount: 1,
++        pendingObservationDispatchCount: 0,
++      },
 +    });
 +  });
 +
-+  it("atomically refines concurrent dispatches exactly to the prompt limit", async () => {
++  it("settles pending observation when provider code throws before onPayload", async () => {
++    const controller = createController();
++    const providerError = new Error("prepare failed");
++    const inner = vi.fn<StreamFn>(() => {
++      throw providerError;
++    });
++
++    await expect(
++      wrapStreamFnWithRunSafety({
++        streamFn: inner,
++        controller,
++        runId: "run-1",
++      })(createModel(), createContext()),
++    ).rejects.toBe(providerError);
++
++    expect(controller.snapshot().promptExposure).toMatchObject({
++      estimateUnavailableDispatchCount: 1,
++      pendingObservationDispatchCount: 0,
++      unavailableReasonCounts: {
++        payload_not_observed_before_completion: 1,
++      },
++    });
++  });
++
++  it("settles pending observation when a stream completes without onPayload", async () => {
++    const controller = createController();
++    const inner: StreamFn = (model) => {
++      const stream = createAssistantMessageEventStream();
++      stream.push({
++        type: "done",
++        reason: "stop",
++        message: createAssistantMessage(model),
++      });
++      return stream;
++    };
++
++    const stream = await wrapStreamFnWithRunSafety({
++      streamFn: inner,
++      controller,
++      runId: "run-1",
++    })(createModel(), createContext());
++    await stream.result();
++    await Promise.resolve();
++
++    expect(controller.snapshot().promptExposure).toMatchObject({
++      estimateUnavailableDispatchCount: 1,
++      pendingObservationDispatchCount: 0,
++      unavailableReasonCounts: {
++        payload_not_observed_before_completion: 1,
++      },
++    });
++  });
++
++  it("atomically observes concurrent final payloads exactly once", async () => {
 +    const model = createModel();
 +    const finalPayloads = [
 +      { messages: [{ role: "user", content: "first final payload" }] },
 +      { messages: [{ role: "user", content: "second final payload" }] },
 +    ];
 +    const finalEstimates = finalPayloads.map((payload) => requirePromptEstimate(payload, model));
-+    const exactLimit = finalEstimates.reduce((total, estimate) => total + estimate, 0);
++    const expectedTotal = finalEstimates.reduce((total, estimate) => total + estimate, 0);
 +    const controller = createController({
-+      maxProviderDispatchesPerBudgetScope: 2,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: exactLimit,
++      maxProviderDispatchesPerBudgetScope: 3,
++      promptExposure: { mode: "observe", legacyDiagnosticThreshold: 1 },
 +    });
 +    let readyCount = 0;
 +    let releaseBoth!: () => void;
 +    const bothReserved = new Promise<void>((resolve) => {
 +      releaseBoth = resolve;
 +    });
-+    const totalsBeforeFinalGate: number[] = [];
++    const pendingBeforeObservation: number[] = [];
 +    let transportCount = 0;
 +    const inner: StreamFn = async (modelValue, _context, options) => {
 +      const payloadIndex = readyCount;
@@ -4137,7 +3567,9 @@ index 000000000..5a554f94b
 +        releaseBoth();
 +      }
 +      await bothReserved;
-+      totalsBeforeFinalGate.push(controller.snapshot().cumulativeEstimatedPromptTokens);
++      pendingBeforeObservation.push(
++        controller.snapshot().promptExposure.pendingObservationDispatchCount,
++      );
 +      await options?.onPayload?.(finalPayloads[payloadIndex], modelValue);
 +      transportCount += 1;
 +      const stream = createAssistantMessageEventStream();
@@ -4160,21 +3592,25 @@ index 000000000..5a554f94b
 +    ]);
 +    await Promise.all(streams.map(async (stream) => await stream.result()));
 +
-+    expect(totalsBeforeFinalGate).toEqual([2, 2]);
++    expect(pendingBeforeObservation).toEqual([2, 2]);
 +    expect(transportCount).toBe(2);
 +    expect(controller.snapshot()).toMatchObject({
-+      continuationClosedReason: RunSafetyTerminationKind.RunPromptExposureBudget,
-+      cumulativeEstimatedPromptTokens: exactLimit,
 +      providerDispatchCount: 2,
 +      status: "active",
++      promptExposure: {
++        legacyEstimatedExposureUnitsTotal: expectedTotal,
++        knownEstimateDispatchCount: 2,
++        pendingObservationDispatchCount: 0,
++        legacyDiagnosticThresholdCrossed: true,
++      },
 +    });
 +    expect(controller.terminationReason).toBeUndefined();
++    expect(controller.continuationClosedReason).toBeUndefined();
 +  });
 +
 +  it("blocks the next logical dispatch before invoking the provider", async () => {
 +    const controller = createController({
 +      maxProviderDispatchesPerBudgetScope: 1,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 10_000,
 +    });
 +    const model = createModel();
 +    const inner = vi.fn<StreamFn>((modelValue) => {
@@ -4206,39 +3642,51 @@ index 000000000..5a554f94b
 +    );
 +  });
 +
-+  it("keeps the minimal reservation when final-payload refinement is rejected", async () => {
++  it("continues transport when final prompt estimation is unavailable", async () => {
 +    const controller = createController({
 +      maxProviderDispatchesPerBudgetScope: 2,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 500,
 +    });
-+    const model = createModel();
++    const model = { ...createModel(), contextWindow: undefined } as Model;
 +    const replacePayload = vi.fn(() => ({
-+      messages: [{ role: "user", content: "x".repeat(2_000) }],
++      messages: [
++        {
++          role: "user",
++          content: [{ type: "image_url", url: "https://example.test/image.png" }],
++        },
++      ],
 +    }));
 +    const inner: StreamFn = async (modelValue, _context, options) => {
 +      await options?.onPayload?.({ messages: [] }, modelValue);
-+      return createAssistantMessageEventStream();
++      const stream = createAssistantMessageEventStream();
++      stream.push({
++        type: "done",
++        reason: "stop",
++        message: createAssistantMessage(modelValue),
++      });
++      return stream;
 +    };
 +
-+    const blockedStream = await wrapStreamFnWithRunSafety({
++    const stream = await wrapStreamFnWithRunSafety({
 +      streamFn: inner,
 +      controller,
 +      runId: "run-1",
 +    })(model, createContext(), { onPayload: replacePayload });
-+    const blockedResult = await blockedStream.result();
++    const result = await stream.result();
 +
 +    expect(replacePayload).toHaveBeenCalledTimes(1);
-+    expect(blockedResult).toMatchObject({
-+      stopReason: "error",
-+      errorMessage: expect.stringContaining(RunSafetyTerminationKind.RunPromptExposureBudget),
-+    });
-+    expect(controller.terminationReason?.kind).toBe(
-+      RunSafetyTerminationKind.RunPromptExposureBudget,
-+    );
++    expect(result.stopReason).toBe("stop");
++    expect(controller.terminationReason).toBeUndefined();
 +    expect(controller.snapshot()).toMatchObject({
-+      cumulativeEstimatedPromptTokens: 1,
 +      providerDispatchCount: 1,
-+      status: "ended",
++      status: "active",
++      promptExposure: {
++        knownEstimateDispatchCount: 0,
++        estimateUnavailableDispatchCount: 1,
++        pendingObservationDispatchCount: 0,
++        unavailableReasonCounts: {
++          unknown_media_without_context_window: 1,
++        },
++      },
 +    });
 +  });
 +});
@@ -4302,15 +3750,15 @@ index 000000000..5a554f94b
 +});
 diff --git a/src/agents/embedded-agent-runner/run/run-safety-gate.ts b/src/agents/embedded-agent-runner/run/run-safety-gate.ts
 new file mode 100644
-index 000000000..90af6d47b
+index 000000000..98ae74664
 --- /dev/null
 +++ b/src/agents/embedded-agent-runner/run/run-safety-gate.ts
-@@ -0,0 +1,282 @@
+@@ -0,0 +1,258 @@
 +import { runWithRunSafetyProviderDispatch } from "../../../llm/run-safety-provider-dispatch-context.js";
 +import type { AssistantMessage, Model } from "../../../llm/types.js";
 +import { createAssistantMessageEventStream } from "../../../llm/utils/event-stream.js";
 +import {
-+  estimateRunSafetyPromptTokens,
++  estimateRunSafetyPromptObservation,
 +  type RunSafetyController,
 +  type RunSafetyTermination,
 +  RunSafetyTerminationKind,
@@ -4326,20 +3774,12 @@ index 000000000..90af6d47b
 +  "Tool execution was blocked by the local run safety controller.";
 +const RUN_SAFETY_PROVIDER_BLOCK_MESSAGE =
 +  "Provider dispatch was blocked by the local run safety controller.";
-+const RUN_SAFETY_PROVIDER_DISPATCH_SLOT_ESTIMATE = 1;
 +
 +export class RunSafetyProviderGateError extends Error {
 +  constructor(readonly terminationReason: RunSafetyTermination) {
 +    super(RUN_SAFETY_PROVIDER_BLOCK_MESSAGE);
 +    this.name = "RunSafetyProviderGateError";
 +  }
-+}
-+
-+function throwProviderGateError(reason: RunSafetyTermination | undefined): never {
-+  if (!reason) {
-+    throw new Error(RUN_SAFETY_PROVIDER_BLOCK_MESSAGE);
-+  }
-+  throw new RunSafetyProviderGateError(reason);
 +}
 +
 +function filterAssistantToolCalls(
@@ -4524,9 +3964,6 @@ index 000000000..90af6d47b
 +    const reservation = params.controller.reserveProviderDispatch({
 +      runId: params.runId,
 +      providerDispatchId,
-+      // Reserve the logical dispatch before invoking provider code, but leave
-+      // prompt accounting authoritative to the final-payload seam below.
-+      estimatedPromptTokens: RUN_SAFETY_PROVIDER_DISPATCH_SLOT_ESTIMATE,
 +    });
 +    if (!reservation.allowed) {
 +      const reason =
@@ -4545,23 +3982,10 @@ index 000000000..90af6d47b
 +    ) => {
 +      const replacement = await originalOnPayload?.(payload, payloadModel);
 +      const finalPayload = replacement ?? payload;
-+      const finalEstimate = estimateRunSafetyPromptTokens(finalPayload, payloadModel);
-+      if (!finalEstimate.ok) {
-+        throwProviderGateError(
-+          params.controller.tryTerminate({
-+            kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable,
-+            runId: params.runId,
-+          }),
-+        );
-+      }
-+      const refinement = params.controller.refineProviderPromptEstimate({
-+        runId: params.runId,
++      params.controller.observeProviderPromptEstimate({
 +        providerDispatchId,
-+        estimatedPromptTokens: finalEstimate.estimatedPromptTokens,
++        observation: estimateRunSafetyPromptObservation(finalPayload, payloadModel),
 +      });
-+      if (!refinement.allowed) {
-+        throwProviderGateError(refinement.reason);
-+      }
 +      return replacement;
 +    };
 +
@@ -4592,40 +4016,27 @@ diff --git a/src/agents/embedded-agent-runner/types.ts b/src/agents/embedded-age
 index 4e4376373..39fb3a56f 100644
 --- a/src/agents/embedded-agent-runner/types.ts
 +++ b/src/agents/embedded-agent-runner/types.ts
-@@ -11,6 +11,7 @@ import type {
-   MessagingToolSourceReplyPayload,
- } from "../embedded-agent-messaging.types.js";
+@@ -13,2 +13,3 @@ import type {
  import type { FallbackAttempt } from "../model-fallback.types.js";
 +import type { RunSafetyTermination } from "../run-safety-controller.js";
  import type { AgentRunTimeoutPhase } from "../run-timeout-attribution.js";
- 
- export type EmbeddedAgentMeta = {
-@@ -146,6 +147,8 @@ export type EmbeddedAgentRunMeta = {
-   livenessState?: EmbeddedRunLivenessState;
-   timeoutPhase?: AgentRunTimeoutPhase;
+@@ -148,2 +149,4 @@ export type EmbeddedAgentRunMeta = {
    providerStarted?: boolean;
 +  /** Typed local safety terminal; never eligible for provider/model fallback. */
 +  terminationReason?: RunSafetyTermination;
    agentHarnessResultClassification?: "empty" | "reasoning-only" | "planning-only";
-   terminalReplyKind?: "silent-empty";
-   yielded?: boolean;
 diff --git a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
 index 5c545464c..b5ff796d1 100644
 --- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
 +++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
-@@ -1,7 +1,8 @@
- import { describe, expect, it, vi } from "vitest";
+@@ -2,4 +2,5 @@ import { describe, expect, it, vi } from "vitest";
  import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
 -import { handleAgentEnd } from "./embedded-agent-subscribe.handlers.lifecycle.js";
 +import { handleAgentEnd, handleAgentStart } from "./embedded-agent-subscribe.handlers.lifecycle.js";
  import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 +import { RunSafetyTerminationKind } from "./run-safety-controller.js";
  
- const { emitAgentEventMock } = vi.hoisted(() => ({
-   emitAgentEventMock: vi.fn(),
-@@ -207,6 +208,76 @@ describe("handleAgentEnd", () => {
-     });
-   });
+@@ -209,2 +210,72 @@ describe("handleAgentEnd", () => {
  
 +  it("includes the full run-safety reason on the first lifecycle terminal", async () => {
 +    emitAgentEventMock.mockClear();
@@ -4698,36 +4109,24 @@ index 5c545464c..b5ff796d1 100644
 +  });
 +
    it("attaches raw provider error metadata and includes model/provider in console output", async () => {
-     const ctx = createContext({
-       role: "assistant",
 diff --git a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
 index 6b5e10190..147ce1720 100644
 --- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
 +++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
-@@ -30,17 +30,19 @@ export {
- 
- export function handleAgentStart(ctx: EmbeddedAgentSubscribeContext) {
+@@ -32,2 +32,3 @@ export function handleAgentStart(ctx: EmbeddedAgentSubscribeContext) {
    ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
 +  const runSafetyScopeIdentity = ctx.params.getRunSafetyScopeIdentity?.();
    emitAgentEvent({
-     runId: ctx.params.runId,
-     stream: "lifecycle",
-     data: {
-       phase: "start",
+@@ -38,2 +39,3 @@ export function handleAgentStart(ctx: EmbeddedAgentSubscribeContext) {
        startedAt: Date.now(),
 +      ...runSafetyScopeIdentity,
      },
-   });
-   void ctx.params.onAgentEvent?.({
+@@ -42,3 +44,3 @@ export function handleAgentStart(ctx: EmbeddedAgentSubscribeContext) {
      stream: "lifecycle",
 -    data: { phase: "start" },
 +    data: { phase: "start", ...runSafetyScopeIdentity },
    });
- }
- 
-@@ -134,8 +136,13 @@ export function handleAgentEnd(
-   }
- 
+@@ -136,4 +138,9 @@ export function handleAgentEnd(
    const emitLifecycleTerminal = () => {
 +    const terminationReason = ctx.params.getRunSafetyTerminationReason?.();
      const terminalMeta = {
@@ -4738,11 +4137,7 @@ index 6b5e10190..147ce1720 100644
 +          ? { stopReason: ctx.state.terminalStopReason }
 +          : {}),
        ...(ctx.state.yielded === true ? { yielded: true } : {}),
-       ...(ctx.state.timeoutPhase ? { timeoutPhase: ctx.state.timeoutPhase } : {}),
-       ...(typeof ctx.state.providerStarted === "boolean"
-@@ -150,8 +157,12 @@ export function handleAgentEnd(
-           phase: "error",
-           error: lifecycleErrorText ?? GENERIC_ASSISTANT_ERROR_TEXT,
+@@ -152,4 +159,8 @@ export function handleAgentEnd(
            ...terminalMeta,
 -          ...(lifecycleErrorMetadata ?? {}),
 -          ...(livenessState ? { livenessState } : {}),
@@ -4753,11 +4148,7 @@ index 6b5e10190..147ce1720 100644
 +              ? { livenessState }
 +              : {}),
            ...(replayInvalid ? { replayInvalid } : {}),
-           endedAt: Date.now(),
-         },
-@@ -162,8 +173,11 @@ export function handleAgentEnd(
-           phase: "error",
-           error: lifecycleErrorText ?? GENERIC_ASSISTANT_ERROR_TEXT,
+@@ -164,4 +175,7 @@ export function handleAgentEnd(
            ...terminalMeta,
 -          ...(lifecycleErrorMetadata ?? {}),
 -          ...(livenessState ? { livenessState } : {}),
@@ -4767,11 +4158,7 @@ index 6b5e10190..147ce1720 100644
 +              ? { livenessState }
 +              : {}),
            ...(replayInvalid ? { replayInvalid } : {}),
-         },
-       });
-@@ -176,7 +190,11 @@ export function handleAgentEnd(
-       data: {
-         phase: successPhase,
+@@ -178,3 +192,7 @@ export function handleAgentEnd(
          ...terminalMeta,
 -        ...(livenessState ? { livenessState } : {}),
 +        ...(terminationReason
@@ -4780,11 +4167,7 @@ index 6b5e10190..147ce1720 100644
 +            ? { livenessState }
 +            : {}),
          ...(replayInvalid ? { replayInvalid } : {}),
-         endedAt: Date.now(),
-       },
-@@ -186,7 +204,11 @@ export function handleAgentEnd(
-       data: {
-         phase: successPhase,
+@@ -188,3 +206,7 @@ export function handleAgentEnd(
          ...terminalMeta,
 -        ...(livenessState ? { livenessState } : {}),
 +        ...(terminationReason
@@ -4793,38 +4176,26 @@ index 6b5e10190..147ce1720 100644
 +            ? { livenessState }
 +            : {}),
          ...(replayInvalid ? { replayInvalid } : {}),
-       },
-     });
 diff --git a/src/agents/embedded-agent-subscribe.types.ts b/src/agents/embedded-agent-subscribe.types.ts
 index cca0050f8..6d553f86b 100644
 --- a/src/agents/embedded-agent-subscribe.types.ts
 +++ b/src/agents/embedded-agent-subscribe.types.ts
-@@ -15,6 +15,7 @@ import type {
-   ToolResultFormat,
- } from "./embedded-agent-subscribe.shared-types.js";
+@@ -17,2 +17,3 @@ import type {
  import type { AgentInternalEvent } from "./internal-events.js";
 +import type { RunSafetyTermination } from "./run-safety-controller.js";
  import type { AgentMessage } from "./runtime/index.js";
- import type { AgentSession } from "./sessions/index.js";
- export type {
-@@ -79,6 +80,10 @@ export type SubscribeEmbeddedAgentSessionParams = {
-   }) => void | Promise<void | { suppressTerminalDelivery?: boolean }>;
-   /** Best-effort hook invoked immediately before the terminal lifecycle event is emitted. */
+@@ -81,2 +82,6 @@ export type SubscribeEmbeddedAgentSessionParams = {
    onBeforeLifecycleTerminal?: () => void | Promise<void>;
 +  /** Trusted live terminal lookup used by the first lifecycle terminal event. */
 +  getRunSafetyTerminationReason?: () => RunSafetyTermination | undefined;
 +  /** Trusted scope identity exposed on lifecycle start for host correlation. */
 +  getRunSafetyScopeIdentity?: () => { rootInvocationId: string; budgetScopeId: string } | undefined;
    enforceFinalTag?: boolean;
-   silentExpected?: boolean;
-   config?: OpenClawConfig;
 diff --git a/src/agents/main-session-restart-recovery.test.ts b/src/agents/main-session-restart-recovery.test.ts
 index 4a955a15f..449e66c8f 100644
 --- a/src/agents/main-session-restart-recovery.test.ts
 +++ b/src/agents/main-session-restart-recovery.test.ts
-@@ -66,18 +66,6 @@ function cleanedLock(sessionsDir: string, sessionId: string): SessionLockInspect
-   return cleanedLockForPath(path.join(sessionsDir, `${sessionId}.jsonl.lock`));
- }
+@@ -68,14 +68,2 @@ function cleanedLock(sessionsDir: string, sessionId: string): SessionLockInspect
  
 -function firstGatewayParams(): Record<string, unknown> {
 -  const call = vi.mocked(callGateway).mock.calls[0];
@@ -4839,11 +4210,7 @@ index 4a955a15f..449e66c8f 100644
 -}
 -
  describe("main-session-restart-recovery", () => {
-   it("marks only matching running main sessions by active session key", async () => {
-     const sessionsDir = await makeSessionsDir();
-@@ -161,7 +149,10 @@ describe("main-session-restart-recovery", () => {
-       stateDir: tmpDir,
-     });
+@@ -163,3 +151,6 @@ describe("main-session-restart-recovery", () => {
  
 -    expect(recovery).toEqual({ recovered: 1, failed: 0, skipped: 0 });
 +    expect(recovery).toEqual({ recovered: 0, failed: 1, skipped: 0 });
@@ -4851,20 +4218,12 @@ index 4a955a15f..449e66c8f 100644
 +      false,
 +    );
    });
- 
-   it("uses active session ids to avoid marking stale duplicate keys in another store", async () => {
-@@ -387,7 +378,7 @@ describe("main-session-restart-recovery", () => {
-     expect(store["agent:main:main"]?.abortedLastRun).toBe(true);
-   });
+@@ -389,3 +380,3 @@ describe("main-session-restart-recovery", () => {
  
 -  it("resumes marked sessions with a tool-result transcript tail", async () => {
 +  it("fails closed after restart without dispatching an agent provider run", async () => {
      const sessionsDir = await makeSessionsDir();
-     await writeStore(sessionsDir, {
-       "agent:main:main": {
-@@ -405,17 +396,16 @@ describe("main-session-restart-recovery", () => {
- 
-     const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+@@ -407,13 +398,12 @@ describe("main-session-restart-recovery", () => {
  
 -    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
 -    expect(callGateway).toHaveBeenCalledOnce();
@@ -4885,11 +4244,7 @@ index 4a955a15f..449e66c8f 100644
 -  it("delivers resumed marked sessions through the current run recovery context", async () => {
 +  it("fails closed without provider dispatch when a current delivery context exists", async () => {
      const sessionsDir = await makeSessionsDir();
-     await writeStore(sessionsDir, {
-       "agent:main:discord:direct:123": {
-@@ -444,18 +434,10 @@ describe("main-session-restart-recovery", () => {
- 
-     const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+@@ -446,14 +436,6 @@ describe("main-session-restart-recovery", () => {
  
 -    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
 -    const resumeParams = firstGatewayParams();
@@ -4908,11 +4263,7 @@ index 4a955a15f..449e66c8f 100644
 +      false,
 +    );
    });
- 
-   it("does not infer restart delivery from historical session routes", async () => {
-@@ -481,8 +463,10 @@ describe("main-session-restart-recovery", () => {
- 
-     const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+@@ -483,4 +465,6 @@ describe("main-session-restart-recovery", () => {
  
 -    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
 -    expect(firstGatewayParams().deliver).toBe(false);
@@ -4921,31 +4272,19 @@ index 4a955a15f..449e66c8f 100644
 +      false,
 +    );
    });
- 
-   it("does not deliver restart recovery when session send policy denies sends", async () => {
-@@ -511,8 +495,8 @@ describe("main-session-restart-recovery", () => {
-       stateDir: tmpDir,
-     });
+@@ -513,4 +497,4 @@ describe("main-session-restart-recovery", () => {
  
 -    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
 -    expect(firstGatewayParams().deliver).toBe(false);
 +    expect(result).toEqual({ recovered: 0, failed: 1, skipped: 0 });
 +    expect(callGateway).not.toHaveBeenCalled();
    });
- 
-   it("fails marked sessions with stale approval-pending exec tool results", async () => {
-@@ -549,7 +533,7 @@ describe("main-session-restart-recovery", () => {
-     expect(store["agent:main:main"]?.abortedLastRun).toBe(true);
-   });
+@@ -551,3 +535,3 @@ describe("main-session-restart-recovery", () => {
  
 -  it("resumes marked sessions with a durable pending final delivery payload (Phase 2)", async () => {
 +  it("does not use a durable pending payload to restart provider work", async () => {
      const sessionsDir = await makeSessionsDir();
-     const pendingPayload = "The final answer is 42.";
-     await writeStore(sessionsDir, {
-@@ -581,33 +565,16 @@ describe("main-session-restart-recovery", () => {
- 
-     const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+@@ -583,29 +567,12 @@ describe("main-session-restart-recovery", () => {
  
 -    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
 -    expect(callGateway).toHaveBeenCalledOnce();
@@ -4981,11 +4320,7 @@ index 4a955a15f..449e66c8f 100644
 -  it("sanitizes durable pending final delivery payloads before resume prompts", async () => {
 +  it("does not restart provider work for pending final text", async () => {
      const sessionsDir = await makeSessionsDir();
-     const pendingPayload = [
-       "The final answer is 42.",
-@@ -639,13 +606,13 @@ describe("main-session-restart-recovery", () => {
- 
-     const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+@@ -641,9 +608,9 @@ describe("main-session-restart-recovery", () => {
  
 -    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
 -    expect(firstGatewayParams().message).toContain("The final answer is 42.");
@@ -5001,35 +4336,23 @@ index 4a955a15f..449e66c8f 100644
 +      abortedLastRun: true,
 +    });
    });
- 
-   it("does not scan ordinary running sessions without the restart-aborted marker", async () => {
 diff --git a/src/agents/main-session-restart-recovery.ts b/src/agents/main-session-restart-recovery.ts
 index 7a5f32c27..22f88d9fe 100644
 --- a/src/agents/main-session-restart-recovery.ts
 +++ b/src/agents/main-session-restart-recovery.ts
-@@ -2,11 +2,9 @@
-  * Post-restart recovery for main sessions interrupted while holding a transcript lock.
-  */
+@@ -4,3 +4,2 @@
  
 -import crypto from "node:crypto";
  import fs from "node:fs";
- import path from "node:path";
+@@ -8,3 +7,2 @@ import path from "node:path";
  import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 -import { sanitizePendingFinalDeliveryText } from "../auto-reply/reply/pending-final-delivery.js";
  import { resolveStateDir } from "../config/paths.js";
- import {
-   type SessionEntry,
-@@ -21,7 +19,6 @@ import { callGateway } from "../gateway/call.js";
- import { readSessionMessagesAsync } from "../gateway/session-utils.fs.js";
- import { resolveGatewaySessionStoreTarget } from "../gateway/session-utils.js";
+@@ -23,3 +21,2 @@ import { resolveGatewaySessionStoreTarget } from "../gateway/session-utils.js";
  import { createSubsystemLogger } from "../logging/subsystem.js";
 -import { CommandLane } from "../process/lanes.js";
  import { isAcpSessionKey, isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
- import { resolveSendPolicy } from "../sessions/send-policy.js";
- import {
-@@ -240,21 +237,6 @@ function resolveMainSessionResumeBlockReason(messages: unknown[]): string | null
-   return null;
- }
+@@ -242,17 +239,2 @@ function resolveMainSessionResumeBlockReason(messages: unknown[]): string | null
  
 -function buildResumeMessage(pendingFinalDeliveryText?: string | null): string {
 -  const base =
@@ -5047,11 +4370,7 @@ index 7a5f32c27..22f88d9fe 100644
 -}
 -
  async function markSessionFailed(params: {
-   storePath: string;
-   sessionKey: string;
-@@ -290,9 +272,10 @@ async function markSessionFailed(params: {
- async function sendUnresumableSessionNotice(params: {
-   cfg?: OpenClawConfig;
+@@ -292,5 +274,6 @@ async function sendUnresumableSessionNotice(params: {
    entry: SessionEntry;
 +  message?: string;
    reason: string;
@@ -5059,26 +4378,17 @@ index 7a5f32c27..22f88d9fe 100644
 -}): Promise<boolean> {
 +}): Promise<{ delivered: boolean; error?: string }> {
    const deliveryContext = resolveRestartRecoveryDeliveryContext({
-     cfg: params.cfg,
-     entry: params.entry,
-@@ -300,12 +283,12 @@ async function sendUnresumableSessionNotice(params: {
-     sessionKey: params.sessionKey,
-   });
+@@ -302,3 +285,3 @@ async function sendUnresumableSessionNotice(params: {
    if (!deliveryContext) {
 -    return false;
 +    return { delivered: false, error: "no eligible restart recovery delivery route" };
    }
- 
-   const messageParams: Record<string, unknown> = {
+@@ -307,3 +290,3 @@ async function sendUnresumableSessionNotice(params: {
      to: deliveryContext.to,
 -    message: UNRESUMABLE_SESSION_NOTICE,
 +    message: params.message ?? UNRESUMABLE_SESSION_NOTICE,
      bestEffort: true,
-   };
-   if (deliveryContext?.threadId != null) {
-@@ -333,12 +316,13 @@ async function sendUnresumableSessionNotice(params: {
-     log.info(
-       `sent interrupted main session recovery notice: ${params.sessionKey} (${params.reason})`,
+@@ -335,8 +318,9 @@ async function sendUnresumableSessionNotice(params: {
      );
 -    return true;
 +    return { delivered: true };
@@ -5091,11 +4401,7 @@ index 7a5f32c27..22f88d9fe 100644
 -    return false;
 +    return { delivered: false, error };
    }
- }
- 
-@@ -376,89 +360,6 @@ function resolveRestartRecoveryDeliveryContext(params: {
-   };
- }
+@@ -378,85 +362,2 @@ function resolveRestartRecoveryDeliveryContext(params: {
  
 -async function resumeMainSession(params: {
 -  cfg?: OpenClawConfig;
@@ -5181,11 +4487,7 @@ index 7a5f32c27..22f88d9fe 100644
 -}
 -
  export async function markRestartAbortedMainSessionsFromLocks(params: {
-   sessionsDir: string;
-   cleanedLocks: SessionLockInspection[];
-@@ -553,35 +454,23 @@ async function recoverStore(params: {
-     }
- 
+@@ -555,31 +456,19 @@ async function recoverStore(params: {
      const resumeBlockReason = resolveMainSessionResumeBlockReason(messages);
 -    if (resumeBlockReason) {
 -      await sendUnresumableSessionNotice({
@@ -5229,49 +4531,31 @@ index 7a5f32c27..22f88d9fe 100644
 -    }
 +    result.failed++;
    }
- 
-   return result;
 diff --git a/src/agents/openclaw-tools.ts b/src/agents/openclaw-tools.ts
 index c2f149b48..f4219bf17 100644
 --- a/src/agents/openclaw-tools.ts
 +++ b/src/agents/openclaw-tools.ts
-@@ -30,6 +30,7 @@ import {
-   collectPresentOpenClawTools,
-   shouldIncludeUpdatePlanToolForOpenClawTools,
+@@ -32,2 +32,3 @@ import {
  } from "./openclaw-tools.registration.js";
 +import type { RunSafetyContext } from "./run-safety-controller.js";
  import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
- import type { SpawnedToolContext } from "./spawned-context.js";
- import type { ToolFsPolicy } from "./tool-fs-policy.js";
-@@ -168,6 +169,8 @@ export function createOpenClawTools(
-     spawnWorkspaceDir?: string;
-     /** Callback invoked when sessions_yield tool is called. */
+@@ -170,2 +171,4 @@ export function createOpenClawTools(
      onYield?: (message: string) => Promise<void> | void;
 +    /** Trusted host-owned safety scope shared with spawned subagents. */
 +    runSafety?: RunSafetyContext;
      /** Allow plugin tools for this tool set to late-bind the gateway subagent. */
-     allowGatewaySubagentBinding?: boolean;
-   } & SpawnedToolContext,
-@@ -495,6 +498,10 @@ export function createOpenClawTools(
-             sandboxed: options?.sandboxed,
-             config: resolvedConfig,
+@@ -497,2 +500,6 @@ export function createOpenClawTools(
              callGateway: openClawToolsDeps.callGateway,
 +            runId: options?.runId,
 +            // `null` makes a lost production identity fail closed while direct
 +            // legacy tool construction can remain explicitly outside a run.
 +            runSafety: options?.runSafety ?? null,
            }),
-         ]),
-     ...(includeSubagentSpawnTool
-@@ -516,6 +523,8 @@ export function createOpenClawTools(
-             workspaceDir: spawnWorkspaceDir,
-             inheritedToolAllowlist: options?.inheritedToolAllowlist,
+@@ -518,2 +525,4 @@ export function createOpenClawTools(
              inheritedToolDenylist: options?.inheritedToolDenylist,
 +            runId: options?.runId,
 +            runSafety: options?.runSafety,
            }),
-         ]
-       : []),
 diff --git a/src/agents/provider-run-safety-contract.test.ts b/src/agents/provider-run-safety-contract.test.ts
 new file mode 100644
 index 000000000..d6e06b42e
@@ -5507,8 +4791,7 @@ diff --git a/src/agents/provider-stream.ts b/src/agents/provider-stream.ts
 index 90e4e40b2..e2a230856 100644
 --- a/src/agents/provider-stream.ts
 +++ b/src/agents/provider-stream.ts
-@@ -1,7 +1,11 @@
- import type { OpenClawConfig } from "../config/types.openclaw.js";
+@@ -2,4 +2,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
  import type { Api, Model } from "../llm/types.js";
 -import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
 +import {
@@ -5518,11 +4801,7 @@ index 90e4e40b2..e2a230856 100644
  import { ensureCustomApiRegistered } from "./custom-api-registry.js";
 +import { ProviderStreamPurpose } from "./provider-run-safety-contract.js";
  import { createTransportAwareStreamFnForModel } from "./provider-transport-stream.js";
- import type { StreamFn } from "./runtime/index.js";
- 
-@@ -12,32 +16,48 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
-   workspaceDir?: string;
-   env?: NodeJS.ProcessEnv;
+@@ -14,25 +18,41 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
    allowRuntimePluginLoad?: boolean;
 +  purpose?: ProviderStreamPurpose;
  }): StreamFn | undefined {
@@ -5583,27 +4862,20 @@ index 90e4e40b2..e2a230856 100644
 +      return transportStreamFn;
 +    })();
    if (!streamFn) {
-     return undefined;
+@@ -40,3 +60,3 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
    }
 -  ensureCustomApiRegistered(params.model.api, streamFn);
 +  ensureCustomApiRegistered(params.model.api, streamFn, { purpose });
    return streamFn;
- }
 diff --git a/src/agents/provider-transport-fetch.test.ts b/src/agents/provider-transport-fetch.test.ts
 index 26aad0cdf..39e32bb5a 100644
 --- a/src/agents/provider-transport-fetch.test.ts
 +++ b/src/agents/provider-transport-fetch.test.ts
-@@ -2,6 +2,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
- import { Stream } from "openai/streaming";
- import type { Model } from "openclaw/plugin-sdk/llm";
+@@ -4,2 +4,3 @@ import type { Model } from "openclaw/plugin-sdk/llm";
  import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 +import { runWithRunSafetyProviderDispatch } from "../llm/run-safety-provider-dispatch-context.js";
  import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
- 
- type ProviderRequestPolicyConfigMockResult = {
-@@ -537,16 +538,14 @@ describe("buildGuardedModelFetch", () => {
-     };
-     transient.cause = { name: "SocketError", code: "UND_ERR_SOCKET" };
+@@ -539,12 +540,10 @@ describe("buildGuardedModelFetch", () => {
      const release = vi.fn(async () => undefined);
 -    fetchWithSsrFGuardMock
 -      .mockRejectedValueOnce(transient)
@@ -5624,11 +4896,7 @@ index 26aad0cdf..39e32bb5a 100644
 +      release,
 +    });
      const model = {
-       id: "gpt-5.4",
-       provider: "openai",
-@@ -567,6 +566,36 @@ describe("buildGuardedModelFetch", () => {
-     expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
-   });
+@@ -569,2 +568,32 @@ describe("buildGuardedModelFetch", () => {
  
 +  it("does not hide a second fetch inside a run-safety provider dispatch", async () => {
 +    const transient = new TypeError("fetch failed") as TypeError & {
@@ -5661,23 +4929,15 @@ index 26aad0cdf..39e32bb5a 100644
 +  });
 +
    it("does not retry transient transport failures when the request body cannot be replayed", async () => {
-     const transient = new TypeError("fetch failed") as TypeError & {
-       cause?: { name: string; code: string };
 diff --git a/src/agents/provider-transport-fetch.ts b/src/agents/provider-transport-fetch.ts
 index e19b5fb0a..a865a7b4a 100644
 --- a/src/agents/provider-transport-fetch.ts
 +++ b/src/agents/provider-transport-fetch.ts
-@@ -20,6 +20,7 @@ import {
-   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
-   type SsrFPolicy,
+@@ -22,2 +22,3 @@ import {
  } from "../infra/net/ssrf.js";
 +import { shouldDisableInternalProviderTransportRetries } from "../llm/run-safety-provider-dispatch-context.js";
  import type { Model } from "../llm/types.js";
- import { createSubsystemLogger } from "../logging/subsystem.js";
- import { resolveDebugProxySettings } from "../proxy-capture/env.js";
-@@ -547,7 +548,10 @@ function buildModelRequestSignal(
-   return AbortSignal.any([baseSignal, timeoutSignal]);
- }
+@@ -549,3 +550,6 @@ function buildModelRequestSignal(
  
 -function readErrorStringField(error: unknown, key: "code" | "message" | "name"): string | undefined {
 +function readErrorStringField(
@@ -5685,21 +4945,13 @@ index e19b5fb0a..a865a7b4a 100644
 +  key: "code" | "message" | "name",
 +): string | undefined {
    if (!error || typeof error !== "object") {
-     return undefined;
-   }
-@@ -560,7 +564,8 @@ function readErrorCause(error: unknown): unknown {
- }
- 
+@@ -562,3 +566,4 @@ function readErrorCause(error: unknown): unknown {
  function isTransientProviderFetchTransportError(error: unknown): boolean {
 -  const code = readErrorStringField(error, "code") ?? readErrorStringField(readErrorCause(error), "code");
 +  const code =
 +    readErrorStringField(error, "code") ?? readErrorStringField(readErrorCause(error), "code");
    if (code && TRANSIENT_PROVIDER_FETCH_ERROR_CODES.has(code)) {
-     return true;
-   }
-@@ -570,9 +575,12 @@ function isTransientProviderFetchTransportError(error: unknown): boolean {
-     return true;
-   }
+@@ -572,5 +577,8 @@ function isTransientProviderFetchTransportError(error: unknown): boolean {
  
 -  const message = error instanceof Error ? error.message : readErrorStringField(error, "message") ?? "";
 -  return /\b(?:socket hang up|connection reset|connection aborted|fetch failed)\b/i.test(message) &&
@@ -5711,11 +4963,7 @@ index e19b5fb0a..a865a7b4a 100644
 +    (causeName === "ConnectTimeoutError" || causeName === "SocketError" || Boolean(code))
 +  );
  }
- 
- function isReplayableProviderFetchBody(body: BodyInit | null | undefined): boolean {
-@@ -592,8 +600,10 @@ function shouldRetryProviderFetch(error: unknown, init: RequestInit | undefined)
-   if (init?.signal?.aborted) {
-     return false;
+@@ -594,4 +602,6 @@ function shouldRetryProviderFetch(error: unknown, init: RequestInit | undefined)
    }
 -  return isReplayableProviderFetchBody(init?.body as BodyInit | null | undefined) &&
 -    isTransientProviderFetchTransportError(error);
@@ -5724,11 +4972,7 @@ index e19b5fb0a..a865a7b4a 100644
 +    isTransientProviderFetchTransportError(error)
 +  );
  }
- 
- function delayProviderFetchRetry(): Promise<void> {
-@@ -801,7 +811,11 @@ export function buildGuardedModelFetch(
-           );
-           break;
+@@ -803,3 +813,7 @@ export function buildGuardedModelFetch(
          } catch (error) {
 -          if (attempt >= 2 || !shouldRetryProviderFetch(error, baseInit)) {
 +          if (
@@ -5737,13 +4981,11 @@ index e19b5fb0a..a865a7b4a 100644
 +            !shouldRetryProviderFetch(error, baseInit)
 +          ) {
              throw error;
-           }
-           log.warn(
 diff --git a/src/agents/provider-transport-stream.test.ts b/src/agents/provider-transport-stream.test.ts
 index dba642589..86c6802d1 100644
 --- a/src/agents/provider-transport-stream.test.ts
 +++ b/src/agents/provider-transport-stream.test.ts
-@@ -1,7 +1,9 @@
+@@ -1,5 +1,7 @@
  import type { Api, Model } from "openclaw/plugin-sdk/llm";
 -import { describe, expect, it } from "vitest";
 +import { afterEach, describe, expect, it, vi } from "vitest";
@@ -5752,11 +4994,7 @@ index dba642589..86c6802d1 100644
  import { attachModelProviderRequestTransport } from "./provider-request-config.js";
 +import { isProviderRunSafetyStreamFnV1 } from "./provider-run-safety-contract.js";
  import {
-   buildTransportAwareSimpleStreamFn,
-   createBoundaryAwareStreamFnForModel,
-@@ -12,6 +14,19 @@ import {
-   resolveTransportAwareSimpleApi,
- } from "./provider-transport-stream.js";
+@@ -14,2 +16,15 @@ import {
  
 +const { transportFetchMock } = vi.hoisted(() => ({
 +  transportFetchMock: vi.fn(),
@@ -5772,11 +5010,7 @@ index dba642589..86c6802d1 100644
 +});
 +
  function buildModel<TApi extends Api>(
-   api: TApi,
-   params: {
-@@ -176,6 +191,76 @@ describe("provider transport stream contracts", () => {
-     }
-   });
+@@ -178,2 +193,72 @@ describe("provider transport stream contracts", () => {
  
 +  it.each([
 +    { label: "built-in", provider: "openai" },
@@ -5849,14 +5083,11 @@ index dba642589..86c6802d1 100644
 +  });
 +
    it("routes localService models through the OpenClaw simple-completion transport", () => {
-     const model = attachModelProviderLocalService(
-       buildModel("openai-completions", {
 diff --git a/src/agents/provider-transport-stream.ts b/src/agents/provider-transport-stream.ts
 index bee179264..ca8a1b27e 100644
 --- a/src/agents/provider-transport-stream.ts
 +++ b/src/agents/provider-transport-stream.ts
-@@ -1,6 +1,9 @@
- import type { OpenClawConfig } from "../config/types.openclaw.js";
+@@ -2,3 +2,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
  import type { Api, Model } from "../llm/types.js";
 -import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
 +import {
@@ -5864,11 +5095,7 @@ index bee179264..ca8a1b27e 100644
 +  resolveProviderStreamFn,
 +} from "../plugins/provider-runtime.js";
  import { createAnthropicMessagesTransportStreamFn } from "./anthropic-transport-stream.js";
- import {
-   createAzureOpenAIResponsesTransportStreamFn,
-@@ -9,6 +12,11 @@ import {
- } from "./openai-transport-stream.js";
- import { getModelProviderLocalService } from "./provider-local-service.js";
+@@ -11,2 +14,7 @@ import { getModelProviderLocalService } from "./provider-local-service.js";
  import { getModelProviderRequestTransport } from "./provider-request-config.js";
 +import {
 +  adaptBundledAuditedProviderPayloadHookStreamFnV1,
@@ -5876,18 +5103,11 @@ index bee179264..ca8a1b27e 100644
 +  ProviderStreamPurpose,
 +} from "./provider-run-safety-contract.js";
  import type { StreamFn } from "./runtime/index.js";
- 
- const SUPPORTED_TRANSPORT_APIS = new Set<Api>([
-@@ -34,14 +42,19 @@ type ProviderTransportStreamContext = {
-   agentDir?: string;
-   workspaceDir?: string;
+@@ -36,2 +44,3 @@ type ProviderTransportStreamContext = {
    env?: NodeJS.ProcessEnv;
 +  purpose?: ProviderStreamPurpose;
  };
- 
- function createProviderOwnedGoogleTransportStreamFn(
-   model: Model,
-   ctx?: ProviderTransportStreamContext,
+@@ -42,4 +51,8 @@ function createProviderOwnedGoogleTransportStreamFn(
  ): StreamFn | undefined {
 +  const resolveStreamFn =
 +    ctx?.purpose === ProviderStreamPurpose.Agent
@@ -5897,20 +5117,12 @@ index bee179264..ca8a1b27e 100644
 -    resolveProviderStreamFn({
 +    resolveStreamFn({
        provider: model.provider,
-       config: ctx?.cfg,
-       workspaceDir: ctx?.workspaceDir,
-@@ -55,7 +68,7 @@ function createProviderOwnedGoogleTransportStreamFn(
-         model,
-       },
+@@ -57,3 +70,3 @@ function createProviderOwnedGoogleTransportStreamFn(
      }) ??
 -    resolveProviderStreamFn({
 +    resolveStreamFn({
        provider: "google",
-       config: ctx?.cfg,
-       workspaceDir: ctx?.workspaceDir,
-@@ -94,6 +107,20 @@ function createSupportedTransportStreamFn(
-   }
- }
+@@ -96,2 +109,16 @@ function createSupportedTransportStreamFn(
  
 +function applyAgentRunSafetyContract(
 +  streamFn: StreamFn | undefined,
@@ -5927,20 +5139,12 @@ index bee179264..ca8a1b27e 100644
 +}
 +
  function hasOpenClawTransportRequirement(model: Model): boolean {
-   const request = getModelProviderRequestTransport(model);
-   return Boolean(request?.proxy || request?.tls || getModelProviderLocalService(model));
-@@ -119,7 +146,7 @@ export function createTransportAwareStreamFnForModel(
-       `Model-provider request.proxy/request.tls/localService is not yet supported for api "${model.api}"`,
-     );
+@@ -121,3 +148,3 @@ export function createTransportAwareStreamFnForModel(
    }
 -  return createSupportedTransportStreamFn(model, ctx);
 +  return applyAgentRunSafetyContract(createSupportedTransportStreamFn(model, ctx), ctx?.purpose);
  }
- 
- export function createOpenClawTransportStreamFnForModel(
-@@ -145,7 +172,11 @@ export function createBoundaryAwareStreamFnForModel(
-   if (!isTransportAwareApiSupported(model.api)) {
-     return undefined;
+@@ -147,3 +174,7 @@ export function createBoundaryAwareStreamFnForModel(
    }
 -  return createSupportedTransportStreamFn(model, ctx);
 +  const agentContext = { ...ctx, purpose: ProviderStreamPurpose.Agent };
@@ -5949,27 +5153,32 @@ index bee179264..ca8a1b27e 100644
 +    ProviderStreamPurpose.Agent,
 +  );
  }
- 
- export function prepareTransportAwareSimpleModel<TApi extends Api>(
 diff --git a/src/agents/run-safety-controller.test.ts b/src/agents/run-safety-controller.test.ts
 new file mode 100644
-index 000000000..02e653d57
+index 000000000..5b19ee4e8
 --- /dev/null
 +++ b/src/agents/run-safety-controller.test.ts
-@@ -0,0 +1,454 @@
+@@ -0,0 +1,520 @@
 +import { describe, expect, it, vi } from "vitest";
 +import {
 +  estimateRunSafetyPromptTokens,
++  PromptEstimateSource,
++  PromptEstimateUnavailableReason,
++  PromptObservationStatus,
 +  resolveRunSafetyBudgetLimits,
++  resolveRunSafetyPromptExposureConfig,
 +  RunSafetyBudgetDefaults,
 +  RunSafetyController,
++  RunSafetyPromptExposureDefaults,
 +  RunSafetyRootCoordinator,
++  RunSafetyTelemetryEvent,
 +  RunSafetyTerminationKind,
 +} from "./run-safety-controller.js";
 +
 +function createController(
-+  limits: Partial<ConstructorParameters<typeof RunSafetyController>[0]["limits"]> = {},
++  limits: NonNullable<ConstructorParameters<typeof RunSafetyController>[0]["limits"]> = {},
 +  onDrained?: ConstructorParameters<typeof RunSafetyController>[0]["onDrained"],
++  onTelemetry?: ConstructorParameters<typeof RunSafetyController>[0]["onTelemetry"],
 +): RunSafetyController {
 +  return new RunSafetyController({
 +    rootInvocationId: "root-1",
@@ -5977,6 +5186,7 @@ index 000000000..02e653d57
 +    rootRunId: "run-1",
 +    limits,
 +    onDrained,
++    onTelemetry,
 +  });
 +}
 +
@@ -5986,62 +5196,86 @@ index 000000000..02e653d57
 +      resolveRunSafetyBudgetLimits({
 +        maxToolCallReservationsPerBudgetScope: 0,
 +        maxProviderDispatchesPerBudgetScope: Number.NaN,
-+        maxCumulativeEstimatedPromptTokensPerBudgetScope: Number.POSITIVE_INFINITY,
 +        warningRatio: 1,
 +      }),
 +    ).toEqual(RunSafetyBudgetDefaults);
++    expect(
++      resolveRunSafetyPromptExposureConfig({
++        mode: "observe",
++        legacyDiagnosticThreshold: Number.POSITIVE_INFINITY,
++      }),
++    ).toEqual(RunSafetyPromptExposureDefaults);
 +  });
 +
 +  it("allows the configured provider dispatches and blocks the next one before dispatch", () => {
 +    const controller = createController({
 +      maxProviderDispatchesPerBudgetScope: 2,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 100,
 +    });
 +
 +    expect(
 +      controller.reserveProviderDispatch({
 +        runId: "run-1",
 +        providerDispatchId: "dispatch-1",
-+        estimatedPromptTokens: 10,
 +      }).allowed,
 +    ).toBe(true);
 +    expect(
 +      controller.reserveProviderDispatch({
 +        runId: "run-1",
 +        providerDispatchId: "dispatch-2",
-+        estimatedPromptTokens: 10,
 +      }).allowed,
 +    ).toBe(true);
 +    const blocked = controller.reserveProviderDispatch({
 +      runId: "run-1",
 +      providerDispatchId: "dispatch-3",
-+      estimatedPromptTokens: 10,
 +    });
 +
 +    expect(blocked.allowed).toBe(false);
 +    expect(blocked.reason?.kind).toBe(RunSafetyTerminationKind.RunProviderDispatchBudget);
 +    expect(controller.snapshot()).toMatchObject({
 +      providerDispatchCount: 2,
-+      cumulativeEstimatedPromptTokens: 20,
 +      status: "draining",
++      promptExposure: {
++        knownEstimateDispatchCount: 0,
++        pendingObservationDispatchCount: 2,
++      },
 +    });
 +  });
 +
-+  it("keeps provider reservations idempotent without refunding exposure", () => {
++  it("keeps prompt observations immutable and idempotent", () => {
 +    const controller = createController({
 +      maxProviderDispatchesPerBudgetScope: 2,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 100,
 +    });
 +
 +    const first = controller.reserveProviderDispatch({
 +      runId: "run-1",
 +      providerDispatchId: "dispatch-1",
-+      estimatedPromptTokens: 20,
 +    });
 +    const duplicate = controller.reserveProviderDispatch({
 +      runId: "run-1",
 +      providerDispatchId: "dispatch-1",
-+      estimatedPromptTokens: 20,
++    });
++    controller.observeProviderPromptEstimate({
++      providerDispatchId: "dispatch-1",
++      observation: {
++        status: PromptObservationStatus.Known,
++        legacyEstimatedExposureUnits: 20,
++        source: PromptEstimateSource.StableTextTokens,
++      },
++    });
++    controller.observeProviderPromptEstimate({
++      providerDispatchId: "dispatch-1",
++      observation: {
++        status: PromptObservationStatus.Known,
++        legacyEstimatedExposureUnits: 20,
++        source: PromptEstimateSource.StableTextTokens,
++      },
++    });
++    controller.observeProviderPromptEstimate({
++      providerDispatchId: "dispatch-1",
++      observation: {
++        status: PromptObservationStatus.Unavailable,
++        reason: PromptEstimateUnavailableReason.EstimatorThrew,
++      },
 +    });
 +    controller.completeProviderDispatch("dispatch-1");
 +
@@ -6049,73 +5283,92 @@ index 000000000..02e653d57
 +    expect(duplicate).toMatchObject({ allowed: true, duplicate: true });
 +    expect(controller.snapshot()).toMatchObject({
 +      providerDispatchCount: 1,
-+      cumulativeEstimatedPromptTokens: 20,
++      promptExposure: {
++        legacyEstimatedExposureUnitsTotal: 20,
++        knownEstimateDispatchCount: 1,
++        estimateUnavailableDispatchCount: 0,
++        pendingObservationDispatchCount: 0,
++      },
 +    });
 +  });
 +
-+  it("allows prompt exposure exactly at the limit and closes continuation", () => {
-+    const controller = createController({
-+      maxProviderDispatchesPerBudgetScope: 10,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 20,
-+    });
++  it("observes prompt exposure above the legacy threshold without terminating", () => {
++    const onTelemetry = vi.fn();
++    const controller = createController(
++      {
++        maxProviderDispatchesPerBudgetScope: 10,
++        promptExposure: { mode: "observe", legacyDiagnosticThreshold: 20 },
++      },
++      undefined,
++      onTelemetry,
++    );
 +
 +    expect(
 +      controller.reserveProviderDispatch({
 +        runId: "run-1",
 +        providerDispatchId: "dispatch-1",
-+        estimatedPromptTokens: 20,
 +      }).allowed,
 +    ).toBe(true);
-+    expect(controller.continuationClosedReason).toBe(
-+      RunSafetyTerminationKind.RunPromptExposureBudget,
-+    );
-+
-+    const blockedBatch = controller.reserveToolBatch({
++    controller.observeProviderPromptEstimate({
++      providerDispatchId: "dispatch-1",
++      observation: {
++        status: PromptObservationStatus.Known,
++        legacyEstimatedExposureUnits: 21,
++        source: PromptEstimateSource.StableTextTokens,
++      },
++    });
++    const allowedBatch = controller.reserveToolBatch({
 +      runId: "run-1",
 +      toolBatchId: "batch-1",
 +      toolCalls: [{ toolName: "exec", toolCallId: "call-1" }],
 +    });
-+    expect(blockedBatch[0]).toMatchObject({
-+      allowed: false,
-+      reason: { kind: RunSafetyTerminationKind.RunPromptExposureBudget },
++    expect(allowedBatch[0]).toMatchObject({
++      allowed: true,
 +    });
-+    expect(controller.snapshot().toolCallReservationCount).toBe(0);
++    expect(controller.terminationReason).toBeUndefined();
++    expect(controller.continuationClosedReason).toBeUndefined();
++    expect(controller.snapshot().promptExposure).toMatchObject({
++      legacyEstimatedExposureUnitsTotal: 21,
++      legacyDiagnosticThresholdCrossed: true,
++    });
++    expect(onTelemetry).toHaveBeenCalledTimes(1);
++    expect(onTelemetry).toHaveBeenCalledWith(
++      expect.objectContaining({ event: RunSafetyTelemetryEvent.PromptExposureThresholdCrossed }),
++    );
 +  });
 +
-+  it("refines the final provider payload upward without refunding a smaller estimate", () => {
-+    const controller = createController({
-+      maxProviderDispatchesPerBudgetScope: 10,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 25,
-+    });
++  it("records an unavailable prompt estimate without terminating", () => {
++    const onTelemetry = vi.fn();
++    const controller = createController({}, undefined, onTelemetry);
 +    controller.reserveProviderDispatch({
 +      runId: "run-1",
 +      providerDispatchId: "dispatch-1",
-+      estimatedPromptTokens: 10,
 +    });
-+
-+    expect(
-+      controller.refineProviderPromptEstimate({
-+        runId: "run-1",
-+        providerDispatchId: "dispatch-1",
-+        estimatedPromptTokens: 20,
-+      }).allowed,
-+    ).toBe(true);
-+    expect(
-+      controller.refineProviderPromptEstimate({
-+        runId: "run-1",
-+        providerDispatchId: "dispatch-1",
-+        estimatedPromptTokens: 5,
-+      }).allowed,
-+    ).toBe(true);
-+    expect(controller.snapshot().cumulativeEstimatedPromptTokens).toBe(20);
-+
++    controller.observeProviderPromptEstimate({
++      providerDispatchId: "dispatch-1",
++      observation: {
++        status: PromptObservationStatus.Unavailable,
++        reason: PromptEstimateUnavailableReason.UnknownMediaWithoutContextWindow,
++      },
++    });
 +    const second = controller.reserveProviderDispatch({
 +      runId: "run-1",
 +      providerDispatchId: "dispatch-2",
-+      estimatedPromptTokens: 6,
 +    });
-+    expect(second.allowed).toBe(false);
-+    expect(second.reason?.kind).toBe(RunSafetyTerminationKind.RunPromptExposureBudget);
++    expect(second.allowed).toBe(true);
++    expect(controller.terminationReason).toBeUndefined();
++    expect(controller.snapshot().promptExposure).toMatchObject({
++      estimateUnavailableDispatchCount: 1,
++      pendingObservationDispatchCount: 1,
++      unavailableReasonCounts: {
++        unknown_media_without_context_window: 1,
++      },
++    });
++    expect(onTelemetry).toHaveBeenCalledWith(
++      expect.objectContaining({
++        event: RunSafetyTelemetryEvent.PromptEstimateUnavailableObserved,
++      }),
++    );
 +  });
 +
 +  it("reserves a raw tool batch in declaration order before blocking overflow calls", () => {
@@ -6154,7 +5407,6 @@ index 000000000..02e653d57
 +    const controller = createController({
 +      maxToolCallReservationsPerBudgetScope: 5,
 +      maxProviderDispatchesPerBudgetScope: 5,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 100,
 +      warningRatio: 0.5,
 +    });
 +
@@ -6169,15 +5421,31 @@ index 000000000..02e653d57
 +      controller.reserveProviderDispatch({
 +        runId: "run-1",
 +        providerDispatchId: `dispatch-${index}`,
-+        estimatedPromptTokens: 20,
 +      });
 +    }
 +
 +    expect(controller.getWarnings()).toEqual([
 +      { dimension: "tool_call_reservations", observed: 3, limit: 5 },
 +      { dimension: "provider_dispatches", observed: 3, limit: 5 },
-+      { dimension: "prompt_exposure", observed: 60, limit: 100 },
 +    ]);
++  });
++
++  it("settles a pending prompt observation as unavailable on completion", () => {
++    const controller = createController();
++    controller.reserveProviderDispatch({
++      runId: "run-1",
++      providerDispatchId: "dispatch-1",
++    });
++
++    controller.completeProviderDispatch("dispatch-1");
++
++    expect(controller.snapshot().promptExposure).toMatchObject({
++      estimateUnavailableDispatchCount: 1,
++      pendingObservationDispatchCount: 0,
++      unavailableReasonCounts: {
++        payload_not_observed_before_completion: 1,
++      },
++    });
 +  });
 +
 +  it("owns variant detector history per run and terminates on the third distinct argument", () => {
@@ -6281,10 +5549,10 @@ index 000000000..02e653d57
 +    }
 +  });
 +
-+  it("estimates tokens, not bytes, so the configured budget keeps its calibration", () => {
++  it("estimates tokens, not bytes, so legacy telemetry keeps its calibration", () => {
 +    // ~400K real tokens of ASCII ≈ 1.6MB serialized. The old byte-based
-+    // formula estimated ~1.6M units and blocked the second dispatch of a
-+    // 400K context; a token estimate must stay in the ~400K range.
++    // formula estimated ~1.6M units for a 400K context; the legacy telemetry
++    // estimate should stay in the ~400K range for longitudinal comparability.
 +    const asciiText = "word ".repeat(320_000);
 +    const estimate = estimateRunSafetyPromptTokens({
 +      messages: [{ role: "user", content: asciiText }],
@@ -6318,8 +5586,8 @@ index 000000000..02e653d57
 +
 +  it("caps inline base64 media at a fixed conservative estimate", () => {
 +    // ~1.4MB of inline base64 image data. Counting raw base64 length would
-+    // consume ~350K tokens of budget for a single image; the conservative
-+    // per-blob constant keeps it bounded while remaining well above real
++    // add ~350K legacy units for a single image; the conservative per-blob
++    // constant keeps telemetry bounded while remaining well above real
 +    // provider image billing.
 +    const inlineImage = "A".repeat(1_400_000);
 +    const estimate = estimateRunSafetyPromptTokens({
@@ -6357,7 +5625,7 @@ index 000000000..02e653d57
 +    });
 +  });
 +
-+  it("fails closed for unknown media without a context window", () => {
++  it("reports estimate unavailable for unknown media without a context window", () => {
 +    expect(
 +      estimateRunSafetyPromptTokens({
 +        messages: [{ role: "user", content: [{ type: "image_url", url: "https://x.test/a" }] }],
@@ -6413,12 +5681,13 @@ index 000000000..02e653d57
 +});
 diff --git a/src/agents/run-safety-controller.ts b/src/agents/run-safety-controller.ts
 new file mode 100644
-index 000000000..52fc5e00b
+index 000000000..2cdb983b9
 --- /dev/null
 +++ b/src/agents/run-safety-controller.ts
-@@ -0,0 +1,880 @@
+@@ -0,0 +1,1067 @@
 +import { randomUUID } from "node:crypto";
 +import type { Model } from "../llm/types.js";
++import { logDebug } from "../logger.js";
 +import { estimateStringChars, estimateTokensFromChars } from "../utils/cjk-chars.js";
 +import { stableStringify } from "./stable-stringify.js";
 +
@@ -6438,15 +5707,27 @@ index 000000000..52fc5e00b
 +export const RunSafetyBudgetDefaults = {
 +  maxToolCallReservationsPerBudgetScope: 64,
 +  maxProviderDispatchesPerBudgetScope: 32,
-+  maxCumulativeEstimatedPromptTokensPerBudgetScope: 2_000_000,
 +  warningRatio: 0.75,
 +} as const;
 +
 +export type RunSafetyBudgetLimits = {
 +  maxToolCallReservationsPerBudgetScope: number;
 +  maxProviderDispatchesPerBudgetScope: number;
-+  maxCumulativeEstimatedPromptTokensPerBudgetScope: number;
 +  warningRatio: number;
++};
++
++export const RunSafetyPromptExposureDefaults = {
++  mode: "observe",
++  legacyDiagnosticThreshold: 2_000_000,
++} as const;
++
++export type RunSafetyPromptExposureConfig = {
++  mode: typeof RunSafetyPromptExposureDefaults.mode;
++  legacyDiagnosticThreshold: number;
++};
++
++export type RunSafetyControllerLimits = Partial<RunSafetyBudgetLimits> & {
++  promptExposure?: Partial<RunSafetyPromptExposureConfig>;
 +};
 +
 +export type RunSafetyTermination = {
@@ -6463,10 +5744,7 @@ index 000000000..52fc5e00b
 +  cumulativeEstimatedPromptTokens?: number;
 +};
 +
-+export type RunSafetyWarningDimension =
-+  | "tool_call_reservations"
-+  | "provider_dispatches"
-+  | "prompt_exposure";
++export type RunSafetyWarningDimension = "tool_call_reservations" | "provider_dispatches";
 +
 +export type RunSafetyWarning = {
 +  dimension: RunSafetyWarningDimension;
@@ -6481,7 +5759,7 @@ index 000000000..52fc5e00b
 +  status: "active" | "draining" | "ended";
 +  toolCallReservationCount: number;
 +  providerDispatchCount: number;
-+  cumulativeEstimatedPromptTokens: number;
++  promptExposure: PromptExposureTelemetrySnapshot;
 +  continuationClosedReason?: RunSafetyTerminationKind;
 +  scopeTerminalReason?: RunSafetyTermination;
 +};
@@ -6523,9 +5801,80 @@ index 000000000..52fc5e00b
 +export type RunSafetyProviderReservationDecision = {
 +  allowed: boolean;
 +  providerDispatchId: string;
-+  estimatedPromptTokens: number;
 +  reason?: RunSafetyTermination;
 +  duplicate?: boolean;
++};
++
++export const PromptObservationStatus = {
++  Pending: "pending",
++  Known: "known",
++  Unavailable: "unavailable",
++} as const;
++
++export type PromptObservationStatus =
++  (typeof PromptObservationStatus)[keyof typeof PromptObservationStatus];
++
++export const PromptEstimateSource = {
++  StableTextTokens: "stable_text_tokens",
++  ContextWindowFloor: "context_window_floor",
++} as const;
++
++export type PromptEstimateSource = (typeof PromptEstimateSource)[keyof typeof PromptEstimateSource];
++
++export const PromptEstimateUnavailableReason = {
++  SerializationFailed: "serialization_failed",
++  UnknownMediaWithoutContextWindow: "unknown_media_without_context_window",
++  EstimatorThrew: "estimator_threw",
++  InvalidEstimate: "invalid_estimate",
++  PayloadNotObservedBeforeCompletion: "payload_not_observed_before_completion",
++} as const;
++
++export type PromptEstimateUnavailableReason =
++  (typeof PromptEstimateUnavailableReason)[keyof typeof PromptEstimateUnavailableReason];
++
++export type PromptObservationState =
++  | { status: typeof PromptObservationStatus.Pending }
++  | {
++      status: typeof PromptObservationStatus.Known;
++      legacyEstimatedExposureUnits: number;
++      source: PromptEstimateSource;
++    }
++  | {
++      status: typeof PromptObservationStatus.Unavailable;
++      reason: PromptEstimateUnavailableReason;
++    };
++
++export type FinalPromptObservation = Exclude<
++  PromptObservationState,
++  { status: typeof PromptObservationStatus.Pending }
++>;
++
++export type PromptExposureTelemetrySnapshot = {
++  legacyEstimatedExposureUnitsTotal: number;
++  knownEstimateDispatchCount: number;
++  estimateUnavailableDispatchCount: number;
++  pendingObservationDispatchCount: number;
++  maxLegacyEstimatedExposureUnitsPerDispatch: number;
++  estimateSourceCounts: Partial<Record<PromptEstimateSource, number>>;
++  unavailableReasonCounts: Partial<Record<PromptEstimateUnavailableReason, number>>;
++  legacyDiagnosticThresholdCrossed: boolean;
++};
++
++export const RunSafetyTelemetryEvent = {
++  PromptExposureThresholdCrossed: "run_prompt_exposure_threshold_crossed",
++  PromptEstimateUnavailableObserved: "run_prompt_exposure_estimate_unavailable_observed",
++  ScopeSummary: "run_safety_scope_summary",
++} as const;
++
++export type RunSafetyTelemetryEvent =
++  (typeof RunSafetyTelemetryEvent)[keyof typeof RunSafetyTelemetryEvent];
++
++export type RunSafetyTelemetryRecord = {
++  event: RunSafetyTelemetryEvent;
++  rootInvocationId: string;
++  budgetScopeId: string;
++  rootRunId: string;
++  promptExposure: PromptExposureTelemetrySnapshot;
 +};
 +
 +type ToolReservation = {
@@ -6535,6 +5884,7 @@ index 000000000..52fc5e00b
 +
 +type ProviderReservation = {
 +  decision: RunSafetyProviderReservationDecision;
++  observation: PromptObservationState;
 +  completed: boolean;
 +};
 +
@@ -6554,7 +5904,7 @@ index 000000000..52fc5e00b
 +}
 +
 +export function resolveRunSafetyBudgetLimits(
-+  value?: Partial<RunSafetyBudgetLimits>,
++  value?: RunSafetyControllerLimits,
 +): RunSafetyBudgetLimits {
 +  return {
 +    maxToolCallReservationsPerBudgetScope: isPositiveSafeInteger(
@@ -6567,14 +5917,20 @@ index 000000000..52fc5e00b
 +    )
 +      ? value.maxProviderDispatchesPerBudgetScope
 +      : RunSafetyBudgetDefaults.maxProviderDispatchesPerBudgetScope,
-+    maxCumulativeEstimatedPromptTokensPerBudgetScope: isPositiveSafeInteger(
-+      value?.maxCumulativeEstimatedPromptTokensPerBudgetScope,
-+    )
-+      ? value.maxCumulativeEstimatedPromptTokensPerBudgetScope
-+      : RunSafetyBudgetDefaults.maxCumulativeEstimatedPromptTokensPerBudgetScope,
 +    warningRatio: isWarningRatio(value?.warningRatio)
 +      ? value.warningRatio
 +      : RunSafetyBudgetDefaults.warningRatio,
++  };
++}
++
++export function resolveRunSafetyPromptExposureConfig(
++  value?: RunSafetyControllerLimits["promptExposure"],
++): RunSafetyPromptExposureConfig {
++  return {
++    mode: RunSafetyPromptExposureDefaults.mode,
++    legacyDiagnosticThreshold: isPositiveSafeInteger(value?.legacyDiagnosticThreshold)
++      ? value.legacyDiagnosticThreshold
++      : RunSafetyPromptExposureDefaults.legacyDiagnosticThreshold,
 +  };
 +}
 +
@@ -6674,9 +6030,14 @@ index 000000000..52fc5e00b
 +  | {
 +      ok: true;
 +      estimatedPromptTokens: number;
-+      source: "stable_text_tokens" | "context_window_floor";
++      source: PromptEstimateSource;
 +    }
-+  | { ok: false; reason: "serialization_failed" | "unknown_media_without_context_window" };
++  | {
++      ok: false;
++      reason:
++        | typeof PromptEstimateUnavailableReason.SerializationFailed
++        | typeof PromptEstimateUnavailableReason.UnknownMediaWithoutContextWindow;
++    };
 +
 +/**
 + * Contiguous base64-looking runs of at least this many characters inside the
@@ -6690,7 +6051,7 @@ index 000000000..52fc5e00b
 + * Conservative per-blob prompt token estimate for inline media. Provider
 + * image billing typically lands far below this; counting the raw base64
 + * length instead would overstate one image by two orders of magnitude and
-+ * silently shrink the configured budget.
++ * distort legacy telemetry comparability.
 + */
 +const INLINE_MEDIA_TOKEN_ESTIMATE = 8_192;
 +
@@ -6702,14 +6063,14 @@ index 000000000..52fc5e00b
 +  try {
 +    serialized = stableStringify(payload);
 +  } catch {
-+    return { ok: false, reason: "serialization_failed" };
++    return { ok: false, reason: PromptEstimateUnavailableReason.SerializationFailed };
 +  }
 +  if (typeof serialized !== "string") {
-+    return { ok: false, reason: "serialization_failed" };
++    return { ok: false, reason: PromptEstimateUnavailableReason.SerializationFailed };
 +  }
 +  // CJK-aware chars-per-token estimate over the final serialized payload.
 +  // Counting UTF-8 bytes here would overstate Latin text ~4x and CJK text
-+  // ~2-3x, shrinking the configured token budget far below its calibration.
++  // ~2-3x, breaking legacy telemetry calibration across payload languages.
 +  let textChars = estimateStringChars(serialized);
 +  let inlineMediaTokens = 0;
 +  for (const match of serialized.matchAll(INLINE_MEDIA_BASE64_RUN_RE)) {
@@ -6728,17 +6089,53 @@ index 000000000..52fc5e00b
 +    return {
 +      ok: true,
 +      estimatedPromptTokens: textEstimate,
-+      source: "stable_text_tokens",
++      source: PromptEstimateSource.StableTextTokens,
 +    };
 +  }
 +  const contextWindow = normalizePromptEstimate(model?.contextWindow);
 +  if (!contextWindow) {
-+    return { ok: false, reason: "unknown_media_without_context_window" };
++    return {
++      ok: false,
++      reason: PromptEstimateUnavailableReason.UnknownMediaWithoutContextWindow,
++    };
 +  }
 +  return {
 +    ok: true,
 +    estimatedPromptTokens: Math.max(textEstimate, contextWindow),
-+    source: "context_window_floor",
++    source: PromptEstimateSource.ContextWindowFloor,
++  };
++}
++
++export function estimateRunSafetyPromptObservation(
++  payload: unknown,
++  model?: Pick<Model, "contextWindow">,
++): FinalPromptObservation {
++  let estimate: PromptEstimateResult;
++  try {
++    estimate = estimateRunSafetyPromptTokens(payload, model);
++  } catch {
++    return {
++      status: PromptObservationStatus.Unavailable,
++      reason: PromptEstimateUnavailableReason.EstimatorThrew,
++    };
++  }
++  if (!estimate.ok) {
++    return {
++      status: PromptObservationStatus.Unavailable,
++      reason: estimate.reason,
++    };
++  }
++  const normalizedEstimate = normalizePromptEstimate(estimate.estimatedPromptTokens);
++  if (!normalizedEstimate) {
++    return {
++      status: PromptObservationStatus.Unavailable,
++      reason: PromptEstimateUnavailableReason.InvalidEstimate,
++    };
++  }
++  return {
++    status: PromptObservationStatus.Known,
++    legacyEstimatedExposureUnits: normalizedEstimate,
++    source: estimate.source,
 +  };
 +}
 +
@@ -6806,10 +6203,19 @@ index 000000000..52fc5e00b
 +  readonly budgetScopeId: string;
 +  readonly rootRunId: string;
 +  readonly limits: Readonly<RunSafetyBudgetLimits>;
++  readonly promptExposure: Readonly<RunSafetyPromptExposureConfig>;
 +  private statusValue: "active" | "draining" | "ended" = "active";
 +  private toolCallReservationCountValue = 0;
 +  private providerDispatchCountValue = 0;
-+  private cumulativeEstimatedPromptTokensValue = 0;
++  private legacyEstimatedExposureUnitsTotalValue = 0;
++  private knownEstimateDispatchCountValue = 0;
++  private estimateUnavailableDispatchCountValue = 0;
++  private maxLegacyEstimatedExposureUnitsPerDispatchValue = 0;
++  private readonly estimateSourceCounts = new Map<PromptEstimateSource, number>();
++  private readonly unavailableReasonCounts = new Map<PromptEstimateUnavailableReason, number>();
++  private legacyDiagnosticThresholdCrossedValue = false;
++  private promptUnavailableDiagnosticEmitted = false;
++  private scopeSummaryEmitted = false;
 +  private continuationClosedReasonValue?: RunSafetyTerminationKind;
 +  private scopeTerminalReasonValue?: RunSafetyTermination;
 +  private toolBatchSequence = 0;
@@ -6820,27 +6226,37 @@ index 000000000..52fc5e00b
 +  private readonly variantWarningThreshold: number;
 +  private readonly variantCriticalThreshold: number;
 +  private readonly warnings = new Map<RunSafetyWarningDimension, RunSafetyWarning>();
++  private readonly onTelemetry: (record: RunSafetyTelemetryRecord) => void;
 +  private onDrained?: (reason: RunSafetyTermination) => void;
 +
 +  constructor(params: {
 +    rootInvocationId: string;
 +    budgetScopeId?: string;
 +    rootRunId: string;
-+    limits?: Partial<RunSafetyBudgetLimits>;
++    limits?: RunSafetyControllerLimits;
 +    variantWarningThreshold?: number;
 +    variantCriticalThreshold?: number;
 +    onDrained?: (reason: RunSafetyTermination) => void;
++    onTelemetry?: (record: RunSafetyTelemetryRecord) => void;
 +  }) {
 +    this.rootInvocationId = params.rootInvocationId;
 +    this.budgetScopeId = params.budgetScopeId ?? randomUUID();
 +    this.rootRunId = params.rootRunId;
 +    this.limits = Object.freeze(resolveRunSafetyBudgetLimits(params.limits));
++    this.promptExposure = Object.freeze(
++      resolveRunSafetyPromptExposureConfig(params.limits?.promptExposure),
++    );
 +    this.variantWarningThreshold = isPositiveSafeInteger(params.variantWarningThreshold)
 +      ? params.variantWarningThreshold
 +      : 2;
 +    this.variantCriticalThreshold = isPositiveSafeInteger(params.variantCriticalThreshold)
 +      ? Math.max(params.variantCriticalThreshold, this.variantWarningThreshold + 1)
 +      : 3;
++    this.onTelemetry =
++      params.onTelemetry ??
++      ((record) => {
++        logDebug(`run-safety: ${JSON.stringify(record)}`);
++      });
 +    this.onDrained = params.onDrained;
 +  }
 +
@@ -6941,21 +6357,7 @@ index 000000000..52fc5e00b
 +  reserveProviderDispatch(params: {
 +    runId: string;
 +    providerDispatchId: string;
-+    estimatedPromptTokens: number;
 +  }): RunSafetyProviderReservationDecision {
-+    const normalizedEstimate = normalizePromptEstimate(params.estimatedPromptTokens);
-+    if (!normalizedEstimate) {
-+      const reason = this.tryTerminate({
-+        kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable,
-+        runId: params.runId,
-+      });
-+      return {
-+        allowed: false,
-+        providerDispatchId: params.providerDispatchId,
-+        estimatedPromptTokens: 0,
-+        reason,
-+      };
-+    }
 +    const existing = this.providerReservations.get(params.providerDispatchId);
 +    if (existing) {
 +      return { ...existing.decision, duplicate: true };
@@ -6965,7 +6367,6 @@ index 000000000..52fc5e00b
 +      return {
 +        allowed: false,
 +        providerDispatchId: params.providerDispatchId,
-+        estimatedPromptTokens: normalizedEstimate,
 +        reason: existingTerminal,
 +      };
 +    }
@@ -6973,7 +6374,6 @@ index 000000000..52fc5e00b
 +      return {
 +        allowed: false,
 +        providerDispatchId: params.providerDispatchId,
-+        estimatedPromptTokens: normalizedEstimate,
 +        reason:
 +          this.scopeTerminalReasonValue ??
 +          this.buildTermination(RunSafetyTerminationKind.RunSafetyStateUnavailable, params.runId),
@@ -6989,38 +6389,18 @@ index 000000000..52fc5e00b
 +      return {
 +        allowed: false,
 +        providerDispatchId: params.providerDispatchId,
-+        estimatedPromptTokens: normalizedEstimate,
-+        reason,
-+      };
-+    }
-+    const nextPromptTotal = saturatingAdd(
-+      this.cumulativeEstimatedPromptTokensValue,
-+      normalizedEstimate,
-+    );
-+    if (nextPromptTotal > this.limits.maxCumulativeEstimatedPromptTokensPerBudgetScope) {
-+      const reason = this.tryTerminate({
-+        kind: RunSafetyTerminationKind.RunPromptExposureBudget,
-+        runId: params.runId,
-+        observedCount: nextPromptTotal,
-+        limit: this.limits.maxCumulativeEstimatedPromptTokensPerBudgetScope,
-+      });
-+      return {
-+        allowed: false,
-+        providerDispatchId: params.providerDispatchId,
-+        estimatedPromptTokens: normalizedEstimate,
 +        reason,
 +      };
 +    }
 +
 +    this.providerDispatchCountValue += 1;
-+    this.cumulativeEstimatedPromptTokensValue = nextPromptTotal;
 +    const decision: RunSafetyProviderReservationDecision = {
 +      allowed: true,
 +      providerDispatchId: params.providerDispatchId,
-+      estimatedPromptTokens: normalizedEstimate,
 +    };
 +    this.providerReservations.set(params.providerDispatchId, {
 +      decision,
++      observation: { status: PromptObservationStatus.Pending },
 +      completed: false,
 +    });
 +    this.recordWarning(
@@ -7028,84 +6408,68 @@ index 000000000..52fc5e00b
 +      this.providerDispatchCountValue,
 +      this.limits.maxProviderDispatchesPerBudgetScope,
 +    );
-+    this.recordWarning(
-+      "prompt_exposure",
-+      this.cumulativeEstimatedPromptTokensValue,
-+      this.limits.maxCumulativeEstimatedPromptTokensPerBudgetScope,
-+    );
 +    if (this.providerDispatchCountValue === this.limits.maxProviderDispatchesPerBudgetScope) {
 +      this.continuationClosedReasonValue = RunSafetyTerminationKind.RunProviderDispatchBudget;
-+    } else if (
-+      this.cumulativeEstimatedPromptTokensValue ===
-+      this.limits.maxCumulativeEstimatedPromptTokensPerBudgetScope
-+    ) {
-+      this.continuationClosedReasonValue = RunSafetyTerminationKind.RunPromptExposureBudget;
 +    }
 +    return decision;
 +  }
 +
-+  refineProviderPromptEstimate(params: {
-+    runId: string;
++  observeProviderPromptEstimate(params: {
 +    providerDispatchId: string;
-+    estimatedPromptTokens: number;
-+  }): RunSafetyProviderReservationDecision {
++    observation: FinalPromptObservation;
++  }): void {
 +    const reservation = this.providerReservations.get(params.providerDispatchId);
 +    if (!reservation || !reservation.decision.allowed) {
-+      return this.reserveProviderDispatch(params);
++      return;
 +    }
-+    const normalizedEstimate = normalizePromptEstimate(params.estimatedPromptTokens);
-+    if (!normalizedEstimate) {
-+      const reason = this.tryTerminate({
-+        kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable,
-+        runId: params.runId,
-+      });
-+      return {
-+        allowed: false,
-+        providerDispatchId: params.providerDispatchId,
-+        estimatedPromptTokens: reservation.decision.estimatedPromptTokens,
-+        reason,
-+      };
++    const normalizedObservation = this.normalizeFinalPromptObservation(params.observation);
++    if (reservation.observation.status !== PromptObservationStatus.Pending) {
++      // Immutable final observations make retries/idempotent settlement safe.
++      // A conflicting second observation never mutates the first accounting.
++      return;
 +    }
-+    const priorEstimate = reservation.decision.estimatedPromptTokens;
-+    if (normalizedEstimate <= priorEstimate) {
-+      return { ...reservation.decision, duplicate: true };
++    reservation.observation = normalizedObservation;
++    if (normalizedObservation.status === PromptObservationStatus.Known) {
++      this.knownEstimateDispatchCountValue += 1;
++      this.legacyEstimatedExposureUnitsTotalValue = saturatingAdd(
++        this.legacyEstimatedExposureUnitsTotalValue,
++        normalizedObservation.legacyEstimatedExposureUnits,
++      );
++      this.maxLegacyEstimatedExposureUnitsPerDispatchValue = Math.max(
++        this.maxLegacyEstimatedExposureUnitsPerDispatchValue,
++        normalizedObservation.legacyEstimatedExposureUnits,
++      );
++      this.incrementTelemetryCount(this.estimateSourceCounts, normalizedObservation.source);
++      if (
++        !this.legacyDiagnosticThresholdCrossedValue &&
++        this.legacyEstimatedExposureUnitsTotalValue >= this.promptExposure.legacyDiagnosticThreshold
++      ) {
++        this.legacyDiagnosticThresholdCrossedValue = true;
++        this.emitTelemetry(RunSafetyTelemetryEvent.PromptExposureThresholdCrossed);
++      }
++      return;
 +    }
-+    const delta = normalizedEstimate - priorEstimate;
-+    const nextPromptTotal = saturatingAdd(this.cumulativeEstimatedPromptTokensValue, delta);
-+    if (nextPromptTotal > this.limits.maxCumulativeEstimatedPromptTokensPerBudgetScope) {
-+      const reason = this.tryTerminate({
-+        kind: RunSafetyTerminationKind.RunPromptExposureBudget,
-+        runId: params.runId,
-+        observedCount: nextPromptTotal,
-+        limit: this.limits.maxCumulativeEstimatedPromptTokensPerBudgetScope,
-+      });
-+      return {
-+        allowed: false,
-+        providerDispatchId: params.providerDispatchId,
-+        estimatedPromptTokens: priorEstimate,
-+        reason,
-+      };
++    this.estimateUnavailableDispatchCountValue += 1;
++    this.incrementTelemetryCount(this.unavailableReasonCounts, normalizedObservation.reason);
++    if (!this.promptUnavailableDiagnosticEmitted) {
++      this.promptUnavailableDiagnosticEmitted = true;
++      this.emitTelemetry(RunSafetyTelemetryEvent.PromptEstimateUnavailableObserved);
 +    }
-+    this.cumulativeEstimatedPromptTokensValue = nextPromptTotal;
-+    reservation.decision.estimatedPromptTokens = normalizedEstimate;
-+    this.recordWarning(
-+      "prompt_exposure",
-+      this.cumulativeEstimatedPromptTokensValue,
-+      this.limits.maxCumulativeEstimatedPromptTokensPerBudgetScope,
-+    );
-+    if (
-+      this.cumulativeEstimatedPromptTokensValue ===
-+      this.limits.maxCumulativeEstimatedPromptTokensPerBudgetScope
-+    ) {
-+      this.continuationClosedReasonValue = RunSafetyTerminationKind.RunPromptExposureBudget;
-+    }
-+    return { ...reservation.decision, duplicate: true };
 +  }
 +
 +  completeProviderDispatch(providerDispatchId: string): void {
 +    const reservation = this.providerReservations.get(providerDispatchId);
 +    if (!reservation || reservation.completed) {
 +      return;
++    }
++    if (reservation.observation.status === PromptObservationStatus.Pending) {
++      this.observeProviderPromptEstimate({
++        providerDispatchId,
++        observation: {
++          status: PromptObservationStatus.Unavailable,
++          reason: PromptEstimateUnavailableReason.PayloadNotObservedBeforeCompletion,
++        },
++      });
 +    }
 +    reservation.completed = true;
 +    this.maybeDrain();
@@ -7201,7 +6565,9 @@ index 000000000..52fc5e00b
 +      this.maybeDrain();
 +      return;
 +    }
++    this.finalizePendingPromptObservations();
 +    this.statusValue = "ended";
++    this.emitScopeSummary();
 +  }
 +
 +  get terminationReason(): RunSafetyTermination | undefined {
@@ -7224,7 +6590,7 @@ index 000000000..52fc5e00b
 +      status: this.statusValue,
 +      toolCallReservationCount: this.toolCallReservationCountValue,
 +      providerDispatchCount: this.providerDispatchCountValue,
-+      cumulativeEstimatedPromptTokens: this.cumulativeEstimatedPromptTokensValue,
++      promptExposure: this.promptExposureSnapshot(),
 +      ...(this.continuationClosedReasonValue
 +        ? { continuationClosedReason: this.continuationClosedReasonValue }
 +        : {}),
@@ -7259,9 +6625,97 @@ index 000000000..52fc5e00b
 +      runId,
 +      toolCallReservationCount: this.toolCallReservationCountValue,
 +      providerDispatchCount: this.providerDispatchCountValue,
-+      cumulativeEstimatedPromptTokens: this.cumulativeEstimatedPromptTokensValue,
 +      ...details,
 +    };
++  }
++
++  private normalizeFinalPromptObservation(
++    observation: FinalPromptObservation,
++  ): FinalPromptObservation {
++    if (observation.status === PromptObservationStatus.Known) {
++      const normalizedEstimate = normalizePromptEstimate(observation.legacyEstimatedExposureUnits);
++      if (normalizedEstimate && Object.values(PromptEstimateSource).includes(observation.source)) {
++        return {
++          status: PromptObservationStatus.Known,
++          legacyEstimatedExposureUnits: normalizedEstimate,
++          source: observation.source,
++        };
++      }
++      return {
++        status: PromptObservationStatus.Unavailable,
++        reason: PromptEstimateUnavailableReason.InvalidEstimate,
++      };
++    }
++    if (
++      observation.status === PromptObservationStatus.Unavailable &&
++      Object.values(PromptEstimateUnavailableReason).includes(observation.reason)
++    ) {
++      return observation;
++    }
++    return {
++      status: PromptObservationStatus.Unavailable,
++      reason: PromptEstimateUnavailableReason.InvalidEstimate,
++    };
++  }
++
++  private incrementTelemetryCount<T extends string>(counts: Map<T, number>, key: T): void {
++    counts.set(key, (counts.get(key) ?? 0) + 1);
++  }
++
++  private promptExposureSnapshot(): PromptExposureTelemetrySnapshot {
++    let pendingObservationDispatchCount = 0;
++    for (const reservation of this.providerReservations.values()) {
++      if (reservation.observation.status === PromptObservationStatus.Pending) {
++        pendingObservationDispatchCount += 1;
++      }
++    }
++    return {
++      legacyEstimatedExposureUnitsTotal: this.legacyEstimatedExposureUnitsTotalValue,
++      knownEstimateDispatchCount: this.knownEstimateDispatchCountValue,
++      estimateUnavailableDispatchCount: this.estimateUnavailableDispatchCountValue,
++      pendingObservationDispatchCount,
++      maxLegacyEstimatedExposureUnitsPerDispatch:
++        this.maxLegacyEstimatedExposureUnitsPerDispatchValue,
++      estimateSourceCounts: Object.fromEntries(this.estimateSourceCounts),
++      unavailableReasonCounts: Object.fromEntries(this.unavailableReasonCounts),
++      legacyDiagnosticThresholdCrossed: this.legacyDiagnosticThresholdCrossedValue,
++    };
++  }
++
++  private emitTelemetry(event: RunSafetyTelemetryEvent): void {
++    try {
++      this.onTelemetry({
++        event,
++        rootInvocationId: this.rootInvocationId,
++        budgetScopeId: this.budgetScopeId,
++        rootRunId: this.rootRunId,
++        promptExposure: this.promptExposureSnapshot(),
++      });
++    } catch {
++      // Diagnostics must never affect run execution.
++    }
++  }
++
++  private emitScopeSummary(): void {
++    if (this.scopeSummaryEmitted) {
++      return;
++    }
++    this.scopeSummaryEmitted = true;
++    this.emitTelemetry(RunSafetyTelemetryEvent.ScopeSummary);
++  }
++
++  private finalizePendingPromptObservations(): void {
++    for (const [providerDispatchId, reservation] of this.providerReservations) {
++      if (reservation.observation.status === PromptObservationStatus.Pending) {
++        this.observeProviderPromptEstimate({
++          providerDispatchId,
++          observation: {
++            status: PromptObservationStatus.Unavailable,
++            reason: PromptEstimateUnavailableReason.PayloadNotObservedBeforeCompletion,
++          },
++        });
++      }
++    }
 +  }
 +
 +  private recordWarning(
@@ -7292,6 +6746,7 @@ index 000000000..52fc5e00b
 +      return;
 +    }
 +    this.statusValue = "ended";
++    this.emitScopeSummary();
 +    const callback = this.onDrained;
 +    this.onDrained = undefined;
 +    callback?.(this.scopeTerminalReasonValue);
@@ -7854,7 +7309,7 @@ index 000000000..4913c742a
 +});
 diff --git a/src/agents/run-safety-registry.ts b/src/agents/run-safety-registry.ts
 new file mode 100644
-index 000000000..6f3823bd4
+index 000000000..618fa794f
 --- /dev/null
 +++ b/src/agents/run-safety-registry.ts
 @@ -0,0 +1,646 @@
@@ -7863,7 +7318,7 @@ index 000000000..6f3823bd4
 +  RunSafetyController,
 +  RunSafetyRootCoordinator,
 +  RunSafetyTerminationKind,
-+  type RunSafetyBudgetLimits,
++  type RunSafetyControllerLimits,
 +  type RunSafetyContext,
 +  type RunSafetyTermination,
 +} from "./run-safety-controller.js";
@@ -7974,7 +7429,7 @@ index 000000000..6f3823bd4
 +  rootRunId: string;
 +  rootInvocationId?: string;
 +  budgetScopeId?: string;
-+  limits?: Partial<RunSafetyBudgetLimits>;
++  limits?: RunSafetyControllerLimits;
 +  variantWarningThreshold?: number;
 +  variantCriticalThreshold?: number;
 +  onOrphanedTerminal?: (reason: RunSafetyTermination) => Promise<void> | void;
@@ -8508,17 +7963,11 @@ diff --git a/src/agents/simple-completion-transport.ts b/src/agents/simple-compl
 index 606186501..d15daa4da 100644
 --- a/src/agents/simple-completion-transport.ts
 +++ b/src/agents/simple-completion-transport.ts
-@@ -4,6 +4,7 @@ import type { Api, Model } from "../llm/types.js";
- import { createAnthropicVertexStreamFnForModel } from "./anthropic-vertex-stream.js";
- import { ensureCustomApiRegistered } from "./custom-api-registry.js";
+@@ -6,2 +6,3 @@ import { ensureCustomApiRegistered } from "./custom-api-registry.js";
  import { prepareGoogleSimpleCompletionModel } from "./google-simple-completion-stream.js";
 +import { ProviderStreamPurpose } from "./provider-run-safety-contract.js";
  import { registerProviderStreamForModel } from "./provider-stream.js";
- import {
-   buildTransportAwareSimpleStreamFn,
-@@ -82,7 +83,14 @@ export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
- }): Model {
-   const { model, cfg } = params;
+@@ -84,3 +85,10 @@ export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
    // Only provider-owned custom APIs need runtime stream registration here.
 -  if (!getApiProvider(model.api) && registerProviderStreamForModel({ model, cfg })) {
 +  if (
@@ -8530,32 +7979,22 @@ index 606186501..d15daa4da 100644
 +    })
 +  ) {
      return model;
-   }
- 
 diff --git a/src/agents/subagent-control.test.ts b/src/agents/subagent-control.test.ts
 index a0a813856..444ac26c5 100644
 --- a/src/agents/subagent-control.test.ts
 +++ b/src/agents/subagent-control.test.ts
-@@ -5,13 +5,14 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi }
- import type { SessionEntry } from "../config/sessions/types.js";
- import type { OpenClawConfig } from "../config/types.openclaw.js";
+@@ -7,2 +7,3 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
  import type { CallGatewayOptions } from "../gateway/call.js";
 +import { runSafetyRegistry } from "./run-safety-registry.js";
  import {
-   testing,
-   killAllControlledSubagentRuns,
-   killControlledSubagentRun,
+@@ -12,4 +13,4 @@ import {
    killSubagentRunAdmin,
 -  sendControlledSubagentMessage,
 -  steerControlledSubagentRun,
 +  sendControlledSubagentMessage as sendControlledSubagentMessageImpl,
 +  steerControlledSubagentRun as steerControlledSubagentRunImpl,
  } from "./subagent-control.js";
- import {
-   testing as subagentRegistryTesting,
-@@ -127,6 +128,36 @@ function setSubagentControlDepsForTest(
-   });
- }
+@@ -129,2 +130,32 @@ function setSubagentControlDepsForTest(
  
 +let runSafetyInvocationIndex = 0;
 +
@@ -8588,35 +8027,21 @@ index a0a813856..444ac26c5 100644
 +}
 +
  let tempRoot = "";
- let tempStoreIndex = 0;
- 
-@@ -175,6 +206,7 @@ beforeEach(() => {
- });
- 
+@@ -177,2 +208,3 @@ beforeEach(() => {
  afterEach(() => {
 +  runSafetyRegistry.resetForTests();
    subagentRegistryTesting.setDepsForTest();
- });
- 
-@@ -239,7 +271,8 @@ describe("sendControlledSubagentMessage", () => {
-       },
-     });
+@@ -241,3 +273,4 @@ describe("sendControlledSubagentMessage", () => {
  
 -    const result = await sendControlledSubagentMessage({
 +    const invocation = createRunSafetyInvocation();
 +    const result = await sendControlledSubagentMessageImpl({
        cfg: {
-         channels: { whatsapp: { allowFrom: ["*"] } },
-       } as OpenClawConfig,
-@@ -261,11 +294,21 @@ describe("sendControlledSubagentMessage", () => {
-         startedAt: Date.now() - 4_000,
-       },
+@@ -263,2 +296,3 @@ describe("sendControlledSubagentMessage", () => {
        message: "continue",
 +      ...invocation,
      });
- 
-     expect(result.status).toBe("error");
-     expect(typeof result.runId).toBe("string");
+@@ -268,2 +302,11 @@ describe("sendControlledSubagentMessage", () => {
      expect(result.error).toBe("gateway unavailable");
 +    expect(
 +      runSafetyRegistry.releaseRun({
@@ -8628,11 +8053,7 @@ index a0a813856..444ac26c5 100644
 +      false,
 +    );
    });
- 
-   it("does not send to a newer live run when the caller passes a stale run entry", async () => {
-@@ -520,6 +563,180 @@ describe("sendControlledSubagentMessage", () => {
-       replyText: undefined,
-     });
+@@ -522,2 +565,176 @@ describe("sendControlledSubagentMessage", () => {
    });
 +
 +  it("fails closed before any gateway call when run-safety identity is missing", async () => {
@@ -8809,11 +8230,7 @@ index a0a813856..444ac26c5 100644
 +    expect(consumedClaim).toBe(true);
 +  });
  });
- 
- describe("killSubagentRunAdmin", () => {
-@@ -1480,4 +1697,137 @@ describe("steerControlledSubagentRun", () => {
-     const agentParams = agentCalls[0]?.params as { sessionId?: string } | undefined;
-     expect(agentParams?.sessionId).toBe(result.sessionId);
+@@ -1482,2 +1699,135 @@ describe("steerControlledSubagentRun", () => {
    });
 +
 +  it("fails closed before abort, state mutation, or gateway calls when safety identity is missing", async () => {
@@ -8953,9 +8370,7 @@ diff --git a/src/agents/subagent-control.ts b/src/agents/subagent-control.ts
 index d66fbdc76..d2d2b4397 100644
 --- a/src/agents/subagent-control.ts
 +++ b/src/agents/subagent-control.ts
-@@ -12,6 +12,11 @@ import { isSubagentSessionKey, parseAgentSessionKey } from "../routing/session-k
- import { createLazyImportLoader } from "../shared/lazy-promise.js";
- import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
+@@ -14,2 +14,7 @@ import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
  import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 +import type { RunSafetyContext } from "./run-safety-controller.js";
 +import {
@@ -8963,28 +8378,16 @@ index d66fbdc76..d2d2b4397 100644
 +  runSafetyRegistry,
 +} from "./run-safety-registry.js";
  import {
-   readLatestAssistantReplySnapshot,
-   waitForAgentRunAndReadUpdatedAssistantReply,
-@@ -428,6 +433,8 @@ export async function steerControlledSubagentRun(params: {
-   controller: ResolvedSubagentController;
-   entry: SubagentRunRecord;
+@@ -430,2 +435,4 @@ export async function steerControlledSubagentRun(params: {
    message: string;
 +  runId?: string;
 +  runSafety?: RunSafetyContext;
  }): Promise<
-   | {
-       status: "forbidden" | "done" | "rate_limited" | "error";
-@@ -502,6 +509,7 @@ export async function steerControlledSubagentRun(params: {
-   }
- 
+@@ -504,2 +511,3 @@ export async function steerControlledSubagentRun(params: {
    const rateKey = `${params.controller.callerSessionKey}:${params.entry.childSessionKey}`;
 +  let steerRateLimitTimestamp: number | undefined;
    if (process.env.VITEST !== "true") {
-     const now = Date.now();
-     const lastSentAt = steerRateLimit.get(rateKey) ?? 0;
-@@ -513,11 +521,9 @@ export async function steerControlledSubagentRun(params: {
-         error: "Steer rate limit exceeded. Wait a moment before sending another steer.",
-       };
+@@ -515,7 +523,5 @@ export async function steerControlledSubagentRun(params: {
      }
 -    steerRateLimit.set(rateKey, now);
 +    steerRateLimitTimestamp = now;
@@ -8993,11 +8396,7 @@ index d66fbdc76..d2d2b4397 100644
 -  markSubagentRunForSteerRestart(params.entry.runId);
 -
    const targetSession = resolveSessionEntryForKey({
-     cfg: params.cfg,
-     key: params.entry.childSessionKey,
-@@ -528,35 +534,64 @@ export async function steerControlledSubagentRun(params: {
-       ? targetSession.entry.sessionId.trim()
-       : undefined;
+@@ -530,31 +536,60 @@ export async function steerControlledSubagentRun(params: {
    const restartSessionId = sessionId ? crypto.randomUUID() : undefined;
 -
 -  if (sessionId) {
@@ -9081,39 +8480,23 @@ index d66fbdc76..d2d2b4397 100644
 +    }
 +
      const response = await subagentControlDeps.callGateway<{ runId: string }>({
-       method: "agent",
-       params: {
-@@ -568,6 +603,7 @@ export async function steerControlledSubagentRun(params: {
-         channel: INTERNAL_MESSAGE_CHANNEL,
-         lane: AGENT_LANE_SUBAGENT,
+@@ -570,2 +605,3 @@ export async function steerControlledSubagentRun(params: {
          timeout: 0,
 +        runSafety: safetyClaim.identity,
        },
-       timeoutMs: 10_000,
-     });
-@@ -575,6 +611,10 @@ export async function steerControlledSubagentRun(params: {
-       runId = response.runId;
-     }
+@@ -577,2 +613,6 @@ export async function steerControlledSubagentRun(params: {
    } catch (err) {
 +    runSafetyRegistry.cancelInheritedClaim({
 +      context: params.runSafety,
 +      claimToken: safetyClaim.identity.claimToken,
 +    });
      clearSubagentRunSteerRestart(params.entry.runId);
-     const error = formatErrorMessage(err);
-     return {
-@@ -619,6 +659,8 @@ export async function sendControlledSubagentMessage(params: {
-   controller: ResolvedSubagentController;
-   entry: SubagentRunRecord;
+@@ -621,2 +661,4 @@ export async function sendControlledSubagentMessage(params: {
    message: string;
 +  runId?: string;
 +  runSafety?: RunSafetyContext;
  }) {
-   const ownershipError = ensureControllerOwnsRun({
-     controller: params.controller,
-@@ -654,6 +696,29 @@ export async function sendControlledSubagentMessage(params: {
- 
-   const idempotencyKey = crypto.randomUUID();
+@@ -656,2 +698,25 @@ export async function sendControlledSubagentMessage(params: {
    let runId: string = idempotencyKey;
 +  if (!params.runId?.trim() || !params.runSafety) {
 +    return {
@@ -9139,57 +8522,34 @@ index d66fbdc76..d2d2b4397 100644
 +    };
 +  }
    try {
-     const baselineReply = await readLatestAssistantReplySnapshot({
-       sessionKey: targetSessionKey,
-@@ -672,6 +737,7 @@ export async function sendControlledSubagentMessage(params: {
-         channel: INTERNAL_MESSAGE_CHANNEL,
-         lane: AGENT_LANE_SUBAGENT,
+@@ -674,2 +739,3 @@ export async function sendControlledSubagentMessage(params: {
          timeout: 0,
 +        runSafety: safetyClaim.identity,
        },
-       timeoutMs: 10_000,
-     });
-@@ -700,6 +766,10 @@ export async function sendControlledSubagentMessage(params: {
-     }
-     return { status: "ok" as const, runId, replyText: result.replyText };
+@@ -702,2 +768,6 @@ export async function sendControlledSubagentMessage(params: {
    } catch (err) {
 +    runSafetyRegistry.cancelInheritedClaim({
 +      context: params.runSafety,
 +      claimToken: safetyClaim.identity.claimToken,
 +    });
      const error = formatErrorMessage(err);
-     return { status: "error" as const, runId, error };
-   }
 diff --git a/src/agents/subagent-spawn.test.ts b/src/agents/subagent-spawn.test.ts
 index 8041dafc5..77dd65de4 100644
 --- a/src/agents/subagent-spawn.test.ts
 +++ b/src/agents/subagent-spawn.test.ts
-@@ -1,5 +1,6 @@
- import os from "node:os";
+@@ -2,2 +2,3 @@ import os from "node:os";
  import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 +import { RunSafetyTerminationKind } from "./run-safety-controller.js";
  import {
-   createSubagentSpawnTestConfig,
-   expectPersistedRuntimeModel,
-@@ -21,6 +22,7 @@ const hoisted = vi.hoisted(() => ({
- 
- let resetSubagentRegistryForTests: typeof import("./subagent-registry.js").resetSubagentRegistryForTests;
+@@ -23,2 +24,3 @@ let resetSubagentRegistryForTests: typeof import("./subagent-registry.js").reset
  let spawnSubagentDirect: typeof import("./subagent-spawn.js").spawnSubagentDirect;
 +let runSafetyRegistry: typeof import("./run-safety-registry.js").runSafetyRegistry;
  
- function createConfigOverride(overrides?: Record<string, unknown>) {
-   return createSubagentSpawnTestConfig(os.tmpdir(), {
-@@ -74,6 +76,7 @@ describe("spawnSubagentDirect seam flow", () => {
-       resolveSandboxRuntimeStatus: () => ({ sandboxed: false }),
-       sessionStorePath: "/tmp/subagent-spawn-session-store.json",
+@@ -76,2 +78,3 @@ describe("spawnSubagentDirect seam flow", () => {
      }));
 +    ({ runSafetyRegistry } = await import("./run-safety-registry.js"));
    });
- 
-   beforeEach(() => {
-@@ -262,6 +265,80 @@ describe("spawnSubagentDirect seam flow", () => {
-     expect(agentParams.cleanupBundleMcpOnRunEnd).toBe(true);
-   });
+@@ -264,2 +267,76 @@ describe("spawnSubagentDirect seam flow", () => {
  
 +  it("passes only an opaque pre-registered claim and reuses the parent controller", async () => {
 +    const root = runSafetyRegistry.registerRoot({
@@ -9266,15 +8626,11 @@ index 8041dafc5..77dd65de4 100644
 +  });
 +
    it("inherits requester thinking level when no spawn or subagent default is configured", async () => {
-     let persistedStore: Record<string, Record<string, unknown>> | undefined;
-     hoisted.loadSessionStoreMock.mockReturnValue({
 diff --git a/src/agents/subagent-spawn.ts b/src/agents/subagent-spawn.ts
 index 72ee94184..8a0fed25b 100644
 --- a/src/agents/subagent-spawn.ts
 +++ b/src/agents/subagent-spawn.ts
-@@ -46,6 +46,12 @@ import {
-   resolvePersistedSelectedModelRef,
- } from "./model-selection.js";
+@@ -48,2 +48,8 @@ import {
  import { resolveThinkingDefault } from "./model-thinking-default.js";
 +import type { RunSafetyContext, RunSafetyTermination } from "./run-safety-controller.js";
 +import {
@@ -9283,11 +8639,7 @@ index 72ee94184..8a0fed25b 100644
 +  runSafetyRegistry,
 +} from "./run-safety-registry.js";
  import {
-   mapToolContextToSpawnedRunMetadata,
-   normalizeSpawnedRunMetadata,
-@@ -195,6 +201,13 @@ export type SpawnSubagentContext = {
-   workspaceDir?: string;
-   inheritedToolAllowlist?: string[];
+@@ -197,2 +203,9 @@ export type SpawnSubagentContext = {
    inheritedToolDenylist?: string[];
 +  /** Active parent run id used to bind the pre-start child claim. */
 +  runId?: string;
@@ -9297,19 +8649,11 @@ index 72ee94184..8a0fed25b 100644
 +   */
 +  runSafety?: RunSafetyContext | null;
  };
- 
- export type SpawnSubagentResult = {
-@@ -210,6 +223,7 @@ export type SpawnSubagentResult = {
-   resolvedProvider?: string;
-   modelApplied?: boolean;
+@@ -212,2 +225,3 @@ export type SpawnSubagentResult = {
    error?: string;
 +  terminationReason?: RunSafetyTermination;
    attachments?: {
-     count: number;
-     totalBytes: number;
-@@ -1512,6 +1526,39 @@ export async function spawnSubagentDirect(
- 
-   const childIdem = crypto.randomUUID();
+@@ -1514,2 +1528,35 @@ export async function spawnSubagentDirect(
    let childRunId: string = childIdem;
 +  const runSafetyClaim =
 +    ctx.runSafety === null || (ctx.runSafety && !ctx.runId)
@@ -9345,19 +8689,11 @@ index 72ee94184..8a0fed25b 100644
 +    };
 +  }
    const deliverInitialChildRunDirectly =
-     requestThreadBinding && spawnMode === "session" && hasBoundThreadDeliveryOrigin;
-   const shouldAnnounceCompletion = deliverInitialChildRunDirectly
-@@ -1544,6 +1591,7 @@ export async function spawnSubagentDirect(
-         thinking: thinkingOverride,
-         timeout: runTimeoutSeconds,
+@@ -1546,2 +1593,3 @@ export async function spawnSubagentDirect(
          label: label || undefined,
 +        ...(runSafetyClaim?.ok ? { runSafety: runSafetyClaim.identity } : {}),
          ...(bootstrapContextMode
-           ? {
-               bootstrapContextMode,
-@@ -1559,6 +1607,12 @@ export async function spawnSubagentDirect(
-       childRunId = runId;
-     }
+@@ -1561,2 +1609,8 @@ export async function spawnSubagentDirect(
    } catch (err) {
 +    if (runSafetyClaim?.ok) {
 +      runSafetyRegistry.cancelInheritedClaim({
@@ -9366,11 +8702,7 @@ index 72ee94184..8a0fed25b 100644
 +      });
 +    }
      await rollbackPreparedContextEngine(contextEnginePreparation);
-     if (attachmentAbsDir) {
-       try {
-@@ -1613,11 +1667,22 @@ export async function spawnSubagentDirect(
-       // Best-effort only.
-     }
+@@ -1615,2 +1669,12 @@ export async function spawnSubagentDirect(
      const messageText = summarizeError(err);
 +    const errorDetails =
 +      err && typeof err === "object" && "details" in err
@@ -9383,21 +8715,15 @@ index 72ee94184..8a0fed25b 100644
 +          )
 +        : undefined;
      return {
-       status: "error",
-       error: messageText,
-       childSessionKey,
+@@ -1620,2 +1684,3 @@ export async function spawnSubagentDirect(
        runId: childRunId,
 +      ...(terminationReason ? { terminationReason } : {}),
      };
-   }
- 
 diff --git a/src/agents/tool-loop-detection.test.ts b/src/agents/tool-loop-detection.test.ts
 index e2ba74147..ab9a8040d 100644
 --- a/src/agents/tool-loop-detection.test.ts
 +++ b/src/agents/tool-loop-detection.test.ts
-@@ -8,10 +8,15 @@ import {
-   GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
-   TOOL_CALL_HISTORY_SIZE,
+@@ -10,6 +10,11 @@ import {
    UNKNOWN_TOOL_THRESHOLD,
 +  VARIANT_NO_PROGRESS_CRITICAL_THRESHOLD,
 +  VARIANT_NO_PROGRESS_WARNING_THRESHOLD,
@@ -9409,11 +8735,7 @@ index e2ba74147..ab9a8040d 100644
 +  hashToolCallFamily,
 +  normalizeToolCallFamily,
    recordToolCall,
-   recordToolCallOutcome,
- } from "./tool-loop-detection.js";
-@@ -117,6 +122,49 @@ function createAbortedExecFixture() {
-   } as const;
- }
+@@ -119,2 +124,45 @@ function createAbortedExecFixture() {
  
 +function createPowerShellWindowParams(windowSize: number, path = "C:\\project\\artifacts") {
 +  return {
@@ -9459,11 +8781,7 @@ index e2ba74147..ab9a8040d 100644
 +}
 +
  function createPingPongFixture() {
-   return {
-     state: createState(),
-@@ -256,6 +304,317 @@ describe("tool-loop-detection", () => {
-     });
-   });
+@@ -258,2 +306,313 @@ describe("tool-loop-detection", () => {
  
 +  describe("hashToolCallFamily", () => {
 +    it("exposes the normalized family shape for replay-time recomputation", () => {
@@ -9777,29 +9095,20 @@ index e2ba74147..ab9a8040d 100644
 +  });
 +
    describe("recordToolCall", () => {
-     it("adds tool call to empty history", () => {
-       const state = createState();
 diff --git a/src/agents/tool-loop-detection.ts b/src/agents/tool-loop-detection.ts
 index 7833fcb73..c6cc3c29d 100644
 --- a/src/agents/tool-loop-detection.ts
 +++ b/src/agents/tool-loop-detection.ts
-@@ -15,11 +15,12 @@ type LoopDetectorKind =
-   | "generic_repeat"
-   | "unknown_tool_repeat"
+@@ -17,2 +17,3 @@ type LoopDetectorKind =
    | "known_poll_no_progress"
 +  | "variant_no_progress"
    | "aborted_tool_loop"
-   | "global_circuit_breaker"
-   | "ping_pong";
+@@ -21,3 +22,3 @@ type LoopDetectorKind =
  
 -type LoopDetectionResult =
 +export type LoopDetectionResult =
    | { stuck: false }
-   | {
-       stuck: true;
-@@ -39,19 +40,41 @@ export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
- export const ABORTED_TOOL_LOOP_WARNING_THRESHOLD = 5;
- export const ABORTED_TOOL_LOOP_CRITICAL_THRESHOLD = 8;
+@@ -41,4 +42,23 @@ export const ABORTED_TOOL_LOOP_CRITICAL_THRESHOLD = 8;
  export const ABORTED_TOOL_LOOP_TOTAL_THRESHOLD = 20;
 +export const VARIANT_NO_PROGRESS_WARNING_THRESHOLD = 2;
 +export const VARIANT_NO_PROGRESS_CRITICAL_THRESHOLD = 3;
@@ -9823,40 +9132,25 @@ index 7833fcb73..c6cc3c29d 100644
 +  "^",
 +] as const;
  const DEFAULT_LOOP_DETECTION_CONFIG = {
-   enabled: false,
-   historySize: TOOL_CALL_HISTORY_SIZE,
-   warningThreshold: WARNING_THRESHOLD,
-   unknownToolThreshold: UNKNOWN_TOOL_THRESHOLD,
+@@ -49,2 +69,4 @@ const DEFAULT_LOOP_DETECTION_CONFIG = {
    criticalThreshold: CRITICAL_THRESHOLD,
 +  variantWarningThreshold: VARIANT_NO_PROGRESS_WARNING_THRESHOLD,
 +  variantCriticalThreshold: VARIANT_NO_PROGRESS_CRITICAL_THRESHOLD,
    globalCircuitBreakerThreshold: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
-   detectors: {
-     genericRepeat: true,
-     knownPollNoProgress: true,
+@@ -54,2 +76,3 @@ const DEFAULT_LOOP_DETECTION_CONFIG = {
      pingPong: true,
 +    variantNoProgress: true,
    },
- };
- 
-@@ -61,11 +84,14 @@ type ResolvedLoopDetectionConfig = {
-   warningThreshold: number;
-   unknownToolThreshold: number;
+@@ -63,2 +86,4 @@ type ResolvedLoopDetectionConfig = {
    criticalThreshold: number;
 +  variantWarningThreshold: number;
 +  variantCriticalThreshold: number;
    globalCircuitBreakerThreshold: number;
-   detectors: {
-     genericRepeat: boolean;
-     knownPollNoProgress: boolean;
+@@ -68,2 +93,3 @@ type ResolvedLoopDetectionConfig = {
      pingPong: boolean;
 +    variantNoProgress: boolean;
    };
- };
- 
-@@ -108,6 +134,17 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
-   if (globalCircuitBreakerThreshold <= criticalThreshold) {
-     globalCircuitBreakerThreshold = criticalThreshold + 1;
+@@ -110,2 +136,13 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
    }
 +  const variantWarningThreshold = asPositiveInt(
 +    config?.variantWarningThreshold,
@@ -9870,30 +9164,18 @@ index 7833fcb73..c6cc3c29d 100644
 +    variantCriticalThreshold = variantWarningThreshold + 1;
 +  }
  
-   return {
-     enabled: config?.enabled ?? DEFAULT_LOOP_DETECTION_CONFIG.enabled,
-@@ -118,6 +155,8 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
-       DEFAULT_LOOP_DETECTION_CONFIG.unknownToolThreshold,
-     ),
+@@ -120,2 +157,4 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
      criticalThreshold,
 +    variantWarningThreshold,
 +    variantCriticalThreshold,
      globalCircuitBreakerThreshold,
-     detectors: {
-       genericRepeat:
-@@ -126,6 +165,9 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
-         config?.detectors?.knownPollNoProgress ??
-         DEFAULT_LOOP_DETECTION_CONFIG.detectors.knownPollNoProgress,
+@@ -128,2 +167,5 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
        pingPong: config?.detectors?.pingPong ?? DEFAULT_LOOP_DETECTION_CONFIG.detectors.pingPong,
 +      variantNoProgress:
 +        config?.detectors?.variantNoProgress ??
 +        DEFAULT_LOOP_DETECTION_CONFIG.detectors.variantNoProgress,
      },
-   };
- }
-@@ -143,6 +185,122 @@ function digestStable(value: unknown): string {
-   return createHash("sha256").update(serialized).digest("hex");
- }
+@@ -145,2 +187,118 @@ function digestStable(value: unknown): string {
  
 +function normalizePipelineNewlines(command: string): string | undefined {
 +  const normalized = command
@@ -10012,11 +9294,7 @@ index 7833fcb73..c6cc3c29d 100644
 +}
 +
  function isKnownPollToolCall(toolName: string, params: unknown): boolean {
-   if (toolName === "command_status") {
-     return true;
-@@ -322,6 +480,64 @@ function hashToolOutcome(
-   };
- }
+@@ -324,2 +482,60 @@ function hashToolOutcome(
  
 +export type ToolOutcomeFingerprint = {
 +  toolName: string;
@@ -10077,11 +9355,7 @@ index 7833fcb73..c6cc3c29d 100644
 +}
 +
  function getUnknownToolRepeatStreak(
-   history: Array<{ toolName: string; unknownToolName?: string }>,
-   toolName: string,
-@@ -378,6 +594,104 @@ function getNoProgressStreak(
-   return { count: streak, latestResultHash };
- }
+@@ -380,2 +596,100 @@ function getNoProgressStreak(
  
 +function getVariantNoProgressStreak(history: readonly ToolCallRecord[]): {
 +  count: number;
@@ -10182,42 +9456,26 @@ index 7833fcb73..c6cc3c29d 100644
 +}
 +
  function getAbortedToolLoopStats(
-   history: Array<{ toolName: string; argsHash: string; resultHash?: string }>,
-   toolName: string,
-@@ -537,6 +851,7 @@ export function detectToolCallLoop(
-   const knownPollTool = isKnownPollToolCall(toolName, params);
-   const abortedLoop = getAbortedToolLoopStats(history, toolName, currentHash);
+@@ -539,2 +853,3 @@ export function detectToolCallLoop(
    const pingPong = getPingPongStreak(history, currentHash);
 +  const variantNoProgress = detectVariantNoProgressInHistory(history, resolvedConfig);
  
-   if (unknownToolStreak.count >= resolvedConfig.unknownToolThreshold) {
-     return {
-@@ -549,6 +864,10 @@ export function detectToolCallLoop(
-     };
-   }
+@@ -551,2 +866,6 @@ export function detectToolCallLoop(
  
 +  if (variantNoProgress.stuck) {
 +    return variantNoProgress;
 +  }
 +
    if (noProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
-     log.error(
-       `Global circuit breaker triggered: ${toolName} repeated ${noProgressStreak} times with no progress`,
-@@ -734,9 +1053,11 @@ export function recordToolCall(
-     state.toolCallHistory = [];
-   }
+@@ -736,2 +1055,3 @@ export function recordToolCall(
  
 +  const familyHash = hashToolCallFamily(toolName, params);
    state.toolCallHistory.push({
-     toolName,
+@@ -739,2 +1059,3 @@ export function recordToolCall(
      argsHash: hashToolCall(toolName, params),
 +    ...(familyHash && { familyHash }),
      toolCallId,
-     ...(runId && { runId }),
-     timestamp: Date.now(),
-@@ -764,9 +1085,8 @@ export function recordToolCallOutcome(
- ): ToolCallRecord | undefined {
-   const resolvedConfig = resolveLoopDetectionConfig(params.config);
+@@ -766,5 +1087,4 @@ export function recordToolCallOutcome(
    const runId = normalizeRunId(params.runId);
 -  const outcome = hashToolOutcome(params.toolName, params.toolParams, params.result, params.error);
 -  const resultHash = outcome.resultHash;
@@ -10225,26 +9483,16 @@ index 7833fcb73..c6cc3c29d 100644
 +  const fingerprint = createToolOutcomeFingerprint(params);
 +  if (!fingerprint) {
      return undefined;
-   }
- 
-@@ -774,7 +1094,6 @@ export function recordToolCallOutcome(
-     state.toolCallHistory = [];
-   }
+@@ -776,3 +1096,2 @@ export function recordToolCallOutcome(
  
 -  const argsHash = hashToolCall(params.toolName, params.toolParams);
    let matched = false;
-   let recordedOutcome: ToolCallRecord | undefined;
-   for (let i = state.toolCallHistory.length - 1; i >= 0; i -= 1) {
-@@ -788,14 +1107,17 @@ export function recordToolCallOutcome(
-     if (params.toolCallId && call.toolCallId !== params.toolCallId) {
-       continue;
+@@ -790,3 +1109,3 @@ export function recordToolCallOutcome(
      }
 -    if (call.toolName !== params.toolName || call.argsHash !== argsHash) {
 +    if (call.toolName !== fingerprint.toolName || call.argsHash !== fingerprint.argsHash) {
        continue;
-     }
-     if (call.resultHash !== undefined) {
-       continue;
+@@ -796,4 +1115,7 @@ export function recordToolCallOutcome(
      }
 -    call.resultHash = resultHash;
 -    call.unknownToolName = outcome.unknownToolName;
@@ -10254,11 +9502,7 @@ index 7833fcb73..c6cc3c29d 100644
 +    call.resultHash = fingerprint.resultHash;
 +    call.unknownToolName = fingerprint.unknownToolName;
      matched = true;
-     recordedOutcome = call;
-     break;
-@@ -803,12 +1125,13 @@ export function recordToolCallOutcome(
- 
-   if (!matched) {
+@@ -805,8 +1127,9 @@ export function recordToolCallOutcome(
      const record: ToolCallRecord = {
 -      toolName: params.toolName,
 -      argsHash,
@@ -10272,26 +9516,19 @@ index 7833fcb73..c6cc3c29d 100644
 +      resultHash: fingerprint.resultHash,
 +      unknownToolName: fingerprint.unknownToolName,
        timestamp: Date.now(),
-     };
-     state.toolCallHistory.push(record);
 diff --git a/src/agents/tools/agent-step.test.ts b/src/agents/tools/agent-step.test.ts
 index 1bf24e508..1b12f275a 100644
 --- a/src/agents/tools/agent-step.test.ts
 +++ b/src/agents/tools/agent-step.test.ts
-@@ -1,5 +1,6 @@
- import { afterEach, describe, expect, it, vi } from "vitest";
+@@ -2,2 +2,3 @@ import { afterEach, describe, expect, it, vi } from "vitest";
  import type { CallGatewayOptions } from "../../gateway/call.js";
 +import { runSafetyRegistry } from "../run-safety-registry.js";
  import { runAgentStep, testing } from "./agent-step.js";
- 
- const runWaitMocks = vi.hoisted(() => ({
-@@ -22,9 +23,87 @@ vi.mock("../agent-bundle-mcp-tools.js", () => ({
- describe("runAgentStep", () => {
-   afterEach(() => {
+@@ -24,2 +25,3 @@ describe("runAgentStep", () => {
      testing.setDepsForTest();
 +    runSafetyRegistry.resetForTests();
      vi.clearAllMocks();
-   });
+@@ -27,2 +29,79 @@ describe("runAgentStep", () => {
  
 +  it("fails closed before transport when a nested step lost its run identity", async () => {
 +    const callGateway = vi.fn();
@@ -10371,15 +9608,11 @@ index 1bf24e508..1b12f275a 100644
 +  });
 +
    it("retires bundle MCP runtime after successful nested agent steps", async () => {
-     const gatewayCalls: CallGatewayOptions[] = [];
-     testing.setDepsForTest({
 diff --git a/src/agents/tools/agent-step.ts b/src/agents/tools/agent-step.ts
 index 3f1874b67..2267300c1 100644
 --- a/src/agents/tools/agent-step.ts
 +++ b/src/agents/tools/agent-step.ts
-@@ -4,6 +4,11 @@ import { annotateInterSessionPromptText } from "../../sessions/input-provenance.
- import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
- import { retireSessionMcpRuntimeForSessionKey } from "../agent-bundle-mcp-tools.js";
+@@ -6,2 +6,7 @@ import { retireSessionMcpRuntimeForSessionKey } from "../agent-bundle-mcp-tools.
  import { resolveNestedAgentLaneForSession } from "../lanes.js";
 +import type { RunSafetyContext } from "../run-safety-controller.js";
 +import {
@@ -10387,11 +9620,7 @@ index 3f1874b67..2267300c1 100644
 +  runSafetyRegistry,
 +} from "../run-safety-registry.js";
  import { waitForAgentRunAndReadUpdatedAssistantReply } from "../run-wait.js";
- 
- export { readLatestAssistantReply } from "../run-wait.js";
-@@ -52,8 +57,34 @@ export async function runAgentStep(params: {
-   sourceSessionKey?: string;
-   sourceChannel?: string;
+@@ -54,4 +59,30 @@ export async function runAgentStep(params: {
    sourceTool?: string;
 +  parentRunId?: string;
 +  /**
@@ -10422,11 +9651,7 @@ index 3f1874b67..2267300c1 100644
 +    );
 +  }
    const inputProvenance = {
-     kind: "inter_session" as const,
-     sourceSessionKey: params.sourceSessionKey,
-@@ -64,40 +95,79 @@ export async function runAgentStep(params: {
-   const lane = params.lane ?? resolveNestedAgentLaneForSession(params.sessionKey);
-   const channel = params.channel ?? INTERNAL_MESSAGE_CHANNEL;
+@@ -66,15 +97,42 @@ export async function runAgentStep(params: {
    if (params.transcriptMessage !== undefined) {
 -    const result = await agentStepDeps.agentCommandFromIngress({
 -      message,
@@ -10482,10 +9707,7 @@ index 3f1874b67..2267300c1 100644
 +      }
 +    }
      await retireSessionMcpRuntimeForSessionKey({
-       sessionKey: params.sessionKey,
-       reason: "nested-agent-step-complete",
-     });
-     return extractAgentCommandReply(result);
+@@ -85,17 +143,29 @@ export async function runAgentStep(params: {
    }
 -  const response = await agentStepDeps.callGateway({
 -    method: "agent",
@@ -10530,27 +9752,19 @@ index 3f1874b67..2267300c1 100644
 +    throw err;
 +  }
  
-   const stepRunId = typeof response?.runId === "string" && response.runId ? response.runId : "";
-   const resolvedRunId = stepRunId || stepIdem;
 diff --git a/src/agents/tools/sessions-send-tool.a2a.test.ts b/src/agents/tools/sessions-send-tool.a2a.test.ts
 index 4ab642ede..e4a345fab 100644
 --- a/src/agents/tools/sessions-send-tool.a2a.test.ts
 +++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
-@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
- import type { CallGatewayOptions } from "../../gateway/call.js";
- import { setActivePluginRegistry } from "../../plugins/runtime.js";
+@@ -4,2 +4,3 @@ import { setActivePluginRegistry } from "../../plugins/runtime.js";
  import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
 +import { runSafetyRegistry } from "../run-safety-registry.js";
  import { readLatestAssistantReplySnapshot, waitForAgentRun } from "../run-wait.js";
- import { runAgentStep } from "./agent-step.js";
- import type { SessionListRow } from "./sessions-helpers.js";
-@@ -75,9 +76,61 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
- 
-   afterEach(() => {
+@@ -77,2 +78,3 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
      testing.setDepsForTest();
 +    runSafetyRegistry.resetForTests();
      vi.restoreAllMocks();
-   });
+@@ -80,2 +82,53 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
  
 +  it("keeps automatic announce steps inside the caller's retained budget scope", async () => {
 +    const parentRunId = "parent-a2a";
@@ -10604,15 +9818,11 @@ index 4ab642ede..e4a345fab 100644
 +  });
 +
    it("passes threadId through to gateway send for Telegram forum topics", async () => {
-     await runSessionsSendA2AFlow({
-       targetSessionKey: "agent:main:telegram:group:-100123:topic:554",
 diff --git a/src/agents/tools/sessions-send-tool.a2a.ts b/src/agents/tools/sessions-send-tool.a2a.ts
 index 2437f3ee4..1b9996a40 100644
 --- a/src/agents/tools/sessions-send-tool.a2a.ts
 +++ b/src/agents/tools/sessions-send-tool.a2a.ts
-@@ -4,6 +4,11 @@ import { formatErrorMessage } from "../../infra/errors.js";
- import { createSubsystemLogger } from "../../logging/subsystem.js";
- import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+@@ -6,2 +6,7 @@ import type { GatewayMessageChannel } from "../../utils/message-channel.js";
  import { resolveNestedAgentLaneForSession } from "../lanes.js";
 +import type { RunSafetyContext } from "../run-safety-controller.js";
 +import {
@@ -10620,11 +9830,7 @@ index 2437f3ee4..1b9996a40 100644
 +  runSafetyRegistry,
 +} from "../run-safety-registry.js";
  import {
-   type AssistantReplySnapshot,
-   readLatestAssistantReplySnapshot,
-@@ -78,8 +83,42 @@ export async function runSessionsSendA2AFlow(params: {
-   baseline?: AssistantReplySnapshot;
-   roundOneReply?: string;
+@@ -80,4 +85,38 @@ export async function runSessionsSendA2AFlow(params: {
    waitRunId?: string;
 +  parentRunId?: string;
 +  /**
@@ -10663,29 +9869,17 @@ index 2437f3ee4..1b9996a40 100644
 +  }
 +  const nestedParentRunId = flowHoldClaim?.ok ? flowHoldRunId : params.parentRunId;
    try {
-     let primaryReply = params.roundOneReply;
-     let latestReply = params.roundOneReply;
-@@ -167,6 +206,8 @@ export async function runSessionsSendA2AFlow(params: {
-           sourceChannel:
-             nextSessionKey === params.requesterSessionKey ? params.requesterChannel : targetChannel,
+@@ -169,2 +208,4 @@ export async function runSessionsSendA2AFlow(params: {
            sourceTool: "sessions_send",
 +          parentRunId: nestedParentRunId,
 +          runSafety: params.runSafety,
          });
-         if (!replyText || isReplySkip(replyText) || isNonDeliverableSessionsReply(replyText)) {
-           break;
-@@ -198,6 +239,8 @@ export async function runSessionsSendA2AFlow(params: {
-       sourceSessionKey: params.requesterSessionKey,
-       sourceChannel: params.requesterChannel,
+@@ -200,2 +241,4 @@ export async function runSessionsSendA2AFlow(params: {
        sourceTool: "sessions_send",
 +      parentRunId: nestedParentRunId,
 +      runSafety: params.runSafety,
      });
-     if (
-       announceTarget &&
-@@ -217,6 +260,13 @@ export async function runSessionsSendA2AFlow(params: {
-       runId: runContextId,
-       error: formatErrorMessage(err),
+@@ -219,2 +262,9 @@ export async function runSessionsSendA2AFlow(params: {
      });
 +  } finally {
 +    if (flowHoldClaim?.ok) {
@@ -10695,15 +9889,11 @@ index 2437f3ee4..1b9996a40 100644
 +      });
 +    }
    }
- }
- 
 diff --git a/src/agents/tools/sessions-send-tool.ts b/src/agents/tools/sessions-send-tool.ts
 index c8d80963f..dae481f8b 100644
 --- a/src/agents/tools/sessions-send-tool.ts
 +++ b/src/agents/tools/sessions-send-tool.ts
-@@ -30,6 +30,11 @@ import {
-   resolveActiveEmbeddedRunSessionId,
- } from "../embedded-agent-runner/runs.js";
+@@ -32,2 +32,7 @@ import {
  import { resolveNestedAgentLaneForSession } from "../lanes.js";
 +import type { RunSafetyContext, RunSafetyTermination } from "../run-safety-controller.js";
 +import {
@@ -10711,20 +9901,12 @@ index c8d80963f..dae481f8b 100644
 +  runSafetyRegistry,
 +} from "../run-safety-registry.js";
  import {
-   type AgentWaitResult,
-   readLatestAssistantReplySnapshot,
-@@ -204,6 +209,8 @@ async function startAgentRun(params: {
-   runId: string;
-   sendParams: Record<string, unknown>;
+@@ -206,2 +211,4 @@ async function startAgentRun(params: {
    sessionKey: string;
 +  parentRunId?: string;
 +  runSafety?: RunSafetyContext;
    deliveryTimeoutMs?: number;
-   allowActiveRunQueueFallback?: boolean;
- }): Promise<
-@@ -216,10 +223,62 @@ async function startAgentRun(params: {
-     }
-   | { ok: false; result: ReturnType<typeof jsonResult> }
+@@ -218,6 +225,58 @@ async function startAgentRun(params: {
  > {
 -  try {
 -    const activeRunSessionId = params.allowActiveRunQueueFallback
@@ -10786,11 +9968,7 @@ index c8d80963f..dae481f8b 100644
 +        ? resolveActiveEmbeddedRunSessionId(params.sessionKey)
 +        : undefined;
      const fallbackSessionKey = activeRunSessionId
-       ? resolveRunScopedFallbackSessionKey(params.sessionKey)
-       : undefined;
-@@ -256,19 +315,21 @@ async function startAgentRun(params: {
-         return { ok: true, runId: params.runId, activeRunQueue: true };
-       }
+@@ -258,11 +317,11 @@ async function startAgentRun(params: {
        try {
 -        const response = await params.callGateway<{ runId: string }>({
 -          method: "agent",
@@ -10810,18 +9988,14 @@ index c8d80963f..dae481f8b 100644
 +          return runSafetyFailure(started.terminationReason);
 +        }
          return {
-           ok: true,
+@@ -270,3 +329,5 @@ async function startAgentRun(params: {
            runId:
 -            typeof response?.runId === "string" && response.runId ? response.runId : params.runId,
 +            typeof started.response.runId === "string" && started.response.runId
 +              ? started.response.runId
 +              : fallbackRunId,
            a2aSessionKey: fallbackSessionKey,
-           a2aDisplayKey: fallbackSessionKey,
-         };
-@@ -280,14 +341,24 @@ async function startAgentRun(params: {
-         });
-       }
+@@ -282,10 +343,20 @@ async function startAgentRun(params: {
      }
 -    const response = await params.callGateway<{ runId: string }>({
 -      method: "agent",
@@ -10847,11 +10021,7 @@ index c8d80963f..dae481f8b 100644
 +          ? started.response.runId
 +          : params.runId,
      };
-   } catch (err) {
-     const messageText =
-@@ -310,6 +381,12 @@ export function createSessionsSendTool(opts?: {
-   sandboxed?: boolean;
-   config?: OpenClawConfig;
+@@ -312,2 +383,8 @@ export function createSessionsSendTool(opts?: {
    callGateway?: GatewayCaller;
 +  runId?: string;
 +  /**
@@ -10860,11 +10030,7 @@ index c8d80963f..dae481f8b 100644
 +   */
 +  runSafety?: RunSafetyContext | null;
  }): AnyAgentTool {
-   return {
-     label: "Session Send",
-@@ -323,6 +400,19 @@ export function createSessionsSendTool(opts?: {
-       const gatewayCall = opts?.callGateway ?? callGateway;
-       const message = readStringParam(params, "message", { required: true });
+@@ -325,2 +402,15 @@ export function createSessionsSendTool(opts?: {
        const timeoutSeconds = readNonNegativeIntegerParam(params, "timeoutSeconds") ?? 30;
 +      if (opts?.runSafety === null || (opts?.runSafety && !opts.runId)) {
 +        const runId = crypto.randomUUID();
@@ -10880,50 +10046,30 @@ index c8d80963f..dae481f8b 100644
 +        });
 +      }
        const { cfg, mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
-         resolveSessionToolContext(opts);
- 
-@@ -634,6 +724,8 @@ export function createSessionsSendTool(opts?: {
-           baseline: baselineReply,
-           roundOneReply,
+@@ -636,2 +726,4 @@ export function createSessionsSendTool(opts?: {
            waitRunId,
 +          parentRunId: opts?.runId,
 +          runSafety: opts?.runSafety,
          });
-       };
- 
-@@ -643,6 +735,8 @@ export function createSessionsSendTool(opts?: {
-           runId,
-           sendParams,
+@@ -645,2 +737,4 @@ export function createSessionsSendTool(opts?: {
            sessionKey: displayKey,
 +          parentRunId: opts?.runId,
 +          runSafety: opts?.runSafety ?? undefined,
            deliveryTimeoutMs: announceTimeoutMs,
-           allowActiveRunQueueFallback: true,
-         });
-@@ -666,6 +760,8 @@ export function createSessionsSendTool(opts?: {
-         runId,
-         sendParams,
+@@ -668,2 +762,4 @@ export function createSessionsSendTool(opts?: {
          sessionKey: displayKey,
 +        parentRunId: opts?.runId,
 +        runSafety: opts?.runSafety ?? undefined,
          deliveryTimeoutMs: announceTimeoutMs,
-       });
-       if (!start.ok) {
 diff --git a/src/agents/tools/sessions-spawn-tool.ts b/src/agents/tools/sessions-spawn-tool.ts
 index 3c8ec4b7b..9f75ca36c 100644
 --- a/src/agents/tools/sessions-spawn-tool.ts
 +++ b/src/agents/tools/sessions-spawn-tool.ts
-@@ -17,6 +17,7 @@ import {
-   formatAcpInheritedToolAllowError,
-   formatAcpInheritedToolDenyError,
+@@ -19,2 +19,3 @@ import {
  } from "../inherited-tool-deny.js";
 +import type { RunSafetyContext } from "../run-safety-controller.js";
  import { optionalStringEnum } from "../schema/typebox.js";
- import type { SpawnedToolContext } from "../spawned-context.js";
- import { resolveAcpSessionsSpawnImageAttachments } from "../subagent-attachments.js";
-@@ -256,8 +257,12 @@ export function createSessionsSpawnTool(
-     agentThreadId?: string | number;
-     sandboxed?: boolean;
+@@ -258,4 +259,8 @@ export function createSessionsSpawnTool(
      config?: OpenClawConfig;
 +    /** Active parent run id used to bind the pre-start child claim. */
 +    runId?: string;
@@ -10932,44 +10078,28 @@ index 3c8ec4b7b..9f75ca36c 100644
 +    /** Trusted host-owned safety scope shared with the child run. */
 +    runSafety?: RunSafetyContext;
    } & SpawnedToolContext,
- ): AnyAgentTool {
-   const acpAvailable = isAcpRuntimeSpawnAvailable({
-@@ -405,6 +410,9 @@ export function createSessionsSpawnTool(
-             sandboxed: opts?.sandboxed,
-             inheritedToolAllowlist: opts?.inheritedToolAllowlist,
+@@ -407,2 +412,5 @@ export function createSessionsSpawnTool(
              inheritedToolDenylist: opts?.inheritedToolDenylist,
 +            runId: opts?.runId,
 +            // `null` marks a production chain that lost its trusted identity.
 +            runSafety: opts?.runSafety ?? null,
            },
-         );
-         const childSessionKey = result.childSessionKey?.trim();
-@@ -504,6 +512,10 @@ export function createSessionsSpawnTool(
-           workspaceDir: opts?.workspaceDir,
-           inheritedToolAllowlist: opts?.inheritedToolAllowlist,
+@@ -506,2 +514,6 @@ export function createSessionsSpawnTool(
            inheritedToolDenylist: opts?.inheritedToolDenylist,
 +          runId: opts?.runId,
 +          // `null` marks a production tool chain that lost its trusted
 +          // identity. Legacy direct callers omit the field entirely.
 +          runSafety: opts?.runSafety ?? null,
          },
-       );
- 
 diff --git a/src/agents/tools/sessions.test.ts b/src/agents/tools/sessions.test.ts
 index 90c2a4bbf..445cdaf65 100644
 --- a/src/agents/tools/sessions.test.ts
 +++ b/src/agents/tools/sessions.test.ts
-@@ -4,6 +4,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
- import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
- import type { ChannelMessagingAdapter } from "../../channels/plugins/types.js";
+@@ -6,2 +6,3 @@ import type { ChannelMessagingAdapter } from "../../channels/plugins/types.js";
  import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 +import { runSafetyRegistry } from "../run-safety-registry.js";
  import { extractAssistantText, sanitizeTextContent } from "./sessions-helpers.js";
- 
- const callGatewayMock = vi.fn();
-@@ -770,6 +771,95 @@ describe("sessions_list channel derivation", () => {
- describe("sessions_send gating", () => {
-   beforeEach(() => {
+@@ -772,2 +773,91 @@ describe("sessions_send gating", () => {
      callGatewayMock.mockClear();
 +    runSafetyRegistry.resetForTests();
 +  });
@@ -11061,13 +10191,11 @@ index 90c2a4bbf..445cdaf65 100644
 +    ]);
 +    runSafetyRegistry.releaseRun({ context: registration.context, runId: rootRunId });
    });
- 
-   it("returns an error when neither sessionKey nor label is provided", async () => {
 diff --git a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
 index 3d8e61a82..a3c6911a0 100644
 --- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
 +++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
-@@ -1,6 +1,18 @@
+@@ -1,4 +1,16 @@
 -import { describe, expect, it, vi } from "vitest";
 +import { afterEach, describe, expect, it, vi } from "vitest";
  import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
@@ -11086,11 +10214,7 @@ index 3d8e61a82..a3c6911a0 100644
 +  resetAgentEventsForTest();
 +});
  
- describe("keepCliSessionBindingOnlyWhenReused", () => {
-   it("keeps the first room-event CLI binding when no binding exists yet", () => {
-@@ -50,3 +62,61 @@ describe("keepCliSessionBindingOnlyWhenReused", () => {
-     expect(result.meta.agentMeta?.cliSessionBinding).toBeUndefined();
-   });
+@@ -52 +64,59 @@ describe("keepCliSessionBindingOnlyWhenReused", () => {
  });
 +
 +describe("runCliAgentWithLifecycle", () => {
@@ -11154,9 +10278,7 @@ diff --git a/src/auto-reply/reply/agent-runner-cli-dispatch.ts b/src/auto-reply/
 index 75a45d7de..d96515c96 100644
 --- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
 +++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
-@@ -11,6 +11,18 @@ import { updateSessionStore, type SessionEntry } from "../../config/sessions.js"
- import type { AgentEventPayload } from "../../infra/agent-events.js";
- import { emitAgentEvent, onAgentEvent } from "../../infra/agent-events.js";
+@@ -13,2 +13,14 @@ import { emitAgentEvent, onAgentEvent } from "../../infra/agent-events.js";
  
 +const cliAgentDispatchDeps = {
 +  runCliAgent,
@@ -11171,28 +10293,16 @@ index 75a45d7de..d96515c96 100644
 +}
 +
  function shouldBridgeCliAssistantTextToReasoning(provider: string): boolean {
-   return normalizeLowercaseStringOrEmpty(provider) === "claude-cli";
- }
-@@ -220,7 +232,7 @@ export async function runCliAgentWithLifecycle(params: {
-   });
-   let lifecycleTerminalEmitted = false;
+@@ -222,3 +234,3 @@ export async function runCliAgentWithLifecycle(params: {
    try {
 -    const rawResult = await runCliAgent(params.runParams);
 +    const rawResult = await cliAgentDispatchDeps.runCliAgent(params.runParams);
      const result = params.transformResult?.(rawResult) ?? rawResult;
-     assistantBridge.unsubscribe();
-     reasoningBridge.unsubscribe();
-@@ -239,6 +251,7 @@ export async function runCliAgentWithLifecycle(params: {
-     }
- 
+@@ -241,2 +253,3 @@ export async function runCliAgentWithLifecycle(params: {
      if (emitLifecycleTerminal) {
 +      const terminationReason = result.meta.terminationReason;
        emitAgentEvent({
-         runId: params.runId,
-         stream: "lifecycle",
-@@ -246,6 +259,15 @@ export async function runCliAgentWithLifecycle(params: {
-           phase: "end",
-           startedAt,
+@@ -248,2 +261,11 @@ export async function runCliAgentWithLifecycle(params: {
            endedAt: Date.now(),
 +          ...(terminationReason
 +            ? {
@@ -11204,57 +10314,35 @@ index 75a45d7de..d96515c96 100644
 +              ? { stopReason: result.meta.stopReason }
 +              : {}),
          },
-       });
-       lifecycleTerminalEmitted = true;
 diff --git a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
 index 79c912bef..2b8f412ad 100644
 --- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
 +++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
-@@ -1,4 +1,5 @@
+@@ -1,2 +1,3 @@
 -import { beforeEach, describe, expect, it, vi } from "vitest";
 +import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 +import { RunSafetyRegistryDefaults, runSafetyRegistry } from "../../agents/run-safety-registry.js";
  import { getReplyPayloadMetadata } from "../reply-payload.js";
- import type { TemplateContext } from "../templating.js";
- import { createTestFollowupRun } from "./agent-runner.test-fixtures.js";
-@@ -154,6 +155,7 @@ function requireMaintenanceCall(mock: MockCallSource, name: string, index = 0) {
-         followupRun?: unknown;
-         sessionKey?: string;
+@@ -156,2 +157,3 @@ function requireMaintenanceCall(mock: MockCallSource, name: string, index = 0) {
          runtimePolicySessionKey?: string;
 +        runSafety?: unknown;
        }
-     | undefined;
-   if (!call) {
-@@ -164,6 +166,7 @@ function requireMaintenanceCall(mock: MockCallSource, name: string, index = 0) {
- 
- describe("runReplyAgent runtime config", () => {
+@@ -166,2 +168,3 @@ describe("runReplyAgent runtime config", () => {
    beforeEach(() => {
 +    runSafetyRegistry.resetForTests();
      resolveQueuedReplyExecutionConfigMock.mockReset();
-     resolveReplyToModeMock.mockReset();
-     createReplyToModeFilterForChannelMock.mockReset();
-@@ -181,6 +184,10 @@ describe("runReplyAgent runtime config", () => {
-     runMemoryFlushIfNeededMock.mockResolvedValue(undefined);
-   });
+@@ -183,2 +186,6 @@ describe("runReplyAgent runtime config", () => {
  
 +  afterEach(() => {
 +    runSafetyRegistry.resetForTests();
 +  });
 +
    it("resolves direct reply runs before early helpers read config", async () => {
-     const { followupRun, replyParams } = createDirectRuntimeReplyParams({
-       shouldFollowup: false,
-@@ -217,6 +224,7 @@ describe("runReplyAgent runtime config", () => {
-     );
-     expect(preflightCall.cfg).toBe(freshCfg);
+@@ -219,2 +226,3 @@ describe("runReplyAgent runtime config", () => {
      expect(preflightCall.followupRun).toBe(followupRun);
 +    expect(preflightCall.runSafety).toBeDefined();
    });
- 
-   it("passes the derived runtime-policy key to pre-run maintenance", async () => {
-@@ -243,6 +251,29 @@ describe("runReplyAgent runtime config", () => {
-     const memoryCall = requireMaintenanceCall(runMemoryFlushIfNeededMock, "runMemoryFlushIfNeeded");
-     expect(memoryCall.sessionKey).toBe("agent:main:main");
+@@ -245,2 +253,25 @@ describe("runReplyAgent runtime config", () => {
      expect(memoryCall.runtimePolicySessionKey).toBe(runtimePolicySessionKey);
 +    expect(memoryCall.runSafety).toBe(preflightCall.runSafety);
 +  });
@@ -11280,24 +10368,16 @@ index 79c912bef..2b8f412ad 100644
 +    expect(runPreflightCompactionIfNeededMock).not.toHaveBeenCalled();
 +    expect(runMemoryFlushIfNeededMock).not.toHaveBeenCalled();
    });
- 
-   it("returns source-suppression-safe memory-flush error payloads before the main reply run", async () => {
 diff --git a/src/auto-reply/reply/agent-runner-execution.ts b/src/auto-reply/reply/agent-runner-execution.ts
 index 03698016f..cc5727aa0 100644
 --- a/src/auto-reply/reply/agent-runner-execution.ts
 +++ b/src/auto-reply/reply/agent-runner-execution.ts
-@@ -53,6 +53,8 @@ import {
-   resolvePersistedOverrideModelRef,
- } from "../../agents/model-selection.js";
+@@ -55,2 +55,4 @@ import {
  import { resolveOpenAIRuntimeProvider } from "../../agents/openai-routing.js";
 +import type { RunSafetyContext, RunSafetyTermination } from "../../agents/run-safety-controller.js";
 +import { runSafetyRegistry } from "../../agents/run-safety-registry.js";
  import { buildAgentRuntimeOutcomePlan } from "../../agents/runtime-plan/build.js";
- import {
-   resolveGroupSessionKey,
-@@ -1454,39 +1456,47 @@ export function resolveRunAfterAutoFallbackPrimaryProbeRecheck(params: {
-   };
- }
+@@ -1456,35 +1458,43 @@ export function resolveRunAfterAutoFallbackPrimaryProbeRecheck(params: {
  
 -export async function runAgentTurnWithFallback(params: {
 -  commandBody: string;
@@ -11374,11 +10454,7 @@ index 03698016f..cc5727aa0 100644
 +  onRunSafetyLease: (lease: { context: RunSafetyContext; runId: string }) => void,
 +): Promise<AgentRunLoopResult> {
    const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
-   let didLogHeartbeatStrip = false;
-   let autoCompactionCount = 0;
-@@ -1546,7 +1556,74 @@ export async function runAgentTurnWithFallback(params: {
-     run.autoFallbackPrimaryProbe = undefined;
-   };
+@@ -1548,3 +1558,70 @@ export async function runAgentTurnWithFallback(params: {
  
 -  const runId = params.opts?.runId ?? crypto.randomUUID();
 +  const runId = params.runSafetyRunId ?? params.opts?.runId ?? crypto.randomUUID();
@@ -11450,27 +10526,15 @@ index 03698016f..cc5727aa0 100644
 +    onRunSafetyLease({ context: runSafety, runId });
 +  }
    const agentTurnTiming = createAgentTurnTimingTracker({
-     profilerEnabled: isReplyProfilerEnabled({ config: runtimeConfig }),
-   });
-@@ -2176,6 +2253,7 @@ export async function runAgentTurnWithFallback(params: {
-                     thinkLevel: params.followupRun.run.thinkLevel,
-                     timeoutMs: params.followupRun.run.timeoutMs,
+@@ -2178,2 +2255,3 @@ export async function runAgentTurnWithFallback(params: {
                      runId,
 +                    runSafety,
                      lane: runLane,
-                     extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-                     sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
-@@ -2284,6 +2362,7 @@ export async function runAgentTurnWithFallback(params: {
-                     groupSpace: normalizeOptionalString(params.sessionCtx.GroupSpace),
-                     ...senderContext,
+@@ -2286,2 +2364,3 @@ export async function runAgentTurnWithFallback(params: {
                      ...runBaseParams,
 +                    runSafety,
                      provider: embeddedRunProvider,
-                     agentHarnessId: embeddedRunHarnessOverride,
-                     agentHarnessRuntimeOverride: embeddedRunHarnessOverride,
-@@ -3016,3 +3095,18 @@ export async function runAgentTurnWithFallback(params: {
-     directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
-   };
+@@ -3018 +3097,16 @@ export async function runAgentTurnWithFallback(params: {
  }
 +
 +export async function runAgentTurnWithFallback(
@@ -11491,63 +10555,37 @@ diff --git a/src/auto-reply/reply/agent-runner-memory.ts b/src/auto-reply/reply/
 index f9dfd4c14..f926c3111 100644
 --- a/src/auto-reply/reply/agent-runner-memory.ts
 +++ b/src/auto-reply/reply/agent-runner-memory.ts
-@@ -13,6 +13,7 @@ import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-p
- import { runWithModelFallback } from "../../agents/model-fallback.js";
- import { isCliProvider } from "../../agents/model-selection.js";
+@@ -15,2 +15,3 @@ import { isCliProvider } from "../../agents/model-selection.js";
  import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
 +import type { RunSafetyContext } from "../../agents/run-safety-controller.js";
  import type { AgentMessage } from "../../agents/runtime/index.js";
- import { resolveSandboxConfigForAgent, resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
- import {
-@@ -686,6 +687,7 @@ export async function runPreflightCompactionIfNeeded(params: {
-   storePath?: string;
-   isHeartbeat: boolean;
+@@ -688,2 +689,3 @@ export async function runPreflightCompactionIfNeeded(params: {
    replyOperation: ReplyOperation;
 +  runSafety?: RunSafetyContext;
  }): Promise<SessionEntry | undefined> {
-   const deps = {
-     compactEmbeddedAgentSession: memoryDeps.compactEmbeddedAgentSession,
-@@ -894,6 +896,8 @@ export async function runPreflightCompactionIfNeeded(params: {
-     currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
-     ownerNumbers: params.followupRun.run.ownerNumbers,
+@@ -896,2 +898,4 @@ export async function runPreflightCompactionIfNeeded(params: {
      abortSignal: params.replyOperation.abortSignal,
 +    runId: params.runSafety?.controller.rootRunId,
 +    runSafety: params.runSafety,
    });
- 
-   if (!result?.ok) {
-@@ -967,6 +971,7 @@ export async function runMemoryFlushIfNeeded(params: {
-   storePath?: string;
-   isHeartbeat: boolean;
+@@ -969,2 +973,3 @@ export async function runMemoryFlushIfNeeded(params: {
    replyOperation: ReplyOperation;
 +  runSafety?: RunSafetyContext;
    onVisibleErrorPayloads?: (payloads: ReplyPayload[]) => void;
- }): Promise<SessionEntry | undefined> {
-   const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
-@@ -1257,6 +1262,7 @@ export async function runMemoryFlushIfNeeded(params: {
-             bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
-           abortSignal: params.replyOperation.abortSignal,
+@@ -1259,2 +1264,3 @@ export async function runMemoryFlushIfNeeded(params: {
            replyOperation: params.replyOperation,
 +          runSafety: params.runSafety,
            onAgentEvent: (evt) => {
-             if (evt.stream === "compaction") {
-               const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
 diff --git a/src/auto-reply/reply/agent-runner.ts b/src/auto-reply/reply/agent-runner.ts
 index cc51c352e..e5d581fc9 100644
 --- a/src/auto-reply/reply/agent-runner.ts
 +++ b/src/auto-reply/reply/agent-runner.ts
-@@ -15,6 +15,8 @@ import {
- } from "../../agents/embedded-agent-runner/runs.js";
- import { resolveModelAuthMode } from "../../agents/model-auth.js";
+@@ -17,2 +17,4 @@ import { resolveModelAuthMode } from "../../agents/model-auth.js";
  import { isCliProvider } from "../../agents/model-selection.js";
 +import type { RunSafetyTermination } from "../../agents/run-safety-controller.js";
 +import { runSafetyRegistry } from "../../agents/run-safety-registry.js";
  import { deriveContextPromptTokens, hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
- import { enqueueCommitmentExtraction } from "../../commitments/runtime.js";
- import type { OpenClawConfig } from "../../config/config.js";
-@@ -1476,10 +1478,53 @@ export async function runReplyAgent(params: {
-   };
-   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
+@@ -1478,2 +1480,32 @@ export async function runReplyAgent(params: {
    let preflightCompactionApplied;
 +  const runSafetyRunId = opts?.runId ?? crypto.randomUUID();
 +  let orphanLifecyclePublished = false;
@@ -11580,8 +10618,7 @@ index cc51c352e..e5d581fc9 100644
 +    onOrphanedTerminal: publishRunSafetyTerminal,
 +  });
  
-   try {
-     await typingSignals.signalRunStart();
+@@ -1482,2 +1514,15 @@ export async function runReplyAgent(params: {
  
 +    if (!runSafetyRegistration.ok) {
 +      emitRunSafetyLifecycleOnce(runSafetyRegistration.reason);
@@ -11597,55 +10634,31 @@ index cc51c352e..e5d581fc9 100644
 +    }
 +
      activeSessionEntry = await traceAgentPhase("reply.preflight_compaction", () =>
-       runPreflightCompactionIfNeeded({
-         cfg,
-@@ -1494,6 +1539,7 @@ export async function runReplyAgent(params: {
-         storePath,
-         isHeartbeat,
+@@ -1496,2 +1541,3 @@ export async function runReplyAgent(params: {
          replyOperation,
 +        runSafety: runSafetyRegistration.context,
        }),
-     );
-     preflightCompactionApplied =
-@@ -1517,6 +1563,7 @@ export async function runReplyAgent(params: {
-         storePath,
-         isHeartbeat,
+@@ -1519,2 +1565,3 @@ export async function runReplyAgent(params: {
          replyOperation,
 +        runSafety: runSafetyRegistration.context,
          onVisibleErrorPayloads: (payloads) => {
-           visibleMemoryFlushErrorPayloads.push(...payloads);
-         },
-@@ -1644,6 +1691,9 @@ export async function runReplyAgent(params: {
-         resolvedVerboseLevel,
-         toolProgressDetail,
+@@ -1646,2 +1693,5 @@ export async function runReplyAgent(params: {
          replyMediaContext,
 +        runSafety: runSafetyRegistration.context,
 +        runSafetyRunId,
 +        onRunSafetyTerminal: publishRunSafetyTerminal,
        }),
-     );
- 
-@@ -1690,6 +1740,7 @@ export async function runReplyAgent(params: {
-       }
-     }
+@@ -1692,2 +1742,3 @@ export async function runReplyAgent(params: {
  
 +    const runSafetyTermination = runResult.meta?.terminationReason;
      const payloadArray = runResult.payloads ?? [];
- 
-     if (blockReplyPipeline) {
-@@ -1819,6 +1870,9 @@ export async function runReplyAgent(params: {
-       messagingToolSentTargets: runResult.messagingToolSentTargets,
-     });
+@@ -1821,2 +1872,5 @@ export async function runReplyAgent(params: {
      const returnSilentFallbackFailureIfNeeded = async (): Promise<ReplyPayload | undefined> => {
 +      if (runSafetyTermination) {
 +        return undefined;
 +      }
        const silentFallbackFailurePayload = buildSilentFallbackFailurePayload({
-         fallbackTransition,
-         fallbackFailureKnown:
-@@ -1842,7 +1896,11 @@ export async function runReplyAgent(params: {
-     };
- 
+@@ -1844,3 +1898,7 @@ export async function runReplyAgent(params: {
      const fallbackNoticePayloads: ReplyPayload[] = [];
 -    if (!preserveUserFacingSessionState && fallbackTransition.fallbackTransitioned) {
 +    if (
@@ -11654,11 +10667,7 @@ index cc51c352e..e5d581fc9 100644
 +      fallbackTransition.fallbackTransitioned
 +    ) {
        emitAgentEvent({
-         runId,
-         sessionKey,
-@@ -1875,7 +1933,11 @@ export async function runReplyAgent(params: {
-         );
-       }
+@@ -1877,3 +1935,7 @@ export async function runReplyAgent(params: {
      }
 -    if (!preserveUserFacingSessionState && fallbackTransition.fallbackCleared) {
 +    if (
@@ -11667,21 +10676,13 @@ index cc51c352e..e5d581fc9 100644
 +      fallbackTransition.fallbackCleared
 +    ) {
        emitAgentEvent({
-         runId,
-         sessionKey,
-@@ -1905,6 +1967,9 @@ export async function runReplyAgent(params: {
-     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
-     // keep the typing indicator stuck.
+@@ -1907,2 +1969,5 @@ export async function runReplyAgent(params: {
      if (payloadArray.length === 0 && fallbackNoticePayloads.length === 0) {
 +      if (runSafetyTermination) {
 +        return returnWithQueuedFollowupDrain(undefined);
 +      }
        const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
-       if (silentFallbackFailurePayload) {
-         return silentFallbackFailurePayload;
-@@ -1984,17 +2049,19 @@ export async function runReplyAgent(params: {
-         ? appendUnscheduledReminderNote(replyPayloads)
-         : replyPayloads;
+@@ -1986,13 +2051,15 @@ export async function runReplyAgent(params: {
  
 -    enqueueCommitmentExtractionForTurn({
 -      cfg,
@@ -11708,11 +10709,7 @@ index cc51c352e..e5d581fc9 100644
 +      });
 +    }
  
-     await signalTypingIfNeeded(guardedReplyPayloads, typingSignals);
- 
-@@ -2417,6 +2484,12 @@ export async function runReplyAgent(params: {
-     returnWithQueuedFollowupDrain(undefined);
-     throw error;
+@@ -2419,2 +2486,8 @@ export async function runReplyAgent(params: {
    } finally {
 +    if (runSafetyRegistration.ok) {
 +      runSafetyRegistry.releaseRun({
@@ -11721,32 +10718,20 @@ index cc51c352e..e5d581fc9 100644
 +      });
 +    }
      try {
-       await clearRestartRecoveryDeliveryContext();
-     } catch (error) {
 diff --git a/src/auto-reply/reply/followup-runner.ts b/src/auto-reply/reply/followup-runner.ts
 index c82ef1eb7..fa90a8d2b 100644
 --- a/src/auto-reply/reply/followup-runner.ts
 +++ b/src/auto-reply/reply/followup-runner.ts
-@@ -15,6 +15,8 @@ import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-p
- import { runWithModelFallback } from "../../agents/model-fallback.js";
- import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
+@@ -17,2 +17,4 @@ import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-a
  import { isCliProvider } from "../../agents/model-selection-cli.js";
 +import type { RunSafetyContext, RunSafetyTermination } from "../../agents/run-safety-controller.js";
 +import { runSafetyRegistry } from "../../agents/run-safety-registry.js";
  import {
-   buildAgentRuntimeDeliveryPlan,
-   buildAgentRuntimeOutcomePlan,
-@@ -420,6 +422,7 @@ export function createFollowupRunner(params: {
-     const queuedImages = queued.images ?? opts?.images;
-     const queuedImageOrder = queued.imageOrder ?? opts?.imageOrder;
+@@ -422,2 +424,3 @@ export function createFollowupRunner(params: {
      let replyOperation: ReplyOperation | undefined;
 +    let runSafetyLease: { context: RunSafetyContext; runId: string } | undefined;
      let deferred = false;
- 
-     try {
-@@ -538,6 +541,57 @@ export function createFollowupRunner(params: {
-         }
-       }
+@@ -540,2 +543,53 @@ export function createFollowupRunner(params: {
        const runId = crypto.randomUUID();
 +      let orphanLifecyclePublished = false;
 +      const emitRunSafetyLifecycleOnce = (reason: RunSafetyTermination): void => {
@@ -11800,35 +10785,19 @@ index c82ef1eb7..fa90a8d2b 100644
 +      const runSafety = runSafetyRegistration.context;
 +      runSafetyLease = { context: runSafety, runId };
        const shouldSurfaceToControlUi = isInternalMessageChannel(
-         resolveOriginMessageProvider({
-           originatingChannel: queued.originatingChannel,
-@@ -561,6 +615,7 @@ export function createFollowupRunner(params: {
-           storePath,
-           isHeartbeat: opts?.isHeartbeat === true,
+@@ -563,2 +617,3 @@ export function createFollowupRunner(params: {
            replyOperation,
 +          runSafety,
          });
-       } catch (err) {
-         const message = formatErrorMessage(err);
-@@ -820,6 +875,7 @@ export function createFollowupRunner(params: {
-                     thinkLevel: run.thinkLevel,
-                     timeoutMs: run.timeoutMs,
+@@ -822,2 +877,3 @@ export function createFollowupRunner(params: {
                      runId,
 +                    runSafety,
                      extraSystemPrompt: run.extraSystemPrompt,
-                     sourceReplyDeliveryMode: run.sourceReplyDeliveryMode,
-                     silentReplyPromptMode: run.silentReplyPromptMode,
-@@ -935,6 +991,7 @@ export function createFollowupRunner(params: {
-                 bashElevated: run.bashElevated,
-                 timeoutMs: run.timeoutMs,
+@@ -937,2 +993,3 @@ export function createFollowupRunner(params: {
                  runId,
 +                runSafety,
                  abortSignal: runAbortSignal,
-                 images: queuedImages,
-                 imageOrder: queuedImageOrder,
-@@ -1017,6 +1074,15 @@ export function createFollowupRunner(params: {
-               phase: "end",
-               startedAt: pendingDeferredCliTerminal.startedAt,
+@@ -1019,2 +1076,11 @@ export function createFollowupRunner(params: {
                endedAt: Date.now(),
 +              ...(runResult.meta.terminationReason
 +                ? {
@@ -11840,103 +10809,87 @@ index c82ef1eb7..fa90a8d2b 100644
 +                  ? { stopReason: runResult.meta.stopReason }
 +                  : {}),
              },
-           });
-         }
-@@ -1164,6 +1230,9 @@ export function createFollowupRunner(params: {
-         { runId },
-       );
+@@ -1166,2 +1232,5 @@ export function createFollowupRunner(params: {
      } finally {
 +      if (runSafetyLease) {
 +        runSafetyRegistry.releaseRun(runSafetyLease);
 +      }
        for (const end of endDeliveryCorrelations.toReversed()) {
-         try {
-           end();
 diff --git a/src/config/types.agent-defaults.ts b/src/config/types.agent-defaults.ts
-index 297aad77b..853a20124 100644
+index 297aad77b..ea69906b3 100644
 --- a/src/config/types.agent-defaults.ts
 +++ b/src/config/types.agent-defaults.ts
-@@ -104,6 +104,17 @@ export type AgentRunRetriesConfig = {
-   max?: number;
- };
+@@ -106,2 +106,16 @@ export type AgentRunRetriesConfig = {
  
 +export type AgentRunSafetyConfig = {
 +  /** Raw tool-call reservations allowed for one external task scope. */
 +  maxToolCallReservationsPerBudgetScope?: number;
 +  /** Provider adapter invocations allowed for one external task scope. */
 +  maxProviderDispatchesPerBudgetScope?: number;
-+  /** Conservative cumulative prompt exposure allowed for one external task scope. */
-+  maxCumulativeEstimatedPromptTokensPerBudgetScope?: number;
 +  /** Fraction of a limit at which a one-shot diagnostic warning is recorded. */
 +  warningRatio?: number;
++  /** Observe-only legacy prompt exposure telemetry. Never terminates a run. */
++  promptExposure?: {
++    mode: "observe";
++    legacyDiagnosticThreshold: number;
++  };
 +};
 +
  export type CliBackendConfig = {
-   /** CLI command to execute (absolute path or on PATH). */
-   command: string;
-@@ -311,6 +322,8 @@ export type AgentDefaultsConfig = {
-   compaction?: AgentCompactionConfig;
-   /** Outer run loop retry iteration boundaries. */
+@@ -313,2 +327,4 @@ export type AgentDefaultsConfig = {
    runRetries?: AgentRunRetriesConfig;
 +  /** Provider-neutral local safety budgets for one external task scope. */
 +  runSafety?: AgentRunSafetyConfig;
    /** Embedded OpenClaw runner hardening and compatibility controls. */
-   embeddedAgent?: {
-     /**
 diff --git a/src/config/types.tools.ts b/src/config/types.tools.ts
 index fe96a51c7..6e16f8b9d 100644
 --- a/src/config/types.tools.ts
 +++ b/src/config/types.tools.ts
-@@ -165,6 +165,8 @@ export type ToolLoopDetectionDetectorConfig = {
-   knownPollNoProgress?: boolean;
-   /** Enable warning/blocking for no-progress ping-pong alternating patterns. */
+@@ -167,2 +167,4 @@ export type ToolLoopDetectionDetectorConfig = {
    pingPong?: boolean;
 +  /** Enable no-progress detection across allowlisted argument variants. */
 +  variantNoProgress?: boolean;
  };
- 
- export type ToolLoopPostCompactionGuardConfig = {
-@@ -183,6 +185,10 @@ export type ToolLoopDetectionConfig = {
-   unknownToolThreshold?: number;
-   /** Critical threshold for blocking repetitive loops (default: 20). */
+@@ -185,2 +187,6 @@ export type ToolLoopDetectionConfig = {
    criticalThreshold?: number;
 +  /** Warning threshold for allowlisted argument variants with identical outcomes (default: 2). */
 +  variantWarningThreshold?: number;
 +  /** Critical threshold for distinct allowlisted argument variants with identical outcomes (default: 3). */
 +  variantCriticalThreshold?: number;
    /** Global no-progress breaker threshold (default: 30). */
-   globalCircuitBreakerThreshold?: number;
-   /** Detector toggles. */
 diff --git a/src/config/zod-schema.agent-defaults.test.ts b/src/config/zod-schema.agent-defaults.test.ts
-index b6b6a1b8b..c6c71e46e 100644
+index b6b6a1b8b..2bc453914 100644
 --- a/src/config/zod-schema.agent-defaults.test.ts
 +++ b/src/config/zod-schema.agent-defaults.test.ts
-@@ -26,6 +26,37 @@ function expectSchemaFailurePath(result: SchemaParseResult, expectedPathPrefix:
- }
- 
+@@ -28,2 +28,63 @@ function expectSchemaFailurePath(result: SchemaParseResult, expectedPathPrefix:
  describe("agent defaults schema", () => {
 +  it("accepts positive safe run-safety budgets", () => {
 +    const parsed = AgentDefaultsSchema.parse({
 +      runSafety: {
 +        maxToolCallReservationsPerBudgetScope: 64,
 +        maxProviderDispatchesPerBudgetScope: 32,
-+        maxCumulativeEstimatedPromptTokensPerBudgetScope: 2_000_000,
 +        warningRatio: 0.75,
++        promptExposure: {
++          mode: "observe",
++          legacyDiagnosticThreshold: 2_000_000,
++        },
 +      },
 +    });
 +
 +    expect(parsed?.runSafety).toEqual({
 +      maxToolCallReservationsPerBudgetScope: 64,
 +      maxProviderDispatchesPerBudgetScope: 32,
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 2_000_000,
 +      warningRatio: 0.75,
++      promptExposure: {
++        mode: "observe",
++        legacyDiagnosticThreshold: 2_000_000,
++      },
 +    });
 +  });
 +
 +  it.each([
 +    ["maxToolCallReservationsPerBudgetScope", 0],
 +    ["maxProviderDispatchesPerBudgetScope", -1],
-+    ["maxCumulativeEstimatedPromptTokensPerBudgetScope", Number.MAX_VALUE],
 +    ["warningRatio", 0],
 +    ["warningRatio", 1],
 +  ])("rejects invalid run-safety %s", (field, value) => {
@@ -11946,58 +10899,68 @@ index b6b6a1b8b..c6c71e46e 100644
 +    );
 +  });
 +
++  it("rejects legacy prompt hard limits and invalid observe-only prompt telemetry", () => {
++    expectSchemaFailurePath(
++      AgentDefaultsSchema.safeParse({
++        runSafety: { maxCumulativeEstimatedPromptTokensPerBudgetScope: 2_000_000 },
++      }),
++      "runSafety",
++    );
++    expectSchemaFailurePath(
++      AgentDefaultsSchema.safeParse({
++        runSafety: {
++          promptExposure: { mode: "enforce", legacyDiagnosticThreshold: 2_000_000 },
++        },
++      }),
++      "runSafety.promptExposure.mode",
++    );
++    expectSchemaFailurePath(
++      AgentDefaultsSchema.safeParse({
++        runSafety: {
++          promptExposure: { mode: "observe", legacyDiagnosticThreshold: Number.MAX_VALUE },
++        },
++      }),
++      "runSafety.promptExposure.legacyDiagnosticThreshold",
++    );
++  });
++
    it("accepts subagent archiveAfterMinutes=0 to disable archiving", () => {
-     expectSchemaSuccess(
-       AgentDefaultsSchema.safeParse({
 diff --git a/src/config/zod-schema.agent-defaults.ts b/src/config/zod-schema.agent-defaults.ts
-index 1863c0501..f30d61547 100644
+index 1863c0501..451677a8a 100644
 --- a/src/config/zod-schema.agent-defaults.ts
 +++ b/src/config/zod-schema.agent-defaults.ts
-@@ -204,6 +204,20 @@ export const AgentDefaultsSchema = z
-       .strict()
-       .optional(),
+@@ -206,2 +206,17 @@ export const AgentDefaultsSchema = z
      runRetries: AgentRunRetriesConfigSchema.optional(),
 +    runSafety: z
 +      .object({
 +        maxToolCallReservationsPerBudgetScope: z.number().int().positive().safe().optional(),
 +        maxProviderDispatchesPerBudgetScope: z.number().int().positive().safe().optional(),
-+        maxCumulativeEstimatedPromptTokensPerBudgetScope: z
-+          .number()
-+          .int()
-+          .positive()
-+          .safe()
-+          .optional(),
 +        warningRatio: z.number().gt(0).lt(1).optional(),
++        promptExposure: z
++          .object({
++            mode: z.literal("observe"),
++            legacyDiagnosticThreshold: z.number().int().positive().safe(),
++          })
++          .strict()
++          .optional(),
 +      })
 +      .strict()
 +      .optional(),
      embeddedAgent: EmbeddedAgentConfigSchema.optional(),
-     thinkingDefault: z
-       .union([
 diff --git a/src/config/zod-schema.agent-runtime.ts b/src/config/zod-schema.agent-runtime.ts
 index 301d38d8e..c572169f8 100644
 --- a/src/config/zod-schema.agent-runtime.ts
 +++ b/src/config/zod-schema.agent-runtime.ts
-@@ -619,6 +619,7 @@ const ToolLoopDetectionDetectorSchema = z
-     genericRepeat: z.boolean().optional(),
-     knownPollNoProgress: z.boolean().optional(),
+@@ -621,2 +621,3 @@ const ToolLoopDetectionDetectorSchema = z
      pingPong: z.boolean().optional(),
 +    variantNoProgress: z.boolean().optional(),
    })
-   .strict()
-   .optional();
-@@ -637,6 +638,8 @@ const ToolLoopDetectionSchema = z
-     warningThreshold: z.number().int().positive().optional(),
-     unknownToolThreshold: z.number().int().positive().optional(),
+@@ -639,2 +640,4 @@ const ToolLoopDetectionSchema = z
      criticalThreshold: z.number().int().positive().optional(),
 +    variantWarningThreshold: z.number().int().positive().optional(),
 +    variantCriticalThreshold: z.number().int().positive().optional(),
      globalCircuitBreakerThreshold: z.number().int().positive().optional(),
-     detectors: ToolLoopDetectionDetectorSchema,
-     postCompactionGuard: ToolLoopPostCompactionGuardSchema,
-@@ -666,6 +669,18 @@ const ToolLoopDetectionSchema = z
-           "tools.loopDetection.criticalThreshold must be lower than globalCircuitBreakerThreshold.",
-       });
+@@ -668,2 +671,14 @@ const ToolLoopDetectionSchema = z
      }
 +    if (
 +      value.variantWarningThreshold !== undefined &&
@@ -12012,8 +10975,6 @@ index 301d38d8e..c572169f8 100644
 +      });
 +    }
    })
-   .optional();
- 
 diff --git a/src/config/zod-schema.tool-loop-variant.test.ts b/src/config/zod-schema.tool-loop-variant.test.ts
 new file mode 100644
 index 000000000..328b30174
@@ -12076,15 +11037,79 @@ index 000000000..328b30174
 +    expect(result.success).toBe(false);
 +  });
 +});
+diff --git a/src/context-engine/run-safety-compaction.test.ts b/src/context-engine/run-safety-compaction.test.ts
+new file mode 100644
+index 000000000..be8aa12f1
+--- /dev/null
++++ b/src/context-engine/run-safety-compaction.test.ts
+@@ -0,0 +1,59 @@
++import { describe, expect, it, vi } from "vitest";
++import {
++  RunSafetyController,
++  RunSafetyRootCoordinator,
++  type RunSafetyContext,
++} from "../agents/run-safety-controller.js";
++import { createContextEngineRunSafetyHostV1 } from "./run-safety-compaction.js";
++import type { ContextEngineRuntimeContext } from "./types.js";
++
++function createRunSafety(): RunSafetyContext {
++  const coordinator = new RunSafetyRootCoordinator("root-context-engine");
++  return {
++    coordinator,
++    controller: new RunSafetyController({
++      rootInvocationId: coordinator.rootInvocationId,
++      budgetScopeId: "scope-context-engine",
++      rootRunId: "run-context-engine",
++    }),
++  };
++}
++
++describe("context engine run-safety compaction host", () => {
++  it("calls compaction transport when final prompt estimation is unavailable", async () => {
++    const runSafety = createRunSafety();
++    const runtimeContext = {
++      runId: "run-context-engine",
++      runSafety,
++    } as ContextEngineRuntimeContext;
++    const host = createContextEngineRunSafetyHostV1(runtimeContext);
++    const transport = vi.fn(async () => "compacted");
++
++    const result = await host.dispatch({
++      finalPayload: {
++        messages: [
++          {
++            role: "user",
++            content: [{ type: "image_url", url: "https://example.test/image.png" }],
++          },
++        ],
++      },
++      model: { contextWindow: undefined },
++      transport,
++    });
++
++    expect(result).toBe("compacted");
++    expect(transport).toHaveBeenCalledOnce();
++    expect(runSafety.controller.terminationReason).toBeUndefined();
++    expect(runSafety.controller.snapshot()).toMatchObject({
++      providerDispatchCount: 1,
++      promptExposure: {
++        estimateUnavailableDispatchCount: 1,
++        pendingObservationDispatchCount: 0,
++        unavailableReasonCounts: {
++          unknown_media_without_context_window: 1,
++        },
++      },
++    });
++  });
++});
 diff --git a/src/context-engine/run-safety-compaction.ts b/src/context-engine/run-safety-compaction.ts
 new file mode 100644
-index 000000000..93bb556d8
+index 000000000..bd56ed6dc
 --- /dev/null
 +++ b/src/context-engine/run-safety-compaction.ts
-@@ -0,0 +1,100 @@
+@@ -0,0 +1,91 @@
 +import {
-+  estimateRunSafetyPromptTokens,
-+  RunSafetyTerminationKind,
++  estimateRunSafetyPromptObservation,
 +  type RunSafetyTermination,
 +} from "../agents/run-safety-controller.js";
 +import type {
@@ -12123,22 +11148,10 @@ index 000000000..93bb556d8
 +    model,
 +    transport,
 +  }) => {
-+    const estimate = estimateRunSafetyPromptTokens(finalPayload, model);
-+    if (!estimate.ok) {
-+      const reason = runSafety.controller.tryTerminate({
-+        kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable,
-+        runId,
-+      });
-+      throw new ContextEngineRunSafetyContractError(
-+        "Plugin-owned compaction payload could not be estimated safely.",
-+        reason,
-+      );
-+    }
 +    const providerDispatchId = runSafety.controller.createProviderDispatchId(runId);
 +    const reservation = runSafety.controller.reserveProviderDispatch({
 +      runId,
 +      providerDispatchId,
-+      estimatedPromptTokens: estimate.estimatedPromptTokens,
 +    });
 +    if (!reservation.allowed) {
 +      throw new ContextEngineRunSafetyContractError(
@@ -12147,6 +11160,10 @@ index 000000000..93bb556d8
 +      );
 +    }
 +    try {
++      runSafety.controller.observeProviderPromptEstimate({
++        providerDispatchId,
++        observation: estimateRunSafetyPromptObservation(finalPayload, model),
++      });
 +      return await transport();
 +    } finally {
 +      runSafety.controller.completeProviderDispatch(providerDispatchId);
@@ -12183,20 +11200,16 @@ index 000000000..93bb556d8
 +  };
 +}
 diff --git a/src/context-engine/types.ts b/src/context-engine/types.ts
-index 917a6135a..7807eef2d 100644
+index 917a6135a..076b9b717 100644
 --- a/src/context-engine/types.ts
 +++ b/src/context-engine/types.ts
-@@ -1,5 +1,7 @@
+@@ -1,3 +1,5 @@
 +import type { RunSafetyContext } from "../agents/run-safety-controller.js";
  import type { AgentMessage } from "../agents/runtime/index.js";
  import type { MemoryCitationsMode } from "../config/types.memory.js";
 +import type { Model } from "../llm/types.js";
  
- // Result types
- 
-@@ -226,8 +228,71 @@ export type ContextEngineRuntimeContext = Record<string, unknown> & {
-       params: import("../plugins/runtime/types-core.js").LlmCompleteParams,
-     ) => Promise<import("../plugins/runtime/types-core.js").LlmCompleteResult>;
+@@ -228,4 +230,68 @@ export type ContextEngineRuntimeContext = Record<string, unknown> & {
    };
 +  /** Host-owned run-safety scope. Plugins never receive this object directly. */
 +  runSafety?: RunSafetyContext;
@@ -12240,7 +11253,8 @@ index 917a6135a..7807eef2d 100644
 +export type ContextEngineRunSafetyHostV1 = Readonly<{
 +  contractVersion: 1;
 +  /**
-+   * Reserve provider/prompt budget before starting the supplied transport.
++   * Reserve provider dispatch count and observe the immutable final payload
++   * before starting the supplied transport.
 +   * Engine-owned network I/O is forbidden outside this callback.
 +   */
 +  dispatch: ContextEngineRunSafetyDispatchV1;
@@ -12264,11 +11278,7 @@ index 917a6135a..7807eef2d 100644
 +}>;
 +
  /**
-  * ContextEngine defines the pluggable contract for context management.
-  *
-@@ -238,6 +303,14 @@ export interface ContextEngine {
-   /** Engine identifier and metadata */
-   readonly info: ContextEngineInfo;
+@@ -240,2 +306,10 @@ export interface ContextEngine {
  
 +  /**
 +   * Mandatory contract for an engine with `info.ownsCompaction === true`.
@@ -12279,11 +11289,7 @@ index 917a6135a..7807eef2d 100644
 +  readonly runSafetyCompactionV1?: ContextEngineRunSafetyCompactionV1;
 +
    /**
-    * Initialize engine state for a session, optionally importing historical context.
-    */
-@@ -334,27 +407,7 @@ export interface ContextEngine {
-    * compaction can be canceled promptly on run abort or host timeout instead
-    * of running to completion in the background.
+@@ -336,23 +410,3 @@ export interface ContextEngine {
     */
 -  compact(params: {
 -    sessionId: string;
@@ -12308,48 +11314,28 @@ index 917a6135a..7807eef2d 100644
 -  }): Promise<CompactResult>;
 +  compact(params: ContextEngineCompactParams): Promise<CompactResult>;
  
-   /**
-    * Prepare context-engine-managed subagent state before the child run starts.
 diff --git a/src/cron/isolated-agent/run-executor.ts b/src/cron/isolated-agent/run-executor.ts
 index 1b2710a86..cc1699da8 100644
 --- a/src/cron/isolated-agent/run-executor.ts
 +++ b/src/cron/isolated-agent/run-executor.ts
-@@ -1,6 +1,8 @@
- import { createHash } from "node:crypto";
- import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
+@@ -3,2 +3,4 @@ import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
  import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 +import type { RunSafetyContext, RunSafetyTermination } from "../../agents/run-safety-controller.js";
 +import { runSafetyRegistry } from "../../agents/run-safety-registry.js";
  import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
- import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
- import type { OpenClawConfig } from "../../config/types.openclaw.js";
-@@ -147,6 +149,7 @@ export function createCronPromptExecutor(params: {
-   cronSession: MutableCronSession;
-   abortSignal?: AbortSignal;
+@@ -149,2 +151,3 @@ export function createCronPromptExecutor(params: {
    abortReason: () => string;
 +  runSafety: RunSafetyContext;
    onExecutionStarted?: () => void;
-   onExecutionPhase?: (
-     info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
-@@ -237,6 +240,7 @@ export function createCronPromptExecutor(params: {
-             thinkLevel: params.thinkLevel,
-             timeoutMs: params.timeoutMs,
+@@ -239,2 +242,3 @@ export function createCronPromptExecutor(params: {
              runId: params.cronSession.sessionEntry.sessionId,
 +            runSafety: params.runSafety,
              lane: resolveCronAgentLane(params.lane),
-             cliSessionId,
-             skillsSnapshot: params.skillsSnapshot,
-@@ -318,6 +322,7 @@ export function createCronPromptExecutor(params: {
-             : undefined,
-           sourceReplyDeliveryMode,
+@@ -320,2 +324,3 @@ export function createCronPromptExecutor(params: {
            runId: params.cronSession.sessionEntry.sessionId,
 +          runSafety: params.runSafety,
            requireExplicitMessageTarget: params.sourceDelivery.messageTool.requireExplicitTarget,
-           disableMessageTool: !params.sourceDelivery.messageTool.enabled,
-           forceMessageTool: params.sourceDelivery.messageTool.force,
-@@ -355,47 +360,51 @@ export function createCronPromptExecutor(params: {
- }
- 
+@@ -357,43 +362,47 @@ export function createCronPromptExecutor(params: {
  /** Executes an isolated cron prompt, including live model-switch and interim-ack retries. */
 -export async function executeCronRun(params: {
 -  cfg: OpenClawConfig;
@@ -12438,19 +11424,11 @@ index 1b2710a86..cc1699da8 100644
 +  runSafety: RunSafetyContext,
 +): Promise<CronExecutionResult> {
    const resolvedVerboseLevel: VerboseLevel =
-     normalizeVerboseLevel(params.cronSession.sessionEntry.verboseLevel) ??
-     normalizeVerboseLevel(params.agentVerboseDefault) ??
-@@ -430,6 +439,7 @@ export async function executeCronRun(params: {
-     cronSession: params.cronSession,
-     abortSignal: params.abortSignal,
+@@ -432,2 +441,3 @@ export async function executeCronRun(params: {
      abortReason: params.abortReason,
 +    runSafety,
      onExecutionStarted: params.onExecutionStarted,
-     onExecutionPhase: params.onExecutionPhase,
-   });
-@@ -543,3 +553,58 @@ export async function executeCronRun(params: {
-     liveSelection: params.liveSelection,
-   };
+@@ -545 +555,56 @@ export async function executeCronRun(params: {
  }
 +
 +export async function executeCronRun(
@@ -12511,9 +11489,7 @@ diff --git a/src/gateway/server-methods/agent.ts b/src/gateway/server-methods/ag
 index a8c483afc..55121fc66 100644
 --- a/src/gateway/server-methods/agent.ts
 +++ b/src/gateway/server-methods/agent.ts
-@@ -36,7 +36,13 @@ import {
- } from "../../agents/identity-avatar.js";
- import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "../../agents/internal-event-contract.js";
+@@ -38,3 +38,9 @@ import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "../../agents/internal
  import type { AgentInternalEvent } from "../../agents/internal-events.js";
 +import { AGENT_LANE_SUBAGENT } from "../../agents/lanes.js";
  import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
@@ -12523,11 +11499,7 @@ index a8c483afc..55121fc66 100644
 +  runSafetyRegistry,
 +} from "../../agents/run-safety-registry.js";
  import {
-   normalizeAgentRunTimeoutPhase,
-   normalizeProviderStarted,
-@@ -978,6 +984,12 @@ function dispatchAgentRunFromGateway(params: {
-       });
-     })
+@@ -980,2 +986,8 @@ function dispatchAgentRunFromGateway(params: {
      .finally(() => {
 +      if (params.ingressOpts.runSafety) {
 +        runSafetyRegistry.releaseRun({
@@ -12536,11 +11508,7 @@ index a8c483afc..55121fc66 100644
 +        });
 +      }
        const entry = params.context.chatAbortControllers.get(params.runId);
-       if (entry?.controller === params.abortController) {
-         params.context.chatAbortControllers.delete(params.runId);
-@@ -1056,6 +1068,11 @@ export const agentHandlers: GatewayRequestHandlers = {
-       bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
-       acpTurnSource?: "manual_spawn";
+@@ -1058,2 +1070,7 @@ export const agentHandlers: GatewayRequestHandlers = {
        internalRuntimeHandoffId?: string;
 +      runSafety?: {
 +        rootInvocationId: string;
@@ -12548,11 +11516,7 @@ index a8c483afc..55121fc66 100644
 +        claimToken: string;
 +      };
        internalEvents?: AgentInternalEvent[];
-       suppressPromptPersistence?: boolean;
-       sessionEffects?: "visible" | "internal";
-@@ -1106,6 +1123,20 @@ export const agentHandlers: GatewayRequestHandlers = {
-     const cfg = context.getRuntimeConfig();
-     const idem = request.idempotencyKey;
+@@ -1108,2 +1125,16 @@ export const agentHandlers: GatewayRequestHandlers = {
      const runId = idem;
 +    if (request.lane === AGENT_LANE_SUBAGENT && !request.runSafety) {
 +      const terminationReason = createRunSafetyIdentityMissingTermination({ runId });
@@ -12569,11 +11533,7 @@ index a8c483afc..55121fc66 100644
 +    }
 +    let inheritedRunSafety: RunSafetyContext | undefined;
      const execApprovalFollowupApprovalId = parseExecApprovalFollowupApprovalId(idem);
-     if (execApprovalFollowupApprovalId && !canUseInternalRuntimeHandoff) {
-       respond(
-@@ -2250,6 +2281,28 @@ export const agentHandlers: GatewayRequestHandlers = {
-         }
-       }
+@@ -2252,2 +2283,24 @@ export const agentHandlers: GatewayRequestHandlers = {
  
 +      if (request.runSafety) {
 +        const resolution = runSafetyRegistry.resolveInheritedRun({
@@ -12598,11 +11558,7 @@ index a8c483afc..55121fc66 100644
 +      }
 +
        const accepted = {
-         runId,
-         sessionKey: resolvedSessionKey,
-@@ -2370,84 +2423,87 @@ export const agentHandlers: GatewayRequestHandlers = {
-           const execApprovalFollowupElevatedDefaults =
-             execApprovalFollowupRuntimeHandoff?.bashElevated;
+@@ -2372,30 +2425,22 @@ export const agentHandlers: GatewayRequestHandlers = {
  
 -          dispatchAgentRunFromGateway({
 -            ingressOpts: {
@@ -12652,7 +11608,7 @@ index a8c483afc..55121fc66 100644
 -                ? { bashElevated: execApprovalFollowupElevatedDefaults }
 -                : {}),
                groupId: resolvedGroupId,
-               groupChannel: resolvedGroupChannel,
+@@ -2403,49 +2448,60 @@ export const agentHandlers: GatewayRequestHandlers = {
                groupSpace: resolvedGroupSpace,
 -              spawnedBy: spawnedByValue,
 -              timeout: request.timeout?.toString(),
@@ -12758,11 +11714,7 @@ index a8c483afc..55121fc66 100644
 +          dispatchAgentRunFromGateway({
 +            ingressOpts,
              runId,
-             dedupeKeys: agentDedupeKeys,
-             abortController: activeRunAbort.controller,
-@@ -2479,6 +2535,12 @@ export const agentHandlers: GatewayRequestHandlers = {
-           });
-         } finally {
+@@ -2481,2 +2537,8 @@ export const agentHandlers: GatewayRequestHandlers = {
            if (!dispatched) {
 +            if (inheritedRunSafety) {
 +              runSafetyRegistry.releaseRun({
@@ -12771,34 +11723,23 @@ index a8c483afc..55121fc66 100644
 +              });
 +            }
              activeRunAbort.cleanup();
-           }
-         }
 diff --git a/src/infra/diagnostic-events.ts b/src/infra/diagnostic-events.ts
 index eb87abc47..f03b50f86 100644
 --- a/src/infra/diagnostic-events.ts
 +++ b/src/infra/diagnostic-events.ts
-@@ -360,6 +360,7 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
-     | "generic_repeat"
-     | "unknown_tool_repeat"
+@@ -362,2 +362,3 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
      | "known_poll_no_progress"
 +    | "variant_no_progress"
      | "aborted_tool_loop"
-     | "global_circuit_breaker"
-     | "ping_pong";
 diff --git a/src/llm/providers/openai-chatgpt-responses.test.ts b/src/llm/providers/openai-chatgpt-responses.test.ts
 index bb6986ba0..7ea7411d1 100644
 --- a/src/llm/providers/openai-chatgpt-responses.test.ts
 +++ b/src/llm/providers/openai-chatgpt-responses.test.ts
-@@ -1,5 +1,6 @@
- import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
+@@ -2,2 +2,3 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
  import { afterEach, describe, expect, it, vi } from "vitest";
 +import { runWithRunSafetyProviderDispatch } from "../run-safety-provider-dispatch-context.js";
  import type { Context, Model } from "../types.js";
- import {
-   extractOpenAICodexAccountId,
-@@ -131,6 +132,65 @@ describe("streamOpenAICodexResponses transport", () => {
-     expect(result.errorMessage).toContain("websocket connect failed");
-   });
+@@ -133,2 +134,61 @@ describe("streamOpenAICodexResponses transport", () => {
  
 +  it("does not fall back from websocket to SSE inside a run-safety dispatch", async () => {
 +    const fetchMock = vi.fn(async () => {
@@ -12860,50 +11801,30 @@ index bb6986ba0..7ea7411d1 100644
 +  });
 +
    it("honors timeoutMs for explicit SSE transport requests", async () => {
-     stubHangingFetch(5);
- 
 diff --git a/src/llm/providers/openai-chatgpt-responses.ts b/src/llm/providers/openai-chatgpt-responses.ts
 index 77cc38660..04578a6e8 100644
 --- a/src/llm/providers/openai-chatgpt-responses.ts
 +++ b/src/llm/providers/openai-chatgpt-responses.ts
-@@ -26,6 +26,7 @@ import {
- } from "@openclaw/normalization-core/number-coercion";
- import { getEnvApiKey } from "../env-api-keys.js";
+@@ -28,2 +28,3 @@ import { getEnvApiKey } from "../env-api-keys.js";
  import { clampThinkingLevel } from "../model-utils.js";
 +import { shouldDisableInternalProviderTransportRetries } from "../run-safety-provider-dispatch-context.js";
  import { registerSessionResourceCleanup } from "../session-resources.js";
- import type {
-   Api,
-@@ -146,6 +147,10 @@ function resolveRequestTimeoutMs(options?: OpenAICodexResponsesOptions): number
-     : undefined;
- }
+@@ -148,2 +149,6 @@ function resolveRequestTimeoutMs(options?: OpenAICodexResponsesOptions): number
  
 +function resolveMaxRetries(disableInternalTransportRetries: boolean): number {
 +  return disableInternalTransportRetries ? 0 : MAX_RETRIES;
 +}
 +
  function buildRequestSignal(
-   baseSignal: AbortSignal | undefined,
-   timeoutMs: number | undefined,
-@@ -198,6 +203,7 @@ export const streamOpenAICodexResponses: StreamFunction<
-   options?: OpenAICodexResponsesOptions,
- ) => {
+@@ -200,2 +205,3 @@ export const streamOpenAICodexResponses: StreamFunction<
    const stream = new AssistantMessageEventStream();
 +  const disableInternalTransportRetries = shouldDisableInternalProviderTransportRetries();
  
-   void (async () => {
-     let requestTimeoutMs: number | undefined;
-@@ -253,6 +259,7 @@ export const streamOpenAICodexResponses: StreamFunction<
-       const requestOptions =
-         activeSignal === options?.signal ? options : { ...options, signal: activeSignal };
+@@ -255,2 +261,3 @@ export const streamOpenAICodexResponses: StreamFunction<
        const transport = options?.transport || "auto";
 +      const maxRetries = resolveMaxRetries(disableInternalTransportRetries);
        const websocketDisabledForSession =
-         transport === "auto" && isWebSocketSseFallbackActive(options?.sessionId);
-       if (websocketDisabledForSession) {
-@@ -294,7 +301,10 @@ export const streamOpenAICodexResponses: StreamFunction<
-             output,
-             createAssistantMessageDiagnostic("provider_transport_failure", error, {
+@@ -296,3 +303,6 @@ export const streamOpenAICodexResponses: StreamFunction<
                configuredTransport: transport,
 -              fallbackTransport: transport === "auto" && !websocketStarted ? "sse" : undefined,
 +              fallbackTransport:
@@ -12911,44 +11832,26 @@ index 77cc38660..04578a6e8 100644
 +                  ? "sse"
 +                  : undefined,
                eventsEmitted: websocketStarted,
-               phase: websocketStarted
-                 ? "after_message_stream_start"
-@@ -305,7 +315,7 @@ export const streamOpenAICodexResponses: StreamFunction<
-           recordWebSocketFailure(options?.sessionId, error, {
-             activateSseFallback: transport === "auto",
+@@ -307,3 +317,3 @@ export const streamOpenAICodexResponses: StreamFunction<
            });
 -          if (websocketStarted || transport !== "auto") {
 +          if (websocketStarted || transport !== "auto" || disableInternalTransportRetries) {
              throw error;
-           }
-           recordWebSocketSseFallback(options?.sessionId);
-@@ -316,7 +326,7 @@ export const streamOpenAICodexResponses: StreamFunction<
-       let response: Response | undefined;
-       let lastError: Error | undefined;
+@@ -318,3 +328,3 @@ export const streamOpenAICodexResponses: StreamFunction<
  
 -      for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
 +      for (let attempt = 0; attempt <= maxRetries; attempt++) {
          if (activeSignal?.aborted) {
-           throw new Error("Request was aborted");
-         }
-@@ -338,7 +348,7 @@ export const streamOpenAICodexResponses: StreamFunction<
-           }
- 
+@@ -340,3 +350,3 @@ export const streamOpenAICodexResponses: StreamFunction<
            const errorText = await response.text();
 -          if (attempt < MAX_RETRIES && isRetryableError(response.status, errorText)) {
 +          if (attempt < maxRetries && isRetryableError(response.status, errorText)) {
              let delayMs = BASE_DELAY_MS * 2 ** attempt;
- 
-             const retryAfterMs = response.headers.get("retry-after-ms");
-@@ -392,7 +402,7 @@ export const streamOpenAICodexResponses: StreamFunction<
-           }
-           lastError = error instanceof Error ? error : new Error(String(error));
+@@ -394,3 +404,3 @@ export const streamOpenAICodexResponses: StreamFunction<
            // Network errors are retryable
 -          if (attempt < MAX_RETRIES && !lastError.message.includes("usage limit")) {
 +          if (attempt < maxRetries && !lastError.message.includes("usage limit")) {
              const delayMs = BASE_DELAY_MS * 2 ** attempt;
-             await sleep(delayMs, activeSignal);
-             continue;
 diff --git a/src/llm/run-safety-provider-dispatch-context.ts b/src/llm/run-safety-provider-dispatch-context.ts
 new file mode 100644
 index 000000000..98e9f8bd9
@@ -12979,62 +11882,40 @@ diff --git a/src/logging/diagnostic-session-state.ts b/src/logging/diagnostic-se
 index 6dafdd06e..0d8a0c08b 100644
 --- a/src/logging/diagnostic-session-state.ts
 +++ b/src/logging/diagnostic-session-state.ts
-@@ -19,6 +19,7 @@ export type SessionState = {
- export type ToolCallRecord = {
-   toolName: string;
+@@ -21,2 +21,3 @@ export type ToolCallRecord = {
    argsHash: string;
 +  familyHash?: string;
    toolCallId?: string;
-   runId?: string;
-   resultHash?: string;
 diff --git a/src/logging/diagnostic.ts b/src/logging/diagnostic.ts
 index 2830c0994..a6d98f468 100644
 --- a/src/logging/diagnostic.ts
 +++ b/src/logging/diagnostic.ts
-@@ -1106,6 +1106,7 @@ export function logToolLoopAction(
-       | "generic_repeat"
-       | "unknown_tool_repeat"
+@@ -1108,2 +1108,3 @@ export function logToolLoopAction(
        | "known_poll_no_progress"
 +      | "variant_no_progress"
        | "aborted_tool_loop"
-       | "global_circuit_breaker"
-       | "ping_pong";
 diff --git a/src/media-understanding/image.ts b/src/media-understanding/image.ts
 index de4b62ed0..d52f32bed 100644
 --- a/src/media-understanding/image.ts
 +++ b/src/media-understanding/image.ts
-@@ -8,6 +8,7 @@ import {
- import { normalizeModelRef } from "../agents/model-selection.js";
- import { ensureOpenClawModelsJson } from "../agents/models-config.js";
+@@ -10,2 +10,3 @@ import { ensureOpenClawModelsJson } from "../agents/models-config.js";
  import { resolveProviderRequestCapabilities } from "../agents/provider-attribution.js";
 +import { ProviderStreamPurpose } from "../agents/provider-run-safety-contract.js";
  import { registerProviderStreamForModel } from "../agents/provider-stream.js";
- import {
-   coerceImageAssistantText,
-@@ -506,6 +507,7 @@ async function describeImagesWithModelInternal(
-     cfg: params.cfg,
-     agentDir: params.agentDir,
+@@ -508,2 +509,3 @@ async function describeImagesWithModelInternal(
      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
 +    purpose: ProviderStreamPurpose.Utility,
    });
- 
-   const context = buildImageContext(prompt, params.images, {
 diff --git a/src/plugin-sdk/provider-model-shared.ts b/src/plugin-sdk/provider-model-shared.ts
 index ee30f0603..e49982210 100644
 --- a/src/plugin-sdk/provider-model-shared.ts
 +++ b/src/plugin-sdk/provider-model-shared.ts
-@@ -27,6 +27,8 @@ import type {
-   ProviderThinkingProfile,
- } from "./plugin-entry.js";
+@@ -29,2 +29,4 @@ import type {
  
 +export { shouldDisableInternalProviderTransportRetries } from "../llm/run-safety-provider-dispatch-context.js";
 +
  export type {
-   ModelApi,
-   ModelProviderDeclarationConfig as ModelProviderConfig,
-@@ -92,6 +94,15 @@ export {
-   createMoonshotThinkingWrapper,
-   resolveMoonshotThinkingType,
+@@ -94,2 +96,11 @@ export {
  } from "../llm/providers/stream-wrappers/moonshot-thinking.js";
 +export {
 +  createProviderRunSafetyStreamFnV1,
@@ -13046,23 +11927,15 @@ index ee30f0603..e49982210 100644
 +  type ProviderRunSafetyTransportV1,
 +} from "../agents/provider-run-safety-contract.js";
  export {
-   cloneFirstTemplateModel,
-   matchesExactOrPrefix,
 diff --git a/src/plugins/provider-hook-runtime.ts b/src/plugins/provider-hook-runtime.ts
 index 062aef996..be8aee611 100644
 --- a/src/plugins/provider-hook-runtime.ts
 +++ b/src/plugins/provider-hook-runtime.ts
-@@ -14,6 +14,7 @@ import {
- import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
- import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
+@@ -16,2 +16,3 @@ import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.type
  import { resolveProviderConfigApiOwnerHint } from "./provider-config-owner.js";
 +import { cloneProviderPluginWithHostProvenance } from "./provider-registration-provenance.js";
  import { isPluginProvidersLoadInFlight, resolvePluginProviders } from "./providers.runtime.js";
- import type { PluginRegistry } from "./registry-types.js";
- import {
-@@ -177,7 +178,12 @@ function findProviderRuntimePluginInRegistry(params: {
-   apiOwnerHint?: string;
- }): ProviderPlugin | undefined {
+@@ -179,3 +180,8 @@ function findProviderRuntimePluginInRegistry(params: {
    return params.registry.providers
 -    .map((entry) => Object.assign({}, entry.provider, { pluginId: entry.pluginId }))
 +    .map((registration) =>
@@ -13072,8 +11945,6 @@ index 062aef996..be8aee611 100644
 +      }),
 +    )
      .find((plugin) => {
-       if (params.apiOwnerHint) {
-         return (
 diff --git a/src/plugins/provider-registration-provenance.ts b/src/plugins/provider-registration-provenance.ts
 new file mode 100644
 index 000000000..08d55d3b1
@@ -13112,25 +11983,15 @@ diff --git a/src/plugins/provider-runtime.test.ts b/src/plugins/provider-runtime
 index 71f83208a..0a4d04b60 100644
 --- a/src/plugins/provider-runtime.test.ts
 +++ b/src/plugins/provider-runtime.test.ts
-@@ -65,6 +65,7 @@ let resolveProviderAuthProfileId: typeof import("./provider-runtime.js").resolve
- let resolveProviderConfigApiKeyWithPlugin: typeof import("./provider-runtime.js").resolveProviderConfigApiKeyWithPlugin;
- let resolveProviderExtraParamsForTransport: typeof import("./provider-runtime.js").resolveProviderExtraParamsForTransport;
+@@ -67,2 +67,3 @@ let resolveProviderExtraParamsForTransport: typeof import("./provider-runtime.js
  let resolveProviderFollowupFallbackRoute: typeof import("./provider-runtime.js").resolveProviderFollowupFallbackRoute;
 +let resolveProviderAgentStreamFnV1: typeof import("./provider-runtime.js").resolveProviderAgentStreamFnV1;
  let resolveProviderStreamFn: typeof import("./provider-runtime.js").resolveProviderStreamFn;
- let resolveProviderCacheTtlEligibility: typeof import("./provider-runtime.js").resolveProviderCacheTtlEligibility;
- let resolveProviderBinaryThinking: typeof import("./provider-runtime.js").resolveProviderBinaryThinking;
-@@ -328,6 +329,7 @@ describe("provider-runtime", () => {
-       resolveProviderConfigApiKeyWithPlugin,
-       resolveProviderExtraParamsForTransport,
+@@ -330,2 +331,3 @@ describe("provider-runtime", () => {
        resolveProviderFollowupFallbackRoute,
 +      resolveProviderAgentStreamFnV1,
        resolveProviderStreamFn,
-       resolveProviderCacheTtlEligibility,
-       resolveProviderBinaryThinking,
-@@ -596,6 +598,62 @@ describe("provider-runtime", () => {
-     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
-   });
+@@ -598,2 +600,58 @@ describe("provider-runtime", () => {
  
 +  it("applies the audited compatibility bridge only to host-proven bundled providers", () => {
 +    const rawStreamFn = vi.fn();
@@ -13189,15 +12050,11 @@ index 71f83208a..0a4d04b60 100644
 +  });
 +
    it("does not load runtime plugins for stream hooks when loading is disabled", () => {
-     expect(
-       resolveProviderStreamFn({
 diff --git a/src/plugins/provider-runtime.ts b/src/plugins/provider-runtime.ts
 index eb1c990a7..ffe348242 100644
 --- a/src/plugins/provider-runtime.ts
 +++ b/src/plugins/provider-runtime.ts
-@@ -11,6 +11,11 @@ import {
-   applyPluginTextReplacements,
-   mergePluginTextTransforms,
+@@ -13,2 +13,7 @@ import {
  } from "../agents/plugin-text-transforms.js";
 +import {
 +  adaptBundledAuditedProviderPayloadHookStreamFnV1,
@@ -13205,27 +12062,15 @@ index eb1c990a7..ffe348242 100644
 +  ProviderRunSafetyContractError,
 +} from "../agents/provider-run-safety-contract.js";
  import type { ProviderSystemPromptContribution } from "../agents/system-prompt-contribution.js";
- import type { ModelProviderConfig } from "../config/types.js";
- import type { OpenClawConfig } from "../config/types.openclaw.js";
-@@ -33,6 +38,7 @@ import {
-   wrapProviderStreamFn,
- } from "./provider-hook-runtime.js";
+@@ -35,2 +40,3 @@ import {
  import { resolveBundledProviderPolicySurface } from "./provider-public-artifacts.js";
 +import { resolveProviderPluginHostOrigin } from "./provider-registration-provenance.js";
  import type { ProviderRuntimeModel } from "./provider-runtime-model.types.js";
- import type { ProviderThinkingProfile } from "./provider-thinking.types.js";
- import {
-@@ -52,6 +58,7 @@ import type {
-   ProviderBuildUnknownModelHintContext,
-   ProviderCacheTtlEligibilityContext,
+@@ -54,2 +60,3 @@ import type {
    ProviderCreateEmbeddingProviderContext,
 +  ProviderCreateAgentStreamFnV1Context,
    ProviderDeferSyntheticProfileAuthContext,
-   ProviderResolveSyntheticAuthContext,
-   ProviderCreateStreamFnContext,
-@@ -562,6 +569,48 @@ export function resolveProviderStreamFn(params: {
-   return plugin?.createStreamFn?.(params.context) ?? undefined;
- }
+@@ -564,2 +571,44 @@ export function resolveProviderStreamFn(params: {
  
 +/**
 + * Resolve a provider-owned stream for an Agent turn.
@@ -13270,23 +12115,15 @@ index eb1c990a7..ffe348242 100644
 +}
 +
  export function resolveProviderTransportTurnStateWithPlugin(params: {
-   provider: string;
-   config?: OpenClawConfig;
 diff --git a/src/plugins/providers.runtime.ts b/src/plugins/providers.runtime.ts
 index fc9c83581..adeb39a5c 100644
 --- a/src/plugins/providers.runtime.ts
 +++ b/src/plugins/providers.runtime.ts
-@@ -14,6 +14,7 @@ import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
- import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
- import { hasExplicitPluginIdScope } from "./plugin-scope.js";
+@@ -16,2 +16,3 @@ import { hasExplicitPluginIdScope } from "./plugin-scope.js";
  import { resolveProviderConfigApiOwnerHint } from "./provider-config-owner.js";
 +import { cloneProviderPluginWithHostProvenance } from "./provider-registration-provenance.js";
  import {
-   resolveActivatableProviderOwnerPluginIds,
-   resolveDiscoverableProviderOwnerPluginIds,
-@@ -349,8 +350,11 @@ export function resolvePluginProviders(params: {
-       return [];
-     }
+@@ -351,4 +352,7 @@ export function resolvePluginProviders(params: {
      const registry = loadOpenClawPlugins(loadState.loadOptions);
 -    return registry.providers.map((entry) =>
 -      Object.assign({}, entry.provider, { pluginId: entry.pluginId }),
@@ -13296,11 +12133,7 @@ index fc9c83581..adeb39a5c 100644
 +        records: registry.plugins,
 +      }),
      );
-   }
-   const loadState = resolveRuntimeProviderPluginLoadState(params, base, snapshot);
-@@ -370,7 +374,10 @@ export function resolvePluginProviders(params: {
-     return [];
-   }
+@@ -372,4 +376,7 @@ export function resolvePluginProviders(params: {
  
 -  return registry.providers.map((entry) =>
 -    Object.assign({}, entry.provider, { pluginId: entry.pluginId }),
@@ -13310,14 +12143,11 @@ index fc9c83581..adeb39a5c 100644
 +      records: registry.plugins,
 +    }),
    );
- }
 diff --git a/src/plugins/types.ts b/src/plugins/types.ts
 index ce9cd9d1b..84fe6176b 100644
 --- a/src/plugins/types.ts
 +++ b/src/plugins/types.ts
-@@ -892,6 +892,18 @@ export type ProviderCreateStreamFnContext = {
-   model: ProviderRuntimeModel;
- };
+@@ -894,2 +894,14 @@ export type ProviderCreateStreamFnContext = {
  
 +/**
 + * Provider-owned Agent transport creation under the host run-safety V1
@@ -13332,11 +12162,7 @@ index ce9cd9d1b..84fe6176b 100644
 +export type ProviderCreateAgentStreamFnV1Context = ProviderCreateStreamFnContext;
 +
  /**
-  * Provider-owned stream wrapper hook after OpenClaw applies its generic
-  * transport-independent wrappers.
-@@ -1464,6 +1476,16 @@ export type ProviderPlugin = {
-    * wrapper around the normal `streamSimple` path.
-    */
+@@ -1466,2 +1478,12 @@ export type ProviderPlugin = {
    createStreamFn?: (ctx: ProviderCreateStreamFnContext) => StreamFn | null | undefined;
 +  /**
 +   * Provider-owned Agent transport factory with mandatory host run-safety.
@@ -13349,5 +12175,3 @@ index ce9cd9d1b..84fe6176b 100644
 +    ctx: ProviderCreateAgentStreamFnV1Context,
 +  ) => StreamFn | null | undefined;
    /**
-    * Provider-owned stream wrapper applied after generic OpenClaw wrappers.
-    *

--- a/scripts/patches/v2026.6.1/openclaw-z-agent-harness-run-safety.patch
+++ b/scripts/patches/v2026.6.1/openclaw-z-agent-harness-run-safety.patch
@@ -2,7 +2,7 @@ diff --git a/extensions/codex/harness.ts b/extensions/codex/harness.ts
 index 9486a5db2..d2d416cc4 100644
 --- a/extensions/codex/harness.ts
 +++ b/extensions/codex/harness.ts
-@@ -1,6 +1,9 @@
+@@ -1,4 +1,7 @@
 -import type {
 -  AgentHarness,
 -  ContextEngineHostCapability,
@@ -13,48 +13,35 @@ index 9486a5db2..d2d416cc4 100644
 +  type AgentHarnessRunSafetyDispatchV1,
 +  type ContextEngineHostCapability,
  } from "openclaw/plugin-sdk/agent-harness-runtime";
- import type {
-   CodexAppServerListModelsOptions,
-@@ -50,13 +53,14 @@ export function createCodexAppServerAgentHarness(options?: {
-         reason: `provider is not one of: ${[...providerIds].toSorted().join(", ")}`,
-       };
+@@ -52,3 +55,3 @@ export function createCodexAppServerAgentHarness(options?: {
      },
 -    runAttempt: async (params) => {
 +    runAttemptV1: createAgentHarnessRunAttemptV1(async (params, host) => {
        const { runCodexAppServerAttempt } = await import("./src/app-server/run-attempt.js");
-       return runCodexAppServerAttempt(params, {
-         pluginConfig: options?.resolvePluginConfig?.() ?? options?.pluginConfig,
+@@ -57,4 +60,5 @@ export function createCodexAppServerAgentHarness(options?: {
          nativeHookRelay: { enabled: true },
 +        runSafetyDispatch: host.dispatch,
        });
 -    },
 +    }),
      runSideQuestion: async (params) => {
-       const { runCodexAppServerSideQuestion } = await import("./src/app-server/side-question.js");
-       return runCodexAppServerSideQuestion(params, {
-@@ -64,12 +68,13 @@ export function createCodexAppServerAgentHarness(options?: {
-         nativeHookRelay: { enabled: true },
-       });
+@@ -66,3 +70,3 @@ export function createCodexAppServerAgentHarness(options?: {
      },
 -    compact: async (params) => {
 +    compactV1: createAgentHarnessCompactV1(async (params, host) => {
        const { maybeCompactCodexAppServerSession } = await import("./src/app-server/compact.js");
-       return maybeCompactCodexAppServerSession(params, {
+@@ -70,4 +74,5 @@ export function createCodexAppServerAgentHarness(options?: {
          pluginConfig: options?.resolvePluginConfig?.() ?? options?.pluginConfig,
 +        runSafetyDispatch: host.dispatch as AgentHarnessRunSafetyDispatchV1,
        });
 -    },
 +    }),
      reset: async (params) => {
-       if (params.sessionFile) {
-         const { clearCodexAppServerBinding } = await import("./src/app-server/session-binding.js");
 diff --git a/extensions/codex/index.test.ts b/extensions/codex/index.test.ts
 index 27cb7517b..0024cb6db 100644
 --- a/extensions/codex/index.test.ts
 +++ b/extensions/codex/index.test.ts
-@@ -22,6 +22,24 @@ function mockCallArg(mock: { mock: { calls: unknown[][] } }, index = 0, argIndex
-   return mockCall(mock, index)?.at(argIndex);
- }
+@@ -24,2 +24,20 @@ function mockCallArg(mock: { mock: { calls: unknown[][] } }, index = 0, argIndex
  
 +const TEST_RUN_SAFETY_HOST = {
 +  contractVersion: 1 as const,
@@ -75,54 +62,33 @@ index 27cb7517b..0024cb6db 100644
 +}
 +
  describe("codex plugin", () => {
-   it("is opt-in by default", () => {
-     const manifest = JSON.parse(
-@@ -145,13 +163,14 @@ describe("codex plugin", () => {
-     const result = { success: true };
-     runCodexAppServerAttemptMock.mockResolvedValueOnce(result);
+@@ -147,3 +165,3 @@ describe("codex plugin", () => {
  
 -    await expect(harness.runAttempt({ prompt: "hello" } as never)).resolves.toBe(result);
 +    await expect(runHarnessAttempt(harness, { prompt: "hello" } as never)).resolves.toBe(result);
  
-     expect(runCodexAppServerAttemptMock).toHaveBeenCalledWith(
-       { prompt: "hello" },
-       {
-         pluginConfig: { appServer: {} },
+@@ -154,2 +172,3 @@ describe("codex plugin", () => {
          nativeHookRelay: { enabled: true },
 +        runSafetyDispatch: TEST_RUN_SAFETY_HOST.dispatch,
        },
-     );
-   });
-@@ -203,13 +222,14 @@ describe("codex plugin", () => {
-     const result = { success: true };
-     runCodexAppServerAttemptMock.mockResolvedValueOnce(result);
+@@ -205,3 +224,3 @@ describe("codex plugin", () => {
  
 -    await expect(harness.runAttempt({ prompt: "calendar" } as never)).resolves.toBe(result);
 +    await expect(runHarnessAttempt(harness, { prompt: "calendar" } as never)).resolves.toBe(result);
  
-     expect(runCodexAppServerAttemptMock).toHaveBeenCalledWith(
-       { prompt: "calendar" },
-       {
-         pluginConfig: liveConfig.plugins.entries.codex.config,
+@@ -212,2 +231,3 @@ describe("codex plugin", () => {
          nativeHookRelay: { enabled: true },
 +        runSafetyDispatch: TEST_RUN_SAFETY_HOST.dispatch,
        },
-     );
-   });
 diff --git a/extensions/codex/src/app-server/compact.ts b/extensions/codex/src/app-server/compact.ts
 index e35df2557..a1787255b 100644
 --- a/extensions/codex/src/app-server/compact.ts
 +++ b/extensions/codex/src/app-server/compact.ts
-@@ -1,5 +1,6 @@
- import {
+@@ -2,2 +2,3 @@ import {
    embeddedAgentLog,
 +  type AgentHarnessRunSafetyDispatchV1,
    type CompactEmbeddedAgentSessionParams,
-   type EmbeddedAgentCompactResult,
- } from "openclaw/plugin-sdk/agent-harness-runtime";
-@@ -16,7 +17,11 @@ const warnedIgnoredCompactionOverrides = new Set<string>();
- 
- export async function maybeCompactCodexAppServerSession(
+@@ -18,3 +19,7 @@ export async function maybeCompactCodexAppServerSession(
    params: CompactEmbeddedAgentSessionParams,
 -  options: { pluginConfig?: unknown; clientFactory?: CodexAppServerClientFactory } = {},
 +  options: {
@@ -131,11 +97,7 @@ index e35df2557..a1787255b 100644
 +    runSafetyDispatch?: AgentHarnessRunSafetyDispatchV1;
 +  } = {},
  ): Promise<EmbeddedAgentCompactResult | undefined> {
-   warnIfIgnoringOpenClawCompactionOverrides(params);
-   // Codex owns automatic context-pressure compaction for Codex runtime sessions.
-@@ -126,7 +131,11 @@ function readRecord(value: unknown): Record<string, unknown> | undefined {
- 
- async function compactCodexNativeThread(
+@@ -128,3 +133,7 @@ async function compactCodexNativeThread(
    params: CompactEmbeddedAgentSessionParams,
 -  options: { pluginConfig?: unknown; clientFactory?: CodexAppServerClientFactory } = {},
 +  options: {
@@ -144,11 +106,7 @@ index e35df2557..a1787255b 100644
 +    runSafetyDispatch?: AgentHarnessRunSafetyDispatchV1;
 +  } = {},
  ): Promise<EmbeddedAgentCompactResult | undefined> {
-   if (params.trigger !== "manual") {
-     embeddedAgentLog.info("skipping codex app-server compaction for non-manual trigger", {
-@@ -185,9 +194,19 @@ async function compactCodexNativeThread(
-     params.config,
-   );
+@@ -187,5 +196,15 @@ async function compactCodexNativeThread(
    try {
 -    await client.request("thread/compact/start", {
 +    const compactPayload = {
@@ -166,31 +124,19 @@ index e35df2557..a1787255b 100644
 +      await sendCompact(compactPayload);
 +    }
      embeddedAgentLog.info("started codex app-server compaction", {
-       sessionId: params.sessionId,
-       threadId: binding.threadId,
 diff --git a/extensions/codex/src/app-server/run-attempt.ts b/extensions/codex/src/app-server/run-attempt.ts
 index b98dd9607..c2e778de5 100644
 --- a/extensions/codex/src/app-server/run-attempt.ts
 +++ b/extensions/codex/src/app-server/run-attempt.ts
-@@ -31,6 +31,7 @@ import {
-   runAgentCleanupStep,
-   type EmbeddedRunAttemptParams,
+@@ -33,2 +33,3 @@ import {
    type EmbeddedRunAttemptResult,
 +  type AgentHarnessRunSafetyDispatchV1,
    type NativeHookRelayEvent,
-   type NativeHookRelayRegistrationHandle,
- } from "openclaw/plugin-sdk/agent-harness-runtime";
-@@ -342,6 +343,7 @@ export async function runCodexAppServerAttempt(
-     postToolRawAssistantCompletionIdleTimeoutMs?: number;
-     turnTerminalIdleTimeoutMs?: number;
+@@ -344,2 +345,3 @@ export async function runCodexAppServerAttempt(
      clientFactory?: CodexAppServerClientFactory;
 +    runSafetyDispatch?: AgentHarnessRunSafetyDispatchV1;
    } = {},
- ): Promise<EmbeddedRunAttemptResult> {
-   const attemptStartedAt = Date.now();
-@@ -1863,12 +1865,19 @@ export async function runCodexAppServerAttempt(
-         workspaceBootstrapContext.heartbeatCollaborationInstructions,
-     });
+@@ -1865,8 +1867,15 @@ export async function runCodexAppServerAttempt(
      codexModelCallDiagnostics.setRequestPayloadBytes(utf8JsonByteLength(turnStartParams));
 -    const startedTurn = assertCodexTurnStartResponse(
 -      await client.request("turn/start", turnStartParams, {
@@ -210,15 +156,11 @@ index b98dd9607..c2e778de5 100644
 +      : await sendTurnStart(turnStartParams);
 +    const startedTurn = assertCodexTurnStartResponse(response);
      throwIfTurnStartAcceptedAfterAbort();
-     return startedTurn;
-   };
 diff --git a/extensions/copilot/harness.test.ts b/extensions/copilot/harness.test.ts
 index f01a68b77..59f786a6a 100644
 --- a/extensions/copilot/harness.test.ts
 +++ b/extensions/copilot/harness.test.ts
-@@ -36,6 +36,27 @@ const TEST_SESSION_CONFIG = {
-   tools: [],
-   workingDirectory: "/workspace",
+@@ -38,2 +38,23 @@ const TEST_SESSION_CONFIG = {
  };
 +const TEST_RUN_SAFETY_HOST = {
 +  contractVersion: 1 as const,
@@ -242,190 +184,110 @@ index f01a68b77..59f786a6a 100644
 +  return harness.compactV1(params, TEST_RUN_SAFETY_HOST);
 +}
  
- function makePoolMock(): CopilotClientPool {
-   return {
-@@ -206,7 +227,7 @@ describe("createCopilotAgentHarness", () => {
-     expect(mocks.createCopilotClientPool).not.toHaveBeenCalled();
-     expect(mocks.runCopilotAttempt).not.toHaveBeenCalled();
+@@ -208,3 +229,3 @@ describe("createCopilotAgentHarness", () => {
  
 -    await expect(harness.runAttempt(ATTEMPT_PARAMS)).resolves.toBe(ATTEMPT_RESULT);
 +    await expect(runHarnessAttempt(harness, ATTEMPT_PARAMS)).resolves.toBe(ATTEMPT_RESULT);
  
-     expect(mocks.createCopilotClientPool).toHaveBeenCalledTimes(1);
-     expect(mocks.runCopilotAttempt).toHaveBeenCalledTimes(1);
-@@ -220,8 +241,8 @@ describe("createCopilotAgentHarness", () => {
-     mocks.runCopilotAttempt.mockResolvedValueOnce(firstResult).mockResolvedValueOnce(secondResult);
-     const harness = createCopilotAgentHarness();
+@@ -222,4 +243,4 @@ describe("createCopilotAgentHarness", () => {
  
 -    await expect(harness.runAttempt(ATTEMPT_PARAMS)).resolves.toBe(firstResult);
 -    await expect(harness.runAttempt(ATTEMPT_PARAMS)).resolves.toBe(secondResult);
 +    await expect(runHarnessAttempt(harness, ATTEMPT_PARAMS)).resolves.toBe(firstResult);
 +    await expect(runHarnessAttempt(harness, ATTEMPT_PARAMS)).resolves.toBe(secondResult);
  
-     expect(mocks.createCopilotClientPool).toHaveBeenCalledTimes(1);
-     expect(mocks.runCopilotAttempt).toHaveBeenNthCalledWith(
-@@ -243,8 +264,8 @@ describe("createCopilotAgentHarness", () => {
-     const firstHarness = createCopilotAgentHarness();
-     const secondHarness = createCopilotAgentHarness();
+@@ -245,4 +266,4 @@ describe("createCopilotAgentHarness", () => {
  
 -    await expect(firstHarness.runAttempt(ATTEMPT_PARAMS)).resolves.toBe(ATTEMPT_RESULT);
 -    await expect(secondHarness.runAttempt(ATTEMPT_PARAMS)).resolves.toBe(ATTEMPT_RESULT);
 +    await expect(runHarnessAttempt(firstHarness, ATTEMPT_PARAMS)).resolves.toBe(ATTEMPT_RESULT);
 +    await expect(runHarnessAttempt(secondHarness, ATTEMPT_PARAMS)).resolves.toBe(ATTEMPT_RESULT);
  
-     expect(mocks.createCopilotClientPool).toHaveBeenCalledTimes(2);
-     expect(mocks.runCopilotAttempt).toHaveBeenNthCalledWith(
-@@ -267,8 +288,8 @@ describe("createCopilotAgentHarness", () => {
-     mocks.runCopilotAttempt.mockResolvedValueOnce(firstResult).mockResolvedValueOnce(secondResult);
-     const harness = createCopilotAgentHarness();
+@@ -269,4 +290,4 @@ describe("createCopilotAgentHarness", () => {
  
 -    await expect(harness.runAttempt(ATTEMPT_PARAMS)).resolves.toBe(firstResult);
 -    await expect(harness.runAttempt(ATTEMPT_PARAMS)).resolves.toBe(secondResult);
 +    await expect(runHarnessAttempt(harness, ATTEMPT_PARAMS)).resolves.toBe(firstResult);
 +    await expect(runHarnessAttempt(harness, ATTEMPT_PARAMS)).resolves.toBe(secondResult);
  
-     expect(mocks.createCopilotClientPool).toHaveBeenCalledTimes(1);
-     expect(mocks.runCopilotAttempt).toHaveBeenCalledTimes(2);
-@@ -285,7 +306,7 @@ describe("createCopilotAgentHarness", () => {
-   it("dispose during lazy startup prevents the attempt from creating a pool", async () => {
-     const harness = createCopilotAgentHarness();
+@@ -287,3 +308,3 @@ describe("createCopilotAgentHarness", () => {
  
 -    const attemptPromise = harness.runAttempt(ATTEMPT_PARAMS);
 +    const attemptPromise = runHarnessAttempt(harness, ATTEMPT_PARAMS);
      const disposePromise = harness.dispose?.();
- 
-     await expect(attemptPromise).rejects.toThrow(
-@@ -301,7 +322,7 @@ describe("createCopilotAgentHarness", () => {
-     mocks.createCopilotClientPool.mockReturnValue(pool);
-     const harness = createCopilotAgentHarness();
+@@ -303,3 +324,3 @@ describe("createCopilotAgentHarness", () => {
  
 -    await harness.runAttempt(ATTEMPT_PARAMS);
 +    await runHarnessAttempt(harness, ATTEMPT_PARAMS);
  
-     const firstDispose = harness.dispose?.();
-     const secondDispose = harness.dispose?.();
-@@ -318,7 +339,7 @@ describe("createCopilotAgentHarness", () => {
-     mocks.runCopilotAttempt.mockImplementation(() => deferred.promise);
-     const harness = createCopilotAgentHarness();
+@@ -320,3 +341,3 @@ describe("createCopilotAgentHarness", () => {
  
 -    const attemptPromise = harness.runAttempt(ATTEMPT_PARAMS);
 +    const attemptPromise = runHarnessAttempt(harness, ATTEMPT_PARAMS);
      await flushAsyncWork();
- 
-     const disposePromise = harness.dispose?.();
-@@ -344,7 +365,7 @@ describe("createCopilotAgentHarness", () => {
- 
-     await harness.dispose?.();
+@@ -346,3 +367,3 @@ describe("createCopilotAgentHarness", () => {
  
 -    await expect(harness.runAttempt(ATTEMPT_PARAMS)).rejects.toThrow(
 +    await expect(runHarnessAttempt(harness, ATTEMPT_PARAMS)).rejects.toThrow(
        "[copilot] harness has been disposed; cannot start new attempts",
-     );
-     expect(mocks.createCopilotClientPool).not.toHaveBeenCalled();
-@@ -357,7 +378,7 @@ describe("createCopilotAgentHarness", () => {
-     mocks.createCopilotClientPool.mockReturnValue(pool);
-     const harness = createCopilotAgentHarness();
+@@ -359,3 +380,3 @@ describe("createCopilotAgentHarness", () => {
  
 -    await harness.runAttempt(ATTEMPT_PARAMS);
 +    await runHarnessAttempt(harness, ATTEMPT_PARAMS);
  
-     try {
-       await harness.dispose?.();
-@@ -373,7 +394,7 @@ describe("createCopilotAgentHarness", () => {
-     const pool = makePoolMock();
-     const harness = createCopilotAgentHarness({ pool });
+@@ -375,3 +396,3 @@ describe("createCopilotAgentHarness", () => {
  
 -    await harness.runAttempt(ATTEMPT_PARAMS);
 +    await runHarnessAttempt(harness, ATTEMPT_PARAMS);
      await expect(harness.dispose?.()).resolves.toBeUndefined();
- 
-     expect(pool["dispose"]).not.toHaveBeenCalled();
-@@ -383,7 +404,7 @@ describe("createCopilotAgentHarness", () => {
-     const pool = makePoolMock();
-     const harness = createCopilotAgentHarness({ pool });
+@@ -385,3 +406,3 @@ describe("createCopilotAgentHarness", () => {
  
 -    await expect(harness.runAttempt(ATTEMPT_PARAMS)).resolves.toBe(ATTEMPT_RESULT);
 +    await expect(runHarnessAttempt(harness, ATTEMPT_PARAMS)).resolves.toBe(ATTEMPT_RESULT);
  
-     expect(mocks.createCopilotClientPool).not.toHaveBeenCalled();
-     expect(mocks.runCopilotAttempt).toHaveBeenCalledWith(
-@@ -420,7 +441,7 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -422,3 +443,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt({ ...ATTEMPT_PARAMS, sessionId: "oc-sess-1" });
 +      await runHarnessAttempt(harness, { ...ATTEMPT_PARAMS, sessionId: "oc-sess-1" });
        await harness.reset?.({ sessionId: "oc-sess-1" });
- 
-       expect(deleteSession).toHaveBeenCalledTimes(1);
-@@ -433,7 +454,7 @@ describe("createCopilotAgentHarness", () => {
-       mocks.runCopilotAttempt.mockImplementation(async (_params, _deps) => ATTEMPT_RESULT);
-       const harness = createCopilotAgentHarness({ pool });
+@@ -435,3 +456,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt({ ...ATTEMPT_PARAMS, sessionId: "oc-sess-2" });
 +      await runHarnessAttempt(harness, { ...ATTEMPT_PARAMS, sessionId: "oc-sess-2" });
        await harness.reset?.({ sessionId: "oc-sess-2" });
- 
-       expect(deleteSession).not.toHaveBeenCalled();
-@@ -452,7 +473,7 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -454,3 +475,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt({ ...ATTEMPT_PARAMS, sessionId: "oc-sess-3" });
 +      await runHarnessAttempt(harness, { ...ATTEMPT_PARAMS, sessionId: "oc-sess-3" });
  
-       await expect(harness.reset?.({ sessionId: "oc-sess-3" })).resolves.toBeUndefined();
-       expect(deleteSession).toHaveBeenCalledTimes(1);
-@@ -471,7 +492,7 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -473,3 +494,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt({ ...ATTEMPT_PARAMS, sessionId: "oc-sess-4" });
 +      await runHarnessAttempt(harness, { ...ATTEMPT_PARAMS, sessionId: "oc-sess-4" });
        await harness.reset?.({ sessionId: "oc-sess-4" });
-       await harness.reset?.({ sessionId: "oc-sess-4" });
- 
-@@ -491,7 +512,7 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -493,3 +514,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt({ ...ATTEMPT_PARAMS, sessionId: "oc-A" });
 +      await runHarnessAttempt(harness, { ...ATTEMPT_PARAMS, sessionId: "oc-A" });
        await harness.reset?.({ sessionId: "oc-B" });
- 
-       expect(deleteSession).not.toHaveBeenCalled();
-@@ -511,7 +532,7 @@ describe("createCopilotAgentHarness", () => {
-     });
-     const harness = createCopilotAgentHarness({ pool });
+@@ -513,3 +534,3 @@ describe("createCopilotAgentHarness", () => {
  
 -    await harness.runAttempt({ ...ATTEMPT_PARAMS, sessionId: "oc-disp" });
 +    await runHarnessAttempt(harness, { ...ATTEMPT_PARAMS, sessionId: "oc-disp" });
      await harness.dispose?.();
-     await harness.reset?.({ sessionId: "oc-disp" });
- 
-@@ -553,8 +574,8 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -555,4 +576,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeAttemptParams({ runId: "t1" }));
 -      await harness.runAttempt(makeAttemptParams({ runId: "t2" }));
 +      await runHarnessAttempt(harness, makeAttemptParams({ runId: "t1" }));
 +      await runHarnessAttempt(harness, makeAttemptParams({ runId: "t2" }));
  
-       expect(mocks.runCopilotAttempt).toHaveBeenCalledTimes(2);
-       const secondCallParams = mocks.runCopilotAttempt.mock.calls[1]?.[0] as {
-@@ -576,7 +597,7 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -578,3 +599,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeAttemptParams({ runId: "t1" }));
 +      await runHarnessAttempt(harness, makeAttemptParams({ runId: "t1" }));
  
-       const firstCallParams = mocks.runCopilotAttempt.mock.calls[0]?.[0] as {
-         initialReplayState?: { sdkSessionId?: string };
-@@ -595,10 +616,12 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -597,6 +618,8 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
@@ -436,87 +298,55 @@ index f01a68b77..59f786a6a 100644
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({
-           runId: "t2",
-           model: { provider: "github-copilot", id: "claude-sonnet-4.5" },
-@@ -622,13 +645,15 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -624,3 +647,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({
-           runId: "t1",
-           model: { api: "chat", provider: "github-copilot", id: "gpt-4.1" },
-         }),
+@@ -630,3 +654,4 @@ describe("createCopilotAgentHarness", () => {
        );
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({
-           runId: "t2",
-           model: { api: "responses", provider: "github-copilot", id: "gpt-4.1" },
-@@ -657,13 +682,15 @@ describe("createCopilotAgentHarness", () => {
-       // surfaces the version into authProfileVersion) so a profile
-       // version bump is a real auth rotation, not a no-op fall-through
+@@ -659,3 +684,4 @@ describe("createCopilotAgentHarness", () => {
        // to useLoggedInUser.
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({
-           runId: "t1",
-           auth: { gitHubToken: "tok-1", profileId: "p1", profileVersion: "v1" },
-         }),
+@@ -665,3 +691,4 @@ describe("createCopilotAgentHarness", () => {
        );
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({
-           runId: "t2",
-           auth: { gitHubToken: "tok-1", profileId: "p1", profileVersion: "v2" },
-@@ -693,7 +720,8 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -695,3 +722,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({
-           runId: "t1",
-           auth: undefined,
-@@ -701,7 +729,8 @@ describe("createCopilotAgentHarness", () => {
-           resolvedApiKey: "tok-same",
-         }),
+@@ -703,3 +731,4 @@ describe("createCopilotAgentHarness", () => {
        );
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({
-           runId: "t2",
-           auth: undefined,
-@@ -733,7 +762,8 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -735,3 +764,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({
-           runId: "t1",
-           auth: undefined,
-@@ -741,7 +771,8 @@ describe("createCopilotAgentHarness", () => {
-           resolvedApiKey: "tok-a",
-         }),
+@@ -743,3 +773,4 @@ describe("createCopilotAgentHarness", () => {
        );
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({
-           runId: "t2",
-           auth: undefined,
-@@ -767,8 +798,9 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -769,4 +800,5 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeAttemptParams({ runId: "t1" }));
 -      await harness.runAttempt(
@@ -524,11 +354,7 @@ index f01a68b77..59f786a6a 100644
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({
-           runId: "t2",
-           initialReplayState: { replayInvalid: true },
-@@ -798,9 +830,9 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -800,5 +832,5 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeAttemptParams({ runId: "t1" }));
 +      await runHarnessAttempt(harness, makeAttemptParams({ runId: "t1" }));
@@ -536,60 +362,36 @@ index f01a68b77..59f786a6a 100644
 -      await harness.runAttempt(makeAttemptParams({ runId: "t2" }));
 +      await runHarnessAttempt(harness, makeAttemptParams({ runId: "t2" }));
        await harness.reset?.({ sessionId: "oc-sess-reuse" });
- 
-       expect(deleteSession).toHaveBeenCalledTimes(1);
-@@ -829,8 +861,8 @@ describe("createCopilotAgentHarness", () => {
-         sessionStore: sessionStore.store,
-       });
+@@ -831,4 +863,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await firstHarness.runAttempt(makeAttemptParams({ runId: "t1" }));
 -      await secondHarness.runAttempt(makeAttemptParams({ runId: "t2" }));
 +      await runHarnessAttempt(firstHarness, makeAttemptParams({ runId: "t1" }));
 +      await runHarnessAttempt(secondHarness, makeAttemptParams({ runId: "t2" }));
  
-       expect(sessionStore.store.register).toHaveBeenCalledWith(
-         "oc-sess-reuse",
-@@ -859,7 +891,7 @@ describe("createCopilotAgentHarness", () => {
-         sessionStore: sessionStore.store,
-       });
+@@ -861,3 +893,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await firstHarness.runAttempt(makeAttemptParams({ runId: "t1" }));
 +      await runHarnessAttempt(firstHarness, makeAttemptParams({ runId: "t1" }));
        const stored = sessionStore.entries.get("oc-sess-reuse");
-       if (!stored) {
-         throw new Error("expected persisted binding");
-@@ -876,7 +908,7 @@ describe("createCopilotAgentHarness", () => {
-         sessionStore: sessionStore.store,
-       });
+@@ -878,3 +910,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await secondHarness.runAttempt(makeAttemptParams({ runId: "t2" }));
 +      await runHarnessAttempt(secondHarness, makeAttemptParams({ runId: "t2" }));
  
-       const secondCallParams = mocks.runCopilotAttempt.mock.calls[0]?.[0] as {
-         initialReplayState?: { sdkSessionId?: string };
-@@ -895,7 +927,7 @@ describe("createCopilotAgentHarness", () => {
-         sessionStore: sessionStore.store,
-       });
+@@ -897,3 +929,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await expect(harness.runAttempt(makeAttemptParams({ runId: "t1" }))).resolves.toBe(
 +      await expect(runHarnessAttempt(harness, makeAttemptParams({ runId: "t1" }))).resolves.toBe(
          ATTEMPT_RESULT,
-       );
- 
-@@ -931,8 +963,8 @@ describe("createCopilotAgentHarness", () => {
-         sessionStore: sessionStore.store,
-       });
+@@ -933,4 +965,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeAttemptParams({ runId: "t1" }));
 -      await harness.runAttempt(makeAttemptParams({ runId: "t2" }));
 +      await runHarnessAttempt(harness, makeAttemptParams({ runId: "t1" }));
 +      await runHarnessAttempt(harness, makeAttemptParams({ runId: "t2" }));
  
-       const secondCallParams = mocks.runCopilotAttempt.mock.calls[1]?.[0] as {
-         initialReplayState?: { sdkSessionId?: string };
-@@ -960,10 +992,12 @@ describe("createCopilotAgentHarness", () => {
-         sessionStore: sessionStore.store,
-       });
+@@ -962,6 +994,8 @@ describe("createCopilotAgentHarness", () => {
  
 -      await firstHarness.runAttempt(
 +      await runHarnessAttempt(
@@ -600,166 +402,102 @@ index f01a68b77..59f786a6a 100644
 +      await runHarnessAttempt(
 +        secondHarness,
          makeAttemptParams({
-           runId: "t2",
-           model: { provider: "github-copilot", id: "claude-sonnet-4.5" },
-@@ -998,14 +1032,16 @@ describe("createCopilotAgentHarness", () => {
-         copilotHome: undefined,
-       };
+@@ -1000,3 +1034,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await firstHarness.runAttempt(
 +      await runHarnessAttempt(
 +        firstHarness,
          makeAttemptParams({
-           ...defaultHomeParams,
-           runId: "t1",
-           agentId: "main",
-         }),
+@@ -1007,3 +1042,4 @@ describe("createCopilotAgentHarness", () => {
        );
 -      await secondHarness.runAttempt(
 +      await runHarnessAttempt(
 +        secondHarness,
          makeAttemptParams({
-           ...defaultHomeParams,
-           runId: "t2",
-@@ -1033,20 +1069,23 @@ describe("createCopilotAgentHarness", () => {
-         sessionStore: sessionStore.store,
-       });
+@@ -1035,3 +1071,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({ runId: "t1", model: { provider: "github-copilot", id: "gpt-4.1" } }),
-       );
-       const persisted = sessionStore.entries.get("oc-sess-reuse");
-       expect(persisted).toBeDefined();
+@@ -1041,3 +1078,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({
-           runId: "t2",
-           model: { provider: "github-copilot", id: "claude-sonnet-4.5" },
-         }),
-       );
+@@ -1048,3 +1086,4 @@ describe("createCopilotAgentHarness", () => {
        sessionStore.entries.set("oc-sess-reuse", persisted!);
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeAttemptParams({ runId: "t3", model: { provider: "github-copilot", id: "gpt-4.1" } }),
-       );
- 
-@@ -1095,7 +1134,7 @@ describe("createCopilotAgentHarness", () => {
-         sessionStore: sessionStore.store,
-       });
+@@ -1097,3 +1136,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeAttemptParams({ runId: "t1" }));
 +      await runHarnessAttempt(harness, makeAttemptParams({ runId: "t1" }));
        await harness.reset?.({ sessionId: "oc-sess-reuse" });
- 
-       expect(deleteSession).toHaveBeenCalledWith("sdk-sess-reset");
-@@ -1115,7 +1154,7 @@ describe("createCopilotAgentHarness", () => {
-         sessionStore: sessionStore.store,
-       });
+@@ -1117,3 +1156,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await firstHarness.runAttempt(makeAttemptParams({ runId: "t1" }));
 +      await runHarnessAttempt(firstHarness, makeAttemptParams({ runId: "t1" }));
        expect(sessionStore.entries.get("oc-sess-reuse")?.sdkSessionId).toBe("sdk-sess-before-reset");
-       sessionStore.store.delete.mockImplementation(() => {
-         throw new Error("sqlite delete failed");
-@@ -1127,7 +1166,7 @@ describe("createCopilotAgentHarness", () => {
-       });
- 
+@@ -1129,3 +1168,3 @@ describe("createCopilotAgentHarness", () => {
        await harness.reset?.({ sessionId: "oc-sess-reuse" });
 -      await harness.runAttempt(makeAttemptParams({ runId: "t2" }));
 +      await runHarnessAttempt(harness, makeAttemptParams({ runId: "t2" }));
  
-       const callParams = mocks.runCopilotAttempt.mock.calls[1]?.[0] as {
-         initialReplayState?: { sdkSessionId?: string };
-@@ -1153,7 +1192,7 @@ describe("createCopilotAgentHarness", () => {
- 
-     it("returns ok:false when sessionId is missing", async () => {
+@@ -1155,3 +1194,3 @@ describe("createCopilotAgentHarness", () => {
        const harness = createCopilotAgentHarness({ pool: makePoolMock() });
 -      const result = await harness.compact?.({ workspaceDir: "/ws" } as any);
 +      const result = await runHarnessCompact(harness, { workspaceDir: "/ws" } as any);
        expect(result).toEqual({
-         ok: false,
-         compacted: false,
-@@ -1163,7 +1202,7 @@ describe("createCopilotAgentHarness", () => {
- 
-     it("returns ok:false when the SDK session is not tracked", async () => {
+@@ -1165,3 +1204,3 @@ describe("createCopilotAgentHarness", () => {
        const harness = createCopilotAgentHarness({ pool: makePoolMock() });
 -      const result = await harness.compact?.({
 +      const result = await runHarnessCompact(harness, {
          sessionId: "oc-sess-compact-1",
-         trigger: "budget",
-         currentTokenCount: 12345,
-@@ -1210,14 +1249,15 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -1212,3 +1251,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeCompactParams({
-           agentId: "main",
-           sessionId: "oc-sess-compact-1",
-           sessionKey: "agent:main:main",
-         }),
+@@ -1219,3 +1259,3 @@ describe("createCopilotAgentHarness", () => {
        );
 -      const result = await harness.compact?.({
 +      const result = await runHarnessCompact(harness, {
          ...makeCompactParams({ sessionId: "oc-sess-compact-1" }),
-         model: "gpt-4.1",
-         sessionKey: "agent:main:main",
-@@ -1282,14 +1322,15 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -1284,3 +1324,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeCompactParams({
-           agentId: "main",
-           sessionId: "oc-sess-abort",
-           sessionKey: "agent:main:main",
-         }),
+@@ -1291,3 +1332,3 @@ describe("createCopilotAgentHarness", () => {
        );
 -      const result = await harness.compact?.({
 +      const result = await runHarnessCompact(harness, {
          ...makeCompactParams({ sessionId: "oc-sess-abort" }),
-         abortSignal: abortController.signal,
-         model: "gpt-4.1",
-@@ -1376,13 +1417,15 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -1378,3 +1419,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(
 +      await runHarnessAttempt(
 +        harness,
          makeCompactParams({
-           auth: { gitHubToken: "ghp_test", profileId: "p1", profileVersion: "v1" },
-           sessionId: "oc-sess-token",
-         }),
+@@ -1384,3 +1426,4 @@ describe("createCopilotAgentHarness", () => {
        );
 -      const result = await harness.compact?.(
 +      const result = await runHarnessCompact(
 +        harness,
          makeCompactParams({
-           auth: undefined,
-           sessionId: "oc-sess-token",
-@@ -1398,7 +1441,8 @@ describe("createCopilotAgentHarness", () => {
-         failure: { reason: "missing_thread_binding" },
-       });
+@@ -1400,3 +1443,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      const matchingResult = await harness.compact?.(
 +      const matchingResult = await runHarnessCompact(
 +        harness,
          makeCompactParams({
-           auth: undefined,
-           authProfileId: "p1",
-@@ -1441,8 +1485,9 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -1443,4 +1487,5 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeCompactParams({ sessionId: "oc-sess-model" }));
 -      const result = await harness.compact?.(
@@ -767,30 +505,18 @@ index f01a68b77..59f786a6a 100644
 +      const result = await runHarnessCompact(
 +        harness,
          makeCompactParams({ model: "gpt-5", sessionId: "oc-sess-model" }),
-       );
- 
-@@ -1476,7 +1521,7 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -1478,3 +1523,3 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeCompactParams({ sessionId: "oc-sess-login" }));
 +      await runHarnessAttempt(harness, makeCompactParams({ sessionId: "oc-sess-login" }));
        mocks.resolvePoolAcquire.mockReturnValueOnce({
-         auth: {
-           agentId: "test",
-@@ -1489,7 +1534,8 @@ describe("createCopilotAgentHarness", () => {
-         key: { agentId: "test", authMode: "gitHubToken", copilotHome: "/copilot-home" },
-         options: { copilotHome: "/copilot-home", gitHubToken: "ghp_test" },
+@@ -1491,3 +1536,4 @@ describe("createCopilotAgentHarness", () => {
        });
 -      const result = await harness.compact?.(
 +      const result = await runHarnessCompact(
 +        harness,
          makeCompactParams({
-           auth: { gitHubToken: "ghp_test", profileId: "p1", profileVersion: "v1" },
-           sessionId: "oc-sess-login",
-@@ -1529,8 +1575,11 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool, sessionStore: sessionStore.store });
+@@ -1531,4 +1577,7 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeCompactParams({ sessionId: "oc-sess-stale" }));
 -      const result = await harness.compact?.(makeCompactParams({ sessionId: "oc-sess-stale" }));
@@ -800,11 +526,7 @@ index f01a68b77..59f786a6a 100644
 +        makeCompactParams({ sessionId: "oc-sess-stale" }),
 +      );
  
-       expect(sessionStore.store.delete).toHaveBeenCalledWith("oc-sess-stale");
-       expect(result).toEqual({
-@@ -1564,8 +1613,9 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -1566,4 +1615,5 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeCompactParams({ sessionId: "oc-sess-abort" }));
 -      const result = await harness.compact?.(
@@ -812,11 +534,7 @@ index f01a68b77..59f786a6a 100644
 +      const result = await runHarnessCompact(
 +        harness,
          makeCompactParams({ abortSignal: abort.signal, sessionId: "oc-sess-abort" }),
-       );
- 
-@@ -1618,8 +1668,9 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -1620,4 +1670,5 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeCompactParams({ sessionId: "oc-sess-cancel" }));
 -      const resultPromise = harness.compact?.(
@@ -824,112 +542,68 @@ index f01a68b77..59f786a6a 100644
 +      const resultPromise = runHarnessCompact(
 +        harness,
          makeCompactParams({ abortSignal: abort.signal, sessionId: "oc-sess-cancel" }),
-       );
-       await vi.waitFor(() => expect(compact).toHaveBeenCalledTimes(1));
-@@ -1667,7 +1718,8 @@ describe("createCopilotAgentHarness", () => {
-         pool: makePoolMock(),
-         sessionStore: sessionStore.store,
+@@ -1669,3 +1720,4 @@ describe("createCopilotAgentHarness", () => {
        });
 -      await firstHarness.runAttempt(
 +      await runHarnessAttempt(
 +        firstHarness,
          makeCompactParams({
-           auth: { gitHubToken: "ghp_test", profileId: "p1", profileVersion: "v1" },
-           sessionId: "oc-sess-persisted-token",
-@@ -1685,7 +1737,8 @@ describe("createCopilotAgentHarness", () => {
-         pool: secondPool,
-         sessionStore: sessionStore.store,
+@@ -1687,3 +1739,4 @@ describe("createCopilotAgentHarness", () => {
        });
 -      const result = await secondHarness.compact?.(
 +      const result = await runHarnessCompact(
 +        secondHarness,
          makeCompactParams({ auth: undefined, sessionId: "oc-sess-persisted-token" }),
-       );
- 
-@@ -1717,7 +1770,8 @@ describe("createCopilotAgentHarness", () => {
-         pool: rotatedPool,
-         sessionStore: sessionStore.store,
+@@ -1719,3 +1772,4 @@ describe("createCopilotAgentHarness", () => {
        });
 -      const rotatedResult = await rotatedHarness.compact?.(
 +      const rotatedResult = await runHarnessCompact(
 +        rotatedHarness,
          makeCompactParams({
-           auth: { gitHubToken: "ghp_other", profileId: "p1", profileVersion: "v2" },
-           sessionId: "oc-sess-persisted-token",
-@@ -1750,7 +1804,7 @@ describe("createCopilotAgentHarness", () => {
-         });
-         return ATTEMPT_RESULT;
+@@ -1752,3 +1806,3 @@ describe("createCopilotAgentHarness", () => {
        });
 -      await firstHarness.runAttempt(makeCompactParams({ sessionId: "oc-sess-persisted" }));
 +      await runHarnessAttempt(firstHarness, makeCompactParams({ sessionId: "oc-sess-persisted" }));
  
-       const resumeSession = vi.fn();
-       const secondPool = makePoolMock();
-@@ -1765,7 +1819,8 @@ describe("createCopilotAgentHarness", () => {
-         sessionStore: sessionStore.store,
-       });
+@@ -1767,3 +1821,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      const result = await secondHarness.compact?.(
 +      const result = await runHarnessCompact(
 +        secondHarness,
          makeCompactParams({ sessionId: "oc-sess-persisted" }),
-       );
- 
-@@ -1809,8 +1864,8 @@ describe("createCopilotAgentHarness", () => {
-       });
-       const harness = createCopilotAgentHarness({ pool });
+@@ -1811,4 +1866,4 @@ describe("createCopilotAgentHarness", () => {
  
 -      await harness.runAttempt(makeCompactParams({ sessionId: "oc-sess-noop" }));
 -      const result = await harness.compact?.({
 +      await runHarnessAttempt(harness, makeCompactParams({ sessionId: "oc-sess-noop" }));
 +      const result = await runHarnessCompact(harness, {
          ...makeCompactParams({ sessionId: "oc-sess-noop" }),
-         sessionId: "oc-sess-noop",
-         workspaceDir: "/this\u0000is/illegal",
 diff --git a/extensions/copilot/harness.ts b/extensions/copilot/harness.ts
 index b26482841..77d342219 100644
 --- a/extensions/copilot/harness.ts
 +++ b/extensions/copilot/harness.ts
-@@ -1,6 +1,8 @@
- import type { CopilotClient } from "@github/copilot-sdk";
- import {
+@@ -3,2 +3,4 @@ import {
    compactWithSafetyTimeout,
 +  createAgentHarnessCompactV1,
 +  createAgentHarnessRunAttemptV1,
    resolveCompactionTimeoutMs,
-   type AgentHarness,
-   type AgentHarnessAttemptParams,
-@@ -448,7 +450,8 @@ export function createCopilotAgentHarness(
-       return { supported: true, priority: 100 };
-     },
+@@ -450,3 +452,4 @@ export function createCopilotAgentHarness(
  
 -    async runAttempt(params: AgentHarnessAttemptParams): Promise<AgentHarnessAttemptResult> {
 +    runAttemptV1: createAgentHarnessRunAttemptV1(
 +      async (params: AgentHarnessAttemptParams, host): Promise<AgentHarnessAttemptResult> => {
        const attemptPromise = (async () => {
-         if (disposed) {
-           throw new Error("[copilot] harness has been disposed; cannot start new attempts");
-@@ -511,6 +514,7 @@ export function createCopilotAgentHarness(
- 
-         return runCopilotAttempt(effectiveParams, {
+@@ -513,2 +516,3 @@ export function createCopilotAgentHarness(
            pool,
 +          runSafetyDispatch: host.dispatch,
            onSessionEstablished: openclawSessionId
-             ? ({
-                 sdkSessionId,
-@@ -552,7 +556,8 @@ export function createCopilotAgentHarness(
-       } finally {
-         inFlight.delete(attemptPromise);
+@@ -554,3 +558,4 @@ export function createCopilotAgentHarness(
        }
 -    },
 +      },
 +    ),
  
-     async reset(params: AgentHarnessResetParams): Promise<void> {
-       const openclawSessionId = typeof params.sessionId === "string" ? params.sessionId : undefined;
-@@ -580,9 +585,11 @@ export function createCopilotAgentHarness(
-       }
-     },
+@@ -582,5 +587,7 @@ export function createCopilotAgentHarness(
  
 -    async compact(
 -      params: AgentHarnessCompactParams,
@@ -940,11 +614,7 @@ index b26482841..77d342219 100644
 +        host,
 +      ): Promise<AgentHarnessCompactResult | undefined> => {
        // The SDK owns Copilot history compaction. OpenClaw only resumes
-       // the tracked SDK session and calls the session-scoped RPC; durable
-       // OpenClaw session/transcript state stays in SQLite, with no marker
-@@ -627,32 +634,43 @@ export function createCopilotAgentHarness(
-         pool = await getPool();
-         handle = await pool.acquire(poolAcquire.key, poolAcquire.options);
+@@ -629,28 +636,39 @@ export function createCopilotAgentHarness(
          const client = handle.client;
 -        compactResult = await compactWithSafetyTimeout(
 -          (abortSignal) =>
@@ -1009,25 +679,17 @@ index b26482841..77d342219 100644
 +            ),
 +        });
        } catch (err) {
-         const rawError = err instanceof Error ? err.message : String(err);
-         if (isStaleSdkSessionError(err)) {
-@@ -697,7 +715,8 @@ export function createCopilotAgentHarness(
-         compacted,
-         reason: compacted ? "copilot-sdk-history-compacted" : "already under target",
+@@ -699,3 +717,4 @@ export function createCopilotAgentHarness(
        };
 -    },
 +      },
 +    ),
  
-     async dispose() {
-       if (disposePromise) {
 diff --git a/extensions/copilot/src/attempt.live.test.ts b/extensions/copilot/src/attempt.live.test.ts
 index 3669b313c..cdb871d42 100644
 --- a/extensions/copilot/src/attempt.live.test.ts
 +++ b/extensions/copilot/src/attempt.live.test.ts
-@@ -159,7 +159,10 @@ describeLive("copilot agent runtime live smoke", () => {
-     ).toEqual({ supported: true, priority: 100 });
- 
+@@ -161,3 +161,6 @@ describeLive("copilot agent runtime live smoke", () => {
      try {
 -      const result = await harness.runAttempt(
 +      if (!harness.runAttemptV1) {
@@ -1035,42 +697,26 @@ index 3669b313c..cdb871d42 100644
 +      }
 +      const result = await harness.runAttemptV1(
          createAttemptParams({
-           copilotHome,
-           onAssistantDelta: ({ text }) => {
-@@ -169,6 +172,10 @@ describeLive("copilot agent runtime live smoke", () => {
-           },
-           prompt,
+@@ -171,2 +174,6 @@ describeLive("copilot agent runtime live smoke", () => {
          }),
 +        {
 +          contractVersion: 1,
 +          dispatch: async ({ finalPayload, transport }) => await transport(finalPayload),
 +        },
        );
-       const assistantText = result.assistantTexts.join("\n").trim();
-       const hasAssistantText = result.assistantTexts.some((text) => text.trim().length > 0);
 diff --git a/extensions/copilot/src/attempt.ts b/extensions/copilot/src/attempt.ts
 index bc3af4962..cf008c969 100644
 --- a/extensions/copilot/src/attempt.ts
 +++ b/extensions/copilot/src/attempt.ts
-@@ -3,6 +3,7 @@ import type { MessageOptions, SessionConfig, Tool as SdkTool } from "@github/cop
- import type {
-   AgentHarnessAttemptParams,
+@@ -5,2 +5,3 @@ import type {
    AgentHarnessAttemptResult,
 +  AgentHarnessRunSafetyDispatchV1,
    AgentMessage,
-   SandboxContext,
- } from "openclaw/plugin-sdk/agent-harness-runtime";
-@@ -105,6 +106,7 @@ export type ResolveSandboxContextFn = typeof defaultResolveSandboxContext;
- 
- export interface CopilotAttemptDeps {
+@@ -107,2 +108,3 @@ export interface CopilotAttemptDeps {
    pool: CopilotClientPool;
 +  runSafetyDispatch?: AgentHarnessRunSafetyDispatchV1;
    now?: () => number;
-   createToolBridge?: typeof createCopilotToolBridge;
-   /**
-@@ -456,7 +458,21 @@ export async function runCopilotAttempt(
-       externalAbort = true;
-     } else {
+@@ -458,3 +460,17 @@ export async function runCopilotAttempt(
        sentTurnStarted = true;
 -      const result = await session.sendAndWait(messageOptions, input.timeoutMs);
 +      const finalPayload = {
@@ -1089,22 +735,15 @@ index bc3af4962..cf008c969 100644
 +          })
 +        : await sendTurn(finalPayload);
        await bridge.awaitDeltaChain();
-       if (!bridge.recordSendResult(result) && !aborted) {
-         // SDK sendAndWait returning undefined is treated as a timeout by the
 diff --git a/src/agents/harness/builtin-openclaw.ts b/src/agents/harness/builtin-openclaw.ts
 index c76fbaf6c..cdb02b90f 100644
 --- a/src/agents/harness/builtin-openclaw.ts
 +++ b/src/agents/harness/builtin-openclaw.ts
-@@ -1,5 +1,6 @@
- import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../context-engine/host-compat.js";
+@@ -2,2 +2,3 @@ import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../context-engine/host
  import { runEmbeddedAttempt } from "../embedded-agent-runner/run/attempt.js";
 +import { createAgentHarnessRunAttemptV1 } from "./run-safety-contract.js";
  import type { AgentHarness } from "./types.js";
- 
- export function createOpenClawAgentHarness(): AgentHarness {
-@@ -8,6 +9,9 @@ export function createOpenClawAgentHarness(): AgentHarness {
-     label: "OpenClaw embedded agent",
-     contextEngineHostCapabilities: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST.capabilities,
+@@ -10,3 +11,6 @@ export function createOpenClawAgentHarness(): AgentHarness {
      supports: () => ({ supported: true, priority: 0 }),
 -    runAttempt: runEmbeddedAttempt,
 +    // Native OpenClaw provider sends are already guarded by the lower-level
@@ -1112,33 +751,22 @@ index c76fbaf6c..cdb02b90f 100644
 +    // still rejects every unversioned AgentHarness uniformly.
 +    runAttemptV1: createAgentHarnessRunAttemptV1(async (params) => runEmbeddedAttempt(params)),
    };
- }
 diff --git a/src/agents/harness/compaction.ts b/src/agents/harness/compaction.ts
 index 7aa0ebf81..1c54bce05 100644
 --- a/src/agents/harness/compaction.ts
 +++ b/src/agents/harness/compaction.ts
-@@ -9,7 +9,9 @@ import { resolveModelAsync } from "../embedded-agent-runner/model.js";
- import type { EmbeddedAgentCompactResult } from "../embedded-agent-runner/types.js";
- import { getApiKeyForModel } from "../model-auth.js";
+@@ -11,3 +11,5 @@ import { getApiKeyForModel } from "../model-auth.js";
  import { isCliRuntimeAliasForProvider, isCliRuntimeProvider } from "../model-runtime-aliases.js";
 +import { runSafetyRegistry } from "../run-safety-registry.js";
  import { resolveAgentHarnessPolicy as resolveConfiguredAgentHarnessPolicy } from "./policy.js";
 +import { runAgentHarnessCompactV1 } from "./run-safety-contract.js";
  import { selectAgentHarness } from "./selection.js";
- import type { AgentHarness } from "./types.js";
- 
-@@ -113,7 +115,7 @@ export async function maybeCompactAgentHarnessSession(
-     }
-     throw err;
+@@ -115,3 +117,3 @@ export async function maybeCompactAgentHarnessSession(
    }
 -  if (!harness.compact) {
 +  if (!harness.compact && !harness.compactV1) {
      if (harness.id !== "openclaw") {
-       return {
-         ok: false,
-@@ -141,5 +143,51 @@ export async function maybeCompactAgentHarnessSession(
-       error: formatErrorMessage(err),
-     });
+@@ -143,3 +145,49 @@ export async function maybeCompactAgentHarnessSession(
    }
 -  return harness.compact(resolvedApiKey ? { ...compactParams, resolvedApiKey } : compactParams);
 +  // Production compaction entry points (manual compact RPC, /compact, memory
@@ -1193,9 +821,7 @@ diff --git a/src/agents/harness/lifecycle.test.ts b/src/agents/harness/lifecycle
 index a792aa960..63d14ba99 100644
 --- a/src/agents/harness/lifecycle.test.ts
 +++ b/src/agents/harness/lifecycle.test.ts
-@@ -15,11 +15,14 @@ import {
-   type DiagnosticTraceContext,
- } from "../../infra/diagnostic-trace-context.js";
+@@ -17,4 +17,6 @@ import {
  import type { EmbeddedRunAttemptResult } from "../embedded-agent-runner/run/types.js";
 +import { RunSafetyController, RunSafetyRootCoordinator } from "../run-safety-controller.js";
  import { createOpenClawAgentHarness } from "./builtin-openclaw.js";
@@ -1203,15 +829,11 @@ index a792aa960..63d14ba99 100644
 +import { runAgentHarnessLifecycleAttempt as runAgentHarnessLifecycleAttemptRaw } from "./lifecycle.js";
 +import { createAgentHarnessRunAttemptV1 } from "./run-safety-contract.js";
  import type { AgentHarness, AgentHarnessAttemptParams } from "./types.js";
- 
+@@ -22,2 +24,3 @@ import type { AgentHarness, AgentHarnessAttemptParams } from "./types.js";
  function createAttemptParams(): AgentHarnessAttemptParams {
 +  const coordinator = new RunSafetyRootCoordinator("root-1");
    return {
-     prompt: "hello",
-     sessionId: "session-1",
-@@ -37,9 +40,32 @@ function createAttemptParams(): AgentHarnessAttemptParams {
-     thinkLevel: "low",
-     messageChannel: "qa",
+@@ -39,2 +42,9 @@ function createAttemptParams(): AgentHarnessAttemptParams {
      trigger: "manual",
 +    runSafety: {
 +      coordinator,
@@ -1221,7 +843,7 @@ index a792aa960..63d14ba99 100644
 +      }),
 +    },
    } as AgentHarnessAttemptParams;
- }
+@@ -42,2 +52,18 @@ function createAttemptParams(): AgentHarnessAttemptParams {
  
 +function runAgentHarnessLifecycleAttempt(harness: AgentHarness, params: AgentHarnessAttemptParams) {
 +  const legacyRunAttempt = harness.runAttempt;
@@ -1240,23 +862,15 @@ index a792aa960..63d14ba99 100644
 +}
 +
  function createDiagnosticTrace() {
-   return {
-     traceId: "11111111111111111111111111111111",
 diff --git a/src/agents/harness/lifecycle.ts b/src/agents/harness/lifecycle.ts
 index adce712d5..b3620f0e1 100644
 --- a/src/agents/harness/lifecycle.ts
 +++ b/src/agents/harness/lifecycle.ts
-@@ -16,6 +16,7 @@ import {
-   type DiagnosticTraceContext,
- } from "../../infra/diagnostic-trace-context.js";
+@@ -18,2 +18,3 @@ import {
  import { applyAgentHarnessResultClassification } from "./result-classification.js";
 +import { runAgentHarnessAttemptV1 } from "./run-safety-contract.js";
  import type {
-   AgentHarness,
-   AgentHarnessAttemptParams,
-@@ -236,7 +237,11 @@ export async function runAgentHarnessLifecycleAttempt(
-     }
-     const runAndClassify = async () => {
+@@ -238,3 +239,7 @@ export async function runAgentHarnessLifecycleAttempt(
        phase = "send";
 -      const rawResult = await harness.runAttempt(params);
 +      const rawResult = await runAgentHarnessAttemptV1({
@@ -1265,19 +879,17 @@ index adce712d5..b3620f0e1 100644
 +        attemptParams: params,
 +      });
        phase = "resolve";
-       return applyAgentHarnessResultClassification(harness, rawResult, params);
-     };
 diff --git a/src/agents/harness/run-safety-contract.test.ts b/src/agents/harness/run-safety-contract.test.ts
 new file mode 100644
-index 000000000..ff435393d
+index 000000000..6ef0cae47
 --- /dev/null
 +++ b/src/agents/harness/run-safety-contract.test.ts
-@@ -0,0 +1,174 @@
+@@ -0,0 +1,218 @@
 +import { describe, expect, it, vi } from "vitest";
 +import {
 +  RunSafetyController,
 +  RunSafetyRootCoordinator,
-+  type RunSafetyBudgetLimits,
++  type RunSafetyControllerLimits,
 +  type RunSafetyContext,
 +} from "../run-safety-controller.js";
 +import {
@@ -1293,7 +905,7 @@ index 000000000..ff435393d
 +} from "./types.js";
 +
 +function createRunSafety(
-+  limits: Partial<RunSafetyBudgetLimits> = {},
++  limits: RunSafetyControllerLimits = {},
 +  runId = "run-1",
 +): RunSafetyContext {
 +  const rootInvocationId = "root-1";
@@ -1380,7 +992,6 @@ index 000000000..ff435393d
 +    runSafety.controller.reserveProviderDispatch({
 +      runId: "run-1",
 +      providerDispatchId,
-+      estimatedPromptTokens: 1,
 +    });
 +    runSafety.controller.completeProviderDispatch(providerDispatchId);
 +    const transport = vi.fn(async () => "sent");
@@ -1399,9 +1010,9 @@ index 000000000..ff435393d
 +    expect(transport).not.toHaveBeenCalled();
 +  });
 +
-+  it("does not call transport when final prompt exposure exceeds the limit", async () => {
++  it("calls transport when final prompt exposure exceeds the legacy threshold", async () => {
 +    const runSafety = createRunSafety({
-+      maxCumulativeEstimatedPromptTokensPerBudgetScope: 32,
++      promptExposure: { mode: "observe", legacyDiagnosticThreshold: 32 },
 +    });
 +    const transport = vi.fn(async () => "sent");
 +    const handler = createAgentHarnessRunAttemptV1(async (_attemptParams, host) => {
@@ -1412,14 +1023,59 @@ index 000000000..ff435393d
 +      return createAttemptResult();
 +    });
 +
-+    await expect(
-+      runAgentHarnessAttemptV1({
-+        handler,
-+        legacyHandlerPresent: false,
-+        attemptParams: createAttemptParams(runSafety),
-+      }),
-+    ).rejects.toThrow("prompt exposure was blocked");
-+    expect(transport).not.toHaveBeenCalled();
++    await runAgentHarnessAttemptV1({
++      handler,
++      legacyHandlerPresent: false,
++      attemptParams: createAttemptParams(runSafety),
++    });
++
++    expect(transport).toHaveBeenCalledOnce();
++    expect(runSafety.controller.terminationReason).toBeUndefined();
++    expect(runSafety.controller.snapshot().promptExposure).toMatchObject({
++      legacyDiagnosticThresholdCrossed: true,
++      knownEstimateDispatchCount: 1,
++      pendingObservationDispatchCount: 0,
++    });
++  });
++
++  it("calls transport when final prompt estimation is unavailable", async () => {
++    const runSafety = createRunSafety();
++    const transport = vi.fn(async () => "sent");
++    const handler = createAgentHarnessRunAttemptV1(async (_attemptParams, host) => {
++      await host.dispatch({
++        finalPayload: {
++          messages: [
++            {
++              role: "user",
++              content: [{ type: "image_url", url: "https://example.test/image.png" }],
++            },
++          ],
++        },
++        transport,
++      });
++      return createAttemptResult();
++    });
++    const attemptParams = createAttemptParams(runSafety);
++    attemptParams.model = {
++      ...attemptParams.model,
++      contextWindow: undefined,
++    } as AgentHarnessAttemptParams["model"];
++
++    await runAgentHarnessAttemptV1({
++      handler,
++      legacyHandlerPresent: false,
++      attemptParams,
++    });
++
++    expect(transport).toHaveBeenCalledOnce();
++    expect(runSafety.controller.terminationReason).toBeUndefined();
++    expect(runSafety.controller.snapshot().promptExposure).toMatchObject({
++      estimateUnavailableDispatchCount: 1,
++      pendingObservationDispatchCount: 0,
++      unavailableReasonCounts: {
++        unknown_media_without_context_window: 1,
++      },
++    });
 +  });
 +
 +  it("requires the same versioned seam for harness compaction", async () => {
@@ -1449,16 +1105,15 @@ index 000000000..ff435393d
 +});
 diff --git a/src/agents/harness/run-safety-contract.ts b/src/agents/harness/run-safety-contract.ts
 new file mode 100644
-index 000000000..d7573b229
+index 000000000..0fffd1e18
 --- /dev/null
 +++ b/src/agents/harness/run-safety-contract.ts
-@@ -0,0 +1,169 @@
+@@ -0,0 +1,147 @@
 +import type { Model } from "../../llm/types.js";
 +import {
-+  estimateRunSafetyPromptTokens,
++  estimateRunSafetyPromptObservation,
 +  type RunSafetyContext,
 +  type RunSafetyTermination,
-+  RunSafetyTerminationKind,
 +} from "../run-safety-controller.js";
 +import type {
 +  AgentHarnessAttemptParams,
@@ -1546,9 +1201,6 @@ index 000000000..d7573b229
 +    const reservation = runSafety.controller.reserveProviderDispatch({
 +      runId,
 +      providerDispatchId,
-+      // Reserve the logical send first. Final prompt exposure is authoritative
-+      // only after the harness has supplied its immutable dispatch payload.
-+      estimatedPromptTokens: 1,
 +    });
 +    if (!reservation.allowed) {
 +      throw new AgentHarnessRunSafetyContractError(
@@ -1557,28 +1209,10 @@ index 000000000..d7573b229
 +      );
 +    }
 +    try {
-+      const estimate = estimateRunSafetyPromptTokens(finalPayload, model);
-+      if (!estimate.ok) {
-+        const reason = runSafety.controller.tryTerminate({
-+          kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable,
-+          runId,
-+        });
-+        throw new AgentHarnessRunSafetyContractError(
-+          "Agent harness final payload could not be estimated safely.",
-+          reason,
-+        );
-+      }
-+      const refinement = runSafety.controller.refineProviderPromptEstimate({
-+        runId,
++      runSafety.controller.observeProviderPromptEstimate({
 +        providerDispatchId,
-+        estimatedPromptTokens: estimate.estimatedPromptTokens,
++        observation: estimateRunSafetyPromptObservation(finalPayload, model),
 +      });
-+      if (!refinement.allowed) {
-+        throw new AgentHarnessRunSafetyContractError(
-+          "Agent harness prompt exposure was blocked by run safety.",
-+          refinement.reason,
-+        );
-+      }
 +      return await transport(finalPayload);
 +    } finally {
 +      runSafety.controller.completeProviderDispatch(providerDispatchId);
@@ -1626,9 +1260,7 @@ diff --git a/src/agents/harness/selection.test.ts b/src/agents/harness/selection
 index 26a5a6941..54e5356f0 100644
 --- a/src/agents/harness/selection.test.ts
 +++ b/src/agents/harness/selection.test.ts
-@@ -8,8 +8,16 @@ import type {
-   EmbeddedRunAttemptParams,
-   EmbeddedRunAttemptResult,
+@@ -10,4 +10,12 @@ import type {
  } from "../embedded-agent-runner/run/types.js";
 -import { maybeCompactAgentHarnessSession } from "./compaction.js";
 -import { clearAgentHarnesses, registerAgentHarness } from "./registry.js";
@@ -1643,37 +1275,21 @@ index 26a5a6941..54e5356f0 100644
 +  createAgentHarnessRunAttemptV1,
 +} from "./run-safety-contract.js";
  import {
-   resolveAgentHarnessPolicy,
-   resolveAvailableAgentHarnessPolicy,
-@@ -18,7 +26,7 @@ import {
- } from "./selection.js";
- import type { AgentHarness } from "./types.js";
+@@ -20,3 +28,3 @@ import type { AgentHarness } from "./types.js";
  
 -const agentRunAttempt = vi.fn<AgentHarness["runAttempt"]>(async () =>
 +const agentRunAttempt = vi.fn<NonNullable<AgentHarness["runAttempt"]>>(async () =>
    createAttemptResult("openclaw"),
- );
- const compactAuthMocks = vi.hoisted(() => ({
-@@ -32,7 +40,7 @@ vi.mock("./builtin-openclaw.js", () => ({
-     label: "OpenClaw embedded agent",
-     contextEngineHostCapabilities: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST.capabilities,
+@@ -34,3 +42,3 @@ vi.mock("./builtin-openclaw.js", () => ({
      supports: () => ({ supported: true, priority: 0 }),
 -    runAttempt: agentRunAttempt,
 +    runAttemptV1: createAgentHarnessRunAttemptV1(async (params) => agentRunAttempt(params)),
    }),
- }));
- vi.mock("../model-auth.js", () => ({
-@@ -89,6 +97,7 @@ afterEach(() => {
- });
- 
+@@ -91,2 +99,3 @@ afterEach(() => {
  function createAttemptParams(config?: OpenClawConfig): EmbeddedRunAttemptParams {
 +  const coordinator = new RunSafetyRootCoordinator("root-1");
    return {
-     prompt: "hello",
-     sessionId: "session-1",
-@@ -104,9 +113,60 @@ function createAttemptParams(config?: OpenClawConfig): EmbeddedRunAttemptParams
-     modelRegistry: {} as never,
-     thinkLevel: "low",
+@@ -106,2 +115,9 @@ function createAttemptParams(config?: OpenClawConfig): EmbeddedRunAttemptParams
      config,
 +    runSafety: {
 +      coordinator,
@@ -1683,7 +1299,7 @@ index 26a5a6941..54e5356f0 100644
 +      }),
 +    },
    } as EmbeddedRunAttemptParams;
- }
+@@ -109,2 +125,46 @@ function createAttemptParams(config?: OpenClawConfig): EmbeddedRunAttemptParams
  
 +function registerAgentHarness(harness: AgentHarness, options?: { ownerPluginId?: string }): void {
 +  const legacyRunAttempt = harness.runAttempt;
@@ -1730,11 +1346,7 @@ index 26a5a6941..54e5356f0 100644
 +}
 +
  function createAttemptResult(sessionIdUsed: string): EmbeddedRunAttemptResult {
-   return {
-     aborted: false,
-@@ -817,6 +877,85 @@ describe("selectAgentHarness", () => {
-     });
-   });
+@@ -819,2 +879,81 @@ describe("selectAgentHarness", () => {
  
 +  it("compacts a production-shaped request without a run id or run-safety scope", async () => {
 +    // Manual compact RPC, /compact, memory flush, and native CLI harness
@@ -1816,15 +1428,11 @@ index 26a5a6941..54e5356f0 100644
 +  });
 +
    it("keeps compaction recoverable when auth profile lookup fails", async () => {
-     compactAuthMocks.getApiKeyForModel.mockRejectedValue(new Error("missing auth profile"));
-     const compact = vi.fn<NonNullable<AgentHarness["compact"]>>(async () => ({
 diff --git a/src/agents/harness/types.ts b/src/agents/harness/types.ts
 index 9af8ba453..58ffe644d 100644
 --- a/src/agents/harness/types.ts
 +++ b/src/agents/harness/types.ts
-@@ -77,7 +77,13 @@ export type AgentHarnessRunCapability = {
-   contextEngineHostCapabilities?: readonly import("../../context-engine/types.js").ContextEngineHostCapability[];
-   deliveryDefaults?: AgentHarnessDeliveryDefaults;
+@@ -79,3 +79,9 @@ export type AgentHarnessRunCapability = {
    supports(ctx: AgentHarnessSupportContext): AgentHarnessSupport;
 -  runAttempt(params: AgentHarnessAttemptParams): Promise<AgentHarnessAttemptResult>;
 +  /**
@@ -1835,25 +1443,17 @@ index 9af8ba453..58ffe644d 100644
 +  runAttempt?(params: AgentHarnessAttemptParams): Promise<AgentHarnessAttemptResult>;
 +  runAttemptV1?: import("./run-safety-contract.js").AgentHarnessRunAttemptHandlerV1;
  };
- 
- export type AgentHarnessSideQuestionCapability = {
-@@ -92,7 +98,9 @@ export type AgentHarnessClassificationCapability = {
- };
- 
+@@ -94,3 +100,5 @@ export type AgentHarnessClassificationCapability = {
  export type AgentHarnessCompactionCapability = {
 +  /** Legacy unversioned capability. The host rejects this before invocation. */
    compact?(params: AgentHarnessCompactParams): Promise<AgentHarnessCompactResult | undefined>;
 +  compactV1?: import("./run-safety-contract.js").AgentHarnessCompactHandlerV1;
  };
- 
- export type AgentHarnessSessionLifecycleCapability = {
 diff --git a/src/plugin-sdk/agent-harness-runtime.ts b/src/plugin-sdk/agent-harness-runtime.ts
 index f82214274..6a07728f8 100644
 --- a/src/plugin-sdk/agent-harness-runtime.ts
 +++ b/src/plugin-sdk/agent-harness-runtime.ts
-@@ -41,6 +41,15 @@ export type {
-   AgentHarnessSupport,
-   AgentHarnessSupportContext,
+@@ -43,2 +43,11 @@ export type {
  } from "../agents/harness/types.js";
 +export {
 +  AgentHarnessRunSafetyContractVersion,
@@ -1865,26 +1465,18 @@ index f82214274..6a07728f8 100644
 +  type AgentHarnessRunSafetyHostV1,
 +} from "../agents/harness/run-safety-contract.js";
  export type {
-   EmbeddedRunAttemptParams,
-   EmbeddedRunAttemptResult,
-@@ -154,9 +163,7 @@ export {
-   resolveActiveEmbeddedRunSessionId,
-   setActiveEmbeddedRun,
+@@ -156,5 +165,3 @@ export {
  };
 -export type {
 -  AbortAndDrainEmbeddedAgentRunResult as AbortAndDrainAgentHarnessRunResult,
 -};
 +export type { AbortAndDrainEmbeddedAgentRunResult as AbortAndDrainAgentHarnessRunResult };
  
- /**
-  * @deprecated Active-run queueing is an internal runtime concern. This legacy
 diff --git a/src/plugins/registry.ts b/src/plugins/registry.ts
 index 34fc1a7be..88a50f5f7 100644
 --- a/src/plugins/registry.ts
 +++ b/src/plugins/registry.ts
-@@ -1067,7 +1067,10 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
-       });
-       return;
+@@ -1069,3 +1069,6 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
      }
 -    if (typeof harness.supports !== "function" || typeof harness.runAttempt !== "function") {
 +    if (
@@ -1892,5 +1484,3 @@ index 34fc1a7be..88a50f5f7 100644
 +      (typeof harness.runAttemptV1 !== "function" && typeof harness.runAttempt !== "function")
 +    ) {
        pushDiagnostic({
-         level: "error",
-         pluginId: record.id,

--- a/specs/bugfixes/openclaw-no-progress-tool-loop-token-burn/2026-07-28-openclaw-run-prompt-exposure-budget-false-stop-design.md
+++ b/specs/bugfixes/openclaw-no-progress-tool-loop-token-burn/2026-07-28-openclaw-run-prompt-exposure-budget-false-stop-design.md
@@ -1,0 +1,1291 @@
+# OpenClaw 累计 Prompt 暴露预算误停修复设计文档
+
+> 状态：Draft — 待评审，未实施
+>
+> 最后更新：2026-07-28
+>
+> 本文交付门槛：P0；P1/P2 为不阻塞 P0 的后续方向，实施前需独立评审
+>
+> LobsterAI 目标 OpenClaw：`v2026.6.1`
+>
+> 上游核对快照：OpenClaw `v2026.7.2-beta.5` 与 2026-07-28 的相关 PR head
+>
+> 取代范围：本文只取代 2026-07-22 设计中“累计 estimated Prompt 暴露达到
+> 2,000,000 后硬停止”及其关联的估算失败、warning、终止和验收契约；raw tool、
+> Provider dispatch、Run scope、semantic detector、唯一 terminal owner、历史折叠和
+> native stop 等其余契约继续有效。
+
+## 1. 概述
+
+### 1.1 用户问题与现场证据
+
+2026-07-27 的用户日志显示，同一桌面 Cowork 会话
+`de103925-b033-4b61-8294-8813269fb625` 在执行一个持续推进的本地任务时，连续三次被
+`run_prompt_exposure_budget` 自动停止。用户在前两次停止后分别发送新的继续指令，但新的
+Run 仍在数分钟后因同一原因停止。
+
+三段 Run 的关键数据如下。累计值来自对当前 `RunSafetyController` reservation 规则的离线
+重建：
+
+| 任务段 | `rootInvocationId` | 首次 Prompt estimate | 已放行 Provider dispatch | 被拒绝的 dispatch 序号 | raw tool result | 被拒绝时预计累计暴露 |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| 原始任务段 | `04d5a81d-4de4-43c7-8d3b-23140da3288f` | 114,849 | 15 | 16 | 15 | 2,096,802 |
+| 第一次用户继续 | `50a02631-2036-40b9-8629-0373c618ae28` | 152,508 | 14 | 15 | 14 | 2,136,105 |
+| 第二次用户继续 | `21783951-c505-4df3-b011-845c234b121d` | 163,869 | 13 | 14 | 13 | 2,107,423 |
+
+证据来源为用户提供的
+`lobsterai-logs-20260727-232858/main-2026-07-27.log`：三次 terminal 分别位于
+60273、61548、62360 行；三段首次 context precheck 分别位于 59307、60457、61716 行。
+
+三段 Run 均满足：
+
+- OpenClaw context precheck 为 `route=fits`；
+- `overflowTokens=0`；
+- 模型 `contextTokenBudget=1,000,000`；
+- 没有达到 32 次 Provider dispatch；
+- 没有达到 64 次 raw tool reservation；
+- 没有命中 `variant_no_progress` 或其它 semantic critical detector；
+- 每段 Run 都返回了多个不同工具结果，未呈现原事故的稳定相同结果循环特征。
+
+Transcript 回放中，三段 Run 分别产生 15、14、13 个工具结果，其中精确内容分别有
+15、12、13 种。它们不是 2026-07-20 事故中的“205 次稳定相同结果”循环。
+
+因此，本次停止不是模型上下文溢出，也不是整个聊天累计耗尽预算。三个不同的
+`rootInvocationId` 证明每条外部用户指令都创建了新的执行过程；误停发生在每个新 Run
+内部。
+
+### 1.2 当前根因
+
+当前 managed 配置为：
+
+```ts
+const MANAGED_RUN_SAFETY = {
+  maxToolCallReservationsPerBudgetScope: 64,
+  maxProviderDispatchesPerBudgetScope: 32,
+  maxCumulativeEstimatedPromptTokensPerBudgetScope: 2_000_000,
+  warningRatio: 0.75,
+} as const;
+```
+
+当前 controller 在每次 Provider dispatch 前执行：
+
+```text
+nextPromptTotal =
+  cumulativeEstimatedPromptTokens + estimatedPromptTokensForThisDispatch
+
+if nextPromptTotal > 2_000_000:
+  terminate(run_prompt_exposure_budget)
+```
+
+Agent 每取得一次工具结果，下一轮模型请求通常会再次携带 system prompt、历史消息、
+tool call、tool result 和 tool definitions。累计公式按每次完整 Provider-visible payload
+相加，因此近似成本为：
+
+```text
+累计 raw Prompt exposure ≈ 当前上下文大小 × Provider dispatch 次数
+```
+
+当单次 Prompt 已达到 15 万左右时，只需约 13～14 次正常模型请求就会接近 200 万。该
+指标优先惩罚的是“上下文已经较长”，而不是“任务是否陷入循环”。
+
+2026-07-20 的原始事故中，2,000,000 阈值是为了给 semantic detector 漏报提供额外止损；
+但当前实现已经同时拥有：
+
+- `variant_no_progress` 参数族 detector；
+- exact repeat、known poll、ping-pong 等上游 detector；
+- 64 次 raw tool reservation 硬边界；
+- 32 次 Provider dispatch 硬边界；
+- critical 后的唯一终止闭环。
+
+继续把完整 Prompt 的单调累计值作为默认硬停止条件，会在已知循环保护之外制造独立的正常
+任务误伤。
+
+### 1.3 为什么不能只把 2M 调大
+
+把阈值改成 20M、200M 或按模型 context window 成比例扩大，只能延后误伤，不能修复指标
+语义：
+
+1. 同一个正常任务仍会因为上下文较长而更早停止；
+2. 不同 Provider 的 tokenizer、媒体估算、缓存和 fallback payload 不同，统一阈值无法
+   稳定代表成本；
+3. raw Prompt exposure 不等于 Provider 实际 input usage，更不等于积分；
+4. 上下文缓存可能降低部分重复前缀的实际计费，但缓存命中、倍率和失效策略因 Provider
+   而异；
+5. 真正需要硬边界的无人干预执行已经由 64 次 raw tool 和 32 次 Provider dispatch 约束。
+
+Prompt exposure 仍然是有价值的诊断指标，但不应在当前证据下继续作为通用聊天任务的默认
+硬停止条件。
+
+### 1.4 为什么不能按“任意进度”直接清零
+
+一个直观方案是：工具返回新结果或 assistant 输出可见文本时，把 2M 计数清零。该方案能
+放过本次现场，但不能建立可靠的通用安全语义：
+
+- 时间戳、PID、随机 ID、滚动日志、进度条和 cursor 都会制造新的 `resultHash`；
+- 模型每轮输出“仍在处理”之类文本即可持续清零；
+- 工具返回 `success` 只代表调用成功，不代表用户目标推进；
+- argument novelty 和 result novelty 只能清除某个具体 detector 的模式证据，不能证明整个
+  任务取得进展；
+- parent、recovery 和 subagent 共享 root `budgetScopeId`，任一 child 清零全局计数会替
+  parent 或 sibling 续期；
+- 如果改成每个 run 独立 2M，又会丢失 root aggregate 语义，并被 subagent 数量放大。
+
+因此本文不重置总 Prompt exposure，也不在 P0 建立模糊的全局 progress oracle。
+
+### 1.5 上游方向核对
+
+截至 2026-07-28：
+
+| 上游工作 | 状态 | 已验证语义 | 本文结论 |
+| --- | --- | --- | --- |
+| [`#112620`](https://github.com/openclaw/openclaw/pull/112620) stable tool argument churn | 已合并，并进入 [`v2026.7.2-beta.5`](https://github.com/openclaw/openclaw/releases/tag/v2026.7.2-beta.5) | 至少两个参数变体各重复三次且共享稳定 `resultHash` 后产生 warning-only churn 信号；独立 semantic liveness clock 负责 stale recovery | 证明“停滞应由语义证据处理”的方向，但 distinct result 或 later model output 只是该 detector 的证据清除条件，不是全局任务进展证明 |
+| [`#97485`](https://github.com/openclaw/openclaw/pull/97485) `maxToolCallingRounds` | Open | 当前 head 默认关闭，按工具调用轮次计数；一次响应的多个并行工具只算一轮；耗尽后强制再做一次 text-only summary | 只能作为未来的 tool-round 补充上限，不能替代 64 raw tool 或 32 Provider dispatch |
+| [`#114598`](https://github.com/openclaw/openclaw/pull/114598) sliding run deadline | Open | activity 可滑动 timeout，但最多扩展 10 次、总时长硬上限 120 秒 | 可参考“活动窗口仍需绝对上限”的设计思想，但它是 wall-clock timeout，不是 Prompt 或账单预算 |
+| [`#110633`](https://github.com/openclaw/openclaw/pull/110633) critical 后终止 Run | Open | 目标是让 critical detector 真正终止 Run，当前仍有兼容语义和 exact-head proof 待决 | 合并并进入目标 stable tag 后可接管部分 terminal owner，当前不能假设已交付 |
+
+上游没有累计 Prompt hard cap 只能作为方向信号，不能单独证明任何本地安全策略错误。本文的
+修改依据是本次现场误停、当前 controller 语义和已有绝对次数边界的共同证据。
+
+### 1.6 旧契约与新契约
+
+| 维度 | 2026-07-22 契约 | 本文契约 |
+| --- | --- | --- |
+| raw tool reservation | root scope 最多 64 次，硬停止 | 不变 |
+| Provider dispatch | root scope 最多 32 次，pre-transport 硬停止 | 不变 |
+| legacy Prompt estimate units | 超过 2,000,000 时硬停止 | 单调遥测，不参与停止 |
+| Prompt estimator 不可用 | `run_prompt_estimate_unavailable` 硬停止 | 记录 unavailable telemetry，若 32 次预算仍有槽则允许 transport |
+| Prompt 75% warning | `prompt_exposure` warning dimension | 从 safety warning 中移除；2M 只产生一次内部 diagnostic event |
+| semantic detector | critical 后终止 | 不变 |
+| Run scope | 新外部指令创建；retry、fallback、compaction、recovery、subagent 继承 | 不变 |
+| legacy Prompt terminal | 新旧 runtime 均可能发出 | 新 runtime 不再发出；LobsterAI 继续解析和展示旧事件 |
+| 进度感知 exposure | 无 | P1 只做 shadow telemetry，不终止、不刷新绝对预算 |
+
+### 1.7 修复目标
+
+1. 正常长上下文任务即使累计 legacy Prompt exposure units 超过 2,000,000，只要未达到其它
+   硬边界，仍可继续执行。
+2. 保留 64 次 raw tool 和 32 次 Provider dispatch 的 root-scope 原子硬边界。
+3. 保留 semantic loop detector 和唯一安全终止闭环，原始无进展事故仍能提前停止。
+4. Prompt exposure 继续单调记录，明确区分已知 estimate、不可估算 dispatch 和实际 usage。
+5. Prompt estimator 失败不再伪装成任务安全终止。
+6. 新 runtime 不再产生 Prompt exposure 两种 terminal kind，同时兼容历史持久化消息和旧
+   runtime 事件。
+7. P1 可另行建立可审计的 lane-level shadow state-change 数据，为后续是否引入停滞
+   exposure guard 提供证据；P1 不属于本文 P0 完成条件。
+8. OpenClaw patch、managed config、patch manifest 和 bundled runtime 以原子方式升级，不能
+   只改 LobsterAI config。
+
+### 1.8 非目标
+
+- 不把 64 次 raw tool 改成 100 次；阈值调整需要独立产品证据。
+- 不取消 32 次 Provider dispatch 硬边界。
+- 不把 Prompt exposure 换算成精确积分、金额或账单。
+- 不假设 context cache 必然命中、免费或跨 Provider 等价。
+- 不把任意 assistant 文本、成功工具结果、新参数或新 `resultHash` 定义为 confirmed
+  progress。
+- 不允许 subagent、retry、fallback、compaction 或 recovery 重置 root 的 64/32 计数。
+- 不在 P0 新增长任务模式、用户自定义预算或模型可修改阈值。
+- 不在本次升级 LobsterAI 固定的 OpenClaw tag；上游升级是后续独立发布工作。
+- 不删除原始 transcript，不改写历史 Run 的终止原因。
+- 不在 P1 shadow 数据完成评估前启用 `noProgressLegacyExposureUnits` 硬停止。
+
+## 2. 用户场景
+
+### 场景 1：正常长上下文任务累计超过 2M
+
+**Given** 单次最终 Prompt estimate 约 15 万<br>
+**And** fixture 连续构造 20 个不同的最终 Provider payload 与不同工具结果<br>
+**And** raw tool 少于 64、Provider dispatch 少于 32<br>
+**When** legacy Prompt exposure estimate 总和超过 2,000,000<br>
+**Then** Run 继续执行<br>
+**And** 不产生 `run_prompt_exposure_budget`<br>
+**And** 不关闭 continuation<br>
+**And** 记录一次内部 Prompt exposure threshold diagnostic
+
+### 场景 2：原始稳定结果参数循环
+
+**Given** Agent 依次执行同一 allowlisted 只读命令族<br>
+**And** `N=80/100/120` 得到相同 canonical `resultHash`<br>
+**When** 第三个参数变体完成<br>
+**Then** `variant_no_progress` 仍进入 critical<br>
+**And** Run 通过唯一 terminal owner 结束<br>
+**And** `N=150` 不执行<br>
+**And** 不依赖 Prompt exposure hard stop
+
+### 场景 3：达到 Provider dispatch 硬边界
+
+**Given** 同一 root `budgetScopeId` 已完成 32 次 Provider reservation<br>
+**When** retry、fallback、compaction、subagent 或主 Run 尝试第 33 次 dispatch<br>
+**Then** 在 provider adapter、transport 或本地 inference 前拒绝<br>
+**And** 产生 `run_provider_dispatch_budget`<br>
+**And** Prompt telemetry 不得改变该决定
+
+### 场景 4：达到 raw tool 硬边界
+
+**Given** 同一 root `budgetScopeId` 已 reservation 63 个 raw tool call<br>
+**When** 下一批同时包含第 64、65、66 个 raw call<br>
+**Then** 第 64 个获得 ticket，并立即产生 `run_tool_budget`、使 scope 进入 draining<br>
+**And** 第 65、66 个在工具 lookup、schema validation、hook 和副作用前拒绝<br>
+**And** 单轮并行工具仍逐项占用 raw tool 槽位
+
+### 场景 5：Prompt estimator 不可用
+
+**Given** 最终 payload 含无法可靠估算的媒体或 estimator 抛错<br>
+**And** Provider dispatch 预算仍有可用槽位<br>
+**When** host 到达 pre-transport seam<br>
+**Then** 当前 dispatch 仍计入 32 次硬预算<br>
+**And** telemetry 记录一次 unavailable estimate<br>
+**And** transport 可以执行<br>
+**And** 不产生 `run_prompt_estimate_unavailable`
+
+### 场景 6：内部自动路径不能获得新预算
+
+**Given** 当前外部任务仍处于 active scope<br>
+**When** runtime 发生 retry、profile rotation、fallback、compaction、summary、recovery 或
+subagent 调用<br>
+**Then** 使用原 `rootInvocationId + budgetScopeId`<br>
+**And** 继续扣减 root 32 次 Provider 与 64 次 raw tool 预算<br>
+**And** 不因 runId、attemptId 或 provider/model 变化获得新预算
+
+### 场景 7：用户发出新的明确指令
+
+**Given** 上一个 scope 已正常结束或安全停止<br>
+**When** 用户提交一条新的非空外部指令<br>
+**Then** 创建新的 `rootInvocationId + budgetScopeId`<br>
+**And** 获得新的 64/32 预算<br>
+**And** 保留原会话历史和 Prompt telemetry 供审计
+
+若产品提供“继续处理”按钮，该按钮不能静默重放旧任务或由系统自动创建 scope。它只能聚焦
+输入框或预填可编辑文本；用户显式提交后才创建新的外部任务。
+
+### 场景 8：读取历史 Prompt terminal
+
+**Given** SQLite、session JSONL 或旧 bundled runtime 中存在
+`run_prompt_exposure_budget` 或 `run_prompt_estimate_unavailable`<br>
+**When** LobsterAI 解析该历史事件<br>
+**Then** 继续按 legacy safety terminal 展示和去重<br>
+**And** 不把历史事件改写成其它原因<br>
+**And** 新 bundled runtime 的正向路径不得再产生这两个 kind
+
+### 场景 9：subagent 产生噪声结果
+
+**Given** parent lane 无进展<br>
+**And** child lane 返回包含时间戳、随机 ID 或滚动日志的新结果<br>
+**When** P1 shadow progress collector 观察该结果<br>
+**Then** 不刷新 parent 或 sibling lane<br>
+**And** 不重置 root 的 64/32 预算<br>
+**And** 普通 child success 不得记录为 host-verified state change
+
+### 场景 10：host 可验证的状态变化
+
+**Given** host 能证明一个新 artifact revision 已提交，或 trusted tool 返回带 before/after
+版本和幂等 receipt 的状态迁移<br>
+**When** P1 shadow collector 记录该事件<br>
+**Then** 可以开启当前 `progressLaneId` 的新 shadow epoch<br>
+**And** 仍不改变任何 hard gate<br>
+**And** 该事件的来源、lane、epoch 和 receipt 类型可审计<br>
+**And** `goalRelevance` 保持 `unknown`，不能称为 confirmed progress
+
+## 3. 功能需求
+
+### FR-1：managed Run Safety 改为两项硬预算加 Prompt 观测
+
+新的 managed config 使用独立的 Prompt 观测结构，不能复用旧
+`maxCumulativeEstimatedPromptTokensPerBudgetScope` 名称：
+
+```ts
+export const RunSafetyPromptExposureMode = {
+  Observe: 'observe',
+} as const;
+
+export type RunSafetyPromptExposureMode =
+  typeof RunSafetyPromptExposureMode[keyof typeof RunSafetyPromptExposureMode];
+
+const MANAGED_RUN_SAFETY = {
+  maxToolCallReservationsPerBudgetScope: 64,
+  maxProviderDispatchesPerBudgetScope: 32,
+  warningRatio: 0.75,
+  promptExposure: {
+    mode: RunSafetyPromptExposureMode.Observe,
+    legacyDiagnosticThreshold: 2_000_000,
+  },
+} as const;
+```
+
+要求：
+
+1. 从 LobsterAI managed config、OpenClaw config type 和 Zod schema 中删除
+   `maxCumulativeEstimatedPromptTokensPerBudgetScope`。
+2. 不把旧字段解释为 telemetry threshold。
+3. `warningRatio` 只作用于 raw tool 和 Provider dispatch 两个硬预算。
+4. `promptExposure.legacyDiagnosticThreshold` 只控制内部一次性 diagnostic，不产生 warning、
+   continuation close 或 terminal。
+5. `promptExposure.mode` 只能由 host-managed config 生成；Prompt、Agent、Skill、Provider
+   响应和模型输出不能修改。
+6. 新 runtime 必须显式支持该结构。只删除 config 字段但继续使用旧 runtime 默认 2M
+   的组合不允许发布。
+
+### FR-2：64 次 raw tool 硬边界保持不变
+
+- 每个 root `budgetScopeId` 最多 reservation 64 个原始工具调用。
+- batch 中每个 raw call 独立占槽，一次十个并行工具占十个槽。
+- reservation 继续位于 lookup、validation、policy hook 和副作用之前。
+- unknown、invalid、client-hosted 和 plugin tool 不能绕过 host 可观察的 reservation seam。
+- 第 64 个 reservation 获得 ticket 后立即写入 `run_tool_budget` 并使 scope 进入 draining；
+  该 ticket 已获准执行，但同 batch 的第 65 个及后续调用不得获得 reservation。
+- 已经 reservation 并开始执行的 sibling 可以正常收尾；terminal 后未开始的调用不得执行。
+- tool count 不因 Prompt threshold、Prompt estimator 状态或 P1 progress epoch 重置。
+
+### FR-3：32 次 Provider dispatch 硬边界保持不变
+
+- 每个 root `budgetScopeId` 最多 32 次实际可能到达模型 backend 的 dispatch。
+- 第 33 次在远程 transport 或本地 inference 前拒绝。
+- retry、auth/profile rotation 后的新请求、fallback、模型型 compaction/summary、recovery、
+  subagent、AgentHarness turn 和 host 可观察的 CLI spawn 都重新占用 dispatch 槽。
+- 失败、timeout、stream 中断、业务错误和用户取消不返还已 reservation 槽位。
+- 同一个 `providerDispatchId` 重入只返回已有 accounting decision，不能重复计数；调用方不得
+  把同一个 ID 用于第二次 transport，真正的新 retry/fallback 必须创建新 ID。
+- 只剩一个槽位时，并发 root/child 最多一个 reservation 成功。
+- 第 32 个响应如果是无工具最终文本，允许正常交付；如果包含 tool calls，continuation close
+  在任何工具副作用前提升为 `run_provider_dispatch_budget` terminal。
+
+### FR-4：Run scope 生命周期保持不变
+
+Run 是由一条外部用户指令或一个独立 external trigger 发起的完整自动执行过程。
+
+创建新 root scope 的入口：
+
+- 上一 scope 已结束后的桌面端新用户消息；
+- native IM 新入站消息；
+- Cron 的一次独立 fire；
+- 安全停止后用户显式提交的新指令。
+
+继承当前 scope 的路径：
+
+- active Run 中的 steering/follow-up；
+- retry、fallback、profile rotation；
+- compaction、summary、automatic recovery；
+- parent 创建的 subagent；
+- native IM background continuation；
+- 同一外部任务的其它 attempt。
+
+内部路径即使创建新 runId，也不能生成新的 root 64/32 预算。缺少 scope identity 和
+controller state 的现有 fail-closed 契约保持不变：
+
+- `run_budget_identity_missing`；
+- `run_safety_state_unavailable`。
+
+### FR-5：拆分 Provider dispatch reservation 与 Prompt observation
+
+当前 `reserveProviderDispatch({ estimatedPromptTokens })` 同时承担 hard gate 和 Prompt 累加。
+P0 保持“先预占 Provider 次数，再进入 provider-controlled code”的现有计数语义，只把
+Prompt hard gate 拆成一次性的 final-payload observation：
+
+```ts
+export const PromptObservationStatus = {
+  Pending: 'pending',
+  Known: 'known',
+  Unavailable: 'unavailable',
+} as const;
+
+export type PromptObservationStatus =
+  typeof PromptObservationStatus[keyof typeof PromptObservationStatus];
+
+export const PromptEstimateSource = {
+  StableTextTokens: 'stable_text_tokens',
+  ContextWindowFloor: 'context_window_floor',
+} as const;
+
+export type PromptEstimateSource =
+  typeof PromptEstimateSource[keyof typeof PromptEstimateSource];
+
+export const PromptEstimateUnavailableReason = {
+  SerializationFailed: 'serialization_failed',
+  UnknownMediaWithoutContextWindow: 'unknown_media_without_context_window',
+  EstimatorThrew: 'estimator_threw',
+  InvalidEstimate: 'invalid_estimate',
+  PayloadNotObservedBeforeCompletion: 'payload_not_observed_before_completion',
+} as const;
+
+export type PromptEstimateUnavailableReason =
+  typeof PromptEstimateUnavailableReason[keyof typeof PromptEstimateUnavailableReason];
+
+export type PromptObservationState =
+  | { status: typeof PromptObservationStatus.Pending }
+  | {
+      status: typeof PromptObservationStatus.Known;
+      legacyEstimatedExposureUnits: number;
+      source: PromptEstimateSource;
+    }
+  | {
+      status: typeof PromptObservationStatus.Unavailable;
+      reason: PromptEstimateUnavailableReason;
+    };
+
+export type FinalPromptObservation = Exclude<
+  PromptObservationState,
+  { status: typeof PromptObservationStatus.Pending }
+>;
+
+declare function reserveProviderDispatch(params: {
+  runId: string;
+  providerDispatchId: string;
+}): RunSafetyProviderReservationDecision;
+
+declare function observeProviderPromptEstimate(params: {
+  providerDispatchId: string;
+  observation: FinalPromptObservation;
+}): void;
+```
+
+执行顺序：
+
+1. wrapper 为这次逻辑 dispatch 创建新的 `providerDispatchId`；
+2. 在调用 provider-controlled code 前原子 reservation Provider dispatch count，并把该
+   reservation 的 Prompt observation 初始化为 `pending`；
+3. reservation 被拒绝时，不进入 provider adapter、payload prepare 或 transport；
+4. reservation 成功后调用 V1 provider path，继续强制 `maxRetries=0`；
+5. `onPayload` 先取得原 hook 可能替换后的 final payload，再估算并把 observation 原子终结为
+   `known` 或 `unavailable`；两种状态都允许后续 transport；
+6. provider 在 `onPayload` 前同步失败、取消或结束时，统一 settlement helper 把仍为
+   `pending` 的 observation 终结为
+   `unavailable(payload_not_observed_before_completion)`，随后 complete reservation；
+   helper 同时挂到同步 `catch` 与 `stream.result()` 的 resolve/reject 路径。
+
+约束：
+
+- Prompt observation 不返回 `allowed: false`；
+- known legacy estimate 规范化为正 safe integer 并使用 saturating add；
+- 每个 dispatch 只有一次 immutable final observation，不再支持向上/向下 refinement；
+- 相同 observation 的重复提交幂等；冲突的第二次提交只记录低基数 diagnostic，不覆盖首次
+  状态、不重复累计；
+- actual usage、cache read 和失败响应不返还 legacy total；
+- 正常可控退出时，每个已 reservation dispatch 必须归类为 known 或 unavailable；
+- 进程崩溃可能来不及执行 settlement helper，scope snapshot 必须单独记录
+  `pendingObservationDispatchCount`，不能伪装成 known 或 unavailable；重启后的现有
+  fail-closed recovery 契约保持不变；
+- provider path 在 final payload 构建前失败仍消耗一次 dispatch 槽，这是对现有
+  pre-provider reservation 语义的刻意保留；
+- provider-controlled SDK 内部 retry 必须关闭或重新进入 host seam。
+
+### FR-6：Prompt exposure 只保留单调 telemetry
+
+每个 root scope 维护：
+
+```ts
+export type PromptExposureTelemetrySnapshot = {
+  legacyEstimatedExposureUnitsTotal: number;
+  knownEstimateDispatchCount: number;
+  estimateUnavailableDispatchCount: number;
+  pendingObservationDispatchCount: number;
+  maxLegacyEstimatedExposureUnitsPerDispatch: number;
+  estimateSourceCounts: Partial<Record<PromptEstimateSource, number>>;
+  unavailableReasonCounts: Partial<Record<PromptEstimateUnavailableReason, number>>;
+  legacyDiagnosticThresholdCrossed: boolean;
+};
+```
+
+语义：
+
+- `legacyEstimatedExposureUnitsTotal` 只包含成功取得 estimate 的 dispatch；
+- 值从 0 开始，只能单调增加或 saturate 到 `Number.MAX_SAFE_INTEGER`；
+- unavailable dispatch 不用 0 静默伪装成精确 estimate；
+- 使用 model context window 保守兜底时必须显式标记
+  `source=context_window_floor`，不能伪装成 `stable_text_tokens`；
+- `knownEstimateDispatchCount + estimateUnavailableDispatchCount` 必须等于已经完成 Prompt
+  observation 的 Provider reservation 数；
+- 三种 observation 状态的 dispatch count 之和必须等于所有已允许 Provider reservation
+  数；
+- `pendingObservationDispatchCount` 正常收口时必须为 0，只用于表达进程崩溃等无法执行
+  settlement hook 的不完整 snapshot；
+- threshold crossing 后继续累计；
+- telemetry 不参与 `tryTerminate()`、`continuationClosedReason`、fallback 选择或用户提示；
+- scope end 记录结构化 summary；
+- 若现有 provider result 已提供 actual usage、cache read/cache write 或账单字段，继续由原
+  usage 通道记录；P0 不新增 usage 聚合 API，也不能从 raw estimate 中推导、扣除或改变
+  safety decision。
+
+`legacyEstimatedExposureUnits` 明确保留当前 estimator 的历史口径，用于衡量“旧 2M gate
+本来会在何时触发”。当前实现不是 runtime tokenizer，也不是 UTF-8 byte count：
+`stable_text_tokens` 对稳定序列化后的 final payload 使用 CJK-aware
+`estimateStringChars + estimateTokensFromChars`，并叠加结构与媒体开销；
+`context_window_floor` 在存在未知远程媒体时以 model context window 作为保守下限。因此：
+
+- 该总量不得继续命名或展示为精确 token；
+- 不同 `PromptEstimateSource` 的值不得用于 Provider 间成本比较；
+- `legacyDiagnosticThreshold` 只是旧策略的反事实观测阈值；
+- 若未来需要真实 token telemetry，应另加带明确 unit/model tokenizer version 的字段，
+  不能静默改义 legacy 总量。
+
+### FR-7：Prompt diagnostic 不属于 safety warning
+
+Telemetry event 使用集中常量：
+
+```ts
+export const RunSafetyTelemetryEvent = {
+  PromptExposureThresholdCrossed: 'run_prompt_exposure_threshold_crossed',
+  PromptEstimateUnavailableObserved:
+    'run_prompt_exposure_estimate_unavailable_observed',
+  ScopeSummary: 'run_safety_scope_summary',
+} as const;
+
+export type RunSafetyTelemetryEvent =
+  typeof RunSafetyTelemetryEvent[keyof typeof RunSafetyTelemetryEvent];
+```
+
+Prompt telemetry 达到 `legacyDiagnosticThreshold=2_000_000` 时：
+
+- 每个 `budgetScopeId` 最多记录一次 `run_prompt_exposure_threshold_crossed`；
+- 日志包含 root/scope/run identity、resolved provider/model、legacy total、已估算 dispatch 数、
+  unavailable 数和最大单次 estimate；
+- 不记录 Prompt 正文、工具参数、工具结果、文件内容、Token、API key 或用户标识；
+- 不写入 `RunSafetyWarningDimension`；
+- 不通过 renderer、IM 或系统通知打扰用户；
+- 不生成 `run_prompt_exposure_budget`；
+- 不触发 retry、fallback、compaction 或自动 summary。
+
+Prompt estimator 首次不可用时可以记录一次
+`run_prompt_exposure_estimate_unavailable_observed`，后续同 scope 只累计次数，避免热路径刷屏。
+
+### FR-8：Prompt estimator 不可用不再 fail-closed
+
+`run_prompt_estimate_unavailable` 从新 runtime 的 terminal producer 中移除。
+
+以下行为保持 fail-closed：
+
+- 缺少 `budgetScopeId`；
+- controller 丢失；
+- provider adapter 没有实现强制 V1 pre-transport seam；
+- 第 33 次 Provider dispatch；
+- 第 64 个 raw tool reservation 后关闭 scope，第 65 个及后续 reservation 拒绝；
+- semantic detector critical。
+
+以下行为改为 telemetry incomplete，但不阻断：
+
+- final payload 稳定序列化失败；
+- 存在未知远程媒体且 model context window 不可用；
+- estimator 抛错、返回 `NaN`、`Infinity`、负数或溢出值。
+
+Prompt estimate 的不确定性不能弱化 Provider dispatch count gate。
+
+### FR-9：legacy Prompt terminal 只接收、不再产生
+
+为兼容旧持久化数据和旧 runtime：
+
+- LobsterAI `RunSafetyTerminationKind` 暂时保留
+  `run_prompt_exposure_budget` 和 `run_prompt_estimate_unavailable`；
+- OpenClaw patch 内的 `RunSafetyTerminationKind` 也暂时保留这两个 wire value，标记为
+  receive-only；delivery/native compatibility code 可以继续引用；
+- parser 继续验证并解析旧 payload；
+- Adapter、terminal 去重、metadata 和中英文 i18n 继续支持旧 kind；
+- 历史 system message 不迁移、不删除、不改写；
+- 旧 terminal 收到后仍按一次安全终止处理。
+
+新 bundled OpenClaw runtime：
+
+- controller 不得再对 Prompt total 调用 `tryTerminate()`；
+- 不得再把 Prompt threshold 写入 `continuationClosedReason`；
+- 不得再 emit 上述两个 Prompt terminal kind；
+- patch contract test 必须检查 `tryTerminate()`、`continuationClosedReason` 和 emit call
+  site 中不存在这两个 kind；不能用全局搜索“字符串不存在”作为证明，因为 receive-only enum
+  与 legacy parser 仍会合法包含这些字符串。
+
+“保留 legacy wire kind”不等于“保留旧 managed config”。
+
+### FR-10：唯一 terminal owner 与交付闭环不变
+
+下列真实 hard terminal 继续进入同一个 root coordinator：
+
+- `variant_no_progress` 和其它 critical semantic detector；
+- `run_tool_budget`；
+- `run_provider_dispatch_budget`；
+- `run_budget_identity_missing`；
+- `run_safety_state_unavailable`。
+
+要求：
+
+- root、child 或 recovery 并发命中时只发布一个 terminal reason；
+- root 结束后后台 child 命中安全终态时仍能唤醒 coordinator；
+- native delivery、Desktop system message 和 lifecycle 各最多一次；
+- ended controller 的 late event 不能复活 Run；
+- Prompt diagnostic 和 P1 shadow progress 不能进入 terminal owner。
+
+### FR-11：产品提示与“继续”行为
+
+P0 不新增 Prompt exposure 用户预警。
+
+- 75% warning 只保留 48/64 raw tool 和 24/32 Provider dispatch 两个维度；
+- Prompt telemetry 不显示为余额、积分、成本或“即将停止”倒计时；
+- legacy Prompt terminal 文案保留，只用于历史和旧 runtime 兼容；
+- 新的 tool/provider/semantic terminal 继续说明真实停止原因；
+- 若增加“继续处理”入口，不能自动发送通用 continuation，也不能绕过用户提交创建 scope；
+- UI 可以预填类似“继续处理 `<目标>` 的剩余步骤”的可编辑文本，用户提交后按普通外部指令
+  创建新 scope。
+
+### FR-12：P1 只观测 lane-level 状态变化，不阻塞 P0
+
+P1 不是本文 P0 的交付项。实施 P1 前必须另立设计，明确 typed event seam、lane owner、内存
+上界和数据保留期。本文只冻结以下方向，避免把“状态发生变化”误写成“用户目标取得进展”：
+
+- P1 使用 `HostVerifiedStateChange`、`Candidate`、`Rejected` 等名称，不使用
+  `ConfirmedProgress`；
+- host 能证明 artifact revision 或持久状态版本发生变化时，
+  `goalRelevance` 仍为 `unknown`；
+- 只有绑定 immutable task/checkpoint ID、且由 host 验证接受的 typed checkpoint 才能进入
+  “与目标绑定”的候选集合；模型自报文本不能创建 checkpoint；
+- assistant 文本、thinking、tool start、普通 `success=true`、argument/resultHash novelty、
+  时间戳、PID、随机 ID、cursor、retry、fallback、compaction 和 cache activity 都不能
+  证明目标进展。
+
+若 P1 后续实施，lane 与 observation 必须形成闭环：
+
+1. root task 创建 root `progressLaneId`；每个 subagent 创建独立 child lane；
+2. Provider reservation 需要不可变地保存 `runId + progressLaneId`，Prompt observation 只按
+   reservation 中保存的 lane 归属累计，不能信任调用方临时传入另一个 lane；
+3. retry、fallback、compaction 和 recovery 继承原 lane；
+4. known observation 增加当前 lane 的 shadow exposure；unavailable 只增加不完整计数；
+5. host-verified state change 可以结束当前 shadow epoch，但不能清零 root Prompt telemetry，
+   也不能刷新 parent 或 sibling；
+6. child completion receipt 最多向 parent 上报 candidate，不直接开启 parent 新 epoch；
+7. lane 在 scope end 统一关闭；实现必须设置 active lane 数和 summary 大小的固定上界。
+
+无论 P1 数据达到何值，都不得：
+
+- 调用 `tryTerminate()` 或关闭 continuation；
+- 产生用户 warning；
+- 改变 raw tool / Provider reservation；
+- 重置 root 64/32；
+- 被远程配置切换为 enforce mode。
+
+至少完成一个发布周期的真实遥测、事故回放和误判/逃逸评估后，若仍需 hard stagnation
+guard，必须新建独立 spec 和发布门禁。
+
+### FR-13：可观测性与隐私
+
+每个 scope end 至少记录：
+
+- `rootInvocationId`、`budgetScopeId`、最终 runId；
+- 实际 resolved provider/model；
+- tool reservation count；
+- Provider dispatch count；
+- Prompt telemetry snapshot；
+- estimator unavailable reason 的低基数分类计数；
+- semantic warning/terminal kind；
+- 是否正常完成、用户取消或安全终止。
+
+若 P1 已通过独立评审并启用 shadow collector，scope summary 可以额外记录有固定上界的 lane
+epoch 与 evidence 类型计数；该字段不属于 P0 schema 的必需项。
+
+不得记录：
+
+- Prompt 正文；
+- assistant 正文；
+- 工具参数和结果；
+- 文件内容和完整路径；
+- API key、Token、Cookie；
+- 高基数随机 error body。
+
+日志中的 legacy exposure estimate、actual usage、cacheRead 和 cacheWrite 必须使用不同字段，不能把
+其中任意一个展示成精确账单。
+
+### FR-14：原子升级与 runtime capability 门禁
+
+只修改 `openclawConfigSync.ts` 会留下严重版本错配：旧 `v2026.6.1` patch 在缺少
+`maxCumulativeEstimatedPromptTokensPerBudgetScope` 时会回退默认 2M，误停仍然存在。
+
+本文采用“build manifest + pre-spawn 校验”，不新增 Gateway RPC handshake：
+
+1. `package.json#openclaw.runSafetyContract` 是 host 期望值，P0 固定为
+   `count-hardcaps-prompt-observe-v1`；
+2. `apply-openclaw-patches.cjs` 的 strong contract 验证 controller、schema、V1 seam、
+   AgentHarness 和 legacy producer call site；
+3. runtime build 只在上述验证和目标测试通过后，把同一 contract ID、OpenClaw version、
+   commit 与 patch hash 写入现有 `runtime-build-info.json`；
+   build cache 命中条件必须同时比较 version、patch hash 和 contract ID，旧 build info
+   缺少 marker 时强制重建；
+4. `OpenClawEngineManager` 在 Gateway spawn 和配置解析前读取 build info，精确比较
+   contract ID 与 pinned version；缺失或不匹配时设置专用
+   `RuntimeContractMismatch` 状态，不 spawn Gateway；
+5. contract marker 不是行为证明本身；行为证明来自 clean-tag patch replay、contract tests
+   和 fake-provider probe，marker 只防止运行时拿错已构建产物。
+
+升级启动顺序固定为：
+
+```text
+停止旧 Gateway
+  → 解析并验证新 runtime-build-info
+  → ConfigSync 从当前应用状态重新生成完整 managed config
+  → 以现有 temp + rename 方式原子替换 openclaw.json
+  → 校验新 config 不含 legacy hard-limit 字段
+  → spawn 已匹配的新 Gateway
+  → /ready
+```
+
+fake-provider behavior probe 在 CI、runtime 构建验收和发布前 E2E 执行，不在普通用户每次
+启动时调用。
+
+用户磁盘上的旧 `openclaw.json` 初始可以含 legacy 字段；它不能先交给新 schema 解析。若
+runtime marker 不匹配、config 生成失败或原子 rename 失败：
+
+- 不启动新旧任一 Gateway；
+- 原文件保持可恢复，不写半截配置；
+- 开发环境提示运行 `npm run openclaw:runtime:host`；
+- 正式包显示可重试的 runtime/config mismatch 状态，不静默回退旧 2M。
+
+active controller 在创建时冻结完整 policy snapshot，包括 64/32、
+`promptExposure.mode` 和 `legacyDiagnosticThreshold`。配置刷新只影响新 scope，不能让同一
+scope 的反事实 diagnostic 口径漂移。
+
+### FR-15：上游迁移门禁
+
+升级 OpenClaw 前必须重新核对目标 stable tag，而不是只看 PR 状态：
+
+- `#112620` 进入目标 stable 后，可接管低基数 argument churn warning 与 semantic stale
+  clock；本地 allowlisted high-cardinality family detector 是否删除仍需现场 fixture 证明；
+- `#110633` 合并并进入目标 tag 后，才评估接管 critical terminal owner；
+- `#97485` 只可新增 tool-round 维度；当前 forced summary 语义不能替代 Provider gate；
+- `#114598` 只影响 timeout，不替代 64/32 或 Prompt telemetry；
+- 任一去补丁都必须验证零重复 terminal、零重复 delivery 和无后续 Provider dispatch。
+
+## 4. 实现方案
+
+### 4.1 OpenClaw core controller
+
+在 `openclaw-varying-args-no-progress-core.patch` 中：
+
+1. `RunSafetyBudgetDefaults` 删除累计 Prompt hard limit。
+2. `RunSafetyBudgetLimits` 只保留 64、32 和 `warningRatio`。
+3. 新增独立 `PromptExposureTelemetrySnapshot`。
+4. `RunSafetyWarningDimension` 删除 `prompt_exposure`。
+5. `reserveProviderDispatch()` 不再接收 Prompt hard-limit 参数，只原子处理 dispatch count。
+6. `refineProviderPromptEstimate()` 改为不产生 decision 的
+   `observeProviderPromptEstimate()`。
+7. 删除两处 Prompt total 超限的 `tryTerminate()`。
+8. 删除 Prompt threshold 对 `continuationClosedReason` 的赋值。
+9. estimator unavailable 记录 telemetry，不创建 terminal。
+10. scope end 输出完整 telemetry summary。
+11. 保留 saturating add，并用 immutable observation finalization 避免 counter 溢出或重入
+    重复累计。
+
+核心伪代码：
+
+```text
+reserveProviderDispatch(id):
+  if duplicate id:
+    return existing decision
+  if existing terminal or controller not active:
+    reject
+  if providerDispatchCount + 1 > 32:
+    terminate(run_provider_dispatch_budget)
+    reject
+  providerDispatchCount += 1
+  save reservation(observation = pending)
+  record 75% provider warning if needed
+  if providerDispatchCount == 32:
+    close continuation with run_provider_dispatch_budget
+  allow
+
+observeProviderPromptEstimate(id, observation):
+  if reservation missing:
+    record low-cardinality invalid-observation diagnostic
+    return
+  if observation already finalized:
+    return idempotently when equal; diagnose conflict when different
+  if known:
+    add normalized legacy estimate to legacy total
+    update source count and max
+    emit threshold diagnostic once if crossed
+  else:
+    increment unavailable count
+    emit first-unavailable diagnostic once
+  finalize observation
+```
+
+### 4.2 Provider pre-transport seam
+
+`run-safety-gate.ts` 和所有 Provider V1 adapter 保持 host-owned seam：
+
+```text
+create providerDispatchId
+  → reserve Provider dispatch count before provider-controlled code
+  → provider locally prepares payload
+  → onPayload obtains the final replaced payload
+  → estimate/finalize observation
+  → invoke transport
+  → stream settlement hook finalizes any pending observation and completes reservation
+```
+
+要求：
+
+- fallback 使用最终目标 Provider/Model 的 payload 重新 observation；
+- retry 使用新的 `providerDispatchId`；
+- prompt cache create/PATCH、preload 和隐藏 SDK retry 继续遵守现有 side-effect 收口；
+- estimator 抛错只转成 unavailable observation；
+- count reservation 被拒绝时 provider prepare、estimator 和 transport 都不执行；
+- provider prepare、取消或同步错误发生在 `onPayload` 前时仍消耗已预占的 dispatch，并由
+  settlement hook 将 observation 收口为 unavailable；
+- `providerDispatchId` 只提供 accounting 幂等，不是 transport 去重 key；调用方每次真实
+  transport 都必须使用新的 ID；
+- AgentHarness、Codex/Copilot host path、plugin Provider 和本地模型保持一致。
+
+### 4.3 LobsterAI managed config
+
+`openclawConfigSync.ts`：
+
+- 删除旧 `maxCumulativeEstimatedPromptTokensPerBudgetScope`；
+- 写入 `promptExposure: { mode: 'observe', legacyDiagnosticThreshold: 2_000_000 }`；
+- 保留 64、32 和 0.75；
+- 配置刷新不能改变 active scope 已冻结的 64/32、Prompt mode 或 diagnostic threshold；
+- sync 后验证生成配置不再含旧字段。
+
+OpenClaw config type/Zod patch：
+
+- 严格接受新的 `promptExposure` 结构；
+- 拒绝未知 mode、非正 safe diagnostic threshold 和遗留 hard-limit 字段；
+- 配置缺失时 bundled runtime 默认也必须是 observe-only，不能回退 2M hard stop。
+
+### 4.4 shared wire 与 Adapter
+
+`src/shared/cowork/runSafety.ts`：
+
+- 保留两个 legacy Prompt terminal kind；
+- 注释为 receive-only compatibility；
+- 保持 parser 对旧字段的严格验证；
+- 新增测试证明旧 payload 仍可解析。
+
+`runSafetyTermination.ts`、main i18n 和 Adapter：
+
+- 保留 legacy 文案与去重；
+- 新 runtime 正向测试不得走这两个分支；
+- Prompt diagnostic 不写 Cowork system message；
+- 不向 renderer 增加 Prompt countdown。
+
+### 4.5 patch manifest 与 runtime 检查
+
+`scripts/apply-openclaw-patches.cjs` 和 patch contract tests：
+
+- 删除“必须存在 2M hard gate”的断言；
+- 增加“不得存在 Prompt total `tryTerminate()`”的负向断言；
+- 增加 observe-only config schema、telemetry API 和 unavailable fail-open 的正向断言；
+- core、AgentHarness、delivery 和 native receipt 仍按 required manifest 原子应用；
+- clean `v2026.6.1` patch replay 后构建 runtime；
+- build info 写入 `count-hardcaps-prompt-observe-v1` 与 patch hash；
+- `OpenClawEngineManager` 在 spawn 前比较 app 期望与 build info；
+- bundled runtime 通过 targeted call-site 检查和 fake-provider 行为检查。
+
+### 4.6 P1 shadow collector（非 P0 交付项）
+
+P1 实现前必须先列出现有 typed artifact/state receipt seam，并另立 spec 决定模块边界、
+lane 存储上限、reservation-to-lane 绑定和 summary schema。若某类状态变化只能通过解析
+assistant 文本或猜测工具结果获得，则不得把它记录为 host-verified state change。
+
+### 4.7 上游 stable 升级
+
+后续目标是 OpenClaw `v2026.7.2` stable 或更新 stable tag，但升级不是本文 P0 的前置条件。
+
+升级步骤：
+
+1. 核对目标 tag 是否包含 `#112620` merge commit；
+2. 重新读取 `#97485`、`#110633`、`#114598` 的目标 head 与合并状态；
+3. 从 clean tag 回放 LobsterAI patches；
+4. 对冲突按能力矩阵决定去补丁，不手工修改 vendor 输出；
+5. 回放本次正常长任务、原始稳定结果事故、并发 subagent 和 legacy terminal；
+6. 确认只有一个 terminal owner 和一次用户交付；
+7. 再更新 `package.json` pinned version。
+
+## 5. 状态与边界处理
+
+| 场景 | Provider dispatch | Prompt telemetry | terminal / UI |
+| --- | --- | --- | --- |
+| legacy total 从 1.9M 跨到 2.1M，dispatch count < 32 | 允许 | 单调增加，threshold diagnostic 一次 | 无 terminal、无 UI |
+| 单次 Prompt estimate > 2M，但模型 precheck 允许 | 允许 | 记录该 estimate | 普通模型结果或普通 Provider error |
+| estimate 为 `NaN` / 抛错 | 允许，仍占 dispatch 槽 | unavailable +1 | 无 Prompt terminal |
+| provider 在 `onPayload` 前失败/取消 | 已预占并计数 | finally 记 unavailable | 普通 Provider error/cancel |
+| fallback 到新 Provider | 新占一个 dispatch 槽 | 按最终新 payload 重估 | 受 32 次硬边界 |
+| cache hit / cache miss | safety decision 相同 | raw estimate 与已有 usage 通道分开 | 不按 cache 返还 |
+| 第 32 次返回最终文本 | 已允许 | 正常记录 | 正常完成 |
+| 第 32 次返回 tool calls | response 已发生 | 正常记录 | 工具执行前提升 Provider budget terminal |
+| 第 33 次 dispatch | transport 前拒绝 | 不新增已发送 payload estimate | `run_provider_dispatch_budget` |
+| 第 64 个 raw tool | 获得 ticket | 不相关 | 写入 `run_tool_budget`，进入 draining |
+| 第 65 个及后续 raw tool | reservation 前拒绝 | 不相关 | 复用既有 `run_tool_budget` |
+| semantic detector critical | 不再继续 dispatch | scope summary 保留 | detector terminal |
+| external 新用户指令 | 新 scope | 新 scope total 从 0 开始 | 新 64/32 |
+| active steering / internal continue | 继承 scope | 继续原 total | 不重置 64/32 |
+| child 有噪声结果 | 按 root 扣减 | root total 增加 | 不刷新 parent shadow lane |
+| legacy Prompt terminal 入站 | 不继续旧 Run | 读取 legacy fields | 按历史原因展示一次 |
+| controller ended 后 late event | 拒绝复活 | 可记录 dropped-late 诊断 | 不重复交付 |
+| runtime/config capability 不匹配 | Gateway 不宣告 ready | 记录 mismatch | 提示重建/修复 runtime |
+
+## 6. 涉及文件
+
+### 6.1 P0 预计修改
+
+| 文件 | 变化 |
+| --- | --- |
+| `package.json` | 声明 host 期望的 `openclaw.runSafetyContract` |
+| `src/main/libs/openclawConfigSync.ts` | managed run-safety 改为 64/32 + Prompt observe |
+| `src/main/libs/openclawConfigSync.runtime.test.ts` | 锁定新配置，证明旧 hard-limit 字段消失 |
+| `src/main/main.ts` | 冻结“runtime 校验 → config 原子重写 → Gateway spawn”启动顺序 |
+| `src/main/libs/openclawEngineManager.ts` | pre-spawn 读取 build info 并拒绝 contract mismatch |
+| `src/main/libs/openclawEngineManager.test.ts` | runtime marker 缺失/错配/匹配回归 |
+| `src/shared/openclawEngine/constants.ts` | 增加集中式 `RuntimeContractMismatch` error code |
+| `src/main/i18n.ts` | 增加开发重建/正式修复所需的中英文错误文案 |
+| `scripts/build-openclaw-runtime.sh` | 把 contract ID 与 patch hash 写入 runtime build info |
+| `scripts/patches/v2026.6.1/openclaw-varying-args-no-progress-core.patch` | controller、config schema、Provider seam、telemetry 与 tests |
+| `scripts/patches/v2026.6.1/openclaw-z-agent-harness-run-safety.patch` | AgentHarness 使用 count reservation + Prompt observation |
+| `scripts/apply-openclaw-patches.cjs` | required manifest 和行为符号检查 |
+| `src/main/libs/openclawPatches/varyingArgsNoProgressCorePatch.test.ts` | 替换 2M hard-gate contract 断言 |
+| `src/main/libs/openclawPatches/agentHarnessRunSafetyPatch.test.ts` | estimator unavailable 和 >2M fail-open contract |
+| `src/shared/cowork/runSafety.ts` | 标记 legacy receive-only kind，保持 parser 兼容 |
+| `src/shared/cowork/runSafety.test.ts` | 历史 Prompt terminal 解析回归 |
+| `src/main/libs/agentEngine/runSafetyTermination.test.ts` | legacy 文案/metadata 回归 |
+| `src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts` | 旧 terminal 可接收、新 runtime 不产生 |
+
+### 6.2 P0 预计不改行为
+
+| 文件 | 原因 |
+| --- | --- |
+| `scripts/patches/v2026.6.1/openclaw-varying-args-no-progress-delivery.patch` | Prompt legacy terminal 仍可交付；新 runtime 不再生产 |
+| `scripts/patches/v2026.6.1/openclaw-varying-args-no-progress-native-receipt.patch` | 同上，保留旧事件兼容 |
+| `src/main/i18n.ts` | legacy Prompt 文案保留，不新增 Prompt warning |
+| renderer Cowork 组件 | P0 不增加 Prompt countdown 或自动继续按钮 |
+
+### 6.3 P1 可能新增
+
+P1 的具体文件边界必须在确认 OpenClaw typed state-change seam 后由独立 spec 决定。若最终
+需要修改 OpenClaw，仍以版本化 patch 交付，不直接修改 sibling checkout 或生成的
+`vendor/openclaw-runtime` 源文件。
+
+## 7. 发布与兼容策略
+
+### 7.1 P0：停止正常长任务误伤
+
+P0 必须一次性交付：
+
+- 64/32 两项 hard gate；
+- Prompt observe-only telemetry；
+- estimator unavailable fail-open；
+- legacy wire receive-only；
+- core + AgentHarness patch；
+- managed config；
+- patch manifest；
+- clean-tag replay、runtime build 和 Gateway restart。
+
+P0 不等待上游 stable 升级，也不等待 P1 shadow collector。
+
+### 7.2 P1：影子状态变化数据（不阻塞 P0）
+
+P1 在 P0 稳定后灰度：
+
+- 只采集低基数 lane/epoch/evidence 计数；
+- 不展示用户 warning；
+- 不影响 Run outcome；
+- 对正常长任务、原始事故、timestamp/PID churn、assistant 状态话术和并发 subagent 回放；
+- 至少观察一个发布周期；
+- 分开输出 host-verified state change、goal-bound checkpoint candidate 和 rejected activity 的
+  命中率、错误刷新率和漏报样本。
+
+没有完成上述评估前，不得把 shadow counter 改成 hard gate。
+
+### 7.3 P2：上游吸收
+
+- 只升级 stable tag；
+- `#112620` 可减少本地通用 churn patch 面；
+- `#97485` 最多增加 tool-round 维度；
+- `#110633` 合并后评估 terminal owner；
+- 32 Provider dispatch 在上游没有等价 pre-transport aggregate gate 前继续保留；
+- 64 raw tool 在上游 round budget 不能逐 call 约束时继续保留。
+
+### 7.4 兼容与回滚
+
+- 历史 Prompt terminal 继续可读；
+- 旧 config 字段不迁移为新含义；
+- 生成的 OpenClaw config 由 config sync 移除旧字段；
+- runtime/config 不匹配时不静默运行；
+- 回滚必须回滚完整 LobsterAI 包和 bundled runtime，不能只回滚 renderer/main；
+- 若 P0 出现 telemetry 问题，可关闭 diagnostic 日志，但不能通过远程配置恢复旧 2M hard
+  stop；
+- 若未来确需重新引入 Prompt hard boundary，必须用新的字段、明确的产品模式和独立 spec。
+
+## 8. 测试与验证计划
+
+所有行为测试使用 fake/stub Provider、本地 fixture 和 transport spy，不调用真实计费模型，也
+不需要账号凭据。
+
+### 8.1 P0 Prompt 误停回归
+
+1. fixture 生成连续 20 个不同 final payload 与不同工具结果，初始 estimate 约 150k，
+   legacy total > 2M、dispatch < 32、raw tools < 64：Run 正常完成。
+2. 回放 2026-07-27 三段现场：原先在第 16/15/14 个 reservation 被 Prompt gate 拒绝，
+   修改后均不产生 Prompt terminal。
+3. 单次 estimate > 2M 但 context precheck 为 `fits`：允许 transport。
+4. legacy total 恰好等于、刚超过和远超过 2M：都只记录一次 diagnostic。
+5. threshold crossing 后 `continuationClosedReason` 仍为空。
+6. `getWarnings()` 只含 tool/provider 两个维度。
+7. 新 runtime 的 termination producer 搜索不到 Prompt total `tryTerminate()`。
+
+### 8.2 Provider reservation 与 telemetry
+
+1. dispatch limit=2 时前两次成功，第三次 transport spy 保持 2。
+2. controller 对相同 `providerDispatchId` 的重复 reservation 不重复 count；相同 observation
+   幂等，冲突 observation 不覆盖首次状态。transport caller 的测试另行断言每次真实 retry
+   都创建新 ID。
+3. 每个 dispatch 只接受一次 immutable final-payload observation，不存在 refinement delta。
+4. `onPayload` 后的 failure、timeout、cancel、business error 不返还 dispatch 或 legacy
+   total；`onPayload` 前失败由 `finally` 记 unavailable。
+5. estimator 抛错、未知远程媒体且无 context window、serialization failure：transport 仍
+   执行，unavailable +1。
+6. 正常完成/错误/取消路径最终为 known 或 unavailable，不留 pending；模拟进程崩溃的
+   snapshot 用 `pendingObservationDispatchCount` 如实表达不完整。
+7. concurrent requests 在 Prompt total 跨 2M 时均可继续；只剩一个 dispatch 槽时只有一个
+   成功。
+8. 在相同剩余硬预算的独立 scope 中，cache hit/miss 不影响 Prompt gate；同 scope 的真实
+   retry 仍额外消耗 dispatch。
+9. fallback 按最终新 payload observation；已有 actual cache usage 通道不写入 legacy
+   total。
+10. `stable_text_tokens` 保持当前 CJK-aware chars-to-token 算法；
+    `context_window_floor` 保持显式 source，不改成 byte estimator。
+11. saturating add 不溢出，不触发 terminal。
+
+### 8.3 其它 hard gate 不回归
+
+1. 已使用 63 槽时提交三项并行 batch：第 64 项获准并立即进入 draining，第 65/66 项在
+   副作用前拒绝。
+2. 第 33 次 Provider dispatch 在 transport 前拒绝。
+3. retry、fallback、compaction、summary、recovery、subagent 和 AgentHarness 共享 root
+   controller。
+4. 两个 child 竞争最后一个 dispatch 槽时最多一个成功。
+5. root 先结束、child 后命中 terminal 时只交付一次。
+6. ended controller 的 late event 不复活。
+7. `run_budget_identity_missing` 和 `run_safety_state_unavailable` 继续 fail-closed。
+8. 未实现 Provider V1 seam 的 adapter 在插件或 transport 前拒绝。
+
+### 8.4 semantic detector 事故回放
+
+1. 原始 `N=80/100/120` stable-result fixture 仍在第三个结果后
+   `variant_no_progress` critical。
+2. `N=150` 不执行。
+3. 41 个参数、`historySize=40` 的回放不依赖 exact args 重复。
+4. 普通 15 参数批处理、不同 URL/path/query 和变化结果不误判。
+5. 上游 `#112620` 与本地 detector/terminal owner 三种组合都只有一个 terminal。
+
+### 8.5 legacy wire 与产品交付
+
+1. `run_prompt_exposure_budget` 旧 payload 仍能解析、格式化、去重和交付一次。
+2. `run_prompt_estimate_unavailable` 同上。
+3. 新 runtime 正向执行永不 emit 两种 Prompt terminal。
+4. Prompt threshold diagnostic 不写 Cowork message、IM reply 或 Desktop notification。
+5. tool/provider/semantic terminal 的中英文文案不回归。
+6. “继续处理”入口若实现，不自动调用 `chat.send`；只有用户提交才创建新 scope。
+
+### 8.6 P1 shadow state-change 建议测试（不阻塞 P0）
+
+1. assistant 每轮输出“仍在处理”后继续调用工具：不产生 host-verified state change。
+2. result 每轮只变化时间戳、PID、随机 ID、cursor 或进度条：不产生 host-verified state
+   change。
+3. tool start、普通 `success=true`、retry、fallback、compaction 和 cache activity 不刷新
+   epoch。
+4. host-verified artifact revision 只刷新当前 lane 的 shadow epoch，且
+   `goalRelevance=unknown`。
+5. child 普通新结果不能刷新 parent/sibling。
+6. child completion receipt 只上报 parent candidate。
+7. root 64/32 始终不随 epoch 重置。
+8. shadow counter 达到任意值都不产生 terminal 或用户 warning。
+
+### 8.7 配置、patch 与 bundled runtime
+
+1. generated config 含 64、32、0.75 和 Prompt observe 结构。
+2. generated config 不含旧 `maxCumulativeEstimatedPromptTokensPerBudgetScope`。
+3. clean `v2026.6.1` 完整 patch manifest 可应用。
+4. core 与 AgentHarness 使用相同 Prompt observe 语义。
+5. runtime build info 含匹配的 pinned version、patch hash 与
+   `count-hardcaps-prompt-observe-v1`。
+6. build cache 的 version + patch hash 相同但 contract ID 缺失/错配时仍强制重建。
+7. marker 缺失或错配时 `OpenClawEngineManager` 在 spawn 前返回
+   `RuntimeContractMismatch`。
+8. fixture 从含 legacy 字段的旧 config 启动时，先原子重写新 config，再启动新 Gateway；
+   新 schema 不会先解析旧文件。
+9. config 生成/rename 失败时不 spawn Gateway，原文件可恢复。
+10. targeted call-site probe 证明 Prompt hard producer 不存在、64/32 gate 存在。
+
+建议验证命令：
+
+```bash
+npm test -- src/main/libs/openclawPatches/varyingArgsNoProgressCorePatch.test.ts
+npm test -- src/main/libs/openclawPatches/agentHarnessRunSafetyPatch.test.ts
+npm test -- src/main/libs/openclawConfigSync.runtime.test.ts
+npm test -- src/main/libs/openclawEngineManager.test.ts
+npm test -- src/shared/cowork/runSafety.test.ts
+npm test -- src/main/libs/agentEngine/runSafetyTermination.test.ts
+npm test -- src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+npm run compile:electron
+```
+
+实现完成后还必须：
+
+- 对所有 touched TypeScript 文件运行 changed-file ESLint；
+- 运行官方 `npm test`；
+- 从 clean pinned tag 回放 patches；
+- 构建当前平台 OpenClaw runtime；
+- 启动 Gateway；
+- 用 fake Provider 完成三类现场 E2E；
+- 发布前在 Windows 与至少一个 native IM 渠道验证真实 bundled runtime。
+
+## 9. 验收标准
+
+### 9.1 P0 行为验收
+
+- [ ] 当前 checkout 的 hard budget 明确为 64 raw tool / 32 Provider dispatch，不写成
+      100/32。
+- [ ] 不同 final payload 的 deterministic fixture 在 legacy Prompt exposure total 超过 2M
+      后继续执行。
+- [ ] 新 runtime 不产生 `run_prompt_exposure_budget`。
+- [ ] estimator 不可用时不产生 `run_prompt_estimate_unavailable`，但 dispatch 仍计入 32。
+- [ ] legacy exposure total 单调记录；正常退出时 known/unavailable 状态完整，崩溃
+      snapshot 可显式记录 pending。
+- [ ] 2M threshold 只记录一次内部 diagnostic，不进入 warning、terminal 或 UI。
+- [ ] 第 33 次 Provider dispatch 仍在 transport 前拒绝。
+- [ ] 第 64 个 raw tool 获准后立即进入 draining，第 65 个及后续在副作用前拒绝。
+- [ ] retry、fallback、compaction、recovery 和 subagent 不能重置 64/32。
+- [ ] 新外部用户指令创建新 scope；系统内部自动 continue 不创建。
+
+### 9.2 事故与 detector 验收
+
+- [ ] 2026-07-27 三段正常 Run 回放不再因 2M 停止。
+- [ ] 2026-07-20 stable-result 参数循环仍在第三个相同结果后停止。
+- [ ] `N=150` 不执行，不重新出现 200+ 工具调用。
+
+### 9.3 兼容与交付验收
+
+- [ ] 两种 legacy Prompt terminal 仍可解析和展示一次。
+- [ ] Prompt diagnostic 不产生用户可见安全消息。
+- [ ] tool/provider/semantic terminal 的唯一 owner、一次 delivery 和 lifecycle 收口不回归。
+- [ ] generated config 与 bundled runtime 使用同一 observe-only policy。
+- [ ] runtime contract marker 在 Gateway spawn 前校验；旧 config 先原子重写再交给新 schema。
+- [ ] clean-tag patch replay、runtime build、Gateway startup 和 fake-provider E2E 通过。
+- [ ] 当前平台自动化通过；Windows 与 native IM E2E 在发布前补齐。
+
+### 9.4 产品口径验收
+
+- [ ] UI、日志说明和发布说明不把 raw Prompt estimate 描述为精确积分或账单。
+- [ ] 不把 context cache 描述为必然命中或免费。
+- [ ] 不展示 Prompt exposure 75% 倒计时。
+- [ ] 如展示 hard budget 进度，只展示 raw tool / Provider dispatch 的真实计数。
+- [ ] “继续处理”不能静默续命，必须由用户提交新的外部指令。
+- [ ] 不宣称上游 iteration budget 已替代本地 64/32。
+
+### 9.5 P1 后续验收方向（不阻塞 P0）
+
+- [ ] 时间戳、PID、随机结果和 assistant 状态话术不会被记录为 host-verified state change。
+- [ ] artifact/state receipt 即使由 host 验证，仍显式标记 `goalRelevance=unknown`。
+- [ ] subagent 噪声不能刷新 root 或 sibling lane。
+- [ ] reservation-to-lane 绑定、active lane 上限和 summary 大小上限由独立 spec 验证。
+- [ ] 任意 shadow counter 都不影响 terminal、warning 或 64/32。
+
+## 10. 风险与后续项
+
+### 10.1 移除 2M hard stop 后的最坏暴露上界
+
+Prompt total 不再硬停后，通用最坏 raw exposure 上界近似：
+
+```text
+32 × 单次 Provider-visible Prompt
+```
+
+对 1M context 模型理论上可接近 32M raw exposure。它不是精确账单，但说明 32 次 Provider
+dispatch 是不可重置的关键硬帽。本文不能在取消 2M 的同时放宽或移除 32。
+
+### 10.2 estimator fail-open 的观测不完整
+
+Prompt estimator 不可用时允许 transport，会导致 raw exposure summary 不完整。必须通过
+unavailable count、reason 分类和 Provider dispatch hard cap 明确表达，而不是写入 0
+伪装完整。
+
+### 10.3 context cache 误读
+
+缓存可能降低重复前缀的实际 input 成本，也可能因 payload、Provider、TTL、fallback 或配置
+变化失效。Prompt telemetry 与 cache usage 必须分栏；任何安全决定都不能依赖“预计会命中
+缓存”。
+
+### 10.4 progress oracle 误判与逃逸
+
+即使 host 能确认 artifact 或状态变化，也不一定能证明它与用户目标相关。P1 只做 shadow，
+未来启用 hard stagnation guard 前必须评估：
+
+- 正常任务错误停滞率；
+- 噪声结果错误刷新率；
+- 模型刻意制造低价值 artifact 的逃逸率；
+- parent/child lane 传播准确性；
+- 不同 Provider 和工具类型的覆盖率。
+
+### 10.5 runtime/config 版本错配
+
+旧 runtime 在缺失旧字段时默认回退 2M。任何只更新 main/config、未更新 bundled runtime 的
+产物都仍会误停。原子 patch、runtime rebuild、Gateway restart 和行为探针是发布硬门禁。
+
+### 10.6 legacy kind 长期维护
+
+两个 Prompt terminal kind 在新 runtime 中不再产生，但持久化消息和旧版本事件仍可能长期
+存在。删除 wire kind 必须等到：
+
+- 支持窗口内版本均不再产生；
+- 数据迁移策略明确；
+- 历史导入/导出兼容测试完成。
+
+### 10.7 上游 PR 漂移
+
+Open PR 的配置名、summary 行为、hard cap 和合并状态都可能变化。后续升级必须读取目标 tag
+源码，不能引用本文快照直接删除本地保护。
+
+### 10.8 服务器侧账单边界仍独立
+
+客户端 64/32 只能限制可观察的自动运行，不是账号级积分上限。若产品需要精确金额保护，
+仍需服务端按账号、runId/providerDispatchId、模型倍率和真实账本建立独立幂等与额度策略。
+该工作不应复用 Prompt estimate 作为精确金额。
+
+## 11. 与既有设计的关系
+
+### 11.1 对 2026-07-22 文档的取代范围
+
+本文取代：
+
+- FR-12.1 中 2,000,000 Prompt hard limit 和 Prompt 75% warning；
+- FR-12.3 中 Prompt exposure 作为统一 gate 的部分；
+- FR-12.4 中 estimator 不可用 fail-closed、Prompt total 超限 reservation；
+- FR-12.5 中两种 Prompt terminal 的新生产路径；
+- 7.4 中“三项预算均作为用户可见硬边界”的表述；
+- 8.5 中 Prompt exact-limit、超限阻断和 estimator fail-closed 测试；
+- 9.1、9.4 中累计 Prompt 不超过阈值的验收；
+- 10.3、10.4、10.7 中把 2M 作为合法长任务硬帽的风险处理。
+
+本文不取代：
+
+- FR-1～FR-11；
+- 64 raw tool reservation；
+- 32 Provider dispatch；
+- `budgetScopeId` 生命周期；
+- Provider V1 pre-transport seam；
+- semantic detector 和 critical termination；
+- history sanitizer；
+- native stop 与 terminal delivery；
+- 上游 capability detection 和去补丁门禁。
+
+旧文档保留为历史设计，不回写状态或删除原始决策。
+
+### 11.2 相邻本地设计
+
+- `openclaw-critical-tool-loop-termination`：继续负责 detector critical 后终止 Run。
+- `openclaw-aborted-tool-loop-token-burn`：继续负责 aborted outcome 循环。
+- `openclaw-oversized-transcript-oom`：处理 transcript 物理体积和 Gateway OOM，不由本文的
+  Prompt telemetry 替代。
+- `cowork-context-compaction`：处理模型上下文收缩与质量，不以成本名义强制在 2M 时触发。
+
+### 11.3 上游能力
+
+- `#112620`：通用低基数 argument churn 与 semantic liveness 信号。
+- `#97485`：可选 tool-calling round hard limit；当前不能替代 raw tool/provider dispatch。
+- `#114598`：有绝对帽的 sliding timeout；只作为进度窗口设计参考。
+- `#110633`：未来可能接管 critical terminal owner。
+
+本文的长期方向是减少 LobsterAI 自维护 patch，但任何上游吸收都必须以目标 stable tag 的
+源码、clean-tag 回放和现场行为测试为准。

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -63,6 +63,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
       '本地未能可靠建立本次任务的安全预算标识，已在调用模型前停止。请通过一条新指令重试。',
     runSafetyStateUnavailable:
       '本地安全状态暂时不可用，已在调用模型前停止。请稍后通过一条新指令重试。',
+    openClawRuntimeContractMismatchDev:
+      '本地 AI 引擎组件与当前应用不匹配（需要 OpenClaw {expectedVersion}，安全契约 {expectedContract}）。请运行 npm run openclaw:runtime:host 重新构建后重试。',
+    openClawRuntimeContractMismatchPackaged:
+      '本地 AI 引擎组件与当前应用版本不匹配，已阻止启动以避免使用错误的安全策略。请使用“快速修复”重试；若仍失败，请重新安装当前版本。',
+    openClawRuntimeConfigMismatch:
+      '本地 AI 引擎配置尚未按当前安全策略完整生成，已阻止启动。请使用“快速修复”重新生成配置后重试。',
 
     // Thinking-only hint
     taskThinkingOnly:
@@ -398,6 +404,12 @@ const translations: Record<LanguageType, Record<string, string>> = {
       'The local runtime could not reliably establish this task’s safety-budget identity, so it stopped before calling the model. Retry with a new instruction.',
     runSafetyStateUnavailable:
       'The local safety state is temporarily unavailable, so the task stopped before calling the model. Retry later with a new instruction.',
+    openClawRuntimeContractMismatchDev:
+      'The local AI runtime does not match this app (expected OpenClaw {expectedVersion}, safety contract {expectedContract}). Run npm run openclaw:runtime:host to rebuild it, then retry.',
+    openClawRuntimeContractMismatchPackaged:
+      'The local AI runtime does not match this app version. Startup was blocked to avoid using the wrong safety policy. Try Quick Repair; if the issue persists, reinstall this version.',
+    openClawRuntimeConfigMismatch:
+      'The local AI runtime configuration was not fully generated with the current safety policy, so startup was blocked. Use Quick Repair to regenerate the configuration, then retry.',
 
     // OAuth flow messages
     qwenOAuthRequestingDeviceCode: 'Requesting device authorization code...',

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -4692,7 +4692,7 @@ test('an unscoped channel safety terminal without an envelope run id is rejected
   );
 });
 
-test('run-safety terminal cancels pending recovery timers without retry or error fallback', async () => {
+test('legacy receive-only prompt exposure terminal cancels recovery without retry', async () => {
   vi.useFakeTimers();
   try {
     const { adapter, session, sessionKey, turn } = createRunSafetyAdapter();
@@ -4737,7 +4737,7 @@ test('run-safety terminal cancels pending recovery timers without retry or error
   }
 });
 
-test('persisted safety metadata deduplicates a replay after adapter restart', () => {
+test('persisted legacy prompt-estimate terminal deduplicates after adapter restart', () => {
   const terminationReason = createRunSafetyTermination(
     RunSafetyTerminationKind.RunPromptEstimateUnavailable,
   );

--- a/src/main/libs/agentEngine/runSafetyTermination.test.ts
+++ b/src/main/libs/agentEngine/runSafetyTermination.test.ts
@@ -41,3 +41,16 @@ test.each(['zh', 'en'] as const)(
     }
   },
 );
+
+test.each([
+  RunSafetyTerminationKind.RunPromptExposureBudget,
+  RunSafetyTerminationKind.RunPromptEstimateUnavailable,
+])('legacy receive-only prompt terminal %s keeps its localized message', (kind) => {
+  const messages = (['zh', 'en'] as const).map((language) => {
+    setLanguage(language);
+    return formatRunSafetyTerminationMessage(createTermination(kind));
+  });
+
+  expect(messages.every(message => message.trim().length > 0)).toBe(true);
+  expect(messages[0]).not.toBe(messages[1]);
+});

--- a/src/main/libs/enterpriseConfigSync.test.ts
+++ b/src/main/libs/enterpriseConfigSync.test.ts
@@ -791,6 +791,60 @@ describe('enterpriseConfigSync', () => {
     });
   });
 
+  test('mergeOpenClawConfigs keeps LobsterAI ownership of run safety', async () => {
+    const mod = await import('./enterpriseConfigSync');
+    const merged = mod.mergeOpenClawConfigs(
+      {
+        agents: {
+          defaults: {
+            sandbox: { mode: 'off' },
+            runSafety: {
+              maxToolCallReservationsPerBudgetScope: 64,
+              maxProviderDispatchesPerBudgetScope: 32,
+              warningRatio: 0.75,
+              promptExposure: {
+                mode: 'observe',
+                legacyDiagnosticThreshold: 2_000_000,
+              },
+            },
+          },
+        },
+      },
+      {
+        agents: {
+          defaults: {
+            cwd: '/enterprise/workspace',
+            runSafety: {
+              maxToolCallReservationsPerBudgetScope: 1,
+              maxProviderDispatchesPerBudgetScope: 1,
+              maxCumulativeEstimatedPromptTokensPerBudgetScope: 1,
+              warningRatio: 0.1,
+            },
+          },
+        },
+      },
+    );
+
+    expect(merged.agents).toMatchObject({
+      defaults: {
+        sandbox: { mode: 'off' },
+        cwd: '/enterprise/workspace',
+        runSafety: {
+          maxToolCallReservationsPerBudgetScope: 64,
+          maxProviderDispatchesPerBudgetScope: 32,
+          warningRatio: 0.75,
+          promptExposure: {
+            mode: 'observe',
+            legacyDiagnosticThreshold: 2_000_000,
+          },
+        },
+      },
+    });
+    expect(
+      ((merged.agents as Record<string, unknown>).defaults as Record<string, unknown>).runSafety,
+    ).not.toHaveProperty('maxCumulativeEstimatedPromptTokensPerBudgetScope');
+  });
+
   test('mergeEnterpriseOpenclawConfig does not inject enterprise plugins source path automatically', async () => {
     const enterpriseDir = path.join(electronPaths.userData, 'enterprise-config');
     const pluginsDir = path.join(enterpriseDir, 'plugins', 'enterprise-test-plugin');
@@ -826,6 +880,7 @@ describe('enterpriseConfigSync', () => {
     );
 
     const mod = await import('./enterpriseConfigSync');
+    const renameSpy = vi.spyOn(fs, 'renameSync');
     mod.mergeEnterpriseOpenclawConfig(runtimeConfigPath);
 
     const merged = JSON.parse(fs.readFileSync(runtimeConfigPath, 'utf-8'));
@@ -839,6 +894,10 @@ describe('enterpriseConfigSync', () => {
         },
       },
     });
+    expect(renameSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/runtime-openclaw\.json\.tmp-\d+-\d+$/),
+      runtimeConfigPath,
+    );
   });
 
   test('mergeOpenClawConfigs overwrites feishu accounts with top-level enterprise fields', async () => {

--- a/src/main/libs/enterpriseConfigSync.ts
+++ b/src/main/libs/enterpriseConfigSync.ts
@@ -5,6 +5,10 @@ import path from 'path';
 import type { IMStore } from '../im/imStore';
 import type { PopoInstanceConfig } from '../im/types';
 import type { SqliteStore } from '../sqliteStore';
+import {
+  applyManagedOpenClawRunSafety,
+  hasManagedOpenClawRunSafety,
+} from './openclawRunSafetyPolicy';
 
 export type EnterpriseUIAction = 'hide' | 'disable' | 'readonly';
 
@@ -1085,9 +1089,23 @@ export function mergeOpenClawConfigs(
     normalizedEnterpriseConfig.channels = normalizedChannels;
   }
 
-  const merged = stripMergedChannelTopLevelAccountCredentialFields(
+  let merged = stripMergedChannelTopLevelAccountCredentialFields(
     deepMerge(runtimeConfig, normalizedEnterpriseConfig),
   );
+  const runtimeAgents = isRecord(runtimeConfig.agents) ? runtimeConfig.agents : null;
+  const runtimeDefaults = isRecord(runtimeAgents?.defaults) ? runtimeAgents.defaults : null;
+  const enterpriseAgents = isRecord(enterpriseConfig.agents) ? enterpriseConfig.agents : null;
+  const enterpriseDefaults = isRecord(enterpriseAgents?.defaults) ? enterpriseAgents.defaults : null;
+  const runtimeRunSafety = runtimeDefaults?.runSafety;
+  const enterpriseRunSafety = enterpriseDefaults?.runSafety;
+  if (runtimeRunSafety !== undefined || enterpriseRunSafety !== undefined) {
+    if (runtimeRunSafety !== undefined && !hasManagedOpenClawRunSafety(runtimeConfig)) {
+      console.warn(
+        '[Enterprise] runtime runSafety policy was not managed; replacing it with the LobsterAI policy',
+      );
+    }
+    merged = applyManagedOpenClawRunSafety(merged);
+  }
 
   const mergedPluginLoadPaths = Array.from(new Set([
     ...readPluginLoadPaths(runtimeConfig),
@@ -1134,7 +1152,13 @@ export function mergeEnterpriseOpenclawConfig(runtimeConfigPath: string): void {
     const enterpriseConfig = JSON.parse(enterpriseRaw) as Record<string, unknown>;
 
     const merged = mergeOpenClawConfigs(runtimeConfig, enterpriseConfig);
-    fs.writeFileSync(runtimeConfigPath, JSON.stringify(merged, null, 2), 'utf-8');
+    const tmpPath = `${runtimeConfigPath}.tmp-${process.pid}-${Date.now()}`;
+    try {
+      fs.writeFileSync(tmpPath, `${JSON.stringify(merged, null, 2)}\n`, 'utf-8');
+      fs.renameSync(tmpPath, runtimeConfigPath);
+    } finally {
+      fs.rmSync(tmpPath, { force: true });
+    }
     console.log('[Enterprise] merged enterprise openclaw.json into runtime config');
   } catch (error) {
     console.error('[Enterprise] failed to merge enterprise openclaw.json:', error);

--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -2653,6 +2653,20 @@ describe('OpenClawConfigSync runtime config output', () => {
   test('enables managed OpenClaw run safety and tool loop detection', async () => {
     const sync = await createSync();
 
+    fs.writeFileSync(configPath, JSON.stringify({
+      gateway: { mode: 'local' },
+      agents: {
+        defaults: {
+          runSafety: {
+            maxToolCallReservationsPerBudgetScope: 64,
+            maxProviderDispatchesPerBudgetScope: 32,
+            maxCumulativeEstimatedPromptTokensPerBudgetScope: 2_000_000,
+            warningRatio: 0.75,
+          },
+        },
+      },
+    }, null, 2));
+
     const result = sync.sync('tool-loop-detection');
     expect(result.ok).toBe(true);
 
@@ -2660,9 +2674,15 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(config.agents.defaults.runSafety).toEqual({
       maxToolCallReservationsPerBudgetScope: 64,
       maxProviderDispatchesPerBudgetScope: 32,
-      maxCumulativeEstimatedPromptTokensPerBudgetScope: 2_000_000,
       warningRatio: 0.75,
+      promptExposure: {
+        mode: 'observe',
+        legacyDiagnosticThreshold: 2_000_000,
+      },
     });
+    expect(config.agents.defaults.runSafety).not.toHaveProperty(
+      'maxCumulativeEstimatedPromptTokensPerBudgetScope',
+    );
     expect(config.tools.loopDetection).toEqual({
       enabled: true,
       historySize: 40,
@@ -2679,6 +2699,38 @@ describe('OpenClawConfigSync runtime config output', () => {
         variantNoProgress: true,
       },
     });
+  });
+
+  test('writes managed run safety in the fresh-install minimal config', async () => {
+    mockRuntimeState.rawApiConfig = {
+      config: null,
+      providerMetadata: undefined,
+    } as never;
+    const sync = await createSync();
+
+    const result = sync.sync('fresh-install-run-safety');
+    expect(result.ok).toBe(true);
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config).toMatchObject({
+      gateway: { mode: 'local' },
+      agents: {
+        defaults: {
+          runSafety: {
+            maxToolCallReservationsPerBudgetScope: 64,
+            maxProviderDispatchesPerBudgetScope: 32,
+            warningRatio: 0.75,
+            promptExposure: {
+              mode: 'observe',
+              legacyDiagnosticThreshold: 2_000_000,
+            },
+          },
+        },
+      },
+    });
+    expect(config.agents.defaults.runSafety).not.toHaveProperty(
+      'maxCumulativeEstimatedPromptTokensPerBudgetScope',
+    );
   });
 
   test('writes browser and web fetch access settings', async () => {

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -61,6 +61,9 @@ import type { OpenClawEngineManager } from './openclawEngineManager';
 import { repairHeartbeatFile, stripProactiveHeartbeatSection } from './openclawHeartbeatRepair';
 import { getMainAgentWorkspacePath } from './openclawMemoryFile';
 import { resolveOpenClawCatalogModelMaxTokens } from './openclawModelCatalog';
+import {
+  cloneManagedOpenClawRunSafety,
+} from './openclawRunSafetyPolicy';
 
 const gwDiagTs = (): string => {
   const d = new Date();
@@ -286,12 +289,6 @@ const MANAGED_OWNER_ALLOW_FROM = [
 ];
 
 const MANAGED_TOOL_DENY = ['web_search'] as const;
-const MANAGED_RUN_SAFETY = {
-  maxToolCallReservationsPerBudgetScope: 64,
-  maxProviderDispatchesPerBudgetScope: 32,
-  maxCumulativeEstimatedPromptTokensPerBudgetScope: 2_000_000,
-  warningRatio: 0.75,
-} as const;
 const MANAGED_TOOL_LOOP_DETECTION = {
   enabled: true,
   historySize: 40,
@@ -2259,7 +2256,7 @@ export class OpenClawConfigSync {
       agents: {
         defaults: {
           timeoutSeconds: OPENCLAW_AGENT_TIMEOUT_SECONDS,
-          runSafety: MANAGED_RUN_SAFETY,
+          runSafety: cloneManagedOpenClawRunSafety(),
           model: {
             primary: primaryModel,
           },
@@ -3884,6 +3881,11 @@ export class OpenClawConfigSync {
     const baseMinimalConfig: Record<string, unknown> = {
       gateway: {
         mode: 'local',
+      },
+      agents: {
+        defaults: {
+          runSafety: cloneManagedOpenClawRunSafety(),
+        },
       },
       // Don't enable plugins in minimal config — plugin loading via jiti happens
       // synchronously BEFORE the HTTP server binds, and can block gateway startup

--- a/src/main/libs/openclawEngineManager.test.ts
+++ b/src/main/libs/openclawEngineManager.test.ts
@@ -1,9 +1,24 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { describe, expect, test, vi } from 'vitest';
+
+const engineTestPaths = vi.hoisted(() => ({
+  appPath: process.cwd(),
+  userData: process.cwd(),
+}));
+const engineMaintenanceMocks = vi.hoisted(() => ({
+  cleanupStaleThirdPartyPluginsFromBundledDir: vi.fn(() => [] as string[]),
+  listLocalOpenClawExtensionIds: vi.fn(() => [] as string[]),
+  syncLocalOpenClawExtensionsIntoRuntime: vi.fn(() => ({
+    copied: [] as string[],
+  })),
+}));
 
 vi.mock('electron', () => ({
   app: {
-    getAppPath: () => process.cwd(),
-    getPath: () => process.cwd(),
+    getAppPath: () => engineTestPaths.appPath,
+    getPath: () => engineTestPaths.userData,
     isPackaged: false,
   },
   utilityProcess: {
@@ -11,12 +26,22 @@ vi.mock('electron', () => ({
   },
 }));
 
+vi.mock('./openclawLocalExtensions', () => engineMaintenanceMocks);
+
+import { OpenClawEngineErrorCode } from '../../shared/openclawEngine/constants';
 import {
   buildOpenClawCompileCacheEnv,
   buildOpenClawGatewayExecArgv,
   isOpenClawConfigStartupFailure,
   isOpenClawGatewayHeapOutOfMemory,
+  OpenClawEngineManager,
 } from './openclawEngineManager';
+import {
+  OpenClawManagedConfigFailureReason,
+  OpenClawRuntimeContractFailureReason,
+  validateOpenClawManagedConfig,
+  validateOpenClawRuntimeContract,
+} from './openclawRuntimeContract';
 
 describe('buildOpenClawCompileCacheEnv', () => {
   test('prevents the packaged launcher from respawning Electron Helper', () => {
@@ -42,6 +67,284 @@ describe('buildOpenClawGatewayExecArgv', () => {
 
   test('respects an existing max old space setting with space syntax', () => {
     expect(buildOpenClawGatewayExecArgv('--max-old-space-size 8192 --trace-warnings')).toEqual([]);
+  });
+});
+
+describe('validateOpenClawRuntimeContract', () => {
+  const expected = {
+    openclawVersion: 'v2026.6.1',
+    runSafetyContract: 'count-hardcaps-prompt-observe-v1',
+  };
+
+  test('accepts a matching pinned version and run-safety contract', () => {
+    expect(validateOpenClawRuntimeContract(expected, {
+      ...expected,
+      patchHash: 'patch-hash',
+    })).toEqual({
+      ok: true,
+      expected,
+      actual: expected,
+    });
+  });
+
+  test('fails closed when runtime build info has no contract marker', () => {
+    expect(validateOpenClawRuntimeContract(expected, {
+      openclawVersion: expected.openclawVersion,
+    })).toMatchObject({
+      ok: false,
+      reason: OpenClawRuntimeContractFailureReason.RuntimeBuildInfoMissing,
+      expected,
+      actual: null,
+    });
+  });
+
+  test('fails closed when the pinned OpenClaw version differs', () => {
+    expect(validateOpenClawRuntimeContract(expected, {
+      openclawVersion: 'v2026.7.2',
+      runSafetyContract: expected.runSafetyContract,
+    })).toMatchObject({
+      ok: false,
+      reason: OpenClawRuntimeContractFailureReason.OpenClawVersionMismatch,
+    });
+  });
+
+  test('fails closed when the run-safety contract differs', () => {
+    expect(validateOpenClawRuntimeContract(expected, {
+      openclawVersion: expected.openclawVersion,
+      runSafetyContract: 'legacy-prompt-hard-stop-v1',
+    })).toMatchObject({
+      ok: false,
+      reason: OpenClawRuntimeContractFailureReason.RunSafetyContractMismatch,
+    });
+  });
+});
+
+describe('OpenClawEngineManager runtime contract gate', () => {
+  test('stops a tracked gateway before returning a contract mismatch', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-runtime-gate-'));
+    const appPath = path.join(tmpDir, 'app');
+    const userData = path.join(tmpDir, 'user-data');
+    const runtimeRoot = path.join(appPath, 'vendor', 'openclaw-runtime', 'current');
+    fs.mkdirSync(runtimeRoot, { recursive: true });
+    fs.writeFileSync(path.join(appPath, 'package.json'), JSON.stringify({
+      openclaw: {
+        version: 'v2026.6.1',
+        runSafetyContract: 'count-hardcaps-prompt-observe-v1',
+        plugins: [],
+      },
+    }));
+    fs.writeFileSync(path.join(runtimeRoot, 'package.json'), JSON.stringify({
+      version: '2026.6.1',
+    }));
+    fs.writeFileSync(path.join(runtimeRoot, 'runtime-build-info.json'), JSON.stringify({
+      openclawVersion: 'v2026.6.1',
+      runSafetyContract: 'legacy-prompt-hard-stop-v1',
+    }));
+
+    const previousAppPath = engineTestPaths.appPath;
+    const previousUserData = engineTestPaths.userData;
+    let restartTimer: NodeJS.Timeout | null = null;
+    engineTestPaths.appPath = appPath;
+    engineTestPaths.userData = userData;
+    try {
+      const manager = new OpenClawEngineManager();
+      type TestGatewayProcess = { pid: number; exitCode: number | null };
+      type TestableManager = {
+        gatewayProcess: TestGatewayProcess | null;
+        gatewayRestartTimer: NodeJS.Timeout | null;
+        stopGatewayProcess: (process: TestGatewayProcess) => Promise<void>;
+      };
+      const testableManager = manager as unknown as TestableManager;
+      const gatewayProcess = { pid: 123, exitCode: null };
+      testableManager.gatewayProcess = gatewayProcess;
+      restartTimer = setTimeout(() => undefined, 60_000);
+      testableManager.gatewayRestartTimer = restartTimer;
+      const stopSpy = vi
+        .spyOn(testableManager, 'stopGatewayProcess')
+        .mockResolvedValue();
+
+      const status = await manager.ensureReady();
+
+      expect(stopSpy).toHaveBeenCalledWith(gatewayProcess);
+      expect(testableManager.gatewayProcess).toBeNull();
+      expect(testableManager.gatewayRestartTimer).toBeNull();
+      expect(status).toMatchObject({
+        phase: 'error',
+        errorCode: OpenClawEngineErrorCode.RuntimeContractMismatch,
+        canRetry: true,
+      });
+    } finally {
+      if (restartTimer) clearTimeout(restartTimer);
+      engineTestPaths.appPath = previousAppPath;
+      engineTestPaths.userData = previousUserData;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('stops a tracked gateway when the runtime root is missing', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-missing-runtime-gate-'));
+    const appPath = path.join(tmpDir, 'app');
+    const userData = path.join(tmpDir, 'user-data');
+    fs.mkdirSync(appPath, { recursive: true });
+
+    const previousAppPath = engineTestPaths.appPath;
+    const previousUserData = engineTestPaths.userData;
+    const realExistsSync = fs.existsSync.bind(fs);
+    const existsSpy = vi.spyOn(fs, 'existsSync').mockImplementation((candidate) => {
+      if (
+        String(candidate).includes(
+          path.join('vendor', 'openclaw-runtime', 'current'),
+        )
+      ) {
+        return false;
+      }
+      return realExistsSync(candidate);
+    });
+    let restartTimer: NodeJS.Timeout | null = null;
+    engineTestPaths.appPath = appPath;
+    engineTestPaths.userData = userData;
+    try {
+      const manager = new OpenClawEngineManager();
+      type TestGatewayProcess = { pid: number; exitCode: number | null };
+      type TestableManager = {
+        gatewayProcess: TestGatewayProcess | null;
+        gatewayRestartTimer: NodeJS.Timeout | null;
+        stopGatewayProcess: (process: TestGatewayProcess) => Promise<void>;
+      };
+      const testableManager = manager as unknown as TestableManager;
+      const gatewayProcess = { pid: 456, exitCode: null };
+      testableManager.gatewayProcess = gatewayProcess;
+      restartTimer = setTimeout(() => undefined, 60_000);
+      testableManager.gatewayRestartTimer = restartTimer;
+      const stopSpy = vi
+        .spyOn(testableManager, 'stopGatewayProcess')
+        .mockResolvedValue();
+
+      const status = await manager.validateRuntimeContractGate();
+
+      expect(stopSpy).toHaveBeenCalledWith(gatewayProcess);
+      expect(testableManager.gatewayProcess).toBeNull();
+      expect(testableManager.gatewayRestartTimer).toBeNull();
+      expect(status).toMatchObject({
+        phase: 'not_installed',
+        canRetry: true,
+      });
+    } finally {
+      if (restartTimer) clearTimeout(restartTimer);
+      existsSpy.mockRestore();
+      engineTestPaths.appPath = previousAppPath;
+      engineTestPaths.userData = previousUserData;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('does not repeat startup maintenance after the runtime is ready', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-running-gate-'));
+    const appPath = path.join(tmpDir, 'app');
+    const userData = path.join(tmpDir, 'user-data');
+    const runtimeRoot = path.join(appPath, 'vendor', 'openclaw-runtime', 'current');
+    fs.mkdirSync(runtimeRoot, { recursive: true });
+    fs.writeFileSync(path.join(appPath, 'package.json'), JSON.stringify({
+      openclaw: {
+        version: 'v2026.6.1',
+        runSafetyContract: 'count-hardcaps-prompt-observe-v1',
+        plugins: [],
+      },
+    }));
+    fs.writeFileSync(path.join(runtimeRoot, 'package.json'), JSON.stringify({
+      version: '2026.6.1',
+    }));
+    fs.writeFileSync(path.join(runtimeRoot, 'runtime-build-info.json'), JSON.stringify({
+      openclawVersion: 'v2026.6.1',
+      runSafetyContract: 'count-hardcaps-prompt-observe-v1',
+    }));
+
+    const previousAppPath = engineTestPaths.appPath;
+    const previousUserData = engineTestPaths.userData;
+    engineTestPaths.appPath = appPath;
+    engineTestPaths.userData = userData;
+    engineMaintenanceMocks.cleanupStaleThirdPartyPluginsFromBundledDir.mockClear();
+    engineMaintenanceMocks.listLocalOpenClawExtensionIds.mockClear();
+    engineMaintenanceMocks.syncLocalOpenClawExtensionsIntoRuntime.mockClear();
+    try {
+      const manager = new OpenClawEngineManager();
+      type TestableManager = {
+        status: {
+          phase: 'ready' | 'running';
+          version: string;
+          message: string;
+          canRetry: false;
+        };
+      };
+      const testableManager = manager as unknown as TestableManager;
+      for (const phase of ['ready', 'running'] as const) {
+        testableManager.status = {
+          phase,
+          version: '2026.6.1',
+          message: phase,
+          canRetry: false,
+        };
+        expect(await manager.validateRuntimeContractGate()).toBeNull();
+        expect(await manager.ensureReady()).toMatchObject({ phase });
+      }
+      expect(
+        engineMaintenanceMocks.syncLocalOpenClawExtensionsIntoRuntime,
+      ).not.toHaveBeenCalled();
+      expect(
+        engineMaintenanceMocks.listLocalOpenClawExtensionIds,
+      ).not.toHaveBeenCalled();
+      expect(
+        engineMaintenanceMocks.cleanupStaleThirdPartyPluginsFromBundledDir,
+      ).not.toHaveBeenCalled();
+    } finally {
+      engineTestPaths.appPath = previousAppPath;
+      engineTestPaths.userData = previousUserData;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('validateOpenClawManagedConfig', () => {
+  test('rejects a legacy prompt-exposure hard limit and accepts observe-only policy', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-managed-config-'));
+    const configPath = path.join(tmpDir, 'openclaw.json');
+    try {
+      fs.writeFileSync(configPath, JSON.stringify({
+        agents: {
+          defaults: {
+            runSafety: {
+              maxToolCallReservationsPerBudgetScope: 64,
+              maxProviderDispatchesPerBudgetScope: 32,
+              maxCumulativeEstimatedPromptTokensPerBudgetScope: 2_000_000,
+              warningRatio: 0.75,
+            },
+          },
+        },
+      }));
+      expect(validateOpenClawManagedConfig(configPath)).toMatchObject({
+        ok: false,
+        reason: OpenClawManagedConfigFailureReason.RunSafetyPolicyMismatch,
+      });
+
+      fs.writeFileSync(configPath, JSON.stringify({
+        agents: {
+          defaults: {
+            runSafety: {
+              maxToolCallReservationsPerBudgetScope: 64,
+              maxProviderDispatchesPerBudgetScope: 32,
+              warningRatio: 0.75,
+              promptExposure: {
+                mode: 'observe',
+                legacyDiagnosticThreshold: 2_000_000,
+              },
+            },
+          },
+        },
+      }));
+      expect(validateOpenClawManagedConfig(configPath)).toEqual({ ok: true });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -13,6 +13,7 @@ import {
   OpenClawGatewayFailureKind,
   type OpenClawGatewayFailureSnapshot,
 } from '../../shared/openclawEngine/constants';
+import { t } from '../i18n';
 import { ensureElectronNodeShim, getElectronNodeRuntimePath, getSkillsRoot } from './coworkUtil';
 import {
   formatGatewayLogDateKey,
@@ -27,6 +28,12 @@ import { getCodexHomeDir } from './openaiCodexAuth';
 import { migrateLegacyCronStorageWithDoctor } from './openclawCronLegacyMigration';
 import { cleanupStaleThirdPartyPluginsFromBundledDir, listLocalOpenClawExtensionIds,syncLocalOpenClawExtensionsIntoRuntime } from './openclawLocalExtensions';
 import { migrateAllFtsOnlyMemoryIndexes } from './openclawMemoryIndexMigration';
+import {
+  readOpenClawRuntimeBuildInfo,
+  readOpenClawRuntimeContractExpectation,
+  validateOpenClawManagedConfig,
+  validateOpenClawRuntimeContract,
+} from './openclawRuntimeContract';
 import { ensureOpenClawWorkerShims } from './openclawWorkerShims';
 import { appendPythonRuntimeToEnv } from './pythonRuntime';
 
@@ -396,10 +403,98 @@ export class OpenClawEngineManager extends EventEmitter {
     };
   }
 
-  async ensureReady(_options: { forceReinstall?: boolean } = {}): Promise<OpenClawEngineStatus> {
+  private async stopTrackedGatewayForRuntimeGateFailure(reason: string): Promise<void> {
+    if (this.gatewayRestartTimer) {
+      clearTimeout(this.gatewayRestartTimer);
+      this.gatewayRestartTimer = null;
+    }
+
+    const gatewayProcess = this.gatewayProcess;
+    if (isGatewayProcessAlive(gatewayProcess)) {
+      console.warn(
+        `[OpenClaw] stopping the existing gateway after runtime gate failure (${reason})`,
+      );
+      await this.stopGatewayProcess(gatewayProcess);
+    }
+    if (this.gatewayProcess === gatewayProcess) {
+      this.gatewayProcess = null;
+    }
+  }
+
+  /**
+   * Validate only the immutable runtime identity used by the current app.
+   *
+   * Returns null when the version/contract pair matches. On failure it
+   * fail-closes the engine status and stops any tracked Gateway, without
+   * running extension sync or plugin cleanup.
+   */
+  async validateRuntimeContractGate(): Promise<OpenClawEngineStatus | null> {
     const runtime = this.resolveRuntimeMetadata();
     this.desiredVersion = runtime.version || DEFAULT_OPENCLAW_VERSION;
 
+    if (!runtime.root) {
+      await this.stopTrackedGatewayForRuntimeGateFailure('runtime_missing');
+      this.setStatus({
+        phase: 'not_installed',
+        version: null,
+        message: `Bundled OpenClaw runtime is missing. Expected: ${runtime.expectedPathHint}`,
+        canRetry: true,
+      });
+      return this.getStatus();
+    }
+
+    const contractValidation = validateOpenClawRuntimeContract(
+      readOpenClawRuntimeContractExpectation(app.getAppPath()),
+      readOpenClawRuntimeBuildInfo(runtime.root),
+    );
+    if (contractValidation.ok === false) {
+      console.error('[OpenClaw] runtime contract validation failed', {
+        reason: contractValidation.reason,
+        expectedVersion: contractValidation.expected?.openclawVersion ?? null,
+        actualVersion: contractValidation.actual?.openclawVersion ?? null,
+        expectedContract: contractValidation.expected?.runSafetyContract ?? null,
+        actualContract: contractValidation.actual?.runSafetyContract ?? null,
+      });
+      await this.stopTrackedGatewayForRuntimeGateFailure(contractValidation.reason);
+      this.setStatus({
+        phase: 'error',
+        version: runtime.version,
+        message: t(
+          app.isPackaged
+            ? 'openClawRuntimeContractMismatchPackaged'
+            : 'openClawRuntimeContractMismatchDev',
+          {
+            expectedVersion: contractValidation.expected?.openclawVersion ?? 'unknown',
+            expectedContract: contractValidation.expected?.runSafetyContract ?? 'unknown',
+          },
+        ),
+        errorCode: OpenClawEngineErrorCode.RuntimeContractMismatch,
+        canRetry: true,
+      });
+      return this.getStatus();
+    }
+
+    return null;
+  }
+
+  async ensureReady(_options: { forceReinstall?: boolean } = {}): Promise<OpenClawEngineStatus> {
+    const contractFailureStatus = await this.validateRuntimeContractGate();
+    if (contractFailureStatus) {
+      return contractFailureStatus;
+    }
+
+    // A prepared or active Gateway only needs the lightweight contract gate
+    // above. Extension sync and stale-plugin cleanup are one-time startup
+    // maintenance, not work to repeat during the following spawn or per task.
+    if (
+      this.status.phase === 'ready'
+      || this.status.phase === 'running'
+      || this.status.phase === 'starting'
+    ) {
+      return this.getStatus();
+    }
+
+    const runtime = this.resolveRuntimeMetadata();
     if (!runtime.root) {
       this.setStatus({
         phase: 'not_installed',
@@ -432,10 +527,6 @@ export class OpenClawEngineManager extends EventEmitter {
       }
     } catch {
       // Best-effort cleanup; don't block startup.
-    }
-
-    if (this.status.phase === 'running') {
-      return this.getStatus();
     }
 
     this.setStatus({
@@ -514,6 +605,21 @@ export class OpenClawEngineManager extends EventEmitter {
       return this.getStatus();
     }
 
+    const configValidation = validateOpenClawManagedConfig(this.configPath);
+    if (configValidation.ok === false) {
+      console.error('[OpenClaw] managed config validation failed before gateway spawn', {
+        reason: configValidation.reason,
+      });
+      this.setStatus({
+        phase: 'error',
+        version: runtime.version,
+        message: t('openClawRuntimeConfigMismatch'),
+        errorCode: OpenClawEngineErrorCode.RuntimeConfigMismatch,
+        canRetry: true,
+      });
+      return this.getStatus();
+    }
+
     this.ensureBareEntryFiles(runtime.root);
     console.log(`[OpenClaw] startGateway: ensureBareEntryFiles done (${elapsed()})`);
     const openclawEntry = this.resolveOpenClawEntry(runtime.root);
@@ -535,7 +641,6 @@ export class OpenClawEngineManager extends EventEmitter {
     console.log(`[OpenClaw] startGateway: resolveGatewayPort done (${elapsed()}), port=${port}`);
     this.gatewayPort = port;
     this.writeGatewayPort(port);
-    this.ensureConfigFile();
     console.log(`[OpenClaw] startGateway: pre-fork setup done (${elapsed()})`);
 
     this.setStatus({
@@ -1353,25 +1458,6 @@ export class OpenClawEngineManager extends EventEmitter {
       return token || null;
     } catch {
       return null;
-    }
-  }
-
-  private ensureConfigFile(): void {
-    ensureDir(path.dirname(this.configPath));
-    if (!fs.existsSync(this.configPath)) {
-      fs.writeFileSync(this.configPath, JSON.stringify({ gateway: { mode: 'local' } }, null, 2) + '\n', 'utf8');
-      return;
-    }
-    // Ensure gateway.mode is set even if config already exists
-    try {
-      const raw = fs.readFileSync(this.configPath, 'utf8');
-      const config = JSON.parse(raw);
-      if (!config.gateway?.mode) {
-        config.gateway = { ...config.gateway, mode: 'local' };
-        fs.writeFileSync(this.configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
-      }
-    } catch {
-      // ignore parse errors
     }
   }
 

--- a/src/main/libs/openclawPatches/agentHarnessRunSafetyPatch.test.ts
+++ b/src/main/libs/openclawPatches/agentHarnessRunSafetyPatch.test.ts
@@ -11,6 +11,17 @@ import {
 const patchFile = 'openclaw-z-agent-harness-run-safety.patch';
 
 describe('OpenClaw AgentHarness run-safety patch', () => {
+  test('contains one complete diff block for the harness contract and its tests', () => {
+    const patch = readCurrentOpenClawPatch(patchFile);
+    for (const file of [
+      'src/agents/harness/run-safety-contract.ts',
+      'src/agents/harness/run-safety-contract.test.ts',
+    ]) {
+      const header = `diff --git a/${file} b/${file}`;
+      expect(patch.split(header)).toHaveLength(2);
+    }
+  });
+
   test('fails closed before invoking an unversioned harness handler', () => {
     const contractAdded = readAddedPatchLines(
       readCurrentOpenClawPatchFileDiff(
@@ -33,7 +44,7 @@ describe('OpenClaw AgentHarness run-safety patch', () => {
     expect(lifecycleRemoved).toContain('await harness.runAttempt(params)');
   });
 
-  test('reserves and refines the final payload before the real transport', () => {
+  test('reserves and observes the final payload before the real transport', () => {
     const contractAdded = readAddedPatchLines(
       readCurrentOpenClawPatchFileDiff(
         patchFile,
@@ -45,19 +56,51 @@ describe('OpenClaw AgentHarness run-safety patch', () => {
       'runSafety.controller.reserveProviderDispatch({',
     );
     const estimateIndex = contractAdded.indexOf(
-      'estimateRunSafetyPromptTokens(finalPayload, model)',
+      'estimateRunSafetyPromptObservation(finalPayload, model)',
     );
-    const refinementIndex = contractAdded.indexOf(
-      'runSafety.controller.refineProviderPromptEstimate({',
+    const observationIndex = contractAdded.indexOf(
+      'runSafety.controller.observeProviderPromptEstimate({',
     );
     const transportIndex = contractAdded.indexOf('return await transport(finalPayload);');
 
     expect(reservationIndex).toBeGreaterThanOrEqual(0);
-    expect(estimateIndex).toBeGreaterThan(reservationIndex);
-    expect(refinementIndex).toBeGreaterThan(estimateIndex);
-    expect(transportIndex).toBeGreaterThan(refinementIndex);
+    expect(observationIndex).toBeGreaterThan(reservationIndex);
+    expect(estimateIndex).toBeGreaterThan(observationIndex);
+    expect(transportIndex).toBeGreaterThan(estimateIndex);
     expect(contractAdded).toContain(
       'runSafety.controller.completeProviderDispatch(providerDispatchId);',
+    );
+  });
+
+  test('keeps prompt observations fail-open and legacy prompt terminals receive-only', () => {
+    const contractAdded = readAddedPatchLines(
+      readCurrentOpenClawPatchFileDiff(
+        patchFile,
+        'src/agents/harness/run-safety-contract.ts',
+      ),
+    );
+    const contractTestsAdded = readAddedPatchLines(
+      readCurrentOpenClawPatchFileDiff(
+        patchFile,
+        'src/agents/harness/run-safety-contract.test.ts',
+      ),
+    );
+
+    expect(contractAdded).toContain(
+      'runSafety.controller.observeProviderPromptEstimate({',
+    );
+    expect(contractAdded).not.toContain('refineProviderPromptEstimate(');
+    expect(contractAdded).not.toContain(
+      'kind: RunSafetyTerminationKind.RunPromptExposureBudget',
+    );
+    expect(contractAdded).not.toContain(
+      'kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable',
+    );
+    expect(contractTestsAdded).toContain(
+      'calls transport when final prompt estimation is unavailable',
+    );
+    expect(contractTestsAdded).toContain(
+      'calls transport when final prompt exposure exceeds the legacy threshold',
     );
   });
 
@@ -116,7 +159,8 @@ describe('OpenClaw AgentHarness run-safety patch', () => {
       'counts one normal send as one provider dispatch',
       'creates a new ticket for each recovery send on the shared controller',
       'does not call transport when the dispatch limit is exhausted',
-      'does not call transport when final prompt exposure exceeds the limit',
+      'calls transport when final prompt estimation is unavailable',
+      'calls transport when final prompt exposure exceeds the legacy threshold',
       'expect(transport).not.toHaveBeenCalled();',
       'it is not an in-process plugin sandbox',
       'A malicious plugin could perform',

--- a/src/main/libs/openclawPatches/varyingArgsNoProgressCorePatch.test.ts
+++ b/src/main/libs/openclawPatches/varyingArgsNoProgressCorePatch.test.ts
@@ -14,6 +14,30 @@ import {
 const patchFile = 'openclaw-varying-args-no-progress-core.patch';
 
 describe('OpenClaw varying-arguments no-progress core patch', () => {
+  test('contains one complete diff block for every required core run-safety file', () => {
+    const patch = readCurrentOpenClawPatch(patchFile);
+    for (const file of [
+      'packages/agent-core/src/agent.run-safety-tool-budget.test.ts',
+      'src/agents/cli-runner.run-safety.test.ts',
+      'src/agents/cli-runner/run-safety.ts',
+      'src/agents/embedded-agent-runner/run.run-safety.test.ts',
+      'src/agents/embedded-agent-runner/run/run-safety-gate.test.ts',
+      'src/agents/embedded-agent-runner/run/run-safety-gate.ts',
+      'src/agents/provider-run-safety-contract.test.ts',
+      'src/agents/provider-run-safety-contract.ts',
+      'src/agents/run-safety-controller.ts',
+      'src/agents/run-safety-controller.test.ts',
+      'src/agents/run-safety-registry.ts',
+      'src/agents/run-safety-registry.test.ts',
+      'src/context-engine/run-safety-compaction.ts',
+      'src/context-engine/run-safety-compaction.test.ts',
+      'src/llm/run-safety-provider-dispatch-context.ts',
+    ]) {
+      const header = `diff --git a/${file} b/${file}`;
+      expect(patch.split(header)).toHaveLength(2);
+    }
+  });
+
   test('keeps all OpenClaw and LobsterAI termination wire kinds exactly aligned', () => {
     const controllerAdded = readAddedPatchLines(
       readCurrentOpenClawPatchFileDiff(patchFile, 'src/agents/run-safety-controller.ts'),
@@ -54,17 +78,18 @@ describe('OpenClaw varying-arguments no-progress core patch', () => {
     for (const snippet of [
       'maxToolCallReservationsPerBudgetScope: 64',
       'maxProviderDispatchesPerBudgetScope: 32',
-      'maxCumulativeEstimatedPromptTokensPerBudgetScope: 2_000_000',
+      'legacyDiagnosticThreshold: 2_000_000',
       'warningRatio: 0.75',
       'reserveToolBatch(params: {',
       'reserveProviderDispatch(params: {',
+      'observeProviderPromptEstimate(params: {',
     ]) {
       expect(controllerAdded).toContain(snippet);
     }
     for (const snippet of [
       'params.controller.reserveProviderDispatch({',
-      'const finalEstimate = estimateRunSafetyPromptTokens(finalPayload, payloadModel);',
-      'params.controller.refineProviderPromptEstimate({',
+      'estimateRunSafetyPromptObservation(finalPayload, payloadModel)',
+      'params.controller.observeProviderPromptEstimate({',
       'maxRetries: 0',
     ]) {
       expect(providerGateAdded).toContain(snippet);
@@ -94,6 +119,99 @@ describe('OpenClaw varying-arguments no-progress core patch', () => {
     ]);
   });
 
+  test('keeps legacy prompt terminals receive-only at targeted producer call sites', () => {
+    const controllerAdded = readAddedPatchLines(
+      readCurrentOpenClawPatchFileDiff(patchFile, 'src/agents/run-safety-controller.ts'),
+    );
+    const producerSources = [
+      controllerAdded,
+      readAddedPatchLines(
+        readCurrentOpenClawPatchFileDiff(
+          patchFile,
+          'src/agents/embedded-agent-runner/run/run-safety-gate.ts',
+        ),
+      ),
+      readAddedPatchLines(
+        readCurrentOpenClawPatchFileDiff(patchFile, 'src/agents/cli-runner/run-safety.ts'),
+      ),
+      readAddedPatchLines(
+        readCurrentOpenClawPatchFileDiff(patchFile, 'src/context-engine/run-safety-compaction.ts'),
+      ),
+    ];
+
+    // The wire values intentionally remain in the controller enum for old
+    // persisted/runtime payloads. Only terminal-producing call sites are
+    // forbidden, so this must not become a whole-patch string assertion.
+    expect(controllerAdded).toContain(
+      'RunPromptExposureBudget: "run_prompt_exposure_budget"',
+    );
+    expect(controllerAdded).toContain(
+      'RunPromptEstimateUnavailable: "run_prompt_estimate_unavailable"',
+    );
+    for (const source of producerSources) {
+      expect(source).not.toContain(
+        'kind: RunSafetyTerminationKind.RunPromptExposureBudget',
+      );
+      expect(source).not.toContain(
+        'kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable',
+      );
+      expect(source).not.toContain('refineProviderPromptEstimate(');
+    }
+    expect(controllerAdded).not.toContain(
+      'continuationClosedReasonValue = RunSafetyTerminationKind.RunPromptExposureBudget',
+    );
+  });
+
+  test('keeps prompt exposure observe-only and estimator failures fail-open', () => {
+    const controllerAdded = readAddedPatchLines(
+      readCurrentOpenClawPatchFileDiff(patchFile, 'src/agents/run-safety-controller.ts'),
+    );
+    const gateTestsAdded = readAddedPatchLines(
+      readCurrentOpenClawPatchFileDiff(
+        patchFile,
+        'src/agents/embedded-agent-runner/run/run-safety-gate.test.ts',
+      ),
+    );
+
+    for (const snippet of [
+      'PromptObservationStatus',
+      'PromptEstimateSource',
+      'PromptEstimateUnavailableReason',
+      'legacyEstimatedExposureUnitsTotal',
+      'knownEstimateDispatchCount',
+      'estimateUnavailableDispatchCount',
+      'pendingObservationDispatchCount',
+      'legacyDiagnosticThresholdCrossed',
+      'run_prompt_exposure_threshold_crossed',
+      'run_prompt_exposure_estimate_unavailable_observed',
+      'run_safety_scope_summary',
+    ]) {
+      expect(controllerAdded).toContain(snippet);
+    }
+    expect(controllerAdded).not.toContain(
+      'maxCumulativeEstimatedPromptTokensPerBudgetScope',
+    );
+    expect(controllerAdded).toMatch(
+      /observeProviderPromptEstimate\(params: \{[\s\S]*?\}\): void \{/,
+    );
+    const warningDimension = controllerAdded.match(
+      /export type RunSafetyWarningDimension =(?<body>[\s\S]*?);/,
+    );
+    expect(warningDimension?.groups?.body).toBeTruthy();
+    expect(warningDimension?.groups?.body).not.toContain('prompt_exposure');
+    expect(gateTestsAdded).toContain(
+      'continues transport when final prompt estimation is unavailable',
+    );
+    expectPatchContains(patchFile, [
+      'allows the configured provider dispatches and blocks the next one before dispatch',
+      'keeps prompt observations immutable and idempotent',
+      'observes prompt exposure above the legacy threshold without terminating',
+      'records an unavailable prompt estimate without terminating',
+      'spawns after recording unavailable telemetry when the final CLI payload cannot be estimated',
+      'calls compaction transport when final prompt estimation is unavailable',
+    ]);
+  });
+
   test('closes audited provider retry, preload, cache, and provenance gaps', () => {
     const attemptDiff = readCurrentOpenClawPatchFileDiff(
       patchFile,
@@ -102,13 +220,8 @@ describe('OpenClaw varying-arguments no-progress core patch', () => {
     const safetyWrapperIndex = attemptDiff.indexOf(
       '+        activeSession.agent.streamFn = wrapStreamFnWithRunSafety({',
     );
-    const thinkingRecoveryPolicyIndex = attemptDiff.indexOf(
-      'transcriptPolicy.preserveSignatures',
-      safetyWrapperIndex,
-    );
 
     expect(safetyWrapperIndex).toBeGreaterThanOrEqual(0);
-    expect(thinkingRecoveryPolicyIndex).toBeGreaterThan(safetyWrapperIndex);
     expectPatchContains(patchFile, [
       'maxAttempts: 1',
       'internal transport retry is disabled for this run',
@@ -244,22 +357,25 @@ describe('OpenClaw varying-arguments no-progress core patch', () => {
     ]);
   });
 
-  test('estimates prompt exposure in CJK-aware tokens instead of raw bytes', () => {
+  test('preserves the CJK-aware legacy prompt estimator instead of raw bytes', () => {
     const controllerAdded = readAddedPatchLines(
       readCurrentOpenClawPatchFileDiff(patchFile, 'src/agents/run-safety-controller.ts'),
     );
 
-    // The 2M budget is calibrated in tokens (FR-12.1). Counting serialized
-    // UTF-8 bytes shrank it 3-4x (worst for CJK) and hard-blocked any single
-    // payload above 2MB on its first dispatch.
+    // This is a legacy exposure unit, not provider usage or billing data. Its
+    // algorithm must nevertheless stay stable across the P0 gate removal
+    // so telemetry remains comparable with the retired 2M policy.
     expect(controllerAdded).toContain(
       'import { estimateStringChars, estimateTokensFromChars } from "../utils/cjk-chars.js";',
     );
     expect(controllerAdded).toContain('INLINE_MEDIA_TOKEN_ESTIMATE');
-    expect(controllerAdded).toContain('source: "stable_text_tokens"');
+    expect(controllerAdded).toContain('StableTextTokens: "stable_text_tokens"');
+    expect(controllerAdded).toContain(
+      'source: PromptEstimateSource.StableTextTokens',
+    );
     expect(controllerAdded).not.toContain('Buffer.byteLength(serialized');
     expectPatchContains(patchFile, [
-      'estimates tokens, not bytes, so the configured budget keeps its calibration',
+      'estimates tokens, not bytes, so legacy telemetry keeps its calibration',
       'weights CJK content fairly instead of tripling it through UTF-8 bytes',
       'caps inline base64 media at a fixed conservative estimate',
     ]);

--- a/src/main/libs/openclawRunSafetyPolicy.ts
+++ b/src/main/libs/openclawRunSafetyPolicy.ts
@@ -1,0 +1,81 @@
+export const OpenClawPromptExposureMode = {
+  Observe: 'observe',
+} as const;
+
+export type OpenClawPromptExposureMode =
+  typeof OpenClawPromptExposureMode[keyof typeof OpenClawPromptExposureMode];
+
+export const OPENCLAW_LEGACY_PROMPT_EXPOSURE_BUDGET_FIELD =
+  'maxCumulativeEstimatedPromptTokensPerBudgetScope';
+
+export const MANAGED_OPENCLAW_RUN_SAFETY = {
+  maxToolCallReservationsPerBudgetScope: 64,
+  maxProviderDispatchesPerBudgetScope: 32,
+  warningRatio: 0.75,
+  promptExposure: {
+    mode: OpenClawPromptExposureMode.Observe,
+    legacyDiagnosticThreshold: 2_000_000,
+  },
+} as const;
+
+const asRecord = (value: unknown): Record<string, unknown> | null => (
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+);
+
+export const cloneManagedOpenClawRunSafety = (): Record<string, unknown> => ({
+  ...MANAGED_OPENCLAW_RUN_SAFETY,
+  promptExposure: {
+    ...MANAGED_OPENCLAW_RUN_SAFETY.promptExposure,
+  },
+});
+
+export const hasManagedOpenClawRunSafety = (config: unknown): boolean => {
+  const root = asRecord(config);
+  const agents = asRecord(root?.agents);
+  const defaults = asRecord(agents?.defaults);
+  const runSafety = asRecord(defaults?.runSafety);
+  if (!runSafety) return false;
+
+  const promptExposure = asRecord(runSafety.promptExposure);
+  const expectedKeys = Object.keys(MANAGED_OPENCLAW_RUN_SAFETY).sort();
+  const actualKeys = Object.keys(runSafety).sort();
+  const expectedPromptKeys = Object.keys(MANAGED_OPENCLAW_RUN_SAFETY.promptExposure).sort();
+  const actualPromptKeys = Object.keys(promptExposure ?? {}).sort();
+
+  return (
+    !Object.prototype.hasOwnProperty.call(
+      runSafety,
+      OPENCLAW_LEGACY_PROMPT_EXPOSURE_BUDGET_FIELD,
+    )
+    && JSON.stringify(actualKeys) === JSON.stringify(expectedKeys)
+    && JSON.stringify(actualPromptKeys) === JSON.stringify(expectedPromptKeys)
+    && runSafety.maxToolCallReservationsPerBudgetScope
+      === MANAGED_OPENCLAW_RUN_SAFETY.maxToolCallReservationsPerBudgetScope
+    && runSafety.maxProviderDispatchesPerBudgetScope
+      === MANAGED_OPENCLAW_RUN_SAFETY.maxProviderDispatchesPerBudgetScope
+    && runSafety.warningRatio === MANAGED_OPENCLAW_RUN_SAFETY.warningRatio
+    && promptExposure?.mode === MANAGED_OPENCLAW_RUN_SAFETY.promptExposure.mode
+    && promptExposure?.legacyDiagnosticThreshold
+      === MANAGED_OPENCLAW_RUN_SAFETY.promptExposure.legacyDiagnosticThreshold
+  );
+};
+
+export const applyManagedOpenClawRunSafety = (
+  config: Record<string, unknown>,
+): Record<string, unknown> => {
+  const agents = asRecord(config.agents) ?? {};
+  const defaults = asRecord(agents.defaults) ?? {};
+
+  return {
+    ...config,
+    agents: {
+      ...agents,
+      defaults: {
+        ...defaults,
+        runSafety: cloneManagedOpenClawRunSafety(),
+      },
+    },
+  };
+};

--- a/src/main/libs/openclawRuntimeContract.ts
+++ b/src/main/libs/openclawRuntimeContract.ts
@@ -1,0 +1,161 @@
+import fs from 'fs';
+import path from 'path';
+
+import { hasManagedOpenClawRunSafety } from './openclawRunSafetyPolicy';
+
+export const OpenClawRuntimeContractFailureReason = {
+  HostManifestMissing: 'host_manifest_missing',
+  RuntimeBuildInfoMissing: 'runtime_build_info_missing',
+  OpenClawVersionMismatch: 'openclaw_version_mismatch',
+  RunSafetyContractMismatch: 'run_safety_contract_mismatch',
+} as const;
+
+export type OpenClawRuntimeContractFailureReason =
+  typeof OpenClawRuntimeContractFailureReason[
+    keyof typeof OpenClawRuntimeContractFailureReason
+  ];
+
+export const OpenClawManagedConfigFailureReason = {
+  ConfigMissingOrInvalid: 'config_missing_or_invalid',
+  RunSafetyPolicyMismatch: 'run_safety_policy_mismatch',
+} as const;
+
+export type OpenClawManagedConfigFailureReason =
+  typeof OpenClawManagedConfigFailureReason[
+    keyof typeof OpenClawManagedConfigFailureReason
+  ];
+
+export type OpenClawRuntimeContractExpectation = {
+  openclawVersion: string;
+  runSafetyContract: string;
+};
+
+export type OpenClawRuntimeBuildInfo = {
+  openclawVersion?: unknown;
+  runSafetyContract?: unknown;
+  patchHash?: unknown;
+};
+
+export type OpenClawRuntimeContractValidation =
+  | {
+      ok: true;
+      expected: OpenClawRuntimeContractExpectation;
+      actual: OpenClawRuntimeContractExpectation;
+    }
+  | {
+      ok: false;
+      reason: OpenClawRuntimeContractFailureReason;
+      expected: OpenClawRuntimeContractExpectation | null;
+      actual: OpenClawRuntimeContractExpectation | null;
+    };
+
+export type OpenClawManagedConfigValidation =
+  | { ok: true }
+  | { ok: false; reason: OpenClawManagedConfigFailureReason };
+
+const parseJsonFile = (filePath: string): unknown => {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+  } catch {
+    return null;
+  }
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => (
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+);
+
+const readContractPair = (
+  value: unknown,
+  versionKey: string,
+): OpenClawRuntimeContractExpectation | null => {
+  const record = asRecord(value);
+  const openclawVersion = record?.[versionKey];
+  const runSafetyContract = record?.runSafetyContract;
+  if (
+    typeof openclawVersion !== 'string'
+    || openclawVersion.length === 0
+    || typeof runSafetyContract !== 'string'
+    || runSafetyContract.length === 0
+  ) {
+    return null;
+  }
+  return { openclawVersion, runSafetyContract };
+};
+
+export const readOpenClawRuntimeContractExpectation = (
+  appRoot: string,
+): OpenClawRuntimeContractExpectation | null => {
+  const packageJson = asRecord(parseJsonFile(path.join(appRoot, 'package.json')));
+  return readContractPair(packageJson?.openclaw, 'version');
+};
+
+export const readOpenClawRuntimeBuildInfo = (
+  runtimeRoot: string,
+): OpenClawRuntimeBuildInfo | null => {
+  const value = parseJsonFile(path.join(runtimeRoot, 'runtime-build-info.json'));
+  return asRecord(value) as OpenClawRuntimeBuildInfo | null;
+};
+
+export const validateOpenClawRuntimeContract = (
+  expected: OpenClawRuntimeContractExpectation | null,
+  buildInfo: OpenClawRuntimeBuildInfo | null,
+): OpenClawRuntimeContractValidation => {
+  if (!expected) {
+    return {
+      ok: false,
+      reason: OpenClawRuntimeContractFailureReason.HostManifestMissing,
+      expected: null,
+      actual: readContractPair(buildInfo, 'openclawVersion'),
+    };
+  }
+
+  const actual = readContractPair(buildInfo, 'openclawVersion');
+  if (!actual) {
+    return {
+      ok: false,
+      reason: OpenClawRuntimeContractFailureReason.RuntimeBuildInfoMissing,
+      expected,
+      actual: null,
+    };
+  }
+  if (actual.openclawVersion !== expected.openclawVersion) {
+    return {
+      ok: false,
+      reason: OpenClawRuntimeContractFailureReason.OpenClawVersionMismatch,
+      expected,
+      actual,
+    };
+  }
+  if (actual.runSafetyContract !== expected.runSafetyContract) {
+    return {
+      ok: false,
+      reason: OpenClawRuntimeContractFailureReason.RunSafetyContractMismatch,
+      expected,
+      actual,
+    };
+  }
+
+  return { ok: true, expected, actual };
+};
+
+export const validateOpenClawManagedConfig = (
+  configPath: string,
+): OpenClawManagedConfigValidation => {
+  const config = parseJsonFile(configPath);
+  if (!asRecord(config)) {
+    return {
+      ok: false,
+      reason: OpenClawManagedConfigFailureReason.ConfigMissingOrInvalid,
+    };
+  }
+  if (!hasManagedOpenClawRunSafety(config)) {
+    return {
+      ok: false,
+      reason: OpenClawManagedConfigFailureReason.RunSafetyPolicyMismatch,
+    };
+  }
+  return { ok: true };
+};

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1960,6 +1960,21 @@ const bootstrapOpenClawEngine = async (
     try {
       console.log(`[OpenClaw] bootstrap starting (reason=${reason})`);
 
+      if (options.forceReinstall) {
+        console.log(
+          `${gwDiagTs()} bootstrap: forceReinstall requested, stopping gateway before runtime validation`,
+        );
+        await manager.stopGateway();
+        console.log(`[OpenClaw] bootstrap: stopGateway done (${elapsed()})`);
+      }
+      const ensuredStatus = await manager.ensureReady();
+      console.log(
+        `[OpenClaw] bootstrap: ensureReady done (${elapsed()}), phase=${ensuredStatus.phase}`,
+      );
+      if (ensuredStatus.phase !== 'ready' && ensuredStatus.phase !== 'running') {
+        return ensuredStatus;
+      }
+
       // Start AskUser HTTP server before config sync
       await startAskUserServer().catch((err: unknown) => {
         console.error(`[OpenClaw] bootstrap: AskUser server startup failed (non-fatal):`, err);
@@ -1984,20 +1999,6 @@ const bootstrapOpenClawEngine = async (
       );
       if (!syncResult.success) {
         return syncResult.status || manager.getStatus();
-      }
-      if (options.forceReinstall) {
-        console.log(
-          `${gwDiagTs()} bootstrap: forceReinstall requested, stopping gateway before reinstall`,
-        );
-        await manager.stopGateway();
-        console.log(`[OpenClaw] bootstrap: stopGateway done (${elapsed()})`);
-      }
-      const ensuredStatus = await manager.ensureReady();
-      console.log(
-        `[OpenClaw] bootstrap: ensureReady done (${elapsed()}), phase=${ensuredStatus.phase}`,
-      );
-      if (ensuredStatus.phase !== 'ready' && ensuredStatus.phase !== 'running') {
-        return ensuredStatus;
       }
       const result = await manager.startGateway(`bootstrap:${reason}`);
       console.log(`[OpenClaw] bootstrap completed (${elapsed()}), phase=${result.phase}`);
@@ -2028,15 +2029,31 @@ const ensureOpenClawRunningForCowork = async () => {
   }
 
   const manager = getOpenClawEngineManager();
-  const status = manager.getStatus();
-  if (status.phase === 'running') {
+  const contractFailureStatus = await manager.validateRuntimeContractGate();
+  if (contractFailureStatus) {
+    return contractFailureStatus;
+  }
+  const currentStatus = manager.getStatus();
+  if (currentStatus.phase === 'running') {
     // Token proxy handles dynamic token injection — no need to restart
     // the gateway for token changes. Just wait for any in-flight refresh.
     await waitForPendingTokenRefresh();
     return manager.getStatus();
   }
-  if (status.phase === 'starting') {
-    return status;
+  if (currentStatus.phase === 'starting') {
+    return currentStatus;
+  }
+
+  const preparedStatus = await manager.ensureReady();
+  if (preparedStatus.phase === 'running') {
+    await waitForPendingTokenRefresh();
+    return manager.getStatus();
+  }
+  if (preparedStatus.phase === 'starting') {
+    return preparedStatus;
+  }
+  if (preparedStatus.phase !== 'ready') {
+    return preparedStatus;
   }
 
   // Wait for any in-flight token refresh so that the gateway starts with
@@ -2054,9 +2071,10 @@ const ensureOpenClawRunningForCowork = async () => {
   });
   if (!syncResult.success) {
     console.error('[OpenClaw] ensureRunning: config sync failed:', syncResult.error);
+    return syncResult.status || manager.getStatus();
   }
 
-  console.log(`${gwDiagTs()} ensureRunning: gateway not running (phase=${status.phase}), starting`);
+  console.log(`${gwDiagTs()} ensureRunning: gateway not running (phase=${preparedStatus.phase}), starting`);
   return await manager.startGateway('ensure-running-for-cowork');
 };
 
@@ -12098,30 +12116,46 @@ if (!gotTheLock) {
       console.warn('[OpenClaw] main agent workspace migration failed (non-fatal):', err);
     }
 
-    profiler.mark('syncOpenClawConfig');
-    const startupSync = await syncOpenClawConfig({
-      reason: 'startup',
-      restartGatewayIfRunning: false,
-    });
-    if (!startupSync.success) {
-      console.error('[OpenClaw] Startup config sync failed:', startupSync.error);
-    }
-    profiler.measure('syncOpenClawConfig');
-    void ensureOpenClawRunningForCowork()
-      .then(() => {
-        // Start cron polling once the gateway is confirmed running.
-        try {
-          getCronJobService().startPolling();
-        } catch (err) {
-          console.warn('[Main] CronJobService not available after OpenClaw startup:', err);
-        }
-        void migrateScheduledTaskAnnounceJobs(scheduledTaskHandlerDeps).catch(err => {
-          console.warn('[Main] Scheduled task IM announce job migration failed:', err);
-        });
-      })
-      .catch(error => {
-        console.error('[OpenClaw] Failed to auto-start gateway on app startup:', error);
+    profiler.mark('ensureOpenClawRuntimeContract');
+    const startupRuntimeStatus = await getOpenClawEngineManager().ensureReady();
+    profiler.measure('ensureOpenClawRuntimeContract');
+    if (
+      startupRuntimeStatus.phase === 'ready'
+      || startupRuntimeStatus.phase === 'running'
+    ) {
+      profiler.mark('syncOpenClawConfig');
+      const startupSync = await syncOpenClawConfig({
+        reason: 'startup',
+        restartGatewayIfRunning: false,
       });
+      if (!startupSync.success) {
+        console.error('[OpenClaw] Startup config sync failed:', startupSync.error);
+      }
+      profiler.measure('syncOpenClawConfig');
+      if (startupSync.success) {
+        void ensureOpenClawRunningForCowork()
+          .then((engineStatus) => {
+            if (engineStatus.phase !== 'running') return;
+            // Start cron polling once the gateway is confirmed running.
+            try {
+              getCronJobService().startPolling();
+            } catch (err) {
+              console.warn('[Main] CronJobService not available after OpenClaw startup:', err);
+            }
+            void migrateScheduledTaskAnnounceJobs(scheduledTaskHandlerDeps).catch(err => {
+              console.warn('[Main] Scheduled task IM announce job migration failed:', err);
+            });
+          })
+          .catch(error => {
+            console.error('[OpenClaw] Failed to auto-start gateway on app startup:', error);
+          });
+      }
+    } else {
+      console.error(
+        '[OpenClaw] Startup blocked before config sync:',
+        startupRuntimeStatus.errorCode || startupRuntimeStatus.phase,
+      );
+    }
 
     // ── Step 1: Show window ASAP ──────────────────────────────────────
     // CSP + createWindow moved before skill initialisation so the user

--- a/src/shared/cowork/runSafety.test.ts
+++ b/src/shared/cowork/runSafety.test.ts
@@ -36,6 +36,33 @@ describe('run-safety wire parser', () => {
     });
   });
 
+  test.each([
+    {
+      kind: RunSafetyTerminationKind.RunPromptExposureBudget,
+      cumulativeEstimatedPromptTokens: 2_100_000,
+    },
+    {
+      kind: RunSafetyTerminationKind.RunPromptEstimateUnavailable,
+      cumulativeEstimatedPromptTokens: undefined,
+    },
+  ])('keeps legacy prompt terminal $kind receive-only wire payloads parseable', ({
+    kind,
+    cumulativeEstimatedPromptTokens,
+  }) => {
+    const legacyPayload = {
+      kind,
+      rootInvocationId: 'legacy-root',
+      budgetScopeId: 'legacy-scope',
+      runId: 'legacy-run',
+      providerDispatchCount: 15,
+      ...(cumulativeEstimatedPromptTokens === undefined
+        ? {}
+        : { cumulativeEstimatedPromptTokens }),
+    };
+
+    expect(parseRunSafetyTermination(legacyPayload)).toEqual(legacyPayload);
+  });
+
   test('requires trusted root, run, and scope fields', () => {
     expect(parseRunSafetyTermination({
       ...validTermination,

--- a/src/shared/cowork/runSafety.ts
+++ b/src/shared/cowork/runSafety.ts
@@ -2,6 +2,8 @@ export const RunSafetyTerminationKind = {
   VariantNoProgress: 'variant_no_progress',
   RunToolBudget: 'run_tool_budget',
   RunProviderDispatchBudget: 'run_provider_dispatch_budget',
+  // Receive-only compatibility for terminals persisted or emitted by older runtimes.
+  // The bundled runtime must not produce either prompt-related kind.
   RunPromptExposureBudget: 'run_prompt_exposure_budget',
   RunPromptEstimateUnavailable: 'run_prompt_estimate_unavailable',
   RunBudgetIdentityMissing: 'run_budget_identity_missing',

--- a/src/shared/openclawEngine/constants.ts
+++ b/src/shared/openclawEngine/constants.ts
@@ -38,6 +38,16 @@ export const OpenClawEngineErrorCode = {
    * from the leftover archive was not possible.
    */
   RuntimeEntryMissing: 'runtime_entry_missing',
+  /**
+   * runtime-build-info.json does not match package.json's pinned OpenClaw
+   * version and run-safety capability contract.
+   */
+  RuntimeContractMismatch: 'runtime_contract_mismatch',
+  /**
+   * openclaw.json is missing or does not contain LobsterAI's managed
+   * run-safety policy, so it must not be parsed by the bundled runtime.
+   */
+  RuntimeConfigMismatch: 'runtime_config_mismatch',
 } as const;
 
 export type OpenClawEngineErrorCode =

--- a/tests/electron-builder-hooks.test.ts
+++ b/tests/electron-builder-hooks.test.ts
@@ -1,0 +1,113 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+  assertOpenClawRuntimeBuildInfoMatchesExpected,
+  computeOpenClawPatchHash,
+} = require('../scripts/electron-builder-hooks.cjs') as {
+  assertOpenClawRuntimeBuildInfoMatchesExpected: (
+    buildInfo: Record<string, unknown> | null,
+    expected: {
+      openclawVersion: string;
+      runSafetyContract: string;
+      patchHash: string;
+    },
+    buildHint: string,
+  ) => void;
+  computeOpenClawPatchHash: (patchesDir: string) => string;
+};
+
+describe('electron-builder OpenClaw runtime contract gate', () => {
+  const expected = {
+    openclawVersion: 'v2026.6.1',
+    runSafetyContract: 'count-hardcaps-prompt-observe-v1',
+    patchHash: 'expected-patch-hash',
+  };
+
+  test('hashes patch bytes in stable filename order', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-patch-hash-'));
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'z-last.patch'), 'last\n');
+      fs.writeFileSync(path.join(tmpDir, 'a-first.patch'), 'first\n');
+      fs.writeFileSync(path.join(tmpDir, 'ignored.txt'), 'ignored\n');
+
+      const expectedHash = createHash('sha256')
+        .update('first\n')
+        .update('last\n')
+        .digest('hex');
+      expect(computeOpenClawPatchHash(tmpDir)).toBe(expectedHash);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('accepts matching build metadata', () => {
+    expect(() => assertOpenClawRuntimeBuildInfoMatchesExpected(
+      {
+        ...expected,
+      },
+      expected,
+      'npm run openclaw:runtime:mac-arm64',
+    )).not.toThrow();
+  });
+
+  test('rejects a stale OpenClaw version before packaging', () => {
+    expect(() => assertOpenClawRuntimeBuildInfoMatchesExpected(
+      {
+        openclawVersion: 'v2026.5.12',
+        runSafetyContract: expected.runSafetyContract,
+        patchHash: expected.patchHash,
+      },
+      expected,
+      'npm run openclaw:runtime:mac-arm64',
+    )).toThrow(/Expected version=v2026\.6\.1.*found version=v2026\.5\.12/);
+  });
+
+  test('rejects missing or mismatched run-safety contracts before packaging', () => {
+    expect(() => assertOpenClawRuntimeBuildInfoMatchesExpected(
+      {
+        openclawVersion: expected.openclawVersion,
+        patchHash: expected.patchHash,
+      },
+      expected,
+      'npm run openclaw:runtime:mac-arm64',
+    )).toThrow(/runSafetyContract=missing/);
+
+    expect(() => assertOpenClawRuntimeBuildInfoMatchesExpected(
+      {
+        openclawVersion: expected.openclawVersion,
+        runSafetyContract: 'legacy-prompt-hard-stop-v1',
+        patchHash: expected.patchHash,
+      },
+      expected,
+      'npm run openclaw:runtime:mac-arm64',
+    )).toThrow(/runSafetyContract=legacy-prompt-hard-stop-v1/);
+  });
+
+  test('rejects missing or stale patch hashes before packaging', () => {
+    expect(() => assertOpenClawRuntimeBuildInfoMatchesExpected(
+      {
+        openclawVersion: expected.openclawVersion,
+        runSafetyContract: expected.runSafetyContract,
+      },
+      expected,
+      'npm run openclaw:runtime:mac-arm64',
+    )).toThrow(/patchHash=missing/);
+
+    expect(() => assertOpenClawRuntimeBuildInfoMatchesExpected(
+      {
+        openclawVersion: expected.openclawVersion,
+        runSafetyContract: expected.runSafetyContract,
+        patchHash: 'stale-patch-hash',
+      },
+      expected,
+      'npm run openclaw:runtime:mac-arm64',
+    )).toThrow(/patchHash=stale-patch-hash/);
+  });
+});


### PR DESCRIPTION
Guard startup with a runtime-build-info and config contract check so the bundled OpenClaw runtime can never run without LobsterAI's managed run-safety policy, and retire prompt-exposure-budget as a terminal kind the bundled runtime can produce.