### PR TITLE
fix(cowork): prevent BTW tool protocol leakage

### DIFF
--- a/scripts/apply-openclaw-patches.cjs
+++ b/scripts/apply-openclaw-patches.cjs
@@ -66,6 +66,60 @@ if (patchFiles.length === 0) {
 console.log(`[apply-openclaw-patches] Applying patches for openclaw ${openclawVersion} (${patchFiles.length} file(s))`);
 
 const strongPatchValidators = {
+  'openclaw-btw-protocol-hygiene.patch': [
+    {
+      file: 'src/agents/btw.ts',
+      snippets: [
+        'This direct /btw fallback has no tools',
+        'sanitizeUserFacingText(rawAnswer).trim()',
+        'errorCode: BtwErrorCode.ToolRequired',
+      ],
+      forbiddenSnippets: [
+        'unless the side question explicitly asks for them',
+      ],
+    },
+    {
+      file: 'src/shared/text/assistant-visible-text.ts',
+      snippets: [
+        'export function stripDeepSeekDsmlToolCallBlocks',
+        'cleaned = stripDeepSeekDsmlToolCallBlocks(cleaned)',
+      ],
+    },
+    {
+      file: 'src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts',
+      snippets: [
+        'stripMinimaxToolCallXml(stripDeepSeekDsmlToolCallBlocks(stripped))',
+      ],
+    },
+    {
+      file: 'src/auto-reply/reply-payload.ts',
+      snippets: [
+        'ToolRequired: "tool_required"',
+        'errorCode?: BtwErrorCode',
+      ],
+    },
+    {
+      file: 'src/gateway/server-methods/chat.ts',
+      snippets: [
+        'const btwErrorCode = btwReplies',
+        '...(btwErrorCode ? { errorCode: btwErrorCode } : {})',
+      ],
+    },
+    {
+      file: 'src/gateway/server.chat.gateway-server-chat.test.ts',
+      snippets: [
+        'errorCode: "tool_required"',
+        'isError: true',
+      ],
+    },
+    {
+      file: 'src/agents/btw.test.ts',
+      snippets: [
+        'sanitizes provider tool protocol text from direct fallback answers',
+        'returns a stable tool-required error when direct fallback emits only tool protocol',
+      ],
+    },
+  ],
   'openclaw-terminate-run-on-critical-tool-loop.patch': [
     {
       file: 'packages/agent-core/src/agent.ts',

--- a/scripts/patches/v2026.6.1/openclaw-btw-protocol-hygiene.patch
+++ b/scripts/patches/v2026.6.1/openclaw-btw-protocol-hygiene.patch
@@ -1,0 +1,467 @@
+diff --git a/src/agents/btw.test.ts b/src/agents/btw.test.ts
+index a23e629991..7d1ff95f14 100644
+--- a/src/agents/btw.test.ts
++++ b/src/agents/btw.test.ts
+@@ -552,6 +552,63 @@ describe("runBtwSideQuestion", () => {
+     });
+   });
+ 
++  it("sanitizes provider tool protocol text from direct fallback answers", async () => {
++    mockDoneAnswer(
++      'Visible answer.<|DSML|tool_calls><|DSML|invoke name="read">private</|DSML|invoke></|DSML|tool_calls>',
++    );
++
++    await expect(runSideQuestion()).resolves.toEqual({ text: "Visible answer." });
++  });
++
++  it("returns a stable tool-required error when direct fallback emits only tool protocol", async () => {
++    mockDoneAnswer("<｜DSML｜tool_calls>private arguments</｜DSML｜tool_calls>");
++
++    await expect(runSideQuestion()).resolves.toEqual({
++      text: "This side question requires a tool operation. Continue in the main conversation.",
++      isError: true,
++      btw: {
++        question: DEFAULT_QUESTION,
++        errorCode: "tool_required",
++      },
++    });
++  });
++
++  it("sanitizes block replies before delivery", async () => {
++    const onBlockReply = vi.fn().mockResolvedValue(undefined);
++    const rawAnswer =
++      'Visible.<minimax:tool_call><invoke name="read">private</invoke></minimax:tool_call>';
++    streamSimpleMock.mockReturnValue(
++      makeAsyncEvents([
++        {
++          type: "text_delta",
++          delta: rawAnswer,
++          partial: {
++            role: "assistant",
++            content: [],
++            provider: DEFAULT_PROVIDER,
++            model: DEFAULT_MODEL,
++          },
++        },
++        createDoneEvent(rawAnswer),
++      ]),
++    );
++
++    await runSideQuestion({
++      blockReplyChunking: {
++        minChars: 1,
++        maxChars: 200,
++        breakPreference: "paragraph",
++      },
++      resolvedBlockStreamingBreak: "message_end",
++      opts: { onBlockReply },
++    });
++
++    expect(onBlockReply).toHaveBeenCalledWith({
++      text: "Visible.",
++      btw: { question: DEFAULT_QUESTION },
++    });
++  });
++
+   it("routes Codex-selected BTW questions through the harness side-question hook", async () => {
+     const codexSideQuestionMock = vi.fn().mockResolvedValue({ text: "Codex side answer." });
+     registerAgentHarness({
+@@ -1096,6 +1153,10 @@ describe("runBtwSideQuestion", () => {
+     await runSideQuestion({ question: "what is the distance to the sun?" });
+ 
+     const context = streamContext();
++    expect(String(context.systemPrompt)).toContain("This direct /btw fallback has no tools");
++    expect(String(context.systemPrompt)).not.toContain(
++      "unless the side question explicitly asks for them",
++    );
+     expect(String(context.systemPrompt)).toContain(
+       "Do not continue, resume, or complete any unfinished task",
+     );
+diff --git a/src/agents/btw.ts b/src/agents/btw.ts
+index 933d09c647..d8f7d51c70 100644
+--- a/src/agents/btw.ts
++++ b/src/agents/btw.ts
+@@ -1,6 +1,6 @@
+ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+ import type { GetReplyOptions } from "../auto-reply/get-reply-options.types.js";
+-import type { ReplyPayload } from "../auto-reply/reply-payload.js";
++import { BtwErrorCode, type ReplyPayload } from "../auto-reply/reply-payload.js";
+ import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
+ import type { SessionEntry as StoredSessionEntry } from "../config/sessions.js";
+ import type { OpenClawConfig } from "../config/types.openclaw.js";
+@@ -20,6 +20,7 @@ import { resolveExternalCliAuthOverlayScopeFromSelection } from "./auth-profiles
+ import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
+ import { readBtwTranscriptMessages, resolveBtwSessionTranscriptPath } from "./btw-transcript.js";
+ import { EmbeddedBlockChunker, type BlockReplyChunking } from "./embedded-agent-block-chunker.js";
++import { sanitizeUserFacingText } from "./embedded-agent-helpers/sanitize-user-facing-text.js";
+ import { resolveModelWithRegistry } from "./embedded-agent-runner/model.js";
+ import { getActiveEmbeddedRunSnapshot } from "./embedded-agent-runner/runs.js";
+ import { resolveEmbeddedAgentStreamFn } from "./embedded-agent-runner/stream-resolution.js";
+@@ -60,12 +61,18 @@ function buildBtwSystemPrompt(): string {
+     "Use the conversation only as background context.",
+     "Answer only the side question in the last user message.",
+     "Do not continue, resume, or complete any unfinished task from the conversation.",
+-    "Do not emit tool calls, pseudo-tool calls, shell commands, file writes, patches, or code unless the side question explicitly asks for them.",
++    "This direct /btw fallback has no tools and cannot read files or inspect state beyond the supplied conversation context.",
++    "Never emit tool calls, pseudo-tool calls, or provider control markup.",
++    "If answering requires a fresh tool operation, say briefly that it must be done in the main conversation.",
++    "Never claim that a command, file operation, or other tool action was executed.",
+     "Do not say you will continue the main task after answering.",
+     "If the question can be answered briefly, answer briefly.",
+   ].join("\n");
+ }
+ 
++const BTW_TOOL_PROTOCOL_RE =
++  /(?:<\s*\/?\s*[|｜]\s*DSML\s*[|｜]\s*(?:tool_use_error|tool_calls?|function_calls)\s*>|<\s*\/?\s*(?:minimax:tool_call|tool_calls?|tool_result|function_calls?|function_response)\b|\[\s*\/?\s*TOOL_(?:CALL|RESULT)\s*\]|\[tool:[A-Za-z_][A-Za-z0-9_.:-]*\])/i;
++
+ function resolveReturnedAuthProfileSource(
+   sessionEntry: StoredSessionEntry | undefined,
+   authProfileId: string | undefined,
+@@ -522,14 +529,15 @@ export async function runBtwSideQuestion(
+   let sawTextEvent = false;
+ 
+   const emitBlockChunk = async (text: string) => {
+-    const trimmed = text.trim();
++    const sanitized = sanitizeUserFacingText(text);
++    const trimmed = sanitized.trim();
+     if (!trimmed || !params.opts?.onBlockReply) {
+       return;
+     }
+     emittedBlocks += 1;
+     blockEmitChain = blockEmitChain.then(async () => {
+       await params.opts?.onBlockReply?.({
+-        text,
++        text: sanitized,
+         btw: { question: params.question },
+       });
+     });
+@@ -632,8 +640,19 @@ export async function runBtwSideQuestion(
+     }
+   }
+ 
+-  const answer = answerText.trim();
++  const rawAnswer = answerText.trim();
++  const answer = sanitizeUserFacingText(rawAnswer).trim();
+   if (!answer) {
++    if (rawAnswer && BTW_TOOL_PROTOCOL_RE.test(rawAnswer)) {
++      return {
++        text: "This side question requires a tool operation. Continue in the main conversation.",
++        isError: true,
++        btw: {
++          question: params.question,
++          errorCode: BtwErrorCode.ToolRequired,
++        },
++      };
++    }
+     throw new Error("No BTW response generated.");
+   }
+ 
+diff --git a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+index 2240f80a9f..7b98154453 100644
+--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
++++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+@@ -281,6 +281,25 @@ describe("sanitizeUserFacingText", () => {
+     expect(sanitizeUserFacingText(input)).toBe("Let me check that.\n\nDone.");
+   });
+ 
++  it("strips complete and truncated DeepSeek DSML blocks before user-facing delivery", () => {
++    expect(
++      sanitizeUserFacingText(
++        'Before<|DSML|tool_calls><|DSML|invoke name="read">private</|DSML|invoke></|DSML|tool_calls>After',
++      ),
++    ).toBe("BeforeAfter");
++    expect(sanitizeUserFacingText("Visible<｜DSML｜tool_call>private payload")).toBe("Visible");
++  });
++
++  it("preserves DeepSeek DSML examples in user-facing code spans", () => {
++    const inline = "Use `<|DSML|tool_calls>example</|DSML|tool_calls>` in protocol docs.";
++    const fenced = ["```text", "<｜DSML｜tool_calls>example</｜DSML｜tool_calls>", "```"].join(
++      "\n",
++    );
++
++    expect(sanitizeUserFacingText(inline)).toBe(inline);
++    expect(sanitizeUserFacingText(fenced)).toBe(fenced);
++  });
++
+   it("preserves MiniMax tool-call XML examples in user-facing code spans", () => {
+     const inline = 'Use `<minimax:tool_call><invoke name="exec">x</invoke></minimax:tool_call>`.';
+     const fenced = [
+diff --git a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+index 2d8da4be50..e72a50740f 100644
+--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
++++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+@@ -1,3 +1,7 @@
++import {
++  normalizeLowercaseStringOrEmpty,
++  normalizeOptionalLowercaseString,
++} from "../../../packages/normalization-core/src/string-coerce.js";
+ import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
+ import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
+ import {
+@@ -11,10 +15,7 @@ import {
+ } from "../../shared/assistant-error-format.js";
+ import { coerceChatContentText } from "../../shared/chat-content.js";
+ import {
+-  normalizeLowercaseStringOrEmpty,
+-  normalizeOptionalLowercaseString,
+-} from "../../../packages/normalization-core/src/string-coerce.js";
+-import {
++  stripDeepSeekDsmlToolCallBlocks,
+   stripLegacyBracketToolCallBlocks,
+   stripMinimaxToolCallXml,
+   stripToolCallXmlTags,
+@@ -407,9 +408,12 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
+   }
+   const errorContext = opts?.errorContext ?? false;
+   const stripped = stripInboundMetadata(stripInternalRuntimeContext(stripFinalTagsFromText(raw)));
+-  const withoutToolCallXml = stripToolCallXmlTags(stripMinimaxToolCallXml(stripped), {
+-    stripFunctionCallsXmlPayloads: true,
+-  });
++  const withoutToolCallXml = stripToolCallXmlTags(
++    stripMinimaxToolCallXml(stripDeepSeekDsmlToolCallBlocks(stripped)),
++    {
++      stripFunctionCallsXmlPayloads: true,
++    },
++  );
+   // Replay repair may synthesize this placeholder to keep provider transcripts valid.
+   // It is internal scaffolding, so drop standalone placeholder lines before delivery
+   // while preserving ordinary inline mentions a user may be discussing.
+diff --git a/src/auto-reply/reply-payload.ts b/src/auto-reply/reply-payload.ts
+index 639e12ca8d..775d6f0b9c 100644
+--- a/src/auto-reply/reply-payload.ts
++++ b/src/auto-reply/reply-payload.ts
+@@ -4,6 +4,11 @@ import type {
+   ReplyPayloadDelivery,
+ } from "../interactive/payload.js";
+ 
++export const BtwErrorCode = {
++  ToolRequired: "tool_required",
++} as const;
++export type BtwErrorCode = (typeof BtwErrorCode)[keyof typeof BtwErrorCode];
++
+ export type ReplyPayload = {
+   text?: string;
+   mediaUrl?: string;
+@@ -24,6 +29,7 @@ export type ReplyPayload = {
+   interactive?: InteractiveReply;
+   btw?: {
+     question: string;
++    errorCode?: BtwErrorCode;
+   };
+   replyToId?: string;
+   replyToTag?: boolean;
+diff --git a/src/auto-reply/reply/commands-btw.test.ts b/src/auto-reply/reply/commands-btw.test.ts
+index 7dc1b5a417..8d92b80657 100644
+--- a/src/auto-reply/reply/commands-btw.test.ts
++++ b/src/auto-reply/reply/commands-btw.test.ts
+@@ -100,6 +100,37 @@ describe("handleBtwCommand", () => {
+     });
+   });
+ 
++  it("preserves a stable BTW error code from the side-question runner", async () => {
++    const params = buildParams("/btw read the file");
++    params.agentDir = "/tmp/agent";
++    params.sessionEntry = {
++      sessionId: "session-1",
++      updatedAt: Date.now(),
++    };
++    runBtwSideQuestionMock.mockResolvedValue({
++      text: "Use the main conversation.",
++      isError: true,
++      btw: {
++        question: "runtime question",
++        errorCode: "tool_required",
++      },
++    });
++
++    const result = await handleBtwCommand(params, true);
++
++    expect(result).toEqual({
++      shouldContinue: false,
++      reply: {
++        text: "Use the main conversation.",
++        isError: true,
++        btw: {
++          question: "read the file",
++          errorCode: "tool_required",
++        },
++      },
++    });
++  });
++
+   it("starts the typing keepalive while the side question runs", async () => {
+     const params = buildParams("/btw what changed?");
+     const typing = createMockTypingController();
+diff --git a/src/auto-reply/reply/commands-btw.ts b/src/auto-reply/reply/commands-btw.ts
+index d188fac08a..76a1a0d8c4 100644
+--- a/src/auto-reply/reply/commands-btw.ts
++++ b/src/auto-reply/reply/commands-btw.ts
+@@ -78,7 +78,15 @@ export const handleBtwCommand: CommandHandler = async (params, allowTextCommands
+     });
+     return {
+       shouldContinue: false,
+-      reply: reply ? { ...reply, btw: { question } } : reply,
++      reply: reply
++        ? {
++            ...reply,
++            btw: {
++              ...reply.btw,
++              question,
++            },
++          }
++        : reply,
+     };
+   } catch (error) {
+     const message = error instanceof Error ? error.message.trim() : "";
+diff --git a/src/gateway/server.chat.gateway-server-chat.test.ts b/src/gateway/server.chat.gateway-server-chat.test.ts
+index d65c20eec2..909e71b316 100644
+--- a/src/gateway/server.chat.gateway-server-chat.test.ts
++++ b/src/gateway/server.chat.gateway-server-chat.test.ts
+@@ -1046,7 +1046,11 @@ describe("gateway server chat", () => {
+         const [params] = args as [
+           {
+             dispatcher: {
+-              sendFinalReply: (payload: { text: string; btw: { question: string } }) => boolean;
++              sendFinalReply: (payload: {
++                text: string;
++                btw: { question: string; errorCode?: string };
++                isError?: boolean;
++              }) => boolean;
+               markComplete: () => void;
+               waitForIdle: () => Promise<void>;
+               getQueuedCounts: () => { final: number; block: number; tool: number };
+@@ -1054,8 +1058,12 @@ describe("gateway server chat", () => {
+           },
+         ];
+         params.dispatcher.sendFinalReply({
+-          text: "323",
+-          btw: { question: "what is 17 * 19?" },
++          text: "Continue in the main conversation.",
++          btw: {
++            question: "what is 17 * 19?",
++            errorCode: "tool_required",
++          },
++          isError: true,
+         });
+         params.dispatcher.markComplete();
+         await params.dispatcher.waitForIdle();
+@@ -1100,7 +1108,9 @@ describe("gateway server chat", () => {
+         runId: "idem-btw-1",
+         sessionKey: "agent:main:main",
+         question: "what is 17 * 19?",
+-        text: "323",
++        text: "Continue in the main conversation.",
++        errorCode: "tool_required",
++        isError: true,
+       });
+       expectRecordFields(finalEvent.payload, {
+         runId: "idem-btw-1",
+diff --git a/src/gateway/server-methods/chat.ts b/src/gateway/server-methods/chat.ts
+index 497024cc3f..cf10d9e857 100644
+--- a/src/gateway/server-methods/chat.ts
++++ b/src/gateway/server-methods/chat.ts
+@@ -490,6 +490,7 @@ type SideResultPayload = {
+   agentId?: string;
+   question: string;
+   text: string;
++  errorCode?: string;
+   isError?: boolean;
+   ts: number;
+ };
+@@ -2186,7 +2187,7 @@ function broadcastChatFinal(params: {
+ }
+ 
+ function isBtwReplyPayload(payload: ReplyPayload | undefined): payload is ReplyPayload & {
+-  btw: { question: string };
++  btw: { question: string; errorCode?: string };
+   text: string;
+ } {
+   return (
+@@ -3684,6 +3685,9 @@ export const chatHandlers: GatewayRequestHandlers = {
+                   .filter(Boolean)
+                   .join("\n\n")
+                   .trim();
++                const btwErrorCode = btwReplies
++                  .map((payload) => payload.btw.errorCode)
++                  .find((value) => value !== undefined);
+                 if (btwReplies.length > 0 && btwText) {
+                   broadcastSideResult({
+                     context,
+@@ -3694,6 +3698,7 @@ export const chatHandlers: GatewayRequestHandlers = {
+                       ...(sessionKey === "global" && agentId ? { agentId } : {}),
+                       question: btwReplies[0].btw.question.trim(),
+                       text: btwText,
++                      ...(btwErrorCode ? { errorCode: btwErrorCode } : {}),
+                       isError: btwReplies.some((payload) => payload.isError),
+                       ts: Date.now(),
+                     },
+diff --git a/src/shared/text/assistant-visible-text.ts b/src/shared/text/assistant-visible-text.ts
+index 1a30bebc84..56a3caadfb 100644
+--- a/src/shared/text/assistant-visible-text.ts
++++ b/src/shared/text/assistant-visible-text.ts
+@@ -11,6 +11,10 @@ import {
+ const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
+ const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
+ const LEGACY_BRACKET_TOOL_BLOCK_QUICK_RE = /\[\s*\/?\s*TOOL_(?:CALL|RESULT)\s*\]/i;
++const DEEPSEEK_DSML_TOOL_BLOCK_RE =
++  /<\s*(\/?)\s*[|｜]\s*DSML\s*[|｜]\s*(?:tool_use_error|tool_calls?|function_calls)\s*>/gi;
++const DEEPSEEK_DSML_TOOL_BLOCK_QUICK_RE =
++  /<\s*\/?\s*[|｜]\s*DSML\s*[|｜]\s*(?:tool_use_error|tool_calls?|function_calls)\s*>/i;
+ 
+ /**
+  * Strip XML-style tool call tags that models sometimes emit as plain text.
+@@ -562,6 +566,46 @@ export function stripLegacyBracketToolCallBlocks(text: string): string {
+   return result;
+ }
+ 
++export function stripDeepSeekDsmlToolCallBlocks(text: string): string {
++  if (!text || !DEEPSEEK_DSML_TOOL_BLOCK_QUICK_RE.test(text)) {
++    return text;
++  }
++
++  const codeRegions = findCodeRegions(text);
++  let result = "";
++  let cursor = 0;
++  let insideBlock = false;
++
++  DEEPSEEK_DSML_TOOL_BLOCK_RE.lastIndex = 0;
++  for (const match of text.matchAll(DEEPSEEK_DSML_TOOL_BLOCK_RE)) {
++    const start = match.index ?? 0;
++    if (isInsideCode(start, codeRegions)) {
++      continue;
++    }
++    const end = start + match[0].length;
++    const isClose = match[1] === "/";
++
++    if (!insideBlock) {
++      result += text.slice(cursor, start);
++      cursor = end;
++      if (!isClose) {
++        insideBlock = true;
++      }
++      continue;
++    }
++
++    cursor = end;
++    if (isClose) {
++      insideBlock = false;
++    }
++  }
++
++  if (!insideBlock) {
++    result += text.slice(cursor);
++  }
++  return result;
++}
++
+ /**
+  * Strip downgraded tool call text representations that leak into user-visible
+  * text content when replaying history across providers.
+@@ -824,6 +868,7 @@ function applyAssistantVisibleTextStagePipeline(
+   };
+   const stripNonReasoningStages = (value: string) => {
+     let cleaned = value;
++    cleaned = stripDeepSeekDsmlToolCallBlocks(cleaned);
+     if (!options.preserveMinimaxToolXml) {
+       cleaned = stripMinimaxToolCallXml(cleaned);
+     }

--- a/specs/features/cowork-btw/2026-07-24-cowork-btw-side-question-design.md
+++ b/specs/features/cowork-btw/2026-07-24-cowork-btw-side-question-design.md
@@ -47,6 +47,9 @@ history, fail during an active turn, or complete without displaying the answer.
 - Use OpenClaw's existing `chat.send` command handling and `chat.side_result`
   contract, with a version-scoped compatibility patch for the pinned runtime's
   provider run-safety integration.
+- Never expose provider-internal tool-call markup such as DeepSeek DSML,
+  MiniMax XML, Grok-style tool lines, or generic tool-call XML as a visible BTW
+  answer.
 - Preserve session and agent isolation when multiple Cowork sessions are open
   or syncing from external channels.
 - Add Chinese and English strings for all BTW UI and error states.
@@ -66,6 +69,12 @@ history, fail during an active turn, or complete without displaying the answer.
 - The side-chat window is not a durable or OpenClaw-native thread. Follow-up
   continuity is assembled from bounded renderer-memory entries and supplied to
   each independent `/btw` request.
+- This design does not make the non-Codex direct BTW fallback tool-capable.
+  Tool execution for that path is a separate runtime feature, not a renderer
+  protocol-parsing task.
+- The renderer must not parse or execute raw model-generated tool-call text.
+  Doing so would bypass OpenClaw's tool policy, sandbox, approval, timeout, and
+  audit boundaries.
 - LobsterAI does not reimplement OpenClaw's context snapshot, model selection,
   tool policy, or provider-specific BTW behavior.
 - External IM rendering remains owned by OpenClaw channel integrations. This
@@ -120,6 +129,189 @@ Agent boundary-aware stream because BTW does not own the host Agent dispatch
 scope required by that stream contract. The resolver defaults every caller
 without an explicit purpose to `Agent`, preserving the main task, compaction,
 and other embedded-agent run-safety paths.
+
+## Tool Capability, Protocol Leakage, and Runtime Safety Analysis
+
+This section records the source-level conclusions verified against the pinned
+OpenClaw `v2026.6.1` runtime on 2026-07-30.
+
+The relevant implementation points are OpenClaw's `src/agents/btw.ts`,
+`extensions/codex/src/app-server/side-question.ts`,
+`src/gateway/server-methods/chat.ts`, provider transport filters and the shared
+user-facing sanitizer, plus LobsterAI's
+`src/main/libs/agentEngine/openclawRuntimeAdapter.ts`.
+
+### Capability Is Selected by Runtime Path
+
+BTW tool support is not determined solely by whether a model can call tools in
+a normal Agent turn.
+
+| Runtime path | BTW implementation | Tool and file behavior |
+| --- | --- | --- |
+| Codex native harness | Forks an ephemeral Codex app-server side thread | Keeps the current Codex sandbox, approval policy, native tools, and bridged OpenClaw tools. It may read files and may perform an explicitly requested mutation when policy permits. |
+| Non-Codex providers, including DeepSeek, Qwen, and Ollama | Uses the direct one-shot provider fallback | Intentionally tool-less. It can answer from captured context but cannot perform a new `read`, `write`, `exec`, or other OpenClaw tool operation. |
+| Normal Cowork Agent turn | Uses the normal embedded/native Agent loop | Keeps the existing structured tool execution and LobsterAI tool UI. It is unaffected by the BTW fallback restriction. |
+
+Therefore, the same DeepSeek or Qwen model may execute tools in the main Cowork
+conversation but not through `/btw`. This is an OpenClaw BTW execution-path
+limitation, not a general model capability limitation and not evidence that
+LobsterAI failed to subscribe to a structured BTW tool event.
+
+The `chat.side_result` payload contains final `text` and no tool-call or
+tool-result fields. Codex BTW may execute tools internally and still return
+only the final text. A structured side-tool protocol is needed only if the
+floating window must display live tool progress, results, approvals, or
+failures.
+
+### Observed Tool-Protocol Leakage
+
+The observed failure renders provider protocol text similar to:
+
+```text
+<|DSML|tool_calls>...<|DSML|invoke name="read">...</|DSML|tool_calls>
+```
+
+This is not a Markdown rendering bug and does not mean a `read` succeeded. The
+failure sequence is:
+
+1. a non-Codex BTW question asks for work that requires a tool;
+2. the direct fallback exposes no tools or Agent tool loop;
+3. the model nevertheless emits a pseudo-tool call in provider-specific text;
+4. the fallback returns that text through `chat.side_result.text`;
+5. LobsterAI correctly routes the final text to the matching ephemeral entry;
+6. the Markdown renderer displays it because Markdown sanitization is not
+   model-protocol sanitization.
+
+The non-Codex fallback prompt currently says not to emit tool calls unless the
+side question explicitly asks for them. That exception is ambiguous for a
+tool-less path and can encourage a pseudo-tool call when the user explicitly
+asks to read or modify a file. The fallback instruction should instead state
+unconditionally that it cannot emit or execute tools and should return a
+concise capability message when a fresh tool operation is required.
+
+### Reuse of the Main Conversation Safety Pipeline
+
+The main Agent path provides the reference architecture:
+
+- native provider tool calls are normalized into structured OpenClaw tool
+  events;
+- DeepSeek DSML recovery/filtering is provider-specific and is enabled by the
+  OpenAI-compatible transport's DeepSeek compatibility metadata;
+- the shared `sanitizeUserFacingText` boundary removes known residual MiniMax,
+  Grok, legacy bracket, generic `<tool_call>`, and function-call markup;
+- LobsterAI consumes normalized Agent tool start/update/result events rather
+  than parsing assistant prose.
+
+There is no safe universal parser that can execute every provider's private
+text protocol. The common handling strategy is layered:
+
+1. provider-specific transport normalization for executable structured calls;
+2. a provider-agnostic final sanitizer for known residual control markup;
+3. a LobsterAI main-process display guard for older, unknown, or incompatible
+   runtime output.
+
+DeepSeek DSML should be factored into the shared user-visible sanitization
+boundary rather than implemented as a renderer-only special case. Coverage
+must include ASCII and full-width bar variants, split and truncated blocks,
+MiniMax, Grok, legacy bracket blocks, and generic tool/function-call XML.
+Literal protocol examples in inline or fenced code must remain visible when
+the user is discussing the syntax.
+
+### How Codex Native BTW Handles Tool Runtime Concerns
+
+The Codex harness implements substantially more than the non-Codex fallback:
+
+1. **Independent temporary execution**
+   - It forks the active Codex thread with `ephemeral: true`.
+   - It injects an explicit side-conversation boundary and starts a separate
+     turn with the same model and working directory.
+   - Parent history is reference context only; the side turn does not append
+     its question or answer to the parent transcript.
+2. **Sandbox and approval**
+   - It inherits the parent binding's `sandbox` and `approvalPolicy`.
+   - It resolves the OpenClaw coding-tool catalog through the same sandbox
+     context and bridges dynamic tool calls back to OpenClaw.
+   - App-server approval requests are handled through the existing approval
+     bridge. Auto-approval is derived from the effective sandbox and approval
+     policy.
+   - Developer instructions allow mutation only when the new side question
+     explicitly requests it. This prompt is guidance; sandbox and approvals
+     remain the actual enforcement boundary.
+3. **Stop, timeout, and cleanup**
+   - The upstream abort signal propagates into the side run and every bridged
+     dynamic tool call.
+   - Dynamic tools have bounded timeouts: 90 seconds by default, specialized
+     media timeouts where configured, and a hard maximum of 600 seconds.
+   - Waiting for the side turn also has a bounded completion timeout.
+   - Final cleanup removes listeners and request handlers, aborts remaining
+     tool work, interrupts an unfinished side turn, unsubscribes the child
+     thread, releases the leased app-server client, and unregisters the native
+     hook relay.
+   - LobsterAI's stop button calls `chat.abort` with the exact BTW run id; the
+     resulting abort signal is independent from the main Cowork turn.
+4. **Tool lifecycle and approvals**
+   - Codex internally handles dynamic tools and relays pre-tool, post-tool,
+     permission-request, and before-finalize hooks.
+   - The current Gateway BTW client contract still publishes only the final
+     `chat.side_result.text`.
+   - `OpenClawRuntimeAdapter` intentionally suppresses Agent events correlated
+     to a BTW run, so the LobsterAI floating window currently shows neither
+     tool progress nor tool result cards.
+
+### Remaining Codex BTW Gap: Concurrent Workspace Mutation
+
+Codex BTW does not provide a file lock, workspace snapshot, transaction,
+automatic merge, or conflict detector between the parent turn and the side
+turn. Both can use the same `cwd`.
+
+OpenClaw reduces risk through side-boundary instructions that prefer
+lightweight, non-mutating exploration and require an explicit side request
+before mutation. This is not hard concurrency isolation. If a user explicitly
+asks the side turn to modify a file while the main turn writes the same
+workspace, last-writer-wins behavior or inconsistent reads remain possible.
+
+Any future non-Codex tool-capable BTW implementation must make an explicit
+product decision:
+
+- start with read-only tools;
+- serialize mutating side tools against main-turn mutations;
+- use a snapshot/worktree and merge deliberately; or
+- allow concurrent writes with a visible warning and conflict detection.
+
+The current feature should not imply that OpenClaw already solves this
+concurrency problem.
+
+### Recommended Near-Term Handling
+
+The immediate fix is protocol hygiene, not renderer-side tool execution:
+
+1. patch the pinned OpenClaw fallback to use an unconditional no-tool prompt;
+2. apply the shared user-visible-text sanitizer before returning direct BTW
+   text and extend that boundary for DSML;
+3. preserve remaining visible prose but treat a tool-only response as a stable
+   tool-required failure;
+4. add a LobsterAI main-process defense that replaces residual protocol markup
+   with localized guidance to continue in the main conversation;
+5. log only marker family, run/session identity, and before/after character
+   counts, never the raw prompt, path, arguments, or answer;
+6. keep the renderer as a presentation layer and never execute parsed markup.
+
+If provider-independent localized copy requires a protocol field, prefer an
+optional stable error code such as `tool_required` over matching an English
+backend error string. Older runtimes remain compatible through the
+main-process fallback.
+
+### Future Tool-Capable Non-Codex BTW
+
+If the product later requires non-Codex BTW to use tools, replace the direct
+provider fallback with an independent ephemeral Agent tool loop that inherits
+the model, cwd, tool policy, sandbox, and approvals while owning separate
+abort, timeout, cleanup, and lifecycle state.
+
+Returning only the final answer can continue to use `chat.side_result.text`.
+Displaying tool progress, results, or approvals requires side-run-correlated
+structured events and a dedicated LobsterAI side-tool UI. Parsing DSML or
+other raw text in the renderer is not an acceptable substitute.
 
 ## Product Behavior
 
@@ -177,7 +369,9 @@ the normal message-list persistence model.
   resize or display-resolution changes automatically bring the full window
   back into view.
 - The message area independently scrolls and renders completed answers with
-  the existing sanitized Markdown renderer.
+  the existing sanitized Markdown renderer. Runtime and main-process protocol
+  sanitization happens before Markdown rendering; the renderer does not infer,
+  execute, or repair provider tool protocols.
 - The window reuses the main conversation's theme tokens, borders,
   rounded-input, and send-button treatments. Its shell uses the elevated
   `surface` layer, and the composer uses the same lighter `surface` layer
@@ -416,8 +610,20 @@ and the newly settled thread remain protected.
 
 BTW does not elevate permissions or bypass sandbox/approval policy. Provider,
 Codex harness, tool, and reasoning behavior remains controlled by OpenClaw.
-LobsterAI renders only the final side-result text and existing approval flows
-remain authoritative.
+LobsterAI never executes model-generated control markup. The current floating
+window renders only normalized final side-result text; existing OpenClaw
+sandbox and approval flows remain authoritative even when Codex native BTW
+uses tools internally.
+
+### INV-6: No Provider Protocol Leakage
+
+Recognized provider control blocks must not be exposed as BTW answers. The
+trusted runtime or main-process boundary removes residual DSML, MiniMax, Grok,
+legacy bracket, generic tool-call XML, and function-call markup before the
+answer reaches renderer state. Ordinary prose and literal protocol examples
+inside inline or fenced code remain intact. A tool-only response becomes a
+localized, stable tool-required failure and never becomes an executable
+renderer action.
 
 ## Compatibility
 
@@ -425,6 +631,12 @@ remain authoritative.
 - The version-scoped OpenClaw `v2026.6.1` patch keeps BTW utility fallbacks
   outside Agent run-safety streams while leaving the default Agent path
   unchanged.
+- The OpenClaw fallback prompt and final-text sanitizer fix applies across
+  non-Codex providers; it is not coupled to DeepSeek model names. DeepSeek DSML
+  is one provider-specific marker family covered by the shared boundary.
+- A LobsterAI main-process residual guard protects installations using an
+  older or incompatible OpenClaw runtime. It changes only BTW display output
+  and must not parse or alter normal main-Agent tool events.
 - macOS and Windows use the same Electron IPC and Gateway event path.
 - Older or incompatible runtimes return a visible ephemeral failure instead of
   silently falling back to a normal chat message.
@@ -439,6 +651,9 @@ remain authoritative.
 - Runtime logs include the resolved session key, active-main-turn presence,
   side-result routing, question-normalization character counts, terminal-final
   suppression, and cleanup reason.
+- Protocol-sanitization diagnostics include only the marker family, run and
+  session identity, whether visible prose remained, and before/after character
+  counts.
 - Logs must not include raw BTW question or answer content.
 - Unexpected `chat.side_result` payloads and session-mapping failures use
   `console.warn`; request or runtime failures use `console.error`.
@@ -459,11 +674,22 @@ remain authoritative.
   - duplicate and out-of-order terminal events;
   - Gateway rejection, disconnect, timeout, and session deletion cleanup;
   - absence of Cowork message and transcript mutations.
+- Sanitizer and compatibility tests verify:
+  - complete, split, and truncated DeepSeek DSML blocks using ASCII and
+    full-width bar variants;
+  - MiniMax XML, Grok-style tool lines, legacy bracket blocks, generic
+    tool-call XML, and function-call markup;
+  - mixed prose preserves the visible answer while removing control markup;
+  - a tool-only BTW response becomes the localized tool-required failure;
+  - literal protocol syntax in inline or fenced code remains visible;
+  - no raw prompts, file paths, tool arguments, or answers are logged;
+  - normal main-Agent structured tool start/update/result behavior is
+    unchanged.
 - The Electron compile verifies the shared IPC/preload request, response, and
   listener type contract.
 - UI tests verify the two-action selected-text toolbar, bottom-right default
-  geometry, viewport clamping, thread state, and pending/result/error rendering
-  outside the normal chat message model.
+  fallback, prompt-anchored default geometry, viewport clamping, thread state,
+  and pending/result/error rendering outside the normal chat message model.
 - Changed TypeScript/TSX files pass targeted ESLint.
 - Main/preload changes pass `npm run compile:electron`.
 - Renderer changes pass `npm run build`.
@@ -471,9 +697,19 @@ remain authoritative.
   - BTW returns while a long main task continues;
   - main streaming/tool state is not interrupted;
   - `/side` behaves identically to `/btw`;
+  - a non-Codex BTW request that needs a fresh tool operation returns safe
+    guidance rather than provider protocol text;
+  - a Codex native BTW tool request follows the inherited sandbox and approval
+    policy, and stopping it does not stop the main task;
+  - the current floating window shows only the Codex BTW final answer and does
+    not falsely imply that live tool progress or approval cards are supported;
+  - explicitly mutating the same workspace from a Codex BTW request and the
+    main task is treated as an unsupported concurrency case until a product
+    isolation policy is implemented;
   - switching sessions does not leak a window or thread;
-  - the window opens in the bottom-right, remains draggable/resizable, and is
-    recovered into view after shrinking the application;
+  - the window opens above and right-aligned with the main prompt, falls back
+    to the bottom-right when no anchor exists, remains draggable/resizable, and
+    is recovered into view after shrinking the application;
   - reload removes the temporary thread;
   - selecting assistant text shows both actions and the side-chat action does
     not send until the side-chat excerpt tag or editable input is submitted;

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -115,6 +115,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkBtwSubmitFailed: '提交顺便问问失败。',
     coworkBtwNoPending: '找不到正在回答的顺便问问。',
     coworkBtwStopFailed: '停止顺便问问失败，请重试。',
+    coworkBtwToolRequired: '这个问题需要调用工具，请在主对话中继续。',
     imErrorPrefix: '处理消息时出错',
 
     // Exec approval continuation
@@ -453,6 +454,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkBtwSubmitFailed: 'Failed to submit the BTW side question.',
     coworkBtwNoPending: 'No pending BTW side question was found.',
     coworkBtwStopFailed: 'Failed to stop the BTW side question. Please try again.',
+    coworkBtwToolRequired:
+      'This question requires a tool operation. Continue in the main conversation.',
     imErrorPrefix: 'Error processing message',
 
     // Exec approval continuation

--- a/src/main/libs/agentEngine/coworkBtwResultSanitizer.test.ts
+++ b/src/main/libs/agentEngine/coworkBtwResultSanitizer.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  CoworkBtwProtocolFamily,
+  sanitizeCoworkBtwResultText,
+} from './coworkBtwResultSanitizer';
+
+describe('sanitizeCoworkBtwResultText', () => {
+  test.each([
+    {
+      name: 'ASCII DeepSeek DSML',
+      input: [
+        'Before',
+        '<|DSML|tool_calls><|DSML|invoke name="read">',
+        '<|DSML|parameter name="filePath">/secret/file</|DSML|parameter>',
+        '</|DSML|invoke></|DSML|tool_calls>',
+        'After',
+      ].join('\n'),
+      expected: 'Before\n\nAfter',
+    },
+    {
+      name: 'full-width DeepSeek DSML with a mismatched close kind',
+      input: 'Before<｜DSML｜tool_call>read</｜DSML｜tool_calls>After',
+      expected: 'BeforeAfter',
+    },
+    {
+      name: 'truncated DeepSeek DSML',
+      input: 'Visible answer.<｜DSML｜tool_calls>private payload',
+      expected: 'Visible answer.',
+    },
+  ])('removes $name', ({ input, expected }) => {
+    const result = sanitizeCoworkBtwResultText(input);
+
+    expect(result.text).toBe(expected);
+    expect(result.detectedFamilies).toEqual([CoworkBtwProtocolFamily.DeepSeekDsml]);
+  });
+
+  test('removes known non-DSML tool protocol families', () => {
+    const input = [
+      'Visible',
+      '<minimax:tool_call><invoke name="exec">private</invoke></minimax:tool_call>',
+      '[TOOL_CALL]{tool => "read", args => {"path":"private"}}[/TOOL_CALL]',
+      '<function_calls><invoke name="find">private</invoke></function_calls>',
+      '[tool:read] {"path":"/private/file"}',
+      'Done',
+    ].join('\n');
+
+    const result = sanitizeCoworkBtwResultText(input);
+
+    expect(result.text).toBe('Visible\n\n\n\nDone');
+    expect(result.detectedFamilies).toEqual([
+      CoworkBtwProtocolFamily.MiniMaxXml,
+      CoworkBtwProtocolFamily.LegacyBracket,
+      CoworkBtwProtocolFamily.XmlToolCall,
+      CoworkBtwProtocolFamily.PlainTextToolCall,
+    ]);
+  });
+
+  test('preserves literal protocol examples inside inline and fenced code', () => {
+    const input = [
+      'Use `<|DSML|tool_calls>example</|DSML|tool_calls>` when documenting the protocol.',
+      '```xml',
+      '<function_calls><invoke name="read">example</invoke></function_calls>',
+      '```',
+    ].join('\n');
+
+    expect(sanitizeCoworkBtwResultText(input)).toEqual({
+      text: input,
+      detectedFamilies: [],
+    });
+  });
+
+  test('does not let an unmatched Markdown delimiter hide provider protocol', () => {
+    const input = 'Visible `unfinished example\n<|DSML|tool_calls>private payload';
+
+    expect(sanitizeCoworkBtwResultText(input)).toEqual({
+      text: 'Visible `unfinished example\n',
+      detectedFamilies: [CoworkBtwProtocolFamily.DeepSeekDsml],
+    });
+  });
+
+  test('leaves ordinary answers unchanged', () => {
+    const input = 'A normal answer with Markdown.\n\n- One\n- Two';
+
+    expect(sanitizeCoworkBtwResultText(input)).toEqual({
+      text: input,
+      detectedFamilies: [],
+    });
+  });
+});

--- a/src/main/libs/agentEngine/coworkBtwResultSanitizer.ts
+++ b/src/main/libs/agentEngine/coworkBtwResultSanitizer.ts
@@ -1,0 +1,171 @@
+export const CoworkBtwProtocolFamily = {
+  DeepSeekDsml: 'deepseek_dsml',
+  MiniMaxXml: 'minimax_xml',
+  XmlToolCall: 'xml_tool_call',
+  LegacyBracket: 'legacy_bracket',
+  PlainTextToolCall: 'plain_text_tool_call',
+} as const;
+
+export type CoworkBtwProtocolFamily =
+  typeof CoworkBtwProtocolFamily[keyof typeof CoworkBtwProtocolFamily];
+
+export interface CoworkBtwSanitizedResult {
+  text: string;
+  detectedFamilies: CoworkBtwProtocolFamily[];
+}
+
+type SegmentSanitizer = (value: string) => string;
+
+const DEEPSEEK_DSML_OPEN_RE =
+  /<\s*[|｜]\s*DSML\s*[|｜]\s*(?:tool_use_error|tool_calls?|function_calls)\s*>/gi;
+const DEEPSEEK_DSML_CLOSE_RE =
+  /<\s*\/\s*[|｜]\s*DSML\s*[|｜]\s*(?:tool_use_error|tool_calls?|function_calls)\s*>/gi;
+const MINIMAX_TOOL_OPEN_RE = /<\s*minimax:tool_call\b[^>]*>/gi;
+const MINIMAX_TOOL_CLOSE_RE = /<\s*\/\s*minimax:tool_call\s*>/gi;
+const XML_TOOL_OPEN_RE =
+  /<\s*(?:tool_calls?|tool_result|function_calls?|function_response)\b[^>]*>/gi;
+const XML_TOOL_CLOSE_RE =
+  /<\s*\/\s*(?:tool_calls?|tool_result|function_calls?|function_response)\s*>/gi;
+const LEGACY_BRACKET_OPEN_RE = /\[\s*TOOL_(?:CALL|RESULT)\s*\]/gi;
+const LEGACY_BRACKET_CLOSE_RE = /\[\s*\/\s*TOOL_(?:CALL|RESULT)\s*\]/gi;
+const PLAIN_TEXT_TOOL_CALL_LINE_RE =
+  /^[ \t]*\[tool:[A-Za-z_][A-Za-z0-9_.:-]{0,119}\][^\r\n]*(?:\r?\n|$)/gim;
+
+const resetRegex = (regex: RegExp, lastIndex: number): void => {
+  regex.lastIndex = lastIndex;
+};
+
+const stripDelimitedProtocolBlocks = (
+  value: string,
+  openPattern: RegExp,
+  closePattern: RegExp,
+): string => {
+  let result = '';
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    resetRegex(openPattern, cursor);
+    const openMatch = openPattern.exec(value);
+    if (!openMatch || openMatch.index === undefined) {
+      result += value.slice(cursor);
+      break;
+    }
+
+    result += value.slice(cursor, openMatch.index);
+    resetRegex(closePattern, openPattern.lastIndex);
+    const closeMatch = closePattern.exec(value);
+    cursor = closeMatch
+      ? closePattern.lastIndex
+      : value.length;
+  }
+
+  return result;
+};
+
+const sanitizeOutsideMarkdownCode = (
+  value: string,
+  sanitize: SegmentSanitizer,
+): string => {
+  let result = '';
+  let cursor = 0;
+  let index = 0;
+
+  while (index < value.length) {
+    if (value[index] !== '`') {
+      index += 1;
+      continue;
+    }
+
+    let delimiterLength = 1;
+    while (value[index + delimiterLength] === '`') {
+      delimiterLength += 1;
+    }
+    const delimiter = '`'.repeat(delimiterLength);
+    const closeIndex = value.indexOf(delimiter, index + delimiterLength);
+    if (closeIndex < 0) {
+      result += sanitize(value.slice(cursor));
+      return result;
+    }
+
+    result += sanitize(value.slice(cursor, index));
+    const codeEnd = closeIndex + delimiterLength;
+    result += value.slice(index, codeEnd);
+    cursor = codeEnd;
+    index = codeEnd;
+  }
+
+  result += sanitize(value.slice(cursor));
+  return result;
+};
+
+const sanitizeFamily = (
+  value: string,
+  family: CoworkBtwProtocolFamily,
+  detectedFamilies: Set<CoworkBtwProtocolFamily>,
+  sanitize: SegmentSanitizer,
+): string => {
+  const sanitized = sanitizeOutsideMarkdownCode(value, sanitize);
+  if (sanitized !== value) {
+    detectedFamilies.add(family);
+  }
+  return sanitized;
+};
+
+export const sanitizeCoworkBtwResultText = (
+  value: string,
+): CoworkBtwSanitizedResult => {
+  const detectedFamilies = new Set<CoworkBtwProtocolFamily>();
+  let text = value;
+
+  text = sanitizeFamily(
+    text,
+    CoworkBtwProtocolFamily.DeepSeekDsml,
+    detectedFamilies,
+    segment => stripDelimitedProtocolBlocks(
+      segment,
+      DEEPSEEK_DSML_OPEN_RE,
+      DEEPSEEK_DSML_CLOSE_RE,
+    ),
+  );
+  text = sanitizeFamily(
+    text,
+    CoworkBtwProtocolFamily.MiniMaxXml,
+    detectedFamilies,
+    segment => stripDelimitedProtocolBlocks(
+      segment,
+      MINIMAX_TOOL_OPEN_RE,
+      MINIMAX_TOOL_CLOSE_RE,
+    ),
+  );
+  text = sanitizeFamily(
+    text,
+    CoworkBtwProtocolFamily.LegacyBracket,
+    detectedFamilies,
+    segment => stripDelimitedProtocolBlocks(
+      segment,
+      LEGACY_BRACKET_OPEN_RE,
+      LEGACY_BRACKET_CLOSE_RE,
+    ),
+  );
+  text = sanitizeFamily(
+    text,
+    CoworkBtwProtocolFamily.XmlToolCall,
+    detectedFamilies,
+    segment => stripDelimitedProtocolBlocks(
+      segment,
+      XML_TOOL_OPEN_RE,
+      XML_TOOL_CLOSE_RE,
+    ),
+  );
+  text = sanitizeFamily(
+    text,
+    CoworkBtwProtocolFamily.PlainTextToolCall,
+    detectedFamilies,
+    segment => segment.replace(PLAIN_TEXT_TOOL_CALL_LINE_RE, ''),
+  );
+
+  return {
+    text,
+    detectedFamilies: Array.from(detectedFamilies),
+  };
+};

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -2689,6 +2689,117 @@ test('BTW side results and terminal events stay isolated from an active main tur
   expect(statusListener).not.toHaveBeenCalled();
 });
 
+test('BTW side results remove provider protocol markup without logging its payload', async () => {
+  const { adapter } = createRunTurnAdapter({
+    autoFinalizeChatSend: false,
+  });
+  const resultListener = vi.fn();
+  adapter.on('btwResult', resultListener);
+  await adapter.submitBtw('session-1', 'What changed?', 'btw-run-sanitize');
+
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    adapter.handleGatewayEvent({
+      event: 'chat.side_result',
+      payload: {
+        kind: 'btw',
+        runId: 'btw-run-sanitize',
+        sessionKey: 'agent:main:lobsterai:session-1',
+        agentId: 'main',
+        question: 'What changed?',
+        text: [
+          'The visible answer.',
+          '<|DSML|tool_calls><|DSML|invoke name="read">',
+          '<|DSML|parameter name="filePath">/private/secret.txt</|DSML|parameter>',
+          '</|DSML|invoke></|DSML|tool_calls>',
+        ].join('\n'),
+        ts: Date.now(),
+      },
+    });
+
+    expect(resultListener).toHaveBeenCalledWith('session-1', expect.objectContaining({
+      runId: 'btw-run-sanitize',
+      status: CoworkBtwStatus.Answered,
+      answer: 'The visible answer.',
+    }));
+    const diagnostic = warn.mock.calls.flat().join(' ');
+    expect(diagnostic).toContain('deepseek_dsml');
+    expect(diagnostic).not.toContain('/private/secret.txt');
+    expect(diagnostic).not.toContain('filePath');
+  } finally {
+    warn.mockRestore();
+  }
+});
+
+test('BTW tool-only protocol output becomes an isolated localized failure', async () => {
+  const { adapter, session } = createRunTurnAdapter({
+    autoFinalizeChatSend: false,
+  });
+  const activeMainTurn = {
+    runId: 'main-run',
+    sessionKey: 'agent:main:lobsterai:session-1',
+  };
+  adapter.activeTurns.set('session-1', activeMainTurn as never);
+  const resultListener = vi.fn();
+  adapter.on('btwResult', resultListener);
+  await adapter.submitBtw('session-1', 'Read the file', 'btw-run-tool-required');
+
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    adapter.handleGatewayEvent({
+      event: 'chat.side_result',
+      payload: {
+        kind: 'btw',
+        runId: 'btw-run-tool-required',
+        sessionKey: 'agent:main:lobsterai:session-1',
+        agentId: 'main',
+        question: 'Read the file',
+        text: '<｜DSML｜tool_calls>private arguments</｜DSML｜tool_calls>',
+        ts: Date.now(),
+      },
+    });
+  } finally {
+    warn.mockRestore();
+  }
+
+  expect(resultListener).toHaveBeenCalledWith('session-1', expect.objectContaining({
+    runId: 'btw-run-tool-required',
+    status: CoworkBtwStatus.Failed,
+    error: expect.not.stringContaining('DSML'),
+  }));
+  expect(adapter.activeTurns.get('session-1')).toBe(activeMainTurn);
+  expect(session.messages).toEqual([]);
+});
+
+test('BTW uses the runtime tool-required error code without matching backend copy or flags', async () => {
+  const { adapter } = createRunTurnAdapter({
+    autoFinalizeChatSend: false,
+  });
+  const resultListener = vi.fn();
+  adapter.on('btwResult', resultListener);
+  await adapter.submitBtw('session-1', 'Read the file', 'btw-run-error-code');
+
+  adapter.handleGatewayEvent({
+    event: 'chat.side_result',
+    payload: {
+      kind: 'btw',
+      runId: 'btw-run-error-code',
+      sessionKey: 'agent:main:lobsterai:session-1',
+      agentId: 'main',
+      question: 'Read the file',
+      text: 'Runtime-specific copy that must not be shown.',
+      errorCode: 'tool_required',
+      ts: Date.now(),
+    },
+  });
+
+  expect(resultListener).toHaveBeenCalledWith('session-1', expect.objectContaining({
+    runId: 'btw-run-error-code',
+    status: CoworkBtwStatus.Failed,
+    error: expect.not.stringContaining('Runtime-specific copy'),
+  }));
+});
+
 test('unknown BTW side results cannot mark an unrelated main run as terminal', () => {
   const { adapter } = createRunTurnAdapter({
     autoFinalizeChatSend: false,

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -24,6 +24,7 @@ import {
   COWORK_BTW_RESULT_MAX_CHARS,
   type CoworkBtwAbortResponse,
   type CoworkBtwEntry,
+  CoworkBtwErrorCode,
   CoworkBtwStatus,
   type CoworkBtwSubmitResponse,
   normalizeCoworkBtwQuestion,
@@ -121,6 +122,7 @@ import {
   resolveChannelSessionTerminalStatus,
 } from './channelSessionRunStatus';
 import { AgentLifecyclePhase, type AgentLifecyclePhase as AgentLifecyclePhaseValue } from './constants';
+import { sanitizeCoworkBtwResultText } from './coworkBtwResultSanitizer';
 import {
   buildCoworkContinuityCapsule,
   ContinuityCapsuleSource,
@@ -521,6 +523,7 @@ type OpenClawBtwSideResultPayload = {
   agentId?: string;
   question: string;
   text: string;
+  errorCode?: CoworkBtwErrorCode;
   isError?: boolean;
   ts: number;
   seq?: number;
@@ -6918,6 +6921,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     const text = typeof payload.text === 'string'
       ? truncateBtwResultText(payload.text)
       : '';
+    const errorCode = payload.errorCode === CoworkBtwErrorCode.ToolRequired
+      ? payload.errorCode
+      : undefined;
     const ts = typeof payload.ts === 'number' && Number.isFinite(payload.ts) ? payload.ts : NaN;
     if (
       !runId
@@ -6938,6 +6944,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       ...(agentId ? { agentId } : {}),
       question,
       text,
+      ...(errorCode ? { errorCode } : {}),
       ...(payload.isError === true ? { isError: true } : {}),
       ts,
       ...(typeof payload.seq === 'number' && Number.isFinite(payload.seq)
@@ -7010,24 +7017,50 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (!this.addPendingBtwRunAlias(pending, result.runId)) {
       return;
     }
+    const sanitizedResult = sanitizeCoworkBtwResultText(result.text);
+    const sanitizedText = sanitizedResult.text.trim();
+    if (sanitizedResult.detectedFamilies.length > 0) {
+      console.warn(
+        '[CoworkBtw] sanitized provider protocol from side result.',
+        `Session ${pending.sessionId}.`,
+        `Run ${result.runId}.`,
+        `Families ${sanitizedResult.detectedFamilies.join(',')}.`,
+        `Before chars ${result.text.length}.`,
+        `After chars ${sanitizedText.length}.`,
+        `Visible text ${sanitizedText ? 'yes' : 'no'}.`,
+      );
+    }
+    const isResultError = result.isError === true || result.errorCode !== undefined;
     console.log(
       '[CoworkBtw] received side result.',
       `Session ${pending.sessionId}.`,
       `Run ${result.runId}.`,
-      `Answer chars ${result.text.length}.`,
-      `Error ${result.isError ? 'yes' : 'no'}.`,
+      `Answer chars ${sanitizedText.length}.`,
+      `Error ${isResultError ? 'yes' : 'no'}.`,
     );
-    if (result.isError && pending.stopRequested) {
+    if (isResultError && pending.stopRequested) {
       this.stopPendingBtwRun(pending, 'gateway returned an error after stop');
+      return;
+    }
+    if (result.errorCode === CoworkBtwErrorCode.ToolRequired) {
+      this.finishPendingBtwRun(pending, {
+        error: t('coworkBtwToolRequired'),
+      });
       return;
     }
     if (result.isError) {
       this.finishPendingBtwRun(pending, {
-        error: result.text.trim() || t('coworkBtwFailed'),
+        error: sanitizedText || t('coworkBtwFailed'),
       });
       return;
     }
-    this.finishPendingBtwRun(pending, { answer: result.text });
+    if (sanitizedResult.detectedFamilies.length > 0 && !sanitizedText) {
+      this.finishPendingBtwRun(pending, {
+        error: t('coworkBtwToolRequired'),
+      });
+      return;
+    }
+    this.finishPendingBtwRun(pending, { answer: sanitizedText });
   }
 
   private handleBtwChatEvent(payload: unknown): boolean {

--- a/src/shared/cowork/btw.ts
+++ b/src/shared/cowork/btw.ts
@@ -14,6 +14,12 @@ export const CoworkBtwStatus = {
 } as const;
 export type CoworkBtwStatus = typeof CoworkBtwStatus[keyof typeof CoworkBtwStatus];
 
+export const CoworkBtwErrorCode = {
+  ToolRequired: 'tool_required',
+} as const;
+export type CoworkBtwErrorCode =
+  typeof CoworkBtwErrorCode[keyof typeof CoworkBtwErrorCode];
+
 // BTW questions have no product-level character limit. Follow-up history stays
 // bounded independently, while the runtime enforces the shared chat frame size.
 export const COWORK_BTW_CONTEXT_MAX_CHARS = 16_000;


### PR DESCRIPTION
- sanitize provider tool-call markup from side-chat results
- return stable guidance when a side question requires tools
- preserve error metadata through the OpenClaw gateway