### PR TITLE
feat(settings): add artifact auto-preview toggle

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -26,7 +26,7 @@ import {
   resolveCodingPlanBaseUrl,
   resolveModelRuntimeProfile,
 } from '../../shared/providers';
-import { type AppConfig, defaultConfig, FontPreferences, getProviderDisplayName, getVisibleProviders, isCustomProvider, normalizeFontPreference, ShortcutAction, type ShortcutConfig } from '../config';
+import { type AppConfig, defaultConfig, FontPreferences, getProviderDisplayName, getVisibleProviders, isCustomProvider, normalizeFontPreference, resolveArtifactAutoPreviewEnabled, ShortcutAction, type ShortcutConfig } from '../config';
 import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
 import { useSkin } from '../providers/SkinProvider';
 import { apiService } from '../services/api';
@@ -1391,6 +1391,7 @@ const Settings: React.FC<SettingsProps> = ({
   const [uiFontSize, setUiFontSize] = useState<number>(FontPreferences.UiFontSizeDefault);
   const [codeFontSize, setCodeFontSize] = useState<number>(FontPreferences.CodeFontSizeDefault);
   const [language, setLanguage] = useState<LanguageType>('zh');
+  const [artifactAutoPreviewEnabled, setArtifactAutoPreviewEnabled] = useState(true);
   const [autoLaunch, setAutoLaunchState] = useState(false);
   const [useSystemProxy, setUseSystemProxy] = useState(false);
   const [sqliteAutoBackupEnabled, setSqliteAutoBackupEnabled] = useState(false);
@@ -1971,6 +1972,9 @@ const Settings: React.FC<SettingsProps> = ({
       setUiFontSize(resolvedUiFontSize);
       setCodeFontSize(resolvedCodeFontSize);
       setLanguage(config.language);
+      setArtifactAutoPreviewEnabled(
+        resolveArtifactAutoPreviewEnabled(config.artifactAutoPreviewEnabled),
+      );
       setUseSystemProxy(config.useSystemProxy ?? false);
       setSqliteAutoBackupEnabled(config.sqliteAutoBackupEnabled === true);
       setUsageAnalyticsEnabled(config.usageAnalyticsEnabled !== false);
@@ -3413,6 +3417,9 @@ const Settings: React.FC<SettingsProps> = ({
       const previousNotificationSettings = normalizeNotificationSettings(
         previousConfig.notificationSettings,
       );
+      const previousArtifactAutoPreviewEnabled = resolveArtifactAutoPreviewEnabled(
+        previousConfig.artifactAutoPreviewEnabled,
+      );
       const previousThemeId = initialThemeIdRef.current;
       const previousUiFontSize = normalizeFontPreference(
         previousConfig.uiFontSize,
@@ -3438,6 +3445,7 @@ const Settings: React.FC<SettingsProps> = ({
         uiFontSize,
         codeFontSize,
         language,
+        artifactAutoPreviewEnabled,
         useSystemProxy,
         sqliteAutoBackupEnabled,
         usageAnalyticsEnabled,
@@ -3453,6 +3461,12 @@ const Settings: React.FC<SettingsProps> = ({
           testMode,
         },
       });
+
+      if (previousArtifactAutoPreviewEnabled !== artifactAutoPreviewEnabled) {
+        console.log(
+          `[Settings] artifact auto-preview preference updated: enabled=${artifactAutoPreviewEnabled}`,
+        );
+      }
 
       applyTypographyPreferences({ uiFontSize, codeFontSize });
 
@@ -3539,6 +3553,13 @@ const Settings: React.FC<SettingsProps> = ({
       if (usageAnalyticsEnabled) {
         if (previousConfig.language !== language) {
           reportGeneralSettingChanged('language', language, previousConfig.language);
+        }
+        if (previousArtifactAutoPreviewEnabled !== artifactAutoPreviewEnabled) {
+          reportGeneralSettingChanged(
+            'artifactAutoPreviewEnabled',
+            artifactAutoPreviewEnabled,
+            previousArtifactAutoPreviewEnabled,
+          );
         }
         if ((previousConfig.useSystemProxy ?? false) !== useSystemProxy) {
           reportGeneralSettingChanged('useSystemProxy', useSystemProxy, previousConfig.useSystemProxy ?? false);
@@ -3653,7 +3674,8 @@ const Settings: React.FC<SettingsProps> = ({
       didSaveRef.current = true;
       onClose();
     } catch (error) {
-      setError(error instanceof Error ? error.message : 'Failed to save settings');
+      console.error('[Settings] failed to save settings:', error);
+      setError(error instanceof Error ? error.message : i18nService.t('failedToSaveSettings'));
     } finally {
       setIsSaving(false);
     }
@@ -4767,6 +4789,17 @@ const Settings: React.FC<SettingsProps> = ({
                     />
                   </div>
                 </div>
+              </SettingsRow>
+
+              <SettingsRow>
+                <SettingsToggleRow
+                  title={i18nService.t('artifactAutoPreviewEnabled')}
+                  description={i18nService.t('artifactAutoPreviewEnabledDescription')}
+                  checked={artifactAutoPreviewEnabled}
+                  onToggle={() => {
+                    setArtifactAutoPreviewEnabled((previous) => !previous);
+                  }}
+                />
               </SettingsRow>
 
               <SettingsRow>

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -40,7 +40,7 @@ import {
   CoworkSteerStatus,
 } from '../../../shared/cowork/steer';
 import { agentService } from '../../services/agent';
-import { configService } from '../../services/config';
+import { configService, ConfigServiceEvent } from '../../services/config';
 import { coworkService } from '../../services/cowork';
 import { buildCoworkCapabilitySelection } from '../../services/coworkCapabilitySelection';
 import {
@@ -2718,8 +2718,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       const latest = configService.getConfig().shortcuts?.sendMessage ?? 'Enter';
       setCurrentSendShortcut(latest);
     };
-    window.addEventListener('config-updated', syncFromConfig);
-    return () => window.removeEventListener('config-updated', syncFromConfig);
+    window.addEventListener(ConfigServiceEvent.Updated, syncFromConfig);
+    return () => window.removeEventListener(ConfigServiceEvent.Updated, syncFromConfig);
   }, []);
 
   const largeModelSelector = showModelSelector ? (

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -31,6 +31,7 @@ import {
   normalizeCoworkSelectedTextSnippets,
 } from '../../../shared/cowork/selectedText';
 import { ShareDeploymentCandidateSource } from '../../../shared/shareDeployment/constants';
+import { resolveArtifactAutoPreviewEnabled } from '../../config';
 import { collectSessionArtifacts, loadDetectedFileArtifact } from '../../services/artifactDetection';
 import {
   dedupeArtifactsForDisplay,
@@ -39,6 +40,7 @@ import {
   normalizeProjectDirectoryForDedup,
   parseMediaTokensFromText,
 } from '../../services/artifactParser';
+import { configService, ConfigServiceEvent } from '../../services/config';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { getInstalledKitSkillIds } from '../../services/kitCapability';
@@ -245,6 +247,7 @@ const AutoScrollDetachSource = {
 } as const;
 type AutoScrollDetachSource = typeof AutoScrollDetachSource[keyof typeof AutoScrollDetachSource];
 const AUTO_PREVIEW_ARTIFACT_SETTLE_MS = 600;
+const MAX_AUTO_PREVIEW_HANDLED_TURNS = 128;
 const LOCAL_SERVICE_PROCESS_DIRECTORY_RETRY_DELAY_MS = 900;
 const ARTIFACT_PANEL_TRANSITION_MS = 200;
 const ARTIFACT_PANEL_RESIZE_HANDLE_WIDTH = 4;
@@ -2097,6 +2100,11 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const previousAutoPreviewMessagesLengthRef = useRef(messagesLength);
   const previousAutoPreviewLatestTurnIdRef = useRef<string | null>(null);
   const [autoPreviewPendingTurnId, setAutoPreviewPendingTurnId] = useState<string | null>(null);
+  const [artifactAutoPreviewEnabled, setArtifactAutoPreviewEnabled] = useState(
+    () => resolveArtifactAutoPreviewEnabled(
+      configService.getConfig().artifactAutoPreviewEnabled,
+    ),
+  );
 
   const getAutoPreviewHandledTurnIds = useCallback((targetSessionId: string): Set<string> => {
     let handled = autoPreviewHandledTurnIdsRef.current[targetSessionId];
@@ -2108,7 +2116,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   }, []);
 
   const clearAutoPreviewArtifactSettleTimer = useCallback(() => {
-    if (autoPreviewArtifactSettleTimerRef.current) {
+    if (autoPreviewArtifactSettleTimerRef.current !== null) {
       window.clearTimeout(autoPreviewArtifactSettleTimerRef.current);
       autoPreviewArtifactSettleTimerRef.current = null;
     }
@@ -2120,7 +2128,13 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
   const markAutoPreviewTurnHandled = useCallback((targetSessionId: string, turnId: string) => {
     clearAutoPreviewArtifactSettleTimer();
-    getAutoPreviewHandledTurnIds(targetSessionId).add(turnId);
+    const handledTurnIds = getAutoPreviewHandledTurnIds(targetSessionId);
+    handledTurnIds.add(turnId);
+    while (handledTurnIds.size > MAX_AUTO_PREVIEW_HANDLED_TURNS) {
+      const oldestTurnId = handledTurnIds.values().next().value;
+      if (!oldestTurnId) break;
+      handledTurnIds.delete(oldestTurnId);
+    }
     if (targetSessionId === sessionId && autoPreviewPendingTurnId === turnId) {
       setAutoPreviewPendingTurnId(null);
     }
@@ -2130,6 +2144,27 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     getAutoPreviewHandledTurnIds,
     sessionId,
   ]);
+
+  useEffect(() => {
+    const syncArtifactAutoPreviewSetting = () => {
+      const enabled = resolveArtifactAutoPreviewEnabled(
+        configService.getConfig().artifactAutoPreviewEnabled,
+      );
+      if (!enabled) {
+        const canceledPendingPreview = autoPreviewArtifactSettleTimerRef.current !== null;
+        clearAutoPreviewArtifactSettleTimer();
+        setAutoPreviewPendingTurnId(null);
+        if (canceledPendingPreview) {
+          console.debug('[ArtifactPreview] canceled pending automatic preview: preference disabled.');
+        }
+      }
+      setArtifactAutoPreviewEnabled(enabled);
+    };
+    window.addEventListener(ConfigServiceEvent.Updated, syncArtifactAutoPreviewSetting);
+    return () => {
+      window.removeEventListener(ConfigServiceEvent.Updated, syncArtifactAutoPreviewSetting);
+    };
+  }, [clearAutoPreviewArtifactSettleTimer]);
 
   useEffect(() => {
     let animationFrame: number | undefined;
@@ -4290,8 +4325,14 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     if (!completedStreamingTurn && !appendedCompletedTurn) return;
 
     if (getAutoPreviewHandledTurnIds(sessionId).has(latestAssistantTurn.id)) return;
+    if (!artifactAutoPreviewEnabled) {
+      clearAutoPreviewArtifactSettleTimer();
+      setCurrentAutoPreviewPendingTurnId(null);
+      return;
+    }
     setCurrentAutoPreviewPendingTurnId(latestAssistantTurn.id);
   }, [
+    artifactAutoPreviewEnabled,
     clearAutoPreviewArtifactSettleTimer,
     getAutoPreviewHandledTurnIds,
     isStreaming,
@@ -4304,6 +4345,12 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   useEffect(() => {
     if (!sessionId || !autoPreviewPendingTurnId || !currentSession) return;
     if (getAutoPreviewHandledTurnIds(sessionId).has(autoPreviewPendingTurnId)) {
+      clearAutoPreviewArtifactSettleTimer();
+      setCurrentAutoPreviewPendingTurnId(null);
+      return;
+    }
+
+    if (!artifactAutoPreviewEnabled) {
       clearAutoPreviewArtifactSettleTimer();
       setCurrentAutoPreviewPendingTurnId(null);
       return;
@@ -4331,6 +4378,13 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     autoPreviewArtifactSettleTimerRef.current = window.setTimeout(() => {
       autoPreviewArtifactSettleTimerRef.current = null;
       if (getAutoPreviewHandledTurnIds(sessionId).has(autoPreviewPendingTurnId)) return;
+      if (!resolveArtifactAutoPreviewEnabled(
+        configService.getConfig().artifactAutoPreviewEnabled,
+      )) {
+        setCurrentAutoPreviewPendingTurnId(null);
+        console.debug('[ArtifactPreview] skipped automatic preview: preference disabled.');
+        return;
+      }
 
       switch (getAutoPreviewOpenTarget(artifact)) {
         case ArtifactAutoPreviewOpenTarget.LocalServiceBrowser:
@@ -4351,6 +4405,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
     return clearAutoPreviewArtifactSettleTimer;
   }, [
+    artifactAutoPreviewEnabled,
     autoPreviewPendingTurnId,
     clearAutoPreviewArtifactSettleTimer,
     currentSession,

--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -82,6 +82,8 @@ export const normalizeFontPreference = (
   return Math.min(max, Math.max(min, Math.round(numericValue)));
 };
 
+export const resolveArtifactAutoPreviewEnabled = (value: unknown): boolean => value !== false;
+
 // 配置类型定义
 export interface AppConfig {
   // API 配置
@@ -117,6 +119,8 @@ export interface AppConfig {
   language: 'zh' | 'en';
   // 是否使用系统代理
   useSystemProxy: boolean;
+  // 是否在生成可预览内容后自动打开 Artifact 预览面板
+  artifactAutoPreviewEnabled?: boolean;
   // 是否启用 SQLite 自动备份与恢复
   sqliteAutoBackupEnabled?: boolean;
   // 是否允许发送基础产品使用统计
@@ -174,6 +178,7 @@ export const defaultConfig: AppConfig = {
   codeFontSize: FontPreferences.CodeFontSizeDefault,
   language: 'zh',
   useSystemProxy: false,
+  artifactAutoPreviewEnabled: true,
   sqliteAutoBackupEnabled: false,
   usageAnalyticsEnabled: true,
   notificationSettings: defaultNotificationSettings,

--- a/src/renderer/services/config.test.ts
+++ b/src/renderer/services/config.test.ts
@@ -1,7 +1,7 @@
 import { ProviderName } from '@shared/providers';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { type AppConfig, CONFIG_KEYS, defaultConfig, FontPreferences, ShortcutAction } from '../config';
+import { type AppConfig, CONFIG_KEYS, defaultConfig, FontPreferences, resolveArtifactAutoPreviewEnabled, ShortcutAction } from '../config';
 
 const makeLegacyConfigWithoutMiniMaxAddedModels = (): AppConfig => ({
   ...defaultConfig,
@@ -185,6 +185,42 @@ describe('configService theme persistence', () => {
       theme: 'dark',
       themeId: 'ocean',
     });
+  });
+});
+
+describe('configService artifact auto-preview persistence', () => {
+  test('disables auto-preview only for an explicit false value', () => {
+    expect(resolveArtifactAutoPreviewEnabled(false)).toBe(false);
+    expect(resolveArtifactAutoPreviewEnabled(true)).toBe(true);
+    expect(resolveArtifactAutoPreviewEnabled(undefined)).toBe(true);
+    expect(resolveArtifactAutoPreviewEnabled(null)).toBe(true);
+  });
+
+  test('defaults legacy configs to auto-preview enabled', async () => {
+    const legacyConfig: Partial<AppConfig> = { ...defaultConfig };
+    delete legacyConfig.artifactAutoPreviewEnabled;
+    const { configService, storeData } = await loadConfigServiceWithStoredConfig(
+      legacyConfig as AppConfig,
+    );
+
+    await configService.init();
+
+    expect(configService.getConfig().artifactAutoPreviewEnabled).toBe(true);
+    expect((storeData[CONFIG_KEYS.APP_CONFIG] as AppConfig).artifactAutoPreviewEnabled).toBe(true);
+  });
+
+  test('preserves a disabled auto-preview preference across partial updates', async () => {
+    const storedConfig: AppConfig = {
+      ...defaultConfig,
+      artifactAutoPreviewEnabled: false,
+    };
+    const { configService, storeData } = await loadConfigServiceWithStoredConfig(storedConfig);
+
+    await configService.init();
+    await configService.updateConfig({ useSystemProxy: true });
+
+    expect(configService.getConfig().artifactAutoPreviewEnabled).toBe(false);
+    expect((storeData[CONFIG_KEYS.APP_CONFIG] as AppConfig).artifactAutoPreviewEnabled).toBe(false);
   });
 });
 

--- a/src/renderer/services/config.ts
+++ b/src/renderer/services/config.ts
@@ -19,10 +19,17 @@ import {
   FontPreferences,
   isCustomProvider,
   normalizeFontPreference,
+  resolveArtifactAutoPreviewEnabled,
   ShortcutAction,
   type ShortcutConfig,
 } from '../config';
 import { localStore } from './store';
+
+export const ConfigServiceEvent = {
+  Updated: 'config-updated',
+} as const;
+
+export type ConfigServiceEvent = typeof ConfigServiceEvent[keyof typeof ConfigServiceEvent];
 
 type ProviderModel = NonNullable<ProviderConfig['models']>[number];
 
@@ -684,6 +691,9 @@ const hydrateStoredConfig = (storedConfig: AppConfig): AppConfig => {
       FontPreferences.CodeFontSizeMin,
       FontPreferences.CodeFontSizeMax,
     ),
+    artifactAutoPreviewEnabled: resolveArtifactAutoPreviewEnabled(
+      storedConfig.artifactAutoPreviewEnabled,
+    ),
     browserWebAccess: normalizeBrowserWebAccessConfig(storedConfig.browserWebAccess),
     notificationSettings: normalizeNotificationSettings(storedConfig.notificationSettings),
   });
@@ -761,7 +771,7 @@ class ConfigService {
       ),
     } as AppConfig);
     await localStore.setItem(CONFIG_KEYS.APP_CONFIG, this.config);
-    window.dispatchEvent(new CustomEvent('config-updated'));
+    window.dispatchEvent(new CustomEvent(ConfigServiceEvent.Updated));
   }
 
   getApiConfig() {

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -2652,6 +2652,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     autoLaunchDescription: '系统启动时自动运行应用',
     autoLaunchRequiresApproval: '需要在系统设置中允许开机自启动',
     autoLaunchUpdateFailed: '更新开机自启动设置失败',
+    artifactAutoPreviewEnabled: '自动打开文件预览',
+    artifactAutoPreviewEnabledDescription: 'AI 生成支持预览的文件后，自动打开右侧预览面板',
     useSystemProxy: '使用系统代理',
     useSystemProxyDescription: '开启后网络请求将跟随系统代理（保存后生效）',
     browserWebAccessTab: '浏览器',
@@ -6038,6 +6040,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     autoLaunchDescription: 'Automatically start the app when you log in',
     autoLaunchRequiresApproval: 'Launch at login requires approval in System Settings',
     autoLaunchUpdateFailed: 'Failed to update launch at login setting',
+    artifactAutoPreviewEnabled: 'Automatically Open File Previews',
+    artifactAutoPreviewEnabledDescription:
+      'Automatically open the right preview panel after AI generates a supported file',
     useSystemProxy: 'Use System Proxy',
     useSystemProxyDescription:
       'When enabled, network requests follow system proxy settings (applies after Save)',


### PR DESCRIPTION
Allow users to disable automatic file preview opening while preserving manual previews and existing defaults.

