### PR TITLE
feat(cowork): classify model capacity overload separately from rate limit

### DIFF
--- a/src/common/coworkErrorClassify.test.ts
+++ b/src/common/coworkErrorClassify.test.ts
@@ -241,8 +241,15 @@ test('rate: too many requests', () => {
   expect(classifyError('Too many requests, please slow down')).toBe('coworkErrorRateLimit');
 });
 
-test('rate: Anthropic overloaded', () => {
-  expect(classifyError('overloaded_error: Overloaded')).toBe('coworkErrorRateLimit');
+test('capacity: Anthropic overloaded', () => {
+  expect(classifyError('overloaded_error: Overloaded')).toBe('coworkErrorModelOverloaded');
+});
+
+test('capacity: Qwen inner 503 system-capacity throttle wins over too-many-requests wording', () => {
+  expect(classifyError(
+    '<503> InternalError.Algo: An error occurred in model serving, error message is: '
+      + '[Too many requests. Your requests are being throttled due to system capacity limits. Please try again later.]',
+  )).toBe('coworkErrorModelOverloaded');
 });
 
 test('rate: Gemini RESOURCE_EXHAUSTED', () => {

--- a/src/common/coworkErrorClassify.ts
+++ b/src/common/coworkErrorClassify.ts
@@ -15,6 +15,7 @@ export const CoworkErrorI18nKey = {
   FreeQuotaExhausted: 'coworkErrorFreeQuotaExhausted',
   InsufficientBalance: 'coworkErrorInsufficientBalance',
   RateLimit: 'coworkErrorRateLimit',
+  ModelOverloaded: 'coworkErrorModelOverloaded',
   ModelResponseTimeout: 'coworkErrorModelResponseTimeout',
   NetworkError: 'coworkErrorNetworkError',
   ServerError: 'coworkErrorServerError',
@@ -24,6 +25,9 @@ export const CoworkErrorI18nKey = {
 
 const LOBSTERAI_QUOTA_EXHAUSTED_PATTERN =
   /\b4020[0-2]\b|(?:今日)?免费额度.*(用完|耗尽)|本月积分.*(用完|耗尽)|积分额度.*(用完|耗尽)|free.*quota.*(exhausted|used up|limit)|monthly.*credits?.*(exhausted|used up|limit)/i;
+
+const MODEL_CAPACITY_OVERLOAD_PATTERN =
+  /overloaded_error|\boverloaded\b|(?:selected\s+)?model\s+(?:is\s+)?at capacity|system capacity(?: limits?)?|(?:service|model).*(?:high demand|high load)|服务过载|当前负载过高|系统容量(?:不足|限制)?/i;
 
 const API_KEY_PATTERN = String.raw`(?:api\s*key|api[_-]?key|apikey)`;
 const UNAVAILABLE_NETWORK_CODE_PATTERN = String.raw`(?:ECONNREFUSED|ECONNRESET|ECONNABORTED|ENOTFOUND|ETIMEDOUT|ENETUNREACH|EHOSTUNREACH|EAI_AGAIN|UND_ERR_[A-Z_]+)`;
@@ -37,9 +41,12 @@ const ERROR_RULES: Array<[RegExp, string]> = [
   [new RegExp(`authentication[_ ](error|fails?)|${API_KEY_PATTERN}.*(invalid|expired|deleted|inactive|not[_ ]valid|not\\s+valid)|invalid.*${API_KEY_PATTERN}|incorrect.*${API_KEY_PATTERN}|unauthorized|PERMISSION_DENIED|\\b401\\b`, 'i'), CoworkErrorI18nKey.AuthInvalid],
   // LobsterAI plan/free quota. Must precede generic 402/billing handling.
   [LOBSTERAI_QUOTA_EXHAUSTED_PATTERN, CoworkErrorI18nKey.QuotaExhausted],
-  // Rate limit: HTTP 429, Anthropic/DeepSeek overloaded, Gemini RESOURCE_EXHAUSTED
+  // Provider/model capacity failures. Must precede rate-limit matching because
+  // capacity errors may also contain phrases such as "too many requests".
+  [MODEL_CAPACITY_OVERLOAD_PATTERN, CoworkErrorI18nKey.ModelOverloaded],
+  // Rate limit: HTTP 429 and Gemini RESOURCE_EXHAUSTED
   // (must precede billing so "RESOURCE_EXHAUSTED: quota exceeded" maps to rate-limit)
-  [/\b429\b|rate[_ ]limit|too many requests|overloaded|RESOURCE_EXHAUSTED/i, CoworkErrorI18nKey.RateLimit],
+  [/\b429\b|rate[_ ]limit|too many requests|RESOURCE_EXHAUSTED/i, CoworkErrorI18nKey.RateLimit],
   // Billing: DeepSeek 402, OpenAI, OpenRouter, Qwen, StepFun
   [/insufficient.*(balance|quota|credits)|billing|quota[_ ]exceeded|Arrearage|account.*not.*in.*good.*standing|余额不足|\b402\b/i, CoworkErrorI18nKey.InsufficientBalance],
   // Oversized Cowork/OpenClaw gateway message payloads.

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -84,6 +84,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorModelResponseTimeout: '模型响应超时，请稍后重试。',
     coworkErrorNetworkError: '网络连接失败，请检查网络设置。',
     coworkErrorRateLimit: '请求过于频繁，请稍后再试。',
+    coworkErrorModelOverloaded: '模型服务当前繁忙或容量不足，请稍后重试。',
     coworkErrorContentFiltered: '内容未通过安全审核，请修改后重试。',
     coworkErrorServerError: '服务端出现错误，请稍后重试。',
     coworkErrorEngineNotReady: 'AI 引擎正在启动中，请稍等几秒后重试。',
@@ -405,6 +406,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorModelResponseTimeout: 'The model response timed out. Please try again.',
     coworkErrorNetworkError: 'Network connection failed. Please check your network settings.',
     coworkErrorRateLimit: 'Too many requests. Please try again later.',
+    coworkErrorModelOverloaded:
+      'The model service is temporarily busy or at capacity. Please try again later.',
     coworkErrorContentFiltered:
       'Content did not pass the safety review. Please modify and try again.',
     coworkErrorServerError: 'Server error occurred. Please try again later.',

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -680,6 +680,40 @@ test('resolveOpenClawRuntimeErrorMessage classifies generic error from safe fetc
   })).toContain('网络连接失败');
 });
 
+test('resolveOpenClawRuntimeErrorMessage prefers Qwen 503 capacity evidence over rate-limit wrappers', () => {
+  const rawErrorPreview =
+    '<503> InternalError.Algo: An error occurred in model serving, error message is: '
+    + '[Too many requests. Your requests are being throttled due to system capacity limits. Please try again later.]';
+
+  const displayMessage = resolveOpenClawRuntimeErrorMessage(
+    '⚠️ API rate limit reached. Please try again later.',
+    {
+      provider: 'lobsterai-server',
+      model: 'qwen3.5-plus-2026-04-20',
+      failoverReason: 'rate_limit',
+      providerRuntimeFailureKind: 'rate_limit',
+      rawErrorPreview,
+    },
+  );
+
+  expect(displayMessage).toContain('模型服务当前繁忙或容量不足');
+  expect(displayMessage).not.toContain('请求过于频繁');
+});
+
+test('resolveOpenClawRuntimeErrorMessage keeps genuine HTTP 429 errors as rate limits', () => {
+  expect(resolveOpenClawRuntimeErrorMessage(
+    '⚠️ API rate limit reached. Please try again later.',
+    {
+      provider: 'lobsterai-server',
+      model: 'qwen3.5-plus-2026-04-20',
+      failoverReason: 'rate_limit',
+      providerRuntimeFailureKind: 'rate_limit',
+      httpCode: '429',
+      rawErrorPreview: '429 Too Many Requests',
+    },
+  )).toContain('请求过于频繁');
+});
+
 test('resolveOpenClawRuntimeErrorMessage prefers safe metadata over stale quota signal', () => {
   consumeRecentOpenClawTokenProxyQuotaError();
   __openClawTokenProxyTestUtils.rememberQuotaError({

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1501,7 +1501,7 @@ const COWORK_ERROR_KEY_BY_OPENCLAW_FAILOVER_REASON: Record<string, string> = {
   auth: CoworkErrorI18nKey.AuthInvalid,
   billing: CoworkErrorI18nKey.InsufficientBalance,
   rate_limit: CoworkErrorI18nKey.RateLimit,
-  overloaded: CoworkErrorI18nKey.RateLimit,
+  overloaded: CoworkErrorI18nKey.ModelOverloaded,
   timeout: CoworkErrorI18nKey.ModelResponseTimeout,
   server_error: CoworkErrorI18nKey.ServerError,
 };
@@ -1516,6 +1516,7 @@ const COWORK_ERROR_KEY_BY_OPENCLAW_RUNTIME_FAILURE_KIND: Record<string, string> 
   auth_html: CoworkErrorI18nKey.OAuthInvalid,
   auth_invalid_token: CoworkErrorI18nKey.OAuthInvalid,
   rate_limit: CoworkErrorI18nKey.RateLimit,
+  overloaded: CoworkErrorI18nKey.ModelOverloaded,
   dns: CoworkErrorI18nKey.NetworkError,
   timeout: CoworkErrorI18nKey.ModelResponseTimeout,
   upstream_html: CoworkErrorI18nKey.ServerError,
@@ -1567,6 +1568,18 @@ function classifyOpenClawSafeRuntimeErrorMetadata(
     return CoworkErrorI18nKey.ModelAccessDenied;
   }
 
+  // Some providers return an HTTP 200 SSE response whose terminal error text
+  // contains an inner 503 capacity failure. OpenClaw can classify that text as
+  // rate_limit because it also says "too many requests" or "throttled". Let
+  // the high-confidence capacity signal in the preserved raw preview win after
+  // retaining LobsterAI's explicit HTTP 403 access-denial rule above.
+  const rawErrorClassifiedKey = metadata.rawErrorPreview
+    ? classifyErrorKey(metadata.rawErrorPreview)
+    : null;
+  if (rawErrorClassifiedKey === CoworkErrorI18nKey.ModelOverloaded) {
+    return rawErrorClassifiedKey;
+  }
+
   const failureKind = metadata.providerRuntimeFailureKind?.trim();
   if (failureKind && COWORK_ERROR_KEY_BY_OPENCLAW_RUNTIME_FAILURE_KIND[failureKind]) {
     return COWORK_ERROR_KEY_BY_OPENCLAW_RUNTIME_FAILURE_KIND[failureKind];
@@ -1608,6 +1621,15 @@ export function resolveOpenClawRuntimeErrorMessage(
   metadata?: OpenClawSafeRuntimeErrorMetadata,
 ): string {
   const normalized = normalizeOpenClawRuntimeErrorMessage(errorMessage);
+  const metadataClassifiedKey = classifyOpenClawSafeRuntimeErrorMetadata(metadata);
+
+  // OpenClaw's friendly wrapper may already say "rate limit" even when its
+  // preserved raw metadata identifies a provider-capacity failure.
+  if (metadataClassifiedKey === CoworkErrorI18nKey.ModelOverloaded) {
+    consumeRecentOpenClawTokenProxyQuotaError();
+    return t(metadataClassifiedKey);
+  }
+
   const classifiedKey = classifyErrorKey(normalized);
 
   if (classifiedKey) {
@@ -1631,7 +1653,6 @@ export function resolveOpenClawRuntimeErrorMessage(
       consumeRecentOpenClawTokenProxyQuotaError();
       return t(CoworkErrorI18nKey.LobsterAILoginExpired);
     }
-    const metadataClassifiedKey = classifyOpenClawSafeRuntimeErrorMetadata(metadata);
     if (metadataClassifiedKey) {
       consumeRecentOpenClawTokenProxyQuotaError();
       return t(metadataClassifiedKey);

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1737,6 +1737,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorModelResponseTimeout: '模型响应超时，请稍后重试。',
     coworkErrorNetworkError: '网络连接失败，请检查网络设置后重试。',
     coworkErrorRateLimit: '请求过于频繁，请稍后再试。',
+    coworkErrorModelOverloaded: '模型服务当前繁忙或容量不足，请稍后重试。',
     coworkErrorContentFiltered: '内容未通过安全审核，请修改后重试。',
     coworkErrorServerError: '服务端出现错误，请稍后重试。',
     coworkErrorSessionStartFailed: '会话启动失败：{error}',
@@ -5057,6 +5058,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkErrorNetworkError:
       'Network connection failed. Please check your network settings and try again.',
     coworkErrorRateLimit: 'Too many requests. Please try again later.',
+    coworkErrorModelOverloaded:
+      'The model service is temporarily busy or at capacity. Please try again later.',
     coworkErrorContentFiltered:
       'Content did not pass the safety review. Please modify and try again.',
     coworkErrorServerError: 'Server error occurred. Please try again later.',

--- a/tests/coworkErrorClassify.test.mjs
+++ b/tests/coworkErrorClassify.test.mjs
@@ -163,8 +163,18 @@ test('rate: too many requests', () => {
   assert.equal(classifyError('Too many requests, please slow down'), 'coworkErrorRateLimit');
 });
 
-test('rate: Anthropic overloaded', () => {
-  assert.equal(classifyError('overloaded_error: Overloaded'), 'coworkErrorRateLimit');
+test('capacity: Anthropic overloaded', () => {
+  assert.equal(classifyError('overloaded_error: Overloaded'), 'coworkErrorModelOverloaded');
+});
+
+test('capacity: Qwen inner 503 system-capacity throttle wins over too-many-requests wording', () => {
+  assert.equal(
+    classifyError(
+      '<503> InternalError.Algo: An error occurred in model serving, error message is: '
+        + '[Too many requests. Your requests are being throttled due to system capacity limits. Please try again later.]',
+    ),
+    'coworkErrorModelOverloaded',
+  );
 });
 
 test('rate: Gemini RESOURCE_EXHAUSTED', () => {


### PR DESCRIPTION
Provider "overloaded"/capacity errors were previously bucketed under the generic rate-limit message, which misleads users into retrying immediately. Split them into a dedicated ModelOverloaded classification, including a raw-error-preview override so OpenClaw's own rate-limit wording doesn't mask an underlying provider capacity failure.