### PR TITLE
fix: complete startup credit campaign analytics fields

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5673,13 +5673,13 @@ if (!gotTheLock) {
       });
       console.log('[Auth] opening portal login with local callback redirect');
       await shell.openExternal(finalUrl);
-      return { success: true };
+      return { success: true, redirectUrl: finalUrl };
     } catch (error) {
       // The callback may be shared by another login page and will clean itself up on timeout.
       console.warn('[Auth] local callback login failed, falling back to deep link login:', error);
       try {
         await shell.openExternal(fallbackUrl);
-        return { success: true };
+        return { success: true, redirectUrl: fallbackUrl };
       } catch (fallbackError) {
         console.error('[Auth] login failed:', fallbackError);
         return {

--- a/src/renderer/components/StartupCreditCampaign.tsx
+++ b/src/renderer/components/StartupCreditCampaign.tsx
@@ -144,6 +144,7 @@ const reportClaimFailure = (
   source: StartupCreditCampaignSourceType,
   errorCode: string | number,
   retryable: boolean,
+  errorMessage = i18nService.t('startupCreditClaimFailed'),
 ): void => {
   reportStartupCreditCampaignEvent(
     LogReporterAction.ActivityClaimFail,
@@ -151,6 +152,7 @@ const reportClaimFailure = (
     {
       source,
       error_code: errorCode,
+      error_message: errorMessage,
       retryable,
     },
   );
@@ -335,6 +337,8 @@ const StartupCreditCampaign: React.FC<StartupCreditCampaignProps> = ({
               offerSourceRef.current,
               ActivityServerErrorCode.AlreadyClaimed,
               false,
+              response.error
+                || i18nService.t('startupCreditAlreadyClaimedDescription'),
             );
             clearPendingStartupCreditClaim(localStorage);
             const refreshed = await fetchCurrentSnapshot();
@@ -367,6 +371,7 @@ const StartupCreditCampaign: React.FC<StartupCreditCampaignProps> = ({
               offerSourceRef.current,
               response.code,
               false,
+              response.error || i18nService.t('startupCreditEndedDescription'),
             );
             clearPendingStartupCreditClaim(localStorage);
             applySnapshot(null, false);
@@ -378,6 +383,7 @@ const StartupCreditCampaign: React.FC<StartupCreditCampaignProps> = ({
             offerSourceRef.current,
             response.code ?? 'request_failed',
             true,
+            response.error || i18nService.t('startupCreditClaimFailed'),
           );
           showTerminalView(
             CampaignModalView.Failed,
@@ -393,6 +399,7 @@ const StartupCreditCampaign: React.FC<StartupCreditCampaignProps> = ({
             offerSourceRef.current,
             'invalid_response',
             true,
+            i18nService.t('startupCreditClaimFailed'),
           );
           showTerminalView(
             CampaignModalView.Failed,
@@ -432,6 +439,9 @@ const StartupCreditCampaign: React.FC<StartupCreditCampaignProps> = ({
         offerSourceRef.current,
         'network_error',
         true,
+        error instanceof Error
+          ? error.message
+          : i18nService.t('startupCreditClaimFailed'),
       );
       showTerminalView(
         CampaignModalView.Failed,
@@ -480,6 +490,7 @@ const StartupCreditCampaign: React.FC<StartupCreditCampaignProps> = ({
           StartupCreditCampaignSource.LoginReturn,
           ActivityServerErrorCode.AlreadyClaimed,
           false,
+          i18nService.t('startupCreditAlreadyClaimedDescription'),
         );
         clearPendingStartupCreditClaim(localStorage);
         showTerminalView(CampaignModalView.AlreadyClaimed, {
@@ -708,18 +719,24 @@ const StartupCreditCampaign: React.FC<StartupCreditCampaignProps> = ({
           createStartupCreditIdempotencyKey(),
         );
     if (!isLoggedIn || !current.context.authenticated) {
-      reportStartupCreditCampaignEvent(
-        LogReporterAction.ActivityLoginRedirect,
-        current.descriptor,
-        {
-          source: offerSourceRef.current,
-          return_to: 'netease_user_bonus_activity',
-          reason: 'claim_requires_login',
-        },
-      );
       showTerminalView(CampaignModalView.StartingLogin);
       try {
-        await authService.login();
+        const loginResult = await authService.login();
+        if (!loginResult.success || !loginResult.redirectUrl) {
+          throw new Error(
+            loginResult.error || i18nService.t('startupCreditLoginFailed'),
+          );
+        }
+        reportStartupCreditCampaignEvent(
+          LogReporterAction.ActivityLoginRedirect,
+          current.descriptor,
+          {
+            source: offerSourceRef.current,
+            redirect_url: loginResult.redirectUrl,
+            return_to: 'netease_user_bonus_activity',
+            reason: 'claim_requires_login',
+          },
+        );
         if (mountedRef.current) setModalView(CampaignModalView.Offer);
       } catch (error) {
         reportClaimFailure(
@@ -727,6 +744,9 @@ const StartupCreditCampaign: React.FC<StartupCreditCampaignProps> = ({
           offerSourceRef.current,
           'login_redirect_failed',
           true,
+          error instanceof Error
+            ? error.message
+            : i18nService.t('startupCreditLoginFailed'),
         );
         clearPendingStartupCreditClaim(localStorage);
         showTerminalView(

--- a/src/renderer/services/auth.test.ts
+++ b/src/renderer/services/auth.test.ts
@@ -118,7 +118,11 @@ describe('authenticated server model mapping', () => {
 describe('login diagnostics', () => {
   test('persists renderer lifecycle logs without including the login URL', async () => {
     const fromRenderer = vi.fn();
-    const login = vi.fn().mockResolvedValue({ success: true });
+    const loginResult = {
+      success: true,
+      redirectUrl: 'https://lobsterai.youdao.com/portal#/login?source=electron',
+    };
+    const login = vi.fn().mockResolvedValue(loginResult);
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'debug').mockImplementation(() => {});
     vi.stubGlobal('window', {
@@ -134,7 +138,7 @@ describe('login diagnostics', () => {
       },
     });
 
-    await authService.login();
+    await expect(authService.login()).resolves.toEqual(loginResult);
 
     expect(login).toHaveBeenCalledWith('https://lobsterai.youdao.com/portal#/login');
     expect(fromRenderer).toHaveBeenCalledWith(
@@ -150,7 +154,7 @@ describe('login diagnostics', () => {
     expect(fromRenderer.mock.calls.flat().join(' ')).not.toContain('lobsterai.youdao.com');
   });
 
-  test('records a warning while preserving the existing non-throwing IPC failure behavior', async () => {
+  test('returns the IPC failure result without throwing and records a warning', async () => {
     const fromRenderer = vi.fn();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'debug').mockImplementation(() => {});
@@ -168,7 +172,10 @@ describe('login diagnostics', () => {
       },
     });
 
-    await expect(authService.login()).resolves.toBeUndefined();
+    await expect(authService.login()).resolves.toEqual({
+      success: false,
+      error: 'open failed',
+    });
 
     expect(fromRenderer).toHaveBeenCalledWith(
       'warn',

--- a/src/renderer/services/auth.ts
+++ b/src/renderer/services/auth.ts
@@ -1,6 +1,7 @@
 import {
   type AuthLifecycleEvent,
   AuthLifecycleEventType,
+  type AuthLoginResult,
   type AuthSessionChangedEvent,
   AuthSessionStatus,
 } from '@shared/auth/constants';
@@ -256,7 +257,7 @@ class AuthService {
   /**
    * Initiate login (opens system browser).
    */
-  async login() {
+  async login(): Promise<AuthLoginResult> {
     const attemptId = ++this.loginAttemptSequence;
     writeAuthRendererLog('info', `login attempt ${attemptId} started`);
 
@@ -268,6 +269,7 @@ class AuthService {
       } else {
         writeAuthRendererLog('warn', `login attempt ${attemptId} could not open the system browser`);
       }
+      return result;
     } catch (error) {
       writeAuthRendererLog('warn', `login attempt ${attemptId} failed before browser handoff`, error);
       throw error;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../shared/asr/constants';
 import type {
   AuthLifecycleEvent,
+  AuthLoginResult,
   AuthRefreshOutcome,
   AuthSessionChangedEvent,
   AuthSessionStatus,
@@ -1758,7 +1759,7 @@ interface IElectronAPI {
     ) => Promise<ActivityResult<ActivityActionResponse>>;
   };
   auth: {
-    login: (loginUrl?: string) => Promise<{ success: boolean; error?: string }>;
+    login: (loginUrl?: string) => Promise<AuthLoginResult>;
     exchange: (
       code: string,
     ) => Promise<{ success: boolean; user?: any; quota?: any; error?: string }>;
@@ -1841,7 +1842,7 @@ interface IElectronAPI {
     send: (status: 'online' | 'offline') => void;
   };
   auth: {
-    login: (loginUrl?: string) => Promise<{ success: boolean; error?: string }>;
+    login: (loginUrl?: string) => Promise<AuthLoginResult>;
     exchange: (code: string) => Promise<{
       success: boolean;
       user?: import('../store/slices/authSlice').UserProfile;

--- a/src/shared/auth/constants.ts
+++ b/src/shared/auth/constants.ts
@@ -21,6 +21,12 @@ export const AuthIpcChannel = {
 
 export type AuthIpcChannel = typeof AuthIpcChannel[keyof typeof AuthIpcChannel];
 
+export interface AuthLoginResult {
+  success: boolean;
+  redirectUrl?: string;
+  error?: string;
+}
+
 export const AuthSessionStatus = {
   Authenticated: 'authenticated',
   Expired: 'expired',


### PR DESCRIPTION
## Summary
- report the full login redirect URL for unauthenticated campaign claims
- include error messages for server, network, and login redirect claim failures
- return the opened login URL through the Electron auth IPC contract
- update auth service coverage for the extended login result

## Verification
- npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/main.ts src/renderer/components/StartupCreditCampaign.tsx src/renderer/services/auth.test.ts src/renderer/services/auth.ts src/renderer/types/electron.d.ts src/shared/auth/constants.ts
- npx vitest run src/renderer/services/auth.test.ts src/renderer/components/startupCreditCampaignState.test.ts src/main/ipcHandlers/activity/handlers.test.ts src/main/libs/activity/activityClient.test.ts
- npm run build

## Electron behavior
The auth login IPC result now includes the exact URL successfully handed to the system browser. Existing callers may continue ignoring the returned value.