### PR TITLE
fix(openclaw): prevent gateway lock poisoning from self-restart races

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -218,6 +218,9 @@ export const OPENCLAW_CHAT_SEND_PAYLOAD_SAFE_LIMIT_BYTES =
   OPENCLAW_CHAT_SEND_PAYLOAD_LIMIT_BYTES - OPENCLAW_CHAT_SEND_PAYLOAD_SAFETY_MARGIN_BYTES;
 const WebSocketCloseCode = {
   MessageTooBig: 1009,
+  // RFC 6455 "Service Restart" — the OpenClaw gateway sends this when a config
+  // reload makes it restart itself (in-process SIGUSR1 restart).
+  ServiceRestart: 1012,
 } as const;
 const MediaGenerationToolAction = {
   Status: 'status',
@@ -5774,6 +5777,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         }
 
         console.warn('[OpenClawRuntime] gateway WS disconnected — code:', _code, 'reason:', reason);
+        if (_code === WebSocketCloseCode.ServiceRestart) {
+          // The gateway is restarting itself after a config reload. Flag the
+          // window so the supervisor doesn't kill the process mid-restart
+          // (which poisons the single-instance lock file on Windows).
+          this.engineManager.noteGatewaySelfRestart(reason || 'service restart');
+        }
         const gatewayFailure = typeof this.engineManager.getLastGatewayFailure === 'function'
           ? this.engineManager.getLastGatewayFailure()
           : null;

--- a/src/main/libs/openclawConfigDelivery.ts
+++ b/src/main/libs/openclawConfigDelivery.ts
@@ -30,6 +30,13 @@ export const OpenClawConfigDeliveryMode = {
 export type OpenClawConfigDeliveryMode =
   typeof OpenClawConfigDeliveryMode[keyof typeof OpenClawConfigDeliveryMode];
 
+/**
+ * Reason prefix for deferred restarts scheduled by the fallback path. Their
+ * only goal is "make the gateway load the already-on-disk config", so a
+ * gateway self-restart satisfies them without a supervisor respawn.
+ */
+export const CONFIG_DELIVERY_FALLBACK_REASON_PREFIX = 'config-delivery-fallback:';
+
 export type OpenClawConfigRpcClient = {
   request: <T = Record<string, unknown>>(
     method: string,
@@ -139,7 +146,7 @@ export async function deliverOpenClawConfigToGateway(
       );
     }
     lastFallbackRestartAtMs = now();
-    input.scheduleDeferredRestart(`config-delivery-fallback:${input.reason}`);
+    input.scheduleDeferredRestart(`${CONFIG_DELIVERY_FALLBACK_REASON_PREFIX}${input.reason}`);
     return finish(OpenClawConfigDeliveryMode.Fallback, detail, true);
   };
 

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -25,6 +25,7 @@ import { recoverInstallerResourcesFromTar } from './installerResourceRecovery';
 import { mergeNoProxyValue } from './noProxyEnv';
 import { getCodexHomeDir } from './openaiCodexAuth';
 import { migrateLegacyCronStorageWithDoctor } from './openclawCronLegacyMigration';
+import { cleanupStaleGatewayLocks, GatewayLockCleanupAction } from './openclawGatewayLock';
 import { cleanupStaleThirdPartyPluginsFromBundledDir, listLocalOpenClawExtensionIds,syncLocalOpenClawExtensionsIntoRuntime } from './openclawLocalExtensions';
 import { migrateAllFtsOnlyMemoryIndexes } from './openclawMemoryIndexMigration';
 import { ensureOpenClawWorkerShims } from './openclawWorkerShims';
@@ -48,6 +49,10 @@ const GATEWAY_PORT_SCAN_LIMIT = 80;
 const GATEWAY_BOOT_TIMEOUT_MS = 300 * 1000;
 const GATEWAY_MAX_RESTART_ATTEMPTS = 5;
 const GATEWAY_RESTART_DELAYS = [3_000, 5_000, 10_000, 20_000, 30_000];
+// How long a gateway-initiated restart (SIGUSR1 in-process restart after a
+// config change) is trusted to complete before LobsterAI resumes managing the
+// process itself.
+const GATEWAY_SELF_RESTART_WINDOW_MS = 30_000;
 const OPENCLAW_GATEWAY_MAX_OLD_SPACE_MB = 4096;
 const OPENCLAW_GATEWAY_MAX_OLD_SPACE_OPTION = `--max-old-space-size=${OPENCLAW_GATEWAY_MAX_OLD_SPACE_MB}`;
 const NODE_MAX_OLD_SPACE_RE = /(?:^|\s)--max-old-space-size(?:=|\s|$)/;
@@ -235,6 +240,7 @@ export class OpenClawEngineManager extends EventEmitter {
   private secretEnvVars: Record<string, string> = {};
   private gatewaySpawnedAt: number | null = null;
   private gatewayLogPrunedDateKey: string | null = null;
+  private gatewaySelfRestartNotedAt: number | null = null;
 
   constructor() {
     super();
@@ -343,6 +349,73 @@ export class OpenClawEngineManager extends EventEmitter {
       return null;
     }
     return { ...failure };
+  }
+
+  getGatewayProcessPid(): number | null {
+    const child = this.gatewayProcess;
+    if (!child || !isGatewayProcessAlive(child)) {
+      return null;
+    }
+    return 'pid' in child && typeof child.pid === 'number' ? child.pid : null;
+  }
+
+  /**
+   * Called when the gateway announced it is restarting itself (WS close 1012
+   * "service restart" after an OpenClaw config reload). While the window is
+   * active LobsterAI must not kill/respawn the process: the gateway is between
+   * releasing and re-acquiring its single-instance lock, and a TerminateProcess
+   * there leaves a poisoned (empty) lock file behind.
+   */
+  noteGatewaySelfRestart(reason: string): void {
+    this.gatewaySelfRestartNotedAt = Date.now();
+    console.log(`${gwDiagTs()} gateway self-restart detected (${reason}); deferring supervisor restarts for up to ${GATEWAY_SELF_RESTART_WINDOW_MS}ms`);
+  }
+
+  isGatewaySelfRestartActive(): boolean {
+    if (this.gatewaySelfRestartNotedAt == null) {
+      return false;
+    }
+    if (Date.now() - this.gatewaySelfRestartNotedAt > GATEWAY_SELF_RESTART_WINDOW_MS) {
+      this.gatewaySelfRestartNotedAt = null;
+      return false;
+    }
+    // An in-process restart keeps the same pid; if the process is gone the
+    // self-restart failed and normal crash handling owns recovery again.
+    if (!isGatewayProcessAlive(this.gatewayProcess)) {
+      this.gatewaySelfRestartNotedAt = null;
+      return false;
+    }
+    return true;
+  }
+
+  clearGatewaySelfRestart(): void {
+    this.gatewaySelfRestartNotedAt = null;
+  }
+
+  /**
+   * Reclaim stale gateway lock files. Safe only when we have no live gateway
+   * child (locks with a live owner are never touched, so the worst case of a
+   * misjudged call is a no-op).
+   */
+  private cleanupStaleGatewayLocksSafely(context: string): void {
+    if (isGatewayProcessAlive(this.gatewayProcess)) {
+      return;
+    }
+    try {
+      const results = cleanupStaleGatewayLocks({ configPath: this.configPath });
+      for (const result of results) {
+        const owner = result.ownerPid != null ? ` ownerPid=${result.ownerPid}` : '';
+        if (result.action === GatewayLockCleanupAction.KeptAliveOwner) {
+          console.warn(`${gwDiagTs()} gateway lock kept (owner alive)${owner} path=${result.lockPath} context=${context}`);
+        } else if (result.action === GatewayLockCleanupAction.RemoveFailed) {
+          console.warn(`${gwDiagTs()} gateway lock remove failed${owner} path=${result.lockPath} context=${context}`);
+        } else {
+          console.log(`${gwDiagTs()} stale gateway lock reclaimed (${result.action})${owner} path=${result.lockPath} context=${context}`);
+        }
+      }
+    } catch (err) {
+      console.warn(`${gwDiagTs()} gateway lock cleanup failed (non-fatal) context=${context}:`, err);
+    }
   }
 
   private pruneGatewayLogsIfNeeded(now = new Date()): void {
@@ -477,6 +550,13 @@ export class OpenClawEngineManager extends EventEmitter {
     }
 
     if (isGatewayProcessAlive(this.gatewayProcess)) {
+      if (this.isGatewaySelfRestartActive()) {
+        // The gateway is mid self-restart (lock release/reacquire window):
+        // killing it now poisons the lock file. Let it finish; callers retry
+        // through their normal ready-wait paths.
+        console.log(`${gwDiagTs()} startGateway: gateway self-restart in progress, leaving process alone (${elapsed()})`);
+        return this.getStatus();
+      }
       const port = this.gatewayPort ?? this.readGatewayPort();
       if (port) {
         const healthy = await this.isGatewayHealthy(port);
@@ -536,6 +616,9 @@ export class OpenClawEngineManager extends EventEmitter {
     this.gatewayPort = port;
     this.writeGatewayPort(port);
     this.ensureConfigFile();
+    // A force-killed (or crashed) gateway can leave a stale/empty lock file
+    // that blocks every new gateway for OpenClaw's 30s staleness window.
+    this.cleanupStaleGatewayLocksSafely('pre-spawn');
     console.log(`[OpenClaw] startGateway: pre-fork setup done (${elapsed()})`);
 
     this.setStatus({
@@ -736,6 +819,8 @@ export class OpenClawEngineManager extends EventEmitter {
 
   async stopGateway(): Promise<void> {
     this.shutdownRequested = true;
+    // The supervisor is explicitly taking over; any self-restart window is moot.
+    this.clearGatewaySelfRestart();
 
     if (this.gatewayRestartTimer) {
       clearTimeout(this.gatewayRestartTimer);
@@ -747,6 +832,9 @@ export class OpenClawEngineManager extends EventEmitter {
       await this.stopGatewayProcess(this.gatewayProcess);
       console.log('[OpenClaw] gateway process stopped');
       this.gatewayProcess = null;
+      // On Windows the kill is TerminateProcess — the gateway had no chance
+      // to release its single-instance lock, so reclaim it now.
+      this.cleanupStaleGatewayLocksSafely('post-stop');
     }
 
     const runtime = this.resolveRuntimeMetadata();
@@ -1682,6 +1770,9 @@ export class OpenClawEngineManager extends EventEmitter {
       this.gatewayRecentOutput.delete(child);
       if (this.gatewayProcess === child) {
         this.gatewayProcess = null;
+        // A self-restart never exits the process; if it exited anyway the
+        // self-restart failed and normal crash handling owns recovery.
+        this.clearGatewaySelfRestart();
       }
       if (this.expectedGatewayExits.has(child)) {
         this.expectedGatewayExits.delete(child);

--- a/src/main/libs/openclawGatewayLock.test.ts
+++ b/src/main/libs/openclawGatewayLock.test.ts
@@ -1,0 +1,148 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  cleanupStaleGatewayLocks,
+  GatewayLockCleanupAction,
+  parseGatewayLockPayload,
+  resolveGatewayLockPathForConfig,
+} from './openclawGatewayLock';
+
+const CONFIG_PATH = path.join(os.tmpdir(), 'lobsterai-lock-test-state', 'openclaw.json');
+
+const expectedHash = (configPath: string): string =>
+  crypto.createHash('sha256').update(path.resolve(configPath.trim())).digest('hex').slice(0, 8);
+
+describe('resolveGatewayLockPathForConfig', () => {
+  test('replicates the OpenClaw lock file name (sha256 of resolved config path)', () => {
+    const lockPath = resolveGatewayLockPathForConfig(CONFIG_PATH, '/locks');
+    expect(path.basename(lockPath)).toBe(`gateway.${expectedHash(CONFIG_PATH)}.lock`);
+  });
+
+  test('trims the config path before hashing, matching resolveUserPath', () => {
+    const padded = `  ${CONFIG_PATH}  `;
+    expect(resolveGatewayLockPathForConfig(padded, '/locks')).toBe(
+      resolveGatewayLockPathForConfig(CONFIG_PATH, '/locks'),
+    );
+  });
+});
+
+describe('parseGatewayLockPayload', () => {
+  test('accepts a valid payload', () => {
+    const parsed = parseGatewayLockPayload(
+      JSON.stringify({ pid: 1234, createdAt: '2026-08-05T07:40:47.280Z', configPath: CONFIG_PATH }),
+    );
+    expect(parsed).toEqual({ pid: 1234, configPath: CONFIG_PATH });
+  });
+
+  test.each([
+    ['empty file', ''],
+    ['truncated json', '{"pid": 123'],
+    ['missing pid', JSON.stringify({ configPath: CONFIG_PATH })],
+    ['non-integer pid', JSON.stringify({ pid: 'abc' })],
+    ['non-positive pid', JSON.stringify({ pid: 0 })],
+  ])('rejects %s', (_label, raw) => {
+    expect(parseGatewayLockPayload(raw)).toBeNull();
+  });
+});
+
+describe('cleanupStaleGatewayLocks', () => {
+  let lockDir: string;
+
+  beforeEach(() => {
+    lockDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-lock-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  });
+
+  const ownLockPath = () => resolveGatewayLockPathForConfig(CONFIG_PATH, lockDir);
+
+  test('returns empty when the lock directory does not exist', () => {
+    const missingDir = path.join(lockDir, 'nope');
+    expect(cleanupStaleGatewayLocks({ configPath: CONFIG_PATH, lockDir: missingDir })).toEqual([]);
+  });
+
+  test('removes our lock when the payload is empty (poisoned by TerminateProcess)', () => {
+    fs.writeFileSync(ownLockPath(), '');
+    const results = cleanupStaleGatewayLocks({
+      configPath: CONFIG_PATH,
+      lockDir,
+      isPidAliveFn: () => true,
+    });
+    expect(results).toEqual([
+      { lockPath: ownLockPath(), action: GatewayLockCleanupAction.RemovedUnreadable },
+    ]);
+    expect(fs.existsSync(ownLockPath())).toBe(false);
+  });
+
+  test('removes our lock when the payload is corrupted', () => {
+    fs.writeFileSync(ownLockPath(), '{"pid": 118');
+    const results = cleanupStaleGatewayLocks({ configPath: CONFIG_PATH, lockDir });
+    expect(results[0]?.action).toBe(GatewayLockCleanupAction.RemovedUnreadable);
+    expect(fs.existsSync(ownLockPath())).toBe(false);
+  });
+
+  test('removes our lock when the owner pid is dead', () => {
+    fs.writeFileSync(ownLockPath(), JSON.stringify({ pid: 11848, createdAt: 'x', configPath: CONFIG_PATH }));
+    const results = cleanupStaleGatewayLocks({
+      configPath: CONFIG_PATH,
+      lockDir,
+      isPidAliveFn: () => false,
+    });
+    expect(results).toEqual([
+      { lockPath: ownLockPath(), action: GatewayLockCleanupAction.RemovedDeadOwner, ownerPid: 11848 },
+    ]);
+    expect(fs.existsSync(ownLockPath())).toBe(false);
+  });
+
+  test('never touches a lock whose owner pid is alive', () => {
+    fs.writeFileSync(ownLockPath(), JSON.stringify({ pid: process.pid, configPath: CONFIG_PATH }));
+    const results = cleanupStaleGatewayLocks({
+      configPath: CONFIG_PATH,
+      lockDir,
+      isPidAliveFn: () => true,
+    });
+    expect(results).toEqual([
+      { lockPath: ownLockPath(), action: GatewayLockCleanupAction.KeptAliveOwner, ownerPid: process.pid },
+    ]);
+    expect(fs.existsSync(ownLockPath())).toBe(true);
+  });
+
+  test('removes an other-hash lock whose payload points at our config with a dead owner', () => {
+    const strayPath = path.join(lockDir, 'gateway.deadbeef.lock');
+    fs.writeFileSync(strayPath, JSON.stringify({ pid: 4242, configPath: CONFIG_PATH }));
+    const results = cleanupStaleGatewayLocks({
+      configPath: CONFIG_PATH,
+      lockDir,
+      isPidAliveFn: () => false,
+    });
+    expect(results).toEqual([
+      { lockPath: strayPath, action: GatewayLockCleanupAction.RemovedDeadOwner, ownerPid: 4242 },
+    ]);
+    expect(fs.existsSync(strayPath)).toBe(false);
+  });
+
+  test('leaves foreign locks alone (different config path or unreadable non-matching hash)', () => {
+    const foreignReadable = path.join(lockDir, 'gateway.00000001.lock');
+    fs.writeFileSync(foreignReadable, JSON.stringify({ pid: 999999, configPath: '/somewhere/else.json' }));
+    const foreignUnreadable = path.join(lockDir, 'gateway.00000002.lock');
+    fs.writeFileSync(foreignUnreadable, '');
+    const unrelatedFile = path.join(lockDir, 'notes.txt');
+    fs.writeFileSync(unrelatedFile, 'keep me');
+
+    const results = cleanupStaleGatewayLocks({
+      configPath: CONFIG_PATH,
+      lockDir,
+      isPidAliveFn: () => false,
+    });
+    expect(results).toEqual([]);
+    expect(fs.existsSync(foreignReadable)).toBe(true);
+    expect(fs.existsSync(foreignUnreadable)).toBe(true);
+    expect(fs.existsSync(unrelatedFile)).toBe(true);
+  });
+});

--- a/src/main/libs/openclawGatewayLock.ts
+++ b/src/main/libs/openclawGatewayLock.ts
@@ -1,0 +1,190 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Stale OpenClaw gateway lock cleanup.
+ *
+ * OpenClaw's gateway holds a single-instance lock file at
+ * `<tmpdir>/openclaw[-<uid>]/gateway.<sha256(configPath)[:8]>.lock` (see
+ * OpenClaw v2026.6.1 src/infra/gateway-lock.ts). The payload is JSON:
+ * `{ pid, createdAt, configPath, startTime? }`.
+ *
+ * When LobsterAI force-kills the gateway (Windows SIGTERM is
+ * TerminateProcess), the kill can land between the lock file's create and
+ * payload write, leaving an EMPTY lock file behind. OpenClaw treats an
+ * unreadable payload as owner "unknown" and only reclaims it after a 30s
+ * mtime staleness window — while its own acquire timeout is 5s — so every
+ * respawn within those 30s fails with "gateway already running; lock
+ * timeout". LobsterAI is the gateway's only supervisor, so whenever it knows
+ * it has no live gateway child it can safely reclaim locks whose owner is
+ * dead or whose payload is unreadable.
+ */
+
+export type GatewayLockPayload = {
+  pid: number;
+  createdAt?: string;
+  configPath?: string;
+};
+
+export const GatewayLockCleanupAction = {
+  RemovedUnreadable: 'removed-unreadable',
+  RemovedDeadOwner: 'removed-dead-owner',
+  KeptAliveOwner: 'kept-alive-owner',
+  RemoveFailed: 'remove-failed',
+} as const;
+export type GatewayLockCleanupAction =
+  typeof GatewayLockCleanupAction[keyof typeof GatewayLockCleanupAction];
+
+export type GatewayLockCleanupResult = {
+  lockPath: string;
+  action: GatewayLockCleanupAction;
+  ownerPid?: number;
+};
+
+const GATEWAY_LOCK_FILE_RE = /^gateway\.[0-9a-f]{8}\.lock$/;
+
+/** Mirrors OpenClaw v2026.6.1 resolveGatewayLockDir(). */
+export function resolveGatewayLockDir(): string {
+  const uid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+  const suffix = uid != null ? `openclaw-${uid}` : 'openclaw';
+  return path.join(os.tmpdir(), suffix);
+}
+
+/**
+ * Mirrors OpenClaw v2026.6.1 resolveGatewayLockPath(): the gateway resolves
+ * OPENCLAW_CONFIG_PATH through resolveUserPath() which is path.resolve() for
+ * absolute paths, then hashes the resolved string.
+ */
+export function resolveGatewayLockPathForConfig(configPath: string, lockDir = resolveGatewayLockDir()): string {
+  const resolved = path.resolve(configPath.trim());
+  const hash = crypto.createHash('sha256').update(resolved).digest('hex').slice(0, 8);
+  return path.join(lockDir, `gateway.${hash}.lock`);
+}
+
+function normalizePathForCompare(input: string): string {
+  const resolved = path.resolve(input.trim());
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+export function parseGatewayLockPayload(raw: string): GatewayLockPayload | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    const pid = (parsed as { pid?: unknown }).pid;
+    if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) {
+      return null;
+    }
+    const configPath = (parsed as { configPath?: unknown }).configPath;
+    return {
+      pid,
+      ...(typeof configPath === 'string' ? { configPath } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the process exists but we lack permission to signal it.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+type CleanupOptions = {
+  configPath: string;
+  /** Override for tests; defaults to the OpenClaw lock directory. */
+  lockDir?: string;
+  /** Override for tests. */
+  isPidAliveFn?: (pid: number) => boolean;
+};
+
+function removeLockFile(
+  lockPath: string,
+  action: typeof GatewayLockCleanupAction.RemovedUnreadable | typeof GatewayLockCleanupAction.RemovedDeadOwner,
+  ownerPid?: number,
+): GatewayLockCleanupResult {
+  try {
+    fs.rmSync(lockPath, { force: true });
+    return { lockPath, action, ...(ownerPid != null ? { ownerPid } : {}) };
+  } catch {
+    return { lockPath, action: GatewayLockCleanupAction.RemoveFailed, ...(ownerPid != null ? { ownerPid } : {}) };
+  }
+}
+
+/**
+ * Reclaim stale gateway lock files for our config path.
+ *
+ * MUST only be called when the caller knows it has no live gateway child of
+ * its own (before spawning a gateway, or right after confirming the previous
+ * one exited). A lock whose payload is readable and whose owner pid is alive
+ * is never touched.
+ *
+ * Two matching strategies:
+ * - The exact lock path for our configPath (hash replica). An unreadable
+ *   payload here is reclaimed: only our own gateway can legitimately own it,
+ *   and the caller guarantees no such process is starting right now.
+ * - Any other `gateway.*.lock` in the directory whose readable payload points
+ *   at our configPath with a dead owner (guards against hash-input drift).
+ *   Unreadable payloads under other hashes are left alone — they may belong
+ *   to a user-run OpenClaw CLI with a different config.
+ */
+export function cleanupStaleGatewayLocks(options: CleanupOptions): GatewayLockCleanupResult[] {
+  const lockDir = options.lockDir ?? resolveGatewayLockDir();
+  const pidAlive = options.isPidAliveFn ?? isPidAlive;
+  const results: GatewayLockCleanupResult[] = [];
+  const ownLockPath = resolveGatewayLockPathForConfig(options.configPath, lockDir);
+  const ownConfigKey = normalizePathForCompare(options.configPath);
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(lockDir);
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (!GATEWAY_LOCK_FILE_RE.test(entry)) {
+      continue;
+    }
+    const lockPath = path.join(lockDir, entry);
+    const isOwnLock = lockPath === ownLockPath;
+
+    let raw: string | null = null;
+    try {
+      raw = fs.readFileSync(lockPath, 'utf8');
+    } catch {
+      // Unreadable file handle: treat like an unreadable payload below.
+      raw = null;
+    }
+    const payload = raw != null ? parseGatewayLockPayload(raw) : null;
+
+    if (!payload) {
+      if (isOwnLock) {
+        results.push(removeLockFile(lockPath, GatewayLockCleanupAction.RemovedUnreadable));
+      }
+      continue;
+    }
+
+    const matchesOurConfig = isOwnLock
+      || (payload.configPath != null && normalizePathForCompare(payload.configPath) === ownConfigKey);
+    if (!matchesOurConfig) {
+      continue;
+    }
+
+    if (pidAlive(payload.pid)) {
+      results.push({ lockPath, action: GatewayLockCleanupAction.KeptAliveOwner, ownerPid: payload.pid });
+      continue;
+    }
+    results.push(removeLockFile(lockPath, GatewayLockCleanupAction.RemovedDeadOwner, payload.pid));
+  }
+
+  return results;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -324,7 +324,7 @@ import {
   DEFAULT_MANAGED_AGENT_ID,
   OpenClawChannelSessionSync,
 } from './libs/openclawChannelSessionSync';
-import { deliverOpenClawConfigToGateway } from './libs/openclawConfigDelivery';
+import { CONFIG_DELIVERY_FALLBACK_REASON_PREFIX, deliverOpenClawConfigToGateway } from './libs/openclawConfigDelivery';
 import {
   classifyAppConfigChange,
   classifyCoworkConfigChange,
@@ -2338,6 +2338,8 @@ const waitForOpenClawConfigApply = async (context: string): Promise<OpenClawEngi
   return null;
 };
 
+const DEFERRED_SYNC_REASON_PREFIX = 'deferred:';
+
 const executeDeferredGatewayRestart = async (reason: string) => {
   clearDeferredRestart();
   deferredRestartReason = null;
@@ -2345,10 +2347,43 @@ const executeDeferredGatewayRestart = async (reason: string) => {
     `${gwDiagTs()} executeDeferredGatewayRestart: performing deferred restart (reason: ${reason})`,
   );
   await syncOpenClawConfig({
-    reason: `deferred:${reason}`,
+    reason: `${DEFERRED_SYNC_REASON_PREFIX}${reason}`,
     restartGatewayIfRunning: true,
     expectedImpact: OpenClawConfigImpact.Restart,
   });
+};
+
+// A hard restart requested while the gateway is restarting itself (config
+// reload → SIGUSR1) is parked here instead of killing the mid-restart process.
+// When the gateway client reconnects we either drop it (the self-restart
+// already loaded the on-disk config) or replay it (env vars need a respawn).
+type PendingSelfRestartReevaluation = {
+  reasons: string[];
+  requiresRespawn: boolean;
+  gatewayPid: number | null;
+};
+let pendingSelfRestartReevaluation: PendingSelfRestartReevaluation | null = null;
+
+/**
+ * True when this sync's restart demand is satisfied by the gateway reloading
+ * the on-disk config (which a self-restart does). Env-var changes need a
+ * respawn (same-process restart keeps the old environment), and explicit
+ * restart flags may depend on out-of-config state — except the
+ * config-delivery fallback, whose only goal is on-disk config convergence.
+ */
+const selfRestartSatisfiesSync = (
+  options: SyncOpenClawConfigOptions,
+  secretEnvVarsChanged: boolean,
+): boolean => {
+  if (secretEnvVarsChanged) {
+    return false;
+  }
+  if (options.restartGatewayIfRunning === true) {
+    return options.reason.startsWith(
+      `${DEFERRED_SYNC_REASON_PREFIX}${CONFIG_DELIVERY_FALLBACK_REASON_PREFIX}`,
+    );
+  }
+  return true;
 };
 
 const scheduleDeferredGatewayRestart = (reason: string) => {
@@ -2536,6 +2571,26 @@ const _syncOpenClawConfigImpl = async (
     };
   }
 
+  if (manager.isGatewaySelfRestartActive()) {
+    // Killing the gateway mid self-restart poisons its single-instance lock
+    // (empty lock file → 30s of "gateway already running; lock timeout").
+    // Park the demand; the gateway-ready callback re-evaluates it.
+    const requiresRespawn = !selfRestartSatisfiesSync(options, secretEnvVarsChanged);
+    pendingSelfRestartReevaluation = {
+      reasons: [...(pendingSelfRestartReevaluation?.reasons ?? []), options.reason],
+      requiresRespawn: (pendingSelfRestartReevaluation?.requiresRespawn ?? false) || requiresRespawn,
+      gatewayPid: pendingSelfRestartReevaluation?.gatewayPid ?? manager.getGatewayProcessPid(),
+    };
+    console.log(
+      `${D()} ──── RESTART PARKED (gateway self-restart in progress). reason=${options.reason}, requiresRespawn=${requiresRespawn}`,
+    );
+    return {
+      success: true,
+      changed: true,
+      status,
+    };
+  }
+
   console.log(
     `${D()} ──── HARD RESTART EXECUTING. reason=${options.reason}, phase=${status.phase}, port=${status.message?.match(/loopback:(\d+)/)?.[1] ?? 'unknown'}`,
   );
@@ -2603,6 +2658,35 @@ const syncOpenClawConfig = async (
       openClawConfigApplyState = null;
     }
   }
+};
+
+// The gateway client reconnected — any self-restart has settled. Resolve the
+// parked restart demand: a same-pid (in-process) restart already loaded the
+// on-disk config, so only env-var style demands still need a real respawn.
+// A changed pid means the process was respawned with fresh env anyway.
+const handleGatewaySelfRestartSettled = () => {
+  const manager = getOpenClawEngineManager();
+  manager.clearGatewaySelfRestart();
+  const pending = pendingSelfRestartReevaluation;
+  if (!pending) {
+    return;
+  }
+  pendingSelfRestartReevaluation = null;
+  const currentPid = manager.getGatewayProcessPid();
+  const respawned = pending.gatewayPid != null && currentPid != null && currentPid !== pending.gatewayPid;
+  if (pending.requiresRespawn && !respawned) {
+    console.log(
+      `${gwDiagTs()} parked restart still required after gateway self-restart (reasons: ${pending.reasons.join(', ')}); executing now`,
+    );
+    void syncOpenClawConfig({
+      reason: `self-restart-reevaluate:${pending.reasons[0]}`,
+      restartGatewayIfRunning: true,
+    });
+    return;
+  }
+  console.log(
+    `${gwDiagTs()} parked restart satisfied by gateway self-restart (reasons: ${pending.reasons.join(', ')}, respawned=${respawned})`,
+  );
 };
 
 type OpenClawGatewayRepairResult = {
@@ -2945,7 +3029,10 @@ const getCoworkEngineRouter = () => {
         getOpenClawEngineManager(),
         {
           normalizeModelRef: normalizeOpenClawModelRef,
-          onGatewayClientReady: () => getCronJobService().notifyGatewayReady(),
+          onGatewayClientReady: () => {
+            getCronJobService().notifyGatewayReady();
+            handleGatewaySelfRestartSettled();
+          },
         },
         new SubagentRunStore(getStore().getDatabase()),
         new SubagentMessageStore(getStore().getDatabase()),


### PR DESCRIPTION
Two independent races could leave the OpenClaw single-instance lock file poisoned, causing every gateway respawn to fail for up to 30s:

- LobsterAI force-killing the gateway (Windows TerminateProcess) could land mid lock-file write, leaving an empty/unreadable lock behind.
- A gateway-initiated self-restart (WS close 1012 after a config reload) could be killed by the supervisor while it was between releasing and reacquiring its own lock.

Add openclawGatewayLock.ts to detect and reclaim stale/dead-owner locks around gateway spawn/stop, and track a self-restart window in OpenClawEngineManager so the supervisor parks (instead of force-killing) restart demands until the gateway reconnects, then re-evaluates whether a real respawn is still needed.
