### PR TITLE
fix(main): harden window lifecycle and shutdown against hangs

### DIFF
--- a/src/main/libs/coworkOpenAICompatProxy.ts
+++ b/src/main/libs/coworkOpenAICompatProxy.ts
@@ -2993,14 +2993,28 @@ export async function stopCoworkOpenAICompatProxy(): Promise<void> {
   proxyPort = null;
   proxyAuthToken = null;
 
+  // server.close() alone waits for every established client connection to
+  // drop. The OpenClaw gateway keeps keep-alive sockets to this proxy, so an
+  // unbounded close can hang shutdown forever: give clients a short drain
+  // window, then force-close connections, with a hard deadline either way.
   await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
+    let settled = false;
+    let drainTimer: ReturnType<typeof setTimeout> | null = null;
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+    const settle = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      if (drainTimer) clearTimeout(drainTimer);
+      if (deadlineTimer) clearTimeout(deadlineTimer);
       if (error) {
         reject(error);
         return;
       }
       resolve();
-    });
+    };
+    drainTimer = setTimeout(() => server.closeAllConnections(), 1_000);
+    deadlineTimer = setTimeout(() => settle(), 3_000);
+    server.close((error) => settle(error ?? undefined));
   });
 }
 

--- a/src/main/libs/htmlPreviewServer.ts
+++ b/src/main/libs/htmlPreviewServer.ts
@@ -331,14 +331,29 @@ export async function startHtmlPreviewServer(): Promise<number> {
 export async function stopHtmlPreviewServer(): Promise<void> {
   if (!server) return;
 
+  const activeServer = server;
+  server = null;
+  serverPort = null;
+  sessions.clear();
+
+  // Bounded shutdown: server.close() waits for open preview connections
+  // (e.g. a renderer webview keeping keep-alive sockets), so force-close
+  // stragglers after a short drain window and cap the total wait.
   return new Promise((resolve) => {
-    server!.close(() => {
+    let settled = false;
+    let drainTimer: ReturnType<typeof setTimeout> | null = null;
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      if (drainTimer) clearTimeout(drainTimer);
+      if (deadlineTimer) clearTimeout(deadlineTimer);
       console.log('[HtmlPreviewServer] Stopped');
-      server = null;
-      serverPort = null;
-      sessions.clear();
       resolve();
-    });
+    };
+    drainTimer = setTimeout(() => activeServer.closeAllConnections(), 1_000);
+    deadlineTimer = setTimeout(settle, 3_000);
+    activeServer.close(() => settle());
   });
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3917,9 +3917,23 @@ if (!gotTheLock) {
     authCallbackRouter.handleDeepLink(url);
   };
 
+  // First-frame gate for window activation. Showing a window whose renderer
+  // has never painted produces a stuck plain-white window (field case: slow
+  // first load after install while security software scans the fresh files,
+  // user clicks the desktop icon, second-instance force-showed the blank
+  // window). Activation requests arriving before the first frame are queued
+  // and honored from ready-to-show / did-finish-load.
+  let hasRenderedFirstFrame = false;
+  let pendingShowOnFirstFrame = false;
+
   const focusMainWindow = (reason: string) => {
     if (!mainWindow || mainWindow.isDestroyed()) return;
     try {
+      if (!mainWindow.isVisible() && !hasRenderedFirstFrame) {
+        pendingShowOnFirstFrame = true;
+        console.log(`[Main] deferred showing main window after ${reason}: renderer has not painted yet`);
+        return;
+      }
       if (mainWindow.isMinimized()) mainWindow.restore();
       if (!mainWindow.isVisible()) mainWindow.show();
       mainWindow.moveTop();
@@ -11241,6 +11255,8 @@ if (!gotTheLock) {
     }
     mainWindow = null;
     isOpenSessionFromNotificationReady = false;
+    hasRenderedFirstFrame = false;
+    pendingShowOnFirstFrame = false;
 
     const initialWindowState = resolveInitialAppWindowState(
       getStore().get(AppWindowStoreKey.State),
@@ -11357,19 +11373,71 @@ if (!gotTheLock) {
       mainWindow.maximize();
     }
 
-    // 设置窗口加载超时
-    const loadTimeout = setTimeout(() => {
-      if (mainWindow && mainWindow.webContents.isLoadingMainFrame()) {
-        console.log('Window load timed out, attempting to reload...');
-        scheduleReload('load-timeout');
+    const markFirstFrameRendered = (source: string) => {
+      hasRenderedFirstFrame = true;
+      if (pendingShowOnFirstFrame && mainWindow && !mainWindow.isDestroyed()) {
+        pendingShowOnFirstFrame = false;
+        focusMainWindow(`deferred activation (${source})`);
       }
-    }, 30000);
+    };
 
-    // 清除超时
-    mainWindow.webContents.once('did-finish-load', () => {
-      clearTimeout(loadTimeout);
-    });
+    // 窗口加载看门狗。一次性 30s 超时救不回被杀软扫描拖慢的首启动(现场案例:
+    // 首次加载超 30s,唯一一次 reload 后再无人接管,窗口永久空白),改为按退避
+    // 重试,封顶后停手保留现场。
+    const LOAD_WATCHDOG_DELAYS_MS = [30_000, 45_000, 60_000, 90_000];
+    let loadRecoveryAttempts = 0;
+    let loadWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearLoadWatchdog = () => {
+      if (loadWatchdogTimer) {
+        clearTimeout(loadWatchdogTimer);
+        loadWatchdogTimer = null;
+      }
+    };
+
+    const scheduleLoadWatchdog = () => {
+      clearLoadWatchdog();
+      const delay = LOAD_WATCHDOG_DELAYS_MS[
+        Math.min(loadRecoveryAttempts, LOAD_WATCHDOG_DELAYS_MS.length - 1)
+      ];
+      loadWatchdogTimer = setTimeout(() => {
+        loadWatchdogTimer = null;
+        if (!mainWindow || mainWindow.isDestroyed()) return;
+        if (!mainWindow.webContents.isLoadingMainFrame()) return;
+        if (loadRecoveryAttempts >= LOAD_WATCHDOG_DELAYS_MS.length) {
+          console.error(
+            `[Main] window still not loaded after ${loadRecoveryAttempts} reload attempts, giving up`,
+          );
+          return;
+        }
+        loadRecoveryAttempts++;
+        console.warn(
+          `[Main] window load watchdog: still loading after ${delay}ms, reload attempt ${loadRecoveryAttempts}/${LOAD_WATCHDOG_DELAYS_MS.length}`,
+        );
+        scheduleReload('load-watchdog');
+        scheduleLoadWatchdog();
+      }, delay);
+    };
+    scheduleLoadWatchdog();
+
+    // 兜底显示:首帧迟迟不来时,宁可让用户看到纯背景色的窗口,也不能看起来
+    // "应用没打开"。开机自启保持仅托盘,不弹窗。
+    const SHOW_FALLBACK_DELAY_MS = 10_000;
+    const showFallbackTimer = setTimeout(() => {
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      if (mainWindow.isVisible() || hasRenderedFirstFrame) return;
+      if (isAutoLaunched()) return;
+      console.warn(
+        `[Main] window not ready after ${SHOW_FALLBACK_DELAY_MS}ms, showing it before first paint`,
+      );
+      pendingShowOnFirstFrame = false;
+      mainWindow.show();
+    }, SHOW_FALLBACK_DELAY_MS);
+
     mainWindow.webContents.on('did-finish-load', () => {
+      clearLoadWatchdog();
+      loadRecoveryAttempts = 0;
+      markFirstFrameRendered('did-finish-load');
       windowStatePersist.emitState();
       if (openClawEngineManager && !mainWindow?.isDestroyed()) {
         mainWindow.webContents.send(
@@ -11446,6 +11514,15 @@ if (!gotTheLock) {
           setTimeout(() => {
             scheduleReload('did-fail-load');
           }, 3000);
+        } else if (loadRecoveryAttempts < LOAD_WATCHDOG_DELAYS_MS.length) {
+          loadRecoveryAttempts++;
+          console.warn(
+            `[Main] retrying window load after failure (attempt ${loadRecoveryAttempts}/${LOAD_WATCHDOG_DELAYS_MS.length})`,
+          );
+          setTimeout(() => {
+            scheduleReload('did-fail-load');
+            scheduleLoadWatchdog();
+          }, 3_000);
         }
       },
     );
@@ -11458,6 +11535,8 @@ if (!gotTheLock) {
 
     // 当窗口关闭时，清除引用
     mainWindow.on('closed', () => {
+      clearLoadWatchdog();
+      clearTimeout(showFallbackTimer);
       windowStatePersist.cleanup();
       authCallbackRouter.markRendererUnavailable();
       isOpenSessionFromNotificationReady = false;
@@ -11468,10 +11547,12 @@ if (!gotTheLock) {
 
     // 等待内容加载完成后再显示窗口
     mainWindow.once('ready-to-show', () => {
+      clearTimeout(showFallbackTimer);
       // 开机自启时不显示窗口，仅显示托盘图标
       if (!isAutoLaunched()) {
         mainWindow?.show();
       }
+      markFirstFrameRendered('ready-to-show');
       // Initialize main-process i18n from stored language before creating UI elements.
       const initLang = getStore().get<{ language?: string }>('app_config')?.language;
       setLanguage(initLang === 'en' ? 'en' : 'zh');
@@ -11684,9 +11765,14 @@ if (!gotTheLock) {
     await new Promise(resolve => { setTimeout(resolve, 500); });
   };
 
+  // Read by the quit watchdog to report which cleanup step was in flight when
+  // it had to force-exit.
+  let currentAppCleanupStep = 'not-started';
+
   const runAppCleanup = async (reason = 'quit'): Promise<void> => {
+    const cleanupStartedAt = Date.now();
     console.log(`[Main] App cleanup started for ${reason}`);
-    destroyTray();
+    currentAppCleanupStep = 'sync-teardown';
     skillManager?.stopWatching();
     stopMediaPollTimer();
     pendingMediaTasks.clear();
@@ -11702,34 +11788,43 @@ if (!gotTheLock) {
       openClawRuntimeAdapter.disconnectGatewayClient();
     }
 
+    // Stop skill services.
+    currentAppCleanupStep = 'skill-services';
+    const skillServices = getSkillServiceManager();
+    await skillServices.stopAll();
+
+    // Stop all IM gateways gracefully.
+    if (imGatewayManager) {
+      currentAppCleanupStep = 'im-gateways';
+      await imGatewayManager.stopAll().catch(err => {
+        console.error('[IM Gateway] Error stopping gateways on quit:', err);
+      });
+    }
+
+    // Stop the gateway before closing the local HTTP proxies below: the
+    // gateway is their client, and closing a server first would leave it
+    // draining the gateway's keep-alive sockets.
+    if (openClawEngineManager) {
+      currentAppCleanupStep = 'openclaw-gateway';
+      await openClawEngineManager.stopGateway().catch(error => {
+        console.error('[OpenClaw] Failed to stop gateway on quit:', error);
+      });
+    }
+
+    currentAppCleanupStep = 'openai-compat-proxy';
     await stopCoworkOpenAICompatProxy().catch(error => {
       console.error('Failed to stop OpenAI compatibility proxy:', error);
     });
 
+    currentAppCleanupStep = 'html-preview-server';
     await stopHtmlPreviewServer().catch(error => {
       console.error('[HtmlPreviewServer] Failed to stop:', error);
     });
 
     stopOpenClawTokenProxy();
 
-    // Stop skill services.
-    const skillServices = getSkillServiceManager();
-    await skillServices.stopAll();
-
-    // Stop all IM gateways gracefully.
-    if (imGatewayManager) {
-      await imGatewayManager.stopAll().catch(err => {
-        console.error('[IM Gateway] Error stopping gateways on quit:', err);
-      });
-    }
-
-    if (openClawEngineManager) {
-      await openClawEngineManager.stopGateway().catch(error => {
-        console.error('[OpenClaw] Failed to stop gateway on quit:', error);
-      });
-    }
-
     // Stop the cron job polling
+    currentAppCleanupStep = 'cron-and-store';
     try {
       getCronJobService().stopPolling();
     } catch {
@@ -11744,6 +11839,42 @@ if (!gotTheLock) {
     } catch {
       // Store may not have been initialized — safe to ignore.
     }
+
+    // Destroyed last so the tray icon keeps reflecting that the process is
+    // still alive while cleanup runs; destroying it first made a hung cleanup
+    // look like a finished exit while the process lived on invisibly.
+    destroyTray();
+    currentAppCleanupStep = 'done';
+    console.log(`[Main] App cleanup finished for ${reason} in ${Date.now() - cleanupStartedAt}ms`);
+  };
+
+  // Hard ceiling for graceful cleanup. Past this the process force-exits and
+  // logs the step that was still in flight: a hung await here used to leave an
+  // invisible zombie (tray destroyed, no window) that only Task Manager could
+  // kill — and that zombie is what the installer later has to hunt down.
+  const APP_CLEANUP_WATCHDOG_MS = 10_000;
+
+  const runAppCleanupAndExit = (trigger: string) => {
+    isCleanupInProgress = true;
+    isQuitting = true;
+
+    const watchdog = setTimeout(() => {
+      console.error(
+        `[Main] App cleanup did not finish within ${APP_CLEANUP_WATCHDOG_MS}ms (trigger=${trigger}, stuck at step: ${currentAppCleanupStep}), forcing exit`,
+      );
+      app.exit(1);
+    }, APP_CLEANUP_WATCHDOG_MS);
+
+    void runAppCleanup()
+      .catch(error => {
+        console.error(`[Main] Cleanup error (trigger=${trigger}):`, error);
+      })
+      .finally(() => {
+        clearTimeout(watchdog);
+        isCleanupFinished = true;
+        isCleanupInProgress = false;
+        app.exit(0);
+      });
   };
 
   app.on('before-quit', e => {
@@ -11754,18 +11885,7 @@ if (!gotTheLock) {
       return;
     }
 
-    isCleanupInProgress = true;
-    isQuitting = true;
-
-    void runAppCleanup()
-      .catch(error => {
-        console.error('[Main] Cleanup error:', error);
-      })
-      .finally(() => {
-        isCleanupFinished = true;
-        isCleanupInProgress = false;
-        app.exit(0);
-      });
+    runAppCleanupAndExit('before-quit');
   });
 
   const handleTerminationSignal = (signal: NodeJS.Signals) => {
@@ -11773,17 +11893,7 @@ if (!gotTheLock) {
       return;
     }
     console.log(`[Main] Received ${signal}, running cleanup before exit...`);
-    isCleanupInProgress = true;
-    isQuitting = true;
-    void runAppCleanup()
-      .catch(error => {
-        console.error(`[Main] Cleanup error during ${signal}:`, error);
-      })
-      .finally(() => {
-        isCleanupFinished = true;
-        isCleanupInProgress = false;
-        app.exit(0);
-      });
+    runAppCleanupAndExit(signal);
   };
 
   process.once('SIGINT', () => handleTerminationSignal('SIGINT'));


### PR DESCRIPTION
- bound OpenAI-compat proxy and HTML preview server shutdown with a drain timer plus a hard deadline, so lingering keep-alive sockets (e.g. from the OpenClaw gateway) can no longer stall app quit
- gate main window activation on first-render: queued show requests from focus/second-instance now wait for did-finish-load or ready-to-show instead of surfacing a blank white window, with a 10s fallback show if first paint never arrives (skipped when auto-launched to tray)
- replace the one-shot 30s load timeout with a backoff retry watchdog (30/45/60/90s) so a slow first load (e.g. antivirus scanning fresh files) gets multiple recovery attempts instead of giving up silently
- reorder app cleanup so the OpenClaw gateway stops before the local HTTP proxies it depends on, and destroy the tray icon last so a stuck cleanup doesn't look like a finished exit
- add a 10s cleanup watchdog that force-exits and logs the stuck step, preventing an invisible zombie process that only Task Manager could previously kill