### PR TITLE
fix(openclaw): preserve provider for slashed model ids

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -1818,6 +1818,7 @@ function createPatchAdapter(options?: {
   isChannelSession?: boolean;
   persistedSessionKey?: string | null;
   scheduledTaskId?: string | null;
+  patchResponse?: unknown;
 }) {
   const session = {
     id: 'session-1',
@@ -1856,7 +1857,7 @@ function createPatchAdapter(options?: {
     stop: () => {},
     request: async (method: string, params?: unknown) => {
       requests.push({ method, params: params as Record<string, unknown> });
-      return {};
+      return method === 'sessions.patch' ? options?.patchResponse ?? {} : {};
     },
   };
   adapter.gatewayClientVersion = 'test-version';
@@ -2160,6 +2161,22 @@ test('cron session routing retains only the latest real gateway run key per job'
   expect(adapter.getSessionKeysForSession(session.id)).not.toContain(
     'agent:ops:cron:daily-monitor',
   );
+});
+
+test('patchSession preserves the provider for model IDs containing slashes', async () => {
+  const modelRef = 'custom_0/deepseek-ai/DeepSeek-V4-Flash';
+  const { adapter } = createPatchAdapter({
+    patchResponse: {
+      entry: {
+        providerOverride: 'custom_0',
+        modelOverride: 'deepseek-ai/DeepSeek-V4-Flash',
+      },
+    },
+  });
+
+  await expect(adapter.patchSession('session-1', { model: modelRef })).resolves.toEqual({
+    modelOverride: modelRef,
+  });
 });
 
 test('pollChannelSessions syncs channel row model into the local session override', async () => {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1132,7 +1132,7 @@ const buildModelRef = (provider: string | null | undefined, model: string | null
   const normalizedModel = model?.trim();
   if (!normalizedModel) return null;
   const normalizedProvider = provider?.trim();
-  if (!normalizedProvider || normalizedModel.includes('/')) return normalizedModel;
+  if (!normalizedProvider || normalizedModel.startsWith(`${normalizedProvider}/`)) return normalizedModel;
   return `${normalizedProvider}/${normalizedModel}`;
 };
 


### PR DESCRIPTION
## Summary

Preserve the OpenClaw provider prefix when a session patch response stores the provider and model separately and the model ID itself contains `/`.

Without this, `custom_0` + `deepseek-ai/DeepSeek-V4-Flash` was persisted as only `deepseek-ai/DeepSeek-V4-Flash`. The renderer then interpreted `deepseek-ai` as the provider and marked the selected model unavailable.

## Related Issue

Fixes #2443

## Changes Made

- Rebuild split OpenClaw model references as `provider/model`, even when the model ID contains slashes.
- Avoid duplicating the prefix when the gateway already returns a complete model reference.
- Add a focused `sessions.patch` regression test using the reported SiliconFlow-style model ID.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

```text
vitest run src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts \
  -t "patchSession preserves the provider for model IDs containing slashes"

Test Files  1 passed (1)
Tests       1 passed | 216 skipped (217)
```

```text
eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 \
  src/main/libs/agentEngine/openclawRuntimeAdapter.ts \
  src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
# no output (passed)

git diff --check
# no output (passed)
```

## Screenshots (if applicable)

Not applicable. The fix is in the main-process OpenClaw session adapter and is covered by a wire-shape regression test.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes

The change is limited to the existing model-reference reconstruction helper. No OpenClaw runtime patch, storage migration, or renderer behavior change is required.