### PR TITLE
fix(plugins): preserve config editor interactions

### DIFF
--- a/src/renderer/components/plugins/PluginConfigPage.tsx
+++ b/src/renderer/components/plugins/PluginConfigPage.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
-import { useCallback,useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
 import { SchemaForm } from '../im/SchemaForm';
@@ -55,6 +55,9 @@ export default function PluginConfigPage({ pluginId, onBack, initialConfig, onCo
   const [schema, setSchema] = useState<ConfigSchemaData | null>(null);
   const [configValue, setConfigValue] = useState<Record<string, unknown>>(initialConfig ?? {});
   const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
+  // The parent echoes every local edit through initialConfig. Only its mount-time
+  // presence decides whether the backend value should initialize this editor.
+  const hasPendingConfigOnMountRef = useRef(initialConfig !== undefined);
 
   const loadSchema = useCallback(async () => {
     setLoading(true);
@@ -65,7 +68,7 @@ export default function PluginConfigPage({ pluginId, onBack, initialConfig, onCo
         setSchema(result.schema);
         const loadedConfig = result.config ?? {};
         // If parent already has a pending config for this plugin, use that instead
-        if (!initialConfig) {
+        if (!hasPendingConfigOnMountRef.current) {
           setConfigValue(loadedConfig);
         }
         // Notify parent about the initial config from backend
@@ -77,7 +80,7 @@ export default function PluginConfigPage({ pluginId, onBack, initialConfig, onCo
       setError(i18nService.t('pluginsConfigLoadError'));
     }
     setLoading(false);
-  }, [pluginId, initialConfig, onConfigLoaded]);
+  }, [pluginId, onConfigLoaded]);
 
   useEffect(() => {
     loadSchema();

--- a/src/renderer/components/plugins/PluginsSettings.tsx
+++ b/src/renderer/components/plugins/PluginsSettings.tsx
@@ -1,5 +1,5 @@
-import { ArrowPathIcon, ArrowUpCircleIcon, Cog6ToothIcon,PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { useCallback, useEffect, useImperativeHandle, useRef,useState } from 'react';
+import { ArrowPathIcon, ArrowUpCircleIcon, Cog6ToothIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
 import { LogReporterAction, reportYdAnalyzer } from '../../services/logReporter';
@@ -410,16 +410,65 @@ export default function PluginsSettings({ handleRef }: PluginsSettingsProps) {
     }
   };
 
+  // This overlay must be shared by both the plugin list and config sub-view.
+  const unsavedChangesDialog = showUnsavedConfirm ? (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="plugins-unsaved-title"
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/35 px-4"
+    >
+      <div className="w-full max-w-sm rounded-2xl bg-background border border-border shadow-modal p-5">
+        <h4 id="plugins-unsaved-title" className="text-sm font-semibold text-foreground mb-2">
+          {i18nService.t('pluginsUnsavedTitle')}
+        </h4>
+        <p className="text-sm text-secondary mb-4">
+          {i18nService.t('pluginsUnsavedMessage')}
+        </p>
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              setShowUnsavedConfirm(false);
+              pendingLeaveActionRef.current = null;
+            }}
+            className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
+          >
+            {i18nService.t('pluginsUnsavedStay')}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setShowUnsavedConfirm(false);
+              // Reset dirty state so subsequent navigation is not blocked
+              setPendingToggles(new Map());
+              setPendingConfigs(new Map());
+              const action = pendingLeaveActionRef.current;
+              pendingLeaveActionRef.current = null;
+              action?.();
+            }}
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity"
+          >
+            {i18nService.t('pluginsUnsavedDiscard')}
+          </button>
+        </div>
+      </div>
+    </div>
+  ) : null;
+
   // Sub-view: Plugin config page
   if (configPluginId) {
     return (
-      <PluginConfigPage
-        pluginId={configPluginId}
-        onBack={() => setConfigPluginId(null)}
-        initialConfig={pendingConfigs.get(configPluginId)}
-        onConfigChange={handleConfigChange}
-        onConfigLoaded={handleConfigLoaded}
-      />
+      <>
+        <PluginConfigPage
+          pluginId={configPluginId}
+          onBack={() => setConfigPluginId(null)}
+          initialConfig={pendingConfigs.get(configPluginId)}
+          onConfigChange={handleConfigChange}
+          onConfigLoaded={handleConfigLoaded}
+        />
+        {unsavedChangesDialog}
+      </>
     );
   }
 
@@ -909,46 +958,7 @@ export default function PluginsSettings({ handleRef }: PluginsSettingsProps) {
         </div>
       )}
 
-      {/* Unsaved changes confirmation dialog */}
-      {showUnsavedConfirm && (
-        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/35 px-4">
-          <div className="w-full max-w-sm rounded-2xl bg-background border border-border shadow-modal p-5">
-            <h4 className="text-sm font-semibold text-foreground mb-2">
-              {i18nService.t('pluginsUnsavedTitle')}
-            </h4>
-            <p className="text-sm text-secondary mb-4">
-              {i18nService.t('pluginsUnsavedMessage')}
-            </p>
-            <div className="flex justify-end gap-3">
-              <button
-                type="button"
-                onClick={() => {
-                  setShowUnsavedConfirm(false);
-                  pendingLeaveActionRef.current = null;
-                }}
-                className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
-              >
-                {i18nService.t('pluginsUnsavedStay')}
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setShowUnsavedConfirm(false);
-                  // Reset dirty state so subsequent navigation is not blocked
-                  setPendingToggles(new Map());
-                  setPendingConfigs(new Map());
-                  const action = pendingLeaveActionRef.current;
-                  pendingLeaveActionRef.current = null;
-                  action?.();
-                }}
-                className="px-4 py-2 text-sm font-medium rounded-lg bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity"
-              >
-                {i18nService.t('pluginsUnsavedDiscard')}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {unsavedChangesDialog}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Preserve the plugin configuration editor state while users change field values, so expanded sections and input focus no longer reset.
- Keep the unsaved-changes confirmation in the active configuration view when cancelling, closing, or navigating away.

## Verification
- Changed-file ESLint passed.
- Production renderer build passed.
- Manual regression testing completed.
- Full Vitest run: 2,856 passed, 10 unrelated existing failures, 2 skipped.