### PR TITLE
fix(python-runtime): repair stale pip shims on Windows runtime upgrade

### DIFF
--- a/scripts/setup-python-runtime.js
+++ b/scripts/setup-python-runtime.js
@@ -45,6 +45,47 @@ const PIP_RUNTIME_ARCHIVE_REL_PATH = path.join('tools', 'pip.pyz');
 const PIP_MODULE_MAIN_REL_PATH = path.join('Lib', 'site-packages', 'pip', '__main__.py');
 const PIP_MODULE_INIT_REL_PATH = path.join('Lib', 'site-packages', 'pip', '__init__.py');
 
+// Canonical pip shim/wrapper content. src/main/libs/pythonPipShim.ts keeps the
+// TypeScript copy used for user-runtime self-repair at app startup;
+// src/main/libs/pythonPipShim.test.ts asserts both copies stay byte-identical.
+const PIP_SHIM_OWNERSHIP_MARKER = 'pip.pyz';
+const PIP_SHIM_MAIN_TEMPLATE = [
+  'import pathlib',
+  'import runpy',
+  'import sys',
+  '',
+  'root = pathlib.Path(__file__).resolve().parents[3]',
+  "pip_pyz = root / 'tools' / 'pip.pyz'",
+  'if not pip_pyz.exists():',
+  "    raise SystemExit(f'pip runtime archive missing: {pip_pyz}')",
+  '',
+  '# Ensure pip imports resolve to the zipapp payload, not this shim package.',
+  'sys.path.insert(0, str(pip_pyz))',
+  'for name in list(sys.modules):',
+  "    if name == 'pip' or name.startswith('pip.'):",
+  '        del sys.modules[name]',
+  '',
+  "sys.argv[0] = 'pip'",
+  "runpy.run_module('pip', run_name='__main__', alter_sys=True)",
+  '',
+].join('\n');
+const PIP_SHIM_INIT_TEMPLATE = '';
+const PIP_WRAPPER_CMD_TEMPLATE = [
+  '@echo off',
+  'setlocal',
+  'set "PYROOT=%~dp0.."',
+  '"%PYROOT%\\python.exe" -m pip %*',
+  '',
+].join('\r\n');
+const PIP_WRAPPER_SH_TEMPLATE = [
+  '#!/usr/bin/env bash',
+  'set -euo pipefail',
+  'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
+  'PYROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"',
+  'exec "${PYROOT}/python.exe" -m pip "$@"',
+  '',
+].join('\n');
+
 function hasPipCommand(rootDir) {
   return PIP_EXECUTABLE_CANDIDATES.some((relPath) => fs.existsSync(path.join(rootDir, relPath)));
 }
@@ -132,32 +173,41 @@ function writeFileIfChanged(filePath, content) {
 
 function createPipWrappers(rootDir) {
   const scriptsDir = path.join(rootDir, 'Scripts');
-  const pipCmd = [
-    '@echo off',
-    'setlocal',
-    'set "PYROOT=%~dp0.."',
-    '"%PYROOT%\\python.exe" -m pip %*',
-    '',
-  ].join('\r\n');
-  const pipSh = [
-    '#!/usr/bin/env bash',
-    'set -euo pipefail',
-    'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
-    'PYROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"',
-    'exec "${PYROOT}/python.exe" -m pip "$@"',
-    '',
-  ].join('\n');
-
-  writeFileIfChanged(path.join(scriptsDir, 'pip.cmd'), pipCmd);
-  writeFileIfChanged(path.join(scriptsDir, 'pip3.cmd'), pipCmd);
-  writeFileIfChanged(path.join(scriptsDir, 'pip'), pipSh);
-  writeFileIfChanged(path.join(scriptsDir, 'pip3'), pipSh);
+  writeFileIfChanged(path.join(scriptsDir, 'pip.cmd'), PIP_WRAPPER_CMD_TEMPLATE);
+  writeFileIfChanged(path.join(scriptsDir, 'pip3.cmd'), PIP_WRAPPER_CMD_TEMPLATE);
+  writeFileIfChanged(path.join(scriptsDir, 'pip'), PIP_WRAPPER_SH_TEMPLATE);
+  writeFileIfChanged(path.join(scriptsDir, 'pip3'), PIP_WRAPPER_SH_TEMPLATE);
   try {
     fs.chmodSync(path.join(scriptsDir, 'pip'), 0o755);
     fs.chmodSync(path.join(scriptsDir, 'pip3'), 0o755);
   } catch {
     // Ignore chmod failures on filesystems without POSIX modes.
   }
+}
+
+// Converge LobsterAI-owned pip shim files to the current templates. Guarded by
+// an ownership marker so a real pip package (copied from a host Python or
+// installed by get-pip) is never overwritten. Returns whether the shim layout
+// is LobsterAI-owned.
+function convergePipShimFiles(rootDir) {
+  const mainPath = path.join(rootDir, PIP_MODULE_MAIN_REL_PATH);
+  let existingMain = null;
+  try {
+    existingMain = fs.readFileSync(mainPath, 'utf8');
+  } catch {
+    existingMain = null;
+  }
+
+  const ownsShim = existingMain === null
+    ? isNonEmptyFile(path.join(rootDir, PIP_RUNTIME_ARCHIVE_REL_PATH))
+    : existingMain.includes(PIP_SHIM_OWNERSHIP_MARKER);
+  if (!ownsShim) {
+    return false;
+  }
+
+  writeFileIfChanged(mainPath, PIP_SHIM_MAIN_TEMPLATE);
+  writeFileIfChanged(path.join(rootDir, PIP_MODULE_INIT_REL_PATH), PIP_SHIM_INIT_TEMPLATE);
+  return true;
 }
 
 function tryCopyPipFromHostPython(rootDir) {
@@ -235,6 +285,13 @@ async function ensurePipPayload(rootDir, options = {}) {
   const required = options.required !== false;
   const existingPipHealth = checkRuntimeHealth(rootDir, { requirePip: true });
   if (existingPipHealth.ok) {
+    // The health check only tests file existence, which can hide a stale shim
+    // from an earlier build (e.g. a cached resources/python-win). Converge
+    // LobsterAI-owned shim/wrapper files to the current templates before
+    // accepting the runtime as prepared.
+    if (convergePipShimFiles(rootDir)) {
+      createPipWrappers(rootDir);
+    }
     return;
   }
 
@@ -271,32 +328,7 @@ async function ensurePipPayload(rootDir, options = {}) {
     }
   }
 
-  const pipModuleDir = path.join(rootDir, 'Lib', 'site-packages', 'pip');
-  const pipInitPath = path.join(pipModuleDir, '__init__.py');
-  const pipMainPath = path.join(pipModuleDir, '__main__.py');
-  const pipMain = [
-    'import pathlib',
-    'import runpy',
-    'import sys',
-    '',
-    'root = pathlib.Path(__file__).resolve().parents[3]',
-    "pip_pyz = root / 'tools' / 'pip.pyz'",
-    'if not pip_pyz.exists():',
-    "    raise SystemExit(f'pip runtime archive missing: {pip_pyz}')",
-    '',
-    '# Ensure pip imports resolve to the zipapp payload, not this shim package.',
-    'sys.path.insert(0, str(pip_pyz))',
-    'for name in list(sys.modules):',
-    "    if name == 'pip' or name.startswith('pip.'):",
-    '        del sys.modules[name]',
-    '',
-    "sys.argv[0] = 'pip'",
-    "runpy.run_module('pip', run_name='__main__', alter_sys=True)",
-    '',
-  ].join('\n');
-
-  writeFileIfChanged(pipInitPath, '');
-  writeFileIfChanged(pipMainPath, pipMain);
+  convergePipShimFiles(rootDir);
   createPipWrappers(rootDir);
 
   const finalHealth = checkRuntimeHealth(rootDir, { requirePip: true });
@@ -671,4 +703,10 @@ module.exports = {
   ensurePortablePythonRuntime,
   findPortablePythonExecutable,
   checkRuntimeHealth,
+  convergePipShimFiles,
+  createPipWrappers,
+  PIP_SHIM_MAIN_TEMPLATE,
+  PIP_SHIM_INIT_TEMPLATE,
+  PIP_WRAPPER_CMD_TEMPLATE,
+  PIP_WRAPPER_SH_TEMPLATE,
 };

--- a/src/main/libs/pythonPipShim.test.ts
+++ b/src/main/libs/pythonPipShim.test.ts
@@ -1,0 +1,223 @@
+import fs from 'fs';
+import { createRequire } from 'module';
+import os from 'os';
+import path from 'path';
+import { describe, expect, test } from 'vitest';
+
+import {
+  PIP_SHIM_INIT_TEMPLATE,
+  PIP_SHIM_MAIN_TEMPLATE,
+  PIP_WRAPPER_CMD_TEMPLATE,
+  PIP_WRAPPER_SH_TEMPLATE,
+  repairPipShims,
+} from './pythonPipShim';
+
+const requireCjs = createRequire(import.meta.url);
+const setupPythonRuntime = requireCjs('../../../scripts/setup-python-runtime.js') as {
+  convergePipShimFiles: (rootDir: string) => boolean;
+  createPipWrappers: (rootDir: string) => void;
+  PIP_SHIM_MAIN_TEMPLATE: string;
+  PIP_SHIM_INIT_TEMPLATE: string;
+  PIP_WRAPPER_CMD_TEMPLATE: string;
+  PIP_WRAPPER_SH_TEMPLATE: string;
+};
+
+// The pre-2026-03 shim shipped by older builds. Its run_path bootstrap
+// re-enters this same file through pip.pyz's `runpy.run_module('pip', ...)`
+// (sys.modules['pip'] still points at the shim package), recursing until
+// RecursionError. Kept verbatim as the regression fixture.
+const LEGACY_RUN_PATH_SHIM = [
+  'import pathlib',
+  'import runpy',
+  'import sys',
+  '',
+  'root = pathlib.Path(__file__).resolve().parents[3]',
+  "pip_pyz = root / 'tools' / 'pip.pyz'",
+  'if not pip_pyz.exists():',
+  "    raise SystemExit(f'pip runtime archive missing: {pip_pyz}')",
+  "sys.argv[0] = 'pip'",
+  "runpy.run_path(str(pip_pyz), run_name='__main__')",
+  '',
+].join('\n');
+
+// A real pip package's __main__.py contains no pip.pyz marker and must never
+// be overwritten by the shim converger.
+const REAL_PIP_MAIN = [
+  'import sys',
+  '',
+  'from pip._internal.cli.main import main',
+  '',
+  "if __name__ == '__main__':",
+  '    sys.exit(main())',
+  '',
+].join('\n');
+
+const SHIM_MAIN_REL = path.join('Lib', 'site-packages', 'pip', '__main__.py');
+const SHIM_INIT_REL = path.join('Lib', 'site-packages', 'pip', '__init__.py');
+const PYZ_REL = path.join('tools', 'pip.pyz');
+const WRAPPER_RELS = [
+  path.join('Scripts', 'pip.cmd'),
+  path.join('Scripts', 'pip3.cmd'),
+  path.join('Scripts', 'pip'),
+  path.join('Scripts', 'pip3'),
+];
+
+function writeLayout(root: string, files: Record<string, string>): void {
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = path.join(root, relPath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content, 'utf8');
+  }
+}
+
+function readIfExists(root: string, relPath: string): string | null {
+  try {
+    return fs.readFileSync(path.join(root, relPath), 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function withRoot(run: (root: string) => void): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pip-shim-test-'));
+  try {
+    run(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe('pip shim template contract with scripts/setup-python-runtime.js', () => {
+  test('templates are byte-identical in both sources', () => {
+    expect(setupPythonRuntime.PIP_SHIM_MAIN_TEMPLATE).toBe(PIP_SHIM_MAIN_TEMPLATE);
+    expect(setupPythonRuntime.PIP_SHIM_INIT_TEMPLATE).toBe(PIP_SHIM_INIT_TEMPLATE);
+    expect(setupPythonRuntime.PIP_WRAPPER_CMD_TEMPLATE).toBe(PIP_WRAPPER_CMD_TEMPLATE);
+    expect(setupPythonRuntime.PIP_WRAPPER_SH_TEMPLATE).toBe(PIP_WRAPPER_SH_TEMPLATE);
+  });
+
+  test('canonical shim boots pip via run_module, never via run_path recursion', () => {
+    expect(PIP_SHIM_MAIN_TEMPLATE).toContain("runpy.run_module('pip'");
+    expect(PIP_SHIM_MAIN_TEMPLATE).toContain('sys.path.insert(0, str(pip_pyz))');
+    expect(PIP_SHIM_MAIN_TEMPLATE).not.toContain('run_path');
+  });
+});
+
+describe('repairPipShims', () => {
+  test('rewrites the legacy run_path shim to the canonical template', () => {
+    withRoot((root) => {
+      writeLayout(root, {
+        [PYZ_REL]: 'fake-pyz',
+        [SHIM_MAIN_REL]: LEGACY_RUN_PATH_SHIM,
+        [SHIM_INIT_REL]: '',
+        [WRAPPER_RELS[0]]: '"%PYROOT%\\python.exe" -m pip %*',
+      });
+      const { changed } = repairPipShims(root);
+      expect(readIfExists(root, SHIM_MAIN_REL)).toBe(PIP_SHIM_MAIN_TEMPLATE);
+      expect(changed).toContain(SHIM_MAIN_REL);
+      expect(readIfExists(root, WRAPPER_RELS[0])).toBe(PIP_WRAPPER_CMD_TEMPLATE);
+      expect(readIfExists(root, WRAPPER_RELS[2])).toBe(PIP_WRAPPER_SH_TEMPLATE);
+    });
+  });
+
+  test('is a no-op on an already-canonical runtime', () => {
+    withRoot((root) => {
+      writeLayout(root, {
+        [PYZ_REL]: 'fake-pyz',
+        [SHIM_MAIN_REL]: PIP_SHIM_MAIN_TEMPLATE,
+        [SHIM_INIT_REL]: PIP_SHIM_INIT_TEMPLATE,
+        [WRAPPER_RELS[0]]: PIP_WRAPPER_CMD_TEMPLATE,
+        [WRAPPER_RELS[1]]: PIP_WRAPPER_CMD_TEMPLATE,
+        [WRAPPER_RELS[2]]: PIP_WRAPPER_SH_TEMPLATE,
+        [WRAPPER_RELS[3]]: PIP_WRAPPER_SH_TEMPLATE,
+      });
+      const { changed } = repairPipShims(root);
+      expect(changed).toEqual([]);
+    });
+  });
+
+  test('leaves a real pip package untouched', () => {
+    withRoot((root) => {
+      writeLayout(root, {
+        [PYZ_REL]: 'fake-pyz',
+        [SHIM_MAIN_REL]: REAL_PIP_MAIN,
+        [SHIM_INIT_REL]: "__version__ = '24.0'\n",
+      });
+      const { changed } = repairPipShims(root);
+      expect(changed).toEqual([]);
+      expect(readIfExists(root, SHIM_MAIN_REL)).toBe(REAL_PIP_MAIN);
+      expect(readIfExists(root, SHIM_INIT_REL)).toBe("__version__ = '24.0'\n");
+      expect(readIfExists(root, WRAPPER_RELS[0])).toBeNull();
+    });
+  });
+
+  test('creates shim files when the pip module is missing but pip.pyz exists', () => {
+    withRoot((root) => {
+      writeLayout(root, { [PYZ_REL]: 'fake-pyz' });
+      const { changed } = repairPipShims(root);
+      expect(changed.length).toBeGreaterThan(0);
+      expect(readIfExists(root, SHIM_MAIN_REL)).toBe(PIP_SHIM_MAIN_TEMPLATE);
+      expect(readIfExists(root, SHIM_INIT_REL)).toBe(PIP_SHIM_INIT_TEMPLATE);
+      expect(readIfExists(root, WRAPPER_RELS[0])).toBe(PIP_WRAPPER_CMD_TEMPLATE);
+    });
+  });
+
+  test('does nothing when neither pip module nor pip.pyz exists', () => {
+    withRoot((root) => {
+      const { changed } = repairPipShims(root);
+      expect(changed).toEqual([]);
+      expect(readIfExists(root, SHIM_MAIN_REL)).toBeNull();
+    });
+  });
+
+  test('does not overwrite a foreign wrapper script', () => {
+    withRoot((root) => {
+      writeLayout(root, {
+        [PYZ_REL]: 'fake-pyz',
+        [SHIM_MAIN_REL]: LEGACY_RUN_PATH_SHIM,
+        [WRAPPER_RELS[0]]: 'echo custom launcher',
+      });
+      repairPipShims(root);
+      expect(readIfExists(root, WRAPPER_RELS[0])).toBe('echo custom launcher');
+      expect(readIfExists(root, WRAPPER_RELS[1])).toBe(PIP_WRAPPER_CMD_TEMPLATE);
+    });
+  });
+});
+
+describe('build-script convergence matches runtime repair', () => {
+  test('both implementations produce identical files from a legacy layout', () => {
+    const layout = {
+      [PYZ_REL]: 'fake-pyz',
+      [SHIM_MAIN_REL]: LEGACY_RUN_PATH_SHIM,
+      [SHIM_INIT_REL]: '',
+    };
+    withRoot((tsRoot) => {
+      withRoot((scriptRoot) => {
+        writeLayout(tsRoot, layout);
+        writeLayout(scriptRoot, layout);
+        repairPipShims(tsRoot);
+        if (setupPythonRuntime.convergePipShimFiles(scriptRoot)) {
+          setupPythonRuntime.createPipWrappers(scriptRoot);
+        }
+        for (const relPath of [SHIM_MAIN_REL, SHIM_INIT_REL, ...WRAPPER_RELS]) {
+          expect(readIfExists(scriptRoot, relPath)).toBe(readIfExists(tsRoot, relPath));
+        }
+      });
+    });
+  });
+
+  test('both implementations refuse to touch a real pip package', () => {
+    const layout = {
+      [SHIM_MAIN_REL]: REAL_PIP_MAIN,
+      [SHIM_INIT_REL]: "__version__ = '24.0'\n",
+    };
+    withRoot((tsRoot) => {
+      withRoot((scriptRoot) => {
+        writeLayout(tsRoot, layout);
+        writeLayout(scriptRoot, layout);
+        expect(repairPipShims(tsRoot).changed).toEqual([]);
+        expect(setupPythonRuntime.convergePipShimFiles(scriptRoot)).toBe(false);
+        expect(readIfExists(scriptRoot, SHIM_MAIN_REL)).toBe(REAL_PIP_MAIN);
+      });
+    });
+  });
+});

--- a/src/main/libs/pythonPipShim.ts
+++ b/src/main/libs/pythonPipShim.ts
@@ -1,0 +1,117 @@
+import fs from 'fs';
+import path from 'path';
+
+// Canonical content of the LobsterAI-generated pip shim and wrapper files for
+// the bundled Windows Python runtime. scripts/setup-python-runtime.js keeps a
+// CJS copy of these templates for packaging time; pythonPipShim.test.ts asserts
+// both copies stay byte-identical so the two can never drift again.
+//
+// This module must stay free of Electron imports so it remains unit-testable.
+
+export const PIP_PYZ_REL_PATH = path.join('tools', 'pip.pyz');
+export const PIP_SHIM_MAIN_REL_PATH = path.join('Lib', 'site-packages', 'pip', '__main__.py');
+export const PIP_SHIM_INIT_REL_PATH = path.join('Lib', 'site-packages', 'pip', '__init__.py');
+
+export const PIP_SHIM_MAIN_TEMPLATE = [
+  'import pathlib',
+  'import runpy',
+  'import sys',
+  '',
+  'root = pathlib.Path(__file__).resolve().parents[3]',
+  "pip_pyz = root / 'tools' / 'pip.pyz'",
+  'if not pip_pyz.exists():',
+  "    raise SystemExit(f'pip runtime archive missing: {pip_pyz}')",
+  '',
+  '# Ensure pip imports resolve to the zipapp payload, not this shim package.',
+  'sys.path.insert(0, str(pip_pyz))',
+  'for name in list(sys.modules):',
+  "    if name == 'pip' or name.startswith('pip.'):",
+  '        del sys.modules[name]',
+  '',
+  "sys.argv[0] = 'pip'",
+  "runpy.run_module('pip', run_name='__main__', alter_sys=True)",
+  '',
+].join('\n');
+
+export const PIP_SHIM_INIT_TEMPLATE = '';
+
+export const PIP_WRAPPER_CMD_TEMPLATE = [
+  '@echo off',
+  'setlocal',
+  'set "PYROOT=%~dp0.."',
+  '"%PYROOT%\\python.exe" -m pip %*',
+  '',
+].join('\r\n');
+
+export const PIP_WRAPPER_SH_TEMPLATE = [
+  '#!/usr/bin/env bash',
+  'set -euo pipefail',
+  'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
+  'PYROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"',
+  'exec "${PYROOT}/python.exe" -m pip "$@"',
+  '',
+].join('\n');
+
+// A pip module dir is "ours" when its __main__.py redirects through pip.pyz —
+// true for every historical LobsterAI shim, never for a real pip package
+// (e.g. copied from a host Python or installed by get-pip/`pip install pip`).
+const PIP_SHIM_OWNERSHIP_MARKER = 'pip.pyz';
+const PIP_WRAPPER_OWNERSHIP_MARKER = '-m pip';
+
+const PIP_WRAPPER_FILES: Array<{ relPath: string; template: string }> = [
+  { relPath: path.join('Scripts', 'pip.cmd'), template: PIP_WRAPPER_CMD_TEMPLATE },
+  { relPath: path.join('Scripts', 'pip3.cmd'), template: PIP_WRAPPER_CMD_TEMPLATE },
+  { relPath: path.join('Scripts', 'pip'), template: PIP_WRAPPER_SH_TEMPLATE },
+  { relPath: path.join('Scripts', 'pip3'), template: PIP_WRAPPER_SH_TEMPLATE },
+];
+
+function readTextIfExists(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Converge LobsterAI-owned pip shim/wrapper files to the current templates.
+ *
+ * Runtimes deployed by older app versions keep whatever shim they were synced
+ * with (the health checks only test file existence), so a broken shim would
+ * otherwise survive every upgrade. Rewriting is guarded by ownership markers:
+ * a real pip package installed into the runtime is never touched, and user
+ * packages in site-packages are never affected.
+ */
+export function repairPipShims(rootDir: string): { changed: string[] } {
+  const changed: string[] = [];
+  const write = (relPath: string, content: string): void => {
+    const fullPath = path.join(rootDir, relPath);
+    if (readTextIfExists(fullPath) === content) {
+      return;
+    }
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content, 'utf8');
+    changed.push(relPath);
+  };
+
+  const shimMain = readTextIfExists(path.join(rootDir, PIP_SHIM_MAIN_REL_PATH));
+  const ownsShim = shimMain === null
+    ? fs.existsSync(path.join(rootDir, PIP_PYZ_REL_PATH))
+    : shimMain.includes(PIP_SHIM_OWNERSHIP_MARKER);
+  if (!ownsShim) {
+    return { changed };
+  }
+
+  write(PIP_SHIM_MAIN_REL_PATH, PIP_SHIM_MAIN_TEMPLATE);
+  write(PIP_SHIM_INIT_REL_PATH, PIP_SHIM_INIT_TEMPLATE);
+
+  for (const wrapper of PIP_WRAPPER_FILES) {
+    const existing = readTextIfExists(path.join(rootDir, wrapper.relPath));
+    if (existing !== null && !existing.includes(PIP_WRAPPER_OWNERSHIP_MARKER)) {
+      continue;
+    }
+    write(wrapper.relPath, wrapper.template);
+  }
+
+  return { changed };
+}

--- a/src/main/libs/pythonRuntime.ts
+++ b/src/main/libs/pythonRuntime.ts
@@ -1,8 +1,9 @@
 import { app } from 'electron';
-import { spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+
 import { cpRecursiveSync } from '../fsCompat';
+import { repairPipShims } from './pythonPipShim';
 
 const PYTHON_RUNTIME_DIR_NAME = 'python-win';
 const PYTHON_RUNTIME_STATE_FILE = 'runtime.json';
@@ -32,19 +33,6 @@ function hasPipSupport(rootDir: string): boolean {
     fs.existsSync(path.join(rootDir, PIP_MODULE_MAIN_REL_PATH))
     || fs.existsSync(path.join(rootDir, PIP_MODULE_INIT_REL_PATH));
   return hasCommand && hasModuleShim;
-}
-
-function findPythonExecutable(rootDir: string): string | null {
-  const candidates = [
-    path.join(rootDir, 'python.exe'),
-    path.join(rootDir, 'python3.exe'),
-  ];
-  for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) {
-      return candidate;
-    }
-  }
-  return null;
 }
 
 function readEmbedPthFiles(rootDir: string): string[] {
@@ -244,6 +232,17 @@ export function appendPythonRuntimeToEnv(env: Record<string, string | undefined>
   return env;
 }
 
+function convergeUserPipShims(userRoot: string): void {
+  try {
+    const { changed } = repairPipShims(userRoot);
+    if (changed.length > 0) {
+      console.log(`[python-runtime] Converged pip shim files: ${changed.join(', ')}`);
+    }
+  } catch (error) {
+    console.warn('[python-runtime] Failed to converge pip shim files:', error);
+  }
+}
+
 export async function ensurePythonRuntimeReady(): Promise<{ success: boolean; error?: string }> {
   if (process.platform !== 'win32') {
     return { success: true };
@@ -257,6 +256,7 @@ export async function ensurePythonRuntimeReady(): Promise<{ success: boolean; er
       } catch (error) {
         console.warn('[python-runtime] Failed to normalize user runtime _pth:', error);
       }
+      convergeUserPipShims(userRoot);
     }
     const userHealth = runtimeHealth(userRoot);
     if (userHealth.ok) {
@@ -289,6 +289,7 @@ export async function ensurePythonRuntimeReady(): Promise<{ success: boolean; er
     fs.mkdirSync(path.dirname(userRoot), { recursive: true });
     cpRecursiveSync(bundledRoot, userRoot, { force: true, dereference: true });
     ensureEmbedSitePackages(userRoot);
+    convergeUserPipShims(userRoot);
 
     const syncedHealth = runtimeHealth(userRoot);
     if (!syncedHealth.ok) {
@@ -310,82 +311,3 @@ export async function ensurePythonRuntimeReady(): Promise<{ success: boolean; er
   }
 }
 
-function runPythonCommand(
-  pythonExe: string,
-  args: string[],
-  rootDir: string
-): { ok: boolean; detail?: string } {
-  const env = {
-    ...process.env,
-    PATH: appendWindowsPath(process.env.PATH, [rootDir, path.join(rootDir, 'Scripts')]),
-  };
-  const result = spawnSync(pythonExe, args, {
-    cwd: rootDir,
-    encoding: 'utf-8',
-    stdio: 'pipe',
-    timeout: 60_000,
-    env,
-    windowsHide: true,
-  });
-  if (result.status === 0) {
-    return { ok: true };
-  }
-  const detail = (result.stderr || result.stdout || '').trim();
-  return { ok: false, detail: detail || `exit code ${String(result.status)}` };
-}
-
-function tryBootstrapPip(rootDir: string): { ok: boolean; detail?: string } {
-  const pythonExe = findPythonExecutable(rootDir);
-  if (!pythonExe) {
-    return { ok: false, detail: 'python executable not found in runtime root' };
-  }
-
-  const ensurePipResult = runPythonCommand(pythonExe, ['-m', 'ensurepip', '--upgrade'], rootDir);
-  if (!ensurePipResult.ok) {
-    return ensurePipResult;
-  }
-
-  const pipVersionResult = runPythonCommand(pythonExe, ['-m', 'pip', '--version'], rootDir);
-  if (!pipVersionResult.ok) {
-    return pipVersionResult;
-  }
-
-  return { ok: true };
-}
-
-export async function ensurePythonPipReady(): Promise<{ success: boolean; error?: string }> {
-  if (process.platform !== 'win32') {
-    return { success: true };
-  }
-
-  const runtimeReady = await ensurePythonRuntimeReady();
-  if (!runtimeReady.success) {
-    return runtimeReady;
-  }
-
-  try {
-    const userRoot = getUserPythonRoot();
-    const userHealth = runtimeHealth(userRoot, { requirePip: true });
-    if (userHealth.ok) {
-      return { success: true };
-    }
-
-    const bootstrapResult = tryBootstrapPip(userRoot);
-    if (bootstrapResult.ok) {
-      const finalHealth = runtimeHealth(userRoot, { requirePip: true });
-      if (finalHealth.ok) {
-        console.log('[python-runtime] ensurepip successfully restored pip in user runtime');
-        return { success: true };
-      }
-    }
-
-    const errorDetail = bootstrapResult.detail ? ` (${bootstrapResult.detail})` : '';
-    const message = `pip is unavailable in bundled runtime${errorDetail}`;
-    console.error(`[python-runtime] ${message}`);
-    return { success: false, error: message };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('[python-runtime] Failed to ensure pip ready:', message);
-    return { success: false, error: message };
-  }
-}


### PR DESCRIPTION
Health checks only verified file existence, so a broken or outdated pip shim from an earlier build could survive every runtime sync. Extract the shim/wrapper templates into a shared pythonPipShim module and converge LobsterAI-owned shim files to the current templates at both packaging time and app startup, guarded by an ownership marker so a real pip package is never overwritten.