### PR TITLE
fix(openclaw): surface provider runtime failures on late chat error

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.test.ts
@@ -4985,6 +4985,99 @@ test('stale chat error after a successful deferred final completes the turn inst
   }
 });
 
+test('model idle timeout chat error still surfaces after a deferred final (text-only payload)', async () => {
+  vi.useFakeTimers();
+  try {
+    const { session, store } = createReconcileStore([
+      { id: 'msg-1', type: 'user', content: 'query bhumi-data', timestamp: 1, metadata: {} },
+    ]);
+    session.status = 'running';
+    const adapter = new OpenClawRuntimeAdapter(store, {});
+    const errorSpy = vi.fn();
+    adapter.on('error', errorSpy);
+    const sessionKey = `agent:main:lobsterai:${session.id}`;
+    const turn = createActiveTurn(session.id, sessionKey, 'run-idle-timeout');
+    adapter.activeTurns.set(session.id, turn);
+    adapter.latestTurnTokenBySession.set(session.id, turn.turnToken);
+
+    adapter.handleChatEvent({
+      state: 'final',
+      runId: 'run-idle-timeout',
+      sessionKey,
+      message: { role: 'assistant', content: '明白，接下来只走 bhumi-data 的只读查询。' },
+    }, 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(turn.finalCompletionTimer).toBeDefined();
+
+    // OpenClaw's surface_error failover delivers the timeout through the
+    // webchat reply path (broadcastChatError): text only, no metadata, and the
+    // lifecycle ended with isError=false so terminatedRunIds stays empty.
+    const timeoutText = 'LLM request timed out. | The model did not produce a response before the model idle timeout. Please try again, or increase `models.providers.<id>.timeoutSeconds` for slow local or self-hosted provider.';
+    adapter.handleChatEvent({
+      state: 'error',
+      runId: 'run-idle-timeout',
+      sessionKey,
+      errorMessage: timeoutText,
+      message: { role: 'assistant', content: [{ type: 'text', text: `Error: ${timeoutText}` }] },
+    }, 2);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(session.status).toBe('error');
+    expect(adapter.activeTurns.has(session.id)).toBe(false);
+  } finally {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  }
+});
+
+test('chat error with provider runtime failure metadata still surfaces after a deferred final', async () => {
+  vi.useFakeTimers();
+  try {
+    const { session, store } = createReconcileStore([
+      { id: 'msg-1', type: 'user', content: 'query bhumi-data', timestamp: 1, metadata: {} },
+    ]);
+    session.status = 'running';
+    const adapter = new OpenClawRuntimeAdapter(store, {});
+    const errorSpy = vi.fn();
+    adapter.on('error', errorSpy);
+    const sessionKey = `agent:main:lobsterai:${session.id}`;
+    const turn = createActiveTurn(session.id, sessionKey, 'run-failover-meta');
+    adapter.activeTurns.set(session.id, turn);
+    adapter.latestTurnTokenBySession.set(session.id, turn.turnToken);
+
+    adapter.handleChatEvent({
+      state: 'final',
+      runId: 'run-failover-meta',
+      sessionKey,
+      message: { role: 'assistant', content: 'partial reply' },
+    }, 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(turn.finalCompletionTimer).toBeDefined();
+
+    // The lifecycle-error forwarding path attaches structured observation
+    // fields (extractSafeChatErrorMetadata) to the late chat error.
+    adapter.handleChatEvent({
+      state: 'error',
+      runId: 'run-failover-meta',
+      sessionKey,
+      errorMessage: 'upstream provider failed',
+      provider: 'openai',
+      model: 'gpt-5.6-sol',
+      failoverReason: 'timeout',
+      providerRuntimeFailureKind: 'timeout',
+    }, 2);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(session.status).toBe('error');
+    expect(adapter.activeTurns.has(session.id)).toBe(false);
+  } finally {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  }
+});
+
 test('chat error still surfaces when a deferred final exists but the run reported a lifecycle error', async () => {
   vi.useFakeTimers();
   try {

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -9897,6 +9897,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
    * successful chat.final is persisted and only its deferred completion is
    * pending. Surfacing that stale notice would flip a successful turn into a
    * session error, so complete the deferred final instead.
+   *
+   * Exception: OpenClaw's surface_error failover (e.g. LLM idle timeout after a
+   * partial reply) ends the lifecycle with isError=false and delivers the real
+   * failure through this same late chat-error path, so it never reaches
+   * terminatedRunIds. Those provider-runtime failures must surface — swallowing
+   * them makes a dead run look completed.
    */
   private completeDeferredFinalOnStaleChatError(
     sessionId: string,
@@ -9914,6 +9920,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
     const staleErrorText = payload.errorMessage?.trim()
       || extractGatewayMessageText(payload.message).trim();
+    if (this.isProviderRuntimeFailureChatError(payload, staleErrorText)) {
+      console.warn(
+        '[OpenClawRuntime] surfacing a provider runtime failure that arrived as a late chat error despite a pending deferred final.',
+        `Session ${sessionId}.`,
+        `Run ${errorRunId || turn.finalCompletionRunId || turn.runId}.`,
+        `Error ${staleErrorText.slice(0, 200) || 'unknown'}.`,
+      );
+      return false;
+    }
     console.warn(
       '[OpenClawRuntime] ignored a stale chat error after a successful final; completing the deferred final instead.',
       `Session ${sessionId}.`,
@@ -9926,6 +9941,29 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       turn.finalCompletionRunId ?? turn.runId,
     );
     return true;
+  }
+
+  /**
+   * True when a late chat error carries evidence of a real provider/LLM runtime
+   * failure rather than a stale tool-failure notice. The lifecycle-error
+   * forwarding path attaches structured observation fields; the webchat reply
+   * path (broadcastChatError) sends text only, so also match the model-timeout
+   * wording OpenClaw uses for surfaced LLM failures. Tool-failure notices carry
+   * neither: broader text classes such as network errors ("request timed out")
+   * overlap with tool error output and must stay swallowed here.
+   */
+  private isProviderRuntimeFailureChatError(payload: ChatEventPayload, errorText: string): boolean {
+    const metadata = normalizeOpenClawSafeRuntimeErrorMetadata(payload);
+    if (
+      metadata?.providerRuntimeFailureKind
+      || metadata?.failoverReason
+      || metadata?.httpCode
+      || metadata?.providerErrorType
+    ) {
+      return true;
+    }
+    if (!errorText) return false;
+    return classifyErrorKey(errorText) === CoworkErrorI18nKey.ModelResponseTimeout;
   }
 
   private handleChatError(sessionId: string, turn: ActiveTurn, payload: ChatEventPayload): void {


### PR DESCRIPTION
completeDeferredFinalOnStaleChatError previously swallowed any late chat error once a deferred final was pending, treating it as a stale tool-failure notice. This also swallowed real provider/LLM runtime failures (e.g. idle timeout failover) that OpenClaw delivers through the same late chat-error path with isError=false, making a dead run look completed.

Add isProviderRuntimeFailureChatError to detect structured runtime failure metadata or model-timeout wording and let those errors surface instead of being discarded.
