### PR TITLE
feat(cowork): render submitted file attachments as clickable cards

### DIFF
--- a/src/renderer/components/cowork/UserMessageFileAttachments.tsx
+++ b/src/renderer/components/cowork/UserMessageFileAttachments.tsx
@@ -1,0 +1,88 @@
+import { FolderOpenIcon } from '@heroicons/react/24/outline';
+import { FolderIcon } from '@heroicons/react/24/solid';
+import React, { useCallback } from 'react';
+
+import { ShellOpenFailureReason } from '../../../shared/shell/constants';
+import { i18nService } from '../../services/i18n';
+import type { UserMessageFileAttachment } from '../../utils/userMessageFileAttachments';
+import FileTypeIcon from '../icons/fileTypes/FileTypeIcon';
+import { getFileTypeInfo } from '../icons/fileTypes/index';
+
+const showToast = (message: string): void => {
+  window.dispatchEvent(new CustomEvent('app:showToast', { detail: message }));
+};
+
+interface UserMessageFileAttachmentsProps {
+  attachments: UserMessageFileAttachment[];
+  className?: string;
+  onReveal?: (attachment: UserMessageFileAttachment) => void;
+}
+
+/**
+ * Renders submitted file/folder attachments inside a user message bubble as
+ * clickable cards. Clicking reveals the original file in the system file
+ * manager; missing files surface a toast instead of failing silently.
+ */
+const UserMessageFileAttachments: React.FC<UserMessageFileAttachmentsProps> = ({
+  attachments,
+  className = '',
+  onReveal,
+}) => {
+  const handleReveal = useCallback(async (attachment: UserMessageFileAttachment) => {
+    onReveal?.(attachment);
+    try {
+      const result = await window.electron.shell.showItemInFolder(attachment.path);
+      if (!result?.success) {
+        showToast(i18nService.t(
+          result?.reason === ShellOpenFailureReason.NotFound
+            ? 'coworkFileAttachmentMissing'
+            : 'coworkFileAttachmentRevealFailed',
+        ));
+      }
+    } catch (error) {
+      console.warn('[UserMessageFileAttachments] failed to reveal attachment path:', error);
+      showToast(i18nService.t('coworkFileAttachmentRevealFailed'));
+    }
+  }, [onReveal]);
+
+  if (attachments.length === 0) return null;
+
+  return (
+    <div className={`flex flex-wrap gap-2 ${className}`}>
+      {attachments.map(attachment => {
+        const typeLabel = attachment.isDirectory
+          ? i18nService.t('folderAttachmentType')
+          : getFileTypeInfo(attachment.name).label;
+        return (
+          <button
+            key={attachment.path}
+            type="button"
+            onClick={() => { void handleReveal(attachment); }}
+            className="group flex h-[52px] w-[200px] items-center gap-2.5 rounded-xl border border-border bg-background px-2.5 text-left shadow-subtle transition-colors hover:border-primary dark:bg-surface-raised"
+            title={`${attachment.path}\n${i18nService.t('coworkFileAttachmentRevealHint')}`}
+            aria-label={`${attachment.name} — ${i18nService.t('coworkFileAttachmentRevealHint')}`}
+          >
+            <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-black/[0.04] dark:bg-white/[0.08]">
+              {attachment.isDirectory ? (
+                <FolderIcon className="h-5 w-5 flex-shrink-0 text-amber-500" />
+              ) : (
+                <FileTypeIcon fileName={attachment.name} className="h-5 w-5 flex-shrink-0" />
+              )}
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col justify-center">
+              <span className="truncate text-[13px] font-medium leading-4 text-foreground">
+                {attachment.name}
+              </span>
+              <span className="mt-0.5 truncate text-[11px] leading-4 text-secondary">
+                {typeLabel}
+              </span>
+            </div>
+            <FolderOpenIcon className="h-4 w-4 flex-shrink-0 text-secondary opacity-0 transition-opacity group-hover:opacity-100" />
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default UserMessageFileAttachments;

--- a/src/renderer/components/cowork/UserMessageItem.tsx
+++ b/src/renderer/components/cowork/UserMessageItem.tsx
@@ -14,6 +14,7 @@ import type { MarketplaceKit } from '../../types/kit';
 import type { Skill } from '../../types/skill';
 import { formatMessageDateTime } from '../../utils/tokenFormat';
 import { parseUserMessageForDisplay } from '../../utils/userMessageDisplay';
+import { extractUserMessageFileAttachments } from '../../utils/userMessageFileAttachments';
 import EditIcon from '../icons/EditIcon';
 import GoalIcon from '../icons/GoalIcon';
 import MessageCopyIcon from '../icons/MessageCopyIcon';
@@ -29,6 +30,7 @@ import {
 } from './messageDisplayUtils';
 import SelectedTextSnippetBadge from './SelectedTextSnippetBadge';
 import UserMessageContent from './UserMessageContent';
+import UserMessageFileAttachments from './UserMessageFileAttachments';
 
 // ── CopyButton (local) ──────────────────────────────────────────────────────
 
@@ -200,12 +202,12 @@ const UserMessageItem: React.FC<{
 
   const metadata = message.metadata as CoworkMessageMetadata | undefined;
   const isGoalSettingMessage = hasGoalSettingMessageMetadata(metadata);
-  const displayContent = useMemo(
-    () => parseUserMessageForDisplay(message.content || '', {
+  const { text: displayContent, attachments: fileAttachments } = useMemo(
+    () => extractUserMessageFileAttachments(parseUserMessageForDisplay(message.content || '', {
       localMediaAttachments: Array.isArray(metadata?.localMediaAttachments)
         ? metadata.localMediaAttachments
         : [],
-    }),
+    })),
     [message.content, metadata?.localMediaAttachments]
   );
 
@@ -248,6 +250,12 @@ const UserMessageItem: React.FC<{
     });
     onReEdit?.(message);
   }, [message, onReEdit]);
+  const handleFileAttachmentReveal = useCallback(() => {
+    reportConversationMessageAction({
+      actionType: 'reveal_message_file',
+      message,
+    });
+  }, [message]);
 
   return (
     <div
@@ -264,7 +272,7 @@ const UserMessageItem: React.FC<{
             <div className="w-full min-w-0 flex flex-col items-end">
               <div className="w-fit max-w-full rounded-2xl px-4 py-2.5 bg-surface text-foreground shadow-subtle">
                 {browserAnnotationCount > 0 && (
-                  <div className={(selectedTextSnippets.length > 0 || displayContent?.trim() || displayImageAttachments.length > 0 || hasCapabilityBadges) ? 'mb-2' : ''}>
+                  <div className={(selectedTextSnippets.length > 0 || displayContent?.trim() || displayImageAttachments.length > 0 || fileAttachments.length > 0 || hasCapabilityBadges) ? 'mb-2' : ''}>
                     <div
                       className="inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-surface-raised px-2.5 text-xs text-foreground"
                       title={browserAnnotations.flatMap(batch => batch.annotations.map(item => item.comment)).join('\n')}
@@ -275,7 +283,7 @@ const UserMessageItem: React.FC<{
                   </div>
                 )}
                 {selectedTextSnippets.length > 0 && (
-                  <div className={(displayContent?.trim() || displayImageAttachments.length > 0 || hasCapabilityBadges) ? 'mb-2' : ''}>
+                  <div className={(displayContent?.trim() || displayImageAttachments.length > 0 || fileAttachments.length > 0 || hasCapabilityBadges) ? 'mb-2' : ''}>
                     <SelectedTextSnippetBadge
                       snippets={selectedTextSnippets}
                       align="right"
@@ -284,7 +292,7 @@ const UserMessageItem: React.FC<{
                   </div>
                 )}
                 {hasCapabilityBadges && (
-                  <div className={(displayContent?.trim() || displayImageAttachments.length > 0) ? 'mb-2' : ''}>
+                  <div className={(displayContent?.trim() || displayImageAttachments.length > 0 || fileAttachments.length > 0) ? 'mb-2' : ''}>
                     <UserMessageCapabilityBadges
                       kitReferences={messageKitReferences}
                       skills={messageSkills}
@@ -322,6 +330,13 @@ const UserMessageItem: React.FC<{
                       </div>
                     ))}
                   </div>
+                )}
+                {fileAttachments.length > 0 && (
+                  <UserMessageFileAttachments
+                    attachments={fileAttachments}
+                    className={(displayContent?.trim() || displayImageAttachments.length > 0) ? 'mt-2' : ''}
+                    onReveal={handleFileAttachmentReveal}
+                  />
                 )}
               </div>
               <div className="flex w-full items-center justify-end gap-2">

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -171,6 +171,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     inputFileLabel: '输入文件',
     inputFolderLabel: '输入文件夹',
     folderAttachmentType: '文件夹',
+    coworkFileAttachmentRevealHint: '点击在文件夹中显示',
+    coworkFileAttachmentMissing: '文件不存在，可能已被移动或删除',
+    coworkFileAttachmentRevealFailed: '无法在文件夹中显示该文件',
     imageVisionHint:
       '当前模型未启用图片输入，图片将以文件路径形式发送。若该模型本身支持图片理解，可在模型配置中开启图片输入选项。',
     copied: '已复制',
@@ -3407,6 +3410,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     inputFileLabel: 'Input Files',
     inputFolderLabel: 'Input Folder',
     folderAttachmentType: 'Folder',
+    coworkFileAttachmentRevealHint: 'Click to reveal in folder',
+    coworkFileAttachmentMissing: 'File not found. It may have been moved or deleted.',
+    coworkFileAttachmentRevealFailed: 'Could not reveal this file in its folder.',
     imageVisionHint:
       'Image input is not enabled for the current model. Images will be sent as file paths. If the model supports vision, you can enable image input in the model configuration.',
     copied: 'Copied',

--- a/src/renderer/utils/userMessageFileAttachments.test.ts
+++ b/src/renderer/utils/userMessageFileAttachments.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'vitest';
+
+import { extractUserMessageFileAttachments } from './userMessageFileAttachments';
+
+// ─── Passthrough ────────────────────────────────────────────
+
+describe('passthrough (no attachment lines)', () => {
+  test('empty string', () => {
+    const result = extractUserMessageFileAttachments('');
+    expect(result.text).toBe('');
+    expect(result.attachments).toEqual([]);
+  });
+
+  test('plain text unchanged', () => {
+    const result = extractUserMessageFileAttachments('帮我总结这份文档');
+    expect(result.text).toBe('帮我总结这份文档');
+    expect(result.attachments).toEqual([]);
+  });
+
+  test('label with relative path is not extracted', () => {
+    const content = '输入文件: docs/readme.md';
+    const result = extractUserMessageFileAttachments(content);
+    expect(result.text).toBe(content);
+    expect(result.attachments).toEqual([]);
+  });
+
+  test('label mentioned mid-sentence is not extracted', () => {
+    const content = '请注意输入文件: /tmp/a.txt 的编码问题';
+    const result = extractUserMessageFileAttachments(content);
+    // The trailing prose keeps this line matching as one long "path"; a path
+    // like that fails the reveal stat-check gracefully. But a mid-line label
+    // preceded by text must never match.
+    expect(result.attachments).toEqual([]);
+    expect(result.text).toBe(content);
+  });
+
+  test('markdown content unchanged', () => {
+    const md = '## 计划\n\n- 第一步\n- 第二步';
+    const result = extractUserMessageFileAttachments(md);
+    expect(result.text).toBe(md);
+    expect(result.attachments).toEqual([]);
+  });
+});
+
+// ─── Extraction ─────────────────────────────────────────────
+
+describe('file attachment extraction', () => {
+  test('zh file line appended after prompt', () => {
+    const result = extractUserMessageFileAttachments(
+      '看看这个日志有什么问题\n\n输入文件: /Users/me/logs/lobsterai-logs-20260810.txt',
+    );
+    expect(result.text).toBe('看看这个日志有什么问题');
+    expect(result.attachments).toEqual([
+      {
+        path: '/Users/me/logs/lobsterai-logs-20260810.txt',
+        name: 'lobsterai-logs-20260810.txt',
+        isDirectory: false,
+      },
+    ]);
+  });
+
+  test('en labels', () => {
+    const result = extractUserMessageFileAttachments(
+      'Summarize these\n\nInput Files: /Users/me/report.pdf\nInput Folder: /Users/me/project',
+    );
+    expect(result.text).toBe('Summarize these');
+    expect(result.attachments).toEqual([
+      { path: '/Users/me/report.pdf', name: 'report.pdf', isDirectory: false },
+      { path: '/Users/me/project', name: 'project', isDirectory: true },
+    ]);
+  });
+
+  test('zh folder label wins over its file-label prefix', () => {
+    const result = extractUserMessageFileAttachments('输入文件夹: /Users/me/project');
+    expect(result.text).toBe('');
+    expect(result.attachments).toEqual([
+      { path: '/Users/me/project', name: 'project', isDirectory: true },
+    ]);
+  });
+
+  test('attachment-only message leaves empty text', () => {
+    const result = extractUserMessageFileAttachments('输入文件: /tmp/a.csv\n输入文件: /tmp/b.csv');
+    expect(result.text).toBe('');
+    expect(result.attachments.map(a => a.name)).toEqual(['a.csv', 'b.csv']);
+  });
+
+  test('windows drive and UNC paths', () => {
+    const result = extractUserMessageFileAttachments(
+      String.raw`输入文件: C:\Users\me\数据 报表.xlsx` + '\n' + String.raw`输入文件: \\server\share\a.docx`,
+    );
+    expect(result.attachments).toEqual([
+      { path: String.raw`C:\Users\me\数据 报表.xlsx`, name: '数据 报表.xlsx', isDirectory: false },
+      { path: String.raw`\\server\share\a.docx`, name: 'a.docx', isDirectory: false },
+    ]);
+  });
+
+  test('path with spaces is kept intact', () => {
+    const result = extractUserMessageFileAttachments('输入文件: /Users/me/My Documents/final report.pdf');
+    expect(result.attachments).toEqual([
+      { path: '/Users/me/My Documents/final report.pdf', name: 'final report.pdf', isDirectory: false },
+    ]);
+  });
+
+  test('duplicate paths are deduped keeping first occurrence', () => {
+    const result = extractUserMessageFileAttachments(
+      '输入文件: /tmp/a.txt\n输入文件: /tmp/a.txt\nInput Files: /TMP/A.TXT',
+    );
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0].path).toBe('/tmp/a.txt');
+  });
+
+  test('blank runs collapse after stripping lines between paragraphs', () => {
+    const result = extractUserMessageFileAttachments(
+      '第一段\n\n输入文件: /tmp/a.txt\n\n第二段',
+    );
+    expect(result.text).toBe('第一段\n\n第二段');
+    expect(result.attachments).toHaveLength(1);
+  });
+
+  test('text after attachments is preserved', () => {
+    const result = extractUserMessageFileAttachments(
+      '输入文件: /tmp/a.txt\n\n用中文回答',
+    );
+    expect(result.text).toBe('用中文回答');
+    expect(result.attachments).toHaveLength(1);
+  });
+});

--- a/src/renderer/utils/userMessageFileAttachments.ts
+++ b/src/renderer/utils/userMessageFileAttachments.ts
@@ -1,0 +1,92 @@
+/**
+ * Display-side extraction of file/folder attachment lines from user messages.
+ *
+ * When a prompt is submitted with non-image attachments, prepareCoworkPromptPayload
+ * appends machine-generated lines like "输入文件: /abs/path" to the prompt text.
+ * This module parses those lines back out at render time so the UI can show
+ * clickable attachment cards instead of raw path text.
+ * DISPLAY ONLY — does not affect what was sent to the AI model.
+ */
+
+// Labels ever produced by the payload builder (i18n `inputFileLabel` /
+// `inputFolderLabel`, plus the pre-i18n hardcoded value). Longest-first so
+// "输入文件夹" wins over its prefix "输入文件".
+const FOLDER_LABELS = ['输入文件夹', 'Input Folder'] as const;
+const FILE_LABELS = ['输入文件', 'Input Files'] as const;
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const LABEL_ALTERNATION = [...FOLDER_LABELS, ...FILE_LABELS].map(escapeRegExp).join('|');
+
+// Absolute paths only: POSIX (/...), Windows drive (C:\... or C:/...), UNC (\\...).
+// Paths may contain spaces, so the path part runs to end of line.
+const ATTACHMENT_LINE_RE = new RegExp(
+  `^[ \\t]*(${LABEL_ALTERNATION}): ((?:\\/|[A-Za-z]:[\\\\/]|\\\\\\\\)[^\\n]*?)[ \\t]*$`,
+  'gm',
+);
+
+export interface UserMessageFileAttachment {
+  path: string;
+  name: string;
+  isDirectory: boolean;
+}
+
+export interface ExtractedUserMessageFileAttachments {
+  text: string;
+  attachments: UserMessageFileAttachment[];
+}
+
+function deriveAttachmentName(rawPath: string): string {
+  const trimmed = rawPath.replace(/[\\/]+$/, '');
+  const lastSeparator = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'));
+  const name = lastSeparator >= 0 ? trimmed.slice(lastSeparator + 1) : trimmed;
+  return name || rawPath;
+}
+
+function normalizePathKey(rawPath: string): string {
+  return rawPath.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+}
+
+/**
+ * Splits attachment lines out of a user message. Returns the remaining text
+ * (with attachment lines removed and blank runs collapsed) plus the parsed
+ * attachments in appearance order. Content without attachment lines is
+ * returned unchanged.
+ */
+export function extractUserMessageFileAttachments(
+  content: string,
+): ExtractedUserMessageFileAttachments {
+  if (!content) {
+    return { text: content, attachments: [] };
+  }
+
+  const attachments: UserMessageFileAttachment[] = [];
+  const seenPathKeys = new Set<string>();
+
+  const re = new RegExp(ATTACHMENT_LINE_RE.source, ATTACHMENT_LINE_RE.flags);
+  const text = content
+    .replace(re, (_match, label: string, rawPath: string) => {
+      const path = rawPath.trim();
+      if (path) {
+        const key = normalizePathKey(path);
+        if (!seenPathKeys.has(key)) {
+          seenPathKeys.add(key);
+          attachments.push({
+            path,
+            name: deriveAttachmentName(path),
+            isDirectory: (FOLDER_LABELS as readonly string[]).includes(label),
+          });
+        }
+      }
+      return '';
+    });
+
+  if (attachments.length === 0) {
+    return { text: content, attachments: [] };
+  }
+
+  return {
+    text: text.replace(/\n{3,}/g, '\n\n').trim(),
+    attachments,
+  };
+}


### PR DESCRIPTION
Previously, non-image attachments submitted with a prompt collapsed into raw '输入文件: /path' text lines after send, unlike image attachments which kept a rich preview. Parse those lines back out at render time and show them as file-type cards (icon + name + type), matching the pre-submit attachment preview. Clicking a card reveals the original file via the system file manager, with a toast fallback when the file is missing.

Display-only change: the prompt sent to the model is unaffected.