### PR TITLE
fix(model-selector): give each model its own thinking level

### DIFF
--- a/src/renderer/components/ModelSelector.test.ts
+++ b/src/renderer/components/ModelSelector.test.ts
@@ -1,10 +1,14 @@
+import { ModelThinkingLevel } from '@shared/providers/modelThinking';
 import { expect, test } from 'vitest';
 
 import {
   canConfigureModelThinking,
+  CascadeSide,
   isModelAgenticBlocked,
+  resolveCascadePlacement,
   resolveDropdownListMaxHeight,
   resolveHoverCardTop,
+  resolvePickerThinkingLevel,
 } from './ModelSelector';
 
 test('keeps model hover card above the viewport bottom', () => {
@@ -23,6 +27,56 @@ test('pins model hover card to the margin when it is taller than the viewport', 
   expect(resolveHoverCardTop(160, 1000, 900)).toBe(8);
 });
 
+test('places a cascaded popover flush against its anchor, without gap or overlap', () => {
+  expect(resolveCascadePlacement({
+    anchorLeft: 400,
+    anchorRight: 700,
+    width: 220,
+    viewportWidth: 1200,
+    preferredSide: CascadeSide.Right,
+  })).toEqual({ left: 700, side: CascadeSide.Right });
+});
+
+test('flips a cascaded popover to the left when the right side does not fit', () => {
+  expect(resolveCascadePlacement({
+    anchorLeft: 700,
+    anchorRight: 1000,
+    width: 220,
+    viewportWidth: 1100,
+    preferredSide: CascadeSide.Right,
+  })).toEqual({ left: 480, side: CascadeSide.Left });
+});
+
+test('keeps cascading towards the side the previous popover took', () => {
+  expect(resolveCascadePlacement({
+    anchorLeft: 300,
+    anchorRight: 520,
+    width: 210,
+    viewportWidth: 1100,
+    preferredSide: CascadeSide.Left,
+  })).toEqual({ left: 90, side: CascadeSide.Left });
+});
+
+test('falls back to the opposite side when the preferred side has no room', () => {
+  expect(resolveCascadePlacement({
+    anchorLeft: 40,
+    anchorRight: 260,
+    width: 210,
+    viewportWidth: 1100,
+    preferredSide: CascadeSide.Left,
+  })).toEqual({ left: 260, side: CascadeSide.Right });
+});
+
+test('clamps a cascaded popover inside the viewport when neither side fits', () => {
+  expect(resolveCascadePlacement({
+    anchorLeft: 20,
+    anchorRight: 260,
+    width: 210,
+    viewportWidth: 280,
+    preferredSide: CascadeSide.Right,
+  })).toEqual({ left: 62, side: CascadeSide.Right });
+});
+
 test('caps the model list at its default height when space allows', () => {
   expect(resolveDropdownListMaxHeight(600, true, true)).toBe(288);
 });
@@ -38,6 +92,56 @@ test('keeps at least three model rows visible when space is extremely tight', ()
 
 test('uses the full available space when tabs and footer are hidden', () => {
   expect(resolveDropdownListMaxHeight(200, false, false)).toBe(198);
+});
+
+const THINKING_CONFIG = {
+  options: [
+    { level: ModelThinkingLevel.Off, openclawLevel: 'off' as const },
+    { level: ModelThinkingLevel.High, openclawLevel: 'high' as const },
+    { level: ModelThinkingLevel.Max, openclawLevel: 'xhigh' as const },
+  ],
+  defaultLevel: ModelThinkingLevel.High,
+};
+
+test('shows the level the user is picking right now', () => {
+  expect(resolvePickerThinkingLevel({
+    config: THINKING_CONFIG,
+    requestedLevel: ModelThinkingLevel.Max,
+    selectedModelLevel: ModelThinkingLevel.Off,
+    rememberedLevel: ModelThinkingLevel.High,
+  })).toBe(ModelThinkingLevel.Max);
+});
+
+test('shows the persisted level for the model that is actually selected', () => {
+  expect(resolvePickerThinkingLevel({
+    config: THINKING_CONFIG,
+    selectedModelLevel: ModelThinkingLevel.Max,
+    rememberedLevel: ModelThinkingLevel.High,
+  })).toBe(ModelThinkingLevel.Max);
+});
+
+test('keeps each unselected model on its own remembered level', () => {
+  expect(resolvePickerThinkingLevel({
+    config: THINKING_CONFIG,
+    rememberedLevel: ModelThinkingLevel.Max,
+  })).toBe(ModelThinkingLevel.Max);
+  expect(resolvePickerThinkingLevel({
+    config: THINKING_CONFIG,
+    selectedModelLevel: null,
+    rememberedLevel: ModelThinkingLevel.Off,
+  })).toBe(ModelThinkingLevel.Off);
+});
+
+test('falls back to the model default when nothing was picked before', () => {
+  expect(resolvePickerThinkingLevel({ config: THINKING_CONFIG })).toBe(ModelThinkingLevel.High);
+});
+
+test('ignores levels the model does not offer', () => {
+  expect(resolvePickerThinkingLevel({
+    config: THINKING_CONFIG,
+    requestedLevel: ModelThinkingLevel.Minimal,
+    rememberedLevel: ModelThinkingLevel.Low,
+  })).toBe(ModelThinkingLevel.High);
 });
 
 test('blocks only explicitly unready server models from agent selection', () => {

--- a/src/renderer/components/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector.tsx
@@ -9,6 +9,7 @@ import {
 import {
   getModelThinkingLevels,
   ModelRuntimeProfile,
+  type ModelThinkingConfig,
   type ModelThinkingLevel as ModelThinkingLevelType,
   ProviderName,
 } from '@shared/providers';
@@ -19,6 +20,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { getProviderIcon, ProviderIconId } from '../providers/uiRegistry';
 import { authService } from '../services/auth';
 import { i18nService } from '../services/i18n';
+import {
+  readRememberedModelThinkingLevel,
+  rememberModelThinkingLevel,
+} from '../services/modelThinkingLevelMemory';
 import { RootState } from '../store';
 import type { Model } from '../store/slices/modelSlice';
 import { getModelIdentityKey, isSameModelIdentity, setSelectedModel } from '../store/slices/modelSlice';
@@ -64,12 +69,18 @@ const DROPDOWN_TABS_BLOCK_HEIGHT = 49; // group tabs block: p-2 + p-0.5 + py-1.5
 const DROPDOWN_FOOTER_HEIGHT = 33; // current-model footer: py-2 + leading-4 + border-t
 const DROPDOWN_BORDER_HEIGHT = 2;
 const HOVER_CARD_WIDTH = 220;
-const HOVER_CARD_GAP = 8;
 const HOVER_CARD_VIEWPORT_MARGIN = 8;
 const HOVER_CLOSE_DELAY = 180;
 const THINKING_MENU_WIDTH = 210;
-const THINKING_MENU_GAP = 8;
+// Cascaded popovers sit flush against their anchor: no gap that makes the stack
+// look disconnected, and no overlap that makes the panels look stacked.
+const CASCADE_OVERLAP = 0;
 const MODEL_ICON_CLASS_NAME = 'h-[18px] w-[18px]';
+export const CascadeSide = {
+  Left: 'left',
+  Right: 'right',
+} as const;
+export type CascadeSide = typeof CascadeSide[keyof typeof CascadeSide];
 export const ModelSelectorGroup = {
   Server: 'server',
   User: 'user',
@@ -207,6 +218,70 @@ export function resolveHoverCardTop(
   return Math.min(Math.max(desiredTop, viewportMargin), maxTop);
 }
 
+/**
+ * Places a cascaded popover (hover card, thinking menu) next to its anchor.
+ * The popover keeps flowing towards `preferredSide` so the stack never
+ * zig-zags back across the panel it came from, and only flips when the
+ * preferred side cannot fit inside the viewport.
+ */
+export function resolveCascadePlacement(options: {
+  anchorLeft: number;
+  anchorRight: number;
+  width: number;
+  viewportWidth: number;
+  preferredSide: CascadeSide;
+  overlap?: number;
+  viewportMargin?: number;
+}): { left: number; side: CascadeSide } {
+  const {
+    anchorLeft,
+    anchorRight,
+    width,
+    viewportWidth,
+    preferredSide,
+    overlap = CASCADE_OVERLAP,
+    viewportMargin = HOVER_CARD_VIEWPORT_MARGIN,
+  } = options;
+  const rightSideLeft = anchorRight - overlap;
+  const leftSideLeft = anchorLeft + overlap - width;
+  const fitsRight = rightSideLeft + width + viewportMargin <= viewportWidth;
+  const fitsLeft = leftSideLeft >= viewportMargin;
+  const side = preferredSide === CascadeSide.Right
+    ? (fitsRight || !fitsLeft ? CascadeSide.Right : CascadeSide.Left)
+    : (fitsLeft || !fitsRight ? CascadeSide.Left : CascadeSide.Right);
+  const desiredLeft = side === CascadeSide.Right ? rightSideLeft : leftSideLeft;
+  const maxLeft = Math.max(viewportMargin, viewportWidth - width - viewportMargin);
+  return { left: Math.min(Math.max(desiredLeft, viewportMargin), maxLeft), side };
+}
+
+/**
+ * Thinking level the picker should show for one model, in precedence order:
+ *
+ * 1. the level being requested right now (the user just clicked it);
+ * 2. the level persisted for the agent/session, but only for the model that is
+ *    actually selected — that record holds a single level, so it says nothing
+ *    about the other models in the list;
+ * 3. the level the user last picked for this specific model;
+ * 4. the model's built-in default.
+ *
+ * Step 3 is what keeps two models from sharing one level: without it, every
+ * model except the selected one falls back to its default, so switching models
+ * silently discards the level chosen for the previous one.
+ */
+export function resolvePickerThinkingLevel(options: {
+  config: ModelThinkingConfig;
+  requestedLevel?: ModelThinkingLevelType;
+  selectedModelLevel?: ModelThinkingLevelType | null;
+  rememberedLevel?: ModelThinkingLevelType;
+}): ModelThinkingLevelType {
+  const { config, requestedLevel, selectedModelLevel, rememberedLevel } = options;
+  const levels = getModelThinkingLevels(config);
+  const candidates = [requestedLevel, selectedModelLevel, rememberedLevel];
+  return candidates.find(
+    (level): level is ModelThinkingLevelType => !!level && levels.includes(level),
+  ) ?? config.defaultLevel;
+}
+
 export function isModelAgenticBlocked(
   model: Pick<Model, 'agenticReady' | 'isServerModel' | 'runtimeProfile'> | null | undefined,
 ): boolean {
@@ -263,6 +338,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
   const selectedItemRef = React.useRef<HTMLButtonElement>(null);
   const [hoveredModel, setHoveredModel] = React.useState<Model | null>(null);
   const [hoverCardStyle, setHoverCardStyle] = React.useState<React.CSSProperties>({});
+  const [hoverCardSide, setHoverCardSide] = React.useState<CascadeSide>(CascadeSide.Right);
   const [isThinkingMenuOpen, setIsThinkingMenuOpen] = React.useState(false);
   const [thinkingMenuStyle, setThinkingMenuStyle] = React.useState<React.CSSProperties>({});
   const [restrictedPrompt, setRestrictedPrompt] = React.useState<ModelAccessPromptKind | null>(null);
@@ -451,14 +527,12 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
   ): ModelThinkingLevelType | undefined => {
     const config = model.thinkingConfig;
     if (!config) return undefined;
-    const levels = getModelThinkingLevels(config);
-    if (requestedLevel && levels.includes(requestedLevel)) {
-      return requestedLevel;
-    }
-    if (isSelected(model) && thinkingLevel && levels.includes(thinkingLevel)) {
-      return thinkingLevel;
-    }
-    return config.defaultLevel;
+    return resolvePickerThinkingLevel({
+      config,
+      requestedLevel,
+      selectedModelLevel: isSelected(model) ? thinkingLevel : undefined,
+      rememberedLevel: readRememberedModelThinkingLevel(getModelIdentityKey(model)),
+    });
   };
 
   const handleModelSelect = (model: Model | null) => {
@@ -498,6 +572,9 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
     const resolvedThinkingLevel = resolveThinkingLevel(model, requestedThinkingLevel);
     if (!resolvedThinkingLevel) return;
 
+    // Each model keeps its own level, so picking one here must not be lost when
+    // the user switches to another model and back.
+    rememberModelThinkingLevel(getModelIdentityKey(model), resolvedThinkingLevel);
     onChange(model, {
       group: getModelGroup(model) ?? visibleGroup,
       thinkingLevel: resolvedThinkingLevel,
@@ -631,18 +708,20 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
       const dropdownEl = dropdownRef.current;
       if (!dropdownEl) return;
       const dropdownRect = dropdownEl.getBoundingClientRect();
-      const spaceRight = window.innerWidth - dropdownRect.right;
-      const style: React.CSSProperties = {
+      const placement = resolveCascadePlacement({
+        anchorLeft: dropdownRect.left,
+        anchorRight: dropdownRect.right,
+        width: HOVER_CARD_WIDTH,
+        viewportWidth: window.innerWidth,
+        preferredSide: CascadeSide.Right,
+      });
+      setHoverCardSide(placement.side);
+      setHoverCardStyle({
         position: 'fixed',
+        left: placement.left,
         top: itemRect.top,
         zIndex: 10001,
-      };
-      if (spaceRight >= HOVER_CARD_WIDTH + HOVER_CARD_GAP) {
-        style.left = dropdownRect.right + HOVER_CARD_GAP;
-      } else {
-        style.right = window.innerWidth - dropdownRect.left + HOVER_CARD_GAP;
-      }
-      setHoverCardStyle(style);
+      });
       setIsThinkingMenuOpen(false);
       setHoveredModel(model);
     }, delay);
@@ -661,23 +740,30 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
     }, HOVER_CLOSE_DELAY);
   };
 
-  const openThinkingMenu = () => {
+  const openThinkingMenu = (trigger: HTMLElement) => {
     if (!thinkingSelectionEnabled || !canConfigureModelThinking(hoveredModel)) {
       setIsThinkingMenuOpen(false);
       return;
     }
+    // Already open for this model: keep the current placement so re-entering
+    // the trigger row does not make the menu jump.
+    if (isThinkingMenuOpen) return;
     const card = hoverCardRef.current;
     if (!card) return;
     const cardRect = card.getBoundingClientRect();
-    const fitsRight = window.innerWidth - cardRect.right
-      >= THINKING_MENU_WIDTH + THINKING_MENU_GAP + HOVER_CARD_VIEWPORT_MARGIN;
-    const left = fitsRight
-      ? cardRect.right + THINKING_MENU_GAP
-      : cardRect.left - THINKING_MENU_WIDTH - THINKING_MENU_GAP;
+    const { left } = resolveCascadePlacement({
+      anchorLeft: cardRect.left,
+      anchorRight: cardRect.right,
+      width: THINKING_MENU_WIDTH,
+      viewportWidth: window.innerWidth,
+      preferredSide: hoverCardSide,
+    });
     setThinkingMenuStyle({
       position: 'fixed',
-      left: Math.max(HOVER_CARD_VIEWPORT_MARGIN, left),
-      top: cardRect.top,
+      left,
+      // Cascade from the row that opened the menu, not from the card top, so the
+      // two panels stay visually attached.
+      top: trigger.getBoundingClientRect().top,
       width: THINKING_MENU_WIDTH,
       zIndex: 10002,
     });
@@ -796,14 +882,16 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
             type="button"
             disabled={!thinkingConfigurable}
             aria-disabled={!thinkingConfigurable}
-            onClick={openThinkingMenu}
-            onMouseEnter={openThinkingMenu}
-            onFocus={openThinkingMenu}
+            onClick={(event) => openThinkingMenu(event.currentTarget)}
+            onMouseEnter={(event) => openThinkingMenu(event.currentTarget)}
+            onFocus={(event) => openThinkingMenu(event.currentTarget)}
             aria-haspopup="menu"
             aria-expanded={isThinkingMenuOpen}
-            className={`mt-2.5 flex w-full items-center justify-between rounded-lg bg-surface-raised px-2.5 py-2 text-left text-[12px] transition-colors ${
+            // Bleeds into the card padding so the label still lines up with the
+            // text above it while the hover highlight keeps some breathing room.
+            className={`-mx-1.5 mt-1.5 flex w-[calc(100%+12px)] items-center justify-between rounded-lg px-1.5 py-2 text-left text-[12px] transition-colors ${
               thinkingConfigurable
-                ? 'text-foreground hover:bg-border/60'
+                ? `text-foreground ${isThinkingMenuOpen ? 'bg-surface-raised' : 'hover:bg-surface-raised'}`
                 : 'cursor-not-allowed text-secondary opacity-60'
             }`}
           >

--- a/src/renderer/components/agent/AgentCreateModal.tsx
+++ b/src/renderer/components/agent/AgentCreateModal.tsx
@@ -11,6 +11,7 @@ import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { imService } from '../../services/im';
 import { LogReporterAction, reportYdAnalyzer } from '../../services/logReporter';
+import { resolveThinkingLevelForModel } from '../../services/modelThinkingLevelMemory';
 import type { RootState } from '../../store';
 import type { Model } from '../../store/slices/modelSlice';
 import type { PresetAgent } from '../../types/agent';
@@ -374,7 +375,7 @@ const AgentCreateModal: React.FC<AgentCreateModalProps> = ({
         systemPrompt: systemPrompt.trim(),
         identity: identity.trim(),
         model: model ? toOpenClawModelRef(model) : '',
-        thinkingLevel: model?.thinkingConfig?.defaultLevel ?? '',
+        thinkingLevel: resolveThinkingLevelForModel(model),
         workingDirectory: workingDirectory.trim(),
         icon: icon.trim() || undefined,
         skillIds,

--- a/src/renderer/components/agent/AgentSettingsPanel.tsx
+++ b/src/renderer/components/agent/AgentSettingsPanel.tsx
@@ -11,6 +11,7 @@ import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { imService } from '../../services/im';
 import { LogReporterAction, reportYdAnalyzer } from '../../services/logReporter';
+import { resolveThinkingLevelForModel } from '../../services/modelThinkingLevelMemory';
 import { RootState } from '../../store';
 import type { Model } from '../../store/slices/modelSlice';
 import type { Agent } from '../../types/agent';
@@ -380,7 +381,7 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
         identity: identity.trim(),
         model: modelRef,
         ...(modelRef !== initialValuesRef.current.model
-          ? { thinkingLevel: model?.thinkingConfig?.defaultLevel ?? '' }
+          ? { thinkingLevel: resolveThinkingLevelForModel(model) }
           : {}),
         workingDirectory: workingDirectory.trim(),
         icon: icon.trim(),

--- a/src/renderer/components/modelSelector/ModelThinkingMenu.tsx
+++ b/src/renderer/components/modelSelector/ModelThinkingMenu.tsx
@@ -67,12 +67,14 @@ const ModelThinkingMenu: React.FC<ModelThinkingMenuProps> = ({
               onSelect(enabledFallback);
             }
           }}
-          className="flex w-full items-center justify-between border-b border-border/60 px-4 py-3 text-left text-[13px] font-medium text-foreground transition-colors hover:bg-surface-raised"
+          // A switch row, not a menu item: the toggle carries the state, so it
+          // never paints a hover background the way the strength options do.
+          className="flex w-full items-center justify-between gap-3 border-b border-border/60 px-3 py-2.5 text-left text-[13px] font-medium leading-5 text-foreground"
         >
           <span>{i18nService.t('modelThinkingMode')}</span>
           <span
             aria-hidden="true"
-            className={`relative h-5 w-9 rounded-full transition-colors ${
+            className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${
               thinkingEnabled ? 'bg-emerald-500' : 'bg-border'
             }`}
           >
@@ -85,10 +87,10 @@ const ModelThinkingMenu: React.FC<ModelThinkingMenuProps> = ({
         </button>
       )}
 
-      <div className="px-4 pb-1 pt-3 text-[11px] font-medium text-secondary">
+      <div className="px-3 pb-0.5 pt-2 text-[11px] font-medium leading-4 text-secondary">
         {i18nService.t('modelThinkingStrength')}
       </div>
-      <div className="p-2 pt-1">
+      <div className="p-1.5 pt-0.5">
         {enabledLevels.map(level => {
           const selected = selectedLevel === level;
           return (
@@ -98,14 +100,14 @@ const ModelThinkingMenu: React.FC<ModelThinkingMenuProps> = ({
               role="menuitemradio"
               aria-checked={selected}
               onClick={() => onSelect(level)}
-              className={`flex w-full items-center justify-between rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors ${
-                selected
-                  ? 'bg-surface-raised font-semibold text-foreground'
-                  : 'text-foreground hover:bg-surface-raised'
+              // The persistent selected fill stays lighter than the hover fill so
+              // the pointer highlight always reads stronger than the current value.
+              className={`flex h-8 w-full items-center justify-between gap-3 rounded-lg px-2.5 text-left text-[13px] leading-5 text-foreground transition-colors hover:bg-surface-raised ${
+                selected ? 'bg-surface-raised/45 font-semibold' : ''
               }`}
             >
-              <span>{getModelThinkingLevelLabel(level)}</span>
-              {selected && <CheckIcon className="h-4 w-4 text-emerald-500" strokeWidth={2.5} />}
+              <span className="min-w-0 truncate">{getModelThinkingLevelLabel(level)}</span>
+              {selected && <CheckIcon className="h-4 w-4 shrink-0 text-emerald-500" strokeWidth={2.5} />}
             </button>
           );
         })}

--- a/src/renderer/services/modelThinkingLevelMemory.test.ts
+++ b/src/renderer/services/modelThinkingLevelMemory.test.ts
@@ -1,0 +1,123 @@
+import { ModelThinkingLevel, OpenClawThinkingLevel } from '@shared/providers/modelThinking';
+import { afterEach, beforeEach, expect, test } from 'vitest';
+
+import {
+  readRememberedModelThinkingLevel,
+  rememberModelThinkingLevel,
+  resetModelThinkingLevelMemoryCache,
+  resolveThinkingLevelForModel,
+} from './modelThinkingLevelMemory';
+
+const STORAGE_KEY = 'lobsterai.model-thinking-levels';
+const PRO_KEY = 'lobsterai-server::deepseek-v4-pro';
+const FLASH_KEY = 'lobsterai-server::deepseek-v4-flash';
+
+const PRO_MODEL = {
+  id: 'deepseek-v4-pro',
+  providerKey: 'lobsterai-server',
+  isServerModel: true,
+  thinkingConfig: {
+    options: [
+      { level: ModelThinkingLevel.High, openclawLevel: OpenClawThinkingLevel.High },
+      { level: ModelThinkingLevel.Max, openclawLevel: OpenClawThinkingLevel.XHigh },
+    ],
+    defaultLevel: ModelThinkingLevel.High,
+  },
+};
+
+function installLocalStorage(initial: Record<string, string> = {}): Map<string, string> {
+  const store = new Map(Object.entries(initial));
+  (globalThis as unknown as { window: unknown }).window = {
+    localStorage: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => { store.set(key, value); },
+    },
+  };
+  return store;
+}
+
+function readStoredMemory(store: Map<string, string>): unknown {
+  return JSON.parse(store.get(STORAGE_KEY) ?? '{}');
+}
+
+beforeEach(() => {
+  resetModelThinkingLevelMemoryCache();
+});
+
+afterEach(() => {
+  delete (globalThis as unknown as { window?: unknown }).window;
+  resetModelThinkingLevelMemoryCache();
+});
+
+test('remembers a thinking level per model instead of one shared level', () => {
+  const store = installLocalStorage();
+
+  rememberModelThinkingLevel(PRO_KEY, ModelThinkingLevel.Max);
+  rememberModelThinkingLevel(FLASH_KEY, ModelThinkingLevel.Max);
+  rememberModelThinkingLevel(FLASH_KEY, ModelThinkingLevel.High);
+
+  expect(readRememberedModelThinkingLevel(PRO_KEY)).toBe(ModelThinkingLevel.Max);
+  expect(readRememberedModelThinkingLevel(FLASH_KEY)).toBe(ModelThinkingLevel.High);
+  expect(readStoredMemory(store)).toEqual({
+    [PRO_KEY]: ModelThinkingLevel.Max,
+    [FLASH_KEY]: ModelThinkingLevel.High,
+  });
+});
+
+test('reloads remembered levels from storage', () => {
+  installLocalStorage({
+    [STORAGE_KEY]: JSON.stringify({ [PRO_KEY]: ModelThinkingLevel.Max }),
+  });
+
+  expect(readRememberedModelThinkingLevel(PRO_KEY)).toBe(ModelThinkingLevel.Max);
+});
+
+test('ignores levels that are no longer valid', () => {
+  installLocalStorage({
+    [STORAGE_KEY]: JSON.stringify({ [PRO_KEY]: 'ultra', [FLASH_KEY]: ModelThinkingLevel.Low }),
+  });
+
+  expect(readRememberedModelThinkingLevel(PRO_KEY)).toBeUndefined();
+  expect(readRememberedModelThinkingLevel(FLASH_KEY)).toBe(ModelThinkingLevel.Low);
+});
+
+test('falls back to no memory when storage is corrupt', () => {
+  installLocalStorage({ [STORAGE_KEY]: '{not json' });
+
+  expect(readRememberedModelThinkingLevel(PRO_KEY)).toBeUndefined();
+});
+
+test('starts a model on its remembered level instead of the model default', () => {
+  installLocalStorage({
+    [STORAGE_KEY]: JSON.stringify({ [PRO_KEY]: ModelThinkingLevel.Max }),
+  });
+
+  expect(resolveThinkingLevelForModel(PRO_MODEL)).toBe(ModelThinkingLevel.Max);
+});
+
+test('starts a model on its default when it has no remembered level', () => {
+  installLocalStorage();
+
+  expect(resolveThinkingLevelForModel(PRO_MODEL)).toBe(ModelThinkingLevel.High);
+});
+
+test('starts a model on its default when the remembered level is not offered', () => {
+  installLocalStorage({
+    [STORAGE_KEY]: JSON.stringify({ [PRO_KEY]: ModelThinkingLevel.Off }),
+  });
+
+  expect(resolveThinkingLevelForModel(PRO_MODEL)).toBe(ModelThinkingLevel.High);
+});
+
+test('resolves no level for models without thinking support', () => {
+  installLocalStorage();
+
+  expect(resolveThinkingLevelForModel({ id: 'plain', providerKey: 'custom' })).toBe('');
+  expect(resolveThinkingLevelForModel(null)).toBe('');
+});
+
+test('stays inert outside a browser window', () => {
+  rememberModelThinkingLevel(PRO_KEY, ModelThinkingLevel.Max);
+
+  expect(readRememberedModelThinkingLevel(PRO_KEY)).toBeUndefined();
+});

--- a/src/renderer/services/modelThinkingLevelMemory.ts
+++ b/src/renderer/services/modelThinkingLevelMemory.ts
@@ -1,0 +1,89 @@
+import {
+  getModelThinkingLevels,
+  type ModelThinkingLevel,
+  parseModelThinkingLevel,
+} from '@shared/providers/modelThinking';
+
+import { getModelIdentityKey, type Model } from '../store/slices/modelSlice';
+
+/**
+ * Remembers the thinking level the user last picked for each model.
+ *
+ * An agent (or a session) stores a single `thinkingLevel`: the level of the
+ * model it currently runs. Without a per-model memory, switching models resets
+ * the other model back to its built-in default, so two models could never hold
+ * different levels at the same time. This map is picker-only state; the agent
+ * and session records stay the source of truth for what actually runs.
+ */
+const STORAGE_KEY = 'lobsterai.model-thinking-levels';
+
+type ModelThinkingLevelMemory = Record<string, ModelThinkingLevel>;
+
+let cachedMemory: ModelThinkingLevelMemory | null = null;
+
+function readMemory(): ModelThinkingLevelMemory {
+  if (cachedMemory) return cachedMemory;
+
+  const memory: ModelThinkingLevelMemory = {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      for (const [modelKey, rawLevel] of Object.entries(parsed as Record<string, unknown>)) {
+        const level = parseModelThinkingLevel(rawLevel);
+        if (modelKey && level) memory[modelKey] = level;
+      }
+    }
+  } catch {
+    // Best-effort memory: unreadable storage just falls back to model defaults.
+  }
+  cachedMemory = memory;
+  return memory;
+}
+
+export function readRememberedModelThinkingLevel(
+  modelKey: string,
+): ModelThinkingLevel | undefined {
+  if (!modelKey || typeof window === 'undefined') return undefined;
+  return readMemory()[modelKey];
+}
+
+export function rememberModelThinkingLevel(
+  modelKey: string,
+  level: ModelThinkingLevel,
+): void {
+  if (!modelKey || typeof window === 'undefined') return;
+
+  const memory = readMemory();
+  if (memory[modelKey] === level) return;
+  memory[modelKey] = level;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(memory));
+  } catch {
+    // Keeping the value in memory is still better than dropping the choice.
+  }
+}
+
+/**
+ * Level to store for a model when no agent/session value applies — after a
+ * model switch, for instance. Prefers the level the user last picked for that
+ * model over the model default, so switching models in one surface does not
+ * discard what was chosen for it in another. Models without a thinking config
+ * resolve to `''`, the "not applicable" value agent records store.
+ */
+export function resolveThinkingLevelForModel(
+  model: Pick<Model, 'id' | 'providerKey' | 'isServerModel' | 'thinkingConfig'> | null | undefined,
+): ModelThinkingLevel | '' {
+  const config = model?.thinkingConfig;
+  if (!config) return '';
+
+  const remembered = readRememberedModelThinkingLevel(getModelIdentityKey(model));
+  return remembered && getModelThinkingLevels(config).includes(remembered)
+    ? remembered
+    : config.defaultLevel;
+}
+
+/** Test-only: drop the cached map so the next read re-parses storage. */
+export function resetModelThinkingLevelMemoryCache(): void {
+  cachedMemory = null;
+}


### PR DESCRIPTION
## Summary

模型选择器里的「思考强度」此前是**全局一份**：两个模型不可能同时保持非默认档位，设了 B 就把 A 的选择冲掉。这个 PR 让每个模型各自记住自己的思考深度，并顺带补齐了这块 UI 的交互细节。

## Related Issue

无（本地复现：DeepSeek-V4-Pro 设「最大」后再把 DeepSeek-V4-Flash 设「最大」，Pro 会被打回「高」）

## Changes Made

**Bug：思考深度在模型之间互斥**

- 根因：`agents.thinking_level` / `cowork_sessions.thinking_level` 只存一个值，语义是"当前选中模型的档位"。选择器只把它用在选中模型上，其余模型一律回落 `thinkingConfig.defaultLevel`；而切模型时又会把这个回落值写回去，于是上一个模型的选择被覆盖。
- 新增 `src/renderer/services/modelThinkingLevelMemory.ts`：按模型身份（`providerKey::id`）记住用户**显式选过**的档位，localStorage 持久化，读取时逐项校验 + 内存缓存（避免每行渲染都 `JSON.parse`）。
- 新增可测的 `resolvePickerThinkingLevel`，取值优先级：正在点的档位 → agent/session 持久值（**仅对选中模型**）→ 该模型记住的档位 → 模型默认。
- Agent 设置面板保存改模型、新建 Agent 选模型，改用同一份记忆（`resolveThinkingLevelForModel`），不再强制重置为模型默认，三个入口口径一致。

**UI 细节（配合设计走查）**

- 二级菜单锚定到触发它的「思考强度」行，而不是悬浮卡片顶部——原来菜单会飘在触发行上方约 130px，中间一大片空白。
- 新增 `resolveCascadePlacement`：级联面板边贴边（不留缝也不压叠），并沿用上一层的展开方向，不再折返盖回模型列表；两侧都放不下时夹在视口内（原左侧摆放没有视口夹取，窄窗口会飞出屏幕）。
- 悬浮卡片里的「思考强度」行去掉常驻灰底（原来看着像已选中），只在悬停/二级菜单打开时高亮；文字与卡片正文左对齐。
- 「思考模式」是开关行，去掉悬停灰底；灰底语义收敛为"悬停/选中"。
- 强度选项：选中态 `bg-surface-raised/45`（淡），悬停态 `bg-surface-raised`（原选中灰），两者不再撞色。
- 菜单内部间距收紧约 20px，贴近参考稿的紧凑度。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other: UI/交互细节打磨

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] Manual testing performed

`npx vitest run src/renderer` → 93 files / 928 tests 全过。新增 15 个用例：

- 级联摆位：贴合、翻边、方向延续、双侧放不下夹取
- 档位优先级：正在点的 / 选中模型持久值 / 各模型记忆 / 模型默认 / 忽略该模型不提供的档位
- 记忆服务：按模型隔离、重载、非法档位剔除、存储损坏、无 `window` 退化、`resolveThinkingLevelForModel` 四种分支

改动文件均通过 CI 同规则 lint（`npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0`），`tsc --noEmit` 无报错。

⚠️ **未跑 Electron 实机**：几何与配色改动建议 reviewer 在 `npm run electron:dev` 里悬停确认一次。

## Screenshots (if applicable)

见 issue 讨论中的对比图（改前：二级菜单与触发行错位、面板之间大片空白；改后：贴合触发行级联）。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation（无文档影响）
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] None

纯 renderer 改动：**没有** SQLite schema/迁移、IPC 通道、preload、OpenClaw config sync 或 runtime 相关变更。agent / session 记录仍然只存一个"当前生效档位"给 OpenClaw 用，新增的按模型记忆只服务于选择器 UI。

## Additional Notes

- 记忆只在用户**显式选档**时写入，切模型不写，避免把 `defaultLevel` 污染进记忆里（否则模型默认档位日后调整会被旧记忆盖住）。
- 记忆按模型全局键，不按 agent 区分：同一个模型在不同 agent 下沿用上次选择。如果希望按 agent 隔离，改键即可。
- 升级后首次使用：老数据里某个模型已有非默认档位但没有记忆记录，来回切一次会回落到默认，重新选一次即可长期生效。
