### PR TITLE
feat(ui): dismiss the topmost overlay on Escape

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -93,6 +93,7 @@ import {
   shouldUseOpenAIResponsesForProvider,
 } from './settings/modelProviderUtils';
 import ModelSettingsSection, { DeleteProviderConfirmDialog, ModelEditorDialog } from './settings/ModelSettingsSection';
+import { resolveSettingsEscapeAction, SettingsEscapeAction } from './settings/settingsEscape';
 import EmailSkillConfig from './skills/EmailSkillConfig';
 import SkinPresentationScope from './skin/SkinPresentationScope';
 import SkinSettingsSection from './skin/SkinSettingsSection';
@@ -4002,6 +4003,40 @@ const Settings: React.FC<SettingsProps> = ({
     }
   };
 
+  // Escape dismisses the innermost stacked layer and closes the panel last.
+  // Dialogs rendered through Modal handle Escape themselves.
+  const handleEscape = () => {
+    const resolution = resolveSettingsEscapeAction({
+      isBlocked: isBackingUpOpenClawData
+        || isRestoringOpenClawData
+        || isRepairingOpenClaw
+        || isCleaningTempStorage
+        || isShortcutInputActive(),
+      layers: [
+        { isOpen: pendingDeleteProvider !== null, dismiss: () => setPendingDeleteProvider(null) },
+        { isOpen: isAddingModel || isEditingModel, dismiss: handleCancelModelEdit },
+        { isOpen: isTestResultModalOpen, dismiss: () => setIsTestResultModalOpen(false) },
+        { isOpen: showOpenClawRepairConfirm, dismiss: () => setShowOpenClawRepairConfirm(false) },
+        { isOpen: showTempCleanConfirm, dismiss: () => setShowTempCleanConfirm(false) },
+        {
+          isOpen: showOpenClawDataRestoreConfirm,
+          dismiss: () => setShowOpenClawDataRestoreConfirm(false),
+        },
+        { isOpen: showMemoryModal, dismiss: resetCoworkMemoryEditor },
+      ],
+    });
+
+    switch (resolution.action) {
+      case SettingsEscapeAction.DismissLayer:
+        resolution.dismiss();
+        return;
+      case SettingsEscapeAction.ClosePanel:
+        guardedClose();
+        return;
+      default:
+    }
+  };
+
   const showTestResultModal = (
     result: Omit<ProviderConnectionTestResult, 'provider'>,
     provider: ProviderType
@@ -5481,6 +5516,7 @@ const Settings: React.FC<SettingsProps> = ({
                     <Modal
                       isOpen
                       onClose={() => setCoworkMemoryRawMode(false)}
+                      onEscape={() => setCoworkMemoryRawMode(false)}
                       overlayClassName="fixed inset-0 z-[60] flex items-center justify-center bg-black/10 dark:bg-black/50 p-6"
                       className="flex h-[min(720px,calc(100vh-48px))] w-[min(960px,calc(100vw-48px))] flex-col overflow-hidden rounded-xl border border-surface bg-surface shadow-[0_12px_40px_rgba(0,0,0,0.16)]"
                     >
@@ -5897,6 +5933,7 @@ const Settings: React.FC<SettingsProps> = ({
   return (
     <Modal
       onClose={guardedClose}
+      onEscape={handleEscape}
       overlayClassName="fixed inset-0 z-50 modal-backdrop flex items-center justify-center p-3 sm:p-4"
       className="w-[calc(100vw-1.5rem)] max-w-[900px] min-w-0 sm:w-[calc(100vw-2rem)]"
     >

--- a/src/renderer/components/common/Modal.tsx
+++ b/src/renderer/components/common/Modal.tsx
@@ -1,9 +1,23 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
+
+import {
+  createModalEscapeLayerId,
+  isDismissEscapeEvent,
+  isTopModalEscapeLayer,
+  registerModalEscapeLayer,
+  unregisterModalEscapeLayer,
+} from './modalEscape';
 
 interface ModalProps {
   isOpen?: boolean;
   onClose: () => void;
+  /**
+   * Opt-in Escape handling. Runs only while this modal is the topmost one, so a
+   * dialog opened inside another modal dismisses itself without closing the
+   * modal behind it. Pass `onClose` when Escape should simply close the modal.
+   */
+  onEscape?: () => void;
   className?: string;
   overlayClassName?: string;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
@@ -19,14 +33,46 @@ interface ModalProps {
 const Modal: React.FC<ModalProps> = ({
   isOpen,
   onClose,
+  onEscape,
   className,
   overlayClassName,
   onClick,
   children,
 }) => {
   const mouseDownOnBackdropRef = useRef(false);
+  const layerIdRef = useRef<number | null>(null);
+  if (layerIdRef.current === null) {
+    layerIdRef.current = createModalEscapeLayerId();
+  }
+  const layerId = layerIdRef.current;
+  const onEscapeRef = useRef(onEscape);
+  const escapeEnabled = Boolean(onEscape);
+  const isVisible = isOpen !== false;
 
-  if (isOpen === false) return null;
+  useEffect(() => {
+    onEscapeRef.current = onEscape;
+  }, [onEscape]);
+
+  useEffect(() => {
+    if (!isVisible) return undefined;
+    registerModalEscapeLayer(layerId);
+    return () => unregisterModalEscapeLayer(layerId);
+  }, [isVisible, layerId]);
+
+  useEffect(() => {
+    if (!isVisible || !escapeEnabled) return undefined;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isDismissEscapeEvent(event)) return;
+      if (!isTopModalEscapeLayer(layerId)) return;
+      // Mark the press as handled so outer listeners keep their overlays open.
+      event.preventDefault();
+      onEscapeRef.current?.();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isVisible, escapeEnabled, layerId]);
+
+  if (!isVisible) return null;
 
   const modal = (
     <div

--- a/src/renderer/components/common/modalEscape.test.ts
+++ b/src/renderer/components/common/modalEscape.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from 'vitest';
+
+import {
+  createModalEscapeLayerId,
+  isDismissEscapeEvent,
+  isTopModalEscapeLayer,
+  registerModalEscapeLayer,
+  unregisterModalEscapeLayer,
+} from './modalEscape';
+
+const openedLayers: number[] = [];
+
+const openLayer = (): number => {
+  const layerId = createModalEscapeLayerId();
+  registerModalEscapeLayer(layerId);
+  openedLayers.push(layerId);
+  return layerId;
+};
+
+afterEach(() => {
+  while (openedLayers.length > 0) {
+    unregisterModalEscapeLayer(openedLayers.pop() as number);
+  }
+});
+
+describe('modal escape layers', () => {
+  test('a single open layer is the top layer', () => {
+    const layerId = openLayer();
+    expect(isTopModalEscapeLayer(layerId)).toBe(true);
+  });
+
+  test('an unregistered layer is never the top layer', () => {
+    const layerId = createModalEscapeLayerId();
+    expect(isTopModalEscapeLayer(layerId)).toBe(false);
+  });
+
+  test('a nested layer takes over from the panel behind it', () => {
+    const panel = openLayer();
+    const nested = openLayer();
+
+    expect(isTopModalEscapeLayer(panel)).toBe(false);
+    expect(isTopModalEscapeLayer(nested)).toBe(true);
+  });
+
+  test('closing the nested layer hands control back to the panel', () => {
+    const panel = openLayer();
+    const nested = openLayer();
+
+    unregisterModalEscapeLayer(nested);
+    openedLayers.pop();
+
+    expect(isTopModalEscapeLayer(panel)).toBe(true);
+  });
+
+  test('ids rank by creation order, not by registration order', () => {
+    // Mount effects run child-first, so the nested layer can register first.
+    const panel = createModalEscapeLayerId();
+    const nested = createModalEscapeLayerId();
+    registerModalEscapeLayer(nested);
+    registerModalEscapeLayer(panel);
+    openedLayers.push(panel, nested);
+
+    expect(isTopModalEscapeLayer(nested)).toBe(true);
+    expect(isTopModalEscapeLayer(panel)).toBe(false);
+  });
+});
+
+describe('isDismissEscapeEvent', () => {
+  test('accepts a plain Escape press', () => {
+    expect(isDismissEscapeEvent({ key: 'Escape' })).toBe(true);
+  });
+
+  test('ignores other keys', () => {
+    expect(isDismissEscapeEvent({ key: 'Enter' })).toBe(false);
+  });
+
+  test('ignores Escape already handled by an inner control', () => {
+    expect(isDismissEscapeEvent({ key: 'Escape', defaultPrevented: true })).toBe(false);
+  });
+
+  test('ignores Escape during IME composition', () => {
+    expect(isDismissEscapeEvent({ key: 'Escape', isComposing: true })).toBe(false);
+    expect(isDismissEscapeEvent({ key: 'Escape', keyCode: 229 })).toBe(false);
+  });
+});

--- a/src/renderer/components/common/modalEscape.ts
+++ b/src/renderer/components/common/modalEscape.ts
@@ -1,0 +1,58 @@
+/**
+ * Escape-key bookkeeping shared by every `Modal` layer.
+ *
+ * Modals portal into `document.body`, so nesting is invisible in the DOM and a
+ * plain `document` keydown listener would let an inner dialog and the panel
+ * behind it both react to one Escape press. Each rendered modal registers a
+ * layer id here; only the newest layer is allowed to act.
+ *
+ * Ids come from a monotonic counter taken during the first render, so a parent
+ * modal always ranks below a modal opened inside it — mount effects fire
+ * child-first and cannot be used for this ordering.
+ */
+
+let nextLayerId = 1;
+const activeLayerIds = new Set<number>();
+
+/** Allocate an id for a modal layer. Later calls always rank above earlier ones. */
+export const createModalEscapeLayerId = (): number => {
+  const id = nextLayerId;
+  nextLayerId += 1;
+  return id;
+};
+
+export const registerModalEscapeLayer = (layerId: number): void => {
+  activeLayerIds.add(layerId);
+};
+
+export const unregisterModalEscapeLayer = (layerId: number): void => {
+  activeLayerIds.delete(layerId);
+};
+
+/** True when `layerId` is registered and no newer modal layer is open above it. */
+export const isTopModalEscapeLayer = (layerId: number): boolean => {
+  if (!activeLayerIds.has(layerId)) return false;
+  for (const activeId of activeLayerIds) {
+    if (activeId > layerId) return false;
+  }
+  return true;
+};
+
+export interface EscapeKeyEventLike {
+  key: string;
+  isComposing?: boolean;
+  keyCode?: number;
+  defaultPrevented?: boolean;
+}
+
+/**
+ * Escape presses an overlay may dismiss itself on: not an IME composition
+ * cancel, and not already handled by an inner control.
+ */
+export const isDismissEscapeEvent = (event: EscapeKeyEventLike): boolean => {
+  if (event.key !== 'Escape') return false;
+  if (event.defaultPrevented) return false;
+  // Let the IME consume Escape while composing; it cancels the composition.
+  if (event.isComposing || event.keyCode === 229) return false;
+  return true;
+};

--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -467,14 +467,17 @@ const IMSettings: React.FC = () => {
     };
 
     const handleWeixinDmPolicyMenuKeydown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setIsWeixinDmPolicyMenuOpen(false);
+      if (event.key !== 'Escape') return;
+      // Claim the press during capture so the settings panel stays open.
+      event.preventDefault();
+      setIsWeixinDmPolicyMenuOpen(false);
     };
 
     document.addEventListener('pointerdown', closeWeixinDmPolicyMenu);
-    document.addEventListener('keydown', handleWeixinDmPolicyMenuKeydown);
+    document.addEventListener('keydown', handleWeixinDmPolicyMenuKeydown, true);
     return () => {
       document.removeEventListener('pointerdown', closeWeixinDmPolicyMenu);
-      document.removeEventListener('keydown', handleWeixinDmPolicyMenuKeydown);
+      document.removeEventListener('keydown', handleWeixinDmPolicyMenuKeydown, true);
     };
   }, [isWeixinDmPolicyMenuOpen]);
 
@@ -3221,6 +3224,9 @@ const IMSettings: React.FC = () => {
         {deleteConfirmTarget && deleteConfirmInstance && (
           <Modal
             onClose={() => {
+              if (!isDeletingInstance) setDeleteConfirmTarget(null);
+            }}
+            onEscape={() => {
               if (!isDeletingInstance) setDeleteConfirmTarget(null);
             }}
             overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60"

--- a/src/renderer/components/settings/BrowserWebAccessSettings.tsx
+++ b/src/renderer/components/settings/BrowserWebAccessSettings.tsx
@@ -191,6 +191,7 @@ const BrowserWebAccessSettings: React.FC<BrowserWebAccessSettingsProps> = ({
       {hostnameDialogTarget ? (
         <Modal
           onClose={closeHostnameDialog}
+          onEscape={closeHostnameDialog}
           overlayClassName="fixed inset-0 z-[60] flex items-center justify-center bg-black/25"
           className="w-full max-w-[420px] rounded-2xl border border-border bg-background p-5 shadow-modal"
         >

--- a/src/renderer/components/settings/settingsEscape.test.ts
+++ b/src/renderer/components/settings/settingsEscape.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { resolveSettingsEscapeAction, SettingsEscapeAction } from './settingsEscape';
+
+describe('resolveSettingsEscapeAction', () => {
+  test('closes the panel when nothing is stacked on top', () => {
+    const result = resolveSettingsEscapeAction({
+      isBlocked: false,
+      layers: [{ isOpen: false, dismiss: vi.fn() }],
+    });
+
+    expect(result.action).toBe(SettingsEscapeAction.ClosePanel);
+  });
+
+  test('does nothing while an operation blocks the panel', () => {
+    const dismiss = vi.fn();
+    const result = resolveSettingsEscapeAction({
+      isBlocked: true,
+      layers: [{ isOpen: true, dismiss }],
+    });
+
+    expect(result.action).toBe(SettingsEscapeAction.Ignore);
+    expect(dismiss).not.toHaveBeenCalled();
+  });
+
+  test('dismisses the topmost open layer instead of closing the panel', () => {
+    const topmost = vi.fn();
+    const below = vi.fn();
+    const result = resolveSettingsEscapeAction({
+      isBlocked: false,
+      layers: [
+        { isOpen: false, dismiss: vi.fn() },
+        { isOpen: true, dismiss: topmost },
+        { isOpen: true, dismiss: below },
+      ],
+    });
+
+    expect(result.action).toBe(SettingsEscapeAction.DismissLayer);
+    if (result.action !== SettingsEscapeAction.DismissLayer) return;
+    result.dismiss();
+    expect(topmost).toHaveBeenCalledTimes(1);
+    expect(below).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/settings/settingsEscape.ts
+++ b/src/renderer/components/settings/settingsEscape.ts
@@ -1,0 +1,46 @@
+/**
+ * Escape handling for the settings panel.
+ *
+ * The panel stacks several confirmations that are plain absolutely-positioned
+ * layers rather than portalled modals, so Escape has to dismiss the innermost
+ * open one first and close the panel only when nothing is stacked on top.
+ * Dialogs rendered through `Modal` handle Escape on their own.
+ */
+
+export const SettingsEscapeAction = {
+  /** A long-running operation owns the panel; Escape does nothing. */
+  Ignore: 'ignore',
+  DismissLayer: 'dismissLayer',
+  ClosePanel: 'closePanel',
+} as const;
+export type SettingsEscapeAction = typeof SettingsEscapeAction[keyof typeof SettingsEscapeAction];
+
+export interface SettingsEscapeLayer {
+  isOpen: boolean;
+  dismiss: () => void;
+}
+
+export interface SettingsEscapeInput {
+  /** True while a backup/restore/repair/clean runs, or while a shortcut is being recorded. */
+  isBlocked: boolean;
+  /** Layers stacked inside the panel, topmost first. */
+  layers: readonly SettingsEscapeLayer[];
+}
+
+export type SettingsEscapeResolution =
+  | { action: typeof SettingsEscapeAction.Ignore }
+  | { action: typeof SettingsEscapeAction.DismissLayer; dismiss: () => void }
+  | { action: typeof SettingsEscapeAction.ClosePanel };
+
+export const resolveSettingsEscapeAction = (
+  { isBlocked, layers }: SettingsEscapeInput,
+): SettingsEscapeResolution => {
+  if (isBlocked) return { action: SettingsEscapeAction.Ignore };
+
+  const openLayer = layers.find(layer => layer.isOpen);
+  if (openLayer) {
+    return { action: SettingsEscapeAction.DismissLayer, dismiss: openLayer.dismiss };
+  }
+
+  return { action: SettingsEscapeAction.ClosePanel };
+};

--- a/src/renderer/components/skills/EmailSkillConfig.tsx
+++ b/src/renderer/components/skills/EmailSkillConfig.tsx
@@ -1000,6 +1000,7 @@ const EmailSkillConfig: React.FC = () => {
       {pendingDeleteAccount && (
         <Modal
           onClose={() => setPendingDeleteAccountId(null)}
+          onEscape={() => setPendingDeleteAccountId(null)}
           overlayClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
           className="w-full max-w-sm rounded-xl border border-border bg-surface p-5 shadow-2xl"
         >


### PR DESCRIPTION
Modals portal into document.body, so nesting is invisible in the DOM and a plain document keydown listener let an inner dialog and the panel behind it both react to a single Escape press. Modal now takes an opt-in onEscape and registers a layer id; only the newest open layer reacts, and IME composition cancels are left to the IME.

The settings panel stacks confirmations that are absolutely-positioned layers rather than portalled modals, so it resolves Escape itself: dismiss the innermost open layer, close the panel only when nothing is stacked on top, and ignore the key entirely while a backup, restore, repair, temp clean or shortcut recording is running.

Wire onEscape through the instance-delete, hostname and raw-memory dialogs, and let the WeChat DM policy menu claim Escape during capture so dismissing it no longer closes the settings panel behind it.
