### PR TITLE
fix(shell): avoid unsupported large file icon size on macOS/Windows

### DIFF
--- a/src/main/shellAppIconPolicy.test.ts
+++ b/src/main/shellAppIconPolicy.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest';
+
+import { resolveShellAppFileIconSize } from './shellAppIconPolicy';
+
+describe('resolveShellAppFileIconSize', () => {
+  test.each([
+    ['darwin', 'normal'],
+    ['win32', 'normal'],
+    ['linux', 'large'],
+  ] as const)('uses %s-safe Electron file icon size %s', (platform, expectedSize) => {
+    expect(resolveShellAppFileIconSize(platform)).toBe(expectedSize);
+  });
+});

--- a/src/main/shellAppIconPolicy.ts
+++ b/src/main/shellAppIconPolicy.ts
@@ -1,0 +1,5 @@
+export type ShellAppFileIconSize = 'normal' | 'large';
+
+export function resolveShellAppFileIconSize(platform: NodeJS.Platform): ShellAppFileIconSize {
+  return platform === 'linux' ? 'large' : 'normal';
+}

--- a/src/main/shellApps.ts
+++ b/src/main/shellApps.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import type { ShellGetBrowserAppsInput } from '../shared/shell/constants';
+import { resolveShellAppFileIconSize } from './shellAppIconPolicy';
 
 export interface AppInfo {
   name: string;
@@ -769,10 +770,12 @@ async function extractIcon(appInfo: AppInfo): Promise<string | null> {
       return png;
     }
   }
-  // Fallback (mainly Windows): use Electron's app.getFileIcon
+  // Electron does not support the "large" file icon size on macOS.
   try {
     if (!app.isReady()) return null;
-    const img = await app.getFileIcon(appInfo.path, { size: 'large' });
+    const img = await app.getFileIcon(appInfo.path, {
+      size: resolveShellAppFileIconSize(process.platform),
+    });
     if (!img.isEmpty()) {
       const dataUrl = img.toDataURL();
       iconDataUrlCache.set(cacheKey, dataUrl);


### PR DESCRIPTION
extractIcon fell back to app.getFileIcon with size 'large', which Electron does not support on macOS. Introduce
resolveShellAppFileIconSize to pick 'large' only on Linux and 'normal' elsewhere.