### PR TITLE
fix(plugins): preserve junctions during Windows install

### DIFF
--- a/src/main/plugins/pluginInstallPublisher.test.ts
+++ b/src/main/plugins/pluginInstallPublisher.test.ts
@@ -1,0 +1,128 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, expect, test, vi } from 'vitest';
+
+import {
+  cleanupPluginInstallStagingDir,
+  createPluginInstallStagingDir,
+  publishStagedPluginDirectory,
+} from './pluginInstallPublisher';
+
+const tempRoots: string[] = [];
+
+const createTempRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lobsterai-plugin-publish-test-'));
+  tempRoots.push(root);
+  return root;
+};
+
+const writePlugin = (pluginDir: string, pluginId: string, marker: string): void => {
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, 'openclaw.plugin.json'),
+    JSON.stringify({ id: pluginId }),
+    'utf8',
+  );
+  fs.writeFileSync(path.join(pluginDir, 'marker.txt'), marker, 'utf8');
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('creates install staging beside the scanned extensions directory', async () => {
+  const root = createTempRoot();
+  const extensionsDir = path.join(root, 'third-party-extensions');
+  fs.mkdirSync(extensionsDir, { recursive: true });
+
+  const stagingDir = createPluginInstallStagingDir(extensionsDir);
+
+  expect(path.dirname(path.dirname(stagingDir))).toBe(root);
+  expect(stagingDir.startsWith(`${extensionsDir}${path.sep}`)).toBe(false);
+  expect(fs.statSync(stagingDir).isDirectory()).toBe(true);
+
+  await cleanupPluginInstallStagingDir(stagingDir);
+  expect(fs.existsSync(stagingDir)).toBe(false);
+});
+
+test('publishes a staged plugin without recreating its runtime junction', async () => {
+  const root = createTempRoot();
+  const extensionsDir = path.join(root, 'third-party-extensions');
+  const stagingDir = createPluginInstallStagingDir(extensionsDir);
+  const stagedPluginDir = path.join(stagingDir, 'extensions', 'memory-tencentdb');
+  const targetPluginDir = path.join(extensionsDir, 'memory-tencentdb');
+  const runtimeDir = path.join(root, 'runtime');
+  const runtimeLink = path.join(stagedPluginDir, 'node_modules', 'openclaw');
+
+  writePlugin(stagedPluginDir, 'memory-tencentdb', 'new');
+  fs.mkdirSync(path.dirname(runtimeLink), { recursive: true });
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  fs.writeFileSync(path.join(runtimeDir, 'openclaw.mjs'), 'runtime', 'utf8');
+  fs.symlinkSync(runtimeDir, runtimeLink, process.platform === 'win32' ? 'junction' : 'dir');
+
+  await publishStagedPluginDirectory(stagedPluginDir, targetPluginDir, 'memory-tencentdb');
+
+  const publishedLink = path.join(targetPluginDir, 'node_modules', 'openclaw');
+  expect(fs.lstatSync(publishedLink).isSymbolicLink()).toBe(true);
+  expect(fs.realpathSync(publishedLink)).toBe(fs.realpathSync(runtimeDir));
+  expect(fs.readFileSync(path.join(targetPluginDir, 'marker.txt'), 'utf8')).toBe('new');
+});
+
+test('restores a valid existing plugin when publishing the replacement fails', async () => {
+  const root = createTempRoot();
+  const extensionsDir = path.join(root, 'third-party-extensions');
+  const stagingDir = createPluginInstallStagingDir(extensionsDir);
+  const stagedPluginDir = path.join(stagingDir, 'extensions', 'example-plugin');
+  const targetPluginDir = path.join(extensionsDir, 'example-plugin');
+  writePlugin(stagedPluginDir, 'example-plugin', 'new');
+  writePlugin(targetPluginDir, 'example-plugin', 'old');
+
+  const rename = fs.promises.rename.bind(fs.promises);
+  let renameCall = 0;
+  vi.spyOn(fs.promises, 'rename').mockImplementation(async (source, destination) => {
+    renameCall += 1;
+    if (renameCall === 2) {
+      throw new Error('simulated publish failure');
+    }
+    await rename(source, destination);
+  });
+
+  await expect(
+    publishStagedPluginDirectory(stagedPluginDir, targetPluginDir, 'example-plugin'),
+  ).rejects.toThrow('simulated publish failure');
+
+  expect(renameCall).toBe(3);
+  expect(fs.readFileSync(path.join(targetPluginDir, 'marker.txt'), 'utf8')).toBe('old');
+});
+
+test('discards an incomplete existing directory when publishing fails', async () => {
+  const root = createTempRoot();
+  const extensionsDir = path.join(root, 'third-party-extensions');
+  const stagingDir = createPluginInstallStagingDir(extensionsDir);
+  const stagedPluginDir = path.join(stagingDir, 'extensions', 'example-plugin');
+  const targetPluginDir = path.join(extensionsDir, 'example-plugin');
+  writePlugin(stagedPluginDir, 'example-plugin', 'new');
+  fs.mkdirSync(targetPluginDir, { recursive: true });
+  fs.writeFileSync(path.join(targetPluginDir, 'partial.txt'), 'partial', 'utf8');
+
+  const rename = fs.promises.rename.bind(fs.promises);
+  let renameCall = 0;
+  vi.spyOn(fs.promises, 'rename').mockImplementation(async (source, destination) => {
+    renameCall += 1;
+    if (renameCall === 2) {
+      throw new Error('simulated publish failure');
+    }
+    await rename(source, destination);
+  });
+
+  await expect(
+    publishStagedPluginDirectory(stagedPluginDir, targetPluginDir, 'example-plugin'),
+  ).rejects.toThrow('simulated publish failure');
+
+  expect(renameCall).toBe(2);
+  expect(fs.existsSync(targetPluginDir)).toBe(false);
+});

--- a/src/main/plugins/pluginInstallPublisher.ts
+++ b/src/main/plugins/pluginInstallPublisher.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+const PLUGIN_INSTALL_STAGING_DIR = 'plugin-install-staging';
+
+interface PluginManifestIdentity {
+  id?: unknown;
+}
+
+const pathExists = async (targetPath: string): Promise<boolean> => {
+  try {
+    await fs.promises.lstat(targetPath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+};
+
+const readPluginManifestId = async (pluginDir: string): Promise<string | null> => {
+  try {
+    const raw = await fs.promises.readFile(path.join(pluginDir, 'openclaw.plugin.json'), 'utf8');
+    const manifest = JSON.parse(raw) as PluginManifestIdentity;
+    return typeof manifest.id === 'string' && manifest.id.trim() ? manifest.id.trim() : null;
+  } catch {
+    return null;
+  }
+};
+
+const getPluginInstallStagingRoot = (extensionsDir: string): string => (
+  path.join(path.dirname(extensionsDir), PLUGIN_INSTALL_STAGING_DIR)
+);
+
+export const createPluginInstallStagingDir = (extensionsDir: string): string => {
+  const stagingRoot = getPluginInstallStagingRoot(extensionsDir);
+  fs.mkdirSync(stagingRoot, { recursive: true });
+  return fs.mkdtempSync(path.join(stagingRoot, 'install-'));
+};
+
+export const cleanupPluginInstallStagingDir = async (stagingDir: string): Promise<void> => {
+  await fs.promises.rm(stagingDir, { recursive: true, force: true }).catch(() => {});
+  await fs.promises.rmdir(path.dirname(stagingDir)).catch(() => {});
+};
+
+/**
+ * Publish a plugin without copying its dependency junctions/symlinks.
+ *
+ * The OpenClaw installer creates peer dependency links inside node_modules.
+ * Because the staging directory is on the same volume as the extensions
+ * directory, rename preserves those links without requiring Windows symlink
+ * privileges. Existing valid plugins are restored if the swap fails, while
+ * incomplete directories are discarded so they cannot break gateway startup.
+ */
+export const publishStagedPluginDirectory = async (
+  stagedPluginDir: string,
+  targetPluginDir: string,
+  expectedPluginId: string,
+): Promise<void> => {
+  const stagedManifestId = await readPluginManifestId(stagedPluginDir);
+  if (stagedManifestId !== expectedPluginId) {
+    throw new Error(
+      `Installed plugin manifest mismatch: expected "${expectedPluginId}", found "${stagedManifestId || 'missing'}"`,
+    );
+  }
+
+  const extensionsDir = path.dirname(targetPluginDir);
+  const stagingRoot = getPluginInstallStagingRoot(extensionsDir);
+  await fs.promises.mkdir(extensionsDir, { recursive: true });
+  await fs.promises.mkdir(stagingRoot, { recursive: true });
+
+  let backupPath: string | null = null;
+  let restorePreviousOnFailure = false;
+
+  if (await pathExists(targetPluginDir)) {
+    restorePreviousOnFailure = await readPluginManifestId(targetPluginDir) !== null;
+    backupPath = path.join(
+      stagingRoot,
+      `backup-${path.basename(targetPluginDir)}-${randomUUID()}`,
+    );
+    await fs.promises.rename(targetPluginDir, backupPath);
+  }
+
+  try {
+    await fs.promises.rename(stagedPluginDir, targetPluginDir);
+  } catch (publishError) {
+    if (backupPath) {
+      if (restorePreviousOnFailure) {
+        try {
+          await fs.promises.rename(backupPath, targetPluginDir);
+          backupPath = null;
+        } catch (rollbackError) {
+          const publishMessage = publishError instanceof Error ? publishError.message : String(publishError);
+          const rollbackMessage = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+          throw new Error(
+            `Failed to publish plugin (${publishMessage}) and restore the previous version (${rollbackMessage}); `
+            + `previous plugin preserved at ${backupPath}`,
+          );
+        }
+      } else {
+        await fs.promises.rm(backupPath, { recursive: true, force: true }).catch(() => {});
+        backupPath = null;
+      }
+    }
+    throw publishError;
+  }
+
+  if (backupPath) {
+    try {
+      await fs.promises.rm(backupPath, { recursive: true, force: true });
+    } catch (error) {
+      console.warn(`[PluginManager] Failed to remove plugin install backup at ${backupPath}.`, error);
+    }
+  }
+};

--- a/src/main/plugins/pluginManager.ts
+++ b/src/main/plugins/pluginManager.ts
@@ -10,6 +10,11 @@ import {
   findThirdPartyExtensionsDir,
   listBundledOpenClawExtensionManifests,
 } from '../libs/openclawLocalExtensions';
+import {
+  cleanupPluginInstallStagingDir,
+  createPluginInstallStagingDir,
+  publishStagedPluginDirectory,
+} from './pluginInstallPublisher';
 
 export interface PluginInstallParams {
   source: PluginSource;
@@ -274,6 +279,8 @@ export class PluginManager {
       return { ok: false, error: `OpenClaw CLI not found at ${openclawMjs}` };
     }
 
+    let stagingDir: string | null = null;
+
     try {
       let installSpec: string;
 
@@ -300,11 +307,12 @@ export class PluginManager {
           return { ok: false, error: `Unknown source: ${params.source}` };
       }
 
-      // Run openclaw plugins install into a temp staging directory, then copy
-      // to the actual extensions dir. This avoids:
+      // Run openclaw plugins install into an isolated staging directory, then
+      // atomically publish it to the actual extensions dir. This avoids:
       // 1. EPERM from gateway locking the target directory
-      // 2. Path mismatch (openclaw creates extensions/ subdir under STATE_DIR)
-      const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lobsterai-plugin-stage-'));
+      // 2. Recreating OpenClaw peer dependency links during a recursive copy
+      // 3. Path mismatch (openclaw creates extensions/ subdir under STATE_DIR)
+      stagingDir = createPluginInstallStagingDir(extensionsDir);
       onLog?.(`Installing plugin from ${installSpec}...\n`);
       const installEnv: NodeJS.ProcessEnv = {
         ...process.env,
@@ -330,7 +338,7 @@ export class PluginManager {
         return { ok: false, error: result.stderr || `Install exited with code ${result.code}` };
       }
 
-      // Discover plugin from staging extensions/ subdir and copy to final location
+      // Discover the plugin in staging before publishing it to the final location.
       const stagedExtDir = path.join(stagingDir, 'extensions');
       const pluginId = this.discoverInstalledPluginId(
         fs.existsSync(stagedExtDir) ? stagedExtDir : stagingDir,
@@ -343,20 +351,11 @@ export class PluginManager {
       const stagedPluginDir = path.join(stagedExtDir, pluginId);
       const targetPluginDir = path.join(extensionsDir, pluginId);
 
-      // Copy from staging to final extensions directory (async to avoid blocking main thread)
-      onLog?.(`Copying ${pluginId} to extensions directory...\n`);
-      try {
-        if (fs.existsSync(targetPluginDir)) {
-          await fs.promises.rm(targetPluginDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
-        }
-      } catch {
-        // On Windows the gateway may hold file handles; proceed with force-overwrite
-      }
-      await fs.promises.cp(stagedPluginDir, targetPluginDir, { recursive: true, force: true });
+      // Publish with same-volume renames so OpenClaw peer dependency junctions
+      // are preserved without requiring Windows symlink privileges.
+      onLog?.(`Publishing ${pluginId} to extensions directory...\n`);
+      await publishStagedPluginDirectory(stagedPluginDir, targetPluginDir, pluginId);
       onLog?.(`Done.\n`);
-
-      // Cleanup staging
-      fs.promises.rm(stagingDir, { recursive: true, force: true }).catch(() => {});
 
       const version = readPluginVersion(targetPluginDir) || params.version;
 
@@ -376,6 +375,10 @@ export class PluginManager {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return { ok: false, error: message };
+    } finally {
+      if (stagingDir) {
+        await cleanupPluginInstallStagingDir(stagingDir);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- stage OpenClaw plugin installs beside the user extensions directory so publishing stays on the same Windows volume
- atomically rename the staged plugin into place to preserve dependency junctions and avoid `EPERM` symlink failures
- validate manifests, restore a valid previous plugin on failure, and remove incomplete targets and staging directories

## Testing

- `npm test -- src/main/plugins/pluginInstallPublisher.test.ts src/main/plugins/pluginManager.test.ts`
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/main/plugins/pluginManager.ts src/main/plugins/pluginInstallPublisher.ts src/main/plugins/pluginInstallPublisher.test.ts`
- `npm run compile:electron`
- `npm run build`
- packaged Windows app: installed `@tencentdb-agent-memory/memory-tencentdb@1.0.1` via npm; its `node_modules/openclaw` remained a junction and the gateway loaded the plugin successfully

## Electron behavior

Changes main-process plugin installation and rollback behavior on Windows. No renderer, IPC, or storage schema changes.