### PR TITLE
feat(sidebar): move task search to header actions

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,7 +12,12 @@ import {
 } from '../shared/appUpdate/constants';
 import { ProviderAuthType, ProviderName, ProviderRegistry } from '../shared/providers';
 import { CoworkView } from './components/cowork';
-import { CoworkShortcutDirection, CoworkUiEvent } from './components/cowork/constants';
+import {
+  CoworkShortcutDirection,
+  type CoworkTaskSearchRequestEventDetail,
+  CoworkTaskSearchRequestSource,
+  CoworkUiEvent,
+} from './components/cowork/constants';
 import {
   ConversationSearchShortcutTarget,
   resolveConversationSearchShortcutTarget,
@@ -703,6 +708,20 @@ const App: React.FC = () => {
     setIsTaskFilterActive(nextActive);
   }, [hasUnreadCompletedTasks, isSidebarCollapsed, isTaskFilterActive, mainView]);
 
+  const handleOpenTaskSearch = useCallback(() => {
+    void reportYdAnalyzer({
+      action: LogReporterAction.SidebarAction,
+      source: 'home_sidebar',
+      actionType: 'open_search',
+      activeView: mainView,
+      isCollapsed: isSidebarCollapsed,
+    });
+    window.dispatchEvent(new CustomEvent<CoworkTaskSearchRequestEventDetail>(
+      CoworkUiEvent.ShortcutSearch,
+      { detail: { source: CoworkTaskSearchRequestSource.WindowsTitleBar } },
+    ));
+  }, [isSidebarCollapsed, mainView]);
+
   const handleNewChat = useCallback(() => {
     // Only clear when already on home (no session) — preserve __home__ draft when returning from a session
     const shouldClearInput = mainView === 'cowork' && !currentSessionId;
@@ -1155,7 +1174,10 @@ const App: React.FC = () => {
           window.dispatchEvent(new CustomEvent(CoworkUiEvent.ShortcutConversationSearch));
         } else if (shortcutTarget === ConversationSearchShortcutTarget.History) {
           event.preventDefault();
-          window.dispatchEvent(new CustomEvent(CoworkUiEvent.ShortcutSearch));
+          window.dispatchEvent(new CustomEvent<CoworkTaskSearchRequestEventDetail>(
+            CoworkUiEvent.ShortcutSearch,
+            { detail: { source: CoworkTaskSearchRequestSource.KeyboardShortcut } },
+          ));
         }
         return;
       }
@@ -1536,8 +1558,12 @@ const App: React.FC = () => {
       isSidebarCollapsed={isSidebarCollapsed}
       sidebarWidth={sidebarWidth}
       onToggleSidebar={canUseWindowsTopBarActions ? handleToggleSidebar : undefined}
+      onSearch={canUseWindowsTopBarActions && !isSidebarCollapsed
+        ? handleOpenTaskSearch
+        : undefined}
       onNewChat={canUseWindowsCollapsedTopBarActions ? handleNewChat : undefined}
       sidebarToggleLabel={isSidebarCollapsed ? i18nService.t('expand') : i18nService.t('collapse')}
+      searchLabel={i18nService.t('search')}
       showFilterIcon={canUseWindowsTopBarActions && !isSidebarCollapsed && mainView === 'cowork'}
       filterLabel={i18nService.t('sidebarFilter')}
       isFilterActive={isTaskFilterActive}

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -21,15 +21,19 @@ import {
 } from './agentSidebar/batchSelection';
 import MyAgentSidebarTree from './agentSidebar/MyAgentSidebarTree';
 import SidebarTaskFilterButton from './agentSidebar/SidebarTaskFilterButton';
+import SidebarTaskSearchButton from './agentSidebar/SidebarTaskSearchButton';
 import Modal from './common/Modal';
-import { CoworkUiEvent } from './cowork/constants';
+import {
+  type CoworkTaskSearchRequestEventDetail,
+  CoworkTaskSearchRequestSource,
+  CoworkUiEvent,
+} from './cowork/constants';
 import CoworkSearchModal from './cowork/CoworkSearchModal';
 import Cog6ToothIcon from './icons/Cog6ToothIcon';
 import ComposeIcon from './icons/ComposeIcon';
 import SidebarAutomationIcon from './icons/SidebarAutomationIcon';
 import SidebarKitsIcon from './icons/SidebarKitsIcon';
 import SidebarMcpIcon from './icons/SidebarMcpIcon';
-import SidebarSearchIcon from './icons/SidebarSearchIcon';
 import SidebarSitesIcon from './icons/SidebarSitesIcon';
 import SidebarToggleIcon from './icons/SidebarToggleIcon';
 import SkillIcon from './icons/SkillIcon';
@@ -133,6 +137,20 @@ const reportSidebarAction = (
     taskStatus: options.taskStatus,
     visibleTaskCount: options.visibleTaskCount,
   });
+};
+
+const logTaskSearchRequest = (
+  source: CoworkTaskSearchRequestSource,
+  activeView: SidebarProps['activeView'],
+): void => {
+  try {
+    const message = `task search requested source=${source} activeView=${activeView} platform=${window.electron?.platform ?? 'unknown'}`;
+    console.debug(`[Sidebar] ${message}`);
+    window.electron?.log?.fromRenderer?.('debug', 'Sidebar', message);
+  } catch (error) {
+    // Task search must remain available when renderer diagnostic logging fails.
+    console.debug('[Sidebar] task search diagnostic logging unavailable:', error);
+  }
 };
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -245,16 +263,22 @@ const Sidebar: React.FC<SidebarProps> = ({
       });
   }, [showKitsNewBadge]);
 
+  const openTaskSearch = useCallback((source: CoworkTaskSearchRequestSource) => {
+    logTaskSearchRequest(source, activeView);
+    onShowCowork();
+    setIsSearchOpen(true);
+  }, [activeView, onShowCowork]);
+
   useEffect(() => {
-    const handleSearch = () => {
-      onShowCowork();
-      setIsSearchOpen(true);
+    const handleSearch = (event: Event) => {
+      const detail = (event as CustomEvent<CoworkTaskSearchRequestEventDetail>).detail;
+      openTaskSearch(detail?.source ?? CoworkTaskSearchRequestSource.UiEvent);
     };
     window.addEventListener(CoworkUiEvent.ShortcutSearch, handleSearch);
     return () => {
       window.removeEventListener(CoworkUiEvent.ShortcutSearch, handleSearch);
     };
-  }, [onShowCowork]);
+  }, [openTaskSearch]);
 
   useEffect(() => {
     if (!isCollapsed) return;
@@ -549,14 +573,26 @@ const Sidebar: React.FC<SidebarProps> = ({
                 >
                   <SidebarToggleIcon className="h-4 w-4" isCollapsed={isCollapsed} />
                 </button>
-                {activeView === 'cowork' && !isCollapsed && (
-                  <SidebarTaskFilterButton
-                    isActive={isTaskFilterActive}
-                    hasUnreadCompletedTasks={hasUnreadCompletedTasks}
-                    label={i18nService.t('sidebarFilter')}
-                    onClick={onToggleTaskFilter}
-                    className="non-draggable"
-                  />
+                {!isCollapsed && (
+                  <>
+                    <SidebarTaskSearchButton
+                      onClick={() => {
+                        reportSidebarAction('open_search', { activeView, isCollapsed });
+                        openTaskSearch(CoworkTaskSearchRequestSource.SidebarHeader);
+                      }}
+                      className="non-draggable"
+                      label={i18nService.t('search')}
+                    />
+                    {activeView === 'cowork' && (
+                      <SidebarTaskFilterButton
+                        isActive={isTaskFilterActive}
+                        hasUnreadCompletedTasks={hasUnreadCompletedTasks}
+                        label={i18nService.t('sidebarFilter')}
+                        onClick={onToggleTaskFilter}
+                        className="non-draggable"
+                      />
+                    )}
+                  </>
                 )}
               </>
             )}
@@ -573,18 +609,6 @@ const Sidebar: React.FC<SidebarProps> = ({
           >
             <ComposeIcon className={sidebarCreateIconClassName} />
             {i18nService.t('newChat')}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              reportSidebarAction('open_search', { activeView, isCollapsed });
-              onShowCowork();
-              setIsSearchOpen(true);
-            }}
-            className={sidebarNavItemClassName}
-          >
-            <SidebarSearchIcon className="h-4 w-4 shrink-0" />
-            {i18nService.t('search')}
           </button>
           <button
             type="button"

--- a/src/renderer/components/agentSidebar/SidebarTaskSearchButton.test.ts
+++ b/src/renderer/components/agentSidebar/SidebarTaskSearchButton.test.ts
@@ -1,0 +1,27 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, test } from 'vitest';
+
+import SidebarTaskSearchButton from './SidebarTaskSearchButton';
+
+describe('SidebarTaskSearchButton', () => {
+  test.each(['Search tasks', '搜索任务'])(
+    'renders an accessible icon-only action for label %s with a stable hit target',
+    (label) => {
+      const html = renderToStaticMarkup(React.createElement(SidebarTaskSearchButton, {
+        label,
+        onClick: () => undefined,
+        className: 'non-draggable',
+      }));
+
+      expect(html).toContain('type="button"');
+      expect(html).toContain(`aria-label="${label}"`);
+      expect(html).toContain(`title="${label}"`);
+      expect(html).toContain('h-8 w-8');
+      expect(html).toContain('h-[18px] w-[18px]');
+      expect(html).toContain('aria-hidden="true"');
+      expect(html).toContain('non-draggable');
+      expect(html).not.toContain(`>${label}<`);
+    },
+  );
+});

--- a/src/renderer/components/agentSidebar/SidebarTaskSearchButton.tsx
+++ b/src/renderer/components/agentSidebar/SidebarTaskSearchButton.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import SidebarSearchIcon from '../icons/SidebarSearchIcon';
+
+interface SidebarTaskSearchButtonProps {
+  label: string;
+  onClick: () => void;
+  className?: string;
+}
+
+const SidebarTaskSearchButton: React.FC<SidebarTaskSearchButtonProps> = ({
+  label,
+  onClick,
+  className = '',
+}) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-secondary transition-colors hover:bg-black/[0.03] dark:hover:bg-white/[0.04] ${className}`}
+      aria-label={label}
+      title={label}
+    >
+      <SidebarSearchIcon className="h-[18px] w-[18px]" />
+    </button>
+  );
+};
+
+export default SidebarTaskSearchButton;

--- a/src/renderer/components/cowork/constants.ts
+++ b/src/renderer/components/cowork/constants.ts
@@ -15,6 +15,20 @@ export const CoworkUiEvent = {
 
 export type CoworkUiEvent = typeof CoworkUiEvent[keyof typeof CoworkUiEvent];
 
+export const CoworkTaskSearchRequestSource = {
+  SidebarHeader: 'sidebar_header',
+  WindowsTitleBar: 'windows_title_bar',
+  KeyboardShortcut: 'keyboard_shortcut',
+  UiEvent: 'ui_event',
+} as const;
+
+export type CoworkTaskSearchRequestSource =
+  typeof CoworkTaskSearchRequestSource[keyof typeof CoworkTaskSearchRequestSource];
+
+export interface CoworkTaskSearchRequestEventDetail {
+  source?: CoworkTaskSearchRequestSource;
+}
+
 export const CoworkShortcutDirection = {
   Previous: 'previous',
   Next: 'next',

--- a/src/renderer/components/window/WindowsAppTitleBar.test.ts
+++ b/src/renderer/components/window/WindowsAppTitleBar.test.ts
@@ -25,6 +25,7 @@ const renderTitleBar = (
 
   return renderToStaticMarkup(React.createElement(WindowsAppTitleBar, {
     onToggleSidebar: () => undefined,
+    searchLabel: 'Search tasks',
     ...props,
   }));
 };
@@ -50,11 +51,40 @@ describe('WindowsAppTitleBar', () => {
     const html = renderTitleBar('win32', { sidebarWidth });
 
     expect(html).toContain(`style="width:${titleBarWidth}px"`);
-    expect(html).toContain('class="truncate text-sm font-medium text-foreground"');
+    expect(html).toContain('class="min-w-0 truncate text-sm font-medium text-foreground"');
+    expect(html).toContain('class="flex min-w-0 items-center gap-2 overflow-hidden"');
   });
 
   test.each(['darwin', 'linux'])('does not render on %s', (platform) => {
     expect(renderTitleBar(platform)).toBe('');
+  });
+
+  test('renders icon-only task search between the sidebar and filter actions', () => {
+    const html = renderTitleBar('win32', {
+      sidebarToggleLabel: 'Toggle sidebar',
+      onSearch: () => undefined,
+      searchLabel: 'Search tasks',
+      showFilterIcon: true,
+      filterLabel: 'Filter tasks',
+      onToggleFilter: () => undefined,
+    });
+
+    const sidebarActionIndex = html.indexOf('aria-label="Toggle sidebar"');
+    const searchActionIndex = html.indexOf('aria-label="Search tasks"');
+    const filterActionIndex = html.indexOf('aria-label="Filter tasks"');
+
+    expect(sidebarActionIndex).toBeGreaterThanOrEqual(0);
+    expect(searchActionIndex).toBeGreaterThan(sidebarActionIndex);
+    expect(filterActionIndex).toBeGreaterThan(searchActionIndex);
+    expect(html).toContain('class="h-[18px] w-[18px]"');
+    expect(html).toContain('title="Search tasks"');
+    expect(html).not.toContain('>Search tasks<');
+  });
+
+  test('does not render task search when no search callback is provided', () => {
+    const html = renderTitleBar('win32');
+
+    expect(html).not.toContain('aria-label="Search tasks"');
   });
 
   test('uses uniform Windows caption glyphs with full-size hit targets', () => {

--- a/src/renderer/components/window/WindowsAppTitleBar.tsx
+++ b/src/renderer/components/window/WindowsAppTitleBar.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
 
 import SidebarTaskFilterButton from '../agentSidebar/SidebarTaskFilterButton';
+import SidebarTaskSearchButton from '../agentSidebar/SidebarTaskSearchButton';
 import ComposeIcon from '../icons/ComposeIcon';
 import SidebarToggleIcon from '../icons/SidebarToggleIcon';
 import WindowTitleBar from './WindowTitleBar';
@@ -10,8 +11,10 @@ interface WindowsAppTitleBarProps {
   isSidebarCollapsed?: boolean;
   sidebarWidth?: number;
   onToggleSidebar?: () => void;
+  onSearch?: () => void;
   onNewChat?: () => void;
   sidebarToggleLabel?: string;
+  searchLabel: string;
   showFilterIcon?: boolean;
   filterLabel?: string;
   isFilterActive?: boolean;
@@ -26,8 +29,10 @@ const WindowsAppTitleBar: React.FC<WindowsAppTitleBarProps> = ({
   isSidebarCollapsed = false,
   sidebarWidth = 244,
   onToggleSidebar,
+  onSearch,
   onNewChat,
   sidebarToggleLabel,
+  searchLabel,
   showFilterIcon = false,
   filterLabel,
   isFilterActive = false,
@@ -72,18 +77,18 @@ const WindowsAppTitleBar: React.FC<WindowsAppTitleBarProps> = ({
         className={`flex h-full shrink-0 items-center ${isSidebarCollapsed ? 'gap-1' : 'justify-between'}`}
         style={isSidebarCollapsed ? undefined : { width: Math.max(0, sidebarWidth - 24) }}
       >
-        <div className="flex shrink-0 items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2 overflow-hidden">
           <img
             src="logo.png"
             alt=""
             draggable={false}
             className="h-4 w-4 max-w-none shrink-0"
           />
-          <span className={`${isSidebarCollapsed ? 'hidden' : 'truncate'} text-sm font-medium text-foreground`}>
+          <span className={`${isSidebarCollapsed ? 'hidden' : 'min-w-0 truncate'} text-sm font-medium text-foreground`}>
             LobsterAI
           </span>
         </div>
-        {(onToggleSidebar || showFilterIcon || onNewChat || updateBadge) && (
+        {(onToggleSidebar || onSearch || showFilterIcon || onNewChat || updateBadge) && (
           <div className="non-draggable flex shrink-0 items-center gap-1">
             {onToggleSidebar && (
               <button
@@ -95,6 +100,12 @@ const WindowsAppTitleBar: React.FC<WindowsAppTitleBarProps> = ({
               >
                 <SidebarToggleIcon className="h-4 w-4" isCollapsed={isSidebarCollapsed} />
               </button>
+            )}
+            {onSearch && (
+              <SidebarTaskSearchButton
+                onClick={onSearch}
+                label={searchLabel}
+              />
             )}
             {showFilterIcon && onToggleFilter && (
               <SidebarTaskFilterButton


### PR DESCRIPTION
- replace the labeled search entry with an icon-only action
- align appearance and layout across macOS and Windows
- add diagnostics and regression coverage


