### PR TITLE
fix(openclaw): key skill entries by frontmatter name

### DIFF
--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -202,6 +202,31 @@ describe('OpenClawConfigSync runtime config output', () => {
     } as never);
   };
 
+  test('keys OpenClaw skill entries by frontmatter name', async () => {
+    const sync = await createSync({
+      getSkillsList: () => [{
+        id: 'technology-news-search',
+        name: 'technology-search',
+        description: 'Technology news search',
+        enabled: false,
+        isOfficial: true,
+        isBuiltIn: true,
+        updatedAt: 0,
+        prompt: '',
+        skillPath: '/skills/technology-news-search/SKILL.md',
+      }],
+    });
+
+    const result = sync.sync('skill-entry-key');
+    expect(result.ok).toBe(true);
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.skills.entries).toMatchObject({
+      'technology-search': { enabled: false },
+    });
+    expect(config.skills.entries).not.toHaveProperty('technology-news-search');
+  });
+
   test('writes OpenClaw config fields required by LobsterAI patches', async () => {
     const legacyWorkingDirectory = path.join(tmpDir, 'legacy-working-directory');
     const mainAgentWorkingDirectory = path.join(tmpDir, 'main-agent-working-directory');

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -3697,7 +3697,7 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
     const skills = this.getSkillsList?.() ?? [];
     const entries: Record<string, { enabled: boolean }> = {};
     for (const skill of skills) {
-      entries[skill.id] = { enabled: skill.enabled };
+      entries[skill.name] = { enabled: skill.enabled };
     }
     return entries;
   }


### PR DESCRIPTION
## Summary

Use each skill's parsed frontmatter `name` when generating OpenClaw `skills.entries`. OpenClaw resolves enable overrides by that name, so directory/frontmatter mismatches previously made UI toggles silently ineffective.

## Related Issue

Addresses the skill-key mismatch reported in #2441. The broader user-config merge proposal in that issue is intentionally out of scope.

## Changes Made

- key generated OpenClaw skill overrides by `SkillRecord.name`
- add focused runtime-config coverage for a directory/frontmatter name mismatch

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] `vitest run src/main/libs/openclawConfigSync.runtime.test.ts -t "keys OpenClaw skill entries by frontmatter name"`
- [x] changed-file ESLint with zero warnings

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] The focused unit test passes locally

## Electron-Specific Changes

- [x] Changes to main process (`src/main/`)
- [ ] Changes to preload script
- [ ] Changes to IPC communication
- [ ] Changes to window management

## Additional Notes

No UI, IPC, storage, or OpenClaw runtime patch changes.