### PR TITLE
fix(openclaw): key skills.entries by frontmatter name

### DIFF
--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -202,6 +202,31 @@ describe('OpenClawConfigSync runtime config output', () => {
     } as never);
   };
 
+  test('keys OpenClaw skill entries by frontmatter name, not directory id', async () => {
+    const sync = await createSync({
+      // Mirrors bundled skills whose SKILL.md frontmatter name differs from
+      // the directory-derived id (see issue #2441): OpenClaw resolves
+      // skills.entries overrides by frontmatter name only.
+      getSkillsList: () => [
+        { id: 'technology-news-search', name: 'technology-search', enabled: false },
+        { id: 'remotion', name: 'remotion-best-practices', enabled: false },
+        { id: 'weather', name: 'weather', enabled: true },
+      ],
+    });
+
+    const result = sync.sync('skill-entry-keys');
+    expect(result.ok).toBe(true);
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.skills.entries).toMatchObject({
+      'technology-search': { enabled: false },
+      'remotion-best-practices': { enabled: false },
+      weather: { enabled: true },
+    });
+    expect(config.skills.entries).not.toHaveProperty('technology-news-search');
+    expect(config.skills.entries).not.toHaveProperty('remotion');
+  });
+
   test('writes OpenClaw config fields required by LobsterAI patches', async () => {
     const legacyWorkingDirectory = path.join(tmpDir, 'legacy-working-directory');
     const mainAgentWorkingDirectory = path.join(tmpDir, 'main-agent-working-directory');

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -1849,7 +1849,7 @@ type OpenClawConfigSyncDeps = {
   getAskUserCallbackUrl?: () => string | null;
   getMediaCallbackUrl?: () => string | null;
   getMcpBridgeSecret?: () => string;
-  getSkillsList?: () => Array<{ id: string; enabled: boolean }>;
+  getSkillsList?: () => Array<{ id: string; name: string; enabled: boolean }>;
   getAgents?: () => Agent[];
   getUserPlugins?: () => Array<{ pluginId: string; enabled: boolean; config?: Record<string, unknown> }>;
   canUseMediaGeneration?: () => boolean;
@@ -1877,7 +1877,7 @@ export class OpenClawConfigSync {
   private readonly getAskUserCallbackUrl?: () => string | null;
   private readonly getMediaCallbackUrl?: () => string | null;
   private readonly getMcpBridgeSecret?: () => string;
-  private readonly getSkillsList?: () => Array<{ id: string; enabled: boolean }>;
+  private readonly getSkillsList?: () => Array<{ id: string; name: string; enabled: boolean }>;
   private readonly getAgents?: () => Agent[];
   private readonly getUserPlugins: () => Array<{ pluginId: string; enabled: boolean; config?: Record<string, unknown> }>;
   private readonly canUseMediaGeneration: () => boolean;
@@ -3692,12 +3692,24 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
   /**
    * Build per-skill `enabled` overrides from the LobsterAI SkillManager state,
    * so that skills disabled in the LobsterAI UI are also hidden from OpenClaw.
+   *
+   * Entries must be keyed by the skill's frontmatter `name`, not the
+   * directory-derived `id`: OpenClaw resolves these overrides through
+   * `resolveSkillKey()`, which uses the frontmatter name (falling back to the
+   * directory name only when the frontmatter has none — the same fallback
+   * SkillManager applies to `SkillRecord.name`).
    */
   private buildSkillEntries(): Record<string, { enabled: boolean }> {
     const skills = this.getSkillsList?.() ?? [];
     const entries: Record<string, { enabled: boolean }> = {};
     for (const skill of skills) {
-      entries[skill.id] = { enabled: skill.enabled };
+      const existing = entries[skill.name];
+      if (existing && existing.enabled !== skill.enabled) {
+        console.warn(
+          `[OpenClawConfigSync] Skills with duplicate name "${skill.name}" disagree on enabled state; last one wins`,
+        );
+      }
+      entries[skill.name] = { enabled: skill.enabled };
     }
     return entries;
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2167,7 +2167,7 @@ const getOpenClawConfigSync = (): OpenClawConfigSync => {
       getSkillsList: () =>
         getSkillManager()
           .listSkills()
-          .map(s => ({ id: s.id, enabled: s.enabled })),
+          .map(s => ({ id: s.id, name: s.name, enabled: s.enabled })),
       getTelegramInstances: () => {
         try {
           return getIMGatewayManager().getIMStore().getTelegramInstances();


### PR DESCRIPTION
OpenClaw resolves skills.entries overrides via resolveSkillKey(), i.e. the skill frontmatter name, but LobsterAI wrote directory-derived ids. Any directory/frontmatter mismatch made the UI skill toggle silently ineffective. Key entries by SkillRecord.name and pass name through the getSkillsList wiring.

Refs #2441