### PR TITLE
fix(account): align credits icon color

### DIFF
--- a/src/renderer/components/LoginButton.tsx
+++ b/src/renderer/components/LoginButton.tsx
@@ -312,7 +312,7 @@ const UserMenu: React.FC<UserMenuProps> = ({
       {/* Account destinations */}
       <div className="border-b border-border py-1">
         <AccountMenuAction
-          icon={<PlusCircleIcon className="h-4 w-4 shrink-0 text-secondary" />}
+          icon={<PlusCircleIcon className="h-4 w-4 shrink-0 text-black dark:text-white" />}
           label={i18nService.t('authCreditsRemaining')}
           trailing={(
             <span className="ml-auto flex shrink-0 items-center gap-1 text-xs font-medium text-foreground">


### PR DESCRIPTION
## Summary
- align the credits balance icon color with the adjacent account menu icons
- keep the icon consistent in both light and dark themes

## Testing
- `npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 src/renderer/components/LoginButton.tsx`
- `npm run build`

## UI impact
- color-only change in the account popover; no layout or behavior changes