### PR TITLE
fix(cowork): keep turn process expanded until an answer exists

### DIFF
--- a/src/renderer/components/cowork/AssistantTurnBlock.tsx
+++ b/src/renderer/components/cowork/AssistantTurnBlock.tsx
@@ -26,6 +26,7 @@ import { reportConversationBlockAction } from './conversationAnalytics';
 import MediaPollingIndicator from './MediaPollingIndicator';
 import { MessageCopyButton } from './MessageActionButton';
 import {
+  canFoldTurnProcess,
   chunkConsolidatedItemsForDisplay,
   collectMediaPollCounts,
   type ConsolidatedItem,
@@ -712,11 +713,16 @@ const AssistantTurnBlock: React.FC<{
   // Once the turn completes, everything before the final answer folds behind
   // a single duration line so the user reads input → answer, expanding only
   // when they want the process. A turn with subagents still running is not
-  // complete — their working cards must stay visible.
+  // complete — their working cards must stay visible. Neither is a turn with
+  // no trailing answer yet (it ended waiting for subagents, or sits in the
+  // gap before the parent run resumes after they hand back): folding then
+  // would hide everything behind an empty duration line.
   const answerStartIndex = getTurnAnswerStartIndex(renderChunks);
   const processChunks = renderChunks.slice(0, answerStartIndex);
   const answerChunks = renderChunks.slice(answerStartIndex);
-  const shouldFoldProcess = !isStreamingTurn && !hasRunningSubagents && processChunks.length > 0;
+  const shouldFoldProcess = !isStreamingTurn
+    && !hasRunningSubagents
+    && canFoldTurnProcess(renderChunks, answerStartIndex);
   const processContainsSearchTarget = Boolean(searchTargetMessageId) && processChunks.some(
     (chunk) => chunk.kind === 'item'
       && chunk.item.type === 'assistant'

--- a/src/renderer/components/cowork/messageDisplayUtils.test.ts
+++ b/src/renderer/components/cowork/messageDisplayUtils.test.ts
@@ -5,6 +5,7 @@ import { computeDiffStats } from './DiffView';
 import {
   buildConversationTurns,
   buildDisplayItems,
+  canFoldTurnProcess,
   chunkConsolidatedItemsForDisplay,
   type ConsolidatedItem,
   formatElapsedDuration,
@@ -281,6 +282,31 @@ test('turn answer start index splits trailing answer text from the process', () 
   // an answer-only turn folds nothing
   const answerOnly = chunkConsolidatedItemsForDisplay([activityTextItem('text-1')]);
   expect(getTurnAnswerStartIndex(answerOnly)).toBe(0);
+});
+
+test('turn process only folds once a trailing answer exists', () => {
+  // Completed turn: tools followed by the final answer text → foldable.
+  const completed = chunkConsolidatedItemsForDisplay([
+    activityToolItem('tool-1'),
+    activityTextItem('text-final'),
+  ]);
+  expect(canFoldTurnProcess(completed, getTurnAnswerStartIndex(completed))).toBe(true);
+
+  // Multi-agent wait: the turn ends with a sessions_yield tool while the
+  // parent waits for subagents to hand back — no answer yet, never fold.
+  const waitingOnSubagents = chunkConsolidatedItemsForDisplay([
+    activityTextItem('text-plan'),
+    activityToolItem('spawn-1', 'sessions_spawn'),
+    activityTextItem('text-progress'),
+    activityToolItem('yield-1', 'sessions_yield'),
+  ]);
+  expect(
+    canFoldTurnProcess(waitingOnSubagents, getTurnAnswerStartIndex(waitingOnSubagents)),
+  ).toBe(false);
+
+  // Answer-only turn: nothing to fold.
+  const answerOnlyTurn = chunkConsolidatedItemsForDisplay([activityTextItem('text-1')]);
+  expect(canFoldTurnProcess(answerOnlyTurn, getTurnAnswerStartIndex(answerOnlyTurn))).toBe(false);
 });
 
 test('turn activity fingerprint changes as streamed content grows', () => {

--- a/src/renderer/components/cowork/messageDisplayUtils.ts
+++ b/src/renderer/components/cowork/messageDisplayUtils.ts
@@ -1270,6 +1270,19 @@ export const getTurnAnswerStartIndex = (chunks: ConsolidatedRenderChunk[]): numb
   return index;
 };
 
+/**
+ * Whether a non-streaming turn's process may fold behind the duration line.
+ * Folding requires both a process to hide and a visible trailing answer —
+ * a turn that still ends with work items (e.g. waiting for subagents to
+ * hand control back, or the gap before the parent run resumes afterwards)
+ * has produced no result yet, and folding it would leave only an empty
+ * duration line that reads as a failure.
+ */
+export const canFoldTurnProcess = (
+  chunks: ConsolidatedRenderChunk[],
+  answerStartIndex: number,
+): boolean => answerStartIndex > 0 && answerStartIndex < chunks.length;
+
 export type ActivityGroupSummary = {
   stepCount: number;
 };


### PR DESCRIPTION
Folding required only that the turn had stopped streaming and had no running subagents, so a turn that ended mid-wait (e.g. right after a sessions_yield, before the parent run resumes) collapsed into an empty duration line that read as a failure. Require a trailing answer chunk before folding via canFoldTurnProcess.