### PR TITLE
fix(scheduled-task): cap cron run history page size

### DIFF
--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -300,6 +300,17 @@ function applyLocalAnnounceDeliveryNormalization(
   return { platform, rawTo, parsedConversation };
 }
 
+function describeRunFilter(
+  filter?: import('../../../scheduledTask/types').RunFilter,
+): Record<string, string | undefined> | null {
+  if (!filter) return null;
+  return {
+    startDate: filter.startDate,
+    endDate: filter.endDate,
+    status: filter.status,
+  };
+}
+
 async function restoreAnnounceDeliveryHintsFromGateway(
   normalizedInput: Record<string, any>,
   context: AnnounceNormalizationContext,
@@ -675,9 +686,28 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
       filter?: import('../../../scheduledTask/types').RunFilter,
     ) => {
       try {
+        console.debug('[ScheduledTask] list job run history request:', JSON.stringify({
+          taskId,
+          limit,
+          offset,
+          filter: describeRunFilter(filter),
+        }));
         const runs = await getCronJobService().listRuns(taskId, limit, offset, filter);
+        console.debug('[ScheduledTask] list job run history result:', JSON.stringify({
+          taskId,
+          limit,
+          offset,
+          returnedCount: runs.length,
+        }));
         return { success: true, runs };
       } catch (error) {
+        console.warn('[ScheduledTask] list job run history failed:', JSON.stringify({
+          taskId,
+          limit,
+          offset,
+          filter: describeRunFilter(filter),
+          error: error instanceof Error ? error.message : String(error),
+        }));
         return {
           success: false,
           error: error instanceof Error ? error.message : 'Failed to list runs',
@@ -707,12 +737,29 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
       filter?: import('../../../scheduledTask/types').RunFilter,
     ) => {
       try {
+        console.debug('[ScheduledTask] list all run history request:', JSON.stringify({
+          limit,
+          offset,
+          filter: describeRunFilter(filter),
+        }));
         if (!(await ensureScheduledTaskGatewayClient(getOpenClawRuntimeAdapter))) {
+          console.debug('[ScheduledTask] list all run history deferred; gateway is not ready.');
           return { success: true, ready: false, runs: [] };
         }
         const runs = await getCronJobService().listAllRuns(limit, offset, filter);
+        console.debug('[ScheduledTask] list all run history result:', JSON.stringify({
+          limit,
+          offset,
+          returnedCount: runs.length,
+        }));
         return { success: true, ready: true, runs };
       } catch (error) {
+        console.warn('[ScheduledTask] list all run history failed:', JSON.stringify({
+          limit,
+          offset,
+          filter: describeRunFilter(filter),
+          error: error instanceof Error ? error.message : String(error),
+        }));
         return {
           success: false,
           error: error instanceof Error ? error.message : 'Failed to list all runs',

--- a/src/renderer/services/scheduledTask.ts
+++ b/src/renderer/services/scheduledTask.ts
@@ -59,6 +59,15 @@ function checkTasksForAnomalies(tasks: ScheduledTask[]): void {
   showToast(msg);
 }
 
+function describeRunFilter(filter?: RunFilter): Record<string, string | undefined> | null {
+  if (!filter) return null;
+  return {
+    startDate: filter.startDate,
+    endDate: filter.endDate,
+    status: filter.status,
+  };
+}
+
 export class ScheduledTaskService {
   private cleanupFns: (() => void)[] = [];
   private initialized = false;
@@ -310,25 +319,56 @@ export class ScheduledTaskService {
     const requestId = this.allRunsRequestId + 1;
     this.allRunsRequestId = requestId;
     try {
+      console.debug('[ScheduledTasks] loading all run history', {
+        limit,
+        offset,
+        initial: isInitialRequest,
+        filter: describeRunFilter(filter),
+      });
       const result = await api.listAllRuns(limit, offset, filter);
       if (this.allRunsRequestId !== requestId) return;
       if (result.ready === false) {
+        console.debug('[ScheduledTasks] all run history request deferred; gateway is not ready', {
+          limit,
+          offset,
+          filter: describeRunFilter(filter),
+        });
         store.dispatch(setAllRunsStatus(ScheduledTaskDataStatus.Starting));
         return;
       }
       if (result.success && result.runs) {
         const hasMore = (result.runs as unknown[]).length >= (limit ?? 50);
+        console.debug('[ScheduledTasks] loaded all run history', {
+          limit,
+          offset,
+          returnedCount: result.runs.length,
+          hasMore,
+          filter: describeRunFilter(filter),
+        });
         if (offset && offset > 0) {
           store.dispatch(appendAllRuns({ runs: result.runs, hasMore }));
         } else {
           store.dispatch(setAllRuns({ runs: result.runs, hasMore }));
         }
       } else if (isInitialRequest) {
-        store.dispatch(setAllRunsError(result.error || 'Failed to load scheduled task history'));
+        const message = result.error || 'Failed to load scheduled task history';
+        console.warn('[ScheduledTasks] all run history request failed', {
+          limit,
+          offset,
+          filter: describeRunFilter(filter),
+          error: message,
+        });
+        store.dispatch(setAllRunsError(message));
       }
     } catch (err: unknown) {
       if (this.allRunsRequestId !== requestId) return;
       const message = err instanceof Error ? err.message : String(err);
+      console.warn('[ScheduledTasks] all run history request threw', {
+        limit,
+        offset,
+        filter: describeRunFilter(filter),
+        error: message,
+      });
       if (isInitialRequest) {
         store.dispatch(setAllRunsError(message));
       }

--- a/src/scheduledTask/cronJobService.test.ts
+++ b/src/scheduledTask/cronJobService.test.ts
@@ -269,6 +269,76 @@ describe('CronJobService run history filtering', () => {
       true,
     );
   });
+
+  test('paginates large global run requests within the gateway limit', async () => {
+    const job = makeGatewayJob({ id: 'job-1', name: 'User task' });
+    const entries = Array.from({ length: 450 }, (_, index) => ({
+      ts: 1_000 - index,
+      jobId: 'job-1',
+      status: GatewayStatus.Ok,
+      runAtMs: 1_000 - index,
+    }));
+    const runRequests: unknown[] = [];
+    const service = new CronJobService({
+      getGatewayClient: () => ({
+        request: async <T>(method: string, params?: unknown) => {
+          if (method === 'cron.list') {
+            return { jobs: [job] } as T;
+          }
+          if (method === 'cron.runs') {
+            runRequests.push(params);
+            const runParams = params as { offset?: number; limit?: number } | undefined;
+            const start = runParams?.offset ?? 0;
+            const end = start + (runParams?.limit ?? entries.length);
+            return { entries: entries.slice(start, end) } as T;
+          }
+          return {} as T;
+        },
+      }),
+      ensureGatewayReady: async () => {},
+    });
+
+    const runs = await service.listAllRuns(450, 0);
+
+    expect(runs).toHaveLength(450);
+    expect(runRequests.map(params => (params as { limit?: number }).limit)).toEqual([200, 200, 50]);
+    expect(runRequests.every(params => (params as { limit?: number }).limit! <= 200)).toBe(true);
+  });
+
+  test('paginates large job run requests within the gateway limit', async () => {
+    const job = makeGatewayJob({ id: 'job-1', name: 'User task' });
+    const entries = Array.from({ length: 450 }, (_, index) => ({
+      ts: 1_000 - index,
+      jobId: 'job-1',
+      status: GatewayStatus.Ok,
+      runAtMs: 1_000 - index,
+    }));
+    const runRequests: unknown[] = [];
+    const service = new CronJobService({
+      getGatewayClient: () => ({
+        request: async <T>(method: string, params?: unknown) => {
+          if (method === 'cron.list') {
+            return { jobs: [job] } as T;
+          }
+          if (method === 'cron.runs') {
+            runRequests.push(params);
+            const runParams = params as { offset?: number; limit?: number } | undefined;
+            const start = runParams?.offset ?? 0;
+            const end = start + (runParams?.limit ?? entries.length);
+            return { entries: entries.slice(start, end) } as T;
+          }
+          return {} as T;
+        },
+      }),
+      ensureGatewayReady: async () => {},
+    });
+
+    const runs = await service.listRuns('job-1', 450, 0);
+
+    expect(runs).toHaveLength(450);
+    expect(runRequests.map(params => (params as { limit?: number }).limit)).toEqual([200, 200, 50]);
+    expect(runRequests.every(params => (params as { limit?: number }).limit! <= 200)).toBe(true);
+  });
 });
 
 describe('CronJobService delivery cache', () => {

--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -126,6 +126,41 @@ interface GatewayRunLogEntry {
   deliveryError?: string;
 }
 
+const CRON_RUNS_MIN_PAGE_SIZE = 50;
+const CRON_RUNS_MAX_PAGE_SIZE = 200;
+
+function normalizeRunPageNumber(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+function getGatewayRunPageSize(visibleLimit: number): number {
+  if (visibleLimit <= 0) return 0;
+  return Math.min(
+    Math.max(visibleLimit, CRON_RUNS_MIN_PAGE_SIZE),
+    CRON_RUNS_MAX_PAGE_SIZE,
+  );
+}
+
+function getGatewayRunRequestLimit(pageSize: number, remainingVisible: number): number {
+  return Math.min(
+    pageSize,
+    Math.max(remainingVisible, CRON_RUNS_MIN_PAGE_SIZE),
+  );
+}
+
+function logGatewayRunPageClamp(
+  scope: 'job' | 'all',
+  visibleLimit: number,
+  visibleOffset: number,
+  pageSize: number,
+): void {
+  if (visibleLimit <= CRON_RUNS_MAX_PAGE_SIZE) return;
+  console.debug(
+    `[CronJobService] paginating ${scope} run history within gateway limit: requestedLimit=${visibleLimit}, offset=${visibleOffset}, gatewayPageSize=${pageSize}.`,
+  );
+}
+
 interface CronJobServiceDeps {
   getGatewayClient: () => GatewayClientLike | null;
   ensureGatewayReady: () => Promise<void>;
@@ -713,20 +748,22 @@ export class CronJobService {
     if (job && isInternalScheduledTaskJob(job)) return [];
 
     const client = await this.client();
-    const visibleLimit = Math.max(0, limit);
-    const visibleOffset = Math.max(0, offset);
+    const visibleLimit = normalizeRunPageNumber(limit);
+    const visibleOffset = normalizeRunPageNumber(offset);
     if (visibleLimit === 0) return [];
 
     const visibleRuns: ScheduledTaskRun[] = [];
     let skippedVisible = 0;
     let rawOffset = 0;
-    const pageSize = Math.max(visibleLimit, 50);
+    const pageSize = getGatewayRunPageSize(visibleLimit);
+    logGatewayRunPageClamp('job', visibleLimit, visibleOffset, pageSize);
 
     while (visibleRuns.length < visibleLimit) {
+      const requestLimit = getGatewayRunRequestLimit(pageSize, visibleLimit - visibleRuns.length);
       const result = await client.request<{ entries?: GatewayRunLogEntry[] }>('cron.runs', {
         scope: 'job',
         id: jobId,
-        limit: pageSize,
+        limit: requestLimit,
         offset: rawOffset,
         sortDir: 'desc',
         ...(filter?.startDate && { startMs: new Date(filter.startDate + 'T00:00:00').getTime() }),
@@ -747,7 +784,7 @@ export class CronJobService {
       }
 
       rawOffset += entries.length;
-      if (entries.length < pageSize) break;
+      if (entries.length < requestLimit) break;
     }
 
     return visibleRuns;
@@ -772,8 +809,8 @@ export class CronJobService {
     filter?: RunFilter,
   ): Promise<ScheduledTaskRunWithName[]> {
     const client = await this.client();
-    const visibleLimit = Math.max(0, limit);
-    const visibleOffset = Math.max(0, offset);
+    const visibleLimit = normalizeRunPageNumber(limit);
+    const visibleOffset = normalizeRunPageNumber(offset);
     if (visibleLimit === 0) return [];
 
     let jobs: GatewayJob[] = [];
@@ -790,12 +827,14 @@ export class CronJobService {
     const visibleRuns: Array<{ entry: GatewayRunLogEntry; run: ScheduledTaskRun }> = [];
     let skippedVisible = 0;
     let rawOffset = 0;
-    const pageSize = Math.max(visibleLimit, 50);
+    const pageSize = getGatewayRunPageSize(visibleLimit);
+    logGatewayRunPageClamp('all', visibleLimit, visibleOffset, pageSize);
 
     while (visibleRuns.length < visibleLimit) {
+      const requestLimit = getGatewayRunRequestLimit(pageSize, visibleLimit - visibleRuns.length);
       const result = await client.request<{ entries?: GatewayRunLogEntry[] }>('cron.runs', {
         scope: 'all',
-        limit: pageSize,
+        limit: requestLimit,
         offset: rawOffset,
         sortDir: 'desc',
         ...(filter?.startDate && { startMs: new Date(filter.startDate + 'T00:00:00').getTime() }),
@@ -817,7 +856,7 @@ export class CronJobService {
       }
 
       rawOffset += entries.length;
-      if (entries.length < pageSize) break;
+      if (entries.length < requestLimit) break;
     }
 
     return visibleRuns.map(({ entry, run }) => ({


### PR DESCRIPTION
Prevent scheduled task history loading from passing a cron.runs limit above the OpenClaw gateway maximum. Large history requests now paginate internally while preserving the requested visible result count.

Add renderer and IPC diagnostics for run history requests, results, and errors, plus regression coverage for global and per-task history pagination.

