### PR TITLE
fix(installer): support silent upload-first web builds

### DIFF
--- a/patches/app-builder-lib+24.13.3.patch
+++ b/patches/app-builder-lib+24.13.3.patch
@@ -258,7 +258,7 @@ index 8ec0be3..253545c 100644
      quit
    ${elseif} $0 != "OK"
 -    Messagebox MB_RETRYCANCEL|MB_ICONEXCLAMATION "Unable to download application package from $packageUrl (status: $0).$\r$\n$\r$\nPlease check your internet connection and retry." IDRETRY download
-+    Messagebox MB_RETRYCANCEL|MB_ICONEXCLAMATION "${U+4E0B}${U+8F7D}${U+5B89}${U+88C5}${U+7EC4}${U+4EF6}${U+5931}${U+8D25}${U+FF08}${U+72B6}${U+6001}${U+FF1A}$0${U+FF09}${U+3002}$\r$\n$\r$\n${U+8BF7}${U+68C0}${U+67E5}${U+7F51}${U+7EDC}${U+8FDE}${U+63A5}${U+540E}${U+70B9}${U+51FB}${U+201C}${U+91CD}${U+8BD5}${U+201D}${U+3002}" IDRETRY download
++    Messagebox MB_RETRYCANCEL|MB_ICONEXCLAMATION "${U+4E0B}${U+8F7D}${U+5B89}${U+88C5}${U+7EC4}${U+4EF6}${U+5931}${U+8D25}${U+FF08}${U+72B6}${U+6001}${U+FF1A}$0${U+FF09}${U+3002}$\r$\n$\r$\n${U+8BF7}${U+68C0}${U+67E5}${U+7F51}${U+7EDC}${U+8FDE}${U+63A5}${U+540E}${U+70B9}${U+51FB}${U+201C}${U+91CD}${U+8BD5}${U+201D}${U+3002}" /SD IDCANCEL IDRETRY download
 +    !ifmacrodef customBeforeInstallerQuit
 +      !insertmacro customBeforeInstallerQuit "web-package-download-failed"
 +    !endif
@@ -422,3 +422,50 @@ index 52a83df..0500e4e 100644
  		StrCpy $isForceMachineInstall "0"
  		StrCpy $isForceCurrentInstall "0"
  		!ifmacrodef customInstallmode
+
+diff --git a/node_modules/app-builder-lib/out/targets/differentialUpdateInfoBuilder.js b/node_modules/app-builder-lib/out/targets/differentialUpdateInfoBuilder.js
+index 0a88df9..ea03f275 100644
+--- a/node_modules/app-builder-lib/out/targets/differentialUpdateInfoBuilder.js
++++ b/node_modules/app-builder-lib/out/targets/differentialUpdateInfoBuilder.js
+@@ -2,8 +2,10 @@
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.createBlockmap = exports.appendBlockmap = exports.configureDifferentialAwareArchiveOptions = exports.createNsisWebDifferentialUpdateInfo = exports.BLOCK_MAP_FILE_SUFFIX = void 0;
+ const builder_util_1 = require("builder-util");
++const fs_1 = require("fs/promises");
+ const path = require("path");
+ const appBuilder_1 = require("../util/appBuilder");
++const hash_1 = require("../util/hash");
+ exports.BLOCK_MAP_FILE_SUFFIX = ".blockmap";
+ function createNsisWebDifferentialUpdateInfo(artifactPath, packageFiles) {
+     if (packageFiles == null) {
+@@ -58,6 +60,30 @@ function configureDifferentialAwareArchiveOptions(archiveOptions) {
+ }
+ exports.configureDifferentialAwareArchiveOptions = configureDifferentialAwareArchiveOptions;
+ async function appendBlockmap(file) {
++    if (process.env.LOBSTERAI_REUSE_NSIS_WEB_PACKAGE === "1") {
++        const fileStat = await (0, fs_1.stat)(file);
++        if (fileStat.size < 4) {
++            throw new Error(`Cannot reuse embedded block map from ${file}: file is too small`);
++        }
++        const footer = Buffer.allocUnsafe(4);
++        const handle = await (0, fs_1.open)(file, "r");
++        try {
++            await handle.read(footer, 0, footer.length, fileStat.size - footer.length);
++        }
++        finally {
++            await handle.close();
++        }
++        const blockMapSize = footer.readUInt32BE(0);
++        if (blockMapSize <= 0 || blockMapSize + footer.length >= fileStat.size) {
++            throw new Error(`Cannot reuse embedded block map from ${file}: invalid footer size ${blockMapSize}`);
++        }
++        builder_util_1.log.info({ file: builder_util_1.log.filePath(file) }, "reusing existing embedded block map");
++        return {
++            size: fileStat.size,
++            blockMapSize,
++            sha512: await (0, hash_1.hashFile)(file),
++        };
++    }
+     builder_util_1.log.info({ file: builder_util_1.log.filePath(file) }, "building embedded block map");
+     return await (0, appBuilder_1.executeAppBuilderAsJson)(["blockmap", "--input", file, "--compression", "deflate"]);
+ }

--- a/patches/app-builder-lib+24.13.3.patch
+++ b/patches/app-builder-lib+24.13.3.patch
@@ -422,7 +422,6 @@ index 52a83df..0500e4e 100644
  		StrCpy $isForceMachineInstall "0"
  		StrCpy $isForceCurrentInstall "0"
  		!ifmacrodef customInstallmode
-
 diff --git a/node_modules/app-builder-lib/out/targets/differentialUpdateInfoBuilder.js b/node_modules/app-builder-lib/out/targets/differentialUpdateInfoBuilder.js
 index 0a88df9..ea03f275 100644
 --- a/node_modules/app-builder-lib/out/targets/differentialUpdateInfoBuilder.js

--- a/scripts/build-env.cjs
+++ b/scripts/build-env.cjs
@@ -7,6 +7,7 @@ const BuildEnv = {
   ChannelBuild: 'LOBSTERAI_CHANNEL_BUILD',
   Keyfrom: 'KEYFROM',
   SilentOnDoubleClick: 'LOBSTERAI_SILENT_ON_DOUBLE_CLICK',
+  ReuseWebPackage: 'LOBSTERAI_REUSE_NSIS_WEB_PACKAGE',
   WebInstaller: 'LOBSTERAI_WEB_INSTALLER',
   WebPkgUrl: 'LOBSTERAI_WEB_PKG_URL',
   WebPkgBaseUrl: 'LOBSTERAI_WEB_PKG_BASE_URL',

--- a/scripts/dist-win-channel.cjs
+++ b/scripts/dist-win-channel.cjs
@@ -19,7 +19,7 @@ const USAGE = `Usage:
 Builds the regular full installer (npm run dist:win) for the given channel.
 Use --silent when the generated installer should enter NSIS silent mode even
 when the user double-clicks it without passing /S.
-For the web-installer variants use: npm run dist:win:web`;
+For the web-installer variants, including --silent builds, use: npm run dist:win:web`;
 
 function fail(message) {
   console.error(`[ChannelBuild] ${message}`);

--- a/scripts/dist-win-web.cjs
+++ b/scripts/dist-win-web.cjs
@@ -6,6 +6,7 @@
 // reproducible from any terminal state (see LOBSTERAI_WEB_* handling below).
 
 const { spawnSync } = require('child_process');
+const { createHash } = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const { parseArgs } = require('util');
@@ -14,13 +15,43 @@ const { BuildEnv, CHANNEL_SCOPED_ENV_VARS } = require('./build-env.cjs');
 const { normalizeKeyfrom } = require('./build-keyfrom.cjs');
 
 const REPO_ROOT = path.join(__dirname, '..');
+const RELEASE_DIR = path.join(REPO_ROOT, 'release');
+const WEB_OUTPUT_DIR = path.join(RELEASE_DIR, 'nsis-web');
+const PREPACKAGED_APP_DIR = path.join(RELEASE_DIR, 'win-unpacked');
 const PLACEHOLDER_BASE_URL = 'https://placeholder.invalid/web-package';
 
+function webPackageFileName(version) {
+  return `lobsterai-${version}-x64.nsis.7z`;
+}
+
+function webSetupFileName(version, keyfrom, silentOnDoubleClick) {
+  return `LobsterAI-WebSetup-x64-${version}-${keyfrom}${silentOnDoubleClick ? '-silent' : ''}.exe`;
+}
+
+function sha256File(filePath) {
+  const hash = createHash('sha256');
+  const buffer = Buffer.allocUnsafe(4 * 1024 * 1024);
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    let bytesRead;
+    do {
+      bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
+      if (bytesRead > 0) {
+        hash.update(buffer.subarray(0, bytesRead));
+      }
+    } while (bytesRead > 0);
+  } finally {
+    fs.closeSync(fd);
+  }
+  return hash.digest('hex');
+}
+
 const USAGE = `Usage:
-  npm run dist:win:web -- --keyfrom <channel> [--pkg-base-url <cdn-dir> | --pkg-url <package-url>]
+  npm run dist:win:web -- --keyfrom <channel> [--silent] [--pkg-base-url <cdn-dir> | --pkg-url <package-url>]
 
 Modes:
-  --pkg-base-url  one-pass build; the installer downloads <dir>/<keyfrom>/LobsterAI-<version>-x64.nsis.7z
+  --silent        make direct launches enter NSIS silent mode without requiring /S
+  --pkg-base-url  one-pass build; the installer downloads <dir>/<keyfrom>/lobsterai-<version>-x64.nsis.7z
   --pkg-url       stub-only rebuild with the exact package URL (upload-first flow, e.g. NOS)
   (no URL flag)   full build with a placeholder URL, to produce the .nsis.7z for upload;
                   the unusable WebSetup exe from this pass is deleted afterwards
@@ -37,6 +68,7 @@ try {
   ({ values } = parseArgs({
     options: {
       keyfrom: { type: 'string' },
+      silent: { type: 'boolean', default: false },
       'pkg-url': { type: 'string' },
       'pkg-base-url': { type: 'string' },
       'dry-run': { type: 'boolean', default: false },
@@ -56,6 +88,7 @@ if (normalizeKeyfrom(keyfrom) !== keyfrom) {
 
 const pkgUrl = (values['pkg-url'] || '').trim();
 const pkgBaseUrl = (values['pkg-base-url'] || '').trim();
+const silentOnDoubleClick = values.silent === true;
 if (pkgUrl && pkgBaseUrl) {
   fail('--pkg-url and --pkg-base-url are mutually exclusive.');
 }
@@ -69,40 +102,68 @@ for (const name of CHANNEL_SCOPED_ENV_VARS) {
     delete env[name];
   }
 }
+env[BuildEnv.ChannelBuild] = '1';
 env[BuildEnv.Keyfrom] = keyfrom;
+env[BuildEnv.SilentOnDoubleClick] = silentOnDoubleClick ? '1' : '0';
 env[BuildEnv.WebInstaller] = '1';
 
 const stubOnly = pkgUrl !== '';
 const usesPlaceholder = !stubOnly && pkgBaseUrl === '';
 let command;
 let args;
+let stubSourcePackageHash;
+let stubSourcePackagePath;
 if (stubOnly) {
-  for (const dir of ['dist', 'dist-electron']) {
-    if (!fs.existsSync(path.join(REPO_ROOT, dir))) {
-      fail(`${dir}/ not found — run the first pass (npm run dist:win:web -- --keyfrom ${keyfrom}) before the stub-only pass.`);
+  if (!values['dry-run']) {
+    const version = require('../package.json').version;
+    const packagePath = path.join(WEB_OUTPUT_DIR, webPackageFileName(version));
+    for (const [label, requiredPath] of [
+      ['prepackaged app directory', PREPACKAGED_APP_DIR],
+      ['web package', packagePath],
+    ]) {
+      if (!fs.existsSync(requiredPath)) {
+        fail(
+          `${label} not found at ${path.relative(REPO_ROOT, requiredPath)} — ` +
+            `run the first pass (npm run dist:win:web -- --keyfrom ${keyfrom}) before the stub-only pass.`,
+        );
+      }
     }
+
+    // The stub-only pass skips prebuild, so .keyfrom-build still holds the first
+    // pass's channel; a mismatch would name the stub after one channel while the
+    // uploaded package carries another.
+    const keyfromBuildPath = path.join(REPO_ROOT, '.keyfrom-build', 'keyfrom.json');
+    if (fs.existsSync(keyfromBuildPath)) {
+      let firstPassKeyfrom;
+      try {
+        firstPassKeyfrom = JSON.parse(fs.readFileSync(keyfromBuildPath, 'utf8'))?.keyfrom;
+      } catch {
+        firstPassKeyfrom = undefined; // unreadable file: fall through to the build
+      }
+      if (firstPassKeyfrom && firstPassKeyfrom !== keyfrom) {
+        fail(
+          `--keyfrom ${keyfrom} does not match the first pass (${firstPassKeyfrom}). ` +
+            `Rerun the first pass with --keyfrom ${keyfrom}, or pass --keyfrom ${firstPassKeyfrom}.`,
+        );
+      }
+    }
+
+    stubSourcePackageHash = sha256File(packagePath);
+    stubSourcePackagePath = packagePath;
   }
-  // The stub-only pass skips prebuild, so .keyfrom-build still holds the first
-  // pass's channel; a mismatch would name the stub after one channel while the
-  // uploaded package carries another.
-  const keyfromBuildPath = path.join(REPO_ROOT, '.keyfrom-build', 'keyfrom.json');
-  if (fs.existsSync(keyfromBuildPath)) {
-    let firstPassKeyfrom;
-    try {
-      firstPassKeyfrom = JSON.parse(fs.readFileSync(keyfromBuildPath, 'utf8'))?.keyfrom;
-    } catch {
-      firstPassKeyfrom = undefined; // unreadable file: fall through to the build
-    }
-    if (firstPassKeyfrom && firstPassKeyfrom !== keyfrom) {
-      fail(
-        `--keyfrom ${keyfrom} does not match the first pass (${firstPassKeyfrom}). ` +
-          `Rerun the first pass with --keyfrom ${keyfrom}, or pass --keyfrom ${firstPassKeyfrom}.`,
-      );
-    }
-  }
+  env[BuildEnv.ReuseWebPackage] = '1';
   env[BuildEnv.WebPkgUrl] = pkgUrl;
   command = 'npx';
-  args = ['electron-builder', '--win', 'nsis-web', '--x64', '--config', 'scripts/electron-builder-config.cjs'];
+  args = [
+    'electron-builder',
+    '--win',
+    'nsis-web',
+    '--x64',
+    '--prepackaged',
+    path.relative(REPO_ROOT, PREPACKAGED_APP_DIR),
+    '--config',
+    'scripts/electron-builder-config.cjs',
+  ];
 } else {
   env[BuildEnv.WebPkgBaseUrl] = pkgBaseUrl || PLACEHOLDER_BASE_URL;
   command = 'npm';
@@ -111,13 +172,28 @@ if (stubOnly) {
 
 const mode = stubOnly ? 'stub-only' : usesPlaceholder ? 'full-build-with-placeholder-url' : 'full-build-with-base-url';
 console.log(`[WebBuild] keyfrom=${keyfrom} mode=${mode}`);
+console.log(
+  `[WebBuild] silentOnDoubleClick=${silentOnDoubleClick} source=${silentOnDoubleClick ? 'cli' : 'default'}`,
+);
 console.log(`[WebBuild] package ${stubOnly ? 'url' : 'base url'}: ${stubOnly ? pkgUrl : env[BuildEnv.WebPkgBaseUrl]}`);
 if (usesPlaceholder) {
   console.log('[WebBuild] no URL flag given: building with a placeholder so the .nsis.7z can be uploaded first.');
 }
 
+const logUploadFollowUp = () => {
+  const version = require('../package.json').version;
+  const packagePath = path.relative(REPO_ROOT, path.join(WEB_OUTPUT_DIR, webPackageFileName(version)));
+  console.log(`[WebBuild] next: upload ${packagePath}, then run`);
+  console.log(
+    `[WebBuild]   npm run dist:win:web -- --keyfrom ${keyfrom}${silentOnDoubleClick ? ' --silent' : ''} --pkg-url <uploaded-url>`,
+  );
+};
+
 if (values['dry-run']) {
   console.log(`[WebBuild] dry-run: would execute \`${command} ${args.join(' ')}\``);
+  if (usesPlaceholder) {
+    logUploadFollowUp();
+  }
   process.exit(0);
 }
 
@@ -131,24 +207,34 @@ if (result.status !== 0) {
   process.exit(result.status ?? 1);
 }
 
+if (stubOnly) {
+  const packageHashAfterBuild = sha256File(stubSourcePackagePath);
+  if (packageHashAfterBuild !== stubSourcePackageHash) {
+    fail(
+      `stub-only build changed ${path.relative(REPO_ROOT, stubSourcePackagePath)}; ` +
+        'the uploaded payload would fail the WebSetup integrity check.',
+    );
+  }
+  console.log(`[WebBuild] verified uploaded payload unchanged: sha256=${packageHashAfterBuild}`);
+}
+
 if (usesPlaceholder) {
   // The stub from this pass points at the placeholder URL and must never be
   // shipped; remove it so only the real second-pass stub can reach a landing page.
-  const releaseDir = path.join(REPO_ROOT, 'release');
-  let removed = 0;
-  if (fs.existsSync(releaseDir)) {
-    for (const name of fs.readdirSync(releaseDir)) {
-      if (name.includes('WebSetup')) {
-        fs.rmSync(path.join(releaseDir, name), { force: true });
-        console.log(`[WebBuild] deleted throwaway ${name}`);
-        removed += 1;
-      }
-    }
-  }
-  if (removed === 0) {
-    console.warn('[WebBuild] no WebSetup artifact found to delete; check the build output.');
-  }
   const version = require('../package.json').version;
-  console.log(`[WebBuild] next: upload release/LobsterAI-${version}-x64.nsis.7z, then run`);
-  console.log(`[WebBuild]   npm run dist:win:web -- --keyfrom ${keyfrom} --pkg-url <uploaded-url>`);
+  const throwawayStub = path.join(
+    WEB_OUTPUT_DIR,
+    webSetupFileName(version, keyfrom, silentOnDoubleClick),
+  );
+  if (!fs.existsSync(throwawayStub)) {
+    fail(`throwaway WebSetup artifact not found at ${path.relative(REPO_ROOT, throwawayStub)}.`);
+  }
+  fs.rmSync(throwawayStub, { force: true });
+  console.log(`[WebBuild] deleted throwaway ${path.relative(REPO_ROOT, throwawayStub)}`);
+
+  const packagePath = path.join(WEB_OUTPUT_DIR, webPackageFileName(version));
+  if (!fs.existsSync(packagePath)) {
+    fail(`web package not found at ${path.relative(REPO_ROOT, packagePath)}.`);
+  }
+  logUploadFollowUp();
 }

--- a/scripts/electron-builder-config.cjs
+++ b/scripts/electron-builder-config.cjs
@@ -27,7 +27,7 @@ function isTruthyBuildEnv(name) {
 // <productName>-<version>-x64.nsis.7z.
 function expectedPackageFileName() {
   const version = require('../package.json').version;
-  return `${config.productName}-${version}-x64.nsis.7z`;
+  return `${config.productName.toLowerCase()}-${version}-x64.nsis.7z`;
 }
 
 // Returns the complete package download URL baked into the web installer.
@@ -134,7 +134,7 @@ if (isWebInstallerEnabled()) {
   };
   config.nsisWeb = {
     appPackageUrl: resolveWebPackageUrl(keyfrom),
-    artifactName: `LobsterAI-WebSetup-\${arch}-\${version}-${keyfrom}.\${ext}`,
+    artifactName: `LobsterAI-WebSetup-\${arch}-\${version}-${keyfrom}${silentOnDoubleClick ? '-silent' : ''}.\${ext}`,
   };
   console.log(`[WebInstaller] nsis-web target enabled, app package url: ${config.nsisWeb.appPackageUrl}`);
 }

--- a/specs/features/channel-silent-installer/2026-08-18-channel-silent-installer-design.md
+++ b/specs/features/channel-silent-installer/2026-08-18-channel-silent-installer-design.md
@@ -4,11 +4,11 @@
 
 LobsterAI 当前 Windows NSIS 安装包已经支持 `/S` 静默安装，企业或渠道侧可以通过命令行完成无人值守部署。但部分渠道希望用户直接双击安装包时也进入静默安装流程，减少安装向导步骤和人工选择，适配批量分发、预装、网管工具下发等场景。
 
-本功能在现有渠道包构建能力上增加显式“双击静默”打包参数：同一套 `dist:win:channel` 构建链路根据命令行参数生成不同安装器行为。传入 `--silent` 的渠道包在用户直接打开时自动进入 NSIS silent mode；未传入该参数时保持普通交互式安装向导。已有 `/S` 命令行能力保持不变。
+本功能在现有渠道包构建能力上增加显式“双击静默”打包参数：`dist:win:channel` 完整安装包和 `dist:win:web` Web 安装包均根据命令行参数生成不同安装器行为。传入 `--silent` 的渠道包在用户直接打开时自动进入 NSIS silent mode；未传入该参数时保持普通交互式安装向导。已有 `/S` 命令行能力保持不变。
 
 ### 1.1 目标
 
-- 允许通过显式打包参数生成“用户双击也静默安装”的 Windows 完整安装包。
+- 允许通过显式打包参数生成“用户双击也静默安装”的 Windows 完整安装包或 Web 安装包。
 - 继续复用现有 NSIS 安装器、渠道归因、签名、OpenClaw runtime 打包和资源恢复流程。
 - 将双击静默行为固化在构建产物中，不依赖用户机器环境变量或安装时读取 `.keyfrom-build`。
 - 保持普通渠道包的安装向导体验不变。
@@ -41,8 +41,8 @@ LobsterAI 当前 Windows NSIS 安装包已经支持 `/S` 静默安装，企业�
 
 ### 3.1 双击静默打包参数
 
-- 新增 `dist:win:channel` 显式参数 `--silent`。
-- 参数只对 Windows NSIS 完整安装包生效；macOS、Linux 和 `nsis-web` 不纳入首版范围。
+- `dist:win:channel` 和 `dist:win:web` 均支持显式参数 `--silent`。
+- 参数只对 Windows NSIS 完整安装包和 `nsis-web` 生效；macOS、Linux 不读取该参数。
 - 未传入参数时默认 `silentOnDoubleClick=false`。
 - 构建脚本必须清理同名环境变量，不从开发者 shell 中继承隐式环境变量。
 - 渠道值继续复用现有规则：小写，允许 `a-z`、`0-9`、`_`、`-`，长度 1 到 64。
@@ -52,6 +52,8 @@ LobsterAI 当前 Windows NSIS 安装包已经支持 `/S` 静默安装，企业�
 ```bash
 npm run dist:win:channel -- --keyfrom dictbind
 npm run dist:win:channel -- --keyfrom dictbind --silent
+npm run dist:win:web -- --keyfrom dictbind --silent
+npm run dist:win:web -- --keyfrom dictbind --silent --pkg-url <uploaded-url>
 ```
 
 示例行为：
@@ -61,10 +63,12 @@ npm run dist:win:channel -- --keyfrom dictbind --silent
 | `--keyfrom dictbind` | `false` | 双击打开普通安装向导 |
 | `--keyfrom dictbind --silent` | `true` | 双击直接静默安装 |
 | `--keyfrom official` | `false` | 双击打开普通安装向导 |
+| `dist:win:web -- --keyfrom dictbind --silent` | `true` | 两阶段构建均保留静默策略，最终 WebSetup 双击直接静默安装 |
 
 ### 3.2 构建脚本路由
 
 - `scripts/dist-win-channel.cjs` 在设置 `KEYFROM` 后，同时解析本次构建的 `silentOnDoubleClick`。
+- `scripts/dist-win-web.cjs` 使用相同参数，并在 upload-first 流程输出包含 `--silent` 的第二阶段命令，避免最终 stub 丢失静默策略。第二阶段通过 `--prepackaged release/win-unpacked` 复用第一阶段应用目录，并设置版本锁定的 app-builder 补丁开关：读取现有 `.nsis.7z` 尾部的 embedded block map 元数据而不再次追加；构建结束后再校验 payload 的 SHA-256 完全一致，防止 WebSetup 内嵌完整性信息与已上传文件不匹配。
 - 渠道构建脚本需要清理所有安装器策略相关环境变量，避免上一轮构建残留影响下一轮。
 - 当 `silentOnDoubleClick=true` 时，构建日志必须明确输出该渠道为双击静默包。
 - dry-run 模式需要输出将要执行的 keyfrom 和安装器 UI 策略。
@@ -78,6 +82,7 @@ npm run dist:win:channel -- --keyfrom dictbind --silent
 
 ```text
 LobsterAI-Setup-x64-${version}-${keyfrom}-silent.exe
+LobsterAI-WebSetup-x64-${version}-${keyfrom}-silent.exe
 ```
 
 - 如果不改变产物名，至少需要在构建日志和发布记录中明确标注 silent 行为。
@@ -131,7 +136,7 @@ ${EndIf}
 | `scripts/dist-win-channel.cjs` | 解析 keyfrom 和双击静默参数，注入本次构建环境，输出 dry-run 和构建日志 |
 | `scripts/electron-builder-config.cjs` | 将策略转换为 NSIS 编译期宏和可选 artifact 命名标记 |
 | `scripts/nsis-installer.nsh` | 在安装器初始化阶段调用 `SetSilent silent`，复用现有 silent 分支 |
-| `scripts/dist-win-web.cjs` | 首版明确不支持双击静默策略，避免 web installer 混用 |
+| `scripts/dist-win-web.cjs` | 在完整构建和 stub-only 构建中显式注入同一双击静默策略；stub-only 复用预打包目录并强制校验 payload 哈希不变 |
 | `specs/features/keyfrom-channel-attribution/` | 保持渠道归因语义说明，不承载安装器 UI 策略 |
 
 主进程和 Renderer 不需要感知安装器双击静默策略；应用启动后的 `keyfrom` 归因仍通过现有 `.keyfrom-build` 资源读取和 SQLite 持久化完成。
@@ -161,4 +166,6 @@ ${EndIf}
 5. `install-timing.log` 对双击静默包记录 `ui_mode=silent`，并能区分是构建参数触发还是命令行 `/S` 触发。
 6. 双击静默包遇到资源解压失败、旧版本迁移失败或校验失败时，仍保留现有日志、回滚和错误默认处理。
 7. 构建日志能清楚显示 `keyfrom`、`silentOnDoubleClick` 和产物路径，发布人员可以区分普通渠道包和双击静默渠道包。
-8. macOS、Linux、web installer 和应用运行时 UI 不受该功能影响。
+8. 传入 `dist:win:web -- --keyfrom dictbind --silent` 时，最终 WebSetup 产物名包含 `-silent`，双击后下载与安装过程均不展示安装器 UI。
+9. WebSetup 静默下载失败时使用非交互默认选项退出，不因错误弹窗阻塞无人值守流程。
+10. macOS、Linux 和应用运行时 UI 不受该功能影响。

--- a/tests/channelInstallPolicy.test.ts
+++ b/tests/channelInstallPolicy.test.ts
@@ -13,6 +13,62 @@ const runChannelDryRun = (args: string[], env: NodeJS.ProcessEnv = {}) => (
   })
 );
 
+const runWebDryRun = (args: string[], env: NodeJS.ProcessEnv = {}) => (
+  spawnSync(process.execPath, ['scripts/dist-win-web.cjs', ...args, '--dry-run'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ...env,
+    },
+    encoding: 'utf8',
+  })
+);
+
+const readWebArtifactName = (silentOnDoubleClick: boolean) => (
+  spawnSync(
+    process.execPath,
+    [
+      '-e',
+      "const config = require('./scripts/electron-builder-config.cjs'); process.stdout.write(`artifact=${config.nsisWeb.artifactName}\\n`);",
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        KEYFROM: 'dictbind',
+        LOBSTERAI_CHANNEL_BUILD: '1',
+        LOBSTERAI_SILENT_ON_DOUBLE_CLICK: silentOnDoubleClick ? '1' : '0',
+        LOBSTERAI_WEB_INSTALLER: '1',
+        LOBSTERAI_WEB_PKG_URL: 'https://cdn.example.test/LobsterAI.nsis.7z',
+      },
+      encoding: 'utf8',
+    },
+  )
+);
+
+const readWebBasePackageUrl = () => (
+  spawnSync(
+    process.execPath,
+    [
+      '-e',
+      "const config = require('./scripts/electron-builder-config.cjs'); process.stdout.write(`packageUrl=${config.nsisWeb.appPackageUrl}\\n`);",
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        KEYFROM: 'dictbind',
+        LOBSTERAI_CHANNEL_BUILD: '1',
+        LOBSTERAI_SILENT_ON_DOUBLE_CLICK: '1',
+        LOBSTERAI_WEB_INSTALLER: '1',
+        LOBSTERAI_WEB_PKG_URL: '',
+        LOBSTERAI_WEB_PKG_BASE_URL: 'https://cdn.example.test/releases',
+      },
+      encoding: 'utf8',
+    },
+  )
+);
+
 describe('channel installer build flags', () => {
   test('keeps channel builds interactive unless the silent flag is explicit', () => {
     const plain = runChannelDryRun(['--keyfrom', 'dictbind']);
@@ -39,5 +95,94 @@ describe('channel installer build flags', () => {
     expect(inherited.stdout).toContain('silentOnDoubleClick=false source=default');
     expect(inherited.stderr).toContain('ignoring inherited LOBSTERAI_CHANNEL_BUILD=1');
     expect(inherited.stderr).toContain('ignoring inherited LOBSTERAI_SILENT_ON_DOUBLE_CLICK=1');
+  });
+});
+
+describe('web installer build flags', () => {
+  test('keeps web installers interactive unless the silent flag is explicit', () => {
+    const plain = runWebDryRun([
+      '--keyfrom',
+      'dictbind',
+      '--pkg-base-url',
+      'https://cdn.example.test/releases',
+    ]);
+
+    expect(plain.status).toBe(0);
+    expect(plain.stdout).toContain('keyfrom=dictbind');
+    expect(plain.stdout).toContain('silentOnDoubleClick=false source=default');
+  });
+
+  test('carries the silent flag through the two-pass web build instructions', () => {
+    const silent = runWebDryRun(['--keyfrom', 'dictbind', '--silent']);
+
+    expect(silent.status).toBe(0);
+    expect(silent.stdout).toContain('silentOnDoubleClick=true source=cli');
+    expect(silent.stdout).toContain(
+      'npm run dist:win:web -- --keyfrom dictbind --silent --pkg-url <uploaded-url>',
+    );
+    expect(silent.stdout).toMatch(
+      /next: upload release[\\/]nsis-web[\\/]lobsterai-[^\s]+-x64\.nsis\.7z/,
+    );
+  });
+
+  test('uses the prepackaged app for the stub-only pass', () => {
+    const stubOnly = runWebDryRun([
+      '--keyfrom',
+      'dictbind',
+      '--silent',
+      '--pkg-url',
+      'https://cdn.example.test/lobsterai.nsis.7z',
+    ]);
+
+    expect(stubOnly.status).toBe(0);
+    expect(stubOnly.stdout).toContain('mode=stub-only');
+    expect(stubOnly.stdout).toMatch(
+      /electron-builder --win nsis-web --x64 --prepackaged release[\\/]win-unpacked/,
+    );
+  });
+
+  test('does not leak inherited silent flags into a web build', () => {
+    const inherited = runWebDryRun(
+      [
+        '--keyfrom',
+        'ci_plain_web',
+        '--pkg-base-url',
+        'https://cdn.example.test/releases',
+      ],
+      {
+        LOBSTERAI_CHANNEL_BUILD: '1',
+        LOBSTERAI_SILENT_ON_DOUBLE_CLICK: '1',
+      },
+    );
+
+    expect(inherited.status).toBe(0);
+    expect(inherited.stdout).toContain('silentOnDoubleClick=false source=default');
+    expect(inherited.stderr).toContain('ignoring inherited LOBSTERAI_CHANNEL_BUILD=1');
+    expect(inherited.stderr).toContain(
+      'ignoring inherited LOBSTERAI_SILENT_ON_DOUBLE_CLICK=1',
+    );
+  });
+
+  test('marks only double-click-silent web artifacts in their filename', () => {
+    const plain = readWebArtifactName(false);
+    const silent = readWebArtifactName(true);
+
+    expect(plain.status).toBe(0);
+    expect(plain.stdout).toContain(
+      'artifact=LobsterAI-WebSetup-${arch}-${version}-dictbind.${ext}',
+    );
+    expect(silent.status).toBe(0);
+    expect(silent.stdout).toContain(
+      'artifact=LobsterAI-WebSetup-${arch}-${version}-dictbind-silent.${ext}',
+    );
+  });
+
+  test('uses the actual lowercase electron-builder package name for base URLs', () => {
+    const probe = readWebBasePackageUrl();
+
+    expect(probe.status).toBe(0);
+    expect(probe.stdout).toMatch(
+      /packageUrl=https:\/\/cdn\.example\.test\/releases\/dictbind\/lobsterai-[^/\s]+-x64\.nsis\.7z/,
+    );
   });
 });

--- a/tests/windowsInstallerContract.test.ts
+++ b/tests/windowsInstallerContract.test.ts
@@ -22,6 +22,9 @@ const rootInstallerTemplate = repoFile(
 const webPackageTemplate = repoFile(
   'node_modules/app-builder-lib/templates/nsis/include/webPackage.nsh',
 );
+const differentialUpdateInfoBuilder = repoFile(
+  'node_modules/app-builder-lib/out/targets/differentialUpdateInfoBuilder.js',
+);
 const appBuilderPatch = repoFile('patches/app-builder-lib+24.13.3.patch');
 const electronBuilderConfig = JSON.parse(repoFile('electron-builder.json')) as {
   nsis?: { deleteAppDataOnUninstall?: boolean };
@@ -175,6 +178,27 @@ describe('Windows installer hardening contracts', () => {
     const cleanup = installerInclude.indexOf('phase=old-install-cleanup-scheduled');
     expect(commit).toBeGreaterThan(-1);
     expect(cleanup).toBeGreaterThan(commit);
+  });
+
+  test('does not block silent web installs on a download failure prompt', () => {
+    const failureMessage = webPackageTemplate
+      .split(/\r?\n/)
+      .find((line) => line.includes('Messagebox MB_RETRYCANCEL|MB_ICONEXCLAMATION'));
+
+    expect(failureMessage).toContain('/SD IDCANCEL IDRETRY download');
+    expect(appBuilderPatch).toContain('/SD IDCANCEL IDRETRY download');
+  });
+
+  test('reuses an uploaded web payload without appending another block map', () => {
+    expect(differentialUpdateInfoBuilder).toContain(
+      'process.env.LOBSTERAI_REUSE_NSIS_WEB_PACKAGE === "1"',
+    );
+    expect(differentialUpdateInfoBuilder).toContain('footer.readUInt32BE(0)');
+    expect(differentialUpdateInfoBuilder).toContain(
+      '"reusing existing embedded block map"',
+    );
+    expect(differentialUpdateInfoBuilder).toContain('hash_1.hashFile)(file)');
+    expect(appBuilderPatch).toContain('LOBSTERAI_REUSE_NSIS_WEB_PACKAGE');
   });
 
   test('terminates the attempt after rename verification rollback', () => {


### PR DESCRIPTION
## Summary

- add an upload-first two-pass Windows web-installer flow for NOS-hosted payloads
- rebuild only the signed WebSetup stub while reusing the already uploaded package and embedded block map
- enforce a before/after SHA-256 invariant so the stub pass cannot invalidate the uploaded payload
- preserve direct-launch silent behavior and make download failures non-blocking in silent mode

## Verification

- npm test -- channelInstallPolicy windowsInstallerContract (35 tests passed)
- changed-file ESLint and git diff --check passed
- patch-package parsed and applied successfully to a clean app-builder-lib 24.13.3 package
- completed a signed dictbind silent WebSetup build through the internal signing service
- verified installer and payload metadata, signatures, CDN lengths, and SHA hashes
- installed the CDN artifact locally; install-timing.log ended with phase=install-complete and the installed dictbind executable matched the packaged executable

## Notes

The repository-wide test run still has six pre-existing Windows/path-related failures outside these installer changes; the targeted installer tests pass.