### PR TITLE
fix(installer): hide banner for dictbind silent package

### DIFF
--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -1,5 +1,17 @@
 !include "FileFunc.nsh"
 
+; The Youdao Dictionary bound package owns the install progress UI. Suppress
+; LobsterAI's plugin-owned silent banner only for the explicitly
+; double-click-silent dictbind artifact. Other channels, ordinary /S installs,
+; interactive installers, update flows, and UAC behavior stay unchanged.
+!if "$%KEYFROM%" == "dictbind"
+  !if "$%LOBSTERAI_CHANNEL_BUILD%" == "1"
+    !if "$%LOBSTERAI_SILENT_ON_DOUBLE_CLICK%" == "1"
+      !define LOBSTERAI_HIDE_SILENT_BANNER
+    !endif
+  !endif
+!endif
+
 Var lobsterCurrentProcessPid
 Var lobsterInstallerAttemptId
 Var lobsterTargetProcessesStopStatus
@@ -708,9 +720,11 @@ FunctionEnd
     ; makensis builds used for local syntax checks reject any non-ASCII byte
     ; (the escapes are fine on the Windows build machine -- the webPackage
     ; patch ships them in production already).
-    ${If} ${Silent}
-      Banner::show /NOUNLOAD "${U+6B63}${U+5728}${U+66F4}${U+65B0} LobsterAI${U+FF0C}${U+8BF7}${U+7A0D}${U+5019}${U+2026}"
-    ${EndIf}
+    !ifndef LOBSTERAI_HIDE_SILENT_BANNER
+      ${If} ${Silent}
+        Banner::show /NOUNLOAD "${U+6B63}${U+5728}${U+66F4}${U+65B0} LobsterAI${U+FF0C}${U+8BF7}${U+7A0D}${U+5019}${U+2026}"
+      ${EndIf}
+    !endif
   !endif
 
   !ifndef BUILD_UNINSTALLER

--- a/specs/features/channel-silent-installer/2026-08-18-channel-silent-installer-design.md
+++ b/specs/features/channel-silent-installer/2026-08-18-channel-silent-installer-design.md
@@ -9,6 +9,7 @@ LobsterAI 当前 Windows NSIS 安装包已经支持 `/S` 静默安装，企业�
 ### 1.1 目标
 
 - 允许通过显式打包参数生成“用户双击也静默安装”的 Windows 完整安装包或 Web 安装包。
+- `dictbind --silent` 绑定包不显示 LobsterAI 自有的静默 Banner，由有道词典绑定流程承载安装体验。
 - 继续复用现有 NSIS 安装器、渠道归因、签名、OpenClaw runtime 打包和资源恢复流程。
 - 将双击静默行为固化在构建产物中，不依赖用户机器环境变量或安装时读取 `.keyfrom-build`。
 - 保持普通渠道包的安装向导体验不变。
@@ -93,8 +94,11 @@ LobsterAI-WebSetup-x64-${version}-${keyfrom}-silent.exe
 - 在 `scripts/nsis-installer.nsh` 的安装器初始化阶段处理双击静默。
 - 判断顺序应保证显式 `/S` 与渠道双击静默最终都进入同一 silent mode。
 - 双击静默包应在写安装日志前完成 `SetSilent silent`，保证 `ui_mode` 记录为 `silent`。
-- 原有 `${Silent}` 分支，包括静默 Banner、失败弹窗默认按钮、进程关闭、回滚和卸载路径，必须继续复用。
+- `keyfrom=dictbind` 且启用双击静默策略时，不调用插件自有的 `Banner::show`；该例外必须由编译期渠道与安装器策略共同限定，不能影响普通 `dictbind` 包或其他渠道包。
+- 除上述 Banner 展示例外外，原有 `${Silent}` 分支，包括失败弹窗默认按钮、进程关闭、回滚和卸载路径，必须继续复用。
+- 其他渠道和普通 `/S` 安装继续保留既有静默 Banner 行为。
 - 该行为只影响安装器 UI 展示，不跳过安装前置校验和失败保护。
+- Windows UAC、安装器 `RequestExecutionLevel` 和 Defender 排除项逻辑保持不变；系统是否显示提权确认由 Windows 策略决定。
 
 建议伪代码：
 
@@ -152,7 +156,7 @@ ${EndIf}
 | 用户对双击静默包传 `/D=<path>` | 遵循 NSIS silent install 对安装目录参数的既有规则 |
 | 未传入双击静默参数 | 默认交互式安装，不失败 |
 | 渠道值非法 | 构建脚本按现有规则失败或回退，不能生成未标识策略的异常包 |
-| 旧版本正在运行 | 复用现有进程停止、Banner 和日志逻辑 |
+| 旧版本正在运行 | 复用现有进程停止与日志逻辑；仅 `dictbind --silent` 不显示 Banner |
 | 安装资源解压失败 | 复用现有失败处理、日志、回滚和 silent MessageBox 默认选择 |
 | UAC 被取消 | 安装不继续，静默策略不绕过系统确认 |
 | 更新安装器带 `--updated` | 保持现有更新模式，不因打包参数隐藏必要进度 |
@@ -166,6 +170,7 @@ ${EndIf}
 5. `install-timing.log` 对双击静默包记录 `ui_mode=silent`，并能区分是构建参数触发还是命令行 `/S` 触发。
 6. 双击静默包遇到资源解压失败、旧版本迁移失败或校验失败时，仍保留现有日志、回滚和错误默认处理。
 7. 构建日志能清楚显示 `keyfrom`、`silentOnDoubleClick` 和产物路径，发布人员可以区分普通渠道包和双击静默渠道包。
-8. 传入 `dist:win:web -- --keyfrom dictbind --silent` 时，最终 WebSetup 产物名包含 `-silent`，双击后下载与安装过程均不展示安装器 UI。
+8. 传入 `dist:win:web -- --keyfrom dictbind --silent` 时，最终 WebSetup 产物名包含 `-silent`，双击后下载与安装过程均不展示 LobsterAI 安装器 UI；Windows UAC 不在此约束内。
 9. WebSetup 静默下载失败时使用非交互默认选项退出，不因错误弹窗阻塞无人值守流程。
 10. macOS、Linux 和应用运行时 UI 不受该功能影响。
+11. `dictbind` 非静默包、其他渠道的双击静默包以及普通 `/S` 安装仍保留各自既有 UI/Banner 行为。

--- a/tests/windowsInstallerContract.test.ts
+++ b/tests/windowsInstallerContract.test.ts
@@ -71,6 +71,25 @@ describe('Windows installer hardening contracts', () => {
     expect(initLog).toBeGreaterThan(setSilent);
   });
 
+  test('hides the silent banner only for double-click-silent dictbind artifacts', () => {
+    const policyEnd = installerInclude.indexOf('Var lobsterCurrentProcessPid');
+    const policy = installerInclude.slice(0, policyEnd);
+    const checkStart = installerInclude.indexOf('!macro customCheckAppRunning');
+    const checkEnd = installerInclude.indexOf('!macroend', checkStart);
+    const check = installerInclude.slice(checkStart, checkEnd);
+    const bannerGuard = check.indexOf('!ifndef LOBSTERAI_HIDE_SILENT_BANNER');
+    const bannerShow = check.indexOf('Banner::show /NOUNLOAD');
+
+    expect(policy).toContain('!if "$%KEYFROM%" == "dictbind"');
+    expect(policy).toContain('!if "$%LOBSTERAI_CHANNEL_BUILD%" == "1"');
+    expect(policy).toContain('!if "$%LOBSTERAI_SILENT_ON_DOUBLE_CLICK%" == "1"');
+    expect(policy).toContain('!define LOBSTERAI_HIDE_SILENT_BANNER');
+    expect(bannerGuard).toBeGreaterThan(-1);
+    expect(bannerShow).toBeGreaterThan(bannerGuard);
+    expect(check.slice(bannerGuard, bannerShow)).not.toContain('!else');
+    expect(installerInclude.match(/Banner::show \/NOUNLOAD/g)).toHaveLength(1);
+  });
+
   test('releases the installer current-directory lock before the update rename', () => {
     const switchOutPath = installerInclude.indexOf('SetOutPath "$PLUGINSDIR"');
     const rename = installerInclude.indexOf(


### PR DESCRIPTION
## Summary

- Hide the plugin-owned silent Banner only for dictbind double-click-silent channel artifacts.
- Preserve the existing Banner behavior for other silent install paths.
- Keep Windows UAC and RequestExecutionLevel behavior unchanged.
- Update the installer design spec and add contract coverage for the channel-specific guard.

## Verification

- npm test -- windowsInstallerContract channelInstallPolicy (36 tests passed)
- npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 tests/windowsInstallerContract.test.ts
- npm run dist:win:web -- --keyfrom dictbind --silent (signed two-stage build)
- CDN round-trip download matched the local SHA-256 and retained a valid Authenticode signature

## Electron / installer behavior

The change is compile-time scoped to the dictbind silent channel package. UAC, elevation level, updater behavior, ordinary command-line silent installs, and interactive installers are unchanged.