### PR TITLE
feat(dsh): add usage analytics for enable toggle and workbench open

### DIFF
--- a/specs/features/usage-analytics/2026-06-22-usage-analytics-design.md
+++ b/specs/features/usage-analytics/2026-06-22-usage-analytics-design.md
@@ -1083,6 +1083,43 @@ export const LogReporterActionPrefix = {
   - 不上传 IM 消息正文、prompt hash、会话 ID、session key、run ID、群 ID、用户 ID、账号 ID、实例 ID、Agent 名称、附件内容、文件名、本地路径或错误详情。
   - 只上传平台、会话状态和 Agent 路由等结构化摘要。
 
+#### 2.4.42 `lobsterai_experimental_setting_changed`
+
+- 状态：已实现。
+- 触发时机：用户在「设置 -> 实验功能」切换 DeepSeek Harness（dsh）开关，主进程 `dsh:setEnabled` 写入配置成功后发送。写入失败不发送；新值与旧值相同（例如重复点击）不发送。
+- 事件含义：统计主动试用实验功能的用户规模。开启事件的去重安装数即"主动试用过 dsh 的人数"，关闭事件用于观察试用后的放弃比例。
+- 业务参数：
+  - `settingKey`：string，变更的实验功能设置项 key。当前取值为 `dshEnabled`。
+  - `settingValue`：boolean，变更后的值。
+  - `previousValue`：boolean，变更前的值。
+  - `source`：string，触发来源。当前固定为 `settings_experimental`。
+- 发送与容错口径：
+  - 事件由主进程直接发送，与 `lobsterai_im_prompt_submit` 共用同一 `MainLogReporter`、使用统计开关和通用参数。
+  - 上报调用包在 try/catch 中，任何上报异常只写警告日志，不影响开关写入、运行时停止或 OpenClaw 配置同步。
+- 隐私边界：不上传 dsh home 路径、runtime 路径、provider 配置或模型信息。
+
+#### 2.4.43 `lobsterai_dsh_action`
+
+- 状态：已实现。
+- 触发时机：用户在「设置 -> 实验功能」点击「打开工作台」，主进程 `dsh:openWorkbench` 处理完成后发送一次。引擎就绪并成功打开或聚焦工作台窗口时发送 `success`；功能未开启、runtime 安装失败、引擎启动失败或窗口打开异常时发送 `failed`。首次打开包含 runtime 下载和解包，仍只在最终结果产生后发送一次，下载进度不单独上报。
+- 事件含义：统计 dsh 工作台的实际使用情况。`result=success` 的当日去重安装数除以当日任意事件的去重安装数即工作台日渗透率；该口径只统计用户主动打开工作台，不统计主 Agent 通过 `dsh_code_task` 的自动委托。
+- 业务参数：
+  - `actionType`：string，动作类型。当前取值为 `open_workbench`。
+  - `source`：string，触发来源。当前固定为 `settings_experimental`。
+  - `phaseBefore`：string，点击时的引擎状态。当前取值包括 `not_installed`、`stopped`、`installing`、`starting`、`ready`、`failed`，用于区分首次安装打开和热打开。
+  - `result`：string，动作结果。当前取值为 `success` 或 `failed`。
+  - `errorCode`：string，失败分类；仅失败时发送。取值来自引擎状态机的 `DshEngineErrorCode`（`runtime_missing`、`runtime_invalid`、`install_failed`、`spawn_failed`、`ready_timeout`、`crashed_early`、`plugin_load_failed`），另有 `not_enabled`（功能未开启时被调用）和 `unknown`（引擎状态未携带本次失败的分类）。
+  - `errorDetail`：string，脱敏后的错误摘要；仅失败且存在错误对象时发送。用于区分 `install_failed` 背后的具体原因（校验和不匹配、HTTP 状态码、tar 不可用、解包不完整等）。
+- 错误摘要脱敏规则（`sanitizeDshErrorDetail`）：
+  - 当前用户 home 目录替换为 `~`，同时识别正斜杠和反斜杠写法，保留其后的相对路径便于定位。
+  - 其他绝对路径（两段以上的 POSIX 路径、带盘符的 Windows 路径）替换为 `<path>`。
+  - URL 去掉 query 和 fragment，只保留 origin 和 path。
+  - 连续空白折叠为单个空格，超过 200 字符截断并以 `…` 结尾。
+  - 引擎启动失败时主进程只把子进程日志尾巴写入本地日志，`errorDetail` 不包含子进程输出。
+- 隐私边界：
+  - 该事件是本文"不上传错误详情"约定的明确例外：只上传经上述规则脱敏和截断后的错误摘要，不上传完整文件路径、完整 URL、子进程日志、provider 配置、API Key 或工作台 URL。
+  - 不上传工作台内的会话内容、prompt 或文件内容。
+
 ### 2.5 请求流程
 
 ```text

--- a/src/main/ipcHandlers/dsh/analytics.test.ts
+++ b/src/main/ipcHandlers/dsh/analytics.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'vitest';
+
+import { LogReporterAction, LogReporterSource } from '../../../shared/analytics/constants';
+import { DshEngineErrorCode, DshEnginePhase } from '../../../shared/dshEngine/constants';
+import {
+  buildDshEnabledChangedEvent,
+  buildDshOpenWorkbenchEvent,
+  DSH_ANALYTICS_ERROR_DETAIL_MAX_LENGTH,
+  DshAnalyticsActionType,
+  DshAnalyticsErrorCode,
+  DshAnalyticsResult,
+  DshAnalyticsSettingKey,
+  resolveDshEngineErrorCode,
+  sanitizeDshErrorDetail,
+} from './analytics';
+
+const MAC_HOME = '/Users/jane doe';
+const WIN_HOME = 'C:\\Users\\Jane Doe';
+
+describe('sanitizeDshErrorDetail', () => {
+  test('replaces the home directory with ~ and keeps the tail for diagnosis', () => {
+    const error = new Error(`Invalid dsh runtime manifest at ${MAC_HOME}/Library/Application Support/LobsterAI/dsh/manifest.json`);
+    expect(sanitizeDshErrorDetail(error, MAC_HOME)).toBe(
+      'Invalid dsh runtime manifest at ~/Library/Application Support/LobsterAI/dsh/manifest.json'
+    );
+  });
+
+  test('masks absolute posix paths outside the home directory', () => {
+    const error = new Error('spawn /opt/homebrew/bin/tar ENOENT');
+    expect(sanitizeDshErrorDetail(error, MAC_HOME)).toBe('spawn <path> ENOENT');
+  });
+
+  test('masks another user home even when it is not the current one', () => {
+    const error = new Error('Another dsh is using /Users/someone-else/.dsh (lock_held)');
+    expect(sanitizeDshErrorDetail(error, MAC_HOME)).toBe('Another dsh is using <path> (lock_held)');
+  });
+
+  test('recognises a windows home logged with either separator', () => {
+    expect(sanitizeDshErrorDetail(new Error(`EPERM: ${WIN_HOME}\\AppData\\Roaming\\LobsterAI\\dsh`), WIN_HOME)).toBe(
+      'EPERM: ~\\AppData\\Roaming\\LobsterAI\\dsh'
+    );
+    expect(sanitizeDshErrorDetail(new Error('EPERM: c:/users/jane doe/AppData/Roaming'), WIN_HOME)).toBe(
+      'EPERM: ~/AppData/Roaming'
+    );
+  });
+
+  test('masks drive-letter windows paths outside the home directory', () => {
+    const error = new Error('tar not found at D:\\Tools\\tar.exe');
+    expect(sanitizeDshErrorDetail(error, WIN_HOME)).toBe('tar not found at <path>');
+  });
+
+  test('drops url queries and fragments but keeps the origin and path', () => {
+    const error = new Error('HTTP 403 from https://dl.example.com/dsh/rc7.tgz?token=secret#frag');
+    expect(sanitizeDshErrorDetail(error, MAC_HOME)).toBe('HTTP 403 from https://dl.example.com/dsh/rc7.tgz');
+  });
+
+  test('keeps structured messages untouched', () => {
+    const error = new Error('DeepSeek Harness engine failed to start (phase=failed, error=ready_timeout)');
+    expect(sanitizeDshErrorDetail(error, MAC_HOME)).toBe(
+      'DeepSeek Harness engine failed to start (phase=failed, error=ready_timeout)'
+    );
+    expect(sanitizeDshErrorDetail(new Error('Archive sha256 mismatch: expected abc, got def'), MAC_HOME)).toBe(
+      'Archive sha256 mismatch: expected abc, got def'
+    );
+  });
+
+  test('collapses whitespace and truncates long messages', () => {
+    const error = new Error(`first line\n  second\tline ${'x'.repeat(400)}`);
+    const detail = sanitizeDshErrorDetail(error, MAC_HOME);
+    expect(detail.startsWith('first line second line xxx')).toBe(true);
+    expect(detail).toHaveLength(DSH_ANALYTICS_ERROR_DETAIL_MAX_LENGTH);
+    expect(detail.endsWith('…')).toBe(true);
+  });
+
+  test('accepts non-Error values and an empty home directory', () => {
+    expect(sanitizeDshErrorDetail('plain string failure', '')).toBe('plain string failure');
+    expect(sanitizeDshErrorDetail({ code: 42 }, '')).toBe('[object Object]');
+    expect(sanitizeDshErrorDetail(undefined, '')).toBe('undefined');
+  });
+});
+
+describe('buildDshEnabledChangedEvent', () => {
+  test('reports an actual toggle with previous and next values', () => {
+    expect(buildDshEnabledChangedEvent(false, true)).toEqual({
+      action: LogReporterAction.ExperimentalSettingChanged,
+      settingKey: DshAnalyticsSettingKey.Enabled,
+      settingValue: true,
+      previousValue: false,
+      source: LogReporterSource.SettingsExperimental,
+    });
+    expect(buildDshEnabledChangedEvent(true, false)?.settingValue).toBe(false);
+  });
+
+  test('returns null when the value did not change', () => {
+    expect(buildDshEnabledChangedEvent(true, true)).toBeNull();
+    expect(buildDshEnabledChangedEvent(false, false)).toBeNull();
+  });
+});
+
+describe('resolveDshEngineErrorCode', () => {
+  test('uses the engine code only in terminal failure phases', () => {
+    expect(resolveDshEngineErrorCode({ phase: DshEnginePhase.Failed, errorCode: DshEngineErrorCode.InstallFailed }))
+      .toBe(DshEngineErrorCode.InstallFailed);
+    expect(resolveDshEngineErrorCode({ phase: DshEnginePhase.NotInstalled, errorCode: DshEngineErrorCode.RuntimeMissing }))
+      .toBe(DshEngineErrorCode.RuntimeMissing);
+  });
+
+  test('falls back to unknown when the phase carries no code for this failure', () => {
+    expect(resolveDshEngineErrorCode({ phase: DshEnginePhase.Failed, errorCode: null })).toBe(DshAnalyticsErrorCode.Unknown);
+    expect(resolveDshEngineErrorCode({ phase: DshEnginePhase.Ready, errorCode: DshEngineErrorCode.InstallFailed }))
+      .toBe(DshAnalyticsErrorCode.Unknown);
+    expect(resolveDshEngineErrorCode({ phase: DshEnginePhase.Stopped, errorCode: null })).toBe(DshAnalyticsErrorCode.Unknown);
+  });
+});
+
+describe('buildDshOpenWorkbenchEvent', () => {
+  test('omits error fields on success', () => {
+    expect(buildDshOpenWorkbenchEvent({ phaseBefore: DshEnginePhase.Ready, result: DshAnalyticsResult.Success })).toEqual({
+      action: LogReporterAction.DshAction,
+      actionType: DshAnalyticsActionType.OpenWorkbench,
+      source: LogReporterSource.SettingsExperimental,
+      phaseBefore: DshEnginePhase.Ready,
+      result: DshAnalyticsResult.Success,
+      errorCode: undefined,
+      errorDetail: undefined,
+    });
+  });
+
+  test('carries the error class and a masked detail on failure', () => {
+    const event = buildDshOpenWorkbenchEvent({
+      phaseBefore: DshEnginePhase.NotInstalled,
+      result: DshAnalyticsResult.Failed,
+      errorCode: DshEngineErrorCode.InstallFailed,
+      error: new Error(`Extracted runtime is incomplete at ${MAC_HOME}/Library/dsh, missing: bin/dsh`),
+      homeDir: MAC_HOME,
+    });
+    expect(event.result).toBe(DshAnalyticsResult.Failed);
+    expect(event.errorCode).toBe(DshEngineErrorCode.InstallFailed);
+    expect(event.errorDetail).toBe('Extracted runtime is incomplete at ~/Library/dsh, missing: bin/dsh');
+  });
+
+  test('defaults a failure without a class to unknown and skips detail without an error', () => {
+    const event = buildDshOpenWorkbenchEvent({ phaseBefore: DshEnginePhase.Stopped, result: DshAnalyticsResult.Failed });
+    expect(event.errorCode).toBe(DshAnalyticsErrorCode.Unknown);
+    expect(event.errorDetail).toBeUndefined();
+  });
+});

--- a/src/main/ipcHandlers/dsh/analytics.ts
+++ b/src/main/ipcHandlers/dsh/analytics.ts
@@ -1,0 +1,142 @@
+// Usage-analytics event builders for the experimental DeepSeek Harness
+// feature. Kept pure and Electron-free so the error-detail masking rules are
+// unit-testable; handlers.ts hands the results to the main-process reporter.
+
+import { LogReporterAction, LogReporterSource } from '../../../shared/analytics/constants';
+import { type DshEngineErrorCode, DshEnginePhase } from '../../../shared/dshEngine/constants';
+import type { MainLogEventParams } from '../../libs/mainLogReporter';
+
+export const DshAnalyticsActionType = {
+  OpenWorkbench: 'open_workbench',
+} as const;
+export type DshAnalyticsActionType = typeof DshAnalyticsActionType[keyof typeof DshAnalyticsActionType];
+
+export const DshAnalyticsSettingKey = {
+  Enabled: 'dshEnabled',
+} as const;
+export type DshAnalyticsSettingKey = typeof DshAnalyticsSettingKey[keyof typeof DshAnalyticsSettingKey];
+
+export const DshAnalyticsResult = {
+  Success: 'success',
+  Failed: 'failed',
+} as const;
+export type DshAnalyticsResult = typeof DshAnalyticsResult[keyof typeof DshAnalyticsResult];
+
+// Failure classes that do not come from the engine state machine.
+export const DshAnalyticsErrorCode = {
+  NotEnabled: 'not_enabled',
+  Unknown: 'unknown',
+} as const;
+export type DshAnalyticsErrorCode = typeof DshAnalyticsErrorCode[keyof typeof DshAnalyticsErrorCode];
+
+export const DSH_ANALYTICS_ERROR_DETAIL_MAX_LENGTH = 200;
+
+const HOME_PLACEHOLDER = '~';
+const PATH_PLACEHOLDER = '<path>';
+
+// Query strings and fragments are where URLs carry tokens; the origin and
+// path of a loopback URL are harmless and useful.
+const URL_QUERY_PATTERN = /(https?:\/\/[^\s?#'"]+)[?#][^\s'"]*/gi;
+// Two or more POSIX segments not already attached to `~`, a word, or another
+// slash (so a `~/Library/...` tail and the `//host/path` part of a URL survive).
+const POSIX_PATH_PATTERN = /(?<![\w~/])(?:\/[^\s/:'"`,;()[\]<>]+){2,}\/?/g;
+// Drive-letter Windows paths, either separator.
+const WINDOWS_PATH_PATTERN = /(?<![\w~])[A-Za-z]:[\\/](?:[^\s\\/:'"`,;()[\]<>]+[\\/]?)+/g;
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Matches the home directory with either separator style so a Windows path
+// that was logged with forward slashes is still recognised.
+const buildHomeDirPattern = (homeDir: string): RegExp | null => {
+  const trimmed = homeDir.trim().replace(/[\\/]+$/, '');
+  if (!trimmed) return null;
+  const source = trimmed
+    .split(/[\\/]+/)
+    .map(escapeRegExp)
+    .join('[\\\\/]+');
+  return new RegExp(source, 'gi');
+};
+
+const errorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return String(error);
+  } catch {
+    return '';
+  }
+};
+
+/**
+ * Reduces an error to a short diagnostic string safe to ship with an event:
+ * the user's home directory becomes `~`, other absolute paths become
+ * `<path>`, URL queries are dropped, whitespace is collapsed, and the result
+ * is capped at DSH_ANALYTICS_ERROR_DETAIL_MAX_LENGTH characters.
+ */
+export function sanitizeDshErrorDetail(error: unknown, homeDir: string): string {
+  let detail = errorMessage(error).replace(URL_QUERY_PATTERN, '$1');
+  const homePattern = buildHomeDirPattern(homeDir);
+  if (homePattern) {
+    detail = detail.replace(homePattern, HOME_PLACEHOLDER);
+  }
+  detail = detail
+    .replace(WINDOWS_PATH_PATTERN, PATH_PLACEHOLDER)
+    .replace(POSIX_PATH_PATTERN, PATH_PLACEHOLDER)
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (detail.length > DSH_ANALYTICS_ERROR_DETAIL_MAX_LENGTH) {
+    detail = `${detail.slice(0, DSH_ANALYTICS_ERROR_DETAIL_MAX_LENGTH - 1)}…`;
+  }
+  return detail;
+}
+
+/** Null when nothing changed, so a repeated toggle to the same value is not counted. */
+export function buildDshEnabledChangedEvent(previous: boolean, next: boolean): MainLogEventParams | null {
+  if (previous === next) return null;
+  return {
+    action: LogReporterAction.ExperimentalSettingChanged,
+    settingKey: DshAnalyticsSettingKey.Enabled,
+    settingValue: next,
+    previousValue: previous,
+    source: LogReporterSource.SettingsExperimental,
+  };
+}
+
+// Only the terminal phases carry a code that describes *this* failure; in
+// any other phase the field is either null or left over from an earlier run.
+export function resolveDshEngineErrorCode(state: {
+  phase: DshEnginePhase;
+  errorCode: DshEngineErrorCode | null;
+}): string {
+  if (state.phase === DshEnginePhase.Failed || state.phase === DshEnginePhase.NotInstalled) {
+    return state.errorCode ?? DshAnalyticsErrorCode.Unknown;
+  }
+  return DshAnalyticsErrorCode.Unknown;
+}
+
+export interface DshOpenWorkbenchEventInput {
+  /** Engine phase when the user clicked, before any install/start ran. */
+  phaseBefore: string;
+  result: DshAnalyticsResult;
+  /** Failure class; required for failed results. */
+  errorCode?: string;
+  /** Raw error; only a masked, truncated form of its message is reported. */
+  error?: unknown;
+  homeDir?: string;
+}
+
+export function buildDshOpenWorkbenchEvent(input: DshOpenWorkbenchEventInput): MainLogEventParams {
+  const failed = input.result === DshAnalyticsResult.Failed;
+  const errorDetail = failed && input.error !== undefined
+    ? sanitizeDshErrorDetail(input.error, input.homeDir ?? '')
+    : '';
+  return {
+    action: LogReporterAction.DshAction,
+    actionType: DshAnalyticsActionType.OpenWorkbench,
+    source: LogReporterSource.SettingsExperimental,
+    phaseBefore: input.phaseBefore,
+    result: input.result,
+    errorCode: failed ? (input.errorCode ?? DshAnalyticsErrorCode.Unknown) : undefined,
+    errorDetail: errorDetail || undefined,
+  };
+}

--- a/src/main/ipcHandlers/dsh/handlers.ts
+++ b/src/main/ipcHandlers/dsh/handlers.ts
@@ -24,7 +24,15 @@ import {
   resolveSharedDataHome,
   writeWriterLock,
 } from '../../libs/dshSharedHome';
+import type { MainLogEventParams } from '../../libs/mainLogReporter';
 import type { ResolvedMcpServer } from '../../libs/openclawConfigSync';
+import {
+  buildDshEnabledChangedEvent,
+  buildDshOpenWorkbenchEvent,
+  DshAnalyticsErrorCode,
+  DshAnalyticsResult,
+  resolveDshEngineErrorCode,
+} from './analytics';
 
 export interface DshStoreLike {
   get<T>(key: string): T | undefined;
@@ -39,6 +47,8 @@ export interface DshHandlerDeps {
   getDefaultCwd: () => string;
   getWorkbenchTitle: () => string;
   syncOpenClawConfig: (options: { reason: string; restartGatewayIfRunning?: boolean }) => Promise<unknown>;
+  /** Fire-and-forget usage analytics; must never throw into the caller. */
+  reportEvent: (params: MainLogEventParams) => void;
 }
 
 let moduleDeps: DshHandlerDeps | null = null;
@@ -74,6 +84,16 @@ function readDshFeatureConfig(store: DshStoreLike): DshFeatureConfig {
 
 export function isDshFeatureEnabled(store: DshStoreLike): boolean {
   return readDshFeatureConfig(store).enabled;
+}
+
+// Analytics is best-effort: a reporter failure must not fail the IPC call.
+function reportDshEvent(params: MainLogEventParams | null): void {
+  if (!params || !moduleDeps) return;
+  try {
+    moduleDeps.reportEvent(params);
+  } catch (error) {
+    console.warn('[DSH] Failed to report a usage analytics event', error);
+  }
 }
 
 function computeManagedSettings(): DshManagedSettings | null {
@@ -201,7 +221,9 @@ export function registerDshHandlers(deps: DshHandlerDeps): void {
   ipcMain.handle(DshIpcChannel.SetEnabled, async (_event, enabled: unknown) => {
     const store = deps.getStore();
     const next = enabled === true;
+    const previous = isDshFeatureEnabled(store);
     store.set(DSH_CONFIG_STORE_KEY, { enabled: next } satisfies DshFeatureConfig);
+    reportDshEvent(buildDshEnabledChangedEvent(previous, next));
     if (!next) {
       await stopDshFeatureRuntimes();
     }
@@ -221,11 +243,32 @@ export function registerDshHandlers(deps: DshHandlerDeps): void {
   });
 
   ipcMain.handle(DshIpcChannel.OpenWorkbench, async () => {
+    const manager = getDshEngineManager();
+    // Captured before anything runs so a failure can be read against the
+    // state the user clicked from (first install vs. warm start).
+    const phaseBefore = manager.getState().phase;
     if (!isDshFeatureEnabled(deps.getStore())) {
+      reportDshEvent(buildDshOpenWorkbenchEvent({
+        phaseBefore,
+        result: DshAnalyticsResult.Failed,
+        errorCode: DshAnalyticsErrorCode.NotEnabled,
+      }));
       throw new Error('DeepSeek Harness is not enabled');
     }
-    const url = await ensureDshEngineReady();
-    openOrFocusWorkbench(url, deps.getWorkbenchTitle());
-    return { url };
+    try {
+      const url = await ensureDshEngineReady();
+      openOrFocusWorkbench(url, deps.getWorkbenchTitle());
+      reportDshEvent(buildDshOpenWorkbenchEvent({ phaseBefore, result: DshAnalyticsResult.Success }));
+      return { url };
+    } catch (error) {
+      reportDshEvent(buildDshOpenWorkbenchEvent({
+        phaseBefore,
+        result: DshAnalyticsResult.Failed,
+        errorCode: resolveDshEngineErrorCode(manager.getState()),
+        error,
+        homeDir: os.homedir(),
+      }));
+      throw error;
+    }
   });
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8380,6 +8380,9 @@ if (!gotTheLock) {
     },
     getWorkbenchTitle: () => t('dshWorkbenchTitle'),
     syncOpenClawConfig,
+    reportEvent: params => {
+      void getMainLogReporter().report(params);
+    },
   });
 
 

--- a/src/shared/analytics/constants.ts
+++ b/src/shared/analytics/constants.ts
@@ -40,10 +40,12 @@ export const LogReporterAction = {
   ConversationMessageAction: 'lobsterai_conversation_message_action',
   ConversationNavigationAction: 'lobsterai_conversation_navigation_action',
   DreamingSettingChanged: 'lobsterai_dreaming_setting_changed',
+  DshAction: 'lobsterai_dsh_action',
   EmailSkillConnectionTested: 'lobsterai_email_skill_connection_tested',
   EmailSkillSettingsSaved: 'lobsterai_email_skill_settings_saved',
   ExpertKitAction: 'lobsterai_expert_kit_action',
   ExpertKitSelected: 'lobsterai_expert_kit_selected',
+  ExperimentalSettingChanged: 'lobsterai_experimental_setting_changed',
   GeneralSettingChanged: 'lobsterai_general_setting_changed',
   ImConnectionTested: 'lobsterai_im_connection_tested',
   ImGatewayToggled: 'lobsterai_im_gateway_toggled',
@@ -78,6 +80,7 @@ export const LogReporterEntry = {
 
 export const LogReporterSource = {
   OpenClawChannel: 'openclaw_channel',
+  SettingsExperimental: 'settings_experimental',
 } as const;
 
 export const PromptAnalyticsSurface = {


### PR DESCRIPTION
Track DSH feature-enabled changes and workbench open attempts (success or failure with error code) via the main log reporter. Reporting is fire-and-forget and never throws into the IPC caller.

Also documents the analytics event shapes in the usage-analytics design spec.
