### PR TITLE
fix(cowork): preserve message selection for context menu

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4270,18 +4270,26 @@ const EDIT_CONTEXT_FORM_CONTROLS = new Set<ContextMenuParams['formControlType']>
 const shouldShowEditContextMenu = (params: ContextMenuParams): boolean =>
   params.isEditable && EDIT_CONTEXT_FORM_CONTROLS.has(params.formControlType);
 
+const hasReadOnlySelection = (params: ContextMenuParams): boolean =>
+  !params.isEditable && params.selectionText.length > 0;
+
+const shouldShowTextContextMenu = (params: ContextMenuParams): boolean =>
+  shouldShowEditContextMenu(params) || hasReadOnlySelection(params);
+
 const installEditContextMenu = (webContents: WebContents) => {
   webContents.on('context-menu', (_event, params) => {
-    if (!shouldShowEditContextMenu(params)) return;
+    if (!shouldShowTextContextMenu(params)) return;
+
+    const isEditContext = shouldShowEditContextMenu(params);
 
     const template: MenuItemConstructorOptions[] = [];
 
     template.push(
-      { label: t('contextMenuCut'), role: 'cut', enabled: params.editFlags.canCut },
-      { label: t('contextMenuCopy'), role: 'copy', enabled: params.editFlags.canCopy },
-      { label: t('contextMenuPaste'), role: 'paste', enabled: params.editFlags.canPaste },
+      { label: t('contextMenuCut'), role: 'cut', enabled: isEditContext && params.editFlags.canCut },
+      { label: t('contextMenuCopy'), role: 'copy', enabled: isEditContext ? params.editFlags.canCopy : true },
+      { label: t('contextMenuPaste'), role: 'paste', enabled: isEditContext && params.editFlags.canPaste },
       { type: 'separator' },
-      { label: t('contextMenuSelectAll'), role: 'selectAll', enabled: params.editFlags.canSelectAll },
+      { label: t('contextMenuSelectAll'), role: 'selectAll', enabled: isEditContext && params.editFlags.canSelectAll },
     );
 
     const targetWindow = BrowserWindow.fromWebContents(webContents);

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -293,6 +293,7 @@ const SUBAGENT_PANEL_POLL_INTERVAL_MS = 5_000;
 const INVALID_FILE_NAME_PATTERN = /[<>:"/\\|?*\u0000-\u001F]/g;
 const SELECTED_TEXT_ACTION_HALF_WIDTH = 150;
 const SELECTED_TEXT_ACTION_SUPPRESS_MS = 250;
+const SECONDARY_POINTER_BUTTON = 2;
 const EXPANDED_CONVERSATION_PREVIEW_COLLAPSED_MAX_LENGTH = 140;
 const EXPANDED_CONVERSATION_PREVIEW_ITEM_MAX_LENGTH = 520;
 const EXPANDED_CONVERSATION_PREVIEW_ITEM_LIMIT = 8;
@@ -797,6 +798,11 @@ const logRailNavigationDiagnostic = (message: string): void => {
 };
 
 const logAutoScrollDiagnostic = (message: string): void => {
+  console.debug(`[CoworkSessionDetail] ${message}`);
+  window.electron?.log?.fromRenderer?.('debug', 'CoworkSessionDetail', message);
+};
+
+const logSelectedTextDiagnostic = (message: string): void => {
   console.debug(`[CoworkSessionDetail] ${message}`);
   window.electron?.log?.fromRenderer?.('debug', 'CoworkSessionDetail', message);
 };
@@ -1616,6 +1622,14 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   useEffect(() => {
     if (!selectedTextAction) return undefined;
     const handlePointerDown = (event: PointerEvent) => {
+      const isSecondaryPointer = event.button === SECONDARY_POINTER_BUTTON;
+      const isMacContextClick = isMac && event.button === 0 && event.ctrlKey;
+      if (isSecondaryPointer || isMacContextClick) {
+        logSelectedTextDiagnostic(
+          `Preserved assistant selected text for context menu; sourceMessageId=${selectedTextAction.sourceMessageId}; selectedLength=${selectedTextAction.text.length}.`,
+        );
+        return;
+      }
       const target = event.target;
       if (target instanceof Element && target.closest('[data-cowork-selected-text-action]')) {
         return;
@@ -1633,7 +1647,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [closeSelectedTextAction, selectedTextAction]);
+  }, [closeSelectedTextAction, isMac, selectedTextAction]);
 
   useEffect(() => {
     if (!showCompactConfirm) return undefined;


### PR DESCRIPTION
Enable the shared edit context menu for read-only selected text while keeping only Copy available outside editable controls.

Prevent assistant selected-text toolbar dismissal from clearing selection before right-click and macOS Ctrl-click context menus open.


