### PR TITLE
fix(cowork): disable OpenClaw heartbeat by default

### DIFF
--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -1332,10 +1332,10 @@ test('getConfig defaults skipMissedJobs to true when config is missing', () => {
   expect(config.skipMissedJobs).toBe(true);
 });
 
-test('getConfig defaults OpenClaw heartbeat to enabled when config is missing', () => {
+test('getConfig defaults OpenClaw heartbeat to disabled when config is missing', () => {
   const config = store.getConfig();
 
-  expect(config.openClawHeartbeatEnabled).toBe(true);
+  expect(config.openClawHeartbeatEnabled).toBe(false);
 });
 
 test('backfillEmptyAgentModels assigns the current default model to empty agents only', () => {

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -2489,7 +2489,7 @@ export class CoworkStore {
         Number(cfg.get('memoryUserMemoriesMaxItems')),
       ),
       skipMissedJobs: parseBooleanConfig(cfg.get('skipMissedJobs'), true),
-      openClawHeartbeatEnabled: parseBooleanConfig(cfg.get('openClawHeartbeatEnabled'), true),
+      openClawHeartbeatEnabled: parseBooleanConfig(cfg.get('openClawHeartbeatEnabled'), false),
       embeddingEnabled: parseBooleanConfig(cfg.get('embeddingEnabled'), DEFAULT_EMBEDDING_ENABLED),
       embeddingProvider: cfg.get('embeddingProvider') || DEFAULT_EMBEDDING_PROVIDER,
       embeddingModel: cfg.get('embeddingModel') || DEFAULT_EMBEDDING_MODEL,

--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -375,15 +375,15 @@ describe('OpenClawConfigSync runtime config output', () => {
     });
   });
 
-  test('enables optimized OpenClaw heartbeat by default', async () => {
+  test('disables optimized OpenClaw heartbeat by default', async () => {
     const sync = await createSync();
 
-    const result = sync.sync('heartbeat-enabled-default');
+    const result = sync.sync('heartbeat-disabled-default');
     expect(result.ok).toBe(true);
 
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
     expect(config.agents.defaults.heartbeat).toEqual({
-      every: '1h',
+      every: '0m',
       target: 'none',
       lightContext: true,
       isolatedSession: true,
@@ -391,7 +391,7 @@ describe('OpenClawConfigSync runtime config output', () => {
     });
   });
 
-  test('writes disabled OpenClaw heartbeat cadence when user disables heartbeat', async () => {
+  test('writes enabled OpenClaw heartbeat cadence when user enables heartbeat', async () => {
     const sync = await createSync({
       getCoworkConfig: () => ({
         workingDirectory: tmpDir,
@@ -404,16 +404,16 @@ describe('OpenClawConfigSync runtime config output', () => {
         memoryGuardLevel: 'balanced',
         memoryUserMemoriesMaxItems: 100,
         skipMissedJobs: false,
-        openClawHeartbeatEnabled: false,
+        openClawHeartbeatEnabled: true,
       }),
     });
 
-    const result = sync.sync('heartbeat-disabled');
+    const result = sync.sync('heartbeat-enabled');
     expect(result.ok).toBe(true);
 
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
     expect(config.agents.defaults.heartbeat).toEqual({
-      every: '0m',
+      every: '1h',
       target: 'none',
       lightContext: true,
       isolatedSession: true,

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -2444,9 +2444,9 @@ loopDetection: MANAGED_TOOL_LOOP_DETECTION,
             },
           },
           heartbeat: {
-            every: coworkConfig.openClawHeartbeatEnabled === false
-              ? OPENCLAW_HEARTBEAT_EVERY_DISABLED
-              : OPENCLAW_HEARTBEAT_EVERY_ENABLED,
+            every: coworkConfig.openClawHeartbeatEnabled === true
+              ? OPENCLAW_HEARTBEAT_EVERY_ENABLED
+              : OPENCLAW_HEARTBEAT_EVERY_DISABLED,
             target: 'none',
             lightContext: true,
             isolatedSession: true,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10429,6 +10429,14 @@ if (!gotTheLock) {
 
       const nextConfig = getCoworkStore().getConfig();
       const impactDecision = classifyCoworkConfigChange(previousConfig, nextConfig);
+      if (
+        normalizedConfig.openClawHeartbeatEnabled !== undefined
+        && previousConfig.openClawHeartbeatEnabled !== nextConfig.openClawHeartbeatEnabled
+      ) {
+        console.log(
+          `[Cowork] OpenClaw heartbeat setting changed: enabled=${nextConfig.openClawHeartbeatEnabled}, previous=${previousConfig.openClawHeartbeatEnabled}, impact=${impactDecision.impact}`,
+        );
+      }
       if (impactDecision.impact !== OpenClawConfigImpact.None) {
         const syncResult = await syncOpenClawConfig({
           reason: 'cowork-config-change',

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1744,7 +1744,7 @@ const Settings: React.FC<SettingsProps> = ({
   const [tempCleanPreviewDirs, setTempCleanPreviewDirs] = useState<CoworkTempDirPreview[]>([]);
   const [tempCleanSelection, setTempCleanSelection] = useState<Record<string, boolean>>({});
   const [showTempCleanConfirm, setShowTempCleanConfirm] = useState<boolean>(false);
-  const [openClawHeartbeatEnabled, setOpenClawHeartbeatEnabled] = useState<boolean>(coworkConfig.openClawHeartbeatEnabled ?? true);
+  const [openClawHeartbeatEnabled, setOpenClawHeartbeatEnabled] = useState<boolean>(coworkConfig.openClawHeartbeatEnabled ?? false);
   const [embeddingEnabled, setEmbeddingEnabled] = useState<boolean>(coworkConfig.embeddingEnabled ?? false);
   const [embeddingProvider, setEmbeddingProvider] = useState<string>(coworkConfig.embeddingProvider ?? 'openai');
   const [embeddingModel, setEmbeddingModel] = useState<string>(coworkConfig.embeddingModel ?? '');
@@ -1786,7 +1786,7 @@ const Settings: React.FC<SettingsProps> = ({
     setCoworkMemoryEnabled(coworkConfig.memoryEnabled ?? true);
     setCoworkMemoryLlmJudgeEnabled(coworkConfig.memoryLlmJudgeEnabled ?? false);
     setSkipMissedJobs(coworkConfig.skipMissedJobs ?? true);
-    setOpenClawHeartbeatEnabled(coworkConfig.openClawHeartbeatEnabled ?? true);
+    setOpenClawHeartbeatEnabled(coworkConfig.openClawHeartbeatEnabled ?? false);
     setEmbeddingEnabled(coworkConfig.embeddingEnabled ?? false);
     setEmbeddingProvider(coworkConfig.embeddingProvider ?? 'openai');
     setEmbeddingModel(coworkConfig.embeddingModel ?? '');
@@ -2828,7 +2828,7 @@ const Settings: React.FC<SettingsProps> = ({
     || coworkMemoryEnabled !== coworkConfig.memoryEnabled
     || coworkMemoryLlmJudgeEnabled !== coworkConfig.memoryLlmJudgeEnabled
     || skipMissedJobs !== (coworkConfig.skipMissedJobs ?? true)
-    || openClawHeartbeatEnabled !== (coworkConfig.openClawHeartbeatEnabled ?? true)
+    || openClawHeartbeatEnabled !== (coworkConfig.openClawHeartbeatEnabled ?? false)
     || openClawSessionKeepAlive !== (coworkConfig.openClawSessionPolicy?.keepAlive || OpenClawSessionKeepAliveValues.ThirtyDays)
     || embeddingEnabled !== (coworkConfig.embeddingEnabled ?? false)
     || embeddingProvider !== (coworkConfig.embeddingProvider ?? 'openai')
@@ -3389,7 +3389,7 @@ const Settings: React.FC<SettingsProps> = ({
         ? normalizeProvidersForSettingsSave(previousConfig.providers as ProvidersConfig)
         : normalizedProviders;
       const previousSkipMissedJobs = coworkConfig.skipMissedJobs ?? true;
-      const previousOpenClawHeartbeatEnabled = coworkConfig.openClawHeartbeatEnabled ?? true;
+      const previousOpenClawHeartbeatEnabled = coworkConfig.openClawHeartbeatEnabled ?? false;
       const previousAgentEngine = coworkConfig.agentEngine || 'openclaw';
       const previousOpenClawSessionKeepAlive = coworkConfig.openClawSessionPolicy?.keepAlive
         || OpenClawSessionKeepAliveValues.ThirtyDays;
@@ -3514,6 +3514,11 @@ const Settings: React.FC<SettingsProps> = ({
       dispatch(setAvailableModels(allModels));
 
       if (hasCoworkConfigChanges) {
+        if (previousOpenClawHeartbeatEnabled !== openClawHeartbeatEnabled) {
+          console.log(
+            `[Settings] updating OpenClaw heartbeat: enabled=${openClawHeartbeatEnabled}, previous=${previousOpenClawHeartbeatEnabled}`,
+          );
+        }
         const updated = await coworkService.updateConfig({
           agentEngine: coworkAgentEngine,
           memoryEnabled: coworkMemoryEnabled,

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -86,7 +86,7 @@ test('defaults hidden OpenClaw session policy to thirty days', () => {
     keepAlive: '30d',
   });
   expect(state.config.skipMissedJobs).toBe(true);
-  expect(state.config.openClawHeartbeatEnabled).toBe(true);
+  expect(state.config.openClawHeartbeatEnabled).toBe(false);
 });
 
 test('clears account-scoped media models and selections together', () => {

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -161,7 +161,7 @@ const initialState: CoworkState = {
     memoryGuardLevel: 'strict',
     memoryUserMemoriesMaxItems: 12,
     skipMissedJobs: true,
-    openClawHeartbeatEnabled: true,
+    openClawHeartbeatEnabled: false,
     embeddingEnabled: false,
     embeddingProvider: 'openai',
     embeddingModel: '',


### PR DESCRIPTION
Default background heartbeat to off for new or unset configs, while preserving explicit user choices. Keep Settings state and OpenClaw config sync behavior aligned, and add low-noise logs for heartbeat setting changes.

