### PR TITLE
style(cowork): highlight startup credit campaign entry

### DIFF
--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -830,13 +830,13 @@ const CoworkView: React.FC<CoworkViewProps> = ({
           <button
             type="button"
             onClick={() => openStartupCreditCampaign()}
-            className="mr-2 inline-flex h-8 max-w-[240px] items-center gap-1.5 rounded-full border border-border bg-surface/90 px-3 text-xs font-medium text-foreground shadow-subtle transition-colors hover:bg-surface-raised"
+            className="mr-2 inline-flex h-8 max-w-[240px] items-center gap-2 rounded-full border border-[#F0B58E] bg-[#FFF7F0] px-3 text-xs font-medium text-[#7C351C] shadow-[0_3px_12px_rgba(235,94,40,0.16)] transition-colors hover:border-[#E89C6C] hover:bg-[#FFEBDD] dark:border-[#704530] dark:bg-[#352A25] dark:text-[#F5C4A5] dark:shadow-[0_3px_14px_rgba(0,0,0,0.32)] dark:hover:bg-[#403029]"
           >
             <img
               src={startupCreditEntryGiftUrl}
               alt=""
               aria-hidden="true"
-              className="h-4 w-4 shrink-0"
+              className="startup-credit-entry-gift h-5 w-5 shrink-0"
             />
             <span className="truncate">
               {startupCreditEntry.label || i18nService.t('startupCreditMenuEntry')}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -651,6 +651,11 @@ select::-ms-expand {
   animation: activity-dot-breathe 1.8s ease-in-out infinite;
 }
 
+.startup-credit-entry-gift {
+  animation: startup-credit-entry-gift-wiggle 1.42s cubic-bezier(0.22, 0.9, 0.3, 1) 0.28s 2 both;
+  transform-origin: 50% 70%;
+}
+
 @keyframes activity-dot-breathe {
   0%, 100% {
     opacity: 0.35;
@@ -683,6 +688,27 @@ select::-ms-expand {
   100% { background-position: -75% 0; }
 }
 
+@keyframes startup-credit-entry-gift-wiggle {
+  0%, 100% {
+    transform: translateY(0) rotate(0deg) scale(1);
+  }
+  16% {
+    transform: translateY(-1px) rotate(-4deg) scale(1.045);
+  }
+  30% {
+    transform: translateY(-1px) rotate(3.5deg) scale(1.055);
+  }
+  44% {
+    transform: translateY(0) rotate(-2deg) scale(1.025);
+  }
+  58% {
+    transform: translateY(0) rotate(1deg) scale(1.01);
+  }
+  72% {
+    transform: translateY(0) rotate(0deg) scale(1);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .shimmer-text {
     animation: none;
@@ -694,6 +720,9 @@ select::-ms-expand {
   .activity-indicator-dot {
     animation: none;
     opacity: 0.7;
+  }
+  .startup-credit-entry-gift {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
Make the startup credit campaign banner more noticeable with a warmer pill style, a larger gift icon, and a short reduced-motion-aware entrance animation.