### PR TITLE
fix(sidebar): delay login promo tip until engine startup completes

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import {
   LibrarySourceFilter,
 } from '../shared/library/constants';
 import type { LibrarySessionRef } from '../shared/library/types';
+import { OpenClawEnginePhase } from '../shared/openclawEngine/constants';
 import { ProviderAuthType, ProviderName, ProviderRegistry } from '../shared/providers';
 import { SIDEBAR_TASK_FILTER_ENABLED } from './components/agentSidebar/SidebarTaskFilterButton';
 import { CoworkView } from './components/cowork';
@@ -180,6 +181,9 @@ const App: React.FC = () => {
   const [isTaskFilterActive, setIsTaskFilterActive] = useState(false);
   const [hasUnreadCompletedTasks, setHasUnreadCompletedTasks] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(244);
+  const [isEngineStartupOverlayVisible, setIsEngineStartupOverlayVisible] = useState(
+    () => coworkService.getOpenClawEngineStatusSnapshot()?.phase === OpenClawEnginePhase.Starting,
+  );
   const [appUpdateState, setAppUpdateState] = useState<AppUpdateRuntimeState>({
     status: AppUpdateStatus.Idle,
     source: null,
@@ -231,6 +235,30 @@ const App: React.FC = () => {
     isUserInitiatedUpdateFlowActive,
     appUpdateState.status,
   );
+
+  useEffect(() => {
+    let isCurrent = true;
+    const resolveOverlayVisible = (phase?: string | null) =>
+      phase === OpenClawEnginePhase.Starting;
+
+    coworkService.getOpenClawEngineStatus()
+      .then((status) => {
+        if (!isCurrent) return;
+        setIsEngineStartupOverlayVisible(resolveOverlayVisible(status?.phase));
+      })
+      .catch((error) => {
+        console.debug('[App] failed to refresh OpenClaw engine status for sidebar promo timing:', error);
+      });
+
+    const unsubscribe = coworkService.onOpenClawEngineStatus((status) => {
+      setIsEngineStartupOverlayVisible(resolveOverlayVisible(status.phase));
+    });
+
+    return () => {
+      isCurrent = false;
+      unsubscribe();
+    };
+  }, []);
 
   const waitWithTimeout = useCallback(
     async <T,>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> => {
@@ -1764,6 +1792,7 @@ const App: React.FC = () => {
           updateNotice={!isSidebarCollapsed && !isUpdateInteractionBlocked ? updateCard : null}
           hideAdBanner={isUpdateCardExpanded}
           hideLogin={enterpriseConfig?.ui?.login === 'hide'}
+          isEngineStartupOverlayVisible={isEngineStartupOverlayVisible}
         />
         <div className={`flex-1 min-w-0 transition-[padding] duration-200 ease-out ${isSidebarCollapsed ? 'pl-1.5' : ''}`}>
           <div

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -69,6 +69,7 @@ interface SidebarProps {
    * promo banner while preserving it for a smooth return after collapse. */
   hideAdBanner?: boolean;
   hideLogin?: boolean;
+  isEngineStartupOverlayVisible?: boolean;
 }
 
 const DEFAULT_SIDEBAR_WIDTH = 244;
@@ -261,6 +262,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   updateNotice,
   hideAdBanner,
   hideLogin,
+  isEngineStartupOverlayVisible = false,
 }) => {
   const currentAgentId = useSelector((state: RootState) => state.agent.currentAgentId);
   const agents = useSelector((state: RootState) => state.agent.agents);
@@ -359,6 +361,24 @@ const Sidebar: React.FC<SidebarProps> = ({
       return undefined;
     }
 
+    if (isEngineStartupOverlayVisible) {
+      if (showLoginPromoTip) {
+        const message = 'pausing login promo tip auto-hide while engine startup overlay is visible';
+        console.debug(`[Sidebar] ${message}`);
+        writeSidebarRendererLog('debug', message);
+        setIsLoginPromoTipFading(false);
+      }
+      return undefined;
+    }
+
+    if (!showLoginPromoTip) {
+      return undefined;
+    }
+
+    const startMessage = 'starting login promo tip auto-hide timer';
+    console.debug(`[Sidebar] ${startMessage}`);
+    writeSidebarRendererLog('debug', startMessage);
+
     const hideTimer = window.setTimeout(() => {
       const message = 'auto hiding login promo tip';
       console.debug(`[Sidebar] ${message}`);
@@ -375,7 +395,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       window.clearTimeout(hideTimer);
       window.clearTimeout(removeTimer);
     };
-  }, [showLoginPromo]);
+  }, [isEngineStartupOverlayVisible, showLoginPromo, showLoginPromoTip]);
 
   const dismissKitsNewBadge = useCallback(() => {
     if (!showKitsNewBadge) return;


### PR DESCRIPTION
Pause the sidebar login promo auto-hide timer while the engine startup overlay is visible, then start the five-second display window after the overlay clears.