### PR TITLE
feat(auth): add rainbow animation to sidebar login CTA

### DIFF
--- a/src/renderer/components/LoginButton.tsx
+++ b/src/renderer/components/LoginButton.tsx
@@ -679,6 +679,8 @@ const LoginButton: React.FC<LoginButtonProps> = ({
       });
       return;
     }
+    const loginVariant = useSidebarPromoLogin ? 'sidebar_promo' : 'default';
+    writeAccountMenuRendererLog('debug', `login requested variant=${loginVariant}`);
     try {
       await authService.login();
       reportAccountMenuAction('login', {
@@ -686,6 +688,7 @@ const LoginButton: React.FC<LoginButtonProps> = ({
         result: 'success',
       });
     } catch (error) {
+      writeAccountMenuRendererLog('warn', `login request failed variant=${loginVariant}`);
       reportAccountMenuAction('login', {
         isLoggedIn: false,
         result: 'failed',
@@ -729,7 +732,7 @@ const LoginButton: React.FC<LoginButtonProps> = ({
         onClick={handleClick}
         className={
           useSidebarPromoLogin
-            ? 'inline-flex h-7 w-[5.25rem] shrink-0 items-center justify-center rounded-md bg-black px-2.5 text-[13px] font-medium text-white shadow-sm transition-colors hover:bg-black/85 dark:bg-white dark:text-black dark:hover:bg-white/85 cursor-pointer'
+            ? 'sidebar-login-rainbow inline-flex h-7 w-[5.25rem] shrink-0 cursor-pointer items-center justify-center rounded-md px-2.5 text-[13px] font-medium transition-[filter,transform]'
             : 'inline-flex h-7 items-center justify-start gap-2 rounded-md px-1.5 text-sm font-normal text-foreground/80 transition-colors hover:bg-black/[0.03] dark:hover:bg-white/[0.04] cursor-pointer'
         }
       >

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -656,6 +656,102 @@ select::-ms-expand {
   transform-origin: 50% 70%;
 }
 
+.sidebar-login-rainbow {
+  position: relative;
+  isolation: isolate;
+  overflow: visible;
+  border: 1.3px solid transparent;
+  color: #ffffff;
+  background:
+    linear-gradient(#121213, #121213) padding-box,
+    linear-gradient(#121213 50%, rgba(18, 18, 19, 0.6) 80%, rgba(18, 18, 19, 0)) border-box,
+    linear-gradient(
+      90deg,
+      hsl(0, 100%, 63%),
+      hsl(30, 100%, 63%),
+      hsl(60, 100%, 63%),
+      hsl(120, 100%, 63%),
+      hsl(180, 100%, 63%),
+      hsl(240, 100%, 63%),
+      hsl(300, 100%, 63%),
+      hsl(360, 100%, 63%)
+    ) border-box;
+  background-size: 200% 100%;
+  animation: sidebar-login-rainbow 3.6s linear infinite;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.10);
+}
+
+.sidebar-login-rainbow::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: -20%;
+  z-index: -1;
+  width: 60%;
+  height: 20%;
+  transform: translateX(-50%);
+  border-radius: 9999px;
+  pointer-events: none;
+  opacity: 0.75;
+  filter: blur(0.5rem);
+  background: linear-gradient(
+    90deg,
+    hsl(0, 100%, 63%),
+    hsl(30, 100%, 63%),
+    hsl(60, 100%, 63%),
+    hsl(120, 100%, 63%),
+    hsl(180, 100%, 63%),
+    hsl(240, 100%, 63%),
+    hsl(300, 100%, 63%),
+    hsl(360, 100%, 63%)
+  );
+  background-size: 200% 100%;
+  animation: sidebar-login-rainbow 3.6s linear infinite;
+}
+
+.sidebar-login-rainbow:hover {
+  filter: brightness(1.08);
+}
+
+.sidebar-login-rainbow:active {
+  transform: scale(0.98);
+}
+
+.dark .sidebar-login-rainbow {
+  color: #121213;
+  background:
+    linear-gradient(#ffffff, #ffffff) padding-box,
+    linear-gradient(rgba(255, 255, 255, 0.9) 36%, rgba(255, 255, 255, 0.24) 70%, rgba(255, 255, 255, 0)) border-box,
+    linear-gradient(
+      90deg,
+      hsl(0, 100%, 63%),
+      hsl(30, 100%, 63%),
+      hsl(60, 100%, 63%),
+      hsl(120, 100%, 63%),
+      hsl(180, 100%, 63%),
+      hsl(240, 100%, 63%),
+      hsl(300, 100%, 63%),
+      hsl(360, 100%, 63%)
+    ) border-box;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.20),
+    0 0 12px rgba(255, 255, 255, 0.08);
+}
+
+.dark .sidebar-login-rainbow::before {
+  opacity: 0.92;
+  filter: blur(0.42rem) saturate(1.18);
+}
+
+@keyframes sidebar-login-rainbow {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
 @keyframes activity-dot-breathe {
   0%, 100% {
     opacity: 0.35;
@@ -723,6 +819,11 @@ select::-ms-expand {
   }
   .startup-credit-entry-gift {
     animation: none;
+  }
+  .sidebar-login-rainbow,
+  .sidebar-login-rainbow::before {
+    animation: none;
+    background-position: 100% 50%;
   }
 }
 


### PR DESCRIPTION
- Add a scoped rainbow border/glow animation for the logged-out sidebar login button
- Preserve light and dark theme button contrast while making the animation visible
- Add renderer logs for login CTA attempts and failures

