### PR TITLE
fix(installer): remove silent-install progress banner for all channels

### DIFF
--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -1,17 +1,5 @@
 !include "FileFunc.nsh"
 
-; The Youdao Dictionary bound package owns the install progress UI. Suppress
-; LobsterAI's plugin-owned silent banner only for the explicitly
-; double-click-silent dictbind artifact. Other channels, ordinary /S installs,
-; interactive installers, update flows, and UAC behavior stay unchanged.
-!if "$%KEYFROM%" == "dictbind"
-  !if "$%LOBSTERAI_CHANNEL_BUILD%" == "1"
-    !if "$%LOBSTERAI_SILENT_ON_DOUBLE_CLICK%" == "1"
-      !define LOBSTERAI_HIDE_SILENT_BANNER
-    !endif
-  !endif
-!endif
-
 Var lobsterCurrentProcessPid
 Var lobsterInstallerAttemptId
 Var lobsterTargetProcessesStopStatus
@@ -730,26 +718,12 @@ FunctionEnd
 ;    before uninstallOldVersion and file extraction
 ;  - uninstaller: un.install section (assisted) or un.onInit (silent /S)
 !macro customCheckAppRunning
-  !ifndef BUILD_UNINSTALLER
-    ; Silent installs (/S -- e.g. enterprise IT deployments; in-app updates
-    ; use --updated mode with a visible progress page instead) have no
-    ; installer UI at all, so without this the machine looks idle for minutes
-    ; mid-replace. Banner is a plugin-owned window, so it shows even in
-    ; silent mode. The window dies with the installer process, so no failure
-    ; path can leave it behind.
-    ;
-    ; The text is "Updating LobsterAI, please wait..." in Chinese, written as
-    ; ${U+xxxx} escapes because this file must stay pure ASCII: the darwin
-    ; makensis builds used for local syntax checks reject any non-ASCII byte
-    ; (the escapes are fine on the Windows build machine -- the webPackage
-    ; patch ships them in production already).
-    !ifndef LOBSTERAI_HIDE_SILENT_BANNER
-      ${If} ${Silent}
-        Banner::show /NOUNLOAD "${U+6B63}${U+5728}${U+66F4}${U+65B0} LobsterAI${U+FF0C}${U+8BF7}${U+7A0D}${U+5019}${U+2026}"
-      ${EndIf}
-    !endif
-  !endif
-
+  ; Silent installs (/S from app stores and IT deployment, or channel builds
+  ; with the double-click-silent flag) must show no installer-owned window at
+  ; all: /S is a zero-UI contract and the invoking store/channel owns the
+  ; install progress experience. Failure dialogs stay silent-safe through
+  ; their /SD defaults. In-app updates use --updated with a visible progress
+  ; page and are unaffected.
   !ifndef BUILD_UNINSTALLER
     !insertmacro EnsureInstallerAttemptId
     StrCpy $lobsterOldInstallOriginalPath "$INSTDIR"
@@ -828,9 +802,6 @@ FunctionEnd
       !insertmacro GetTimestamp $8
       FileWrite $9 "$8 phase=install-failed-before-mutation attempt_id=$lobsterInstallerAttemptId failure_kind=process-stop-failed raw_status=$lobsterTargetProcessesStopStatus exit=$R2 action=old-install-untouched$\r$\n"
       FileClose $9
-      ${If} ${Silent}
-        Banner::destroy
-      ${EndIf}
       MessageBox MB_OK|MB_ICONEXCLAMATION "The LobsterAI update stopped before replacing the previous version because the old application processes could not be confirmed stopped. Please close LobsterAI and retry. Details: $APPDATA\LobsterAI\install-timing.log" /SD IDOK
       SetErrorLevel 2
       Quit
@@ -1041,9 +1012,6 @@ FunctionEnd
       FileWrite $9 "$8 phase=skill-backup-failed-abort attempt_id=$lobsterInstallerAttemptId status=$lobsterLegacySkillsStatus exit=$R2 action=old-install-preserved$\r$\n"
       FileClose $9
       Call lobsterTryRelaunchOldApp
-      ${If} ${Silent}
-        Banner::destroy
-      ${EndIf}
       MessageBox MB_OK|MB_ICONEXCLAMATION "The LobsterAI update stopped because legacy user skills could not be safely inspected or backed up (status=$lobsterLegacySkillsStatus). The previous installation was not replaced. Please retry the update. Details: $APPDATA\LobsterAI\install-timing.log" /SD IDOK
       SetErrorLevel 2
       Quit
@@ -1180,9 +1148,6 @@ FunctionEnd
       FileWrite $9 "$8 phase=old-install-rename-verification-abort attempt_id=$lobsterInstallerAttemptId outcome=recovery-required rollback_status=$lobsterOldInstallRollbackStatus rollback_error=$lobsterOldInstallRollbackError source=$lobsterOldInstallOriginalPath backup=$lobsterOldInstallBackupPath$\r$\n"
       FileClose $9
       MessageBox MB_OK|MB_ICONEXCLAMATION "The LobsterAI update stopped because the previous installation move could not be verified and automatic recovery did not complete. No recovery copy was deleted. Restart Windows before retrying. Details: $APPDATA\LobsterAI\install-timing.log" /SD IDOK
-      ${If} ${Silent}
-        Banner::destroy
-      ${EndIf}
       SetErrorLevel 3
       Quit
 
@@ -1196,9 +1161,6 @@ FunctionEnd
       FileWrite $9 "$8 phase=old-install-rename-verification-abort attempt_id=$lobsterInstallerAttemptId outcome=restored rollback_status=$lobsterOldInstallRollbackStatus relaunch_status=$lobsterOldAppRelaunchStatus source=$lobsterOldInstallOriginalPath$\r$\n"
       FileClose $9
       MessageBox MB_OK|MB_ICONEXCLAMATION "The LobsterAI update stopped because the previous installation move could not be verified. The previous version was restored. Please retry the update. Details: $APPDATA\LobsterAI\install-timing.log" /SD IDOK
-      ${If} ${Silent}
-        Banner::destroy
-      ${EndIf}
       SetErrorLevel 2
       Quit
 
@@ -1933,9 +1895,6 @@ FunctionEnd
     FileWrite $2 "$8 phase=tar-extract-error attempt_id=$lobsterInstallerAttemptId extractor=$R3 exit=$R2 raw_marker=$R4 elapsed_ms=$5 reason=process-termination-failed action=preserve-all-no-concurrent-rollback$\r$\n"
     FileClose $2
     System::Call 'Kernel32::SetEnvironmentVariable(t "ELECTRON_RUN_AS_NODE", t "")i'
-    ${If} ${Silent}
-      Banner::destroy
-    ${EndIf}
     MessageBox MB_OK|MB_ICONEXCLAMATION "The LobsterAI installation stopped because the extractor process could not be confirmed terminated. No automatic rollback or cleanup was attempted while that process may still be writing files. Restart Windows before retrying. Recovery files (if any): $lobsterOldInstallBackupPath. Details: $APPDATA\LobsterAI\install-timing.log" /SD IDOK
     SetErrorLevel 3
     Quit
@@ -2005,9 +1964,6 @@ FunctionEnd
   StrCmp $lobsterOldInstallRollbackStatus "failed" 0 TarExtractAbort
     MessageBox MB_OK|MB_ICONEXCLAMATION "The installation failed and automatic rollback did not complete. No recovery copy was deleted. Previous files: $lobsterOldInstallBackupPath. Partial update: $lobsterOldInstallFailedPath. Details: $APPDATA\LobsterAI\install-timing.log" /SD IDOK
   TarExtractAbort:
-  ${If} ${Silent}
-    Banner::destroy
-  ${EndIf}
   SetErrorLevel 3
   Quit
   TarExtractDone:
@@ -2153,9 +2109,6 @@ FunctionEnd
       SkillRestoreRollbackSucceeded:
         MessageBox MB_OK|MB_ICONEXCLAMATION "The LobsterAI update could not restore user skills, so the previous version was restored. Please retry the update. Details: $APPDATA\LobsterAI\install-timing.log" /SD IDOK
       SkillRestoreAbort:
-      ${If} ${Silent}
-        Banner::destroy
-      ${EndIf}
       SetErrorLevel 2
       Quit
 
@@ -2314,9 +2267,6 @@ FunctionEnd
     NewInstallPrevalidateAbort:
       MessageBox MB_OK|MB_ICONEXCLAMATION "The LobsterAI installation stopped because the new application could not be validated ($lobsterNewInstallValidationReason). New registration and shortcuts were not written. Details: $APPDATA\LobsterAI\install-timing.log" /SD IDOK
     NewInstallPrevalidateAbortAfterMessage:
-    ${If} ${Silent}
-      Banner::destroy
-    ${EndIf}
     SetErrorLevel 2
     Quit
 
@@ -2385,9 +2335,6 @@ FunctionEnd
   FileClose $2
   DetailPrint "[Installer] Installation complete"
 
-  ${If} ${Silent}
-    Banner::destroy
-  ${EndIf}
 !macroend
 
 ; customUnInit intentionally not defined: the uninstaller stops app processes

--- a/specs/features/channel-silent-installer/2026-08-18-channel-silent-installer-design.md
+++ b/specs/features/channel-silent-installer/2026-08-18-channel-silent-installer-design.md
@@ -9,7 +9,7 @@ LobsterAI 当前 Windows NSIS 安装包已经支持 `/S` 静默安装，企业�
 ### 1.1 目标
 
 - 允许通过显式打包参数生成“用户双击也静默安装”的 Windows 完整安装包或 Web 安装包。
-- `dictbind --silent` 绑定包不显示 LobsterAI 自有的静默 Banner，由有道词典绑定流程承载安装体验。
+- 静默安装（双击静默包或命令行 `/S`，如应用商店后台安装）不显示任何 LobsterAI 自有安装窗口，安装体验由分发渠道承载。
 - 继续复用现有 NSIS 安装器、渠道归因、签名、OpenClaw runtime 打包和资源恢复流程。
 - 将双击静默行为固化在构建产物中，不依赖用户机器环境变量或安装时读取 `.keyfrom-build`。
 - 保持普通渠道包的安装向导体验不变。
@@ -94,9 +94,9 @@ LobsterAI-WebSetup-x64-${version}-${keyfrom}-silent.exe
 - 在 `scripts/nsis-installer.nsh` 的安装器初始化阶段处理双击静默。
 - 判断顺序应保证显式 `/S` 与渠道双击静默最终都进入同一 silent mode。
 - 双击静默包应在写安装日志前完成 `SetSilent silent`，保证 `ui_mode` 记录为 `silent`。
-- `keyfrom=dictbind` 且启用双击静默策略时，不调用插件自有的 `Banner::show`；该例外必须由编译期渠道与安装器策略共同限定，不能影响普通 `dictbind` 包或其他渠道包。
-- 除上述 Banner 展示例外外，原有 `${Silent}` 分支，包括失败弹窗默认按钮、进程关闭、回滚和卸载路径，必须继续复用。
-- 其他渠道和普通 `/S` 安装继续保留既有静默 Banner 行为。
+- 安装器不内置任何静默模式 Banner 或自有窗口；静默安装（构建标记或 `/S`）的进度体验由调用方（应用商店、渠道绑定流程、网管工具）承载。
+- 原有 `${Silent}` 分支，包括失败弹窗 `/SD` 默认按钮、进程关闭、回滚和卸载路径，必须继续复用。
+- 交互式安装向导与 `--updated` 更新进度页不受影响。
 - 该行为只影响安装器 UI 展示，不跳过安装前置校验和失败保护。
 - Windows UAC、安装器 `RequestExecutionLevel` 和 Defender 排除项逻辑保持不变；系统是否显示提权确认由 Windows 策略决定。
 
@@ -156,7 +156,7 @@ ${EndIf}
 | 用户对双击静默包传 `/D=<path>` | 遵循 NSIS silent install 对安装目录参数的既有规则 |
 | 未传入双击静默参数 | 默认交互式安装，不失败 |
 | 渠道值非法 | 构建脚本按现有规则失败或回退，不能生成未标识策略的异常包 |
-| 旧版本正在运行 | 复用现有进程停止与日志逻辑；仅 `dictbind --silent` 不显示 Banner |
+| 旧版本正在运行 | 复用现有进程停止与日志逻辑；静默安装不显示任何安装器自有窗口 |
 | 安装资源解压失败 | 复用现有失败处理、日志、回滚和 silent MessageBox 默认选择 |
 | UAC 被取消 | 安装不继续，静默策略不绕过系统确认 |
 | 更新安装器带 `--updated` | 保持现有更新模式，不因打包参数隐藏必要进度 |
@@ -173,4 +173,4 @@ ${EndIf}
 8. 传入 `dist:win:web -- --keyfrom dictbind --silent` 时，最终 WebSetup 产物名包含 `-silent`，双击后下载与安装过程均不展示 LobsterAI 安装器 UI；Windows UAC 不在此约束内。
 9. WebSetup 静默下载失败时使用非交互默认选项退出，不因错误弹窗阻塞无人值守流程。
 10. macOS、Linux 和应用运行时 UI 不受该功能影响。
-11. `dictbind` 非静默包、其他渠道的双击静默包以及普通 `/S` 安装仍保留各自既有 UI/Banner 行为。
+11. 任何静默安装（双击静默包或命令行 `/S`）均不显示 LobsterAI 自有窗口；交互式安装向导与 `--updated` 更新进度页保持既有 UI。

--- a/tests/windowsInstallerContract.test.ts
+++ b/tests/windowsInstallerContract.test.ts
@@ -78,23 +78,20 @@ describe('Windows installer hardening contracts', () => {
     expect(initLog).toBeGreaterThan(setSilent);
   });
 
-  test('hides the silent banner only for double-click-silent dictbind artifacts', () => {
-    const policyEnd = installerInclude.indexOf('Var lobsterCurrentProcessPid');
-    const policy = installerInclude.slice(0, policyEnd);
-    const checkStart = installerInclude.indexOf('!macro customCheckAppRunning');
-    const checkEnd = installerInclude.indexOf('!macroend', checkStart);
-    const check = installerInclude.slice(checkStart, checkEnd);
-    const bannerGuard = check.indexOf('!ifndef LOBSTERAI_HIDE_SILENT_BANNER');
-    const bannerShow = check.indexOf('Banner::show /NOUNLOAD');
+  test('keeps silent installs free of installer-owned UI', () => {
+    // /S is a zero-UI contract: app stores and IT deployment drive silent
+    // installs with their own progress experience, so the installer may not
+    // own any window and every dialog needs a silent default.
+    expect(installerInclude).not.toContain('Banner::');
+    expect(installerInclude).not.toContain('LOBSTERAI_HIDE_SILENT_BANNER');
 
-    expect(policy).toContain('!if "$%KEYFROM%" == "dictbind"');
-    expect(policy).toContain('!if "$%LOBSTERAI_CHANNEL_BUILD%" == "1"');
-    expect(policy).toContain('!if "$%LOBSTERAI_SILENT_ON_DOUBLE_CLICK%" == "1"');
-    expect(policy).toContain('!define LOBSTERAI_HIDE_SILENT_BANNER');
-    expect(bannerGuard).toBeGreaterThan(-1);
-    expect(bannerShow).toBeGreaterThan(bannerGuard);
-    expect(check.slice(bannerGuard, bannerShow)).not.toContain('!else');
-    expect(installerInclude.match(/Banner::show \/NOUNLOAD/g)).toHaveLength(1);
+    const messageBoxLines = installerInclude
+      .split('\n')
+      .filter((line) => line.includes('MessageBox'));
+    expect(messageBoxLines.length).toBeGreaterThan(0);
+    for (const line of messageBoxLines) {
+      expect(line).toContain('/SD');
+    }
   });
 
   test('releases the installer current-directory lock before the update rename', () => {


### PR DESCRIPTION
Silent /S installs must show no installer-owned window at all: /S is a zero-UI contract and the invoking store/channel owns the install progress experience. Drop the dictbind-only banner suppression flag and the banner logic itself, and update the design spec and installer contract test to match.