### PR TITLE
feat(cowork): show login prompt before unauthenticated chat

### DIFF
--- a/src/renderer/components/cowork/ChatLoginExperienceModal.tsx
+++ b/src/renderer/components/cowork/ChatLoginExperienceModal.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { i18nService } from '../../services/i18n';
+import Modal from '../common/Modal';
+
+interface ChatLoginExperienceModalProps {
+  loginPending: boolean;
+  onClose: () => void;
+  onStart: () => void;
+}
+
+const ChatLoginExperienceModal: React.FC<ChatLoginExperienceModalProps> = ({
+  loginPending,
+  onClose,
+  onStart,
+}) => {
+  return (
+    <Modal
+      onClose={onClose}
+      onEscape={onClose}
+      overlayClassName="non-draggable fixed inset-0 z-[10050] flex items-center justify-center bg-black/35 px-6 backdrop-blur-[1px]"
+      className="modal-content relative w-full max-w-[560px] overflow-hidden rounded-[28px] border border-border bg-surface px-6 pb-12 pt-12 text-center text-foreground shadow-modal sm:px-8 sm:pb-16 sm:pt-14"
+    >
+      <div className="relative z-10 flex flex-col items-center">
+        <img
+          src="logo.png"
+          alt="LobsterAI"
+          width={72}
+          height={72}
+          className="rounded-2xl select-none"
+          draggable={false}
+        />
+        <h2 className="mt-8 text-[30px] font-semibold leading-[1.28] tracking-normal sm:text-[32px]">
+          <span className="block">{i18nService.t('chatLoginExperienceTitlePrefix')}</span>
+          <span className="block text-[36px] font-bold leading-[1.2] sm:text-[38px]">LobsterAI</span>
+        </h2>
+        <p className="mt-16 text-lg leading-[1.85] tracking-normal sm:mt-24 sm:text-xl">
+          <span className="block">{i18nService.t('chatLoginExperiencePromoLine1')}</span>
+          <span className="block">{i18nService.t('chatLoginExperiencePromoLine2')}</span>
+        </p>
+        <button
+          type="button"
+          onClick={onStart}
+          disabled={loginPending}
+          className="relative mt-12 h-[56px] w-full max-w-[310px] overflow-hidden rounded-[20px] bg-foreground px-8 text-[26px] font-medium leading-none text-surface shadow-[0_14px_28px_rgba(0,0,0,0.12)] transition-transform hover:scale-[1.01] disabled:cursor-not-allowed disabled:opacity-70 active:scale-[0.99] sm:h-[58px] sm:text-[30px]"
+        >
+          <span
+            className="pointer-events-none absolute inset-x-6 bottom-[-18px] h-8 bg-[linear-gradient(90deg,#26E6A5,#31A8FF,#C53BFF,#FF4C7A)] blur-xl"
+            aria-hidden="true"
+          />
+          <span className="relative">
+            {i18nService.t(loginPending ? 'chatLoginExperienceStarting' : 'chatLoginExperienceStart')}
+          </span>
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export default ChatLoginExperienceModal;

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -41,6 +41,7 @@ import {
   CoworkSteerStatus,
 } from '../../../shared/cowork/steer';
 import { agentService } from '../../services/agent';
+import { authService } from '../../services/auth';
 import { configService, ConfigServiceEvent } from '../../services/config';
 import { coworkService } from '../../services/cowork';
 import { buildCoworkCapabilitySelection } from '../../services/coworkCapabilitySelection';
@@ -135,6 +136,7 @@ import {
 } from './agentModelSelection';
 import AttachmentCard from './AttachmentCard';
 import BrowserAnnotationAttachmentBadge from './BrowserAnnotationAttachmentBadge';
+import ChatLoginExperienceModal from './ChatLoginExperienceModal';
 import { getClipboardAttachmentFiles } from './clipboardAttachments';
 import { CoworkUiEvent } from './constants';
 import FolderSelectorPopover from './FolderSelectorPopover';
@@ -546,6 +548,8 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     const [goalEditDraft, setGoalEditDraft] = useState('');
     const [goalEditSaving, setGoalEditSaving] = useState(false);
     const [modelAccessPrompt, setModelAccessPrompt] = useState<ModelAccessPromptKind | null>(null);
+    const [showChatLoginExperiencePrompt, setShowChatLoginExperiencePrompt] = useState(false);
+    const [chatLoginExperiencePending, setChatLoginExperiencePending] = useState(false);
     const [showVoiceLoginPrompt, setShowVoiceLoginPrompt] = useState(false);
     const [showVoiceQuotaPrompt, setShowVoiceQuotaPrompt] = useState(false);
     const [isLargeToolbarCompact, setIsLargeToolbarCompact] = useState(false);
@@ -682,11 +686,12 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       : currentAgent?.thinkingLevel,
   );
   const modelSupportsImage = !!effectiveSelectedModel?.supportsImage;
+  const hasAccessibleUserModel = useMemo(
+    () => availableModels.some(model => !model.isServerModel && model.accessible !== false),
+    [availableModels],
+  );
 
   const resolveSubmitModelAccessPrompt = useCallback((): ModelAccessPromptKind | null => {
-    const hasAccessibleUserModel = availableModels.some(
-      model => !model.isServerModel && model.accessible !== false
-    );
     if (!isLoggedIn && !hasAccessibleUserModel) {
       return ModelAccessPromptKind.Login;
     }
@@ -701,10 +706,44 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     }
     return null;
   }, [
-    availableModels,
     effectiveSelectedModel,
+    hasAccessibleUserModel,
     isLoggedIn,
   ]);
+
+  const handleChatLoginExperienceStart = useCallback(async () => {
+    if (chatLoginExperiencePending) return;
+    setChatLoginExperiencePending(true);
+    logPromptModelSelection(
+      'debug',
+      'chat login experience prompt primary action clicked; starting login handoff',
+    );
+    try {
+      const result = await authService.login();
+      if (!result.success) {
+        throw new Error(result.error || i18nService.t('welcomeLoginFailed'));
+      }
+      logPromptModelSelection(
+        'debug',
+        'chat login experience prompt login handoff succeeded',
+      );
+      setShowChatLoginExperiencePrompt(false);
+      setChatLoginExperiencePending(false);
+    } catch (error) {
+      logPromptModelSelection(
+        'warn',
+        `chat login experience prompt login handoff failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      showToast(i18nService.t('welcomeLoginFailed'));
+      setChatLoginExperiencePending(false);
+    }
+  }, [chatLoginExperiencePending]);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    setShowChatLoginExperiencePrompt(false);
+    setChatLoginExperiencePending(false);
+  }, [isLoggedIn]);
 
   const {
     handleVoiceInput,
@@ -1654,6 +1693,18 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         ...getPromptTextAnalyticsParams(trimmedValue),
         ...getPromptCapabilityAnalyticsParams(),
       });
+      if (
+        accessPrompt === ModelAccessPromptKind.Login
+        && !isLoggedIn
+        && !hasAccessibleUserModel
+      ) {
+        logPromptModelSelection(
+          'debug',
+          'showing chat login experience prompt because submit requires login and no custom model is configured',
+        );
+        setShowChatLoginExperiencePrompt(true);
+        return;
+      }
       setModelAccessPrompt(accessPrompt);
       return;
     }
@@ -1853,7 +1904,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     resetGoalInput(false);
     draftStartedAnalyticsRef.current = false;
     inputSourceOverrideRef.current = null;
-  }, [value, steerInputActive, steerValue, isVoiceRecording, stopVoiceRecordingAndRecognize, goalInputActive, goalInputMode, resetGoalInput, isStreaming, canSteer, remoteManaged, disabled, submitDisabled, isPatchingModel, onSubmit, onGoalCommand, activeSkillIds, skills, activeKitIds, marketplaceKits, installedKits, attachments, browserAnnotationBatches, showFolderSelector, workingDirectory, dispatch, draftKey, selectedTextSnippets, pendingSteers.length, resolveSubmitModelAccessPrompt, isPlanMode, planConfirmation, reportPromptControl, getPromptCapabilityAnalyticsParams, getPromptContextAnalyticsParams, getPromptInputSource, goal, sessionId, preparePromptPayload, modelSupportsImage, queuedMediaSelection, authOwnerAccountKey, authAccountGeneration]);
+  }, [value, steerInputActive, steerValue, isVoiceRecording, stopVoiceRecordingAndRecognize, goalInputActive, goalInputMode, resetGoalInput, isStreaming, canSteer, remoteManaged, disabled, submitDisabled, isPatchingModel, onSubmit, onGoalCommand, activeSkillIds, skills, activeKitIds, marketplaceKits, installedKits, attachments, browserAnnotationBatches, showFolderSelector, workingDirectory, dispatch, draftKey, selectedTextSnippets, pendingSteers.length, resolveSubmitModelAccessPrompt, isLoggedIn, hasAccessibleUserModel, isPlanMode, planConfirmation, reportPromptControl, getPromptCapabilityAnalyticsParams, getPromptContextAnalyticsParams, getPromptInputSource, goal, sessionId, preparePromptPayload, modelSupportsImage, queuedMediaSelection, authOwnerAccountKey, authAccountGeneration]);
   handleSubmitRef.current = handleSubmit;
 
   const handleSelectSkill = useCallback((skill: Skill) => {
@@ -3948,6 +3999,16 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         )}
       </div>
       {readOnlyContextRow}
+      {showChatLoginExperiencePrompt && (
+        <ChatLoginExperienceModal
+          loginPending={chatLoginExperiencePending}
+          onClose={() => {
+            setShowChatLoginExperiencePrompt(false);
+            setChatLoginExperiencePending(false);
+          }}
+          onStart={() => { void handleChatLoginExperienceStart(); }}
+        />
+      )}
       {modelAccessPrompt && (
         <ModelAccessPromptModal
           promptKind={modelAccessPrompt}

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -420,6 +420,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
     authLogout: '退出登录',
     authLoginRequired: '请先登录后再开始对话。',
     authLoginRequiredBtn: '登录',
+    chatLoginExperienceTitlePrefix: '欢迎使用',
+    chatLoginExperiencePromoLine1: '新朋友限时送百万Token，',
+    chatLoginExperiencePromoLine2: '登录后，获取积分可使用套餐模型。',
+    chatLoginExperienceStart: '开始体验',
+    chatLoginExperienceStarting: '正在打开...',
     authQuotaExhausted:
       '今日免费额度已用完。您可以登录 LobsterAI Portal 购买套餐或积分包继续使用，或在设置中配置自己的 API Key。',
     authTopUpLink: '充值',
@@ -4091,6 +4096,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
     authLogout: 'Log Out',
     authLoginRequired: 'Please log in to start a conversation.',
     authLoginRequiredBtn: 'Log In',
+    chatLoginExperienceTitlePrefix: 'Welcome to',
+    chatLoginExperiencePromoLine1: 'New users get 1M tokens for a limited time.',
+    chatLoginExperiencePromoLine2: 'Sign in to earn credits and use plan models.',
+    chatLoginExperienceStart: 'Start',
+    chatLoginExperienceStarting: 'Opening...',
     authQuotaExhausted:
       'Daily free quota exhausted. Visit LobsterAI Portal to purchase a plan or credits, or configure your own API Key in Settings.',
     authTopUpLink: 'Top Up',


### PR DESCRIPTION
Show a dedicated LobsterAI welcome modal when an unauthenticated user without any configured custom model tries to submit a chat message.

Keep existing subscription, agentic-readiness, and voice-login prompts unchanged. Add localized copy and log the login handoff path for diagnostics.

