### PR TITLE
fix(voice-input): show quota prompt on exhaustion

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -3586,9 +3586,11 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
   const voiceQuotaLimitSeconds = asrQuota.limitSecondsToday
     ?? (isAsrSubscribed ? DEFAULT_SUBSCRIBED_ASR_LIMIT_SECONDS : DEFAULT_FREE_ASR_LIMIT_SECONDS);
   const voiceQuotaLimitText = formatVoiceInputQuotaLimit(voiceQuotaLimitSeconds);
+  const voiceSubscribedQuotaLimitText = formatVoiceInputQuotaLimit(DEFAULT_SUBSCRIBED_ASR_LIMIT_SECONDS);
   const voiceQuotaDescription = i18nService
     .t(isAsrSubscribed ? 'voiceInputQuotaExhaustedSubscribedDesc' : 'voiceInputQuotaExhaustedFreeDesc')
-    .replace('{limit}', voiceQuotaLimitText);
+    .replace('{limit}', voiceQuotaLimitText)
+    .replace('{subscriptionLimit}', voiceSubscribedQuotaLimitText);
   const handleVoiceQuotaPrimary = async () => {
     if (isAsrSubscribed) {
       setShowVoiceQuotaPrompt(false);

--- a/src/renderer/components/cowork/voiceInput/useCoworkVoiceInput.ts
+++ b/src/renderer/components/cowork/voiceInput/useCoworkVoiceInput.ts
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import { AsrApiCode } from '../../../../shared/asr/constants';
 import {
+  applyVoiceInputQuotaConsumption,
   AsrClientError,
   getAsrErrorMessage,
   type RealtimeVoiceInputSession,
@@ -103,6 +104,22 @@ export const useCoworkVoiceInput = ({
     return true;
   }, [dispatch, onQuotaExhausted]);
 
+  const updateQuotaAfterRecording = useCallback((recording: RealtimeVoiceInputSession) => {
+    const consumedSeconds = recording.getConsumedSeconds();
+    if (consumedSeconds <= 0) return false;
+    const quota = applyVoiceInputQuotaConsumption(recording.quota, consumedSeconds);
+    dispatch(updateAsrQuotaFromSession({
+      dayKey: getLocalAsrQuotaDayKey(),
+      data: quota,
+    }));
+    const quotaExhausted = recording.quota.remainingSecondsToday > 0
+      && quota.remainingSecondsToday <= 0;
+    if (quotaExhausted) {
+      onQuotaExhausted?.();
+    }
+    return quotaExhausted;
+  }, [dispatch, onQuotaExhausted]);
+
   const replaceRealtimeRecognizedVoiceText = useCallback((targetDraftKey: string, recognizedText: string): string | null => {
     const text = recognizedText.trim();
     if (!text) return null;
@@ -162,6 +179,7 @@ export const useCoworkVoiceInput = ({
       const text = await activeRecording.stop();
       if (generation !== voiceInputGenerationRef.current) return null;
       const nextValue = replaceRealtimeRecognizedVoiceText(targetDraftKey, text);
+      updateQuotaAfterRecording(activeRecording);
       logVoiceInputDiagnostic('debug', `realtime voice input was finalized for draft ${targetDraftKey}.`);
       realtimeVoiceBaseValueRef.current = null;
       return nextValue ?? valueRef.current;
@@ -169,7 +187,8 @@ export const useCoworkVoiceInput = ({
       if (generation !== voiceInputGenerationRef.current) return null;
       console.warn('[VoiceInput] voice input recognition failed:', error);
       window.electron?.log?.fromRenderer?.('warn', 'VoiceInput', `voice input recognition failed for draft ${targetDraftKey}.`);
-      const quotaExhausted = markQuotaExhaustedIfNeeded(error);
+      const quotaExhausted = markQuotaExhaustedIfNeeded(error)
+        || updateQuotaAfterRecording(activeRecording);
       if (!quotaExhausted) {
         showToast(getAsrErrorMessage(error));
       }
@@ -185,6 +204,7 @@ export const useCoworkVoiceInput = ({
     clearVoiceAutoStopTimer,
     markQuotaExhaustedIfNeeded,
     replaceRealtimeRecognizedVoiceText,
+    updateQuotaAfterRecording,
   ]);
 
   const handleVoiceInput = useCallback(async () => {

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1848,7 +1848,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     voiceInputQuotaExhausted: '暂无语音输入时长',
     voiceInputQuotaExhaustedTitle: '语音输入时长已用完',
     voiceInputQuotaExhaustedFreeDesc:
-      '今日 {limit} 语音输入时长已用完。升级订阅可获得每日 200 分钟语音输入时长。',
+      '今日 {limit} 免费语音输入时长已用完。升级订阅后，每日可使用 {subscriptionLimit} 语音输入。',
     voiceInputQuotaExhaustedSubscribedDesc: '今日 {limit} 语音输入时长已用完。',
     voiceInputUpgradeSubscription: '升级订阅',
     voiceInputQuotaAcknowledge: '知道了',
@@ -5666,7 +5666,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     voiceInputQuotaExhausted: 'No voice input time available',
     voiceInputQuotaExhaustedTitle: 'Voice input time used up',
     voiceInputQuotaExhaustedFreeDesc:
-      'Today’s {limit} voice input time has been used up. Upgrade to get 200 minutes per day.',
+      'You’ve used today’s {limit} of free voice input. Upgrade to get {subscriptionLimit} per day.',
     voiceInputQuotaExhaustedSubscribedDesc: 'Today’s {limit} voice input time has been used up.',
     voiceInputUpgradeSubscription: 'Upgrade subscription',
     voiceInputQuotaAcknowledge: 'Got it',

--- a/src/renderer/services/voiceInput/index.ts
+++ b/src/renderer/services/voiceInput/index.ts
@@ -6,6 +6,11 @@ export {
   getAsrErrorMessage,
 } from './errors';
 export {
+  applyVoiceInputQuotaConsumption,
+  calculateVoiceInputConsumedSeconds,
+  type VoiceInputQuotaSnapshot,
+} from './quota';
+export {
   type RealtimeVoiceInputSession,
   startRealtimeVoiceInput,
 } from './realtimeAsrClient';

--- a/src/renderer/services/voiceInput/quota.test.ts
+++ b/src/renderer/services/voiceInput/quota.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  applyVoiceInputQuotaConsumption,
+  calculateVoiceInputConsumedSeconds,
+} from './quota';
+
+describe('calculateVoiceInputConsumedSeconds', () => {
+  test.each([
+    [0, 0],
+    [1, 1],
+    [16_000, 1],
+    [16_001, 2],
+    [Number.NaN, 0],
+  ])('converts %s output samples to %s billed seconds', (sampleCount, expectedSeconds) => {
+    expect(calculateVoiceInputConsumedSeconds(sampleCount)).toBe(expectedSeconds);
+  });
+});
+
+describe('applyVoiceInputQuotaConsumption', () => {
+  test('subtracts completed recording usage from the session quota snapshot', () => {
+    expect(applyVoiceInputQuotaConsumption({
+      usedSecondsToday: 60,
+      remainingSecondsToday: 1140,
+      limitSecondsToday: 1200,
+    }, 45)).toEqual({
+      usedSecondsToday: 105,
+      remainingSecondsToday: 1095,
+      limitSecondsToday: 1200,
+    });
+  });
+
+  test('marks quota exhausted when recording consumes the exact remainder', () => {
+    expect(applyVoiceInputQuotaConsumption({
+      usedSecondsToday: 1199,
+      remainingSecondsToday: 1,
+      limitSecondsToday: 1200,
+    }, 1)).toEqual({
+      usedSecondsToday: 1200,
+      remainingSecondsToday: 0,
+      limitSecondsToday: 1200,
+    });
+  });
+});

--- a/src/renderer/services/voiceInput/quota.ts
+++ b/src/renderer/services/voiceInput/quota.ts
@@ -1,0 +1,34 @@
+import type { AsrRealtimeSessionData } from '../../../shared/asr/constants';
+import { VOICE_INPUT_TARGET_SAMPLE_RATE } from './constants';
+
+export type VoiceInputQuotaSnapshot = Pick<
+  AsrRealtimeSessionData,
+  'usedSecondsToday' | 'remainingSecondsToday' | 'limitSecondsToday'
+>;
+
+const normalizeSeconds = (seconds: number): number => (
+  Number.isFinite(seconds) ? Math.max(0, Math.ceil(seconds)) : 0
+);
+
+export const calculateVoiceInputConsumedSeconds = (outputSampleCount: number): number => {
+  if (!Number.isFinite(outputSampleCount) || outputSampleCount <= 0) {
+    return 0;
+  }
+  return Math.ceil(Math.floor(outputSampleCount) / VOICE_INPUT_TARGET_SAMPLE_RATE);
+};
+
+export const applyVoiceInputQuotaConsumption = (
+  quota: VoiceInputQuotaSnapshot,
+  consumedSeconds: number,
+): VoiceInputQuotaSnapshot => {
+  const availableSeconds = Math.max(0, quota.remainingSecondsToday);
+  const appliedSeconds = Math.min(availableSeconds, normalizeSeconds(consumedSeconds));
+  return {
+    usedSecondsToday: Math.min(
+      quota.limitSecondsToday,
+      Math.max(0, quota.usedSecondsToday) + appliedSeconds,
+    ),
+    remainingSecondsToday: availableSeconds - appliedSeconds,
+    limitSecondsToday: quota.limitSecondsToday,
+  };
+};

--- a/src/renderer/services/voiceInput/realtimeAsrClient.ts
+++ b/src/renderer/services/voiceInput/realtimeAsrClient.ts
@@ -3,10 +3,13 @@ import {
   AsrLangType,
   type AsrRealtimeEvent,
   AsrRealtimeEventType,
-  type AsrRealtimeSessionData,
 } from '../../../shared/asr/constants';
 import { VOICE_INPUT_TARGET_SAMPLE_RATE } from './constants';
 import { AsrClientError, getFallbackAsrErrorMessage } from './errors';
+import {
+  calculateVoiceInputConsumedSeconds,
+  type VoiceInputQuotaSnapshot,
+} from './quota';
 import {
   type RealtimeVoiceRecordingSession,
   startRealtimeVoiceRecording,
@@ -19,11 +22,9 @@ const PCM16_BYTES_PER_SAMPLE = 2;
 export interface RealtimeVoiceInputSession {
   stop: () => Promise<string>;
   cancel: () => void;
+  getConsumedSeconds: () => number;
   maxSessionSeconds: number;
-  quota: Pick<
-    AsrRealtimeSessionData,
-    'usedSecondsToday' | 'remainingSecondsToday' | 'limitSecondsToday'
-  >;
+  quota: VoiceInputQuotaSnapshot;
 }
 
 interface StartRealtimeVoiceInputOptions {
@@ -335,5 +336,8 @@ export const startRealtimeVoiceInput = async ({
       recorder?.cancel();
       closeSocket();
     },
+    getConsumedSeconds: () => calculateVoiceInputConsumedSeconds(
+      recorder?.getOutputSampleCount() ?? 0,
+    ),
   };
 };


### PR DESCRIPTION
## Summary
- update the desktop quota snapshot from the actual realtime recording duration so exact quota exhaustion opens the prompt immediately after recording stops
- preserve the existing realtime ASR quota-error handling while avoiding a generic error toast when the local recording also exhausts the remaining quota
- clarify the free voice-input copy and render both free and subscribed limits from quota constants instead of hardcoding 200 minutes in i18n text

## Scope
- Desktop client only
- No ASR server or API changes

## Verification
- `npx vitest run src/renderer/services/voiceInput/quota.test.ts src/renderer/services/voiceInput/realtimeAsrClient.test.ts src/renderer/store/slices/asrQuotaSlice.test.ts` (15 tests passed)
- changed-file ESLint passed with zero warnings
- `npm run build` passed