### PR TITLE
feat(dsh): sync reasoning-effort metadata so thinking strength is configurable for LobsterAI models

### DIFF
--- a/src/main/libs/dshConfigSync.test.ts
+++ b/src/main/libs/dshConfigSync.test.ts
@@ -94,6 +94,57 @@ describe('renderDshManagedSettings', () => {
     expect(managed.routes['lobsterai-gw'].models[0].input).toEqual(['text', 'image']);
   });
 
+  test('keeps models without thinking capability free of effort metadata', () => {
+    const managed = renderDshManagedSettings({ gw: providerFixture() });
+    const route = managed.routes['lobsterai-gw'];
+    expect(route.models[0].reasoningEfforts).toBeUndefined();
+    expect(route.compat).toBeUndefined();
+  });
+
+  test('declares default OpenAI efforts and route compat for a thinking model', () => {
+    const managed = renderDshManagedSettings({
+      gw: providerFixture({ models: [{ id: 'thinker', name: 'Thinker', supportsThinking: true }] }),
+    });
+    const route = managed.routes['lobsterai-gw'];
+    expect(route.models[0].reasoningEfforts).toEqual({
+      off: null,
+      low: 'low',
+      medium: 'medium',
+      high: 'high',
+      max: 'max',
+    });
+    expect(route.compat).toEqual({ thinkingFormat: 'openai', supportsReasoningEffort: true });
+  });
+
+  test('maps an explicit per-model thinkingLevelMap instead of the default', () => {
+    const managed = renderDshManagedSettings({
+      gw: providerFixture({
+        models: [{
+          id: 'deepseek-v4',
+          name: 'DeepSeek V4',
+          supportsThinking: true,
+          customParams: { thinkingLevelMap: { off: 'off', high: 'high', xhigh: 'xhigh' } },
+        }],
+      }),
+    });
+    const route = managed.routes['lobsterai-gw'];
+    expect(route.models[0].reasoningEfforts).toEqual({ off: null, high: 'high', xhigh: 'xhigh' });
+    expect(route.compat).toEqual({ thinkingFormat: 'openai', supportsReasoningEffort: true });
+  });
+
+  test('leaves anthropic routes without reasoning compat', () => {
+    const managed = renderDshManagedSettings({
+      gw: providerFixture({
+        apiFormat: 'anthropic',
+        models: [{ id: 'claude', name: 'Claude', supportsThinking: true }],
+      }),
+    });
+    const route = managed.routes['lobsterai-gw'];
+    expect(route.api).toBe('anthropic-messages');
+    expect(route.models[0].reasoningEfforts).toBeUndefined();
+    expect(route.compat).toBeUndefined();
+  });
+
   test('skips disabled, oauth, keyless, model-less, and gemini providers with reasons', () => {
     const managed = renderDshManagedSettings({
       off: providerFixture({ enabled: false }),
@@ -148,6 +199,44 @@ describe('plan provider (token proxy)', () => {
     expect(route.models.map((model) => model.id)).toEqual(['plan-chat', 'plan-vision']);
     // The proxy overwrites Authorization, so the key only has to be non-empty.
     expect(managed.envVars[route.apiKeyEnv]).toBeTruthy();
+  });
+
+  test('declares plan reasoning efforts from server thinking config', () => {
+    const managed = renderDshManagedSettings(
+      {},
+      {
+        planProvider: {
+          ...plan,
+          models: [
+            {
+              modelId: 'plan-chat',
+              supportsThinking: true,
+              thinkingConfig: {
+                options: [
+                  { level: 'off', openclawLevel: 'off' },
+                  { level: 'high', openclawLevel: 'high' },
+                  { level: 'xhigh', openclawLevel: 'xhigh' },
+                ],
+                defaultLevel: 'high',
+              },
+            },
+            { modelId: 'plan-vision' },
+          ],
+        },
+      }
+    );
+    const route = managed.routes[DSH_PLAN_ROUTE_ID];
+    expect(route.models[0].reasoningEfforts).toEqual({ off: null, high: 'high', xhigh: 'xhigh' });
+    expect(route.compat).toEqual({ thinkingFormat: 'openai', supportsReasoningEffort: true });
+    // Models without thinking capability stay untouched.
+    expect(route.models[1].reasoningEfforts).toBeUndefined();
+  });
+
+  test('plan models without thinking capability leave the route bare', () => {
+    const managed = renderDshManagedSettings({}, { planProvider: plan });
+    const route = managed.routes[DSH_PLAN_ROUTE_ID];
+    expect(route.compat).toBeUndefined();
+    expect(route.models.every((model) => model.reasoningEfforts === undefined)).toBe(true);
   });
 
   test('marks the plan as LobsterAI-managed in the picker', () => {

--- a/src/main/libs/dshConfigSync.ts
+++ b/src/main/libs/dshConfigSync.ts
@@ -13,8 +13,15 @@
 //     that disappeared is the one exception, repaired instead of left broken.
 // Nothing else in the home is touched: no composition patch layer, so every
 // shipped provider, tool, and plugin stays exactly as dsh ships it.
-// Reasoning-effort/thinking metadata is deliberately not declared yet; wire
-// dialects differ per upstream and over-claiming breaks requests mid-turn.
+// Reasoning-effort/thinking metadata is declared only when the source model
+// actually supports it, so dsh's thinking-strength control shows up for
+// LobsterAI-managed models without over-claiming: a model whose provider
+// declared no thinking capability keeps the pre-existing behavior (no effort
+// control, provider default thinking). For supporting models the route carries
+// `compat.supportsReasoningEffort` plus per-model `reasoningEfforts` in dsh's
+// own schema; wire dialects still vary per upstream, which is why the values
+// come from LobsterAI-side metadata (thinkingLevelMap) rather than a blanket
+// declaration.
 // No Electron imports; callers pass DSH_HOME explicitly.
 
 import * as fs from 'fs';
@@ -22,6 +29,7 @@ import * as yaml from 'js-yaml';
 import * as path from 'path';
 
 import { ApiFormat, ProviderRegistry } from '../../shared/providers/constants';
+import { type ModelThinkingConfig } from '../../shared/providers/modelThinking';
 import type { ProviderConfig } from '../../shared/providers/types';
 
 export const DSH_MANAGED_PROVIDER_PREFIX = 'lobsterai-';
@@ -51,12 +59,22 @@ export interface DshProviderRoute {
   apiKeyEnv: string;
   api: 'openai-completions' | 'anthropic-messages';
   baseURL: string;
+  /** Reasoning-effort switches, declared only when a model supports thinking. */
+  compat?: {
+    thinkingFormat?: string;
+    supportsReasoningEffort?: boolean;
+  };
   models: Array<{
     id: string;
     name: string;
     contextWindow?: number;
     maxTokens?: number;
     input?: Array<'text' | 'image'>;
+    /**
+     * dsh's per-model effort-to-wire map ({@link https://github.com/deepseek-ai/deepseek-harness}).
+     * Absent when the model has no declared thinking capability.
+     */
+    reasoningEfforts?: Record<string, string | null>;
   }>;
 }
 
@@ -73,6 +91,9 @@ export interface DshPlanProviderInput {
     supportsImage?: boolean;
     contextWindow?: number;
     maxTokens?: number;
+    /** Thinking capability from server model metadata; drives dsh's effort control. */
+    supportsThinking?: boolean;
+    thinkingConfig?: ModelThinkingConfig;
   }>;
 }
 
@@ -106,6 +127,100 @@ export function mapApiFormatToDshProtocol(apiFormat: string | undefined): DshPro
   // compatible endpoints; chat-completions is the universally supported wire.
   if (apiFormat === ApiFormat.OpenAI || apiFormat === undefined) return 'openai-completions';
   return null;
+}
+
+// dsh's reasoning-effort levels for an OpenAI-compatible endpoint. The wire
+// value equals the level name (OpenAI's `reasoning_effort` vocabulary), and
+// `off` maps to null because closing thinking is the parameter's absence.
+const DSH_OPENAI_DEFAULT_REASONING_EFFORTS: Record<string, string | null> = {
+  off: null,
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  max: 'max',
+};
+
+const DSH_THINKING_OFF = 'off';
+
+// A route that declares a reasoning-effort control must also advertise the
+// capability, or dsh's dispatch never sends the wire value. Only
+// openai-completions takes these compat switches (see pi-ai's compat gates);
+// anthropic-messages has no reasoning-effort field, so its routes stay bare.
+function renderRouteThinkingCompat(
+  api: DshProviderRoute['api'],
+  models: DshProviderRoute['models'],
+): DshProviderRoute['compat'] | undefined {
+  if (api !== 'openai-completions') return undefined;
+  const anyEfforts = models.some((model) => model.reasoningEfforts !== undefined);
+  return anyEfforts ? { thinkingFormat: 'openai', supportsReasoningEffort: true } : undefined;
+}
+
+/**
+ * Renders dsh's `reasoningEfforts` from LobsterAI-side thinking metadata.
+ *
+ * A declared LobsterAI thinking level maps to the same level name on the wire
+ * (LobsterAI's OpenClaw sync uses the level name as the wire value), and a
+ * LobsterAI level pinned to null (unsupported) is omitted so dsh never offers
+ * a control it cannot honor. `off` is written as null: dsh's convention where
+ * closing thinking means not sending the parameter at all.
+ *
+ * @returns the effort map, or undefined when the model has no thinking level
+ *   (nothing to declare — dsh falls back to provider default thinking).
+ */
+function renderDshReasoningEfforts(
+  thinkingLevelMap: Record<string, string | null> | undefined,
+): Record<string, string | null> | undefined {
+  if (!thinkingLevelMap) return undefined;
+  const efforts: Record<string, string | null> = {};
+  let hasThinkingLevel = false;
+  for (const [level, wire] of Object.entries(thinkingLevelMap)) {
+    if (wire === null) continue; // pinned unsupported in LobsterAI
+    if (level === DSH_THINKING_OFF) {
+      efforts.off = null;
+      continue;
+    }
+    efforts[level] = wire;
+    hasThinkingLevel = true;
+  }
+  return hasThinkingLevel ? efforts : undefined;
+}
+
+/** Extracts a thinking-level map the user may have declared per model. */
+function providerModelThinkingLevelMap(model: NonNullable<ProviderConfig['models']>[number]): Record<string, string | null> | undefined {
+  if (model.supportsThinking !== true) return undefined;
+  const raw = (model.customParams as Record<string, unknown> | undefined)?.['thinkingLevelMap'];
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const map: Record<string, string | null> = {};
+  for (const [level, wire] of Object.entries(raw as Record<string, unknown>)) {
+    if (wire === null || typeof wire === 'string') {
+      map[level] = wire as string | null;
+    }
+  }
+  return map;
+}
+
+/**
+ * dsh's effort map for one provider model, or undefined when the model has no
+ * declared thinking capability. Models flagged `supportsThinking` without an
+ * explicit level map get the OpenAI-compatible default set, matching how dsh
+ * users hand-write the same routes; everything else stays as it was (no
+ * control, provider default thinking).
+ */
+function renderProviderModelReasoningEfforts(model: NonNullable<ProviderConfig['models']>[number]): Record<string, string | null> | undefined {
+  const explicit = renderDshReasoningEfforts(providerModelThinkingLevelMap(model));
+  if (explicit) return explicit;
+  return model.supportsThinking === true ? DSH_OPENAI_DEFAULT_REASONING_EFFORTS : undefined;
+}
+
+/** dsh's effort map for one plan (token-proxy) model, from server metadata. */
+function renderPlanModelReasoningEfforts(model: DshPlanProviderInput['models'][number]): Record<string, string | null> | undefined {
+  if (model.supportsThinking !== true) return undefined;
+  if (!model.thinkingConfig || model.thinkingConfig.options.length === 0) return undefined;
+  const map: Record<string, string | null> = {};
+  for (const option of model.thinkingConfig.options) {
+    map[option.openclawLevel] = option.openclawLevel;
+  }
+  return renderDshReasoningEfforts(map);
 }
 
 export function renderDshManagedSettings(
@@ -155,6 +270,20 @@ export function renderDshManagedSettings(
     const routeId = sanitizeDshRouteId(providerId);
     const apiKeyEnv = deriveDshApiKeyEnvRef(routeId);
     envVars[apiKeyEnv] = apiKey;
+    const renderedModels = models.map((model) => ({
+      id: model.id,
+      name: model.name?.trim() || model.id,
+      ...(typeof model.contextWindow === 'number' && model.contextWindow > 0
+        ? { contextWindow: Math.floor(model.contextWindow) }
+        : {}),
+      ...(typeof model.maxTokens === 'number' && model.maxTokens > 0 ? { maxTokens: Math.floor(model.maxTokens) } : {}),
+      ...(model.supportsImage ? { input: ['text', 'image'] as Array<'text' | 'image'> } : {}),
+      // Reasoning effort is an OpenAI-completions wire concept; anthropic
+      // routes keep bare models (dsh has no reasoning-effort field there).
+      ...(api === 'openai-completions' && renderProviderModelReasoningEfforts(model)
+        ? { reasoningEfforts: renderProviderModelReasoningEfforts(model) }
+        : {}),
+    }));
     routes[routeId] = {
       // Prefer the canonical label ("DeepSeek") over the raw config key
       // ("deepseek"), and mark the entry as LobsterAI-managed.
@@ -164,15 +293,10 @@ export function renderDshManagedSettings(
       apiKeyEnv,
       api,
       baseURL,
-      models: models.map((model) => ({
-        id: model.id,
-        name: model.name?.trim() || model.id,
-        ...(typeof model.contextWindow === 'number' && model.contextWindow > 0
-          ? { contextWindow: Math.floor(model.contextWindow) }
-          : {}),
-        ...(typeof model.maxTokens === 'number' && model.maxTokens > 0 ? { maxTokens: Math.floor(model.maxTokens) } : {}),
-        ...(model.supportsImage ? { input: ['text', 'image'] as Array<'text' | 'image'> } : {}),
-      })),
+      ...(renderRouteThinkingCompat(api, renderedModels)
+        ? { compat: renderRouteThinkingCompat(api, renderedModels) }
+        : {}),
+      models: renderedModels,
     };
   }
 
@@ -250,20 +374,27 @@ function renderPlanRoutes(
     const apiKeyEnv = deriveDshApiKeyEnvRef(routeId);
     envVars[apiKeyEnv] = DSH_PLAN_API_KEY_PLACEHOLDER;
     const needsProtocolSuffix = protocolCount > 1 && routeId === DSH_PLAN_ANTHROPIC_ROUTE_ID;
+    const renderedModels = protocolModels.map((model) => ({
+      id: model.modelId,
+      name: model.modelName?.trim() || model.modelId,
+      ...(typeof model.contextWindow === 'number' && model.contextWindow > 0
+        ? { contextWindow: Math.floor(model.contextWindow) }
+        : {}),
+      ...(typeof model.maxTokens === 'number' && model.maxTokens > 0 ? { maxTokens: Math.floor(model.maxTokens) } : {}),
+      ...(model.supportsImage ? { input: ['text', 'image'] as Array<'text' | 'image'> } : {}),
+      ...(renderPlanModelReasoningEfforts(model)
+        ? { reasoningEfforts: renderPlanModelReasoningEfforts(model) }
+        : {}),
+    }));
     routes[routeId] = {
       displayName: `${DSH_MANAGED_LABEL_PREFIX}${plan.displayName}${needsProtocolSuffix ? ' (Anthropic)' : ''}`,
       apiKeyEnv,
       api,
       baseURL,
-      models: protocolModels.map((model) => ({
-        id: model.modelId,
-        name: model.modelName?.trim() || model.modelId,
-        ...(typeof model.contextWindow === 'number' && model.contextWindow > 0
-          ? { contextWindow: Math.floor(model.contextWindow) }
-          : {}),
-        ...(typeof model.maxTokens === 'number' && model.maxTokens > 0 ? { maxTokens: Math.floor(model.maxTokens) } : {}),
-        ...(model.supportsImage ? { input: ['text', 'image'] as Array<'text' | 'image'> } : {}),
-      })),
+      ...(renderRouteThinkingCompat(api, renderedModels)
+        ? { compat: renderRouteThinkingCompat(api, renderedModels) }
+        : {}),
+      models: renderedModels,
     };
     emitted.push(routeId);
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8580,6 +8580,9 @@ if (!gotTheLock) {
           modelName: model.modelName,
           apiFormat: model.apiFormat,
           supportsImage: model.supportsImage,
+          // Thinking capability flows into dsh's reasoning-effort control.
+          supportsThinking: model.supportsThinking,
+          thinkingConfig: model.thinkingConfig,
           contextWindow: model.contextWindow,
           maxTokens: model.maxTokens,
         })),


### PR DESCRIPTION
## Summary

LobsterAI 内置的 DSH（DeepSeek Harness）工作台同步模型到 `~/.dsh/settings.yaml` 时没有声明 reasoning-effort 元数据，导致 DSH Web UI 中 LobsterAI 提供模型的"思考强度"控件缺失。本 PR 在 `dshConfigSync.ts` 中把 LobsterAI 侧的 thinking 元数据（`supportsThinking` / `thinkingLevelMap` / `thinkingConfig`）映射为 DSH 的 `reasoningEfforts`（模型级）和 `compat`（路由级），使思考强度可配置，且仅在模型明确支持思考时声明，避免 over-claim。

## Related Issue

Fixes #2577

## Changes Made

- `src/main/libs/dshConfigSync.ts`
  - `DshProviderRoute` 增加可选 `compat`（`thinkingFormat` / `supportsReasoningEffort`），模型条目增加可选 `reasoningEfforts`
  - 自定义 provider 模型：`supportsThinking === true` 时渲染默认 OpenAI 档位（`off/low/medium/high/max`），存在 `customParams.thinkingLevelMap` 时按显式映射
  - 套餐（token-proxy）模型：`DshPlanProviderInput` 增加 `supportsThinking` / `thinkingConfig`，从服务端 thinking 元数据渲染 `reasoningEfforts`
  - 仅 `openai-completions` 路由声明 reasoning compat；`anthropic-messages` 路由保持裸模型（pi-ai 该协议无 reasoning-effort 字段）
- `src/main/main.ts`
  - `getPlanProvider` 转发 `supportsThinking` / `thinkingConfig` 到 DSH plan provider 输入
- `src/main/libs/dshConfigSync.test.ts`
  - 新增 5 个测试：默认 efforts、显式 thinkingLevelMap、套餐 thinking config、anthropic 裸路由、无思考能力模型不受影响

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [ ] Updated existing tests
- [x] Manual testing performed

本地验证（fork 上）：

```text
npx vitest run src/main/libs/dshConfigSync.test.ts   # 34 passed (5 new)
npx vitest run src/main/libs/dsh                     # 90 passed
npx eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0 (touched files)  # clean
npm run compile:electron                             # clean
```

端到端渲染验证：同步后 `settings.yaml` 生成：

```yaml
lobsterai-plan:
  api: openai-completions
  compat:
    thinkingFormat: openai
    supportsReasoningEffort: true
  models:
    - id: deepseek-v4-flash-vision-exp
      reasoningEfforts:
        'off': null
        high: high
        xhigh: xhigh
```

## Screenshots (if applicable)

无 UI 截图（改动在 main 进程配置同步层；DSH Web UI 由内置 runtime 渲染）。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

<!-- If your PR includes Electron-specific changes, describe them here -->
- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

说明：改动在 main 进程的 DSH 配置同步层（`src/main/libs/dshConfigSync.ts` 与 `src/main/main.ts` 的 `getPlanProvider`），不涉及 preload / IPC / 窗口管理。生成的 `settings.yaml` 由内置 DSH runtime（`@deepseek-ai/dsh-llm-pi-ai`）消费，DSH Web UI 的思考强度控件即基于这些字段渲染。

## Additional Notes

- 这是 LobsterAI 侧的集成边界修复，不涉及 OpenClaw patch。
- 保持"不 over-claim"原则：仅当模型明确支持思考（`supportsThinking` / thinking 元数据）时才声明 `reasoningEfforts`；wire 值遵循 DSH 自身 schema（`reasoningEfforts` / `compat`），已对照安装的 `@deepseek-ai/dsh-llm-pi-ai` runtime 验证。
