### PR TITLE
fix(security): harden MCP stdio command and external URL boundaries

### DIFF
--- a/scripts/demo-security-validation.mjs
+++ b/scripts/demo-security-validation.mjs
@@ -1,0 +1,27 @@
+import { openExternalSafe } from '../src/shared/shell/externalUrl.ts';
+import { validateStdioCommand } from '../src/shared/mcp/stdio.ts';
+
+const stdioCases = [
+  ['legal npx server', validateStdioCommand('npx', ['-y', 'tavily-mcp@latest'])],
+  ['absolute path with spaces', validateStdioCommand('C:\\Program Files\\nodejs\\node.exe', ['server.js'])],
+  ['injected inline args', validateStdioCommand('npx -y evil')],
+  ['shell metachar', validateStdioCommand('node & calc')],
+  ['path traversal', validateStdioCommand('C:\\safe\\..\\evil.exe')],
+];
+
+const urlCases = [
+  ['https URL', openExternalSafe('https://example.com/path')],
+  ['mailto', openExternalSafe('mailto:test@example.com')],
+  ['javascript URL', openExternalSafe('javascript:alert(1)')],
+  ['scheme-less URL', openExternalSafe('//host/path')],
+];
+
+console.log('stdio validation:');
+for (const [label, result] of stdioCases) {
+  console.log(`  ${label}: ${JSON.stringify(result)}`);
+}
+
+console.log('external URL validation:');
+for (const [label, result] of urlCases) {
+  console.log(`  ${label}: ${JSON.stringify(result)}`);
+}

--- a/src/main/ipcHandlers/mcp/handlers.ts
+++ b/src/main/ipcHandlers/mcp/handlers.ts
@@ -2,6 +2,10 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import https from 'https';
 
 import { McpIpcChannel } from '../../../shared/mcp/constants';
+import {
+  getStdioCommandValidationMessage,
+  validateStdioCommand,
+} from '../../../shared/mcp/stdio';
 import { normalizeMcpServerUrlInput } from '../../../shared/mcp/url';
 import { OpenClawConfigImpact } from '../../libs/openclawConfigImpact';
 import type { McpRuntime } from '../../mcp/mcpRuntime';
@@ -54,6 +58,13 @@ function syncMcpConfig(
 }
 
 function normalizeMcpServerInput(data: Partial<McpServerFormData>): Partial<McpServerFormData> {
+  if (data.transportType === 'stdio' || (data.transportType === undefined && data.command !== undefined)) {
+    const validation = validateStdioCommand(data.command, data.args);
+    if (!validation.ok) {
+      throw new Error(getStdioCommandValidationMessage(validation));
+    }
+  }
+
   if (
     (data.transportType === 'sse' || data.transportType === 'http')
     && data.url !== undefined

--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -2993,6 +2993,35 @@ describe('OpenClawConfigSync runtime config output', () => {
       },
     });
   });
+
+  test('skips invalid stdio MCP servers while keeping valid ones', async () => {
+    const sync = await createSync({
+      getResolvedMcpServers: () => [
+        {
+          name: 'Evil',
+          transportType: 'stdio',
+          command: 'npx -y evil',
+          args: [],
+        },
+        {
+          name: 'Tavily',
+          transportType: 'stdio',
+          command: 'node',
+          args: ['server.js'],
+        },
+      ],
+    });
+
+    const result = sync.sync('mcp-server-updated');
+
+    expect(result.ok).toBe(true);
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.mcp.servers.Tavily).toMatchObject({
+      command: 'node',
+      args: ['server.js'],
+    });
+    expect(config.mcp.servers.Evil).toBeUndefined();
+  });
 });
 
 describe('resolveModelSourceForOpenClawProvider', () => {

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -14,6 +14,10 @@ import {
 } from '../../shared/browserWebAccess/constants';
 import { COWORK_TEMP_DIR_NAME } from '../../shared/cowork/constants';
 import { CoworkErrorModelSource } from '../../shared/cowork/errorDetail';
+import {
+  getStdioCommandValidationMessage,
+  validateStdioCommand,
+} from '../../shared/mcp/stdio';
 import { normalizeMcpServerUrlInput } from '../../shared/mcp/url';
 import { OPENCLAW_PLUGIN_INDEX_MANAGED_KEYS } from '../../shared/openclawEngine/constants';
 import { OpenClawTranscriptSafetyLimit } from '../../shared/openclawTranscript/constants';
@@ -1775,11 +1779,19 @@ function buildOpenClawMcpServers(
     }
 
     switch (server.transportType) {
-      case 'stdio':
-        if (server.command) entry.command = server.command;
+      case 'stdio': {
+        const stdioValidation = validateStdioCommand(server.command, server.args);
+        if (!stdioValidation.ok) {
+          console.warn(
+            `[OpenClawConfigSync] skipped MCP server "${server.name}" because its stdio command is invalid: ${getStdioCommandValidationMessage(stdioValidation)}`,
+          );
+          continue;
+        }
+        entry.command = stdioValidation.command;
         if (server.args?.length) entry.args = server.args;
         if (server.env && Object.keys(server.env).length > 0) entry.env = server.env;
         break;
+      }
       case 'sse':
         entry.url = normalizedRemoteUrl;
         if (server.headers && Object.keys(server.headers).length > 0)

--- a/src/main/libs/resolveStdioCommand.ts
+++ b/src/main/libs/resolveStdioCommand.ts
@@ -11,6 +11,10 @@ import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
+import {
+  getStdioCommandValidationMessage,
+  validateStdioCommand,
+} from '../../shared/mcp/stdio';
 import type { McpServerRecord } from '../mcp/mcpStore';
 import { getElectronNodeRuntimePath } from './coworkUtil';
 import { findSpawnableSystemNodePath } from './nodeRuntime';
@@ -142,6 +146,12 @@ function isNodeCommand(normalized: string): 'node' | 'npx' | 'npm' | null {
  */
 export async function resolveStdioCommand(server: McpServerRecord): Promise<ResolvedStdioCommand> {
   const stdioCommand = server.command || '';
+  const stdioValidation = validateStdioCommand(server.command, server.args);
+  if (!stdioValidation.ok) {
+    throw new Error(
+      `MCP stdio command for "${server.name}" is invalid: ${getStdioCommandValidationMessage(stdioValidation)}`,
+    );
+  }
   let effectiveCommand = stdioCommand;
   const stdioArgs = server.args || [];
   let effectiveArgs = [...stdioArgs];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -183,6 +183,7 @@ import {
 } from '../shared/shareDeployment/constants';
 import type { ShellOpenFailureReason as ShellOpenFailureReasonType } from '../shared/shell/constants';
 import { type ShellGetBrowserAppsInput, ShellIpc, ShellOpenFailureReason } from '../shared/shell/constants';
+import { openExternalSafe } from '../shared/shell/externalUrl';
 import { AgentManager } from './agentManager';
 import { APP_NAME, APP_USER_MODEL_ID, DB_FILENAME } from './appConstants';
 import { createLocalFileProtocolResponse } from './artifactLocalFileProtocol';
@@ -12312,8 +12313,13 @@ if (!gotTheLock) {
   });
 
   ipcMain.handle(ShellIpc.OpenExternal, async (_event, url: string) => {
+    const safeUrl = openExternalSafe(url);
+    if (!safeUrl.ok) {
+      console.warn('[Shell] blocked external URL with unsupported protocol:', url);
+      return { success: false, error: 'Unsupported URL protocol' };
+    }
     try {
-      await shell.openExternal(url);
+      await shell.openExternal(safeUrl.url);
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
@@ -13027,7 +13033,12 @@ if (!gotTheLock) {
 
     // 处理 window.open 请求（企微 SDK 授权弹窗等）
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-      if (isWecomAuthUrl(url)) {
+      const safeUrl = openExternalSafe(url);
+      if (!safeUrl.ok) {
+        console.warn('[Shell] blocked window.open URL with unsupported protocol:', url);
+        return { action: 'deny' };
+      }
+      if (isWecomAuthUrl(safeUrl.url)) {
         return {
           action: 'allow',
           overrideBrowserWindowOptions: {
@@ -13043,7 +13054,7 @@ if (!gotTheLock) {
           },
         };
       }
-      shell.openExternal(url);
+      shell.openExternal(safeUrl.url);
       return { action: 'deny' };
     });
 

--- a/src/main/mcp/mcpRuntime.ts
+++ b/src/main/mcp/mcpRuntime.ts
@@ -231,14 +231,20 @@ export class McpRuntime {
       return shimEnv;
     };
     const pushRawStdioServer = async (server: typeof enabledServers[number]): Promise<void> => {
-      const r = await resolveStdioCommand(server);
-      resolved.push({
-        name: server.name,
-        transportType: 'stdio',
-        command: r.command,
-        args: r.args,
-        env: { ...buildShimEnv(), ...(r.env || {}) },
-      });
+      try {
+        const r = await resolveStdioCommand(server);
+        resolved.push({
+          name: server.name,
+          transportType: 'stdio',
+          command: r.command,
+          args: r.args,
+          env: { ...buildShimEnv(), ...(r.env || {}) },
+        });
+      } catch (error) {
+        console.warn(
+          `[MCP] skipped raw stdio server "${server.name}": ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     };
 
     for (const server of enabledServers) {

--- a/src/main/mcp/mcpStore.test.ts
+++ b/src/main/mcp/mcpStore.test.ts
@@ -118,4 +118,44 @@ describe('McpStore', () => {
     expect(updated?.args).toBeUndefined();
     expect(updated?.env).toBeUndefined();
   });
+
+  test('rejects invalid stdio commands on create', () => {
+    expect(() =>
+      store.createServer({
+        name: 'invalid-stdio',
+        description: '',
+        transportType: 'stdio',
+        command: 'npx -y evil',
+      }),
+    ).toThrow(/arguments must be listed separately/);
+    expect(store.listServers()).toEqual([]);
+  });
+
+  test('rejects invalid stdio commands on update without changing the record', () => {
+    const server = store.createServer({
+      name: 'valid-stdio',
+      description: '',
+      transportType: 'stdio',
+      command: 'node',
+      args: ['server.js'],
+    });
+
+    expect(() => store.updateServer(server.id, { command: 'node; calc' })).toThrow(
+      /shell metacharacters/,
+    );
+    expect(store.getServer(server.id)).toMatchObject({
+      command: 'node',
+      args: ['server.js'],
+    });
+  });
+
+  test('skips legacy invalid stdio servers in enabled server resolution', () => {
+    db!.exec(`
+      INSERT INTO mcp_servers (id, name, description, enabled, transport_type, config_json, created_at, updated_at)
+      VALUES ('legacy-invalid', 'Legacy Invalid', '', 1, 'stdio', '{"command":"npx -y evil","args":[]}', 1, 1)
+    `);
+
+    expect(store.getEnabledServers()).toEqual([]);
+    expect(store.listServers()).toHaveLength(1);
+  });
 });

--- a/src/main/mcp/mcpStore.ts
+++ b/src/main/mcp/mcpStore.ts
@@ -1,6 +1,10 @@
 import Database from 'better-sqlite3';
 import crypto from 'crypto';
 
+import {
+  getStdioCommandValidationMessage,
+  validateStdioCommand,
+} from '../../shared/mcp/stdio';
 import type { McpLaunchResolution } from './mcpLaunchResolution';
 
 export interface McpServerRecord {
@@ -76,6 +80,16 @@ interface McpLaunchResolutionRow {
   last_probe_at: number | null;
   last_probe_status: string | null;
   updated_at: number;
+}
+
+function assertValidStdioConfig(
+  data: Pick<McpServerFormData, 'transportType' | 'command' | 'args'>,
+): void {
+  if (data.transportType !== 'stdio') return;
+  const validation = validateStdioCommand(data.command, data.args);
+  if (!validation.ok) {
+    throw new Error(getStdioCommandValidationMessage(validation));
+  }
 }
 
 export class McpStore {
@@ -259,6 +273,7 @@ export class McpStore {
     const id = crypto.randomUUID();
     const now = Date.now();
     const normalized = this.normalizeTransportConfig(data);
+    assertValidStdioConfig(normalized);
     const configJson = this.serializeConfig(normalized);
 
     this.db
@@ -290,6 +305,7 @@ export class McpStore {
       registryId: data.registryId !== undefined ? data.registryId : existing.registryId,
     });
 
+    assertValidStdioConfig(merged);
     const configJson = this.serializeConfig(merged);
 
     this.db
@@ -327,6 +343,16 @@ export class McpStore {
         'SELECT id, name, description, enabled, transport_type, config_json, created_at, updated_at FROM mcp_servers WHERE enabled = 1 ORDER BY created_at ASC',
       )
       .all() as McpServerRow[];
-    return rows.map((row) => this.deserializeRow(row));
+    return rows
+      .map((row) => this.deserializeRow(row))
+      .filter(server => {
+        if (server.transportType !== 'stdio') return true;
+        const validation = validateStdioCommand(server.command, server.args);
+        if (validation.ok) return true;
+        console.warn(
+          `[McpStore] skipped enabled stdio MCP server "${server.name}" because its command is invalid: ${getStdioCommandValidationMessage(validation)}`,
+        );
+        return false;
+      });
   }
 }

--- a/src/shared/mcp/stdio.test.ts
+++ b/src/shared/mcp/stdio.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  STDIO_ARG_MAX_LENGTH,
+  STDIO_COMMAND_MAX_LENGTH,
+  StdioCommandValidationError,
+  validateStdioCommand,
+} from './stdio';
+
+describe('validateStdioCommand', () => {
+  test('accepts bare executable names and absolute paths', () => {
+    expect(validateStdioCommand('npx', ['-y', 'my-mcp'])).toEqual({
+      ok: true,
+      command: 'npx',
+      args: ['-y', 'my-mcp'],
+    });
+    expect(validateStdioCommand('C:\\Program Files\\nodejs\\node.exe', ['server.js']).ok).toBe(true);
+    expect(validateStdioCommand('/opt/my app/bin/mcp-server').ok).toBe(true);
+    expect(validateStdioCommand('\\\\server\\share\\mcp server.exe').ok).toBe(true);
+  });
+
+  test('accepts args containing spaces and dollar signs', () => {
+    const result = validateStdioCommand('npx', ['--model', 'gpt-4o', '--token=$TOKEN', '--query=a b']);
+    expect(result).toEqual({
+      ok: true,
+      command: 'npx',
+      args: ['--model', 'gpt-4o', '--token=$TOKEN', '--query=a b'],
+    });
+  });
+
+  test('trims surrounding whitespace from the command', () => {
+    expect(validateStdioCommand('  node  ')).toEqual({ ok: true, command: 'node', args: [] });
+  });
+
+  test.each([
+    ['', StdioCommandValidationError.Empty],
+    ['   ', StdioCommandValidationError.Empty],
+    ['node\u0000-x', StdioCommandValidationError.ControlChar],
+    ['node\n-x', StdioCommandValidationError.ControlChar],
+    ['node\t-x', StdioCommandValidationError.ControlChar],
+    ['node & calc', StdioCommandValidationError.ShellMeta],
+    ['node | cat', StdioCommandValidationError.ShellMeta],
+    ['node; calc', StdioCommandValidationError.ShellMeta],
+    ['node < input', StdioCommandValidationError.ShellMeta],
+    ['node > output', StdioCommandValidationError.ShellMeta],
+    ['echo `whoami`', StdioCommandValidationError.ShellMeta],
+    ['node "$(whoami)"', StdioCommandValidationError.ShellMeta],
+    ['npx -y foo', StdioCommandValidationError.InlineArguments],
+    ['./server', StdioCommandValidationError.RelativePath],
+    ['node_modules/.bin/server', StdioCommandValidationError.RelativePath],
+    ['../server', StdioCommandValidationError.PathTraversal],
+    ['C:\\safe\\..\\evil.exe', StdioCommandValidationError.PathTraversal],
+  ])('rejects injection command "%s"', (command, error) => {
+    const result = validateStdioCommand(command);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe(error);
+  });
+
+  test('rejects non-string and overlong inputs', () => {
+    expect(validateStdioCommand(42 as unknown)).toMatchObject({
+      ok: false,
+      error: StdioCommandValidationError.NonString,
+    });
+    expect(validateStdioCommand('n'.repeat(STDIO_COMMAND_MAX_LENGTH + 1))).toMatchObject({
+      ok: false,
+      error: StdioCommandValidationError.TooLong,
+    });
+  });
+
+  test('validates the args array shape and contents', () => {
+    expect(validateStdioCommand('npx', 'bad')).toMatchObject({
+      ok: false,
+      error: StdioCommandValidationError.InvalidArgs,
+    });
+    expect(validateStdioCommand('npx', [42])).toMatchObject({
+      ok: false,
+      error: StdioCommandValidationError.InvalidArgType,
+    });
+    expect(validateStdioCommand('npx', ['ok', 'bad\narg'])).toMatchObject({
+      ok: false,
+      error: StdioCommandValidationError.ArgControlChar,
+    });
+    expect(validateStdioCommand('npx', ['ok', 'a&b'])).toMatchObject({
+      ok: false,
+      error: StdioCommandValidationError.ArgControlChar,
+    });
+    expect(validateStdioCommand('npx', ['x'.repeat(STDIO_ARG_MAX_LENGTH + 1)])).toMatchObject({
+      ok: false,
+      error: StdioCommandValidationError.ArgTooLong,
+    });
+  });
+});

--- a/src/shared/mcp/stdio.ts
+++ b/src/shared/mcp/stdio.ts
@@ -1,0 +1,148 @@
+export const StdioCommandValidationError = {
+  NonString: 'non-string',
+  Empty: 'empty',
+  TooLong: 'too-long',
+  ControlChar: 'control-char',
+  ShellMeta: 'shell-meta',
+  InlineArguments: 'inline-arguments',
+  RelativePath: 'relative-path',
+  PathTraversal: 'path-traversal',
+  InvalidArgs: 'invalid-args',
+  InvalidArgType: 'invalid-arg-type',
+  TooManyArgs: 'too-many-args',
+  ArgTooLong: 'arg-too-long',
+  ArgControlChar: 'arg-control-char',
+} as const;
+export type StdioCommandValidationError =
+  typeof StdioCommandValidationError[keyof typeof StdioCommandValidationError];
+
+export type StdioCommandValidationResult =
+  | { ok: true; command: string; args: string[] }
+  | { ok: false; error: StdioCommandValidationError; detail?: string };
+
+export const STDIO_COMMAND_MAX_LENGTH = 4096;
+export const STDIO_ARG_MAX_LENGTH = 4096;
+export const STDIO_ARGS_MAX_COUNT = 1024;
+
+const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/;
+const COMMAND_SHELL_META_RE = /[&|;<>`"'$%]/;
+const ARG_SHELL_META_RE = /[&|;<>`]/;
+const ABSOLUTE_PATH_RE = /^(?:[A-Za-z]:[\\/]|[\\/])/;
+const WINDOWS_DRIVE_RE = /^[A-Za-z]:/;
+
+function hasPathTraversal(command: string): boolean {
+  return command.split(/[\\/]+/).includes('..');
+}
+
+/**
+ * Validate an MCP stdio command and its structured argument list.
+ *
+ * Commands must be either a bare executable name or an absolute path.
+ * Arguments are passed as an array to the process spawner, so spaces and
+ * `$` sequences are allowed in individual args; other shell metacharacters
+ * are rejected so the config cannot smuggle a second command.
+ */
+export function validateStdioCommand(command: unknown, args?: unknown): StdioCommandValidationResult {
+  if (typeof command !== 'string') {
+    return { ok: false, error: StdioCommandValidationError.NonString };
+  }
+
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return { ok: false, error: StdioCommandValidationError.Empty };
+  }
+  if (trimmed.length > STDIO_COMMAND_MAX_LENGTH) {
+    return { ok: false, error: StdioCommandValidationError.TooLong };
+  }
+  if (CONTROL_CHAR_RE.test(trimmed)) {
+    return { ok: false, error: StdioCommandValidationError.ControlChar };
+  }
+  if (COMMAND_SHELL_META_RE.test(trimmed)) {
+    return { ok: false, error: StdioCommandValidationError.ShellMeta };
+  }
+  if (/\s/.test(trimmed) && !ABSOLUTE_PATH_RE.test(trimmed)) {
+    return { ok: false, error: StdioCommandValidationError.InlineArguments };
+  }
+  if (hasPathTraversal(trimmed)) {
+    return { ok: false, error: StdioCommandValidationError.PathTraversal };
+  }
+  if (
+    trimmed.startsWith('~')
+    || (WINDOWS_DRIVE_RE.test(trimmed) && !ABSOLUTE_PATH_RE.test(trimmed))
+    || (!ABSOLUTE_PATH_RE.test(trimmed) && /[\\/]/.test(trimmed))
+  ) {
+    return { ok: false, error: StdioCommandValidationError.RelativePath };
+  }
+
+  if (args === undefined) {
+    return { ok: true, command: trimmed, args: [] };
+  }
+  if (!Array.isArray(args)) {
+    return { ok: false, error: StdioCommandValidationError.InvalidArgs };
+  }
+  if (args.length > STDIO_ARGS_MAX_COUNT) {
+    return { ok: false, error: StdioCommandValidationError.TooManyArgs };
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (typeof arg !== 'string') {
+      return {
+        ok: false,
+        error: StdioCommandValidationError.InvalidArgType,
+        detail: String(i),
+      };
+    }
+    if (arg.length > STDIO_ARG_MAX_LENGTH) {
+      return {
+        ok: false,
+        error: StdioCommandValidationError.ArgTooLong,
+        detail: String(i),
+      };
+    }
+    if (CONTROL_CHAR_RE.test(arg) || ARG_SHELL_META_RE.test(arg)) {
+      return {
+        ok: false,
+        error: StdioCommandValidationError.ArgControlChar,
+        detail: String(i),
+      };
+    }
+  }
+
+  return { ok: true, command: trimmed, args: args.slice() };
+}
+
+export function getStdioCommandValidationMessage(
+  result: StdioCommandValidationResult,
+): string {
+  if (result.ok) return '';
+  const failure = result as Extract<StdioCommandValidationResult, { ok: false }>;
+  switch (failure.error) {
+    case StdioCommandValidationError.NonString:
+      return 'MCP stdio command must be a string';
+    case StdioCommandValidationError.Empty:
+      return 'MCP stdio command cannot be empty';
+    case StdioCommandValidationError.TooLong:
+      return 'MCP stdio command is too long';
+    case StdioCommandValidationError.ControlChar:
+      return 'MCP stdio command contains control characters';
+    case StdioCommandValidationError.ShellMeta:
+      return 'MCP stdio command contains shell metacharacters';
+    case StdioCommandValidationError.InlineArguments:
+      return 'MCP stdio command must be an executable path; arguments must be listed separately';
+    case StdioCommandValidationError.RelativePath:
+      return 'MCP stdio command must be an executable name or an absolute path';
+    case StdioCommandValidationError.PathTraversal:
+      return 'MCP stdio command must not contain ".." path segments';
+    case StdioCommandValidationError.InvalidArgs:
+      return 'MCP stdio args must be an array';
+    case StdioCommandValidationError.InvalidArgType:
+      return `MCP stdio arg at index ${failure.detail} must be a string`;
+    case StdioCommandValidationError.TooManyArgs:
+      return 'MCP stdio args list is too long';
+    case StdioCommandValidationError.ArgTooLong:
+      return `MCP stdio arg at index ${failure.detail} is too long`;
+    case StdioCommandValidationError.ArgControlChar:
+      return `MCP stdio arg at index ${failure.detail} contains control characters or shell metacharacters`;
+  }
+}

--- a/src/shared/shell/externalUrl.test.ts
+++ b/src/shared/shell/externalUrl.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest';
+
+import { OPEN_EXTERNAL_URL_MAX_LENGTH, openExternalSafe, OpenExternalUrlError } from './externalUrl';
+
+describe('openExternalSafe', () => {
+  test('allows http, https, mailto and tel', () => {
+    expect(openExternalSafe('https://example.com/path?a=1')).toEqual({
+      ok: true,
+      url: 'https://example.com/path?a=1',
+    });
+    expect(openExternalSafe('http://example.com').ok).toBe(true);
+    expect(openExternalSafe('mailto:test@example.com').ok).toBe(true);
+    expect(openExternalSafe('tel:+861234567890').ok).toBe(true);
+  });
+
+  test('accepts case-insensitive protocols and surrounding whitespace', () => {
+    expect(openExternalSafe('  HTTPS://EXAMPLE.COM  ')).toEqual({
+      ok: true,
+      url: 'https://example.com/',
+    });
+  });
+
+  test.each([
+    ['javascript:alert(1)', OpenExternalUrlError.UnsupportedProtocol],
+    ['data:text/html,<script>alert(1)</script>', OpenExternalUrlError.UnsupportedProtocol],
+    ['file:///etc/passwd', OpenExternalUrlError.UnsupportedProtocol],
+    ['vbscript:msgbox(1)', OpenExternalUrlError.UnsupportedProtocol],
+    ['example.com/path', OpenExternalUrlError.MissingScheme],
+    ['//host/path', OpenExternalUrlError.MissingScheme],
+    ['http://', OpenExternalUrlError.InvalidUrl],
+    ['https://exa mple.com', OpenExternalUrlError.InvalidUrl],
+    ['https://example.com\njavascript:alert(1)', OpenExternalUrlError.InvalidUrl],
+  ])('rejects unsafe URL "%s"', (input, error) => {
+    const result = openExternalSafe(input);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe(error);
+  });
+
+  test('rejects non-string, empty and overlong inputs', () => {
+    expect(openExternalSafe(42 as unknown)).toMatchObject({
+      ok: false,
+      error: OpenExternalUrlError.NonString,
+    });
+    expect(openExternalSafe('   ')).toMatchObject({
+      ok: false,
+      error: OpenExternalUrlError.Empty,
+    });
+    expect(openExternalSafe(`https://example.com/${'x'.repeat(OPEN_EXTERNAL_URL_MAX_LENGTH)}`))
+      .toMatchObject({
+        ok: false,
+        error: OpenExternalUrlError.TooLong,
+      });
+  });
+});

--- a/src/shared/shell/externalUrl.ts
+++ b/src/shared/shell/externalUrl.ts
@@ -1,0 +1,58 @@
+export const OpenExternalUrlError = {
+  NonString: 'non-string',
+  Empty: 'empty',
+  TooLong: 'too-long',
+  MissingScheme: 'missing-scheme',
+  UnsupportedProtocol: 'unsupported-protocol',
+  InvalidUrl: 'invalid-url',
+} as const;
+export type OpenExternalUrlError = typeof OpenExternalUrlError[keyof typeof OpenExternalUrlError];
+
+export type OpenExternalSafeResult =
+  | { ok: true; url: string }
+  | { ok: false; error: OpenExternalUrlError };
+
+export const OPEN_EXTERNAL_URL_MAX_LENGTH = 8192;
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/;
+
+/**
+ * Validate a URL before handing it to Electron's shell.openExternal.
+ *
+ * The allowlist is intentionally small and case-insensitive. A scheme is
+ * required so protocol-relative and scheme-less strings cannot reach the OS
+ * URL handler.
+ */
+export function openExternalSafe(input: unknown): OpenExternalSafeResult {
+  if (typeof input !== 'string') {
+    return { ok: false, error: OpenExternalUrlError.NonString };
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { ok: false, error: OpenExternalUrlError.Empty };
+  }
+  if (trimmed.length > OPEN_EXTERNAL_URL_MAX_LENGTH) {
+    return { ok: false, error: OpenExternalUrlError.TooLong };
+  }
+  if (CONTROL_CHAR_RE.test(trimmed)) {
+    return { ok: false, error: OpenExternalUrlError.InvalidUrl };
+  }
+  if (!SCHEME_RE.test(trimmed)) {
+    return { ok: false, error: OpenExternalUrlError.MissingScheme };
+  }
+
+  const protocol = trimmed.slice(0, trimmed.indexOf(':') + 1).toLowerCase();
+  if (!ALLOWED_PROTOCOLS.has(protocol)) {
+    return { ok: false, error: OpenExternalUrlError.UnsupportedProtocol };
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    return { ok: true, url: parsed.href };
+  } catch {
+    return { ok: false, error: OpenExternalUrlError.InvalidUrl };
+  }
+}


### PR DESCRIPTION
**Problem**

MCP stdio command/args flow from forms, JSON imports and config sync into openclaw.json without shell metacharacter or command path validation. Renderer-provided URLs are also passed directly to shell.openExternal without a protocol allowlist. For an application that executes third-party MCP configs and model-generated links, both boundaries can lead to unintended local process or OS protocol execution.

**Solution**

Add two Electron-free shared pure validators and apply them at multiple boundaries: IPC entry, SQLite persistence, command resolution, final OpenClaw config writing, the OpenExternal IPC handler and window.open handling. The design favors fail-closed validation with skip-and-log behavior for legacy invalid config, without changing existing public signatures or adding runtime dependencies.

**Changes**

- Add `validateStdioCommand()` for MCP stdio commands and args.
- Add `openExternalSafe()` with an http/https/mailto/tel protocol allowlist.
- Enforce stdio validation in `McpStore`, MCP IPC handlers, `resolveStdioCommand`, `mcpRuntime` and `openclawConfigSync`.
- Enforce URL protocol validation in `ShellIpc.OpenExternal` and `setWindowOpenHandler`.
- Add unit tests, store/config-sync compatibility tests and a runnable demo.

**Testing**

- 6 targeted Vitest files, 127 tests pass.
- `tsc -p electron-tsconfig.json --noEmit` and `tsc -p tsconfig.json --noEmit` pass.
- ESLint passes on all touched files with `--max-warnings 0`.
- Demo: `node --experimental-strip-types scripts/demo-security-validation.mjs`.

**Notes for Reviewer**

Args allow spaces and `$` but reject `& | ; < >` and backticks, because OpenClaw spawns MCP stdio with `shell: false`. Legacy invalid stdio entries are skipped for OpenClaw sync while remaining visible for editing in the UI. No runtime dependencies or public API signature changes are introduced.