### PR TITLE
feat(onboarding): add first-run analytics

### DIFF
--- a/specs/features/usage-analytics/2026-06-22-usage-analytics-design.md
+++ b/specs/features/usage-analytics/2026-06-22-usage-analytics-design.md
@@ -1173,6 +1173,30 @@ export const LogReporterActionPrefix = {
   - 该事件是本文"不上传错误详情"约定的明确例外：只上传经上述规则脱敏和截断后的错误摘要，不上传完整文件路径、完整 URL、子进程日志、provider 配置、API Key 或工作台 URL。
   - 不上传工作台内的会话内容、prompt 或文件内容。
 
+#### 2.4.44 `lobsterai_onboarding_action`
+
+- 状态：已实现。
+- 触发时机：新用户引导页曝光、点击下一步/跳过/开始体验、浏览器登录跳转结果、登录回调观察、登录后等待/完成 OpenClaw 网关重启、跳转登录但未登录返回客户端、新人任务打开结果、新人任务本地流式动画开始/结束，以及新人任务输入框上的二次登录按钮点击和登录跳转结果。
+- 事件含义：统计新用户引导漏斗、登录转化、新人任务触达和二次登录入口效果。
+- 业务参数：
+  - `actionType`：string，动作类型。当前取值包括 `guide_exposure`、`guide_next_click`、`guide_skip_click`、`guide_start_experience_click`、`login_redirect_result`、`auth_callback_observed`、`login_success_wait_gateway`、`login_success_gateway_settled`、`login_return_without_auth`、`welcome_task_open_result`、`welcome_stream_start`、`welcome_stream_complete`、`welcome_task_start_experience_click`、`welcome_task_login_redirect_result`。
+  - `source`：string，触发来源。当前取值包括 `first_run_gate`、`new_user_onboarding`、`skip`、`start_experience_login_callback`、`start_experience_window_focus_without_login`、`start_experience_dom_focus_without_login`、`start_experience_visibility_without_login`、`new_user_welcome_task`。
+  - `step`：string，引导步骤。当前取值为 `new_task` 或 `prompt_input`，仅引导页相关动作发送。
+  - `nextStep`：string，下一步引导步骤，仅点击下一步时发送。
+  - `result`：string，动作结果。当前取值为 `success` 或 `failed`，仅登录跳转或新人任务打开结果发送。
+  - `errorCode`：string，失败分类；仅失败时发送。当前取值包括 `login_redirect_failed`、`seed_failed`、`error`、`unknown`。
+  - `created`：boolean，新人任务是否为本次新建；仅新人任务打开成功时发送。
+  - `phase`：string，OpenClaw 网关阶段；仅登录后等待/完成网关重启时发送。
+  - `sawStartup`：boolean，是否观察到 OpenClaw 进入启动阶段；仅登录后完成网关等待时发送。
+  - `pendingAge`：number，跳转登录后未登录返回客户端时的等待毫秒数，四舍五入到整数。
+  - `charCount`：number，新人任务欢迎消息长度；仅本地流式动画开始/结束时发送。
+- 发送与容错口径：
+  - 事件由 Renderer 通过 `reportYdAnalyzer()` 发送，统一使用 `LogReporterAction.OnboardingAction`，走现有 `api:fetch` 链路、使用统计开关和通用参数。
+  - 采用 fire-and-forget，上报失败不影响引导页展示、登录跳转、新人任务创建或本地流式动画。
+  - 本地调试日志只记录动作类型，不记录完整事件参数。
+  - 新人任务流式动画只在开始和结束时发送事件，不按字符、分片或动画帧上报。
+- 隐私边界：不上传引导输入文案、新人任务欢迎正文、用户回复内容、会话 ID、用户 ID、文件名、本地路径、URL、token、API Key 或错误详情；`charCount` 只表示消息长度，不包含正文。
+
 ### 2.5 请求流程
 
 ```text

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -73,6 +73,7 @@ import {
   isLatestAsyncRequest,
 } from './services/latestAsyncRequest';
 import { LogReporterAction, reportYdAnalyzer } from './services/logReporter';
+import { getOnboardingErrorCode, reportOnboardingAction } from './services/onboardingAnalytics';
 import { scheduledTaskService } from './services/scheduledTask';
 import { isTextEditingSafeShortcut, matchesShortcut } from './services/shortcuts';
 import { themeService } from './services/theme';
@@ -297,6 +298,10 @@ const App: React.FC = () => {
   useEffect(() => {
     if (!shouldShowNewUserOnboarding) return;
     console.log(`[Onboarding] showing new user onboarding step=${newUserOnboardingStep}`);
+    reportOnboardingAction('guide_exposure', {
+      source: 'first_run_gate',
+      step: newUserOnboardingStep,
+    });
     setMainView('cowork');
     setIsSidebarCollapsed(false);
   }, [newUserOnboardingStep, shouldShowNewUserOnboarding]);
@@ -1202,15 +1207,30 @@ const App: React.FC = () => {
             `[Onboarding] new user welcome task seed returned no session source=${source}: `
             + `${result.error ?? 'unknown error'}`,
           );
+          reportOnboardingAction('welcome_task_open_result', {
+            source,
+            result: 'failed',
+            errorCode: result.error ? 'seed_failed' : 'unknown',
+          });
           showToast(i18nService.t('newUserWelcomeTaskCreateFailed'));
           return;
         }
         console.log(
           `[Onboarding] new user welcome task opened source=${source} session=${result.session.id}`,
         );
+        reportOnboardingAction('welcome_task_open_result', {
+          source,
+          result: 'success',
+          created: result.created === true,
+        });
       })
       .catch((error) => {
         console.warn(`[Onboarding] failed to open new user welcome task source=${source}:`, error);
+        reportOnboardingAction('welcome_task_open_result', {
+          source,
+          result: 'failed',
+          errorCode: getOnboardingErrorCode(error),
+        });
         showToast(i18nService.t('newUserWelcomeTaskCreateFailed'));
       });
   }, [showToast]);
@@ -1220,6 +1240,9 @@ const App: React.FC = () => {
       pendingNewUserWelcomeAuthCallbackAtRef.current = Date.now();
       if (hasNewUserWelcomeAfterLoginPending()) {
         console.log('[Onboarding] auth callback observed during new user login handoff');
+        reportOnboardingAction('auth_callback_observed', {
+          source: 'new_user_onboarding',
+        });
       }
     });
 
@@ -1246,6 +1269,10 @@ const App: React.FC = () => {
           '[Onboarding] login callback detected; waiting for OpenClaw startup before opening '
           + `new user welcome task phase=${snapshotPhase ?? 'unknown'}`,
         );
+        reportOnboardingAction('login_success_wait_gateway', {
+          source: 'new_user_onboarding',
+          phase: snapshotPhase ?? 'unknown',
+        });
         pendingNewUserWelcomeAfterLoginWaitingLoggedRef.current = true;
       }
       return;
@@ -1281,6 +1308,11 @@ const App: React.FC = () => {
         '[Onboarding] OpenClaw startup settled; opening pending new user welcome task '
         + `phase=${latestPhase ?? 'unknown'} sawStartup=${pendingNewUserWelcomeAfterLoginSawStartupRef.current}`,
       );
+      reportOnboardingAction('login_success_gateway_settled', {
+        source: 'new_user_onboarding',
+        phase: latestPhase ?? 'unknown',
+        sawStartup: pendingNewUserWelcomeAfterLoginSawStartupRef.current,
+      });
       pendingNewUserWelcomeAfterLoginSawStartupRef.current = false;
       pendingNewUserWelcomeAfterLoginWaitingLoggedRef.current = false;
       setIsNewUserOnboardingDismissed(true);
@@ -1339,6 +1371,10 @@ const App: React.FC = () => {
           '[Onboarding] login handoff returned without authenticated callback; opening '
           + `new user welcome task source=${source}`,
         );
+        reportOnboardingAction('login_return_without_auth', {
+          source,
+          pendingAge: Math.round(getNewUserWelcomeAfterLoginPendingAgeMs() ?? 0),
+        });
         pendingNewUserWelcomeAfterLoginSawStartupRef.current = false;
         pendingNewUserWelcomeAfterLoginWaitingLoggedRef.current = false;
         setIsNewUserOnboardingDismissed(true);
@@ -1372,15 +1408,24 @@ const App: React.FC = () => {
   }, [authUser, openNewUserWelcomeTask]);
 
   const handleNewUserOnboardingSkip = useCallback(() => {
+    reportOnboardingAction('guide_skip_click', {
+      source: 'new_user_onboarding',
+      step: newUserOnboardingStep,
+    });
     finishNewUserOnboarding('skip');
     if (privacyAgreed !== false) return;
 
     openNewUserWelcomeTask('skip');
-  }, [finishNewUserOnboarding, openNewUserWelcomeTask, privacyAgreed]);
+  }, [finishNewUserOnboarding, newUserOnboardingStep, openNewUserWelcomeTask, privacyAgreed]);
 
   const handleNewUserOnboardingNext = useCallback(() => {
     if (newUserOnboardingStep === NewUserOnboardingStep.NewTask) {
       console.log('[Onboarding] advancing new user onboarding step=new-task next=prompt-input');
+      reportOnboardingAction('guide_next_click', {
+        source: 'new_user_onboarding',
+        step: newUserOnboardingStep,
+        nextStep: NewUserOnboardingStep.PromptInput,
+      });
       setNewUserOnboardingStep(NewUserOnboardingStep.PromptInput);
       return;
     }
@@ -1389,6 +1434,10 @@ const App: React.FC = () => {
 
   const handleNewUserOnboardingStartExperience = useCallback(() => {
     console.log('[Onboarding] start experience clicked; starting login handoff');
+    reportOnboardingAction('guide_start_experience_click', {
+      source: 'new_user_onboarding',
+      step: newUserOnboardingStep,
+    });
     setNewUserWelcomeAfterLoginPending();
     setNewUserWelcomeAfterLoginSignal((value) => value + 1);
     finishNewUserOnboarding('start_experience');
@@ -1398,19 +1447,33 @@ const App: React.FC = () => {
           console.warn(
             `[Onboarding] login handoff from new user onboarding failed: ${result.error ?? 'unknown error'}`,
           );
+          reportOnboardingAction('login_redirect_result', {
+            source: 'new_user_onboarding',
+            result: 'failed',
+            errorCode: result.error ? 'login_redirect_failed' : 'unknown',
+          });
           consumeNewUserWelcomeAfterLoginPending();
           showToast(i18nService.t('welcomeLoginFailed'));
           return;
         }
         console.log('[Onboarding] login handoff from new user onboarding succeeded');
+        reportOnboardingAction('login_redirect_result', {
+          source: 'new_user_onboarding',
+          result: 'success',
+        });
         setNewUserWelcomeAfterLoginSignal((value) => value + 1);
       })
       .catch((error) => {
         console.warn('[Onboarding] failed to start login from new user onboarding:', error);
+        reportOnboardingAction('login_redirect_result', {
+          source: 'new_user_onboarding',
+          result: 'failed',
+          errorCode: getOnboardingErrorCode(error),
+        });
         consumeNewUserWelcomeAfterLoginPending();
         showToast(i18nService.t('welcomeLoginFailed'));
       });
-  }, [finishNewUserOnboarding, showToast]);
+  }, [finishNewUserOnboarding, newUserOnboardingStep, showToast]);
 
   const handlePermissionResponse = useCallback(async (result: CoworkPermissionResult) => {
     if (!pendingPermission) return;

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -58,6 +58,7 @@ import {
   LogReporterEntry,
   reportYdAnalyzer,
 } from '../../services/logReporter';
+import { getOnboardingErrorCode, reportOnboardingAction } from '../../services/onboardingAnalytics';
 import { resolveLocalizedText, skillService } from '../../services/skill';
 import { RootState } from '../../store';
 import { selectDraftPrompts } from '../../store/selectors/coworkSelectors';
@@ -717,6 +718,12 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     source: 'chat_login_experience_prompt' | 'new_user_welcome_task' = 'chat_login_experience_prompt',
   ) => {
     if (chatLoginExperiencePending) return;
+    const isNewUserWelcomeTaskSource = source === 'new_user_welcome_task';
+    if (isNewUserWelcomeTaskSource) {
+      reportOnboardingAction('welcome_task_start_experience_click', {
+        source: 'new_user_welcome_task',
+      });
+    }
     setChatLoginExperiencePending(true);
     logPromptModelSelection(
       'debug',
@@ -731,6 +738,12 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         'debug',
         `${source} login handoff succeeded`,
       );
+      if (isNewUserWelcomeTaskSource) {
+        reportOnboardingAction('welcome_task_login_redirect_result', {
+          source: 'new_user_welcome_task',
+          result: 'success',
+        });
+      }
       setShowChatLoginExperiencePrompt(false);
       setChatLoginExperiencePending(false);
     } catch (error) {
@@ -738,6 +751,13 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         'warn',
         `${source} login handoff failed: ${error instanceof Error ? error.message : String(error)}`,
       );
+      if (isNewUserWelcomeTaskSource) {
+        reportOnboardingAction('welcome_task_login_redirect_result', {
+          source: 'new_user_welcome_task',
+          result: 'failed',
+          errorCode: getOnboardingErrorCode(error),
+        });
+      }
       showToast(i18nService.t('welcomeLoginFailed'));
       setChatLoginExperiencePending(false);
     }

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -91,6 +91,7 @@ import {
   shouldReloadCurrentSessionForChange,
 } from './coworkSessionRefreshPolicy';
 import { i18nService } from './i18n';
+import { reportOnboardingAction } from './onboardingAnalytics';
 
 const STREAM_ERROR_DUPLICATE_WINDOW_MS = 10_000;
 
@@ -828,6 +829,10 @@ class CoworkService {
       'debug',
       `starting new user welcome task stream animation; session=${session.id}; chars=${characters.length}.`,
     );
+    reportOnboardingAction('welcome_stream_start', {
+      source: 'new_user_welcome_task',
+      charCount: characters.length,
+    });
 
     this.newUserWelcomeAnimationTimer = setInterval(() => {
       visibleCount = Math.min(
@@ -852,6 +857,10 @@ class CoworkService {
           'debug',
           `completed new user welcome task stream animation; session=${session.id}.`,
         );
+        reportOnboardingAction('welcome_stream_complete', {
+          source: 'new_user_welcome_task',
+          charCount: characters.length,
+        });
       }
     }, NEW_USER_WELCOME_STREAM_INTERVAL_MS);
   }
@@ -861,7 +870,7 @@ class CoworkService {
     store.dispatch(existsInSessionList ? setCurrentSession(session) : addSession(session));
   }
 
-  async seedNewUserWelcomeTask(): Promise<{ session: CoworkSession | null; error?: string }> {
+  async seedNewUserWelcomeTask(): Promise<{ session: CoworkSession | null; created?: boolean; error?: string }> {
     const cowork = window.electron?.cowork;
     if (!cowork?.seedNewUserWelcomeTask) {
       this.logDiagnostic('warn', 'new user welcome task seed IPC is unavailable.');
@@ -918,7 +927,7 @@ class CoworkService {
         `new user welcome task ready; session=${result.session.id}; `
         + `created=${Boolean(result.created)}; animated=${Boolean(welcomeMessage)}.`,
       );
-      return { session: result.session };
+      return { session: result.session, created: result.created === true };
     } catch (error) {
       this.logDiagnostic(
         'warn',

--- a/src/renderer/services/onboardingAnalytics.ts
+++ b/src/renderer/services/onboardingAnalytics.ts
@@ -1,0 +1,27 @@
+import { LogReporterAction, reportYdAnalyzer } from './logReporter';
+
+type OnboardingAnalyticsValue = string | number | boolean | null | undefined;
+
+export type OnboardingAnalyticsParams = Record<string, OnboardingAnalyticsValue>;
+
+export const reportOnboardingAction = (
+  actionType: string,
+  params: OnboardingAnalyticsParams = {},
+): void => {
+  console.debug(`[OnboardingAnalytics] reporting action ${actionType}`);
+  void reportYdAnalyzer({
+    action: LogReporterAction.OnboardingAction,
+    actionType,
+    ...params,
+  });
+};
+
+export const getOnboardingErrorCode = (error?: unknown): string => {
+  if (error instanceof Error && error.message.trim()) {
+    return 'error';
+  }
+  if (typeof error === 'string' && error.trim()) {
+    return 'error';
+  }
+  return 'unknown';
+};

--- a/src/shared/analytics/constants.ts
+++ b/src/shared/analytics/constants.ts
@@ -59,6 +59,7 @@ export const LogReporterAction = {
   McpEnabled: 'lobsterai_mcp_enabled',
   McpAction: 'lobsterai_mcp_action',
   ModelSelected: 'lobsterai_model_selected',
+  OnboardingAction: 'lobsterai_onboarding_action',
   PlanModeEnabled: 'lobsterai_plan_mode_enabled',
   PluginAction: 'lobsterai_plugin_action',
   PluginSettingsSaved: 'lobsterai_plugin_settings_saved',


### PR DESCRIPTION
Track the new user onboarding funnel, login handoff, welcome task creation, and welcome stream lifecycle with the existing usage analytics reporter.

Document the onboarding analytics event and keep reported fields limited to structured states, without uploading prompt text, welcome content, paths, URLs, or conversation data.


