### PR TITLE
fix(cowork): dim exhausted voice input button

### DIFF
--- a/src/renderer/components/cowork/voiceInput/VoiceInputButton.test.ts
+++ b/src/renderer/components/cowork/voiceInput/VoiceInputButton.test.ts
@@ -43,4 +43,12 @@ describe('VoiceInputButton', () => {
     expect(html).toContain('rounded-[3px]');
     expect(html).not.toContain('<svg');
   });
+
+  test('dims the microphone when quota is exhausted while keeping the quota prompt clickable', () => {
+    const html = renderButton({ isQuotaExhausted: true });
+
+    expect(html).toContain('aria-label="暂无语音输入时长"');
+    expect(html).toContain('text-secondary opacity-40');
+    expect(html).not.toContain('disabled=""');
+  });
 });

--- a/src/renderer/components/cowork/voiceInput/VoiceInputButton.tsx
+++ b/src/renderer/components/cowork/voiceInput/VoiceInputButton.tsx
@@ -40,9 +40,9 @@ const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
   const stateClass = showsStopIcon
     ? 'bg-neutral-100 text-neutral-950 hover:bg-neutral-200 dark:bg-white/10 dark:text-white dark:hover:bg-white/15'
     : unavailable
-        ? 'cursor-not-allowed text-secondary/40 opacity-60'
+        ? 'cursor-not-allowed text-secondary opacity-60'
         : isQuotaExhausted
-          ? 'text-secondary/30 hover:bg-surface-raised'
+          ? 'text-secondary opacity-40 hover:bg-surface-raised'
         : loginRequired
           ? 'text-secondary hover:bg-surface-raised hover:text-foreground'
         : 'text-secondary hover:bg-surface-raised hover:text-foreground';


### PR DESCRIPTION
Ensure the voice input icon uses a stable dimmed state when today's ASR quota is exhausted, while keeping the button clickable so users can open the quota prompt.

Add coverage for the exhausted quota visual state.


