### PR TITLE
fix(openclaw): stop peer install from bloating plugin bundle size

### DIFF
--- a/scripts/electron-builder-hooks.cjs
+++ b/scripts/electron-builder-hooks.cjs
@@ -8,6 +8,7 @@ const { ensurePortablePythonRuntime, checkRuntimeHealth } = require('./setup-pyt
 const { syncLocalOpenClawExtensions } = require('./sync-local-openclaw-extensions.cjs');
 const { packMultipleSources } = require('./pack-openclaw-tar.cjs');
 const { DIST_DIFFS_EXTENSION_DIR, DIST_EXTENSIONS_DIR, summarizeGatewayAsarEntries } = require('./openclaw-runtime-packaging.cjs');
+const { collectHostPeerLeftovers, measureDirectorySize } = require('./openclaw-plugin-host-peer-leftovers.cjs');
 
 function isWindowsTarget(context) {
   return context?.electronPlatformName === 'win32';
@@ -121,7 +122,47 @@ function verifyPreinstalledPlugins(runtimeRoot, buildHint) {
     );
   }
 
+  verifyNoHostPeerLeftovers(extensionsDir, plugins);
+
   console.log(`[electron-builder-hooks] Verified ${plugins.length} preinstalled OpenClaw plugin(s).`);
+}
+
+// A plugin whose node_modules still carries the openclaw peer dependency tree
+// adds hundreds of MB to the installer (see openclaw-plugin-host-peer-leftovers.cjs).
+// openclaw:prune removes it; anything left here means the runtime was not
+// rebuilt through the normal chain, so fail instead of shipping it silently.
+const PLUGIN_SIZE_WARN_BYTES = 100 * 1024 * 1024;
+
+function verifyNoHostPeerLeftovers(extensionsDir, plugins) {
+  const problems = [];
+  for (const plugin of plugins) {
+    if (!plugin.id) continue;
+    const pluginDir = path.join(extensionsDir, plugin.id);
+    if (!existsSync(pluginDir)) continue;
+
+    const leftovers = collectHostPeerLeftovers(pluginDir);
+    if (leftovers.length > 0) {
+      const preview = leftovers.slice(0, 3).map((item) => item.location).join(', ');
+      const more = leftovers.length > 3 ? ` and ${leftovers.length - 3} more` : '';
+      problems.push(`${plugin.id}: ${preview}${more}`);
+    }
+
+    const sizeBytes = measureDirectorySize(pluginDir);
+    if (sizeBytes > PLUGIN_SIZE_WARN_BYTES) {
+      console.warn(
+        `[electron-builder-hooks] Preinstalled OpenClaw plugin ${plugin.id} is `
+        + `${(sizeBytes / 1024 / 1024).toFixed(1)} MB; check its node_modules before shipping.`,
+      );
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      '[electron-builder-hooks] Preinstalled OpenClaw plugins still contain openclaw peer dependency trees: '
+      + problems.join('; ')
+      + '. Run `npm run openclaw:prune`, or delete vendor/openclaw-plugins/<id> and re-run `npm run openclaw:plugins`.',
+    );
+  }
 }
 
 function hasCompiledLocalExtension(runtimeRoot, extensionId) {

--- a/scripts/ensure-openclaw-plugins.cjs
+++ b/scripts/ensure-openclaw-plugins.cjs
@@ -10,8 +10,13 @@
  *
  * Flow per plugin:
  *   1. Checks a local cache in vendor/openclaw-plugins/{id}/
- *   2. Installs via `openclaw plugins install` if not cached at the right version
- *   3. Copies the plugin into vendor/openclaw-runtime/current/extensions/{id}/
+ *   2. Packs the pinned package and marks its `openclaw` peerDependency
+ *      optional so npm does not download the host package
+ *      (see openclaw-plugin-preparers/host-peer.cjs)
+ *   3. Installs via `openclaw plugins install` if not cached at the right version
+ *   4. Removes any dependency tree that only served the openclaw peer, then
+ *      caches the plugin
+ *   5. Copies the plugin into vendor/openclaw-runtime/current/third-party-extensions/{id}/
  *
  * Environment variables:
  *   OPENCLAW_SKIP_PLUGINS          – Set to "1" to skip this script entirely
@@ -32,6 +37,8 @@ const {
   NIM_PLUGIN_PACKAGE_ID,
   prepareOpenClawNimPackage,
 } = require('./openclaw-plugin-preparers/nim-channel.cjs');
+const { prepareHostPeerPackage } = require('./openclaw-plugin-preparers/host-peer.cjs');
+const { pruneHostPeerLeftovers } = require('./openclaw-plugin-host-peer-leftovers.cjs');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -580,9 +587,10 @@ function resolvePluginInstallSource(plugin) {
 }
 
 function buildPluginInstallEnv(plugin) {
-  const env = {
-    npm_config_legacy_peer_deps: 'true',
-  };
+  // Peer handling is not controlled through npm env here: OpenClaw's npm env
+  // builder drops npm_config_legacy_peer_deps before spawning npm. The host
+  // peer is neutralised in the packed manifest instead (prepareHostPeerPackage).
+  const env = {};
 
   // npm 12 blocks transitive Git dependencies by default. NetEase Bee's
   // pinned SDK currently depends on libsignal from GitHub, so opt in only for
@@ -700,6 +708,15 @@ function main() {
           installSpec = prepareOpenClawNimPackage(installSpec, stagingDir, { log });
         }
 
+        if (fs.existsSync(installSpec) && fs.statSync(installSpec).isFile()) {
+          installSpec = prepareHostPeerPackage(installSpec, stagingDir, {
+            log,
+            packageLabel: npmSpec,
+          });
+        } else {
+          log('  Skipping openclaw peer normalization for a directory install source.');
+        }
+
         const installEnv = buildPluginInstallEnv(plugin);
         if (installEnv.npm_config_allow_git === 'all') {
           log('  Allowing Git dependencies for this NetEase Bee installation only.');
@@ -710,11 +727,6 @@ function main() {
           {
             env: {
               OPENCLAW_STATE_DIR: stagingDir,
-              // Prevent npm from auto-installing peerDependencies (npm v7+).
-              // Channel plugins declare openclaw as a peerDep, but the host
-              // gateway already provides the SDK at runtime.  Without this,
-              // npm installs the full openclaw SDK + transitive deps (~738 MB)
-              // into each plugin's node_modules.
               ...installEnv,
             },
             stdio: 'inherit',
@@ -733,6 +745,16 @@ function main() {
         ensureDir(path.dirname(cacheDir));
         copyInstalledPluginToCache(installedDir, cacheDir);
         fixBinSymlinks(cacheDir);
+
+        // Safety net: if npm still materialised the openclaw peer tree (for
+        // example through a nested dependency), drop it before caching.
+        const hostPeerPrune = pruneHostPeerLeftovers(cacheDir);
+        if (hostPeerPrune.removed.length > 0) {
+          log(
+            `  Removed ${hostPeerPrune.removed.length} openclaw peer leftover package(s) ` +
+            `(${(hostPeerPrune.bytesFreed / 1024 / 1024).toFixed(1)} MB) from ${id}.`
+          );
+        }
 
         // Write install info for cache validation
         fs.writeFileSync(

--- a/scripts/openclaw-plugin-host-peer-leftovers.cjs
+++ b/scripts/openclaw-plugin-host-peer-leftovers.cjs
@@ -1,0 +1,305 @@
+'use strict';
+
+/**
+ * Detect and remove dependency trees that only exist because npm installed the
+ * OpenClaw host package (`openclaw`) as a plugin peerDependency.
+ *
+ * OpenClaw installs archive plugins with `npm install --omit=dev` and without
+ * `--omit=peer`, so a required `openclaw` peer is downloaded at the newest
+ * registry version together with its whole dependency tree. The host gateway
+ * provides openclaw at runtime, and since openclaw 2026.8.x no longer ships an
+ * npm-shrinkwrap.json that tree is hoisted next to the plugin's real
+ * dependencies (openclaw@2026.8.2 adds @anthropic-ai/claude-agent-sdk with a
+ * 300+ MB platform binary). Deleting node_modules/openclaw alone leaves all of
+ * it behind.
+ *
+ * npm's hidden lockfile (node_modules/.package-lock.json) records every
+ * installed package with its dependency edges. Starting from the plugin
+ * manifest, walk every edge except the one pointing at `openclaw`; whatever is
+ * not reachable only serves the host peer and can be removed. This mirrors
+ * `npm prune` with the openclaw peer dropped from the manifest, without
+ * running npm at packaging time.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const HOST_PEER_PACKAGE_NAME = 'openclaw';
+const HIDDEN_LOCKFILE_NAME = '.package-lock.json';
+const HOST_PEER_LOCATION = `node_modules/${HOST_PEER_PACKAGE_NAME}`;
+
+// Packages that only ever arrive through the openclaw peer tree. They are
+// flagged even when no hidden lockfile is available to reason about edges.
+const HOST_PEER_ONLY_PACKAGE_PREFIXES = ['@anthropic-ai/claude-agent-sdk'];
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readJsonIfExists(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function lstatIfExists(targetPath) {
+  try {
+    return fs.lstatSync(targetPath);
+  } catch {
+    return null;
+  }
+}
+
+function readdirNames(dirPath) {
+  try {
+    return fs.readdirSync(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+function measureDirectorySize(targetPath) {
+  const stat = lstatIfExists(targetPath);
+  if (!stat) return 0;
+  if (!stat.isDirectory()) return stat.size;
+
+  let total = 0;
+  for (const entry of readdirNames(targetPath)) {
+    total += measureDirectorySize(path.join(targetPath, entry));
+  }
+  return total;
+}
+
+function dependencyNames(entry) {
+  const names = new Set();
+  if (!isRecord(entry)) return names;
+  for (const group of [entry.dependencies, entry.optionalDependencies, entry.peerDependencies]) {
+    if (!isRecord(group)) continue;
+    for (const name of Object.keys(group)) {
+      if (name !== HOST_PEER_PACKAGE_NAME) names.add(name);
+    }
+  }
+  return names;
+}
+
+function containingNodeModulesLocation(location) {
+  const index = location.lastIndexOf('node_modules/');
+  return location.slice(0, index + 'node_modules'.length);
+}
+
+function parentPackageLocation(location) {
+  const index = location.lastIndexOf('/node_modules/');
+  return index === -1 ? '' : location.slice(0, index);
+}
+
+/**
+ * Resolve `name` the way Node would from a package installed at `fromLocation`
+ * ('' for the plugin root), using only the lockfile's package locations.
+ */
+function resolveDependencyLocation(fromLocation, name, packages) {
+  let base = fromLocation;
+  for (;;) {
+    const candidate = base ? `${base}/node_modules/${name}` : `node_modules/${name}`;
+    if (Object.prototype.hasOwnProperty.call(packages, candidate)) return candidate;
+    if (!base) return null;
+    base = parentPackageLocation(base);
+  }
+}
+
+function collectReachableLocations(pluginDir, packages) {
+  const manifest = readJsonIfExists(path.join(pluginDir, 'package.json')) || {};
+  const reachable = new Set();
+  const queue = [];
+
+  const visit = (fromLocation, entry) => {
+    for (const name of dependencyNames(entry)) {
+      const location = resolveDependencyLocation(fromLocation, name, packages);
+      if (location && !reachable.has(location)) {
+        reachable.add(location);
+        queue.push(location);
+      }
+    }
+  };
+
+  visit('', manifest);
+  while (queue.length > 0) {
+    const location = queue.shift();
+    visit(location, packages[location]);
+  }
+  return reachable;
+}
+
+function listTopLevelPackageLocations(nodeModulesDir) {
+  const locations = [];
+  for (const entry of readdirNames(nodeModulesDir)) {
+    if (entry.startsWith('.')) continue;
+    if (entry.startsWith('@')) {
+      for (const scoped of readdirNames(path.join(nodeModulesDir, entry))) {
+        if (!scoped.startsWith('.')) locations.push(`node_modules/${entry}/${scoped}`);
+      }
+      continue;
+    }
+    locations.push(`node_modules/${entry}`);
+  }
+  return locations;
+}
+
+function isHostPeerOnlyPackage(location) {
+  const name = location.slice(location.lastIndexOf('node_modules/') + 'node_modules/'.length);
+  return HOST_PEER_ONLY_PACKAGE_PREFIXES.some(
+    (prefix) => name === prefix || name.startsWith(`${prefix}-`) || name.startsWith(`${prefix}/`),
+  );
+}
+
+function hasLeftoverAncestor(location, leftovers) {
+  let current = parentPackageLocation(location);
+  while (current) {
+    if (leftovers.has(current)) return true;
+    current = parentPackageLocation(current);
+  }
+  return false;
+}
+
+/**
+ * List packages under `pluginDir/node_modules` that only exist to serve the
+ * openclaw peer. Each item is `{ location, reason }` with a lockfile-style
+ * location such as `node_modules/@anthropic-ai/claude-agent-sdk`.
+ */
+function collectHostPeerLeftovers(pluginDir) {
+  const nodeModulesDir = path.join(pluginDir, 'node_modules');
+  // Only reason about a node_modules the plugin owns. A symlinked node_modules
+  // (for example one pointing at a shared or host install) must never be
+  // inspected or pruned through.
+  const nodeModulesStat = lstatIfExists(nodeModulesDir);
+  if (!nodeModulesStat || !nodeModulesStat.isDirectory()) return [];
+
+  const leftovers = new Map();
+  if (lstatIfExists(path.join(pluginDir, HOST_PEER_LOCATION))) {
+    leftovers.set(HOST_PEER_LOCATION, 'openclaw host package installed into the plugin');
+  }
+  for (const location of listTopLevelPackageLocations(nodeModulesDir)) {
+    if (isHostPeerOnlyPackage(location)) {
+      leftovers.set(location, 'only shipped by the openclaw peer tree');
+    }
+  }
+
+  const lock = readJsonIfExists(path.join(nodeModulesDir, HIDDEN_LOCKFILE_NAME));
+  if (lock && isRecord(lock.packages)) {
+    const reachable = collectReachableLocations(pluginDir, lock.packages);
+    for (const location of Object.keys(lock.packages)) {
+      if (!location || reachable.has(location) || leftovers.has(location)) continue;
+      if (!lstatIfExists(path.join(pluginDir, location))) continue;
+      leftovers.set(location, 'unreachable once openclaw is provided by the host');
+    }
+  }
+
+  return [...leftovers.entries()]
+    .filter(([location]) => !hasLeftoverAncestor(location, leftovers))
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([location, reason]) => ({ location, reason }));
+}
+
+function removeDanglingBinLinks(binDir) {
+  for (const entry of readdirNames(binDir)) {
+    const linkPath = path.join(binDir, entry);
+    const stat = lstatIfExists(linkPath);
+    if (!stat || !stat.isSymbolicLink()) continue;
+    try {
+      fs.statSync(linkPath); // follows the link; throws when the target is gone
+    } catch {
+      fs.unlinkSync(linkPath);
+    }
+  }
+}
+
+function removeEmptyScopeDirs(nodeModulesDir) {
+  for (const entry of readdirNames(nodeModulesDir)) {
+    if (!entry.startsWith('@')) continue;
+    const scopeDir = path.join(nodeModulesDir, entry);
+    const stat = lstatIfExists(scopeDir);
+    if (stat && stat.isDirectory() && readdirNames(scopeDir).length === 0) {
+      fs.rmdirSync(scopeDir);
+    }
+  }
+}
+
+// Drop the removed packages from the hidden lockfile, along with entries whose
+// directory is already gone (for example an openclaw dir deleted earlier).
+function rewriteHiddenLockfile(pluginDir, removedLocations) {
+  const lockPath = path.join(pluginDir, 'node_modules', HIDDEN_LOCKFILE_NAME);
+  const lock = readJsonIfExists(lockPath);
+  if (!lock || !isRecord(lock.packages)) return;
+
+  const packages = {};
+  for (const [location, entry] of Object.entries(lock.packages)) {
+    const removed = removedLocations.some(
+      (removedLocation) => location === removedLocation || location.startsWith(`${removedLocation}/`),
+    );
+    if (removed) continue;
+    if (location && !lstatIfExists(path.join(pluginDir, location))) continue;
+    packages[location] = entry;
+  }
+  fs.writeFileSync(lockPath, `${JSON.stringify({ ...lock, packages }, null, 2)}\n`, 'utf-8');
+}
+
+function isPathInside(parentPath, childPath) {
+  const relative = path.relative(parentPath, childPath);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+// A leftover may only be deleted when its real parent directory lives inside
+// the plugin's own node_modules; a symlinked ancestor would otherwise let the
+// removal escape into a directory the plugin does not own.
+function isDeletableLeftover(pluginDir, location) {
+  try {
+    const nodeModulesReal = fs.realpathSync(path.join(pluginDir, 'node_modules'));
+    const parentReal = fs.realpathSync(path.dirname(path.join(pluginDir, location)));
+    return parentReal === nodeModulesReal || isPathInside(nodeModulesReal, parentReal);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Remove every leftover reported by collectHostPeerLeftovers, then drop the
+ * removed entries from the hidden lockfile and clean up dangling `.bin` links
+ * and empty scope directories. Returns `{ removed, bytesFreed }`.
+ */
+function pruneHostPeerLeftovers(pluginDir) {
+  const leftovers = collectHostPeerLeftovers(pluginDir).filter(({ location }) =>
+    isDeletableLeftover(pluginDir, location),
+  );
+  if (leftovers.length === 0) {
+    return { removed: [], bytesFreed: 0 };
+  }
+
+  const touchedNodeModulesDirs = new Set();
+  let bytesFreed = 0;
+  for (const { location } of leftovers) {
+    const target = path.join(pluginDir, location);
+    bytesFreed += measureDirectorySize(target);
+    fs.rmSync(target, { recursive: true, force: true });
+    touchedNodeModulesDirs.add(path.join(pluginDir, containingNodeModulesLocation(location)));
+  }
+
+  const removed = leftovers.map((item) => item.location);
+  rewriteHiddenLockfile(pluginDir, removed);
+  for (const dir of touchedNodeModulesDirs) {
+    removeDanglingBinLinks(path.join(dir, '.bin'));
+    removeEmptyScopeDirs(dir);
+  }
+
+  return { removed, bytesFreed };
+}
+
+module.exports = {
+  HOST_PEER_ONLY_PACKAGE_PREFIXES,
+  HOST_PEER_PACKAGE_NAME,
+  collectHostPeerLeftovers,
+  collectReachableLocations,
+  measureDirectorySize,
+  pruneHostPeerLeftovers,
+  resolveDependencyLocation,
+};

--- a/scripts/openclaw-plugin-preparers/host-peer.cjs
+++ b/scripts/openclaw-plugin-preparers/host-peer.cjs
@@ -1,0 +1,81 @@
+'use strict';
+
+// Marks the OpenClaw host package as an optional peerDependency inside plugin
+// tarballs before they are handed to `openclaw plugins install`.
+//
+// OpenClaw installs archive plugins with `npm install --omit=dev` and without
+// `--omit=peer`, and its npm environment builder drops
+// npm_config_legacy_peer_deps before spawning npm. npm 7+ therefore
+// auto-installs a required `openclaw` peer at the newest registry version
+// (openclaw@2026.8.x pulls @anthropic-ai/claude-agent-sdk with a 300+ MB
+// platform binary). The host gateway already provides openclaw at runtime, so
+// declaring the peer optional keeps npm from downloading it while leaving the
+// peer range, OpenClaw's host link and its host-version checks untouched.
+
+const fs = require('fs');
+const path = require('path');
+
+const {
+  extractPluginTarball,
+  npmPackDirectory,
+  readJsonFile,
+  writeJsonFile,
+} = require('./typescript-plugin.cjs');
+
+const HOST_PEER_PACKAGE_NAME = 'openclaw';
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function patchHostPeerPackageDirectory(packageDir, opts = {}) {
+  const log = opts.log || (() => {});
+  const packageJsonPath = path.join(packageDir, 'package.json');
+  const pkg = readJsonFile(packageJsonPath);
+  const packageLabel = opts.packageLabel || pkg.name || 'OpenClaw plugin';
+
+  const peerRange = isRecord(pkg.peerDependencies)
+    ? pkg.peerDependencies[HOST_PEER_PACKAGE_NAME]
+    : undefined;
+  if (typeof peerRange !== 'string') {
+    return { changed: false, peerRange: null };
+  }
+
+  const peerMeta = isRecord(pkg.peerDependenciesMeta) ? pkg.peerDependenciesMeta : {};
+  const hostMeta = isRecord(peerMeta[HOST_PEER_PACKAGE_NAME]) ? peerMeta[HOST_PEER_PACKAGE_NAME] : {};
+  if (hostMeta.optional === true) {
+    return { changed: false, peerRange };
+  }
+
+  pkg.peerDependenciesMeta = {
+    ...peerMeta,
+    [HOST_PEER_PACKAGE_NAME]: { ...hostMeta, optional: true },
+  };
+  writeJsonFile(packageJsonPath, pkg);
+
+  log(
+    `  Marked ${packageLabel} peerDependency "${HOST_PEER_PACKAGE_NAME}" (${peerRange}) ` +
+      'optional so npm does not download the host package.',
+  );
+  return { changed: true, peerRange };
+}
+
+function prepareHostPeerPackage(inputTgzPath, outputDir, opts = {}) {
+  const packageLabel = opts.packageLabel || 'OpenClaw plugin';
+  const sourceDir = extractPluginTarball(inputTgzPath, outputDir, packageLabel);
+
+  const result = patchHostPeerPackageDirectory(sourceDir, { ...opts, packageLabel });
+  if (!result.changed) {
+    fs.rmSync(sourceDir, { recursive: true, force: true });
+    return inputTgzPath;
+  }
+
+  const patchedPackDir = fs.mkdtempSync(path.join(outputDir, 'openclaw-plugin-host-peer-'));
+  return npmPackDirectory(sourceDir, patchedPackDir);
+}
+
+module.exports = {
+  HOST_PEER_PACKAGE_NAME,
+  patchHostPeerPackageDirectory,
+  prepareHostPeerPackage,
+};

--- a/scripts/openclaw-plugin-preparers/typescript-plugin.cjs
+++ b/scripts/openclaw-plugin-preparers/typescript-plugin.cjs
@@ -43,7 +43,9 @@ function buildNpmPackEnv() {
 function npmPackDirectory(sourceDir, outputDir) {
   const isWin = process.platform === 'win32';
   const npmBin = isWin ? 'npm.cmd' : 'npm';
-  const args = ['pack', sourceDir, '--pack-destination', outputDir];
+  // The directory is an already-published package, so lifecycle scripts such
+  // as prepack/postpack must not run again; they would mutate package.json.
+  const args = ['pack', sourceDir, '--pack-destination', outputDir, '--ignore-scripts'];
 
   const result = spawnSync(npmBin, args, {
     encoding: 'utf-8',
@@ -160,8 +162,7 @@ function patchTypeScriptPluginPackageDirectory(packageDir, opts = {}) {
   return { changed: true, compiledEntries };
 }
 
-function prepareTypeScriptPluginPackage(inputTgzPath, outputDir, opts = {}) {
-  const packageLabel = opts.packageLabel || 'OpenClaw plugin';
+function extractPluginTarball(inputTgzPath, outputDir, packageLabel = 'OpenClaw plugin') {
   if (!fs.existsSync(inputTgzPath)) {
     throw new Error(`${packageLabel} package tarball not found: ${inputTgzPath}`);
   }
@@ -173,6 +174,12 @@ function prepareTypeScriptPluginPackage(inputTgzPath, outputDir, opts = {}) {
     strip: 1,
     sync: true,
   });
+  return sourceDir;
+}
+
+function prepareTypeScriptPluginPackage(inputTgzPath, outputDir, opts = {}) {
+  const packageLabel = opts.packageLabel || 'OpenClaw plugin';
+  const sourceDir = extractPluginTarball(inputTgzPath, outputDir, packageLabel);
 
   const result = patchTypeScriptPluginPackageDirectory(sourceDir, opts);
   if (!result.changed) {
@@ -184,6 +191,10 @@ function prepareTypeScriptPluginPackage(inputTgzPath, outputDir, opts = {}) {
 }
 
 module.exports = {
+  extractPluginTarball,
+  npmPackDirectory,
   patchTypeScriptPluginPackageDirectory,
   prepareTypeScriptPluginPackage,
+  readJsonFile,
+  writeJsonFile,
 };

--- a/scripts/prune-openclaw-runtime.cjs
+++ b/scripts/prune-openclaw-runtime.cjs
@@ -12,6 +12,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const { pruneHostPeerLeftovers } = require('./openclaw-plugin-host-peer-leftovers.cjs');
+
 // ─── Strategy 1: File cleanup patterns ───
 
 const PATTERNS_TO_DELETE = [
@@ -337,27 +339,27 @@ function main() {
   }
 
   // Step 2c: Remove openclaw SDK duplicates from third-party-extensions.
-  // Plugins like openclaw-qqbot declare openclaw as a peerDependency, and
-  // npm v7+ auto-installs it into the plugin's own node_modules (~226 MB).
-  // At runtime the host gateway already provides the SDK on the module path,
-  // so this copy is redundant and safe to remove.
+  // Plugins that declare openclaw as a required peerDependency get it
+  // auto-installed by npm v7+ into their own node_modules, together with its
+  // whole dependency tree (openclaw@2026.8.x pulls a 300+ MB claude-agent-sdk
+  // binary). The install script now marks that peer optional, but caches
+  // created before that fix still carry the tree, and openclaw >= 2026.8
+  // hoists it next to the plugin's real dependencies. At runtime the host
+  // gateway provides the SDK, so everything only reachable through it goes.
   if (fs.existsSync(thirdPartyDir)) {
     try {
       for (const plugin of fs.readdirSync(thirdPartyDir, { withFileTypes: true })) {
         if (!plugin.isDirectory()) continue;
-        const dupeOC = path.join(thirdPartyDir, plugin.name, 'node_modules', 'openclaw');
-        if (fs.existsSync(dupeOC)) {
-          const size = getDirSize(dupeOC);
-          fs.rmSync(dupeOC, { recursive: true, force: true });
-          stats.bytesFreed += size;
-          stats.dirsRemoved++;
-          console.log(
-            `[prune-openclaw-runtime] Removed duplicate openclaw SDK from ${plugin.name} (${(size / 1024 / 1024).toFixed(1)} MB)`
-          );
-        }
+        const pruned = pruneHostPeerLeftovers(path.join(thirdPartyDir, plugin.name));
+        if (pruned.removed.length === 0) continue;
+        stats.bytesFreed += pruned.bytesFreed;
+        stats.dirsRemoved += pruned.removed.length;
+        console.log(
+          `[prune-openclaw-runtime] Removed ${pruned.removed.length} openclaw peer leftover package(s) from ${plugin.name} (${(pruned.bytesFreed / 1024 / 1024).toFixed(1)} MB)`
+        );
       }
     } catch (err) {
-      console.warn(`[prune-openclaw-runtime] Failed to prune openclaw from third-party-extensions: ${err.message}`);
+      console.warn(`[prune-openclaw-runtime] Failed to prune openclaw peer leftovers from third-party-extensions: ${err.message}`);
     }
   }
 

--- a/tests/ensure-openclaw-plugins.test.ts
+++ b/tests/ensure-openclaw-plugins.test.ts
@@ -156,16 +156,13 @@ describe('ensure-openclaw-plugins', () => {
       id: 'netease-bee-alias',
       npm: 'openclaw-netease-bee',
     })).toEqual({
-      npm_config_legacy_peer_deps: 'true',
       npm_config_allow_git: 'all',
     });
 
     expect(buildPluginInstallEnv({
       id: 'openclaw-weixin',
       npm: '@tencent-weixin/openclaw-weixin',
-    })).toEqual({
-      npm_config_legacy_peer_deps: 'true',
-    });
+    })).toEqual({});
   });
 
   test('finds plugins installed in the legacy extensions directory', () => {

--- a/tests/openclaw-plugin-host-peer-leftovers.test.ts
+++ b/tests/openclaw-plugin-host-peer-leftovers.test.ts
@@ -1,0 +1,196 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const {
+  collectHostPeerLeftovers,
+  pruneHostPeerLeftovers,
+  resolveDependencyLocation,
+} = require('../scripts/openclaw-plugin-host-peer-leftovers.cjs');
+
+type LockPackages = Record<string, Record<string, unknown>>;
+
+// Mirrors what npm leaves behind after installing a plugin whose required
+// `openclaw` peer was auto-installed and hoisted: the plugin's own tree
+// (alpha -> beta -> nested gamma@2, shared) plus the peer tree (openclaw,
+// hoisted gamma@1, claude-agent-sdk and its platform binary).
+const FIXTURE_PACKAGES: LockPackages = {
+  'node_modules/alpha': { version: '1.0.0', dependencies: { beta: '^1.0.0', shared: '^1.0.0' } },
+  'node_modules/beta': { version: '1.0.0', dependencies: { gamma: '^2.0.0' } },
+  'node_modules/beta/node_modules/gamma': { version: '2.0.0' },
+  'node_modules/gamma': { version: '1.0.0', peer: true },
+  'node_modules/shared': { version: '1.0.0' },
+  'node_modules/openclaw': {
+    version: '2026.8.2',
+    peer: true,
+    dependencies: { gamma: '^1.0.0', shared: '^1.0.0', '@anthropic-ai/claude-agent-sdk': '0.3.241' },
+  },
+  'node_modules/@anthropic-ai/claude-agent-sdk': {
+    version: '0.3.241',
+    peer: true,
+    optionalDependencies: { '@anthropic-ai/claude-agent-sdk-darwin-arm64': '0.3.241' },
+  },
+  'node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64': { version: '0.3.241', peer: true, optional: true },
+};
+
+function createPluginFixture(options: { withLockfile?: boolean } = {}): string {
+  const pluginDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-host-peer-leftovers-'));
+  fs.writeFileSync(
+    path.join(pluginDir, 'package.json'),
+    JSON.stringify({
+      name: 'fixture-plugin',
+      version: '1.0.0',
+      dependencies: { alpha: '^1.0.0' },
+      peerDependencies: { openclaw: '>=2026.3.22' },
+      devDependencies: { devtool: '^1.0.0' },
+    }),
+  );
+
+  for (const location of Object.keys(FIXTURE_PACKAGES)) {
+    const packageDir = path.join(pluginDir, location);
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ name: path.basename(location) }));
+    fs.writeFileSync(path.join(packageDir, 'index.js'), 'module.exports = {};\n');
+    fs.writeFileSync(path.join(packageDir, 'cli.js'), '#!/usr/bin/env node\n');
+  }
+
+  const binDir = path.join(pluginDir, 'node_modules', '.bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.symlinkSync(path.join('..', 'alpha', 'cli.js'), path.join(binDir, 'alpha-cli'));
+  fs.symlinkSync(path.join('..', 'gamma', 'cli.js'), path.join(binDir, 'gamma-cli'));
+
+  if (options.withLockfile !== false) {
+    fs.writeFileSync(
+      path.join(pluginDir, 'node_modules', '.package-lock.json'),
+      JSON.stringify({ lockfileVersion: 3, requires: true, packages: FIXTURE_PACKAGES }, null, 2),
+    );
+  }
+  return pluginDir;
+}
+
+function readHiddenLockLocations(pluginDir: string): string[] {
+  const lock = JSON.parse(fs.readFileSync(path.join(pluginDir, 'node_modules', '.package-lock.json'), 'utf-8'));
+  return Object.keys(lock.packages);
+}
+
+describe('openclaw-plugin-host-peer-leftovers', () => {
+  test('resolves dependency names like Node does, walking up nested node_modules', () => {
+    expect(resolveDependencyLocation('node_modules/beta', 'gamma', FIXTURE_PACKAGES))
+      .toBe('node_modules/beta/node_modules/gamma');
+    expect(resolveDependencyLocation('node_modules/alpha', 'gamma', FIXTURE_PACKAGES))
+      .toBe('node_modules/gamma');
+    expect(resolveDependencyLocation('', 'alpha', FIXTURE_PACKAGES)).toBe('node_modules/alpha');
+    expect(resolveDependencyLocation('node_modules/beta/node_modules/gamma', 'missing', FIXTURE_PACKAGES))
+      .toBeNull();
+  });
+
+  test('flags only packages that are unreachable without the openclaw peer', () => {
+    const pluginDir = createPluginFixture();
+
+    const leftovers = collectHostPeerLeftovers(pluginDir).map((item: { location: string }) => item.location);
+    expect(leftovers).toEqual([
+      'node_modules/@anthropic-ai/claude-agent-sdk',
+      'node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64',
+      'node_modules/gamma',
+      'node_modules/openclaw',
+    ]);
+
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+  });
+
+  test('prunes the leftover tree and keeps the plugin dependencies intact', () => {
+    const pluginDir = createPluginFixture();
+    const nodeModulesDir = path.join(pluginDir, 'node_modules');
+
+    const result = pruneHostPeerLeftovers(pluginDir);
+    expect(result.removed).toEqual([
+      'node_modules/@anthropic-ai/claude-agent-sdk',
+      'node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64',
+      'node_modules/gamma',
+      'node_modules/openclaw',
+    ]);
+    expect(result.bytesFreed).toBeGreaterThan(0);
+
+    for (const kept of ['alpha', 'beta', 'beta/node_modules/gamma', 'shared']) {
+      expect(fs.existsSync(path.join(nodeModulesDir, kept, 'index.js'))).toBe(true);
+    }
+    for (const removed of ['openclaw', 'gamma', '@anthropic-ai']) {
+      expect(fs.existsSync(path.join(nodeModulesDir, removed))).toBe(false);
+    }
+    expect(fs.existsSync(path.join(nodeModulesDir, '.bin', 'alpha-cli'))).toBe(true);
+    expect(fs.lstatSync(path.join(nodeModulesDir, '.bin', 'alpha-cli')).isSymbolicLink()).toBe(true);
+    expect(fs.existsSync(path.join(nodeModulesDir, '.bin', 'gamma-cli'))).toBe(false);
+    expect(readHiddenLockLocations(pluginDir)).toEqual([
+      'node_modules/alpha',
+      'node_modules/beta',
+      'node_modules/beta/node_modules/gamma',
+      'node_modules/shared',
+    ]);
+
+    expect(pruneHostPeerLeftovers(pluginDir)).toEqual({ removed: [], bytesFreed: 0 });
+    expect(collectHostPeerLeftovers(pluginDir)).toEqual([]);
+
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+  });
+
+  test('falls back to well-known peer-only packages when no hidden lockfile exists', () => {
+    const pluginDir = createPluginFixture({ withLockfile: false });
+
+    const leftovers = collectHostPeerLeftovers(pluginDir).map((item: { location: string }) => item.location);
+    expect(leftovers).toEqual([
+      'node_modules/@anthropic-ai/claude-agent-sdk',
+      'node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64',
+      'node_modules/openclaw',
+    ]);
+
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+  });
+
+  test('removes a linked host package without touching the link target', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-host-peer-link-'));
+    const pluginDir = path.join(tempDir, 'plugin');
+    const hostDir = path.join(tempDir, 'host-openclaw');
+    fs.mkdirSync(path.join(pluginDir, 'node_modules'), { recursive: true });
+    fs.mkdirSync(hostDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ name: 'linked', version: '1.0.0' }));
+    fs.writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'openclaw', version: '2026.6.1' }));
+    fs.symlinkSync(hostDir, path.join(pluginDir, 'node_modules', 'openclaw'), 'junction');
+
+    expect(pruneHostPeerLeftovers(pluginDir).removed).toEqual(['node_modules/openclaw']);
+    expect(fs.existsSync(path.join(pluginDir, 'node_modules', 'openclaw'))).toBe(false);
+    expect(fs.existsSync(path.join(hostDir, 'package.json'))).toBe(true);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('never inspects or prunes through a symlinked node_modules', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-host-peer-shared-'));
+    const pluginDir = path.join(tempDir, 'plugin');
+    const sharedNodeModules = path.join(tempDir, 'shared-node-modules');
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.mkdirSync(path.join(sharedNodeModules, 'openclaw'), { recursive: true });
+    fs.mkdirSync(path.join(sharedNodeModules, '@anthropic-ai', 'claude-agent-sdk'), { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ name: 'shared', version: '1.0.0' }));
+    fs.writeFileSync(path.join(sharedNodeModules, 'openclaw', 'package.json'), '{"name":"openclaw"}');
+    fs.symlinkSync(sharedNodeModules, path.join(pluginDir, 'node_modules'), 'junction');
+
+    expect(collectHostPeerLeftovers(pluginDir)).toEqual([]);
+    expect(pruneHostPeerLeftovers(pluginDir)).toEqual({ removed: [], bytesFreed: 0 });
+    expect(fs.existsSync(path.join(sharedNodeModules, 'openclaw', 'package.json'))).toBe(true);
+    expect(fs.existsSync(path.join(sharedNodeModules, '@anthropic-ai', 'claude-agent-sdk'))).toBe(true);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('reports nothing for plugins without node_modules', () => {
+    const pluginDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-host-peer-empty-'));
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ name: 'empty', version: '1.0.0' }));
+
+    expect(collectHostPeerLeftovers(pluginDir)).toEqual([]);
+    expect(pruneHostPeerLeftovers(pluginDir)).toEqual({ removed: [], bytesFreed: 0 });
+
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+  });
+});

--- a/tests/prepare-openclaw-host-peer.test.ts
+++ b/tests/prepare-openclaw-host-peer.test.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const tar = require('tar');
+const {
+  patchHostPeerPackageDirectory,
+  prepareHostPeerPackage,
+} = require('../scripts/openclaw-plugin-preparers/host-peer.cjs');
+
+function writePackageJson(dir: string, pkg: Record<string, unknown>): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+function readPackageJson(dir: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf-8'));
+}
+
+function createTarball(tempDir: string, pkg: Record<string, unknown>): string {
+  const packageDir = path.join(tempDir, 'package');
+  writePackageJson(packageDir, pkg);
+  fs.writeFileSync(path.join(packageDir, 'index.js'), 'export {};\n');
+  const tgzPath = path.join(tempDir, 'fixture.tgz');
+  tar.c({ gzip: true, file: tgzPath, cwd: tempDir, sync: true }, ['package']);
+  return tgzPath;
+}
+
+describe('prepare-openclaw-host-peer', () => {
+  test('marks a required openclaw peerDependency optional', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-host-peer-'));
+    writePackageJson(tempDir, {
+      name: '@clawemail/email',
+      version: '0.9.13',
+      dependencies: { ws: '^8.20.0' },
+      peerDependencies: { openclaw: '>=2026.3.22' },
+    });
+
+    const logs: string[] = [];
+    expect(patchHostPeerPackageDirectory(tempDir, { log: (message: string) => logs.push(message) }))
+      .toEqual({ changed: true, peerRange: '>=2026.3.22' });
+
+    const pkg = readPackageJson(tempDir);
+    expect(pkg.peerDependencies).toEqual({ openclaw: '>=2026.3.22' });
+    expect(pkg.peerDependenciesMeta).toEqual({ openclaw: { optional: true } });
+    expect(pkg.dependencies).toEqual({ ws: '^8.20.0' });
+    expect(logs.join('\n')).toContain('@clawemail/email');
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('keeps unrelated peerDependenciesMeta entries', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-host-peer-'));
+    writePackageJson(tempDir, {
+      name: 'fixture-plugin',
+      version: '1.0.0',
+      peerDependencies: { openclaw: '>=2026.3.22', zod: '^4.0.0' },
+      peerDependenciesMeta: { zod: { optional: true }, openclaw: { note: 'host' } },
+    });
+
+    expect(patchHostPeerPackageDirectory(tempDir)).toEqual({ changed: true, peerRange: '>=2026.3.22' });
+    expect(readPackageJson(tempDir).peerDependenciesMeta).toEqual({
+      zod: { optional: true },
+      openclaw: { note: 'host', optional: true },
+    });
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('leaves manifests without a required openclaw peer untouched', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-host-peer-'));
+
+    const noPeerDir = path.join(tempDir, 'no-peer');
+    writePackageJson(noPeerDir, { name: 'no-peer', version: '1.0.0', dependencies: { zod: '^4.0.0' } });
+    const noPeerBefore = fs.readFileSync(path.join(noPeerDir, 'package.json'), 'utf-8');
+    expect(patchHostPeerPackageDirectory(noPeerDir)).toEqual({ changed: false, peerRange: null });
+    expect(fs.readFileSync(path.join(noPeerDir, 'package.json'), 'utf-8')).toBe(noPeerBefore);
+
+    const optionalDir = path.join(tempDir, 'optional');
+    writePackageJson(optionalDir, {
+      name: 'optional-peer',
+      version: '1.0.0',
+      peerDependencies: { openclaw: '>=2026.6.1' },
+      peerDependenciesMeta: { openclaw: { optional: true } },
+    });
+    const optionalBefore = fs.readFileSync(path.join(optionalDir, 'package.json'), 'utf-8');
+    expect(patchHostPeerPackageDirectory(optionalDir)).toEqual({ changed: false, peerRange: '>=2026.6.1' });
+    expect(fs.readFileSync(path.join(optionalDir, 'package.json'), 'utf-8')).toBe(optionalBefore);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('repacks a tarball only when its manifest changed', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-host-peer-'));
+    const outputDir = path.join(tempDir, 'staging');
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    const requiredTgz = createTarball(path.join(tempDir, 'required'), {
+      name: 'host-peer-fixture',
+      version: '1.0.0',
+      files: ['index.js'],
+      peerDependencies: { openclaw: '>=2026.3.22' },
+    });
+    const patchedTgz = prepareHostPeerPackage(requiredTgz, outputDir, { packageLabel: 'fixture' });
+    expect(patchedTgz).not.toBe(requiredTgz);
+    expect(patchedTgz.endsWith('.tgz')).toBe(true);
+
+    const extractDir = path.join(tempDir, 'extracted');
+    fs.mkdirSync(extractDir, { recursive: true });
+    tar.x({ file: patchedTgz, cwd: extractDir, strip: 1, sync: true });
+    expect(readPackageJson(extractDir).peerDependenciesMeta).toEqual({ openclaw: { optional: true } });
+    expect(fs.existsSync(path.join(extractDir, 'index.js'))).toBe(true);
+
+    const optionalTgz = createTarball(path.join(tempDir, 'optional'), {
+      name: 'host-peer-fixture',
+      version: '1.0.0',
+      peerDependencies: { openclaw: '>=2026.3.22' },
+      peerDependenciesMeta: { openclaw: { optional: true } },
+    });
+    expect(prepareHostPeerPackage(optionalTgz, outputDir)).toBe(optionalTgz);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
dsh no longer registers as an MCP server or receives delegated coding tasks through LobsterAI. Remove dshCodeMcpServer/dshSessionClient, drop the McpRuntime resolution hook, and stop re-syncing OpenClaw config on the dsh feature toggle since nothing in openclaw.json depends on it anymore. Update the e2e gate and README wording to reflect the RPC-based provider/model assertion instead of a delegated task run.