### PR TITLE
fix(cowork): keep exhausted voice input visually available

### DIFF
--- a/src/renderer/components/cowork/voiceInput/VoiceInputButton.test.ts
+++ b/src/renderer/components/cowork/voiceInput/VoiceInputButton.test.ts
@@ -44,11 +44,12 @@ describe('VoiceInputButton', () => {
     expect(html).not.toContain('<svg');
   });
 
-  test('dims the microphone when quota is exhausted while keeping the quota prompt clickable', () => {
+  test('keeps the microphone visually available when quota is exhausted', () => {
     const html = renderButton({ isQuotaExhausted: true });
 
     expect(html).toContain('aria-label="暂无语音输入时长"');
-    expect(html).toContain('text-secondary opacity-40');
+    expect(html).toContain('text-secondary hover:bg-surface-raised hover:text-foreground');
+    expect(html).not.toContain('opacity-40');
     expect(html).not.toContain('disabled=""');
   });
 });

--- a/src/renderer/components/cowork/voiceInput/VoiceInputButton.tsx
+++ b/src/renderer/components/cowork/voiceInput/VoiceInputButton.tsx
@@ -40,9 +40,9 @@ const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
   const stateClass = showsStopIcon
     ? 'bg-neutral-100 text-neutral-950 hover:bg-neutral-200 dark:bg-white/10 dark:text-white dark:hover:bg-white/15'
     : unavailable
-        ? 'cursor-not-allowed text-secondary opacity-60'
+        ? 'cursor-not-allowed text-secondary/40 opacity-60'
         : isQuotaExhausted
-          ? 'text-secondary opacity-40 hover:bg-surface-raised'
+          ? 'text-secondary hover:bg-surface-raised hover:text-foreground'
         : loginRequired
           ? 'text-secondary hover:bg-surface-raised hover:text-foreground'
         : 'text-secondary hover:bg-surface-raised hover:text-foreground';


### PR DESCRIPTION
Keep the voice input button visually active when today's ASR quota is exhausted, while preserving the existing quota prompt behavior on click.

Add coverage for the exhausted quota visual state.
