### PR TITLE
fix(browser): add in-app MCP startup diagnostics

### DIFF
--- a/scripts/apply-openclaw-patches.cjs
+++ b/scripts/apply-openclaw-patches.cjs
@@ -66,6 +66,30 @@ if (patchFiles.length === 0) {
 console.log(`[apply-openclaw-patches] Applying patches for openclaw ${openclawVersion} (${patchFiles.length} file(s))`);
 
 const strongPatchValidators = {
+  'openclaw-browser-mcp-startup-diagnostics.patch': [
+    {
+      file: 'extensions/browser/src/browser/chrome-mcp.ts',
+      snippets: [
+        'let stage: "connect" | "list-tools" | "ready" = "connect"',
+        'Chrome MCP subprocess ready profile=',
+        'Chrome MCP attach failed profile=',
+        'stderr=${JSON.stringify(stderrDetail)}',
+      ],
+      forbiddenSnippets: ['let getStderr = () => ""'],
+      orderedSnippets: [
+        'const getStderr = drainStderr(transport);',
+        'await client.connect(transport);',
+      ],
+    },
+    {
+      file: 'extensions/browser/src/browser/chrome-mcp.test.ts',
+      snippets: [
+        'captures subprocess stderr when the MCP handshake exits early',
+        'lobster-startup-probe-before-initialize',
+        'expect(logs).not.toContain',
+      ],
+    },
+  ],
   'openclaw-terminate-run-on-critical-tool-loop.patch': [
     {
       file: 'packages/agent-core/src/agent.ts',

--- a/scripts/patches/v2026.6.1/openclaw-browser-mcp-startup-diagnostics.patch
+++ b/scripts/patches/v2026.6.1/openclaw-browser-mcp-startup-diagnostics.patch
@@ -1,0 +1,137 @@
+diff --git a/extensions/browser/src/browser/chrome-mcp.test.ts b/extensions/browser/src/browser/chrome-mcp.test.ts
+index aa9a566c9f8..f59299ae133 100644
+--- a/extensions/browser/src/browser/chrome-mcp.test.ts
++++ b/extensions/browser/src/browser/chrome-mcp.test.ts
+@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
+ import os from "node:os";
+ import path from "node:path";
+ import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
++import { resetLogger, setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
+ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+ import {
+   clickChromeMcpCoords,
+@@ -128,6 +129,8 @@ describe("chrome MCP page parsing", () => {
+   afterEach(() => {
+     vi.useRealTimers();
+     vi.unstubAllEnvs();
++    setLoggerOverride(null);
++    resetLogger();
+   });
+ 
+   it("parses list_pages text responses when structuredContent is missing", async () => {
+@@ -398,6 +401,51 @@ describe("chrome MCP page parsing", () => {
+     expect(message).not.toContain(secretToken);
+   });
+ 
++  it("captures subprocess stderr when the MCP handshake exits early", async () => {
++    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chrome-mcp-test-"));
++    const logFile = path.join(tempDir, "openclaw.log");
++    const marker = "lobster-startup-probe-before-initialize";
++    const fakeMcpScript = path.join(tempDir, "fake-mcp.mjs");
++    await fs.writeFile(
++      fakeMcpScript,
++      `#!/usr/bin/env node
++process.stderr.write(${JSON.stringify("lobster-startup-probe-before-initialize\n")});
++process.exit(17);
++`,
++    );
++    await fs.chmod(fakeMcpScript, 0o755);
++
++    let fakeMcpCommand = fakeMcpScript;
++    if (process.platform === "win32") {
++      fakeMcpCommand = path.join(tempDir, "fake-mcp.cmd");
++      const runtimePath = process.execPath.replaceAll("%", "%%");
++      const scriptPath = fakeMcpScript.replaceAll("%", "%%");
++      await fs.writeFile(fakeMcpCommand, `@echo off\r\n"${runtimePath}" "${scriptPath}" %*\r\n`);
++    }
++
++    setLoggerOverride({ level: "warn", consoleLevel: "silent", file: logFile });
++    try {
++      await expect(
++        ensureChromeMcpAvailable(
++          "lobster-in-app",
++          { mcpCommand: fakeMcpCommand },
++          { ephemeral: true },
++        ),
++      ).rejects.toThrow(/Chrome MCP existing-session attach failed/);
++
++      const logs = await fs.readFile(logFile, "utf8");
++      expect(logs).toContain("Chrome MCP attach failed");
++      expect(logs).toContain('profile=\\"lobster-in-app\\"');
++      expect(logs).toContain("stage=connect");
++      expect(logs).toContain(marker);
++      expect(logs).not.toContain('stderr=\\"<empty>\\"');
++    } finally {
++      setLoggerOverride(null);
++      resetLogger();
++      await fs.rm(tempDir, { recursive: true, force: true });
++    }
++  });
++
+   it("redacts home-relative user data dirs from attach failures", async () => {
+     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chrome-mcp-test-"));
+     const homeDir = os.homedir();
+diff --git a/extensions/browser/src/browser/chrome-mcp.ts b/extensions/browser/src/browser/chrome-mcp.ts
+index 5a01fed0613..907b7fc79a4 100644
+--- a/extensions/browser/src/browser/chrome-mcp.ts
++++ b/extensions/browser/src/browser/chrome-mcp.ts
+@@ -697,37 +697,48 @@ async function createRealSession(
+     {},
+   );
+ 
+-  let getStderr = () => "";
++  const startedAt = Date.now();
++  const profileLabel = redactChromeMcpProfileLabelForDiagnostic(profileName);
++  const commandLabel = redactChromeMcpLocalPathForDiagnostic(options.command);
++  let stage: "connect" | "list-tools" | "ready" = "connect";
++  const getStderr = drainStderr(transport);
+   const ready = (async () => {
+     try {
++      log.debug(
++        `Chrome MCP subprocess starting profile=${JSON.stringify(profileLabel)} stage=${stage} command=${JSON.stringify(commandLabel)}`,
++      );
+       await withChromeMcpHandshakeTimeout(
+         (async () => {
+           await client.connect(transport);
+-          getStderr = drainStderr(transport);
++          stage = "list-tools";
+           const tools = await client.listTools();
+           if (!tools.tools.some((tool) => tool.name === "list_pages")) {
+             throw new Error("Chrome MCP server did not expose the expected navigation tools.");
+           }
+         })(),
+       );
++      stage = "ready";
++      log.debug(
++        `Chrome MCP subprocess ready profile=${JSON.stringify(profileLabel)} stage=${stage} durationMs=${Date.now() - startedAt} pid=${readChromeMcpTransportPid(transport) ?? "unavailable"} command=${JSON.stringify(commandLabel)}`,
++      );
+     } catch (err) {
++      const failedPid = readChromeMcpTransportPid(transport);
+       await closeChromeMcpClientAndProcess({ client, transport, ownsProcessTree: true });
+       const stderr = getStderr();
+-      if (stderr) {
+-        log.warn(
+-          `Chrome MCP attach failed for profile "${redactChromeMcpProfileLabelForDiagnostic(profileName)}". Subprocess stderr:\n${redactChromeMcpDiagnosticTextWithLocalPaths(stderr)}`,
+-        );
+-      }
++      const detail = redactChromeMcpDiagnosticTextWithLocalPaths(
++        err instanceof Error ? err.message : String(err),
++      );
++      const stderrDetail = stderr ? redactChromeMcpDiagnosticTextWithLocalPaths(stderr) : "<empty>";
++      log.warn(
++        `Chrome MCP attach failed profile=${JSON.stringify(profileLabel)} stage=${stage} durationMs=${Date.now() - startedAt} pid=${failedPid ?? "unavailable"} command=${JSON.stringify(commandLabel)} error=${JSON.stringify(detail)} stderr=${JSON.stringify(stderrDetail)}`,
++      );
+       const targetLabel = options.browserUrl
+         ? `the configured Chrome endpoint (${redactToolPayloadText(redactCdpUrl(options.browserUrl) ?? options.browserUrl)})`
+         : options.userDataDir
+           ? `the configured Chromium user data dir (${redactChromeMcpLocalPathForDiagnostic(options.userDataDir)})`
+           : "Google Chrome's default profile";
+-      const detail = redactChromeMcpDiagnosticTextWithLocalPaths(
+-        err instanceof Error ? err.message : String(err),
+-      );
+       throw new BrowserProfileUnavailableError(
+-        `Chrome MCP existing-session attach failed for profile "${redactChromeMcpProfileLabelForDiagnostic(profileName)}". ` +
++        `Chrome MCP existing-session attach failed for profile "${profileLabel}". ` +
+           `Make sure ${targetLabel} is running locally with remote debugging enabled. ` +
+           `Details: ${detail}`,
+       );

--- a/src/main/libs/lobsterBrowserMcpServer.test.ts
+++ b/src/main/libs/lobsterBrowserMcpServer.test.ts
@@ -159,7 +159,64 @@ describe('resolveLobsterBrowserMcpCommand', () => {
     }
 
     expect(receivedSecrets).toEqual([bridgeSecret]);
-    expect(stderr.join('')).not.toContain('LOBSTERAI_ELECTRON_PATH is not set');
+    const stderrText = stderr.join('');
+    expect(stderrText).toContain('[LobsterBrowserMcp] startup');
+    expect(stderrText).toContain('runtimeConfig=loaded');
+    expect(stderrText).toContain('bridgeUrlArg=true');
+    expect(stderrText).toContain('bridgeSecretConfigured=true');
+    expect(stderrText).not.toContain(bridgeSecret);
+    expect(stderrText).not.toContain('LOBSTERAI_ELECTRON_PATH is not set');
+  }, 15_000);
+
+  test('writes bridge failures to stderr without exposing the bridge secret', async () => {
+    const baseDir = createTempDirectory();
+    const bridgeSecret = 'diagnostic-secret-must-not-leak';
+    const bridgeServer = http.createServer((request, response) => {
+      request.resume();
+      request.on('end', () => {
+        response.writeHead(503, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ error: 'Browser host is not ready.' }));
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      bridgeServer.once('error', reject);
+      bridgeServer.listen(0, '127.0.0.1', resolve);
+    });
+    const address = bridgeServer.address() as AddressInfo;
+    const bridgeUrl = `http://127.0.0.1:${address.port}/browser/tool?private=ignored`;
+    const launch = resolveLobsterBrowserMcpStdioLaunch(baseDir, {
+      electronNodeRuntimePath: process.execPath,
+      bridgeUrl,
+      bridgeSecret,
+    });
+    const transport = new StdioClientTransport({
+      command: launch.command,
+      args: launch.args,
+      env: launch.env,
+      stderr: 'pipe',
+    });
+    const stderr: string[] = [];
+    transport.stderr?.on('data', chunk => stderr.push(String(chunk)));
+    const client = new Client({ name: 'lobster-browser-diagnostic-test', version: '1.0.0' }, {});
+
+    try {
+      await client.connect(transport);
+      const result = await client.callTool({ name: 'list_pages', arguments: {} });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        { type: 'text', text: 'Browser host is not ready.' },
+      ]);
+    } finally {
+      await client.close().catch(() => {});
+      await new Promise<void>(resolve => bridgeServer.close(() => resolve()));
+    }
+
+    const stderrText = stderr.join('');
+    expect(stderrText).toContain('bridge-http-error tool="list_pages"');
+    expect(stderrText).toContain(`bridge=http://127.0.0.1:${address.port}/browser/tool`);
+    expect(stderrText).toContain('status=503');
+    expect(stderrText).not.toContain('?private=ignored');
+    expect(stderrText).not.toContain(bridgeSecret);
   }, 15_000);
 
   test('can expose only the saved-credential login tool to the Agent runtime', async () => {

--- a/src/main/libs/lobsterBrowserMcpServer.ts
+++ b/src/main/libs/lobsterBrowserMcpServer.ts
@@ -27,6 +27,33 @@ export interface LobsterBrowserMcpStdioLaunch {
 const MCP_SERVER_SOURCE = String.raw`import fs from 'node:fs/promises';
 import readline from 'node:readline';
 
+function formatDiagnosticError(error) {
+  const message = error instanceof Error ? error.stack || error.message : String(error);
+  return message.replace(/\s+/g, ' ').slice(0, 2000);
+}
+
+function writeDiagnostic(message) {
+  process.stderr.write('[LobsterBrowserMcp] ' + message + '\n');
+}
+
+function formatBridgeEndpoint(value) {
+  if (!value) return '<missing>';
+  try {
+    const endpoint = new URL(value);
+    return endpoint.protocol + '//' + endpoint.host + endpoint.pathname;
+  } catch {
+    return '<invalid>';
+  }
+}
+
+process.on('uncaughtExceptionMonitor', (error, origin) => {
+  writeDiagnostic(
+    'uncaught-exception origin=' + JSON.stringify(origin)
+    + ' error=' + JSON.stringify(formatDiagnosticError(error)),
+  );
+});
+
+let runtimeConfigState = 'loaded';
 const runtimeConfig = await fs.readFile(
   new URL('./${RUNTIME_CONFIG_FILE_NAME}', import.meta.url),
   'utf8',
@@ -37,10 +64,15 @@ const runtimeConfig = await fs.readFile(
     || typeof parsed.bridgeUrl !== 'string'
     || typeof parsed.bridgeSecret !== 'string'
   ) {
+    runtimeConfigState = 'invalid';
     return null;
   }
   return parsed;
-}).catch(() => null);
+}).catch((error) => {
+  runtimeConfigState = 'read-error';
+  writeDiagnostic('runtime-config-error error=' + JSON.stringify(formatDiagnosticError(error)));
+  return null;
+});
 
 const bridgeUrlArg = process.argv.find((arg) => arg.startsWith('--lobster-bridge-url='));
 const bridgeUrl = bridgeUrlArg
@@ -49,6 +81,18 @@ const bridgeUrl = bridgeUrlArg
 const bridgeSecret = runtimeConfig?.bridgeSecret || '';
 
 const credentialOnly = process.argv.includes('${BrowserCredentialMcpServer.ToolSetArgument}');
+writeDiagnostic(
+  'startup pid=' + process.pid
+  + ' platform=' + process.platform
+  + ' arch=' + process.arch
+  + ' node=' + process.version
+  + ' electronRunAsNode=' + (process.env.ELECTRON_RUN_AS_NODE === '1')
+  + ' runtimeConfig=' + runtimeConfigState
+  + ' bridge=' + formatBridgeEndpoint(bridgeUrl)
+  + ' bridgeUrlArg=' + Boolean(bridgeUrlArg)
+  + ' bridgeSecretConfigured=' + Boolean(bridgeSecret)
+  + ' credentialOnly=' + credentialOnly,
+);
 const toolDefinitions = [
   ['list_pages', {}],
   ['new_page', { url: { type: 'string' }, timeout: { type: 'number' } }],
@@ -95,21 +139,49 @@ function errorResult(message) {
 
 async function callBridge(name, args) {
   if (!bridgeUrl || !bridgeSecret) {
+    writeDiagnostic(
+      'bridge-unavailable tool=' + JSON.stringify(name)
+      + ' bridge=' + formatBridgeEndpoint(bridgeUrl)
+      + ' bridgeSecretConfigured=' + Boolean(bridgeSecret),
+    );
     return errorResult('LobsterAI browser bridge is not configured.');
   }
-  const response = await fetch(bridgeUrl, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      'x-mcp-bridge-secret': bridgeSecret,
-    },
-    body: JSON.stringify({ tool: name, args: args || {} }),
-  });
+  let response;
+  try {
+    response = await fetch(bridgeUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-mcp-bridge-secret': bridgeSecret,
+      },
+      body: JSON.stringify({ tool: name, args: args || {} }),
+    });
+  } catch (error) {
+    writeDiagnostic(
+      'bridge-request-failed tool=' + JSON.stringify(name)
+      + ' bridge=' + formatBridgeEndpoint(bridgeUrl)
+      + ' error=' + JSON.stringify(formatDiagnosticError(error)),
+    );
+    throw error;
+  }
   const payload = await response.json().catch(() => null);
+  if (!payload) {
+    writeDiagnostic(
+      'bridge-invalid-json tool=' + JSON.stringify(name)
+      + ' bridge=' + formatBridgeEndpoint(bridgeUrl)
+      + ' status=' + response.status,
+    );
+  }
   if (!response.ok) {
     const message = payload && typeof payload.error === 'string'
       ? payload.error
       : 'LobsterAI browser bridge returned HTTP ' + response.status + '.';
+    writeDiagnostic(
+      'bridge-http-error tool=' + JSON.stringify(name)
+      + ' bridge=' + formatBridgeEndpoint(bridgeUrl)
+      + ' status=' + response.status
+      + ' error=' + JSON.stringify(formatDiagnosticError(message)),
+    );
     return errorResult(message);
   }
   return payload;
@@ -177,6 +249,11 @@ input.on('line', (line) => {
   try {
     const message = JSON.parse(trimmed);
     void handleRequest(message).catch((error) => {
+      writeDiagnostic(
+        'request-failed method=' + JSON.stringify(message.method)
+        + ' tool=' + JSON.stringify(message.params?.name || '')
+        + ' error=' + JSON.stringify(formatDiagnosticError(error)),
+      );
       if (message.id !== undefined) {
         writeMessage({
           jsonrpc: '2.0',
@@ -186,10 +263,19 @@ input.on('line', (line) => {
       }
     });
   } catch (error) {
-    process.stderr.write('[LobsterBrowserMcp] Invalid JSON-RPC message: ' + String(error) + '\n');
+    writeDiagnostic('invalid-json-rpc error=' + JSON.stringify(formatDiagnosticError(error)));
   }
 });
 `;
+
+const formatBridgeEndpointForLog = (bridgeUrl: string): string => {
+  try {
+    const endpoint = new URL(bridgeUrl);
+    return `${endpoint.protocol}//${endpoint.host}${endpoint.pathname}`;
+  } catch {
+    return '<invalid>';
+  }
+};
 
 const escapeWindowsBatchValue = (value: string): string => value.replace(/%/g, '%%');
 
@@ -276,6 +362,14 @@ export const resolveLobsterBrowserMcpCommand = (
       buildWindowsLauncherSource(options.electronNodeRuntimePath),
       0o700,
     );
+    console.log('[LobsterBrowserMcp] Prepared browser MCP launcher', {
+      platform: options.platform ?? process.platform,
+      launcherPath,
+      launcherExists: fs.existsSync(launcherPath),
+      electronNodeRuntimePath: options.electronNodeRuntimePath,
+      electronNodeRuntimeExists: fs.existsSync(options.electronNodeRuntimePath),
+      bridgeEndpoint: formatBridgeEndpointForLog(options.bridgeUrl),
+    });
     return launcherPath;
   }
 
@@ -285,6 +379,14 @@ export const resolveLobsterBrowserMcpCommand = (
     buildPosixLauncherSource(options.electronNodeRuntimePath),
     0o700,
   );
+  console.log('[LobsterBrowserMcp] Prepared browser MCP launcher', {
+    platform: options.platform ?? process.platform,
+    launcherPath,
+    launcherExists: fs.existsSync(launcherPath),
+    electronNodeRuntimePath: options.electronNodeRuntimePath,
+    electronNodeRuntimeExists: fs.existsSync(options.electronNodeRuntimePath),
+    bridgeEndpoint: formatBridgeEndpointForLog(options.bridgeUrl),
+  });
   return launcherPath;
 };
 
@@ -293,6 +395,14 @@ export const resolveLobsterBrowserMcpStdioLaunch = (
   options: LobsterBrowserMcpLaunchOptions,
 ): LobsterBrowserMcpStdioLaunch => {
   const { serverPath } = prepareLobsterBrowserMcpRuntime(baseDir, options);
+  console.log('[LobsterBrowserMcp] Prepared browser MCP stdio launch', {
+    platform: options.platform ?? process.platform,
+    serverPath,
+    serverExists: fs.existsSync(serverPath),
+    electronNodeRuntimePath: options.electronNodeRuntimePath,
+    electronNodeRuntimeExists: fs.existsSync(options.electronNodeRuntimePath),
+    bridgeEndpoint: formatBridgeEndpointForLog(options.bridgeUrl),
+  });
   return {
     command: options.electronNodeRuntimePath,
     args: [serverPath],


### PR DESCRIPTION
## Summary

- add secret-safe launcher, runtime, and bridge diagnostics for the LobsterAI in-app browser MCP server
- capture subprocess stderr before the OpenClaw MCP handshake and log the startup stage, duration, PID, command, error, and stderr tail
- add strong validation for the version-scoped OpenClaw patch and regression coverage for early handshake exits

This PR only improves diagnostics. The functional fix will be designed after QA reproduces the issue with a package containing these logs.

## QA log markers

- `[LobsterBrowserMcp] Prepared browser MCP launcher`
- `[LobsterBrowserMcp] startup`
- `Chrome MCP attach failed profile="lobster-in-app"`
- `bridge-request-failed`, `bridge-http-error`, or `request-failed`

Bridge secrets and URL query strings are not logged.

## Verification

- `npm test -- lobsterBrowserMcpServer agentBrowserHost` (10 tests passed)
- changed-file ESLint passed with zero warnings
- `npm run compile:electron` passed
- all 30 versioned OpenClaw patches applied successfully to a clean v2026.6.1 worktree
- targeted OpenClaw regression test for handshake-time stderr capture passed

The full OpenClaw `chrome-mcp.test.ts` run also had one unrelated existing Windows path-separator assertion failure (`/` expected, `\` received); the other 51 tests passed.