### PR TITLE
fix(cowork): preserve model display during login refresh

### DIFF
--- a/src/renderer/components/ModelSelector.test.ts
+++ b/src/renderer/components/ModelSelector.test.ts
@@ -13,8 +13,26 @@ import {
   resolveHoverCardTop,
   resolveNestedCascadePlacement,
   resolvePickerThinkingLevel,
+  shouldRenderSelectedModelUnavailableFallback,
   supportsConfigurableModelThinkingProtocol,
 } from './ModelSelector';
+
+test('keeps a logged-in stale server model visible only while the model list is empty', () => {
+  const selectedModel = {
+    id: 'deepseek-v4-flash',
+    name: 'DeepSeek V4 Flash',
+    isServerModel: true,
+  };
+
+  expect(shouldRenderSelectedModelUnavailableFallback(0, selectedModel, true)).toBe(true);
+  expect(shouldRenderSelectedModelUnavailableFallback(1, selectedModel, true)).toBe(false);
+  expect(shouldRenderSelectedModelUnavailableFallback(0, selectedModel, false)).toBe(false);
+  expect(shouldRenderSelectedModelUnavailableFallback(0, {
+    id: 'deepseek-v4-flash',
+    name: 'DeepSeek V4 Flash',
+  }, true)).toBe(false);
+  expect(shouldRenderSelectedModelUnavailableFallback(0, null, true)).toBe(false);
+});
 
 test('keeps primary and more-model order stable while moving the folded group last', () => {
   const primaryFirst = { id: 'primary-1', name: 'Primary 1' };

--- a/src/renderer/components/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector.tsx
@@ -108,6 +108,16 @@ export const countVisibleModelSelectorRows = (
     + (moreModelsExpanded ? sections.moreModels.length : 0);
 };
 
+export const shouldRenderSelectedModelUnavailableFallback = (
+  availableModelCount: number,
+  selectedModel: Model | null | undefined,
+  isLoggedIn: boolean,
+): selectedModel is Model & { isServerModel: true } => (
+  isLoggedIn
+  && availableModelCount === 0
+  && selectedModel?.isServerModel === true
+);
+
 export interface ModelSelectorChangeMeta {
   group: ModelSelectorGroup;
   thinkingLevel?: ModelThinkingLevelType;
@@ -456,6 +466,41 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
   const stableListMinHeight = shouldShowGroupTabs
     ? Math.min(largestGroupRowCount * MODEL_ITEM_HEIGHT + LIST_VERTICAL_PADDING, LIST_MAX_HEIGHT)
     : undefined;
+  const showSelectedModelUnavailableFallback = shouldRenderSelectedModelUnavailableFallback(
+    availableModels.length,
+    selectedModel,
+    isLoggedIn,
+  );
+  const selectedModelUnavailableFallbackLogKey = showSelectedModelUnavailableFallback
+    ? `${selectedModel.providerKey ?? ''}:${selectedModel.id}`
+    : '';
+  const selectedModelUnavailableFallbackLogKeyRef = React.useRef('');
+  const triggerMaxWidthClass = triggerMaxWidthClassName ?? (compact ? 'max-w-[220px]' : 'max-w-[280px]');
+  const triggerClassName = compact
+    ? `space-x-1.5 px-2 py-1 rounded-lg ${triggerMaxWidthClass}`
+    : `space-x-2 px-3 py-1.5 rounded-xl ${triggerMaxWidthClass}`;
+  const triggerTextClassName = compact
+    ? 'font-normal text-[13px] leading-5'
+    : 'font-medium text-sm';
+  const triggerIconClassName = compact ? 'h-3.5 w-3.5' : 'h-4 w-4';
+  const resolveModelIconProviderKey = (model: Model): string => {
+    const providerKey = model.providerKey?.trim();
+    if (providerKey && providerKey !== ProviderName.LobsteraiServer) return providerKey;
+
+    const searchableText = `${model.name} ${model.id}`;
+    return MODEL_ICON_PROVIDER_HINTS.find(({ pattern }) => pattern.test(searchableText))?.providerName
+      ?? providerKey
+      ?? '';
+  };
+  const renderProviderIcon = (model: Model): React.ReactNode => {
+    const icon = getProviderIcon(resolveModelIconProviderKey(model));
+    if (!React.isValidElement<{ className?: string }>(icon)) return icon;
+
+    const existingClassName = icon.props.className ? `${icon.props.className} ` : '';
+    return React.cloneElement(icon, {
+      className: `${existingClassName}${MODEL_ICON_CLASS_NAME}`,
+    });
+  };
 
   // 点击外部区域关闭下拉框
   React.useEffect(() => {
@@ -736,8 +781,48 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
     if (hoverCloseTimerRef.current) clearTimeout(hoverCloseTimerRef.current);
   }, []);
 
+  React.useEffect(() => {
+    if (!showSelectedModelUnavailableFallback) {
+      selectedModelUnavailableFallbackLogKeyRef.current = '';
+      return;
+    }
+    if (selectedModelUnavailableFallbackLogKeyRef.current === selectedModelUnavailableFallbackLogKey) {
+      return;
+    }
+    selectedModelUnavailableFallbackLogKeyRef.current = selectedModelUnavailableFallbackLogKey;
+    const message = `preserving stale server model display while authenticated model list is empty: ${selectedModelUnavailableFallbackLogKey}`;
+    console.debug(`[ModelSelector] ${message}`);
+    try {
+      window.electron?.log?.fromRenderer?.('debug', 'ModelSelector', message);
+    } catch {
+      // Diagnostics only.
+    }
+  }, [
+    selectedModelUnavailableFallbackLogKey,
+    showSelectedModelUnavailableFallback,
+  ]);
+
   // 如果没有可用模型，显示提示
   if (availableModels.length === 0) {
+    if (showSelectedModelUnavailableFallback) {
+      return (
+        <div ref={containerRef} className="relative cursor-wait">
+          <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            className={`flex min-w-0 items-center overflow-hidden text-foreground transition-colors disabled:cursor-wait disabled:opacity-70 ${triggerClassName}`}
+          >
+            <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-secondary">
+              {renderProviderIcon(selectedModel)}
+            </span>
+            <span className={`${triggerTextClassName} min-w-0 truncate`}>{selectedModel.name}</span>
+            <ChevronDownIcon className={`${triggerIconClassName} shrink-0 dark:text-claude-darkTextSecondary text-claude-textSecondary`} />
+          </button>
+        </div>
+      );
+    }
+
     return (
       <div className="px-3 py-1.5 rounded-xl bg-surface text-secondary text-sm">
         {i18nService.t('modelSelectorNoModels')}
@@ -754,32 +839,6 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
     if (!selectedModel) return false;
     return isSameModelIdentity(model, selectedModel);
   };
-  const resolveModelIconProviderKey = (model: Model): string => {
-    const providerKey = model.providerKey?.trim();
-    if (providerKey && providerKey !== ProviderName.LobsteraiServer) return providerKey;
-
-    const searchableText = `${model.name} ${model.id}`;
-    return MODEL_ICON_PROVIDER_HINTS.find(({ pattern }) => pattern.test(searchableText))?.providerName
-      ?? providerKey
-      ?? '';
-  };
-  const renderProviderIcon = (model: Model): React.ReactNode => {
-    const icon = getProviderIcon(resolveModelIconProviderKey(model));
-    if (!React.isValidElement<{ className?: string }>(icon)) return icon;
-
-    const existingClassName = icon.props.className ? `${icon.props.className} ` : '';
-    return React.cloneElement(icon, {
-      className: `${existingClassName}${MODEL_ICON_CLASS_NAME}`,
-    });
-  };
-  const triggerMaxWidthClass = triggerMaxWidthClassName ?? (compact ? 'max-w-[220px]' : 'max-w-[280px]');
-  const triggerClassName = compact
-    ? `space-x-1.5 px-2 py-1 rounded-lg ${triggerMaxWidthClass}`
-    : `space-x-2 px-3 py-1.5 rounded-xl ${triggerMaxWidthClass}`;
-  const triggerTextClassName = compact
-    ? 'font-normal text-[13px] leading-5'
-    : 'font-medium text-sm';
-  const triggerIconClassName = compact ? 'h-3.5 w-3.5' : 'h-4 w-4';
 
   const cancelHoverClose = () => {
     if (hoverCloseTimerRef.current) {

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -94,6 +94,7 @@ import {
 } from '../../store/slices/coworkSlice';
 import { setActiveKitIds, toggleActiveKit } from '../../store/slices/kitSlice';
 import type { Model } from '../../store/slices/modelSlice';
+import { isSameModelIdentity } from '../../store/slices/modelSlice';
 import { setActiveSkillIds, setSkills, toggleActiveSkill } from '../../store/slices/skillSlice';
 import { CoworkCollaborationMode, CoworkImageAttachment } from '../../types/cowork';
 import type { MediaAttachmentRef } from '../../types/mediaGeneration';
@@ -682,6 +683,13 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     agentSelectedModel,
     globalSelectedModel: currentAgentSelectedModel,
   });
+  const effectiveModelIsAvailable = useMemo(() => (
+    !!effectiveSelectedModel
+    && availableModels.some(model => isSameModelIdentity(model, effectiveSelectedModel))
+  ), [availableModels, effectiveSelectedModel]);
+  const modelSelectionRefreshPending = isLoggedIn
+    && availableModels.length === 0
+    && effectiveSelectedModel?.isServerModel === true;
   const effectiveThinkingLevel = resolveModelThinkingLevel(
     effectiveSelectedModel,
     sessionId && currentSession?.id === sessionId
@@ -1713,6 +1721,29 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
       : CoworkCollaborationMode.Default;
 
     const accessPrompt = resolveSubmitModelAccessPrompt();
+    if (!effectiveModelIsAvailable && accessPrompt !== ModelAccessPromptKind.Login) {
+      const message = `blocked submit because selected model is unavailable; refreshPending=${modelSelectionRefreshPending}; model=${effectiveSelectedModel?.id ?? 'none'}; provider=${effectiveSelectedModel?.providerKey ?? 'none'}`;
+      console.debug(`[CoworkPromptInput] ${message}`);
+      try {
+        window.electron?.log?.fromRenderer?.('debug', 'CoworkPromptInput', message);
+      } catch {
+        // Diagnostics only.
+      }
+      reportPromptControl('submit_blocked', {
+        blockedReason: 'model_unavailable',
+        modelRefreshPending: modelSelectionRefreshPending,
+        submitMethod: effectiveSubmitMethod,
+        ...getPromptTextAnalyticsParams(trimmedValue),
+        ...getPromptCapabilityAnalyticsParams(),
+      });
+      showToast(i18nService.t(
+        modelSelectionRefreshPending
+          ? 'coworkModelRefreshing'
+          : 'coworkModelSettingsRequired',
+      ));
+      return;
+    }
+
     if (accessPrompt) {
       reportPromptControl('submit_blocked', {
         blockedReason: 'model_access_required',
@@ -1932,7 +1963,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     resetGoalInput(false);
     draftStartedAnalyticsRef.current = false;
     inputSourceOverrideRef.current = null;
-  }, [value, steerInputActive, steerValue, isVoiceRecording, stopVoiceRecordingAndRecognize, goalInputActive, goalInputMode, resetGoalInput, isStreaming, canSteer, remoteManaged, disabled, submitDisabled, isPatchingModel, onSubmit, onGoalCommand, activeSkillIds, skills, activeKitIds, marketplaceKits, installedKits, attachments, browserAnnotationBatches, showFolderSelector, workingDirectory, dispatch, draftKey, selectedTextSnippets, pendingSteers.length, resolveSubmitModelAccessPrompt, isLoggedIn, hasAccessibleUserModel, isPlanMode, planConfirmation, reportPromptControl, getPromptCapabilityAnalyticsParams, getPromptContextAnalyticsParams, getPromptInputSource, goal, sessionId, preparePromptPayload, modelSupportsImage, queuedMediaSelection, authOwnerAccountKey, authAccountGeneration]);
+  }, [value, steerInputActive, steerValue, isVoiceRecording, stopVoiceRecordingAndRecognize, goalInputActive, goalInputMode, resetGoalInput, isStreaming, canSteer, remoteManaged, disabled, submitDisabled, isPatchingModel, onSubmit, onGoalCommand, activeSkillIds, skills, activeKitIds, marketplaceKits, installedKits, attachments, browserAnnotationBatches, showFolderSelector, workingDirectory, dispatch, draftKey, selectedTextSnippets, pendingSteers.length, resolveSubmitModelAccessPrompt, isLoggedIn, hasAccessibleUserModel, isPlanMode, planConfirmation, reportPromptControl, getPromptCapabilityAnalyticsParams, getPromptContextAnalyticsParams, getPromptInputSource, goal, sessionId, preparePromptPayload, modelSupportsImage, queuedMediaSelection, authOwnerAccountKey, authAccountGeneration, effectiveModelIsAvailable, modelSelectionRefreshPending, effectiveSelectedModel?.id, effectiveSelectedModel?.providerKey]);
   handleSubmitRef.current = handleSubmit;
 
   const handleSelectSkill = useCallback((skill: Skill) => {
@@ -2801,6 +2832,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     && !isVoiceRecognizing
     && !isPatchingModel
     && !agentModelIsInvalid
+    && (effectiveModelIsAvailable || resolveSubmitModelAccessPrompt() === ModelAccessPromptKind.Login)
     && (!!activeTextareaValue.trim() || (!steerInputActive && (hasAttachments || browserAnnotationBatches.length > 0)));
   const showNewUserWelcomeLockOverlay = showNewUserWelcomeLoginOverlay && !isLoggedIn;
   const enhancedContainerClass = isDraggingFiles
@@ -2860,7 +2892,7 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
         alignDropdownToTriggerEnd={useHomeContextLayout}
         portal={showReadOnlyContext}
         triggerMaxWidthClassName={largeModelTriggerMaxWidthClassName}
-        disabled={isPatchingModel || isPersistingAgentModel}
+        disabled={isPatchingModel || isPersistingAgentModel || modelSelectionRefreshPending}
         thinkingLevel={effectiveThinkingLevel ?? null}
         value={agentModelIsInvalid && currentSession?.modelOverride
           ? { id: '__invalid__', name: currentSession.modelOverride.split('/').pop() || currentSession.modelOverride } as Model

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1217,6 +1217,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mediaTokenPricingThinkingOutput: '思考输出',
     mediaTokenBillingEstimateNote: '按实际 token 扣费，列表价格为默认 1 张输出的预估消耗。',
     modelSelectorNoModels: '请先在设置中配置模型',
+    coworkModelRefreshing: '模型列表正在刷新，请稍后再试。',
     coworkApiConfigTitle: 'API 配置',
     coworkApiConfigHint:
       '支持 Anthropic 兼容与 OpenAI 兼容协议（OpenAI 兼容通过本地转换服务接入）。',
@@ -4979,6 +4980,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mediaTokenBillingEstimateNote:
       'Billed by actual tokens. List price is the estimate for the default 1-image output.',
     modelSelectorNoModels: 'Please configure models in settings first',
+    coworkModelRefreshing: 'Models are refreshing. Please try again shortly.',
     coworkApiConfigTitle: 'API Configuration',
     coworkApiConfigHint:
       'Supports Anthropic-compatible and OpenAI-compatible APIs (OpenAI compatibility is bridged by a local adapter).',


### PR DESCRIPTION
Keep the selected server model visible while authenticated model metadata is temporarily empty during login refresh, without allowing stale models to run.

Also add renderer diagnostics and coverage for the guarded fallback state.
