### PR TITLE
fix(ci): bound skill audit duration

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -72,7 +72,11 @@ jobs:
             if [ -f "$skill/package.json" ]; then
               echo ""
               echo "=== Auditing $skill ==="
-              (cd "$skill" && npm install --package-lock-only 2>/dev/null && npm audit --audit-level=moderate 2>/dev/null) || echo "⚠ Audit issues found in $skill (non-blocking)"
+              (
+                cd "$skill" &&
+                npm install --package-lock-only --ignore-scripts --no-audit &&
+                timeout 90s npm audit --audit-level=moderate
+              ) || echo "⚠ Audit issues found in $skill (non-blocking)"
             fi
           done
           


### PR DESCRIPTION
## Summary

- disable the implicit audit performed by the lockfile-only install step
- keep one explicit npm audit per Skill and cap it at 90 seconds
- preserve stderr so registry failures remain visible
- retain the existing non-blocking audit behavior

## Background

The npm audit endpoint has intermittently waited for the default five-minute HTTP timeout before returning Service Unavailable. The previous workflow audited every Skill twice and serialized those delays.

## Verification

- parsed .github/workflows/security.yml with js-yaml
- validated the Audit Skills shell block with bash -n
- git diff --check