### PR TITLE
test: fix Windows path portability in installer and thumbnail tests

### DIFF
--- a/src/main/libs/appUpdateInstaller.test.ts
+++ b/src/main/libs/appUpdateInstaller.test.ts
@@ -19,6 +19,22 @@ const cpMocks = vi.hoisted(() => ({
   spawn: vi.fn(),
 }));
 
+const pathMocks = vi.hoisted(() => ({ usePosix: false }));
+
+vi.mock('path', async (importOriginal) => {
+  const actual = await importOriginal<{ default: typeof path }>();
+  return {
+    ...actual,
+    // Stubbing process.platform does not change Node's native path implementation.
+    // Keep the override local to these imports so Vitest's own paths are unaffected.
+    default: new Proxy(actual.default, {
+      get(target, key) {
+        return Reflect.get(pathMocks.usePosix ? target.posix : target, key);
+      },
+    }),
+  };
+});
+
 vi.mock('electron', () => ({
   app: {
     getPath: mocks.getPath,
@@ -530,6 +546,14 @@ describe('hdiutil plist parsing', () => {
 });
 
 describe('mac swap builders', () => {
+  beforeEach(() => {
+    pathMocks.usePosix = true;
+  });
+
+  afterEach(() => {
+    pathMocks.usePosix = false;
+  });
+
   test('places staging and backup next to the target app, hidden and not .app-suffixed', () => {
     const swapPaths = buildMacSwapPaths('/Applications/Lobster AI.app', 1234);
 
@@ -662,6 +686,7 @@ describe('macOS DMG install', () => {
     cpMocks.spawn.mockReset();
 
     Object.defineProperty(process, 'platform', { value: 'darwin' });
+    pathMocks.usePosix = true;
     Object.defineProperty(process, 'resourcesPath', {
       value: `${TARGET_APP}/Contents/Resources`,
       configurable: true,
@@ -732,6 +757,7 @@ describe('macOS DMG install', () => {
 
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
+    pathMocks.usePosix = false;
     Object.defineProperty(process, 'resourcesPath', {
       value: originalResourcesPath,
       configurable: true,
@@ -771,7 +797,9 @@ describe('macOS DMG install', () => {
     expect(detachCommands[0]).toContain('/Volumes/LobsterAI');
     expect(fs.promises.unlink).toHaveBeenCalledWith(DMG_PATH);
     expect(cpMocks.execFile).not.toHaveBeenCalled();
-    expect(mocks.relaunch).toHaveBeenCalledOnce();
+    expect(mocks.relaunch).toHaveBeenCalledExactlyOnceWith({
+      execPath: `${TARGET_APP}/Contents/MacOS/LobsterAI`,
+    });
     expect(mocks.quit).toHaveBeenCalledOnce();
     expect(mocks.openPath).not.toHaveBeenCalled();
     expect(fs.promises.mkdir).not.toHaveBeenCalled();

--- a/src/main/libs/libraryThumbnailService.test.ts
+++ b/src/main/libs/libraryThumbnailService.test.ts
@@ -142,6 +142,9 @@ describe('LibraryThumbnailService', () => {
   });
 
   test('promotes a visible request ahead of queued near-viewport work', async () => {
+    const runningPath = path.resolve(os.tmpdir(), 'running.pdf');
+    const nearPath = path.resolve(os.tmpdir(), 'near.pdf');
+    const visiblePath = path.resolve(os.tmpdir(), 'visible.pdf');
     const started: string[] = [];
     const releases: Array<() => void> = [];
     const service = new LibraryThumbnailService({
@@ -154,28 +157,29 @@ describe('LibraryThumbnailService', () => {
       },
     });
 
-    const running = service.generate('/tmp/running.pdf', {
+    const running = service.generate(runningPath, {
       requestId: 'running',
       priority: LibraryThumbnailRequestPriority.NearViewport,
     });
-    const near = service.generate('/tmp/near.pdf', {
+    const near = service.generate(nearPath, {
       requestId: 'near',
       priority: LibraryThumbnailRequestPriority.NearViewport,
     });
-    const visible = service.generate('/tmp/visible.pdf', {
+    const visible = service.generate(visiblePath, {
       requestId: 'visible',
       priority: LibraryThumbnailRequestPriority.Visible,
     });
     await flushTasks();
-    expect(started).toEqual(['/tmp/running.pdf']);
+    expect(started).toEqual([runningPath]);
 
     releases.shift()?.();
     await flushTasks();
-    expect(started).toEqual(['/tmp/running.pdf', '/tmp/visible.pdf']);
+    expect(started).toEqual([runningPath, visiblePath]);
     releases.shift()?.();
     await flushTasks();
     releases.shift()?.();
     await Promise.all([running, near, visible]);
+    expect(started).toEqual([runningPath, visiblePath, nearPath]);
   });
 
   test('cancels a queued request before renderer work starts', async () => {


### PR DESCRIPTION
## Summary

修复将最新 main 合入 OpenClaw v2026.8.1 升级分支后，在 Windows 验收中发现的 4 个测试失败：3 个 macOS 安装器路径用例，以及 1 个缩略图队列优先级用例。

本 PR 仅修改两个测试文件，不修改生产代码、OpenClaw runtime 或 patches，也不改变用户侧行为。

## Related Issue

无关联 issue；来自升级分支的本地构建验收。

## Changes Made

- macOS 安装器测试在模拟 `process.platform = 'darwin'` 时同步使用 POSIX 路径语义。路径 mock 仅作用于测试模块的导入，不修改 Node 全局 `path` 实现，并在用例结束后恢复，避免干扰 Vitest 或其他平台测试。
- 缩略图队列用例使用 `path.resolve(os.tmpdir(), ...)` 构造当前平台的绝对路径，消除硬编码 `/tmp` 与 Windows 路径规范化之间的不一致。
- 加强 macOS 重启入口路径和缩略图完整执行顺序的断言，保留原有行为验证强度。

## Type of Change

- [x] Other: test portability fixes only

## Testing

- [x] Tested locally on Windows
- [x] Updated existing tests
- 修复前，两个相关测试文件共 49 个用例，复现上述 4 个失败。
- 修复后，相关用例 **49/49 通过**；单 worker、随机顺序（seed `20260801`）再次运行 **49/49 通过**。
- 两个改动文件通过 CI 同等要求的 ESLint（`--report-unused-disable-directives --max-warnings 0`）。
- 与此前合并验收一致，将 `TEMP` / `TMP` 指向 D 盘隔离目录后，全量测试 **403 个文件通过，3972 个用例通过、11 个跳过、0 个失败**。
- `npm run compile:electron` 通过，并恢复 Electron 对应的 native dependencies。

### Known environment-dependent failures outside this PR

使用本机默认 C 盘临时目录、仓库位于 D 盘时，全量测试结果为 **3969 通过、11 跳过、3 失败**。这 3 项是此前已识别的环境依赖，不属于本次修复的 4 项：

1. `tests/imapSmtpEmailAttachmentStorage.test.ts`：`preserves relative output paths in returned results`。跨盘符时 `path.relative()` 返回绝对路径，测试的相对路径假设不成立。
2. `src/main/libs/shareDeployment/nodeServiceProjectAnalyzer.test.ts`：session context 优先级用例。
3. 同文件：working-directory fallback 用例。

后两项受到临时目录祖先路径中本机已有 `package.json` 的影响。它们在上述 D 盘隔离临时目录中通过；本 PR 未修改这些用例或对应生产逻辑，也未更改系统环境变量。

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed; diff contains only the two intended test files
- [x] Non-obvious mock behavior is documented inline
- [x] Changed-file lint passes with no warnings
- [x] Existing assertions are retained or strengthened
- [x] Full suite passes with isolated TEMP / TMP; default-environment limitations are documented above

## Electron-Specific Changes

- [x] None — changes under `src/main/` are test-only; no main-process runtime, preload, IPC, storage, windowing, or OpenClaw configuration/startup changes

## Additional Notes

Target branch: `feat/openclaw-v2026.8.1`. No UI changes, so screenshots and manual UI validation are not applicable.
