### PR TITLE
fix(installer): use modern CJK UI fonts in NSIS dialogs

### DIFF
--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -471,6 +471,34 @@ FunctionEnd
   ; welcome/finish sidebar bitmap to the scaled control, so layout is kept.
   ManifestDPIAware true
 
+  ; NSIS ships its CJK language files with the dialog font pinned to the
+  ; Windows XP-era UI fonts: SimpChinese.nlf = SimSun 9pt, TradChinese.nlf =
+  ; PMingLiU 9pt, Japanese.nlf = MS PGothic 9pt, Korean.nlf = Gulim 9pt. Those
+  ; fonts carry embedded bitmap strikes for 12-16 px, which GDI draws as-is
+  ; with no anti-aliasing, so at 9pt every label, button, the branding text
+  ; and the bold MUI header (CreateFont from $(^Font)) come out jagged --
+  ; and with the installer DPI-aware the pixels are no longer even blurred
+  ; away by bitmap scaling. English and the other Latin languages keep the
+  ; language-file default ("-" = MS Shell Dlg), an outline font that is
+  ; unaffected. Override each CJK language with the font Windows 10+ itself
+  ; uses for that locale's UI. SetFont /LANG replaces the language file's
+  ; font for the per-language dialog templates and for $(^Font)/$(^FontSize),
+  ; and LANG_* is only defined once addLangs has run, which is why this lives
+  ; in customHeader (inserted after addLangs). Guarded so a narrowed
+  ; installerLanguages list still compiles.
+  !ifdef LANG_SIMPCHINESE
+    SetFont /LANG=${LANG_SIMPCHINESE} "Microsoft YaHei UI" 9
+  !endif
+  !ifdef LANG_TRADCHINESE
+    SetFont /LANG=${LANG_TRADCHINESE} "Microsoft JhengHei UI" 9
+  !endif
+  !ifdef LANG_JAPANESE
+    SetFont /LANG=${LANG_JAPANESE} "Yu Gothic UI" 9
+  !endif
+  !ifdef LANG_KOREAN
+    SetFont /LANG=${LANG_KOREAN} "Malgun Gothic" 9
+  !endif
+
   ; Keep only the progress bar visible. The details box stays hidden and
   ; NSIS/electron-builder retains the default status text behavior.
   ShowInstDetails nevershow

--- a/tests/windowsInstallerContract.test.ts
+++ b/tests/windowsInstallerContract.test.ts
@@ -1222,6 +1222,43 @@ describe('Windows installer hardening contracts', () => {
     expect(afterUninstallerGuard).toContain('ManifestDPIAware true');
   });
 
+  test('replaces the bitmap-strike CJK fonts pinned by the NSIS language files', () => {
+    // NSIS's SimpChinese/TradChinese/Japanese/Korean .nlf files set the dialog
+    // font to SimSun/PMingLiU/MS PGothic/Gulim 9pt. GDI draws those from their
+    // embedded bitmap strikes with no anti-aliasing, so every label on the
+    // Chinese wizard is jagged. SetFont /LANG is a file-scope attribute and
+    // LANG_* only exists once addLangs has run, so the overrides must live in
+    // customHeader (inserted after addLangs) and outside the BUILD_UNINSTALLER
+    // guard so the uninstaller dialogs get them too.
+    const addLangs = rootInstallerTemplate.indexOf('!insertmacro addLangs');
+    expect(addLangs).toBeGreaterThan(-1);
+    expect(rootInstallerTemplate.indexOf('!insertmacro customHeader')).toBeGreaterThan(addLangs);
+
+    const headerStart = installerInclude.indexOf('!macro customHeader');
+    const header = installerInclude.slice(
+      headerStart,
+      installerInclude.indexOf('!macroend', headerStart),
+    );
+    const afterUninstallerGuard = header.slice(header.indexOf('!endif'));
+    const overrides: Array<[string, string]> = [
+      ['SIMPCHINESE', 'Microsoft YaHei UI'],
+      ['TRADCHINESE', 'Microsoft JhengHei UI'],
+      ['JAPANESE', 'Yu Gothic UI'],
+      ['KOREAN', 'Malgun Gothic'],
+    ];
+    for (const [lang, font] of overrides) {
+      expect(afterUninstallerGuard).toMatch(
+        new RegExp(
+          `!ifdef LANG_${lang}\\s+SetFont /LANG=\\$\\{LANG_${lang}\\} "${font}" 9\\s+!endif`,
+        ),
+      );
+    }
+    // Per-language only: a global SetFont would restyle every language and
+    // take precedence over all /LANG overrides.
+    expect(installerInclude.match(/^\s*SetFont\b/gm)?.length).toBe(overrides.length);
+    expect(installerInclude).not.toMatch(/^\s*SetFont\s+"/m);
+  });
+
   test('stages the embedded package through a selectable staging directory', () => {
     // Template contract: default init -> selection hook -> materialize hook ->
     // File materialize, all against $appPackageStagingDir, so the preflight


### PR DESCRIPTION
Override the bitmap-strike fonts baked into NSIS's CJK language files (SimSun/PMingLiU/MS PGothic/Gulim at 9pt) with the Windows 10+ system UI fonts per locale via SetFont /LANG, fixing jagged text on the DPI-aware installer. Guarded with !ifdef so a narrowed installerLanguages list still compiles.