### PR TITLE
fix(browser): resolve in-app element refs and preserve tool error details

### DIFF
--- a/src/main/libs/agentBrowserHost.test.ts
+++ b/src/main/libs/agentBrowserHost.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { runInNewContext } from 'node:vm';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 const electronMocks = vi.hoisted(() => {
   const createWebContents = () => {
@@ -14,6 +16,7 @@ const electronMocks = vi.hoisted(() => {
         sendCommand: vi.fn(),
       },
       executeJavaScript: vi.fn(),
+      emit: (event: string, ...args: unknown[]) => listeners.get(event)?.(...args),
       focus: vi.fn(),
       getTitle: vi.fn(() => ''),
       getURL: vi.fn(() => currentUrl),
@@ -86,9 +89,11 @@ import {
   AgentBrowserPartition,
   BrowserDisplayMode,
 } from '../../shared/browserWebAccess/constants';
-import { AgentBrowserHost, BrowserMcpTool } from './agentBrowserHost';
+import { AgentBrowserHost, BrowserCdpCommand, BrowserMcpTool } from './agentBrowserHost';
 
-const createHost = (): AgentBrowserHost => new AgentBrowserHost({
+const createHost = (
+  overrides: Partial<ConstructorParameters<typeof AgentBrowserHost>[0]> = {},
+): AgentBrowserHost => new AgentBrowserHost({
   getMainWindow: () => null,
   getBrowserConfig: () => ({ displayMode: BrowserDisplayMode.InApp }),
   useSystemProxy: () => false,
@@ -96,6 +101,7 @@ const createHost = (): AgentBrowserHost => new AgentBrowserHost({
   credentialService: {} as never,
   credentialApprovalService: {} as never,
   resolveSessionKey: () => undefined,
+  ...overrides,
 });
 
 beforeEach(() => {
@@ -117,6 +123,10 @@ beforeEach(() => {
     setPermissionRequestHandler: electronMocks.setPermissionRequestHandler,
     setProxy: electronMocks.setProxy,
   });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe('AgentBrowserHost', () => {
@@ -416,5 +426,233 @@ describe('AgentBrowserHost OpenClaw browser baseline', () => {
     expect(reopened.structuredContent).toEqual({
       pages: [{ id: 4, url: AgentBrowserPageUrl.Blank, selected: true }],
     });
+  });
+});
+
+describe('AgentBrowserHost script evaluation', () => {
+  const scrollFunction = '(el) => { el.scrollIntoView({ block: "center", inline: "center" }); return true; }';
+
+  const setupPage = async (overrides: Parameters<typeof createHost>[0] = {}) => {
+    const host = createHost(overrides);
+    await host.newPage();
+    const webContents = electronMocks.webContentsInstances[0];
+    const sendCommand = webContents.debugger.sendCommand;
+    const nodes = [
+      { nodeId: 'root', backendDOMNodeId: 100, childIds: ['first', 'second'], role: { value: 'RootWebArea' } },
+      { nodeId: 'first', parentId: 'root', backendDOMNodeId: 101, role: { value: 'button' } },
+      { nodeId: 'second', parentId: 'root', backendDOMNodeId: 102, role: { value: 'button' } },
+    ];
+    const evaluation: { response: Record<string, unknown> } = { response: { result: { value: true } } };
+    sendCommand.mockImplementation(async (command: string, params?: Record<string, unknown>) => {
+      switch (command) {
+        case BrowserCdpCommand.GetFullAXTree:
+          return { nodes };
+        case BrowserCdpCommand.ResolveNode:
+          return { object: { objectId: `element-${params?.backendNodeId}` } };
+        case BrowserCdpCommand.CallFunctionOn:
+        case BrowserCdpCommand.Evaluate:
+          return evaluation.response;
+        default:
+          return {};
+      }
+    });
+    const snapshot = await host.handleToolRequest({ tool: BrowserMcpTool.TakeSnapshot, args: { pageId: 1 } });
+    const refs = (snapshot.structuredContent?.snapshot as { children: Array<{ id: string }> })
+      .children.map(node => node.id);
+    const evaluate = (source = scrollFunction, args: unknown[] = [refs[0]]) => host.handleToolRequest({
+      tool: BrowserMcpTool.EvaluateScript,
+      args: { pageId: 1, function: source, args },
+    });
+    return { host, webContents, sendCommand, nodes, evaluation, refs, evaluate };
+  };
+
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  test('passes snapshot refs as DOM objects for the OpenClaw scroll action', async () => {
+    const { sendCommand, evaluate } = await setupPage();
+
+    const response = await evaluate();
+
+    expect(response).toMatchObject({ content: [{ text: 'true' }] });
+    expect(response.isError).not.toBe(true);
+    expect(sendCommand).toHaveBeenCalledWith(BrowserCdpCommand.ResolveNode, {
+      backendNodeId: 101,
+      objectGroup: expect.any(String),
+    });
+    const call = sendCommand.mock.calls.find(([command]) => command === BrowserCdpCommand.CallFunctionOn)?.[1];
+    expect(call).toMatchObject({
+      objectId: 'element-101',
+      arguments: [{ objectId: 'element-101' }],
+      awaitPromise: true,
+      returnByValue: true,
+      userGesture: true,
+    });
+    const scrollIntoView = vi.fn();
+    expect(runInNewContext(`(${call.functionDeclaration})`)({ scrollIntoView })).toBe(true);
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'center', inline: 'center' });
+    expect(sendCommand).toHaveBeenCalledWith(BrowserCdpCommand.ReleaseObjectGroup, { objectGroup: call.objectGroup });
+  });
+
+  test('preserves literal arguments when no DOM refs are supplied', async () => {
+    const { sendCommand, evaluate, evaluation } = await setupPage();
+    const args = ['plain text', 42, null, true, { nested: ['value'] }];
+    evaluation.response = { result: { value: args } };
+
+    const response = await evaluate('async (...values) => values', args);
+
+    const call = sendCommand.mock.calls.find(([command]) => command === BrowserCdpCommand.Evaluate)?.[1];
+    await expect(runInNewContext(call.expression)).resolves.toEqual(args);
+    expect(response.structuredContent?.message).toBe(JSON.stringify(args));
+    expect(sendCommand.mock.calls.some(([command]) => command === BrowserCdpCommand.ResolveNode)).toBe(false);
+    expect(sendCommand).toHaveBeenCalledWith(BrowserCdpCommand.ReleaseObjectGroup, { objectGroup: call.objectGroup });
+  });
+
+  test('preserves argument order with multiple DOM refs and literal values', async () => {
+    const { sendCommand, refs, evaluate } = await setupPage();
+
+    await evaluate('(...values) => values.length', [7, refs[1], 'label', refs[0], { enabled: true }]);
+
+    expect(sendCommand).toHaveBeenCalledWith(BrowserCdpCommand.CallFunctionOn, expect.objectContaining({
+      objectId: 'element-102',
+      arguments: [
+        { value: 7 },
+        { objectId: 'element-102' },
+        { value: 'label' },
+        { objectId: 'element-101' },
+        { value: { enabled: true } },
+      ],
+    }));
+    const groups = sendCommand.mock.calls
+      .filter(([command]) => command === BrowserCdpCommand.ResolveNode)
+      .map(([, params]) => params.objectGroup);
+    expect(groups).toHaveLength(2);
+    expect(new Set(groups).size).toBe(1);
+  });
+
+  test.each([false, true])('rejects stale refs after invalidation (navigation: %s)', async navigation => {
+    const { host, webContents, nodes, refs, sendCommand, evaluate } = await setupPage();
+    if (navigation) {
+      webContents.emit('did-navigate');
+    } else {
+      nodes.splice(1);
+      await host.handleToolRequest({ tool: BrowserMcpTool.TakeSnapshot, args: { pageId: 1 } });
+    }
+
+    const response = await evaluate();
+
+    expect(response).toMatchObject({
+      isError: true,
+      content: [{ text: `Browser element ${refs[0]} is stale. Take a new snapshot and try again.` }],
+    });
+    expect(sendCommand.mock.calls.some(([command]) => command === BrowserCdpCommand.CallFunctionOn)).toBe(false);
+    expect(sendCommand.mock.calls.some(([command]) => command === BrowserCdpCommand.Evaluate)).toBe(false);
+  });
+
+  test.each([
+    {
+      response: { exceptionDetails: { text: 'Uncaught', exception: { description: 'TypeError: detailed failure' } } },
+      message: 'TypeError: detailed failure',
+    },
+    {
+      response: { result: { description: 'Error: remote failure' }, exceptionDetails: { text: 'Uncaught' } },
+      message: 'Error: remote failure',
+    },
+    {
+      response: { exceptionDetails: { text: 'Uncaught', exception: { value: 'Thrown string' } } },
+      message: 'Thrown string',
+    },
+    {
+      response: { exceptionDetails: { text: 'Evaluation context unavailable' } },
+      message: 'Evaluation context unavailable',
+    },
+  ])('returns actionable exception details: $message', async ({ response, message }) => {
+    const { evaluate, evaluation, sendCommand, host } = await setupPage();
+    evaluation.response = response;
+
+    expect(await evaluate()).toMatchObject({ isError: true, content: [{ text: message }] });
+    expect(sendCommand).toHaveBeenLastCalledWith(BrowserCdpCommand.ReleaseObjectGroup, { objectGroup: expect.any(String) });
+    expect(host.getState().error).toBeUndefined();
+  });
+
+  test('releases already resolved DOM objects if a later ref cannot be resolved', async () => {
+    const { sendCommand, refs, evaluate } = await setupPage();
+    const implementation = sendCommand.getMockImplementation()!;
+    sendCommand.mockImplementation(async (command, params) => {
+      if (command === BrowserCdpCommand.ResolveNode && params.backendNodeId === 102) {
+        throw new Error('DOM node is no longer available');
+      }
+      return implementation(command, params);
+    });
+
+    expect(await evaluate('(first, second) => true', refs)).toMatchObject({
+      isError: true,
+      content: [{ text: 'DOM node is no longer available' }],
+    });
+    const group = sendCommand.mock.calls.find(([command]) => command === BrowserCdpCommand.ResolveNode)?.[1].objectGroup;
+    expect(sendCommand).toHaveBeenLastCalledWith(BrowserCdpCommand.ReleaseObjectGroup, { objectGroup: group });
+  });
+
+  test('does not replace the operation result when navigation interrupts object cleanup', async () => {
+    const { sendCommand, evaluate, evaluation } = await setupPage();
+    const implementation = sendCommand.getMockImplementation()!;
+    sendCommand.mockImplementation(async (command, params) => {
+      if (command === BrowserCdpCommand.ReleaseObjectGroup) throw new Error('Execution context destroyed');
+      return implementation(command, params);
+    });
+
+    expect((await evaluate()).isError).not.toBe(true);
+    evaluation.response = { exceptionDetails: { text: 'Original failure' } };
+    expect(await evaluate()).toMatchObject({ isError: true, content: [{ text: 'Original failure' }] });
+  });
+
+  test('keeps the native view attached and free of stale banners after a tool failure', async () => {
+    const removeChildView = vi.fn();
+    const { host, evaluate, evaluation, webContents } = await setupPage({
+      getMainWindow: () => ({
+        isVisible: () => true,
+        isDestroyed: () => false,
+        getContentBounds: () => ({ width: 800, height: 600 }),
+        contentView: { addChildView: vi.fn(), removeChildView },
+      }) as never,
+    });
+    host.setView({ visible: true, bounds: { x: 0, y: 80, width: 800, height: 520 } });
+    evaluation.response = { exceptionDetails: { text: 'Uncaught', exception: { description: 'Error: tool failure' } } };
+
+    expect((await evaluate()).isError).toBe(true);
+    expect(host.getState()).toMatchObject({ visible: true, selectedPageId: 1 });
+    expect(host.getState().error).toBeUndefined();
+    evaluation.response = { result: { value: true } };
+    expect((await evaluate()).isError).not.toBe(true);
+    expect(host.getState().error).toBeUndefined();
+    expect(removeChildView).not.toHaveBeenCalled();
+    expect(webContents.close).not.toHaveBeenCalled();
+  });
+
+  test('keeps page load errors separate from subsequent tool successes and failures', async () => {
+    const { host, webContents, evaluation, evaluate } = await setupPage();
+    webContents.emit('did-fail-load', {}, -2, 'ERR_FAILED', 'https://example.com', true);
+    const pageError = host.getState().error;
+    expect(pageError).toBe('ERR_FAILED (https://example.com)');
+
+    expect((await evaluate()).isError).not.toBe(true);
+    expect(host.getState().error).toBe(pageError);
+    evaluation.response = { exceptionDetails: { text: 'Uncaught' } };
+    expect((await evaluate()).isError).toBe(true);
+    expect(host.getState().error).toBe(pageError);
+
+    webContents.emit('did-start-loading');
+    expect(host.getState().error).toBeUndefined();
+  });
+
+  test('honors the script evaluation setting for DOM ref arguments', async () => {
+    const { evaluate, sendCommand } = await setupPage({
+      getBrowserConfig: () => ({ displayMode: BrowserDisplayMode.InApp, evaluateEnabled: false }),
+    });
+    sendCommand.mockClear();
+
+    expect((await evaluate()).isError).toBe(true);
+    expect(sendCommand).not.toHaveBeenCalled();
   });
 });

--- a/src/main/libs/agentBrowserHost.ts
+++ b/src/main/libs/agentBrowserHost.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import {
   type BrowserWindow,
   type NativeImage,
@@ -68,11 +69,28 @@ export const BrowserMcpTool = {
   LoginWithSavedCredential: BrowserCredentialLoginTool.Name,
 } as const;
 
+export const BrowserCdpCommand = {
+  GetFullAXTree: 'Accessibility.getFullAXTree',
+  ResolveNode: 'DOM.resolveNode',
+  Evaluate: 'Runtime.evaluate',
+  CallFunctionOn: 'Runtime.callFunctionOn',
+  ReleaseObjectGroup: 'Runtime.releaseObjectGroup',
+} as const;
+
 const DEFAULT_PAGE_URL = AgentBrowserPageUrl.Blank;
 const DEFAULT_OPERATION_TIMEOUT_MS = 30_000;
 const SCREENSHOT_CAPTURE_TIMEOUT_MS = 10_000;
 const MAX_OPERATION_TIMEOUT_MS = 60_000;
 const MAX_SNAPSHOT_NODES = 2_000;
+const SNAPSHOT_REF_PREFIX = 'ax-';
+
+type BrowserEvaluationResult = {
+  result?: { value?: unknown; description?: string };
+  exceptionDetails?: {
+    text?: string;
+    exception?: { value?: unknown; description?: string };
+  };
+};
 
 type AxValue = {
   value?: unknown;
@@ -547,8 +565,8 @@ export class AgentBrowserHost {
       return await this.dispatchTool(request.tool, request.args);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      this.lastError = message;
-      this.emitState();
+      // Tool failures belong to the tool result, not the page's navigation state.
+      console.warn('[AgentBrowserHost] Browser tool failed:', request.tool, error);
       return errorResult(message);
     }
   }
@@ -743,6 +761,7 @@ export class AgentBrowserHost {
     });
     webContents.on('page-title-updated', emit);
     webContents.on('did-navigate', () => {
+      page.refs.clear();
       if (this.preserveCredentialLoginStatusForNavigationPageId !== page.pageId) {
         this.clearCredentialLoginStatus();
       }
@@ -781,7 +800,15 @@ export class AgentBrowserHost {
       this.lastError = `${errorDescription} (${validatedURL})`;
       emit();
     });
+    webContents.on('render-process-gone', (_event, details) => {
+      console.error('[AgentBrowserHost] Browser renderer exited:', {
+        pageId: page.pageId,
+        reason: details.reason,
+        exitCode: details.exitCode,
+      });
+    });
     webContents.on('destroyed', () => {
+      console.debug('[AgentBrowserHost] Browser page destroyed:', page.pageId);
       this.markBrowserToolBootstrapPageUsed(page.pageId);
       this.manualCredentialCapture.clearPage(page.pageId);
       const fallbackPageId = this.getAdjacentPageId(page.pageId);
@@ -912,7 +939,7 @@ export class AgentBrowserHost {
 
   private async takeSnapshot(page: BrowserPage): Promise<BrowserToolResponse> {
     await this.ensureDebugger(page);
-    const result = await page.view.webContents.debugger.sendCommand('Accessibility.getFullAXTree') as {
+    const result = await page.view.webContents.debugger.sendCommand(BrowserCdpCommand.GetFullAXTree) as {
       nodes?: AxNode[];
     };
     const nodes = (result.nodes ?? [])
@@ -924,7 +951,7 @@ export class AgentBrowserHost {
     const buildNode = (node: AxNode, ancestors: Set<string>): SnapshotNode | null => {
       if (ancestors.has(node.nodeId)) return null;
       const nextAncestors = new Set(ancestors).add(node.nodeId);
-      const ref = `ax-${page.pageId}-${node.nodeId}`;
+      const ref = `${SNAPSHOT_REF_PREFIX}${page.pageId}-${node.nodeId}`;
       if (typeof node.backendDOMNodeId === 'number') {
         page.refs.set(ref, node.backendDOMNodeId);
       }
@@ -983,7 +1010,7 @@ export class AgentBrowserHost {
     page.view.webContents.focus();
     const debuggerApi = page.view.webContents.debugger;
     const objectId = await this.resolveObjectId(page, backendNodeId);
-    await debuggerApi.sendCommand('Runtime.callFunctionOn', {
+    await debuggerApi.sendCommand(BrowserCdpCommand.CallFunctionOn, {
       objectId,
       functionDeclaration: `function(shouldDoubleClick) {
         this.focus();
@@ -1009,7 +1036,7 @@ export class AgentBrowserHost {
     const debuggerApi = page.view.webContents.debugger;
     page.view.webContents.focus();
     const objectId = await this.resolveObjectId(page, backendNodeId);
-    await debuggerApi.sendCommand('Runtime.callFunctionOn', {
+    await debuggerApi.sendCommand(BrowserCdpCommand.CallFunctionOn, {
       objectId,
       functionDeclaration: `function(nextValue) {
         this.focus();
@@ -1118,21 +1145,51 @@ export class AgentBrowserHost {
     if (!source) throw new Error('Browser evaluation function is missing.');
     const functionArgs = Array.isArray(rawArgs) ? rawArgs : [];
     await this.ensureDebugger(page);
-    const expression = `Promise.resolve((${source})(...${JSON.stringify(functionArgs)}))`;
-    const result = await page.view.webContents.debugger.sendCommand('Runtime.evaluate', {
-      expression,
-      awaitPromise: true,
-      returnByValue: true,
-      userGesture: true,
-    }) as {
-      result?: { value?: unknown; description?: string };
-      exceptionDetails?: { text?: string };
-    };
-    if (result.exceptionDetails) {
-      throw new Error(result.exceptionDetails.text || result.result?.description || 'Browser evaluation failed.');
+    const debuggerApi = page.view.webContents.debugger;
+    const objectGroup = `lobster-browser-evaluation-${randomUUID()}`;
+    try {
+      const callArgs: Array<{ objectId?: string; value?: unknown }> = [];
+      for (const value of functionArgs) {
+        if (typeof value === 'string' && value.startsWith(SNAPSHOT_REF_PREFIX)) {
+          const backendNodeId = this.requireBackendNodeId(page, value);
+          callArgs.push({ objectId: await this.resolveObjectId(page, backendNodeId, objectGroup) });
+        } else {
+          callArgs.push({ value });
+        }
+      }
+      const receiver = callArgs.find(arg => arg.objectId);
+      const result = await debuggerApi.sendCommand(
+        receiver ? BrowserCdpCommand.CallFunctionOn : BrowserCdpCommand.Evaluate,
+        {
+          ...(receiver
+            ? {
+                objectId: receiver.objectId,
+                functionDeclaration: `function(...args) { return (${source})(...args); }`,
+                arguments: callArgs,
+              }
+            : { expression: `Promise.resolve((${source})(...${JSON.stringify(functionArgs)}))` }),
+          objectGroup,
+          awaitPromise: true,
+          returnByValue: true,
+          userGesture: true,
+        },
+      ) as BrowserEvaluationResult;
+      if (result.exceptionDetails) {
+        const exception = result.exceptionDetails.exception;
+        throw new Error(
+          exception?.description
+          || result.result?.description
+          || (exception?.value !== undefined ? String(exception.value) : '')
+          || result.exceptionDetails.text
+          || 'Browser evaluation failed.',
+        );
+      }
+      const message = JSON.stringify(result.result?.value ?? null);
+      return textResult(message, { message });
+    } finally {
+      // Navigation can destroy the execution context before cleanup runs.
+      await debuggerApi.sendCommand(BrowserCdpCommand.ReleaseObjectGroup, { objectGroup }).catch(() => {});
     }
-    const message = JSON.stringify(result.result?.value ?? null);
-    return textResult(message, { message });
   }
 
   private async waitForText(page: BrowserPage, text: string, timeoutMs: number): Promise<void> {
@@ -1196,9 +1253,10 @@ export class AgentBrowserHost {
     return backendNodeId;
   }
 
-  private async resolveObjectId(page: BrowserPage, backendNodeId: number): Promise<string> {
-    const resolved = await page.view.webContents.debugger.sendCommand('DOM.resolveNode', {
+  private async resolveObjectId(page: BrowserPage, backendNodeId: number, objectGroup?: string): Promise<string> {
+    const resolved = await page.view.webContents.debugger.sendCommand(BrowserCdpCommand.ResolveNode, {
       backendNodeId,
+      ...(objectGroup ? { objectGroup } : {}),
     }) as { object?: { objectId?: string } };
     const objectId = resolved.object?.objectId;
     if (!objectId) throw new Error('Browser element could not be resolved.');
@@ -1283,6 +1341,7 @@ export class AgentBrowserHost {
       const page = this.requirePage(this.selectedPageId!);
       mainWindow.contentView.addChildView(page.view);
       this.attachedPageId = page.pageId;
+      console.debug('[AgentBrowserHost] Browser view attached:', page.pageId);
     }
     this.pages.get(this.attachedPageId!)?.view.setBounds(this.normalizeBounds(this.bounds));
   }
@@ -1298,7 +1357,15 @@ export class AgentBrowserHost {
         // The view may already have been detached while the window was closing.
       }
     }
-    if (this.attachedPageId === pageId) this.attachedPageId = undefined;
+    if (this.attachedPageId === pageId) {
+      this.attachedPageId = undefined;
+      console.debug('[AgentBrowserHost] Browser view detached:', {
+        pageId,
+        desiredVisible: this.desiredVisible,
+        windowVisible: this.windowVisible,
+        selectedPageId: this.selectedPageId,
+      });
+    }
   }
 
   private setCredentialLoginView(view: WebContentsView | null): void {

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -778,8 +778,8 @@ export class OpenClawEngineManager extends EventEmitter {
       // unnecessary and its watchdog can flood stderr with re-advertise
       // warnings on Windows.  See openclaw/openclaw#33609, #63153.
       OPENCLAW_DISABLE_BONJOUR: '1',
-      // Enable debug-level logging so gateway emits phase-level detail during startup.
-      OPENCLAW_LOG_LEVEL: 'debug',
+      // Keep diagnostic detail; per-frame WebSocket traces require --verbose separately.
+      OPENCLAW_LOG_LEVEL: process.env.OPENCLAW_LOG_LEVEL || 'debug',
       // Enable V8 compile cache for both CJS and ESM modules.
       // This env var works for import() (ESM), unlike enableCompileCache() which is CJS-only.
       ...buildOpenClawCompileCacheEnv(compileCacheDir),
@@ -884,7 +884,8 @@ export class OpenClawEngineManager extends EventEmitter {
       env,
     });
 
-    const forkArgs = ['gateway', '--bind', 'loopback', '--port', String(port), '--token', token, '--verbose'];
+    // Verbose mode logs every streamed WebSocket event, including thinking deltas.
+    const forkArgs = ['gateway', '--bind', 'loopback', '--port', String(port), '--token', token];
     const gatewayExecArgv = buildOpenClawGatewayExecArgv(process.env.NODE_OPTIONS);
     if (gatewayExecArgv.length > 0) {
       console.log(`[OpenClaw] gateway V8 old-space limit set to ${OPENCLAW_GATEWAY_MAX_OLD_SPACE_MB}MB`);


### PR DESCRIPTION
## Summary

OpenClaw's `scrollIntoView` action passes a snapshot element reference to script evaluation. The in-app browser treated it as a string instead of a DOM element, causing a TypeError reported only as `Uncaught` and leaving an error banner above the browser.

This change resolves element references before evaluation and returns detailed tool errors without writing them into the page's navigation error state.

## Related Issue

None linked.

## Changes Made

- Resolve snapshot refs through CDP, preserve literal argument order, and release remote objects after evaluation.
- Invalidate refs after navigation and keep tool failures separate from page load errors.
- Add browser renderer/view lifecycle diagnostics for investigating disappearing views.
- Preserve the local gateway logging adjustment: respect `OPENCLAW_LOG_LEVEL` and remove forced per-frame verbose logging.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests

Validation completed on this change:

- `npx vitest run src/main/libs/agentBrowserHost.test.ts src/main/libs/lobsterBrowserMcpServer.test.ts` — 35 tests passed.
- Strict changed-file ESLint passed for all three touched TypeScript files.
- `npm run compile:electron` and `npx tsc --project electron-tsconfig.json --noEmit` completed successfully.
- An isolated Electron fixture using the actual browser panel and pinned OpenClaw gateway exercised the gateway → MCP bridge → in-app browser path. `scrollIntoView` succeeded; an injected evaluation failure returned detailed text while the tab, attached view, and viewport bounds remained intact, with no residual error banner.

## Screenshots (if applicable)

Not applicable; no renderer or layout code changed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management

Script evaluation now resolves DOM objects through Electron's debugger API. Tool errors are returned to the agent without overwriting browser navigation errors.

## Additional Notes

The separately reported disappearance of the browser panel was not independently reproduced. The integration check verifies that an evaluation failure leaves the view attached; lifecycle logs are included to help diagnose any remaining disappearance.