### PR TITLE
fix(openclaw): preinstall external provider plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,46 @@
     "repo": "https://github.com/openclaw/openclaw.git",
     "plugins": [
       {
+        "id": "qwen",
+        "npm": "@openclaw/qwen-provider",
+        "version": "2026.8.1"
+      },
+      {
+        "id": "deepseek",
+        "npm": "@openclaw/deepseek-provider",
+        "version": "2026.8.1"
+      },
+      {
+        "id": "moonshot",
+        "npm": "@openclaw/moonshot-provider",
+        "version": "2026.8.1"
+      },
+      {
+        "id": "qianfan",
+        "npm": "@openclaw/qianfan-provider",
+        "version": "2026.8.1"
+      },
+      {
+        "id": "stepfun",
+        "npm": "@openclaw/stepfun-provider",
+        "version": "2026.8.1"
+      },
+      {
+        "id": "zai",
+        "npm": "@openclaw/zai-provider",
+        "version": "2026.8.1"
+      },
+      {
+        "id": "xiaomi",
+        "npm": "@openclaw/xiaomi-provider",
+        "version": "2026.8.1"
+      },
+      {
+        "id": "volcengine",
+        "npm": "@openclaw/volcengine-provider",
+        "version": "2026.8.1"
+      },
+      {
         "id": "dingtalk-connector",
         "npm": "@dingtalk-real-ai/dingtalk-connector",
         "version": "0.8.23"

--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -8,7 +8,7 @@ import {
   BrowserCredentialLoginTool,
   BrowserCredentialMcpServer,
 } from '../../shared/browserCredentials/constants';
-import { ProviderName } from '../../shared/providers';
+import { OpenClawProviderId, ProviderName } from '../../shared/providers';
 import { DEFAULT_QQ_CONFIG } from '../im/types';
 import { OpenClawAgentOwnership } from './openclawAgentModels';
 import { OpenClawQQPlugin, QQ_APPROVALS_DISABLED } from './openclawQQConfig';
@@ -1862,6 +1862,51 @@ describe('OpenClawConfigSync runtime config output', () => {
     });
     expect(config.tools.deny).not.toContain('image_generate');
     expect(config.tools.deny).not.toContain('video_generate');
+  });
+
+  test.each([
+    [ProviderName.Qwen, OpenClawProviderId.Qwen],
+    [ProviderName.DeepSeek, OpenClawProviderId.DeepSeek],
+    [ProviderName.Moonshot, OpenClawProviderId.Moonshot],
+    [ProviderName.Qianfan, OpenClawProviderId.Qianfan],
+    [ProviderName.StepFun, OpenClawProviderId.StepFun],
+    [ProviderName.Zhipu, OpenClawProviderId.Zai],
+    [ProviderName.Xiaomi, OpenClawProviderId.Xiaomi],
+    [ProviderName.Volcengine, OpenClawProviderId.Volcengine],
+  ])('enables the preinstalled plugin when adding %s without changing the primary model', async (providerName, pluginId) => {
+    const { openclaw } = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+    const declaration = openclaw.plugins.find((plugin: { id: string }) => plugin.id === pluginId);
+    expect(declaration).toMatchObject({
+      npm: `@openclaw/${pluginId}-provider`,
+      version: openclaw.version.replace(/^v/, ''),
+    });
+    expect(declaration.optional).not.toBe(true);
+
+    const sync = await createSync();
+    expect(sync.sync('before-provider-added').ok).toBe(true);
+    const before = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+    // A previous runtime may have left this plugin disabled or off the allowlist.
+    before.plugins.entries[pluginId] = { enabled: false };
+    before.plugins.allow = before.plugins.allow.filter((id: string) => id !== pluginId);
+    fs.writeFileSync(configPath, JSON.stringify(before));
+    mockRuntimeState.enabledProviders = [{
+      providerName,
+      baseURL: 'https://provider.example/v1',
+      apiKey: 'sk-provider-test',
+      apiType: 'openai',
+      codingPlanEnabled: false,
+      models: [{ id: 'provider-test', name: 'Provider Test' }],
+    }];
+
+    expect(sync.sync('provider-added').ok).toBe(true);
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.models.providers[pluginId]).toBeDefined();
+    expect(config.agents.defaults.model.primary).toBe(before.agents.defaults.model.primary);
+    expect(config.plugins.entries[pluginId]).toEqual({ enabled: true });
+    expect(config.plugins.allow).toContain(pluginId);
+    expect(config.plugins.entries).not.toHaveProperty('qwen-portal-auth');
+    expect(sync.sync('provider-added-again').changed).toBe(false);
   });
 
   test('declares and allowlists the bundled xai plugin so its compat hooks load', async () => {


### PR DESCRIPTION
## Summary

Adding Qwen after the OpenClaw 2026.8.1 upgrade can stop the gateway with `requires capability consent`, even when the primary model is unchanged. Preinstall the eight supported providers that upstream now distributes as external plugins so startup does not need to download and authorize them.

## Related Issue

OpenClaw upgrade regression; no linked GitHub issue.

## Changes Made

- Pin the Qwen, DeepSeek, Moonshot, Qianfan, StepFun, Z.AI, Xiaomi, and Volcengine provider packages to `2026.8.1` in the existing preinstallation pipeline.
- Add eight regression cases covering required version pins, provider ID mapping, enabled state, allowlisting, preservation of the primary model, and idempotent config sync.

## Type of Change

- [x] Bug fix

## Testing

- [x] Four targeted Vitest suites: 99 passed; one optional test requiring a built vendor runtime skipped.
- [x] Electron TypeScript compilation and changed-file ESLint.
- [x] Actual installation and precompilation of all eight packages; packaging validation rejects the old payload and accepts the completed plugin set.
- [x] Isolated gateway comparison: the missing-Qwen case reproduces the consent failure; all eight configured providers reach `ready: true` while retaining the original primary model. `plugins doctor --json` reports no errors or warnings.

## Checklist

- [x] Changes follow the project style and have been reviewed.
- [x] Regression tests cover the fix.
- [x] Relevant automated and manual checks completed.

## Electron-Specific Changes

The bundled OpenClaw runtime gains eight provider plugins. Existing build-time capability consent, config-sync enablement/allowlisting, and packaging checks apply to the new declarations. Rebuild the OpenClaw runtime to include the packages.

## Additional Notes

The eight installed packages total 270,062 bytes and contain no duplicate OpenClaw dependency tree. A complete installer build and live provider API requests were not performed.
