### PR TITLE
fix(openclaw): adapt native ask_user question protocol

### DIFF
--- a/src/main/libs/agentEngine/coworkEngineRouter.ts
+++ b/src/main/libs/agentEngine/coworkEngineRouter.ts
@@ -6,6 +6,7 @@ import type {
   CoworkBtwSubmitResponse,
 } from '../../../shared/cowork/btw';
 import type { CoworkGoal } from '../../../shared/cowork/goal';
+import { OpenClawQuestion } from '../../../shared/cowork/openclawQuestion';
 import type { CoworkSteerResponse } from '../../../shared/cowork/steer';
 import type {
   CoworkAgentEngine,
@@ -161,7 +162,11 @@ export class CoworkEngineRouter extends EventEmitter implements CoworkRuntime {
     this.requestSession.clear();
   }
 
-  respondToPermission(requestId: string, result: PermissionResult): void {
+  respondToPermission(requestId: string, result: PermissionResult): void | Promise<void> {
+    if (requestId.startsWith(OpenClawQuestion.RequestIdPrefix)) {
+      // Native answers must be acknowledged before the renderer dismisses the question.
+      return this.runtime.respondToPermission(requestId, result);
+    }
     const engine = this.requestEngine.get(requestId);
     if (engine) {
       this.runtime.respondToPermission(requestId, result);
@@ -177,6 +182,10 @@ export class CoworkEngineRouter extends EventEmitter implements CoworkRuntime {
 
   isSessionActive(sessionId: string): boolean {
     return this.runtime.isSessionActive(sessionId);
+  }
+
+  getPendingQuestions() {
+    return this.runtime.getPendingQuestions?.() ?? [];
   }
 
   getActiveSessionIds(): string[] {

--- a/src/main/libs/agentEngine/openclawQuestionController.test.ts
+++ b/src/main/libs/agentEngine/openclawQuestionController.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { OpenClawQuestion, OpenClawQuestionStatus } from '../../../shared/cowork/openclawQuestion';
+import { OpenClawQuestionController } from './openclawQuestionController';
+
+const makeRecord = (id = 'request-1', sessionKey = 'desktop-1') => ({
+  id, sessionKey, runId: 'run-1', expiresAtMs: Date.now() + 900_000,
+  status: OpenClawQuestionStatus.Pending,
+  questions: [{
+    questionId: 'choice', header: '选择', question: '选择一个',
+    options: [{ label: 'A (Recommended)' }, { label: 'B' }], isOther: true,
+  }],
+});
+const requestId = (id = 'request-1') => `${OpenClawQuestion.RequestIdPrefix}${id}`;
+
+function setup() {
+  const request = vi.fn().mockResolvedValue({ status: OpenClawQuestionStatus.Answered });
+  let client: { request: typeof request } | null = { request };
+  const options = {
+    getGatewayClient: () => client,
+    resolveSessionId: vi.fn((key: string) => key.startsWith('desktop-') ? key : undefined),
+    isSessionStopped: vi.fn(() => false),
+    emitPermissionRequest: vi.fn(), emitPermissionResolved: vi.fn(),
+  };
+  return {
+    controller: new OpenClawQuestionController(options), request, options,
+    disconnectClient: () => { client = null; },
+  };
+}
+
+beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(new Date('2026-09-08T08:00:00Z')); });
+afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); });
+
+describe('OpenClaw native questions', () => {
+  test('opens one question in its owning session and sends the nested answers RPC envelope', async () => {
+    const { controller, request, options } = setup();
+    controller.handleRequested(makeRecord());
+    controller.handleRequested(makeRecord());
+    expect(options.emitPermissionRequest).toHaveBeenCalledTimes(1);
+    expect(options.emitPermissionRequest).toHaveBeenCalledWith('desktop-1', expect.objectContaining({
+      requestId: requestId(), toolName: OpenClawQuestion.ToolName,
+    }));
+    await controller.respond(requestId(), { behavior: 'allow', updatedInput: { answers: { choice: ['A (Recommended)'] } } });
+    expect(request).toHaveBeenCalledWith(OpenClawQuestion.Resolve, {
+      id: 'request-1', answers: { answers: { choice: ['A (Recommended)'] } },
+    }, { timeoutMs: 10_000 });
+    expect(options.emitPermissionResolved).toHaveBeenCalledWith('desktop-1', requestId());
+  });
+
+  test('cancel sends cancel:true, not a made-up answer', async () => {
+    const { controller, request } = setup();
+    controller.handleRequested(makeRecord());
+    await controller.respond(requestId(), { behavior: 'deny', message: 'cancel' });
+    expect(request).toHaveBeenCalledWith(OpenClawQuestion.Resolve, { id: 'request-1', cancel: true }, { timeoutMs: 10_000 });
+  });
+
+  test('renderer recovery snapshots include only still-pending questions', () => {
+    const { controller } = setup();
+    controller.handleRequested(makeRecord());
+    expect(controller.getPendingQuestions()).toEqual([expect.objectContaining({
+      sessionId: 'desktop-1', requestId: requestId(), toolName: OpenClawQuestion.ToolName,
+    })]);
+    controller.handleResolved({ id: 'request-1', status: OpenClawQuestionStatus.Answered });
+    expect(controller.getPendingQuestions()).toEqual([]);
+  });
+
+  test('does not route unowned questions to the active desktop task', () => {
+    const { controller, options, request } = setup();
+    controller.handleRequested(makeRecord('im-question', 'im-session'));
+    expect(options.emitPermissionRequest).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  test('retains a failed submission for retry and coalesces double-clicks', async () => {
+    const { controller, request, options } = setup();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    controller.handleRequested(makeRecord());
+    let fail: (error: Error) => void = () => {};
+    request.mockImplementationOnce(() => new Promise((_resolve, reject) => { fail = reject; }));
+    const answer = { behavior: 'allow' as const, updatedInput: { answers: { choice: ['B'] } } };
+    const responses = Promise.allSettled([controller.respond(requestId(), answer), controller.respond(requestId(), answer)]);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(options.emitPermissionResolved).not.toHaveBeenCalled();
+    fail(new Error('disconnected'));
+    expect((await responses).map((result) => result.status)).toEqual(['rejected', 'rejected']);
+    await controller.respond(requestId(), answer);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(options.emitPermissionResolved).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not send malformed answers or silently dismiss a disconnected submission', async () => {
+    const { controller, request, options, disconnectClient } = setup();
+    controller.handleRequested(makeRecord());
+    await expect(controller.respond(requestId(), { behavior: 'allow', updatedInput: { answers: {} } })).rejects.toThrow();
+    disconnectClient();
+    await expect(controller.respond(requestId(), { behavior: 'deny', message: 'cancel' })).rejects.toThrow();
+    expect(request).not.toHaveBeenCalled();
+    expect(options.emitPermissionResolved).not.toHaveBeenCalled();
+  });
+
+  test.each([OpenClawQuestionStatus.Answered, OpenClawQuestionStatus.Cancelled, OpenClawQuestionStatus.Expired])(
+    'dismisses remote %s once and ignores late requested events', (status) => {
+      const { controller, options } = setup();
+      controller.handleRequested(makeRecord());
+      controller.handleResolved({ id: 'request-1', status });
+      controller.handleResolved({ id: 'request-1', status });
+      controller.handleRequested(makeRecord());
+      expect(options.emitPermissionResolved).toHaveBeenCalledTimes(1);
+      expect(options.emitPermissionRequest).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test('closes expired UI even if the resolved event is missed', async () => {
+    const { controller, options, request } = setup();
+    controller.handleRequested(makeRecord());
+    await vi.advanceTimersByTimeAsync(900_000);
+    expect(options.emitPermissionResolved).toHaveBeenCalledTimes(1);
+    await controller.respond(requestId(), { behavior: 'deny', message: 'late' });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  test('cancels only the stopped session and suppresses late questions for it', () => {
+    const { controller, options, request } = setup();
+    controller.handleRequested(makeRecord());
+    controller.handleRequested(makeRecord('request-2', 'desktop-2'));
+    controller.cancelBySession('desktop-1');
+    expect(options.emitPermissionResolved).toHaveBeenCalledWith('desktop-1', requestId());
+    expect(options.emitPermissionResolved).not.toHaveBeenCalledWith('desktop-2', requestId('request-2'));
+    options.isSessionStopped.mockReturnValue(true);
+    controller.handleRequested(makeRecord('late'));
+    expect(request).toHaveBeenCalledWith(OpenClawQuestion.Resolve, { id: 'late', cancel: true }, expect.anything());
+    expect(options.emitPermissionRequest).toHaveBeenCalledTimes(2);
+  });
+
+  test('restores questions after reconnect and rejects a stale list from the previous connection', async () => {
+    const { controller, options, request } = setup();
+    const record = makeRecord();
+    controller.handleRequested(record);
+    let completeList: (value: unknown) => void = () => {};
+    request.mockImplementationOnce(() => new Promise((resolve) => { completeList = resolve; }));
+    const restoring = controller.restorePending();
+    controller.disconnect();
+    completeList({ questions: [record] });
+    await restoring;
+    expect(options.emitPermissionRequest).toHaveBeenCalledTimes(1);
+    request.mockResolvedValueOnce({ questions: [record] });
+    await controller.restorePending();
+    expect(options.emitPermissionRequest).toHaveBeenCalledTimes(2);
+    expect(options.emitPermissionResolved).toHaveBeenCalledTimes(1);
+  });
+
+  test('a resolved event during question.list prevents resurrection', async () => {
+    const { controller, options, request } = setup();
+    let completeList: (value: unknown) => void = () => {};
+    request.mockImplementationOnce(() => new Promise((resolve) => { completeList = resolve; }));
+    const restoring = controller.restorePending();
+    controller.handleResolved({ id: 'request-1', status: OpenClawQuestionStatus.Answered });
+    completeList({ questions: [makeRecord()] });
+    await restoring;
+    expect(options.emitPermissionRequest).not.toHaveBeenCalled();
+  });
+
+  test('a response already resolved by another client closes locally without retrying', async () => {
+    const { controller, request, options } = setup();
+    controller.handleRequested(makeRecord());
+    request.mockRejectedValueOnce({ details: { reason: 'QUESTION_ALREADY_TERMINAL' } });
+    await controller.respond(requestId(), { behavior: 'deny', message: 'cancel' });
+    expect(options.emitPermissionResolved).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/libs/agentEngine/openclawQuestionController.ts
+++ b/src/main/libs/agentEngine/openclawQuestionController.ts
@@ -1,0 +1,195 @@
+import {
+  OpenClawQuestion,
+  type OpenClawQuestionRecord,
+  OpenClawQuestionStatus,
+  parseOpenClawQuestionAnswers,
+  parseOpenClawQuestionRecord,
+} from '../../../shared/cowork/openclawQuestion';
+import type { PermissionRequest, PermissionResult } from './types';
+
+type GatewayClient = {
+  request: <T = Record<string, unknown>>(
+    method: string, params?: unknown, options?: { timeoutMs?: number | null },
+  ) => Promise<T>;
+};
+
+type ControllerOptions = {
+  getGatewayClient: () => GatewayClient | null;
+  resolveSessionId: (sessionKey: string, runId?: string) => string | undefined;
+  isSessionStopped: (sessionId: string, sessionKey: string) => boolean;
+  emitPermissionRequest: (sessionId: string, request: PermissionRequest) => void;
+  emitPermissionResolved: (sessionId: string, requestId: string) => void;
+};
+
+type PendingQuestion = {
+  record: OpenClawQuestionRecord;
+  sessionId: string;
+  timer: ReturnType<typeof setTimeout>;
+  response?: Promise<void>;
+};
+
+const RPC_TIMEOUT_MS = 10_000;
+const TERMINAL_ERROR_REASONS = new Set(['QUESTION_ALREADY_TERMINAL', 'QUESTION_NOT_FOUND']);
+
+/** Owns the native question lifecycle. It never dispatches to the legacy HTTP question bridge. */
+export class OpenClawQuestionController {
+  private readonly pending = new Map<string, PendingQuestion>();
+  private readonly terminal = new Set<string>();
+  private generation = 0;
+
+  constructor(private readonly options: ControllerOptions) {}
+
+  handlesRequest(requestId: string): boolean {
+    return requestId.startsWith(OpenClawQuestion.RequestIdPrefix);
+  }
+
+  getPendingQuestions(): Array<PermissionRequest & { sessionId: string }> {
+    const requests: Array<PermissionRequest & { sessionId: string }> = [];
+    for (const [id, pending] of this.pending) {
+      if (pending.record.expiresAtMs <= Date.now()) { this.finish(id); continue; }
+      requests.push({
+        sessionId: pending.sessionId, requestId: this.toRequestId(id),
+        toolName: OpenClawQuestion.ToolName, toolInput: { ...pending.record }, toolUseId: id,
+      });
+    }
+    return requests;
+  }
+
+  handleRequested(payload: unknown): void {
+    const record = parseOpenClawQuestionRecord(payload);
+    if (!record || this.terminal.has(record.id)) return;
+    if (record.status !== OpenClawQuestionStatus.Pending || record.expiresAtMs <= Date.now()) {
+      this.finish(record.id);
+      return;
+    }
+    if (this.pending.has(record.id)) return;
+    const sessionId = this.options.resolveSessionId(record.sessionKey, record.runId);
+    // Questions owned by IM/other clients must not be assigned to the currently visible desktop task.
+    if (!sessionId) return;
+    if (this.options.isSessionStopped(sessionId, record.sessionKey)) {
+      this.finish(record.id);
+      this.cancel(record.id);
+      return;
+    }
+    const timer = setTimeout(() => this.finish(record.id), Math.min(record.expiresAtMs - Date.now(), 2_147_483_647));
+    timer.unref?.();
+    this.pending.set(record.id, { record, sessionId, timer });
+    this.options.emitPermissionRequest(sessionId, {
+      requestId: this.toRequestId(record.id),
+      toolName: OpenClawQuestion.ToolName,
+      toolInput: { ...record },
+      toolUseId: record.id,
+    });
+  }
+
+  handleResolved(payload: unknown): void {
+    if (!payload || typeof payload !== 'object') return;
+    const { id, status } = payload as Record<string, unknown>;
+    if (typeof id !== 'string' || (status !== OpenClawQuestionStatus.Answered
+      && status !== OpenClawQuestionStatus.Cancelled && status !== OpenClawQuestionStatus.Expired)) return;
+    this.finish(id);
+  }
+
+  /** Restore pending questions after a handshake, without replaying events resolved during the RPC. */
+  async restorePending(): Promise<void> {
+    const client = this.options.getGatewayClient();
+    if (!client) return;
+    const generation = this.generation;
+    const pendingBeforeList = new Set(this.pending.keys());
+    try {
+      const result = await client.request<{ questions?: unknown[] }>(OpenClawQuestion.List, {}, { timeoutMs: RPC_TIMEOUT_MS });
+      if (generation !== this.generation || client !== this.options.getGatewayClient() || !Array.isArray(result.questions)) return;
+      const ids = new Set<string>();
+      for (const record of result.questions) {
+        const parsed = parseOpenClawQuestionRecord(record);
+        if (parsed) ids.add(parsed.id);
+        this.handleRequested(record);
+      }
+      for (const id of pendingBeforeList) {
+        if (!ids.has(id)) this.finish(id);
+      }
+    } catch (error) {
+      if (generation === this.generation) console.warn('[OpenClawQuestion] failed to restore pending questions:', error);
+    }
+  }
+
+  async respond(requestId: string, result: PermissionResult): Promise<void> {
+    const id = requestId.slice(OpenClawQuestion.RequestIdPrefix.length);
+    const pending = this.pending.get(id);
+    if (!pending) return;
+    if (pending.record.expiresAtMs <= Date.now()) {
+      this.finish(id);
+      return;
+    }
+    if (pending.response) return pending.response;
+    const client = this.options.getGatewayClient();
+    if (!client) throw new Error('OpenClaw question gateway is disconnected');
+    const answers = result.behavior === 'allow'
+      ? parseOpenClawQuestionAnswers(pending.record.questions, result.updatedInput?.answers)
+      : undefined;
+    if (answers === null) throw new Error('Invalid OpenClaw question answers');
+    const generation = this.generation;
+    pending.response = (async () => {
+      try {
+        await client.request(OpenClawQuestion.Resolve, {
+          id,
+          ...(answers ? { answers: { answers } } : { cancel: true }),
+        }, { timeoutMs: RPC_TIMEOUT_MS });
+        if (generation === this.generation) this.finish(id);
+      } catch (error) {
+        const reason = (error as { details?: { reason?: string } } | null)?.details?.reason;
+        if (reason && TERMINAL_ERROR_REASONS.has(reason)) {
+          if (generation === this.generation) this.finish(id);
+          return;
+        }
+        // Keep the request and the user's answers available for retry after a transport failure.
+        console.warn('[OpenClawQuestion] failed to submit question response:', error);
+        throw error;
+      } finally {
+        pending.response = undefined;
+      }
+    })();
+    return pending.response;
+  }
+
+  cancelBySession(sessionId: string): void {
+    for (const [id, pending] of this.pending) {
+      if (pending.sessionId !== sessionId) continue;
+      this.finish(id);
+      this.cancel(id);
+    }
+  }
+
+  /** A disconnect closes stale UI; the next handshake restores Gateway-owned pending questions. */
+  disconnect(): void {
+    this.generation += 1;
+    for (const id of this.pending.keys()) this.finish(id);
+    this.terminal.clear();
+  }
+
+  private cancel(id: string): void {
+    const client = this.options.getGatewayClient();
+    if (!client) return;
+    void client.request(OpenClawQuestion.Resolve, { id, cancel: true }, { timeoutMs: RPC_TIMEOUT_MS }).catch((error) => {
+      const reason = (error as { details?: { reason?: string } } | null)?.details?.reason;
+      if (!reason || !TERMINAL_ERROR_REASONS.has(reason)) {
+        console.warn('[OpenClawQuestion] failed to cancel stopped question:', error);
+      }
+    });
+  }
+
+  private finish(id: string): void {
+    this.terminal.add(id);
+    // Only retain enough tombstones to protect against late events/list responses.
+    if (this.terminal.size > 1_000) this.terminal.delete(this.terminal.values().next().value!);
+    const pending = this.pending.get(id);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(id);
+    this.options.emitPermissionResolved(pending.sessionId, this.toRequestId(id));
+  }
+
+  private toRequestId(id: string): string {
+    return `${OpenClawQuestion.RequestIdPrefix}${id}`;
+  }
+}

--- a/src/main/libs/agentEngine/openclawQuestions.integration.test.ts
+++ b/src/main/libs/agentEngine/openclawQuestions.integration.test.ts
@@ -1,0 +1,49 @@
+import { expect, test, vi } from 'vitest';
+
+import { OpenClawQuestion, OpenClawQuestionStatus } from '../../../shared/cowork/openclawQuestion';
+import { CoworkEngineRouter } from './coworkEngineRouter';
+import { OpenClawRuntimeAdapter } from './openclawRuntimeAdapter';
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => process.cwd(), getPath: () => process.cwd(), getVersion: () => 'test' },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+test('native gateway events reach the permission UI and router propagates answer failures for retry', async () => {
+  const sessionId = '33e1f1ef-57b5-404f-a878-c727e764e104';
+  const store = {
+    getSession: (id: string) => id === sessionId ? { id: sessionId, agentId: 'main' } : null,
+  };
+  const adapter = new OpenClawRuntimeAdapter(store as never, {} as never);
+  const router = new CoworkEngineRouter({ getCurrentEngine: () => 'openclaw', openclawRuntime: adapter });
+  const request = vi.fn().mockResolvedValue({ status: OpenClawQuestionStatus.Answered });
+  const internals = adapter as unknown as {
+    gatewayClient: unknown;
+    handleGatewayEvent: (event: unknown) => void;
+    stopGatewayClient: () => void;
+  };
+  internals.gatewayClient = { start: () => {}, stop: () => {}, request };
+  const onQuestion = vi.fn();
+  const onResolved = vi.fn();
+  router.on('permissionRequest', onQuestion);
+  router.on('permissionResolved', onResolved);
+  internals.handleGatewayEvent({ event: OpenClawQuestion.Requested, payload: {
+    id: 'native-request', sessionKey: `agent:main:lobsterai:${sessionId}`,
+    status: OpenClawQuestionStatus.Pending, expiresAtMs: Date.now() + 60_000,
+    questions: [{ questionId: 'topic', header: 'Topic', question: 'Pick', options: [{ label: 'A' }, { label: 'B' }], isOther: true }],
+  } });
+  const requestId = `${OpenClawQuestion.RequestIdPrefix}native-request`;
+  expect(onQuestion).toHaveBeenCalledWith(sessionId, expect.objectContaining({ requestId, toolName: OpenClawQuestion.ToolName }));
+  const response = { behavior: 'allow' as const, updatedInput: { answers: { topic: ['B'] } } };
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  request.mockRejectedValueOnce(new Error('offline'));
+  await expect(router.respondToPermission(requestId, response)).rejects.toThrow('offline');
+  expect(onResolved).not.toHaveBeenCalled();
+  await router.respondToPermission(requestId, response);
+  expect(request).toHaveBeenLastCalledWith(OpenClawQuestion.Resolve, {
+    id: 'native-request', answers: { answers: { topic: ['B'] } },
+  }, expect.anything());
+  expect(onResolved).toHaveBeenCalledWith(sessionId, requestId);
+  warn.mockRestore();
+  internals.stopGatewayClient();
+});

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -56,6 +56,7 @@ import {
   validateCoworkImageAttachmentSize,
 } from '../../../shared/cowork/imageAttachments';
 import { parseOpenClawCronSessionKey } from '../../../shared/cowork/openclawCronSessionKey';
+import { OpenClawQuestion } from '../../../shared/cowork/openclawQuestion';
 import {
   containsPlanModePrompt,
   isPlanImplementationApproval,
@@ -161,6 +162,7 @@ import {
   findCronRunHistoryLocalMatch,
   shouldReplaceLocalConversationWithCronHistory,
 } from './openclawCronRunHistorySync';
+import { OpenClawQuestionController } from './openclawQuestionController';
 import {
   buildOpenClawTranscriptOversizedError,
   inspectOpenClawTranscriptSafety,
@@ -2579,6 +2581,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private readonly subagentTracker: SubagentTracker;
   private readonly subagentSessionMaterializer: SubagentSessionMaterializer;
   private readonly approvalController: OpenClawApprovalController;
+  private readonly questionController: OpenClawQuestionController;
   private readonly thinkingController: OpenClawThinkingController;
   private readonly turnHistorySync: OpenClawTurnHistorySync;
 
@@ -3690,6 +3693,20 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       handleBackfillHistory: (sessionId, messages) => {
         this.handleIncrementalBackfillHistory(sessionId, messages);
       },
+    });
+    this.questionController = new OpenClawQuestionController({
+      getGatewayClient: () => this.gatewayClient,
+      resolveSessionId: (sessionKey, runId) => {
+        // Leave channel questions to their native delivery UI; never fall back to the active task.
+        if (parseChannelSessionKey(sessionKey)) return undefined;
+        const sessionId = this.resolveSessionIdBySessionKey(sessionKey)
+          ?? (runId ? this.sessionIdByRunId.get(runId) : undefined);
+        return sessionId && this.getSessionConfirmationMode(sessionId) !== 'text' ? sessionId : undefined;
+      },
+      isSessionStopped: (sessionId, sessionKey) => this.isSessionInStopCooldown(sessionId)
+        || (this.manuallyStoppedSessions.has(sessionId) && isManagedSessionKey(sessionKey)),
+      emitPermissionRequest: (sessionId, request) => this.emit('permissionRequest', sessionId, request),
+      emitPermissionResolved: (sessionId, requestId) => this.emit('permissionResolved', sessionId, requestId),
     });
     this.approvalController = new OpenClawApprovalController({
       getGatewayClient: () => this.gatewayClient,
@@ -5171,6 +5188,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     this.cleanupSessionTurn(sessionId);
     this.approvalController.clearBySession(sessionId);
+    this.questionController.cancelBySession(sessionId);
     this.store.updateSession(sessionId, { status: 'idle' });
     this.emitSessionStatus(sessionId, 'idle');
     this.emit('sessionStopped', sessionId);
@@ -5202,8 +5220,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     });
   }
 
-  respondToPermission(requestId: string, result: PermissionResult): void {
+  respondToPermission(requestId: string, result: PermissionResult): void | Promise<void> {
+    if (this.questionController.handlesRequest(requestId)) {
+      return this.questionController.respond(requestId, result);
+    }
     this.approvalController.respondToPermission(requestId, result);
+  }
+
+  getPendingQuestions() {
+    return this.questionController.getPendingQuestions();
   }
 
   isSessionActive(sessionId: string): boolean {
@@ -6070,6 +6095,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         this.gatewayReconnectAttempt = 0;
         this.resetGatewayRpcHealth();
         this.subscribeToGatewaySessionEvents(client);
+        void this.questionController.restorePending();
         settleResolve();
         try {
           this.options.onGatewayClientReady?.();
@@ -6186,6 +6212,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
   private stopGatewayClient(): void {
     this.gatewayStoppingIntentionally = true;
+    this.questionController.disconnect();
     this.failAllPendingBtwRuns(t('coworkBtwDisconnected'), 'gateway stopped');
     this.gatewayClientGeneration += 1;
     this.stopChannelPolling();
@@ -7320,6 +7347,15 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       // handleAgentEvent may enqueue events when sessionId mapping isn't ready.
       this.processAgentAssistantText(event.payload);
       this.handleAgentEvent(event.payload, event.seq);
+      return;
+    }
+
+    if (event.event === OpenClawQuestion.Requested) {
+      this.questionController.handleRequested(event.payload);
+      return;
+    }
+    if (event.event === OpenClawQuestion.Resolved) {
+      this.questionController.handleResolved(event.payload);
       return;
     }
 
@@ -11732,6 +11768,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
     // Clean up pending approvals, bridged state, confirmation mode
     this.approvalController.clearBySession(sessionId);
+    this.questionController.cancelBySession(sessionId);
     this.bridgedSessions.delete(sessionId);
     this.continuityFullBridgeCompactedAtBySession.delete(sessionId);
     this.workspaceRehydrationBridgeCompactedAtBySession.delete(sessionId);

--- a/src/main/libs/agentEngine/types.ts
+++ b/src/main/libs/agentEngine/types.ts
@@ -167,7 +167,8 @@ export interface CoworkRuntime {
   getForkCompactionSummary?(sessionId: string, beforeCreatedAt?: number): Promise<CoworkForkCompactionSummary | null>;
   stopSession(sessionId: string): void;
   stopAllSessions(): void;
-  respondToPermission(requestId: string, result: PermissionResult): void;
+  respondToPermission(requestId: string, result: PermissionResult): void | Promise<void>;
+  getPendingQuestions?(): Array<PermissionRequest & { sessionId: string }>;
   isSessionActive(sessionId: string): boolean;
   getSessionConfirmationMode(sessionId: string): 'modal' | 'text' | null;
   deleteSubagentSession?(parentSessionId: string, runId: string): Promise<boolean>;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -115,6 +115,7 @@ import {
   formatCoworkImageAttachmentLimit,
   validateCoworkImageAttachmentSize,
 } from '../shared/cowork/imageAttachments';
+import { OpenClawQuestion } from '../shared/cowork/openclawQuestion';
 import { containsPlanModePrompt } from '../shared/cowork/planMode';
 import type { CoworkSearchMessageCursor } from '../shared/cowork/search';
 import {
@@ -3440,6 +3441,13 @@ const bindCoworkRuntimeForwarder = (): void => {
 
   runtime.on('permissionResolved', (_sessionId: string, requestId: string) => {
     getDesktopNotificationManager().handlePermissionResolved(requestId);
+    if (requestId.startsWith(OpenClawQuestion.RequestIdPrefix)) {
+      for (const win of BrowserWindow.getAllWindows()) {
+        if (!win.isDestroyed()) {
+          win.webContents.send(CoworkIpcChannel.StreamPermissionDismiss, { requestId });
+        }
+      }
+    }
   });
 
   runtime.on('sessionStopped', (sessionId: string) => {
@@ -10472,11 +10480,17 @@ if (!gotTheLock) {
     }
   });
 
-  ipcMain.handle('cowork:permission:respond', async (_event, options: {
+  ipcMain.handle(CoworkIpcChannel.GetPendingQuestions, () => getCoworkEngineRouter().getPendingQuestions());
+
+  ipcMain.handle(CoworkIpcChannel.PermissionRespond, async (_event, options: {
     requestId: string;
     result: PermissionResult;
   }) => {
     try {
+      if (options.requestId?.startsWith(OpenClawQuestion.RequestIdPrefix)) {
+        await getCoworkEngineRouter().respondToPermission(options.requestId, options.result);
+        return { success: true };
+      }
       // Dual-dispatch pattern: permission responses arrive through one IPC channel
       // but may target either of two independent subsystems.
       //

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -647,7 +647,7 @@ contextBridge.exposeInMainWorld('electron', {
 
     // Permission handling
     respondToPermission: (options: { requestId: string; result: any }) =>
-      ipcRenderer.invoke('cowork:permission:respond', options),
+      ipcRenderer.invoke(CoworkIpcChannel.PermissionRespond, options),
 
     // Configuration
     getConfig: () => ipcRenderer.invoke('cowork:config:get'),
@@ -771,10 +771,11 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.on('cowork:stream:permission', handler);
       return () => ipcRenderer.removeListener('cowork:stream:permission', handler);
     },
+    getPendingQuestions: () => ipcRenderer.invoke(CoworkIpcChannel.GetPendingQuestions),
     onStreamPermissionDismiss: (callback: (data: { requestId: string }) => void) => {
       const handler = (_event: any, data: { requestId: string }) => callback(data);
-      ipcRenderer.on('cowork:stream:permissionDismiss', handler);
-      return () => ipcRenderer.removeListener('cowork:stream:permissionDismiss', handler);
+      ipcRenderer.on(CoworkIpcChannel.StreamPermissionDismiss, handler);
+      return () => ipcRenderer.removeListener(CoworkIpcChannel.StreamPermissionDismiss, handler);
     },
     onStreamComplete: (
       callback: (data: { sessionId: string; claudeSessionId: string | null }) => void,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import {
   AppUpdateStatus,
   isManualDownloadUrl,
 } from '../shared/appUpdate/constants';
+import { OpenClawQuestion } from '../shared/cowork/openclawQuestion';
 import {
   LibraryNavigationEvent,
   LibrarySourceFilter,
@@ -29,6 +30,7 @@ import {
   ConversationSearchShortcutTarget,
   resolveConversationSearchShortcutTarget,
 } from './components/cowork/conversationSearchShortcut';
+import CoworkNativeQuestionModal from './components/cowork/CoworkNativeQuestionModal';
 import CoworkPermissionModal from './components/cowork/CoworkPermissionModal';
 import CoworkQuestionWizard from './components/cowork/CoworkQuestionWizard';
 import EngineFailureOverlay from './components/cowork/EngineFailureOverlay';
@@ -1453,8 +1455,8 @@ const App: React.FC = () => {
   }, [finishNewUserOnboarding, newUserOnboardingStep, showToast]);
 
   const handlePermissionResponse = useCallback(async (result: CoworkPermissionResult) => {
-    if (!pendingPermission) return;
-    await coworkService.respondToPermission(pendingPermission.requestId, result);
+    if (!pendingPermission) return false;
+    return coworkService.respondToPermission(pendingPermission.requestId, result);
   }, [pendingPermission]);
 
   const handleMinimizePermission = useCallback(() => {
@@ -1917,6 +1919,18 @@ const App: React.FC = () => {
   // 避免重新展开后丢失用户已选择/已输入的内容；key 按 requestId 隔离不同请求的状态。
   const permissionModal = useMemo(() => {
     if (!pendingPermission) return null;
+
+    if (pendingPermission.toolName === OpenClawQuestion.ToolName) {
+      return (
+        <CoworkNativeQuestionModal
+          key={pendingPermission.requestId}
+          permission={pendingPermission}
+          onRespond={handlePermissionResponse}
+          onMinimize={handleMinimizePermission}
+          hidden={isPendingPermissionMinimized}
+        />
+      );
+    }
 
     // 检查是否为 AskUserQuestion 且有多个问题 -> 使用向导式组件
     const isQuestionTool = pendingPermission.toolName === 'AskUserQuestion';

--- a/src/renderer/components/cowork/CoworkNativeQuestionModal.tsx
+++ b/src/renderer/components/cowork/CoworkNativeQuestionModal.tsx
@@ -1,0 +1,143 @@
+import { ChatBubbleLeftRightIcon, MinusIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { useMemo, useRef, useState } from 'react';
+
+import {
+  type OpenClawQuestionAnswers,
+  parseOpenClawQuestionAnswers,
+  parseOpenClawQuestionRecord,
+} from '../../../shared/cowork/openclawQuestion';
+import { i18nService } from '../../services/i18n';
+import type { CoworkPermissionRequest, CoworkPermissionResult } from '../../types/cowork';
+import { stripQuestionRecommendation } from './questionOptionLabel';
+
+interface CoworkNativeQuestionModalProps {
+  permission: CoworkPermissionRequest;
+  onRespond: (result: CoworkPermissionResult) => Promise<boolean | void> | boolean | void;
+  onMinimize?: () => void;
+  hidden?: boolean;
+}
+
+/** Native questions use questionId -> string[], without the legacy text keys or separators. */
+export default function CoworkNativeQuestionModal({
+  permission, onRespond, onMinimize, hidden = false,
+}: CoworkNativeQuestionModalProps) {
+  const record = useMemo(() => parseOpenClawQuestionRecord(permission.toolInput), [permission.toolInput]);
+  const [selected, setSelected] = useState<OpenClawQuestionAnswers>({});
+  const [other, setOther] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const submittingRef = useRef(false);
+  const questions = record?.questions ?? [];
+  const answers = Object.fromEntries(questions.map((question) => [
+    question.questionId,
+    [...(selected[question.questionId] ?? []), ...(other[question.questionId]?.trim() ? [other[question.questionId].trim()] : [])],
+  ]));
+  const complete = record !== null && parseOpenClawQuestionAnswers(questions, answers) !== null;
+  const titleId = `${permission.requestId}-title`;
+  const t = i18nService.t.bind(i18nService);
+
+  const respond = async (result: CoworkPermissionResult) => {
+    if (submittingRef.current) return;
+    submittingRef.current = true;
+    setSubmitting(true);
+    setFailed(false);
+    try {
+      if (await onRespond(result) === false) setFailed(true);
+    } catch {
+      setFailed(true);
+    } finally {
+      submittingRef.current = false;
+      setSubmitting(false);
+    }
+  };
+  const cancel = () => void respond({ behavior: 'deny', message: t('cancel') });
+
+  return (
+    <div className={`fixed inset-0 z-50 items-center justify-center modal-backdrop ${hidden ? 'hidden' : 'flex'}`}>
+      <form
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="modal-content w-full max-w-xl mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (complete) void respond({ behavior: 'allow', updatedInput: { answers } });
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') { event.stopPropagation(); cancel(); }
+        }}
+      >
+        <div className="flex items-center gap-3 px-6 py-4 border-b border-border">
+          <ChatBubbleLeftRightIcon className="h-6 w-6 text-primary shrink-0" />
+          <div className="flex-1">
+            <h2 id={titleId} className="text-lg font-semibold text-foreground">{t('coworkSelectionRequired')}</h2>
+            <p className="text-sm text-secondary">{t('coworkSelectionDescription')}</p>
+          </div>
+          {onMinimize && (
+            <button type="button" onClick={onMinimize} aria-label={t('coworkPermissionMinimize')} className="p-2 text-secondary hover:bg-surface-raised rounded-lg">
+              <MinusIcon className="h-5 w-5" />
+            </button>
+          )}
+          <button type="button" onClick={cancel} disabled={submitting} aria-label={t('coworkPermissionCancel')} className="p-2 text-secondary hover:bg-surface-raised rounded-lg">
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="px-6 py-4 space-y-4 max-h-[60vh] overflow-y-auto">
+          {questions.map((question) => (
+            <fieldset key={question.questionId} disabled={submitting} className="border border-border rounded-xl p-4 space-y-3">
+              <legend className="px-1 text-sm font-medium text-foreground">
+                {question.header && <span className="text-xs text-secondary mr-2">{question.header}</span>}
+                {question.question}
+              </legend>
+              {question.options.map((option) => (
+                <label key={option.label} className="flex items-start gap-3 rounded-lg border border-border px-3 py-2 cursor-pointer hover:bg-surface-raised">
+                  <input
+                    type={question.multiSelect ? 'checkbox' : 'radio'}
+                    name={question.questionId}
+                    value={option.label}
+                    checked={(selected[question.questionId] ?? []).includes(option.label)}
+                    className="mt-1 accent-primary"
+                    onChange={() => {
+                      setSelected((previous) => {
+                        const current = previous[question.questionId] ?? [];
+                        const next = question.multiSelect
+                          ? current.includes(option.label) ? current.filter((label) => label !== option.label) : [...current, option.label]
+                          : [option.label];
+                        return { ...previous, [question.questionId]: next };
+                      });
+                      if (!question.multiSelect) setOther((previous) => ({ ...previous, [question.questionId]: '' }));
+                    }}
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-foreground">{stripQuestionRecommendation(option.label)}</span>
+                    {option.description && <span className="block text-xs text-secondary mt-1">{option.description}</span>}
+                  </span>
+                </label>
+              ))}
+              {(question.isOther || question.options.length === 0) && (
+                <label className="block text-sm text-secondary">
+                  {question.options.length > 0 ? t('coworkNativeQuestionOther') : t('coworkNativeQuestionAnswer')}
+                  <textarea
+                    value={other[question.questionId] ?? ''}
+                    placeholder={t('coworkNativeQuestionAnswer')}
+                    rows={2}
+                    className="mt-2 w-full rounded-lg border border-border bg-background p-3 text-sm text-foreground focus:outline-none focus:border-primary"
+                    onChange={(event) => {
+                      setOther((previous) => ({ ...previous, [question.questionId]: event.target.value }));
+                      if (!question.multiSelect) setSelected((previous) => ({ ...previous, [question.questionId]: [] }));
+                    }}
+                  />
+                </label>
+              )}
+            </fieldset>
+          ))}
+          {(failed || !record) && <p role="alert" className="text-sm text-red-500">{t('coworkNativeQuestionSubmitFailed')}</p>}
+        </div>
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border">
+          <button type="button" onClick={cancel} disabled={submitting} className="px-4 py-2 text-sm rounded-lg text-secondary hover:bg-surface-raised disabled:opacity-50">{t('cancel')}</button>
+          <button type="submit" disabled={!complete || submitting} className="px-4 py-2 text-sm rounded-lg bg-primary hover:bg-primary-hover text-white disabled:opacity-50 disabled:cursor-not-allowed">{t('coworkConfirmSelection')}</button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/renderer/components/cowork/CoworkPermissionModal.tsx
+++ b/src/renderer/components/cowork/CoworkPermissionModal.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { ASK_USER_QUESTION_TOOL_NAME } from '../../../shared/cowork/constants';
 import { i18nService } from '../../services/i18n';
 import type { CoworkPermissionRequest, CoworkPermissionResult } from '../../types/cowork';
+import { stripQuestionRecommendation } from './questionOptionLabel';
 
 type DangerLevel = 'safe' | 'caution' | 'destructive';
 
@@ -612,14 +613,14 @@ const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({
             onClick={isConfirmMode && confirmModeButtons ? () => handleConfirmModeSelect(confirmModeButtons.secondary.label) : handleDeny}
             className="px-4 py-2 text-sm font-medium rounded-lg text-secondary hover:bg-surface-raised transition-colors"
           >
-            {isConfirmMode && confirmModeButtons ? confirmModeButtons.secondary.label : denyButtonLabel}
+            {isConfirmMode && confirmModeButtons ? stripQuestionRecommendation(confirmModeButtons.secondary.label) : denyButtonLabel}
           </button>
           <button
             onClick={handleApprove}
             disabled={!isComplete}
             className="px-4 py-2 text-sm font-medium rounded-lg bg-primary hover:bg-primary-hover text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {isConfirmMode && confirmModeButtons ? confirmModeButtons.primary.label : approveButtonLabel}
+            {isConfirmMode && confirmModeButtons ? stripQuestionRecommendation(confirmModeButtons.primary.label) : approveButtonLabel}
           </button>
         </div>
       </div>

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -42,6 +42,7 @@ import {
   type CoworkSelectedTextValidationError,
   normalizeCoworkSelectedTextSnippets,
 } from '../../../shared/cowork/selectedText';
+import { classifyWaitingNotificationKind, WaitingNotificationKind } from '../../../shared/notifications/constants';
 import { ShareDeploymentCandidateSource } from '../../../shared/shareDeployment/constants';
 import { resolveArtifactAutoPreviewEnabled } from '../../config';
 import { EnterpriseQuotaPrompt } from '../../features/enterpriseAccount/components/EnterpriseQuotaPrompt';
@@ -315,7 +316,7 @@ const RAIL_TARGET_SCROLL_RETRY_LIMIT = 6;
 
 const getPermissionPreviewText = (permission: CoworkPermissionRequest): string => {
   const toolInput = permission.toolInput ?? {};
-  if (permission.toolName === 'AskUserQuestion') {
+  if (classifyWaitingNotificationKind(permission.toolName) === WaitingNotificationKind.Question) {
     const rawQuestions = (toolInput as Record<string, unknown>).questions;
     if (Array.isArray(rawQuestions)) {
       const firstQuestion = rawQuestions.find((question): question is Record<string, unknown> => (
@@ -1485,7 +1486,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     : '';
   // AskUserQuestion is the agent asking for input, not a risky action awaiting
   // approval — style it neutrally instead of as an amber warning.
-  const isMinimizedQuestionPermission = minimizedPermission?.toolName === 'AskUserQuestion';
+  const isMinimizedQuestionPermission = classifyWaitingNotificationKind(minimizedPermission?.toolName) === WaitingNotificationKind.Question;
   const handleDenyMinimizedPermission = useCallback(() => {
     onRespondToPermission?.({
       behavior: 'deny',

--- a/src/renderer/components/cowork/questionOptionLabel.test.ts
+++ b/src/renderer/components/cowork/questionOptionLabel.test.ts
@@ -1,0 +1,58 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ASK_USER_QUESTION_TOOL_NAME } from '../../../shared/cowork/constants';
+import { OpenClawQuestion, OpenClawQuestionStatus } from '../../../shared/cowork/openclawQuestion';
+import CoworkNativeQuestionModal from './CoworkNativeQuestionModal';
+import CoworkPermissionModal from './CoworkPermissionModal';
+import { stripQuestionRecommendation } from './questionOptionLabel';
+
+vi.mock('../../services/i18n', () => ({ i18nService: { t: (key: string) => key } }));
+
+describe('question option presentation', () => {
+  test.each(['允许删除 (Recommended)', '允许删除（推荐）', '允许删除 (recommended)  '])(
+    'removes a terminal recommendation from %s', (label) => {
+      expect(stripQuestionRecommendation(label)).toBe('允许删除');
+    },
+  );
+
+  test('preserves ordinary prose, empty-label edge cases and non-terminal parentheses', () => {
+    expect(stripQuestionRecommendation('Read recommended docs')).toBe('Read recommended docs');
+    expect(stripQuestionRecommendation('(Recommended)')).toBe('(Recommended)');
+    expect(stripQuestionRecommendation('A (Recommended) details')).toBe('A (Recommended) details');
+  });
+
+  test('the legacy delete confirmation hides the suffix without mutating its tool input', () => {
+    const permission = {
+      requestId: 'legacy', sessionId: 'session', toolName: ASK_USER_QUESTION_TOOL_NAME,
+      toolInput: { questions: [{
+        question: '允许删除文件吗？', options: [{ label: '允许删除 (Recommended)' }, { label: '取消' }],
+      }] },
+    };
+    const markup = renderToStaticMarkup(createElement(CoworkPermissionModal, { permission, onRespond: () => {} }));
+    expect(markup).toContain('允许删除</button>');
+    expect(markup).not.toContain('Recommended');
+    expect(permission.toolInput.questions[0].options[0].label).toBe('允许删除 (Recommended)');
+  });
+
+  test('native two-choice questions retain other input and have no preselected or auto-submitted recommendation', () => {
+    const permission = {
+      requestId: 'native', sessionId: 'session', toolName: OpenClawQuestion.ToolName,
+      toolInput: {
+        id: 'native', sessionKey: 'agent:main:lobsterai:session', status: OpenClawQuestionStatus.Pending,
+        expiresAtMs: Date.now() + 10_000,
+        questions: [{ questionId: 'topic', header: 'Topic', question: 'Choose a topic', isOther: true,
+          options: [{ label: 'A (Recommended)' }, { label: 'B' }] }],
+      },
+    };
+    const markup = renderToStaticMarkup(createElement(CoworkNativeQuestionModal, { permission, onRespond: () => {} }));
+    expect(markup).toContain('<textarea');
+    expect(markup).toContain('name="topic"');
+    expect(markup).not.toContain('checked=""');
+    expect(markup).toContain('type="submit" disabled=""');
+    // The submitted value is original, while the visible label is neutral.
+    expect(markup).toContain('value="A (Recommended)"');
+    expect(markup).not.toContain('>A (Recommended)<');
+  });
+});

--- a/src/renderer/components/cowork/questionOptionLabel.ts
+++ b/src/renderer/components/cowork/questionOptionLabel.ts
@@ -1,0 +1,5 @@
+/** Recommendation suffixes are display metadata. Always submit the unchanged option label. */
+export function stripQuestionRecommendation(label: string): string {
+  const stripped = label.replace(/\s*[（(]\s*(?:recommended|推荐)\s*[）)]\s*$/i, '').trimEnd();
+  return stripped.trim() ? stripped : label;
+}

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -91,6 +91,7 @@ import {
   shouldReloadCurrentSessionForChange,
 } from './coworkSessionRefreshPolicy';
 import { i18nService } from './i18n';
+import { restoreNativeQuestionPermissions } from './nativeQuestionRecovery';
 import { reportOnboardingAction } from './onboardingAnalytics';
 
 const STREAM_ERROR_DUPLICATE_WINDOW_MS = 10_000;
@@ -438,6 +439,9 @@ class CoworkService {
       store.dispatch(dequeuePendingPermission({ requestId }));
     });
     this.streamListenerCleanups.push(permissionDismissCleanup);
+    this.streamListenerCleanups.push(restoreNativeQuestionPermissions(cowork, (request) => {
+      store.dispatch(enqueuePendingPermission(request));
+    }));
 
     // Complete listener
     const completeCleanup = cowork.onStreamComplete(({ sessionId }) => {

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -6,6 +6,9 @@ export type LanguageType = 'zh' | 'en';
 // 语言文本映射
 const translations: Record<LanguageType, Record<string, string>> = {
   zh: {
+    coworkNativeQuestionOther: '其他回答',
+    coworkNativeQuestionAnswer: '请输入你的回答',
+    coworkNativeQuestionSubmitFailed: '回答未能提交，请重试。',
     // 通用
     save: '保存',
     cancel: '取消',
@@ -3784,6 +3787,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     emailDeleting: '删除中...',
   },
   en: {
+    coworkNativeQuestionOther: 'Other answer',
+    coworkNativeQuestionAnswer: 'Enter your answer',
+    coworkNativeQuestionSubmitFailed: 'Your answer could not be submitted. Please try again.',
     // Common
     save: 'Save',
     cancel: 'Cancel',

--- a/src/renderer/services/nativeQuestionRecovery.test.ts
+++ b/src/renderer/services/nativeQuestionRecovery.test.ts
@@ -1,0 +1,46 @@
+import { expect, test, vi } from 'vitest';
+
+import { OpenClawQuestion } from '../../shared/cowork/openclawQuestion';
+import type { CoworkPermissionRequest } from '../types/cowork';
+import { restoreNativeQuestionPermissions } from './nativeQuestionRecovery';
+
+function setup() {
+  const permission: CoworkPermissionRequest = {
+    requestId: `${OpenClawQuestion.RequestIdPrefix}id`, sessionId: 'session',
+    toolName: OpenClawQuestion.ToolName, toolInput: {},
+  };
+  let resolve: (requests: CoworkPermissionRequest[]) => void = () => {};
+  let dismiss: (data: { requestId: string }) => void = () => {};
+  const unsubscribe = vi.fn();
+  const api = {
+    getPendingQuestions: () => new Promise<CoworkPermissionRequest[]>((callback) => { resolve = callback; }),
+    onStreamPermissionDismiss: (callback: typeof dismiss) => { dismiss = callback; return unsubscribe; },
+  };
+  const enqueue = vi.fn();
+  const cleanup = restoreNativeQuestionPermissions(api, enqueue);
+  return { permission, enqueue, cleanup, unsubscribe, resolve: () => resolve([permission]), dismiss: () => dismiss({ requestId: permission.requestId }) };
+}
+
+test('restores the pending native question when a renderer reloads', async () => {
+  const { resolve, enqueue, permission } = setup();
+  resolve();
+  await Promise.resolve();
+  expect(enqueue).toHaveBeenCalledWith(permission);
+});
+
+test('ignores questions resolved between the snapshot and IPC response', async () => {
+  const { resolve, enqueue, dismiss } = setup();
+  dismiss();
+  resolve();
+  await Promise.resolve();
+  expect(enqueue).not.toHaveBeenCalled();
+});
+
+test('does not dispatch into a disposed renderer service', async () => {
+  const { resolve, enqueue, cleanup, unsubscribe } = setup();
+  cleanup();
+  resolve();
+  await Promise.resolve();
+  expect(enqueue).not.toHaveBeenCalled();
+  expect(unsubscribe).toHaveBeenCalled();
+});

--- a/src/renderer/services/nativeQuestionRecovery.ts
+++ b/src/renderer/services/nativeQuestionRecovery.ts
@@ -1,0 +1,24 @@
+import { OpenClawQuestion } from '../../shared/cowork/openclawQuestion';
+import type { CoworkPermissionRequest } from '../types/cowork';
+
+type RecoveryApi = {
+  getPendingQuestions?: () => Promise<CoworkPermissionRequest[]>;
+  onStreamPermissionDismiss: (callback: (data: { requestId: string }) => void) => () => void;
+};
+
+/** Recover after renderer reload; a concurrent resolution must not resurrect a stale snapshot. */
+export function restoreNativeQuestionPermissions(api: RecoveryApi, enqueue: (request: CoworkPermissionRequest) => void): () => void {
+  if (!api.getPendingQuestions) return () => {};
+  let cancelled = false;
+  const dismissed = new Set<string>();
+  const unsubscribe = api.onStreamPermissionDismiss(({ requestId }) => dismissed.add(requestId));
+  void api.getPendingQuestions().then((requests) => {
+    if (cancelled) return;
+    for (const request of requests) {
+      if (request.toolName === OpenClawQuestion.ToolName && !dismissed.has(request.requestId)) enqueue(request);
+    }
+  }).catch((error) => {
+    if (!cancelled) console.warn('[NativeQuestion] failed to recover pending questions:', error);
+  }).finally(unsubscribe);
+  return () => { cancelled = true; unsubscribe(); };
+}

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1272,6 +1272,7 @@ interface IElectronAPI {
       callback: (data: { sessionId: string; request: CoworkPermissionRequest }) => void,
     ) => () => void;
     onStreamPermissionDismiss: (callback: (data: { requestId: string }) => void) => () => void;
+    getPendingQuestions?: () => Promise<CoworkPermissionRequest[]>;
     onStreamComplete: (
       callback: (data: { sessionId: string; claudeSessionId: string | null }) => void,
     ) => () => void;

--- a/src/shared/cowork/constants.ts
+++ b/src/shared/cowork/constants.ts
@@ -57,6 +57,9 @@ export const COWORK_TEMP_DIR_NAME = '.cowork-temp';
 export const COWORK_TEMP_ATTACHMENTS_DIR_NAME = 'attachments';
 
 export const CoworkIpcChannel = {
+  PermissionRespond: 'cowork:permission:respond',
+  GetPendingQuestions: 'cowork:question:pending',
+  StreamPermissionDismiss: 'cowork:stream:permissionDismiss',
   CancelMediaTask: 'cowork:media:cancel',
   GetMediaModels: 'media:getModels',
   MediaStatusPollUpdate: 'cowork:media:statusPollUpdate',

--- a/src/shared/cowork/openclawQuestion.test.ts
+++ b/src/shared/cowork/openclawQuestion.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+
+import { classifyWaitingNotificationKind, WaitingNotificationKind } from '../notifications/constants';
+import {
+  OpenClawQuestion,
+  type OpenClawQuestionItem,
+  OpenClawQuestionStatus,
+  parseOpenClawQuestionAnswers,
+  parseOpenClawQuestionRecord,
+} from './openclawQuestion';
+
+const question: OpenClawQuestionItem = {
+  questionId: 'choice', header: '选择', question: '选哪个？',
+  options: [{ label: 'A (Recommended)' }, { label: 'B|||C' }], isOther: true,
+};
+const record = {
+  id: 'request', questions: [question], sessionKey: 'agent:main:lobsterai:session',
+  expiresAtMs: 100_000, status: OpenClawQuestionStatus.Pending,
+};
+
+describe('native question contract', () => {
+  test('preserves stable question IDs and exact model-provided labels', () => {
+    expect(parseOpenClawQuestionRecord(record)?.questions).toEqual([{ ...question, multiSelect: false }]);
+    expect(parseOpenClawQuestionAnswers([question], { choice: ['A (Recommended)'] }))
+      .toEqual({ choice: ['A (Recommended)'] });
+  });
+
+  test('keeps identical question text and separator-containing multi-select labels distinct', () => {
+    const questions = [question, { ...question, questionId: 'second', multiSelect: true }];
+    const answers = { choice: ['free-form answer'], second: ['A (Recommended)', 'B|||C'] };
+    expect(parseOpenClawQuestionAnswers(questions, answers)).toEqual(answers);
+  });
+
+  test.each([
+    {}, { choice: 'A' }, { choice: [] }, { choice: ['  '] },
+    { choice: ['A', 'B'] }, { choice: ['A'], unknown: ['B'] },
+  ])('rejects incomplete or malformed answers %j', (answers) => {
+    expect(parseOpenClawQuestionAnswers([question], answers)).toBeNull();
+  });
+
+  test('allows text for free-text questions but rejects unlisted closed choices', () => {
+    expect(parseOpenClawQuestionAnswers([{ ...question, options: [] }], { choice: ['text'] }))
+      .toEqual({ choice: ['text'] });
+    expect(parseOpenClawQuestionAnswers([{ ...question, isOther: false }], { choice: ['unlisted'] })).toBeNull();
+  });
+
+  test.each([
+    { questions: [question, question] },
+    { questions: [{ ...question, isSecret: true }] },
+    { questions: [{ ...question, secretStore: { name: 'API_KEY' } }] },
+    { questions: [{ ...question, questionId: undefined }] },
+    { sessionKey: '' }, { expiresAtMs: Infinity }, { status: 'invalid' },
+  ])('rejects malformed or unsupported records %j', (override) => {
+    expect(parseOpenClawQuestionRecord({ ...record, ...override })).toBeNull();
+  });
+
+  test('native questions use the question notification preference', () => {
+    expect(classifyWaitingNotificationKind(OpenClawQuestion.ToolName)).toBe(WaitingNotificationKind.Question);
+  });
+});

--- a/src/shared/cowork/openclawQuestion.ts
+++ b/src/shared/cowork/openclawQuestion.ts
@@ -1,0 +1,113 @@
+/** OpenClaw's native ask_user contract, independent of the AskUserQuestion plugin. */
+export const OpenClawQuestion = {
+  ToolName: 'ask_user',
+  RequestIdPrefix: 'openclaw-question:',
+  Requested: 'question.requested',
+  Resolved: 'question.resolved',
+  List: 'question.list',
+  Get: 'question.get',
+  Resolve: 'question.resolve',
+} as const;
+
+export const OpenClawQuestionStatus = {
+  Pending: 'pending',
+  Answered: 'answered',
+  Cancelled: 'cancelled',
+  Expired: 'expired',
+} as const;
+export type OpenClawQuestionStatus = typeof OpenClawQuestionStatus[keyof typeof OpenClawQuestionStatus];
+
+export interface OpenClawQuestionItem {
+  questionId: string;
+  header: string;
+  question: string;
+  options: { label: string; description?: string }[];
+  multiSelect?: boolean;
+  isOther?: boolean;
+}
+
+export interface OpenClawQuestionRecord {
+  id: string;
+  questions: OpenClawQuestionItem[];
+  sessionKey: string;
+  runId?: string;
+  expiresAtMs: number;
+  status: OpenClawQuestionStatus;
+}
+
+export type OpenClawQuestionAnswers = Record<string, string[]>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+);
+
+/** Validate only ordinary ask_user questions; secret-store prompts have a separate contract. */
+export function parseOpenClawQuestionRecord(value: unknown): OpenClawQuestionRecord | null {
+  if (!isRecord(value)
+    || typeof value.id !== 'string' || !value.id.trim()
+    || typeof value.sessionKey !== 'string' || !value.sessionKey.trim()
+    || typeof value.expiresAtMs !== 'number' || !Number.isFinite(value.expiresAtMs)
+    || !Object.values(OpenClawQuestionStatus).includes(value.status as OpenClawQuestionStatus)
+    || !Array.isArray(value.questions) || value.questions.length < 1 || value.questions.length > 3) {
+    return null;
+  }
+  const questions: OpenClawQuestionItem[] = [];
+  const ids = new Set<string>();
+  for (const question of value.questions) {
+    if (!isRecord(question)
+      || typeof question.questionId !== 'string' || !/^[a-z][a-z0-9_]*$/.test(question.questionId)
+      || ids.has(question.questionId)
+      || typeof question.question !== 'string' || !question.question.trim()
+      || typeof question.header !== 'string'
+      || question.isSecret === true || question.secretStore !== undefined
+      || !Array.isArray(question.options) || question.options.length === 1 || question.options.length > 4) {
+      return null;
+    }
+    const options: OpenClawQuestionItem['options'] = [];
+    for (const option of question.options) {
+      if (!isRecord(option) || typeof option.label !== 'string' || !option.label.trim()
+        || options.some((existing) => existing.label === option.label)) return null;
+      options.push({
+        label: option.label,
+        ...(typeof option.description === 'string' ? { description: option.description } : {}),
+      });
+    }
+    ids.add(question.questionId);
+    questions.push({
+      questionId: question.questionId,
+      question: question.question,
+      header: question.header,
+      options,
+      multiSelect: question.multiSelect === true,
+      isOther: question.isOther === true,
+    });
+  }
+  return {
+    id: value.id,
+    sessionKey: value.sessionKey,
+    ...(typeof value.runId === 'string' ? { runId: value.runId } : {}),
+    expiresAtMs: value.expiresAtMs,
+    status: value.status as OpenClawQuestionStatus,
+    questions,
+  };
+}
+
+/** Preserve stable IDs and original option labels, including punctuation and multi-select values. */
+export function parseOpenClawQuestionAnswers(
+  questions: OpenClawQuestionItem[],
+  value: unknown,
+): OpenClawQuestionAnswers | null {
+  if (!isRecord(value) || Object.keys(value).length !== questions.length) return null;
+  const answers: OpenClawQuestionAnswers = {};
+  for (const question of questions) {
+    const values = value[question.questionId];
+    if (!Array.isArray(values) || values.length < 1
+      || (!question.multiSelect && values.length !== 1)
+      || values.some((answer) => typeof answer !== 'string' || !answer.trim())
+      || new Set(values).size !== values.length) return null;
+    if (question.options.length > 0 && !question.isOther
+      && values.some((answer) => !question.options.some((option) => option.label === answer))) return null;
+    answers[question.questionId] = [...values] as string[];
+  }
+  return answers;
+}

--- a/src/shared/notifications/constants.ts
+++ b/src/shared/notifications/constants.ts
@@ -1,4 +1,5 @@
 import { ASK_USER_QUESTION_TOOL_NAME } from '../cowork/constants';
+import { OpenClawQuestion } from '../cowork/openclawQuestion';
 
 /** When task-completion notifications are shown. */
 export const TaskCompletionNotificationMode = {
@@ -20,7 +21,7 @@ export type WaitingNotificationKind =
 export const classifyWaitingNotificationKind = (
   toolName: string | null | undefined,
 ): WaitingNotificationKind =>
-  toolName === ASK_USER_QUESTION_TOOL_NAME
+  toolName === ASK_USER_QUESTION_TOOL_NAME || toolName === OpenClawQuestion.ToolName
     ? WaitingNotificationKind.Question
     : WaitingNotificationKind.Permission;
 


### PR DESCRIPTION
## Summary

After the OpenClaw v2026.8.1 upgrade, native `ask_user` requests could wait for an answer without opening a desktop dialog. Connect the new `question.*` protocol to the desktop question UI, and hide the recommendation suffix that leaked into confirmation button labels.

## Related Issue

[OpenClaw upgrade regression sheet](https://docs.popo.netease.com/lingxi/d29fe7dcbb914e5980afd01904c076fe?tab=3), rows 21 and 22.

## Changes Made

- Handle native question events and send the nested `question.resolve` answer envelope using stable question IDs and string arrays. Support multiple questions, multiple selections and free text.
- Keep questions scoped to their owning desktop session. Handle cancellation, expiry, stopped sessions, reconnect recovery and renderer reloads; retain answers for retry when submission fails.
- Strip terminal recommendation markers from visible option/confirmation labels while preserving the original submitted values. The custom `AskUserQuestion` plugin, HTTP bridge and answer protocol remain unchanged.

## Type of Change

- [x] Bug fix

## Testing

- [x] 320 tests passed across the native protocol/controller/recovery/UI coverage and existing runtime adapter, router and desktop notification suites.
- [x] Changed TypeScript files pass ESLint with zero warnings.
- [x] Renderer and Electron TypeScript checks pass after rebasing onto the latest target branch.
- [x] `npm run compile:electron` passed during implementation.
- [x] Manual browser verification with the actual modal components and a real OpenClaw v2026.8.1 gateway: single/multiple questions, multi-select, free text, exact answer payloads, minimize/restore, failed submission and retry, cancellation, expiry, and legacy confirmation values.

Full client/model conversation acceptance testing has not been performed.

## Screenshots

The reported UI screenshots are in column C of the linked regression sheet, rows 21–22. The updated modal layout was visually checked in the isolated verification harness.

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Changes were reviewed for unrelated edits.
- [x] Added regression tests cover the new protocol and preserved legacy values.
- [x] New and relevant existing tests pass locally.

## Electron-Specific Changes

- [x] Main process: translate native gateway question events and acknowledge responses before dismissing the UI.
- [x] Preload and IPC: expose pending native questions for renderer recovery and forward question dismissal.
- [ ] Window management changes.

## Additional Notes

Implemented in an isolated worktree on `fix/openclaw-ask-user-protocol`, rebased onto `feat/openclaw-v2026.8.1`. No upstream OpenClaw patch or runtime configuration change is required.
