### PR TITLE
fix(openclaw): restore DingTalk and Lark plugin compatibility

### DIFF
--- a/scripts/openclaw-plugin-patches/dingtalk.cjs
+++ b/scripts/openclaw-plugin-patches/dingtalk.cjs
@@ -3,6 +3,31 @@
 const fs = require('fs');
 const path = require('path');
 
+function patchDingtalkSdkCompatibility(pluginDir, log) {
+  // Jiti rewrites import.meta.url, but leaves bare/optional import.meta in
+  // its CommonJS output. The published ESM entry always has a module URL.
+  const loadPathExpression = 'typeof import.meta !== "undefined" && import.meta?.url ? String(import.meta.url) : "<unknown>"';
+  const replacements = [
+    [path.join(pluginDir, 'index.ts'), loadPathExpression, 'String(import.meta.url)'],
+    [path.join(pluginDir, 'dist', 'index.mjs'), loadPathExpression, 'String(import.meta.url)'],
+    // OpenClaw 2026.8.1 removed channel-runtime; channel-outbound exports
+    // the reply-prefix, typing callbacks and typing-failure helpers we use.
+    ...[
+      path.join(pluginDir, 'src', 'reply-dispatcher.ts'),
+      ...findDingtalkDistMessageHandlers(pluginDir),
+    ].map(file => [file, '"openclaw/plugin-sdk/channel-runtime"', '"openclaw/plugin-sdk/channel-outbound"']),
+  ];
+  for (const [file, before, after] of replacements) {
+    if (!fs.existsSync(file)) continue;
+    const source = fs.readFileSync(file, 'utf8');
+    const patched = source.replaceAll(before, after);
+    if (patched !== source) {
+      fs.writeFileSync(file, patched);
+      log(`Patched dingtalk-connector/${path.relative(pluginDir, file)}: OpenClaw SDK/module compatibility`);
+    }
+  }
+}
+
 function patchMessageHandler(dingtalkMsgHandlerPath, log) {
   if (!fs.existsSync(dingtalkMsgHandlerPath)) {
     log(`${path.basename(dingtalkMsgHandlerPath)} not found, skipping file:// URL patch`);
@@ -211,6 +236,7 @@ function patchDingtalkAgentWorkspaceResolver(resolverPath, label, log) {
 
 function patchDingtalk({ runtimeExtensionsDir, log }) {
   const pluginDir = path.join(runtimeExtensionsDir, 'dingtalk-connector');
+  patchDingtalkSdkCompatibility(pluginDir, log);
   const messageHandlerPaths = [
     path.join(pluginDir, 'src', 'core', 'message-handler.ts'),
     ...findDingtalkDistMessageHandlers(pluginDir),

--- a/scripts/openclaw-plugin-patches/lark.cjs
+++ b/scripts/openclaw-plugin-patches/lark.cjs
@@ -5,6 +5,28 @@ const path = require('path');
 
 const { readJsonFile, writeJsonFile } = require('./common.cjs');
 
+function patchSdkImports(larkPluginDir, log) {
+  // OpenClaw 2026.8.1 removed the SDK root and channel-runtime barrels.
+  // Keep the plugin on the host's public SDK modules and shared runtime state.
+  const replacements = [
+    ['index.js', '"openclaw/plugin-sdk"', '"openclaw/plugin-sdk/plugin-entry"'],
+    [path.join('src', 'card', 'reply-dispatcher.js'), '"openclaw/plugin-sdk/channel-runtime"', '"openclaw/plugin-sdk/channel-reply-pipeline"'],
+    // Session-store helpers moved out of config-runtime. Without this change,
+    // the plugin catches the missing-function error and ignores /verbose state.
+    [path.join('src', 'card', 'tool-use-config.js'), '"openclaw/plugin-sdk/config-runtime"', '"openclaw/plugin-sdk/session-store-runtime"'],
+  ];
+  for (const [relativePath, before, after] of replacements) {
+    const file = path.join(larkPluginDir, relativePath);
+    if (!fs.existsSync(file)) continue;
+    const source = fs.readFileSync(file, 'utf8');
+    const patched = source.replaceAll(before, after);
+    if (patched !== source) {
+      fs.writeFileSync(file, patched);
+      log(`Patched openclaw-lark/${relativePath}: use public OpenClaw SDK subpaths`);
+    }
+  }
+}
+
 const larkToolContracts = [
   'feishu_ask_user_question',
   'feishu_auth',
@@ -255,6 +277,7 @@ function ${patchMarker}(name) {
 
 function patchLark({ runtimeExtensionsDir, log }) {
   const larkPluginDir = path.join(runtimeExtensionsDir, 'openclaw-lark');
+  patchSdkImports(larkPluginDir, log);
   patchDeferredStartup(larkPluginDir, log);
   patchToolContracts(larkPluginDir, log);
   patchFilenameEncoding(larkPluginDir, log);

--- a/specs/refactors/openclaw-upgrade/2026-09-08-im-plugin-compatibility.md
+++ b/specs/refactors/openclaw-upgrade/2026-09-08-im-plugin-compatibility.md
@@ -1,0 +1,93 @@
+# OpenClaw 2026.8.1 IM 插件兼容性排查
+
+日期：2026-09-08。基线：远端 `feat/openclaw-v2026.8.1` 的 `eb931315a`。
+修复分支：`fix/openclaw-dingtalk-lark-compat`。
+
+在独立 worktree 中复制现有 Windows runtime 进行验证。运行时版本为
+`v2026.8.1`（构建记录中的上游提交为 `ea806575e6450e4d1efdfc72c19f04be982a1b9b`）。
+原工作区、原 runtime 和真实机器人配置未用于写入修复或启动测试。
+
+## 已修复
+
+### 钉钉：`@dingtalk-real-ai/dingtalk-connector@0.8.23`
+
+1. `dist/index.mjs` 的重复加载检测使用了
+   `typeof import.meta` 和 `import.meta?.url`。当前 Windows 插件加载路径进入
+   Jiti 2.7.0 后，只转换了直接访问的 `import.meta.url`，其余两种形式残留在
+   CommonJS 代码中，导致 `Cannot use 'import.meta' outside a module`。
+   改为 `String(import.meta.url)`，保留基于实际模块 URL 的重复加载检测，支持安装目录迁移。
+2. 延迟加载的 `dist/message-handler-*.mjs` 仍引用已移除的
+   `openclaw/plugin-sdk/channel-runtime`。即使入口加载成功，收到消息时仍会触发错误。
+   改为公开的 `channel-outbound`，继续使用原有 reply-prefix、typing 和错误日志函数。
+3. 同步修补发布包内的 `index.ts`、`src/reply-dispatcher.ts`，保持源码和 dist 一致。
+
+### 飞书：`@larksuite/openclaw-lark@2026.7.16`
+
+| 文件 | 原 SDK 路径 | 新 SDK 路径 | 影响 |
+| --- | --- | --- | --- |
+| `index.js` | `plugin-sdk` | `plugin-sdk/plugin-entry` | 恢复插件入口中的 `emptyPluginConfigSchema` |
+| `src/card/reply-dispatcher.js` | `plugin-sdk/channel-runtime` | `plugin-sdk/channel-reply-pipeline` | 恢复回复前缀和 typing 回调 |
+| `src/card/tool-use-config.js` | `plugin-sdk/config-runtime` | `plugin-sdk/session-store-runtime` | 恢复会话级 `/verbose` 设置读取 |
+
+路径均以 `openclaw/` 为前缀。最后一项原先会因 `loadSessionStore` /
+`resolveSessionStoreEntry` 已移出 `config-runtime` 而进入 catch，静默忽略会话设置。
+2026.8.1 的 `session-store-runtime` 仍公开兼容这组调用；已用真实 SQLite 会话数据验证。
+
+修复位于现有 `scripts/openclaw-plugin-patches/dingtalk.cjs` 和 `lark.cjs`，
+由 `ensure-openclaw-plugins.cjs` 在复制插件到 runtime 后执行。补丁可重复运行。
+没有修改全局 SDK bridge、OpenClaw loader、插件版本或其它 IM 的补丁。
+上游加载行为参见 [v2026.8.1 插件加载器](https://github.com/openclaw/openclaw/blob/v2026.8.1/src/plugins/loader-module-runtime.ts)。
+
+## 其它 IM：仅检查，未修改
+
+逐个按 `openclaw.plugin.json` 中的真实插件 ID，调用当前 runtime 的完整插件加载器，
+使用隔离配置完成模块加载和注册，不建立机器人连接、不收发消息。
+
+| IM | 真实插件 ID | 检查结果 |
+| --- | --- | --- |
+| 云信 NIM | `nimsuite-openclaw-nim-channel` | **复现同类错误**：`index.mjs` 引用 SDK 根入口，抛出 `ERR_PACKAGE_PATH_NOT_EXPORTED` |
+| 网易 Bee | `openclaw-netease-bee` | **复现同类错误**：`index.mjs` 引用 SDK 根入口，抛出 `ERR_PACKAGE_PATH_NOT_EXPORTED` |
+| QQ | `openclaw-qqbot` | 模块加载、频道注册通过 |
+| 企业微信 | `wecom-openclaw-plugin` | 模块加载、频道注册通过；其媒体 SDK 探测有 fallback，未判定为导出错误 |
+| 微信 | `openclaw-weixin` | 当前 `dist/index.js` 加载、频道注册通过 |
+| POPO | `moltbot-popo` | 模块加载、频道注册通过 |
+| 邮箱 | `email` | 模块加载、频道注册通过 |
+| Discord | `discord` | 模块加载、频道注册通过 |
+| Telegram | `telegram` | bundled 插件加载、频道注册通过 |
+
+另外记录，均未修改：
+
+- NIM、Bee 的 manifest 缺少 `channelConfigs`，新 loader 提示配置/设置界面能力可能受限。
+- 企业微信在本次最小配置下有 `before_prompt_build` hook 被拦截的提示，原因是未设置
+  `plugins.entries.wecom-openclaw-plugin.hooks.allowConversationAccess=true`。
+  这是 hook 权限迁移问题，不是本次的入口导出错误；需要结合产品实际权限意图另行确认。
+- 微信发布包的 `dist/src/messaging/model-callback-handler.js` 仍从 `config-runtime`
+  导入已移除的 `updateSessionStore`。包内未找到其它文件对该模块的引用，当前加载检查未触发它，
+  因此仅记录为遗留模块风险，不能据此认定当前微信频道不可用。
+- NIM 安装缓存标记为 Git `#1.1.1`，包内 `package.json` 自报 `1.0.3`；以上结论来自当前实际产物，
+  没有重新拉取或替换其它 IM 插件。
+
+## 验证和范围
+
+- Vitest：3 个测试文件、24 项测试通过，包括新增的 SDK 导出边界、延迟导入、路径迁移、
+  会话 verbose、幂等及不影响其它插件的回归用例。
+- 新增 TypeScript 测试文件通过 CI 规则的 ESLint，0 warning。
+- `compile:electron` 通过。
+- 实际 OpenClaw loader：修复前复现两条 QA 错误，修复后两个插件均为 `loaded`，
+  `diagnostics` 为空；飞书注册 29 个工具。
+- 实际 Jiti 2.7.0：钉钉入口注册和延迟消息处理模块均成功加载，注册 13 个 gateway 方法。
+- 实际 SDK + SQLite：飞书读取已保存的 `verboseLevel=full` 成功；内联 `/verbose off` 仍优先。
+- Electron 43.5.0 / Node 24.19.0 启动隔离 gateway，日志包含钉钉、飞书，`/healthz` 返回 HTTP 200。
+  使用 `OPENCLAW_SKIP_CHANNELS=1` 跳过真实连接，测试进程结束后已停止。
+
+使用原工作区的 `node_modules` junction 运行测试和编译，因此以 `npm --ignore-scripts`
+跳过会重建共享 `better-sqlite3` 的生命周期脚本，避免影响用户正在运行的 Electron。
+没有运行完整测试集，也没有用真实账号验证机器人连接、消息往返、群聊和卡片展示。
+
+隔离 worktree 的 `vendor/openclaw-runtime/current` 已指向应用补丁后的 runtime，可用于后续人工 QA。
+常规 `npm run openclaw:plugins` / runtime 构建流程会自动应用这两个补丁；
+已存在的其它工作区 runtime 需要重新应用补丁后重启 gateway，单独重启不会修改已安装插件文件。
+
+本地详细验证输出位于 worktree 的 `.work/im-compat/`（不纳入 Git）：
+`load-before.log`、`load-after.log`、`deferred-smoke.log`、`gateway-smoke.log`、
+`other-im-load.log` 和 `other-im-load-extra.log`。

--- a/tests/openclaw-im-sdk-compat.test.ts
+++ b/tests/openclaw-im-sdk-compat.test.ts
@@ -1,0 +1,150 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test } from 'vitest';
+
+const { patchDingtalk } = require('../scripts/openclaw-plugin-patches/dingtalk.cjs');
+const { patchLark } = require('../scripts/openclaw-plugin-patches/lark.cjs');
+
+const tempDirs: string[] = [];
+
+function writeFile(root: string, relativePath: string, content: string) {
+  const file = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+function createRuntime() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-im-sdk-'));
+  tempDirs.push(root);
+  // Model 2026.8.1's package boundary: the removed barrels are not exported.
+  writeFile(root, 'node_modules/openclaw/package.json', JSON.stringify({
+    name: 'openclaw',
+    exports: {
+      './plugin-sdk/plugin-entry': './plugin-entry.cjs',
+      './plugin-sdk/channel-outbound': './channel-outbound.cjs',
+      './plugin-sdk/channel-reply-pipeline': './channel-outbound.cjs',
+      './plugin-sdk/session-store-runtime': './session-store.cjs',
+    },
+  }));
+  writeFile(root, 'node_modules/openclaw/plugin-entry.cjs',
+    'exports.emptyPluginConfigSchema = () => ({ type: "object", additionalProperties: false });');
+  writeFile(root, 'node_modules/openclaw/channel-outbound.cjs', [
+    'exports.createReplyPrefixContext = () => "prefix";',
+    'exports.createReplyPrefixOptions = () => "options";',
+    'exports.createTypingCallbacks = () => "typing";',
+    'exports.logTypingFailure = () => "failure";',
+  ].join('\n'));
+  writeFile(root, 'node_modules/openclaw/session-store.cjs', [
+    'exports.resolveStorePath = () => "sessions.json";',
+    'exports.loadSessionStore = () => ({ "agent:main:feishu": { verboseLevel: "full" } });',
+    'exports.resolveSessionStoreEntry = ({ store, sessionKey }) => ({ existing: store[sessionKey] });',
+  ].join('\n'));
+  return root;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('DingTalk and Lark OpenClaw SDK compatibility', () => {
+  test('keeps DingTalk load-path detection portable and loads its deferred reply helpers', () => {
+    const root = createRuntime();
+    const pluginDir = path.join(root, 'dingtalk-connector');
+    const entrySource = [
+      'export function recordPath(paths) {',
+      '  const here = typeof import.meta !== "undefined" && import.meta?.url ? String(import.meta.url) : "<unknown>";',
+      '  paths.add(here);',
+      '  return paths.size;',
+      '}',
+      'export const loadReply = () => import("./message-handler-test.mjs");',
+    ].join('\n');
+    const replySource = [
+      'const { createReplyPrefixOptions, createTypingCallbacks, logTypingFailure } = await import("openclaw/plugin-sdk/channel-runtime");',
+      'export const reply = () => [createReplyPrefixOptions(), createTypingCallbacks(), logTypingFailure()];',
+    ].join('\n');
+    writeFile(pluginDir, 'index.ts', entrySource);
+    writeFile(pluginDir, 'dist/index.mjs', entrySource);
+    writeFile(pluginDir, 'src/reply-dispatcher.ts', replySource);
+    writeFile(pluginDir, 'dist/message-handler-test.mjs', replySource);
+    const context = { runtimeExtensionsDir: root, log: () => {} };
+    patchDingtalk(context);
+    const patchedEntry = fs.readFileSync(path.join(pluginDir, 'dist/index.mjs'), 'utf8');
+    // Jiti supports direct import.meta.url, but cannot lower these two forms.
+    expect(patchedEntry).not.toContain('typeof import.meta');
+    expect(patchedEntry).not.toContain('import.meta?');
+    expect(patchedEntry).toContain('String(import.meta.url)');
+    expect(fs.readFileSync(path.join(pluginDir, 'index.ts'), 'utf8')).toBe(patchedEntry);
+    const patchedReply = fs.readFileSync(path.join(pluginDir, 'dist/message-handler-test.mjs'), 'utf8');
+    expect(fs.readFileSync(path.join(pluginDir, 'src/reply-dispatcher.ts'), 'utf8')).toBe(patchedReply);
+    patchDingtalk(context);
+    expect(fs.readFileSync(path.join(pluginDir, 'dist/index.mjs'), 'utf8')).toBe(patchedEntry);
+    expect(fs.readFileSync(path.join(pluginDir, 'dist/message-handler-test.mjs'), 'utf8')).toBe(patchedReply);
+
+    // Move the prepared package: module identity must follow its new location.
+    const relocatedDir = path.join(root, 'relocated-dingtalk');
+    fs.renameSync(pluginDir, relocatedDir);
+    const check = spawnSync(process.execPath, ['--input-type=module', '-e', [
+      'import { pathToFileURL } from "node:url";',
+      'import assert from "node:assert/strict";',
+      'const url = pathToFileURL(process.argv[1]).href;',
+      'const entry = await import(url);',
+      'const paths = new Set();',
+      'assert.equal(entry.recordPath(paths), 1);',
+      'assert.equal(entry.recordPath(paths), 1);',
+      'assert.deepEqual([...paths], [url]);',
+      'assert.deepEqual((await entry.loadReply()).reply(), ["options", "typing", "failure"]);',
+    ].join('\n'), path.join(relocatedDir, 'dist/index.mjs')], { encoding: 'utf8' });
+    expect(check.stderr).toBe('');
+    expect(check.status).toBe(0);
+  });
+
+  test('loads Lark registration, reply callbacks and saved verbose state without legacy SDK exports', () => {
+    const root = createRuntime();
+    const pluginDir = path.join(root, 'openclaw-lark');
+    const entry = writeFile(pluginDir, 'index.js', [
+      'const plugin_sdk_1 = require("openclaw/plugin-sdk");',
+      'exports.configSchema = plugin_sdk_1.emptyPluginConfigSchema();',
+      'exports.reply = require("./src/card/reply-dispatcher.js").reply;',
+      'exports.verbose = require("./src/card/tool-use-config.js").verbose;',
+    ].join('\n'));
+    const reply = writeFile(pluginDir, 'src/card/reply-dispatcher.js', [
+      'const channel_runtime_1 = require("openclaw/plugin-sdk/channel-runtime");',
+      'exports.reply = () => [channel_runtime_1.createReplyPrefixContext(), channel_runtime_1.createTypingCallbacks()];',
+    ].join('\n'));
+    const verbose = writeFile(pluginDir, 'src/card/tool-use-config.js', [
+      'const config_runtime_1 = require("openclaw/plugin-sdk/config-runtime");',
+      'exports.verbose = (sessionKey) => {',
+      '  const storePath = config_runtime_1.resolveStorePath();',
+      '  const store = config_runtime_1.loadSessionStore(storePath);',
+      '  return config_runtime_1.resolveSessionStoreEntry({ store, sessionKey }).existing?.verboseLevel;',
+      '};',
+    ].join('\n'));
+    const unrelated = writeFile(root, 'another-plugin/index.js', 'require("openclaw/plugin-sdk");');
+    const context = { runtimeExtensionsDir: root, log: () => {} };
+    patchLark(context);
+    const firstPass = [entry, reply, verbose].map(file => fs.readFileSync(file, 'utf8'));
+    patchLark(context);
+    expect([entry, reply, verbose].map(file => fs.readFileSync(file, 'utf8'))).toEqual(firstPass);
+    expect(fs.readFileSync(unrelated, 'utf8')).toBe('require("openclaw/plugin-sdk");');
+
+    const plugin = createRequire(entry)(entry);
+    expect(plugin.configSchema).toEqual({ type: 'object', additionalProperties: false });
+    expect(plugin.reply()).toEqual(['prefix', 'typing']);
+    expect(plugin.verbose('agent:main:feishu')).toBe('full');
+    expect(plugin.verbose('missing')).toBeUndefined();
+  });
+
+  test('skips SDK compatibility changes when the two plugins are absent', () => {
+    const root = createRuntime();
+    const before = fs.readdirSync(root);
+    const context = { runtimeExtensionsDir: root, log: () => {} };
+    patchDingtalk(context);
+    patchLark(context);
+    expect(fs.readdirSync(root)).toEqual(before);
+  });
+});


### PR DESCRIPTION
## Summary

Restore DingTalk and Lark plugin compatibility after upgrading the bundled OpenClaw runtime to v2026.8.1. DingTalk currently fails in the Windows Jiti loader with `Cannot use 'import.meta' outside a module`, and Lark fails because the SDK root entry is no longer exported.

## Related Issue

QA report; no linked issue.

## Changes Made

- Patch DingTalk's module URL expression into a form supported by Jiti and migrate its deferred reply imports to `channel-outbound`, keeping the published source and distribution files consistent.
- Move Lark's entry, reply pipeline, and session-store imports to the public SDK subpaths. This also restores saved session `/verbose` settings that previously failed silently.
- Add regression coverage for SDK exports, deferred loading, installation directory relocation, session settings, and idempotent patching. Document the compatibility audit of the other IM plugins.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Testing

- [x] Targeted Vitest suite: 3 files, 24 tests passed.
  `npm --ignore-scripts test -- tests/openclaw-im-sdk-compat.test.ts tests/openclaw-plugin-patches-dingtalk.test.ts tests/ensure-openclaw-plugins.test.ts`
- [x] Added regression tests; changed-file ESLint passed with zero warnings.
- [x] `npm --ignore-scripts run compile:electron` passed.
- [x] Reproduced both failures with the actual runtime loader, then verified both plugins load after patching. Verified DingTalk's deferred message handler with Jiti 2.7.0 and Lark's saved session settings with the actual SDK and SQLite.
- [x] Started an isolated gateway under Electron 43.5.0 / Node 24.19.0; `/healthz` returned HTTP 200. Real channel connections were skipped.

The full test suite and real-bot message round trips were not run. Lifecycle scripts were skipped to avoid rebuilding the shared workspace's native dependencies.

## Screenshots (if applicable)

Not applicable; no UI changes.

## Checklist

- [x] Code follows the project's style guidelines and has been self-reviewed.
- [x] Compatibility behavior is documented and regression tests cover the fixes.
- [x] Targeted new and existing tests pass locally; changed-file lint produces no warnings.

## Electron-Specific Changes

The existing runtime packaging hooks patch installed third-party plugin files. Existing runtime installations need `npm run openclaw:plugins` or a runtime rebuild, followed by a gateway restart, to receive the fixes.

## Additional Notes

This PR contains only the DingTalk/Lark fixes and the IM compatibility audit. NIM and NetEase Bee were found to have the same removed SDK root import; their follow-up fixes are outside this PR. See `specs/refactors/openclaw-upgrade/2026-09-08-im-plugin-compatibility.md` for the other IM results and remaining findings.
