### PR TITLE
fix(openclaw): update Discord DM config for gateway startup

### DIFF
--- a/specs/bugfixes/openclaw-discord-config-startup/2026-09-09-discord-config-startup-fix.md
+++ b/specs/bugfixes/openclaw-discord-config-startup/2026-09-09-discord-config-startup-fix.md
@@ -1,0 +1,98 @@
+# OpenClaw 2026.8.1 Discord 配置导致网关启动失败
+
+## 结论
+
+当前截图中的启动失败由 LobsterAI 生成的 Discord 旧配置字段触发，已在配置同步层修复。
+这不是 Windows 专有分支：macOS 截图中的错误路径也指向相同字段。
+
+Windows 日志还暴露了一个独立问题：`openclaw.json.lock` 是长期残留的零字节文件。
+已在隔离环境复现它导致配置写入超时，但它不是本次 Discord schema 报错的原因。
+本次代码变更不自动清除所有者不明的锁；该机器还需要在所有相关进程退出后，备份残留空锁并复测配置写入。
+
+## 证据与失败链路
+
+输入：
+
+- [PR #2625](https://github.com/netease-youdao/LobsterAI/pull/2625)。此前已改为官方 session SQLite 导入命令，并增加配置锁和旧会话文件诊断。
+- [QA 日志包](https://ydschool-video.nosdn.127.net/1788869245354lobsterai-logs-20260908-200605.zip)。以下行号对应解压后的 `main-2026-09-08.log`。
+- 当前分支 `feat/openclaw-v2026.8.1`，分析起点 `b0ef93ae2`。
+- 本地 runtime：`v2026.8.1`，上游提交 `ea806575e6450e4d1efdfc72c19f04be982a1b9b`，Discord 插件 `@openclaw/discord@2026.8.1`。
+
+19:37—20:04 的六次新增诊断记录中，官方 doctor 均退出为 1。典型记录：
+
+| 日志位置 | 内容 | 含义 |
+| --- | --- | --- |
+| 142873—142885，19:37:05 | doctor 退出 1；两个 Discord 账户的 `dm` 不允许 `policy`、`allowFrom` | CLI 的配置校验先失败 |
+| 149326—149349，20:04:08 | 同样的 schema 错误；JSON 结果为 `cli_error` | 并非已完成会话迁移后才报错 |
+| 149385—149409，20:04:12 | 重试约 3.9 秒后失败；17 份旧会话文件的诊断元数据前后完全一致 | 该次尝试没有迁移这些旧会话文件 |
+| 149383、149408 | `.lock` 为 0 字节，修改时间为 9 月 7 日 20:45:01，无法读取 PID，`.reclaim` 不存在 | 另有持续存在的无所有者信息锁 |
+
+实际失败链路：
+
+1. 启动先由 `OpenClawConfigSync.sync()` 从本地 IM 设置生成 `openclaw.json`。
+2. Discord 账户仍使用旧写法：
+
+   ```json
+   { "dm": { "policy": "open", "allowFrom": ["*"] } }
+   ```
+
+3. 新版 Discord 发布包的 `openclaw.plugin.json` 中，`channelConfigs.discord.schema` 严格校验 `dm`：只允许 `enabled`、`groupEnabled`、`groupChannels`。
+4. `doctor --session-sqlite import --session-sqlite-all-agents --json` 在配置预检阶段退出，LobsterAI 随之阻止网关启动。
+5. 原“一键修复”重建配置时仍执行同一段旧字段生成逻辑，因此重试和重建都无法解决。
+
+上游源码的 Discord Zod schema 虽然包含旧字段预处理逻辑，但发布包的 JSON schema 预检会更早拒绝这些字段。
+因此验证必须包含实际发布插件与 CLI，不能仅直接调用源码 Zod schema。
+
+## 修复范围
+
+`src/main/libs/openclawConfigSync.ts` 改为在账户层输出：
+
+```json
+{ "dmPolicy": "open", "allowFrom": ["*"] }
+```
+
+- 先求有效 `dmPolicy`，再生成白名单；旧记录缺省策略时，默认 `open` 也会补上 `*`。
+- 显式 `allowlist`、`pairing`、`disabled` 保持原策略；不向限制策略额外加入通配符。
+- 配置重写替换所有启用账户的旧字段，停用账户被移除，重复同步保持稳定。
+- 账户 ID、名称、token 环境变量索引、guild 设置保持一致。
+- 在 `src/main/im/types.ts` 集中定义 `DiscordDmPolicy`，供默认配置、同步逻辑及测试使用。
+
+没有修改上游源码、runtime 产物、会话存储或迁移命令，也没有引入上游补丁。
+
+## 空锁问题与恢复
+
+在相同 runtime 下，向隔离配置旁放置一个修改时间为一天前的零字节 `.lock`：
+
+- 修正 Discord 配置后，官方会话迁移仍能成功。
+- 网关 bundle 能启动；健康接口和历史消息 RPC 可以工作。
+- `config set logging.level debug` 在约 22—23 秒后报 `file lock timeout`。
+- 停止该隔离环境的所有 CLI/网关进程后，将空锁改名备份，再执行相同配置写入，退出码为 0。
+
+上游 `src/infra/stale-lock-file.ts` 与 `src/plugin-sdk/file-lock.test.ts` 明确保留所有者不明的锁。
+锁文件是在写入 PID 之前创建的，仅凭文件年龄无法排除暂停中的写入者；本次不把这种保护改成自动删除。
+日志也不足以确定是谁、因何留下了最初的零字节锁。
+
+该 QA Windows 机器的恢复步骤：
+
+1. 完全退出 LobsterAI，并确认相关 OpenClaw 网关、doctor 和 CLI 进程均已结束。不要在网关运行或迁移过程中处理锁。
+2. 检查 `%APPDATA%\LobsterAI\openclaw\state\openclaw.json.lock`，确认仍是日志中对应的零字节普通文件。
+3. 将该文件改名为不冲突的备份名称，例如 `openclaw.json.lock.backup-20260909`。保留备份，不改动 SQLite、旧会话 JSON 或 transcript。
+4. 安装包含本次配置修复的新包并启动；确认迁移完成、网关启动正常，随后在 UI 修改一项配置，核对不再出现 `file lock timeout`。
+
+如果锁含有效 PID、内容发生变化或仍有相关进程，应先调查所有者，不能照搬空锁恢复步骤。
+现有“一键修复”只备份 `openclaw.json`，不会处理这个独立的 `.lock` 文件。
+
+## 验证
+
+- 修复前：8 个新增/扩展的 Discord 回归用例失败；实际 CLI 重现与 QA 相同的 `additional properties` 错误。
+- 修复后：`npm test -- src/main/libs/openclawConfigSync src/main/libs/openclawSessionLegacyMigration src/main/libs/openclawEngineManager`，6 个测试文件、157 项测试全部通过。
+- 三个变更 TypeScript 文件的 CI 同等 ESLint 检查通过；`npm run compile:electron` 通过。
+- 使用实际 Windows Electron 可执行文件、当前 gateway bundle、发布版 Discord 插件和临时隔离数据目录验证：
+  - 用真实 `OpenClawConfigSync` 生成双账户配置；旧格式校验退出 1，重写后退出 0。
+  - 官方迁移成功导入并归档 main 与已移除 agent 的两份合成旧会话存储；配置文件内容未被迁移器改写。
+  - `/healthz` 返回 HTTP 200；`sessions.list` 保留原 UUID；`chat.history` 返回原历史消息。
+  - 空锁写入超时和停机备份后的恢复均已复现。
+
+隔离启动设置 `OPENCLAW_SKIP_CHANNELS=1`，未连接真实 Discord 账户或调用真实模型。
+尚需 QA 在 Windows/macOS 原机器使用新包验证完整插件启动、原始历史数据、真实 IM 收发和配置写入。
+本次没有生成安装包，也未创建提交。

--- a/src/main/im/types.ts
+++ b/src/main/im/types.ts
@@ -192,10 +192,18 @@ export interface DiscordOpenClawGuildConfig {
   systemPrompt?: string;
 }
 
+export const DiscordDmPolicy = {
+  Pairing: 'pairing',
+  Allowlist: 'allowlist',
+  Open: 'open',
+  Disabled: 'disabled',
+} as const;
+export type DiscordDmPolicy = typeof DiscordDmPolicy[keyof typeof DiscordDmPolicy];
+
 export interface DiscordOpenClawConfig {
   enabled: boolean;
   botToken: string;
-  dmPolicy: 'pairing' | 'allowlist' | 'open' | 'disabled';
+  dmPolicy: DiscordDmPolicy;
   allowFrom: string[];
   groupPolicy: 'allowlist' | 'open' | 'disabled';
   groupAllowFrom: string[];
@@ -769,7 +777,7 @@ export const DEFAULT_FEISHU_OPENCLAW_CONFIG: FeishuOpenClawConfig = {
 export const DEFAULT_DISCORD_OPENCLAW_CONFIG: DiscordOpenClawConfig = {
   enabled: false,
   botToken: '',
-  dmPolicy: 'open',
+  dmPolicy: DiscordDmPolicy.Open,
   allowFrom: [],
   groupPolicy: 'allowlist',
   groupAllowFrom: [],

--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -9,7 +9,7 @@ import {
   BrowserCredentialMcpServer,
 } from '../../shared/browserCredentials/constants';
 import { OpenClawProviderId, ProviderName } from '../../shared/providers';
-import { DEFAULT_QQ_CONFIG } from '../im/types';
+import { DEFAULT_DISCORD_OPENCLAW_CONFIG, DEFAULT_QQ_CONFIG, DiscordDmPolicy } from '../im/types';
 import { OpenClawAgentOwnership } from './openclawAgentModels';
 import { OpenClawQQPlugin, QQ_APPROVALS_DISABLED } from './openclawQQConfig';
 
@@ -26,6 +26,7 @@ vi.mock('electron', () => ({
 
 const mockRuntimeState = vi.hoisted(() => ({
   proxyPort: null as number | null,
+  thirdPartyExtensionsDir: null as string | null,
   modelCompatPluginAvailable: true,
   serverModels: [] as Array<{
     modelId: string;
@@ -111,7 +112,7 @@ vi.mock('./claudeSettings', () => ({
 
 vi.mock('./openclawLocalExtensions', () => ({
   findBundledExtensionsDir: () => null,
-  findThirdPartyExtensionsDir: () => null,
+  findThirdPartyExtensionsDir: () => mockRuntimeState.thirdPartyExtensionsDir,
   hasBundledOpenClawExtension: (id: string) => (
     id !== 'qwen-portal-auth'
     && (id !== 'lobsterai-model-compat' || mockRuntimeState.modelCompatPluginAvailable)
@@ -139,6 +140,7 @@ describe('OpenClawConfigSync runtime config output', () => {
 
   beforeEach(() => {
     mockRuntimeState.proxyPort = null;
+    mockRuntimeState.thirdPartyExtensionsDir = null;
     mockRuntimeState.modelCompatPluginAvailable = true;
     mockRuntimeState.serverModels = [];
     mockRuntimeState.enabledProviders = [];
@@ -350,14 +352,22 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(config.meta.lastTouchedAt).toBeUndefined();
   });
 
-  test.runIf(fs.existsSync(path.resolve('vendor/openclaw-runtime/current/openclaw.mjs')))(
-    'passes validation from the pinned OpenClaw runtime',
-    async () => {
-      const sync = await createSync();
+  test.runIf(fs.existsSync(path.resolve('vendor/openclaw-runtime/current/openclaw.mjs'))).each([false, true])(
+    'passes validation from the pinned OpenClaw runtime (Discord enabled: %s)',
+    async (discordEnabled) => {
+      const runtimeRoot = path.resolve('vendor/openclaw-runtime/current');
+      if (discordEnabled) {
+        mockRuntimeState.thirdPartyExtensionsDir = path.join(runtimeRoot, 'third-party-extensions');
+      }
+      const sync = await createSync({
+        getDiscordInstances: () => discordEnabled ? [{
+          ...DEFAULT_DISCORD_OPENCLAW_CONFIG,
+          enabled: true, botToken: 'discord-test-token', instanceId: 'discord1', instanceName: 'Discord',
+        }] : [],
+      });
       const result = sync.sync('pinned-runtime-schema-validation');
       expect(result.ok).toBe(true);
 
-      const runtimeRoot = path.resolve('vendor/openclaw-runtime/current');
       const validation = spawnSync(
         process.execPath,
         [path.join(runtimeRoot, 'openclaw.mjs'), 'config', 'validate'],
@@ -369,6 +379,7 @@ describe('OpenClawConfigSync runtime config output', () => {
             OPENCLAW_STATE_DIR: stateDir,
             OPENCLAW_HOME: tmpDir,
             OPENCLAW_GATEWAY_TOKEN: 'gateway-token',
+            ...sync.collectSecretEnvVars(),
           },
           encoding: 'utf8',
           timeout: 60_000,
@@ -381,6 +392,62 @@ describe('OpenClawConfigSync runtime config output', () => {
     },
     90_000,
   );
+
+  test.each([
+    { dmPolicy: undefined, allowFrom: [], expectedPolicy: DiscordDmPolicy.Open, expectedAllowFrom: ['*'] },
+    { dmPolicy: DiscordDmPolicy.Open, allowFrom: ['123'], expectedPolicy: DiscordDmPolicy.Open, expectedAllowFrom: ['123', '*'] },
+    { dmPolicy: DiscordDmPolicy.Open, allowFrom: ['*'], expectedPolicy: DiscordDmPolicy.Open, expectedAllowFrom: ['*'] },
+    { dmPolicy: DiscordDmPolicy.Allowlist, allowFrom: ['123'], expectedPolicy: DiscordDmPolicy.Allowlist, expectedAllowFrom: ['123'] },
+    { dmPolicy: DiscordDmPolicy.Pairing, allowFrom: [], expectedPolicy: DiscordDmPolicy.Pairing, expectedAllowFrom: [] },
+    { dmPolicy: DiscordDmPolicy.Disabled, allowFrom: [], expectedPolicy: DiscordDmPolicy.Disabled, expectedAllowFrom: [] },
+  ])('writes Discord account DM policy without legacy aliases: $dmPolicy / $allowFrom', async ({
+    dmPolicy, allowFrom, expectedPolicy, expectedAllowFrom,
+  }) => {
+    const originalAllowFrom = [...allowFrom];
+    const sync = await createSync({
+      getDiscordInstances: () => [{
+        ...DEFAULT_DISCORD_OPENCLAW_CONFIG,
+        enabled: true, botToken: 'discord-test-token', instanceId: 'discord1', instanceName: 'Discord',
+        dmPolicy, allowFrom,
+      }],
+    });
+    expect(sync.sync('discord-dm-policy').ok).toBe(true);
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.channels.discord.accounts.discord1).toMatchObject({
+      dmPolicy: expectedPolicy, allowFrom: expectedAllowFrom,
+    });
+    expect(config.channels.discord.accounts.discord1).not.toHaveProperty('dm');
+    expect(allowFrom).toEqual(originalAllowFrom);
+  });
+
+  test('replaces legacy Discord DM config for every enabled account on upgrade and resync', async () => {
+    const instances = ['discord1-long', 'discord2-long', 'disabled-long'].map((instanceId, index) => ({
+      ...DEFAULT_DISCORD_OPENCLAW_CONFIG,
+      enabled: index < 2, botToken: `discord-test-token-${index}`, instanceId, instanceName: instanceId,
+      dmPolicy: DiscordDmPolicy.Allowlist, allowFrom: [String(123 + index)],
+    }));
+    fs.writeFileSync(configPath, JSON.stringify({ channels: { discord: { accounts: {
+      discord1: { dm: { policy: DiscordDmPolicy.Open, allowFrom: ['*'] } },
+      discord2: { dm: { policy: DiscordDmPolicy.Open, allowFrom: ['*'] } },
+      disabled: { dm: { policy: DiscordDmPolicy.Open, allowFrom: ['*'] } },
+    } } } }));
+    const sync = await createSync({ getDiscordInstances: () => instances });
+    expect(sync.sync('discord-upgrade')).toMatchObject({ ok: true, changed: true });
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(Object.keys(config.channels.discord.accounts)).toEqual(['discord1', 'discord2']);
+    for (const [index, account] of Object.values(config.channels.discord.accounts).entries()) {
+      expect(account).toMatchObject({
+        name: instances[index].instanceName, dmPolicy: DiscordDmPolicy.Allowlist, allowFrom: instances[index].allowFrom,
+        guilds: DEFAULT_DISCORD_OPENCLAW_CONFIG.guilds,
+        token: index === 0 ? '${LOBSTER_DC_BOT_TOKEN}' : '${LOBSTER_DC_BOT_TOKEN_1}',
+      });
+      expect(account).not.toHaveProperty('dm');
+    }
+    expect(sync.collectSecretEnvVars()).toMatchObject({
+      LOBSTER_DC_BOT_TOKEN: instances[0].botToken, LOBSTER_DC_BOT_TOKEN_1: instances[1].botToken,
+    });
+    expect(sync.sync('discord-resync')).toMatchObject({ ok: true, changed: false });
+  });
 
   test('strips plugin-index-managed plugins.installs while preserving other plugins keys', async () => {
     // A leaked plugins.installs on disk poisons config.set hot delivery

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -46,6 +46,7 @@ import type { ModelThinkingConfig } from '../../shared/providers/modelThinking';
 import type { Agent, CoworkConfig, CoworkExecutionMode } from '../coworkStore';
 import type { DiscordInstanceConfig, IMSettings, TelegramInstanceConfig } from '../im/types';
 import type { DingTalkInstanceConfig, EmailMultiInstanceConfig, FeishuInstanceConfig, NeteaseBeeChanConfig, NimInstanceConfig, PopoInstanceConfig, QQInstanceConfig, WecomInstanceConfig, WeixinOpenClawConfig } from '../im/types';
+import { DiscordDmPolicy } from '../im/types';
 import { OpenClawSessionKeepAlive } from '../openclawSessionPolicy/constants';
 import { buildOpenClawSessionConfig } from '../openclawSessionPolicy/store';
 import {
@@ -2796,18 +2797,19 @@ export class OpenClawConfigSync {
       for (let idx = 0; idx < enabledDiscordInstances.length; idx++) {
         const inst = enabledDiscordInstances[idx];
         const tokenVar = idx === 0 ? 'LOBSTER_DC_BOT_TOKEN' : `LOBSTER_DC_BOT_TOKEN_${idx}`;
+        const dmPolicy = inst.dmPolicy || DiscordDmPolicy.Open;
         const account: Record<string, unknown> = {
           enabled: true,
           name: inst.instanceName,
           token: `\${${tokenVar}}`,
-          dm: {
-            policy: inst.dmPolicy || 'open',
-            allowFrom: (() => {
-              const ids = inst.allowFrom?.length ? [...inst.allowFrom] : [];
-              if (inst.dmPolicy === 'open' && !ids.includes('*')) ids.push('*');
-              return ids;
-            })(),
-          },
+          // v2026.8.1 validates the published plugin schema before doctor can
+          // normalize legacy dm.policy/dm.allowFrom aliases.
+          dmPolicy,
+          allowFrom: (() => {
+            const ids = inst.allowFrom?.length ? [...inst.allowFrom] : [];
+            if (dmPolicy === DiscordDmPolicy.Open && !ids.includes('*')) ids.push('*');
+            return ids;
+          })(),
           groupPolicy: inst.groupPolicy || 'allowlist',
           guilds: (() => {
             const guilds: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

升级到 OpenClaw v2026.8.1 后，Discord 发布插件的 schema 会拒绝账户下旧的 `dm.policy` / `dm.allowFrom`，使启动前的会话迁移 CLI 退出，网关无法启动；一键修复重建配置时也会再次生成相同的无效字段。

本 PR 在 LobsterAI 配置同步层改为输出账户顶层的 `dmPolicy` / `allowFrom`，使已有 IM 设置在下次启动同步时生成符合新版 schema 的配置。

## Related Issue

关联此前启动诊断与会话迁移修复：#2625。

## Changes Made

- 更新 Discord 私信配置字段位置，统一使用有效的私信策略计算白名单；缺省策略为 open 时补充 `*`，保留其他策略的限制。
- 增加策略、多账户旧配置重写、停用账户移除及重复同步稳定性覆盖，并使用当前发布 runtime 的实际 CLI 验证配置。
- 记录 QA 日志根因、隔离验证和独立残留配置锁问题。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [x] Manual testing performed — 隔离目录中的实际 Electron/CLI/gateway 验证；未连接真实 IM 账户。

本分支验证结果：

- `npm test -- src/main/libs/openclawConfigSync src/main/libs/openclawSessionLegacyMigration src/main/libs/openclawEngineManager`：6 个文件、157 项测试通过。
- 3 个变更 TypeScript 文件的 CI 同等 ESLint 检查通过。
- `npm run compile:electron` 通过。
- 实际 Windows runtime 验证：旧 Discord 配置校验失败，重写后通过；main 与已移除 agent 的合成旧会话成功迁移；网关健康检查、会话 UUID 与历史消息 RPC 验证通过。

## Screenshots (if applicable)

无 UI 变更。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes — 见上述定向测试范围。

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management

启动配置同步会重写 Discord 的旧私信字段；未修改 OpenClaw 上游、会话存储或 runtime 产物。

## Additional Notes

QA 日志还存在独立的零字节 `openclaw.json.lock`。隔离验证中，修正 Discord 后保留空锁也能迁移会话、启动网关并读取历史，但 OpenClaw 配置写入仍会超时。该锁不会由本 PR 或现有一键修复自动恢复，原机完整恢复仍需确认相关进程退出后备份空锁，或另行实现受控恢复。

另行审查发现的 Discord guild 配置兼容问题未包含在本 PR。仍需 QA 使用新包验证原机器的完整插件启动及真实 IM 收发。
