### PR TITLE
fix(i18n): refresh About update label when switching languages

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1661,7 +1661,7 @@ const Settings: React.FC<SettingsProps> = ({
     }
   }, [appVersion, authUser, updateCheckStatus, onUpdateFound]);
 
-  const updateButtonLabel = useMemo(() => {
+  const updateButtonLabel = (() => {
     if (
       updateCheckStatus === 'downloading' &&
       appUpdateState?.progress?.percent != null &&
@@ -1675,7 +1675,7 @@ const Settings: React.FC<SettingsProps> = ({
     if (updateCheckStatus === 'upToDate') return i18nService.t('updateUpToDate');
     if (updateCheckStatus === 'error') return i18nService.t('updateCheckFailed');
     return i18nService.t('checkForUpdate');
-  }, [appUpdateState?.progress?.percent, updateCheckStatus]);
+  })();
 
   const handleOpenUserManual = useCallback(() => {
     reportAboutAction('open_user_manual', 'success');


### PR DESCRIPTION
## Summary
Switching Settings from Chinese to English could leave the About update button displaying `检查更新`. Its translated label was memoized without a language dependency.

Calculate the label on each render so the existing translations follow the active language for both the idle button and update status messages. This is a two-line change in `Settings.tsx`.

## Testing
- [x] Changed-file ESLint with `--report-unused-disable-directives --max-warnings 0`.
- [x] `npx --no-install vitest run src/renderer/services/i18nRepair.test.ts src/renderer/components/update` — 9 files, 38 tests passed.
- [x] `npm run build` — TypeScript, renderer, and Electron bundles passed.
- [x] `git diff --check`.
- [ ] Manual Chinese ↔ English switching: an isolated Electron/Vite session was launched, but UI automation was stopped before completing the language-switch check.

## Screenshots
Not captured for the final English state because the interactive verification session was interrupted.

## Electron-Specific Changes
None. The change only recalculates renderer text; update IPC and runtime behavior are unchanged.