### PR TITLE
fix(openclaw): bundle Discord with trusted plugin origin

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
       {
         "id": "discord",
         "npm": "@openclaw/discord",
-        "version": "2026.8.1"
+        "version": "2026.8.1",
+        "runtimeBundled": true
       },
       {
         "id": "wecom-openclaw-plugin",

--- a/scripts/electron-builder-hooks.cjs
+++ b/scripts/electron-builder-hooks.cjs
@@ -8,7 +8,13 @@ const { OPENCLAW_BUNDLE_ASSET_TARGETS } = require('./openclaw-bundle-assets.cjs'
 const { ensurePortablePythonRuntime, checkRuntimeHealth } = require('./setup-python-runtime.js');
 const { syncLocalOpenClawExtensions } = require('./sync-local-openclaw-extensions.cjs');
 const { packMultipleSources } = require('./pack-openclaw-tar.cjs');
-const { DIST_DIFFS_EXTENSION_DIR, DIST_EXTENSIONS_DIR, summarizeGatewayAsarEntries } = require('./openclaw-runtime-packaging.cjs');
+const {
+  DIST_DIFFS_EXTENSION_DIR,
+  DIST_EXTENSIONS_DIR,
+  resolvePreinstalledPluginDir,
+  summarizeGatewayAsarEntries,
+  verifyRuntimeBundledPlugin,
+} = require('./openclaw-runtime-packaging.cjs');
 const { collectHostPeerLeftovers, measureDirectorySize } = require('./openclaw-plugin-host-peer-leftovers.cjs');
 const { verifyOpenClawPluginSdkBridge } = require('./openclaw-plugin-sdk-bridge.cjs');
 const { createOpenClawWindowsPayload } = require('./openclaw-windows-payload.cjs');
@@ -111,9 +117,11 @@ function verifyPreinstalledPlugins(runtimeRoot, buildHint) {
 
   for (const plugin of plugins) {
     if (!plugin.id) continue;
-    const pluginDir = path.join(extensionsDir, plugin.id);
+    const pluginDir = resolvePreinstalledPluginDir(runtimeRoot, plugin);
     if (!existsSync(pluginDir)) {
       missing.push(plugin.id);
+    } else {
+      verifyRuntimeBundledPlugin(runtimeRoot, plugin);
     }
   }
 
@@ -125,7 +133,11 @@ function verifyPreinstalledPlugins(runtimeRoot, buildHint) {
     );
   }
 
-  verifyNoHostPeerLeftovers(extensionsDir, plugins);
+  verifyNoHostPeerLeftovers(extensionsDir, plugins.filter(plugin => plugin.runtimeBundled !== true));
+  verifyNoHostPeerLeftovers(
+    path.join(runtimeRoot, DIST_EXTENSIONS_DIR),
+    plugins.filter(plugin => plugin.runtimeBundled === true),
+  );
 
   console.log(`[electron-builder-hooks] Verified ${plugins.length} preinstalled OpenClaw plugin(s).`);
 }

--- a/scripts/ensure-openclaw-plugins.cjs
+++ b/scripts/ensure-openclaw-plugins.cjs
@@ -16,7 +16,8 @@
  *   3. Installs via `openclaw plugins install` if not cached at the right version
  *   4. Removes any dependency tree that only served the openclaw peer, then
  *      caches the plugin
- *   5. Copies the plugin into vendor/openclaw-runtime/current/third-party-extensions/{id}/
+ *   5. Copies into third-party-extensions/{id}, or dist/extensions/{id} for
+ *      explicitly reviewed official runtimeBundled packages
  *
  * Environment variables:
  *   OPENCLAW_SKIP_PLUGINS          – Set to "1" to skip this script entirely
@@ -40,6 +41,7 @@ const {
 const { prepareHostPeerPackage } = require('./openclaw-plugin-preparers/host-peer.cjs');
 const { QQ_PACKAGE_NAME, configureQQRuntimeEntry, prepareQQPackage } = require('./openclaw-plugin-preparers/qqbot.cjs');
 const { pruneHostPeerLeftovers } = require('./openclaw-plugin-host-peer-leftovers.cjs');
+const { resolvePreinstalledPluginDir, verifyRuntimeBundledPlugin } = require('./openclaw-runtime-packaging.cjs');
 
 const OPENCLAW_PLUGIN_INSTALL_TIMEOUT_MS = process.platform === 'win32'
   ? 20 * 60 * 1000
@@ -618,6 +620,22 @@ function buildOpenClawPluginInstallArgs(installSpec) {
 // Main
 // ---------------------------------------------------------------------------
 
+function copyPreinstalledPluginToRuntime(cacheDir, runtimeRoot, plugin) {
+  const targetDir = resolvePreinstalledPluginDir(runtimeRoot, plugin);
+  fs.rmSync(targetDir, { recursive: true, force: true });
+  copyDirRecursive(cacheDir, targetDir);
+  fs.rmSync(path.join(targetDir, 'plugin-install-info.json'), { force: true });
+
+  if (plugin.runtimeBundled === true) {
+    // Remove the previous layout as well: plugins.load.paths would discover it
+    // first and Discord would still fail the openKeyedStore trust check.
+    fs.rmSync(path.join(runtimeRoot, 'third-party-extensions', plugin.id), { recursive: true, force: true });
+    pruneHostPeerLeftovers(targetDir);
+    verifyRuntimeBundledPlugin(runtimeRoot, plugin);
+  }
+  return targetDir;
+}
+
 function main() {
   if (process.env.OPENCLAW_SKIP_PLUGINS === '1') {
     log('Skipped (OPENCLAW_SKIP_PLUGINS=1).');
@@ -654,6 +672,9 @@ function main() {
   // and wasted ~30s on serial load failures.  `third-party-extensions/` is discovered
   // solely via `plugins.load.paths` (origin="config"), bypassing the bundled contract.
   // See openclaw/openclaw#60196.
+  // Official Discord 2026.8.1 satisfies that contract and needs bundled trust
+  // for its Activities stores. Its runtimeBundled declaration opts it into
+  // dist/extensions; all other preinstalls keep the layout above.
   const runtimeExtensionsDir = path.join(runtimeCurrentDir, 'third-party-extensions');
 
   ensureDir(runtimeExtensionsDir);
@@ -665,7 +686,6 @@ function main() {
     const { id, npm: npmSpec, version, optional } = plugin;
     const cacheDir = path.join(pluginCacheBase, id);
     const installInfoPath = path.join(cacheDir, 'plugin-install-info.json');
-    const targetDir = path.join(runtimeExtensionsDir, id);
 
     log(`--- Plugin: ${id} (${npmSpec}@${version}) ---`);
 
@@ -825,17 +845,7 @@ function main() {
 
     if (npmSpec === QQ_PACKAGE_NAME) configureQQRuntimeEntry(cacheDir);
 
-    // Remove existing target and copy fresh
-    if (fs.existsSync(targetDir)) {
-      fs.rmSync(targetDir, { recursive: true, force: true });
-    }
-    copyDirRecursive(cacheDir, targetDir);
-
-    // Remove the plugin-install-info.json from the target (it's cache metadata only)
-    const targetInfoPath = path.join(targetDir, 'plugin-install-info.json');
-    if (fs.existsSync(targetInfoPath)) {
-      fs.unlinkSync(targetInfoPath);
-    }
+    const targetDir = copyPreinstalledPluginToRuntime(cacheDir, runtimeCurrentDir, plugin);
 
     log(`Installed ${id} -> ${path.relative(rootDir, targetDir)}`);
   }
@@ -857,6 +867,7 @@ module.exports = {
   buildGitEnv,
   copyDirRecursive,
   copyInstalledPluginToCache,
+  copyPreinstalledPluginToRuntime,
   findInstalledPluginDir,
   gitCloneAndPack,
   isGitSpec,

--- a/scripts/openclaw-runtime-packaging.cjs
+++ b/scripts/openclaw-runtime-packaging.cjs
@@ -9,9 +9,52 @@ const DIST_CONTROL_UI_INDEX = path.join(DIST_DIR, 'control-ui', 'index.html');
 const DIST_ENTRY_JS = path.join(DIST_DIR, 'entry.js');
 const DIST_ENTRY_MJS = path.join(DIST_DIR, 'entry.mjs');
 const DIST_EXTENSIONS_DIR = path.join(DIST_DIR, 'extensions');
+const THIRD_PARTY_EXTENSIONS_DIR = 'third-party-extensions';
 const DIST_DIFFS_EXTENSION_DIR = path.join(DIST_EXTENSIONS_DIR, 'diffs');
 
 const BARE_DIST_TOP_LEVEL_TO_KEEP = new Set(['control-ui', 'extensions']);
+
+// Only explicitly reviewed official packages may use OpenClaw's trusted bundled
+// root. Other preinstalls remain config-origin plugins in third-party-extensions.
+function resolvePreinstalledPluginDir(runtimeRoot, plugin) {
+  if (typeof plugin.id !== 'string' || !/^[a-z0-9][a-z0-9._-]*$/i.test(plugin.id)) {
+    throw new Error('Invalid preinstalled OpenClaw plugin directory id');
+  }
+  if (plugin.runtimeBundled === true && plugin.npm !== `@openclaw/${plugin.id}`) {
+    throw new Error(`Runtime-bundled plugin ${plugin.id} must use its official @openclaw package`);
+  }
+  return path.join(runtimeRoot,
+    plugin.runtimeBundled === true ? DIST_EXTENSIONS_DIR : THIRD_PARTY_EXTENSIONS_DIR,
+    plugin.id);
+}
+
+function verifyRuntimeBundledPlugin(runtimeRoot, plugin) {
+  if (plugin.runtimeBundled !== true) return;
+  const pluginDir = resolvePreinstalledPluginDir(runtimeRoot, plugin);
+  const bundledRoot = path.join(fs.realpathSync(runtimeRoot), DIST_EXTENSIONS_DIR);
+  const relative = path.relative(bundledRoot, fs.realpathSync(pluginDir));
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Runtime-bundled plugin ${plugin.id} must be inside ${bundledRoot}`);
+  }
+  const pkg = JSON.parse(fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf8'));
+  const manifest = JSON.parse(fs.readFileSync(path.join(pluginDir, 'openclaw.plugin.json'), 'utf8'));
+  if (pkg.name !== plugin.npm || pkg.version !== plugin.version || manifest.id !== plugin.id) {
+    throw new Error(`Runtime-bundled plugin ${plugin.id} does not match the pinned official package`);
+  }
+  const entries = pkg.openclaw?.runtimeExtensions;
+  if (!Array.isArray(entries) || entries.length === 0 || entries.some(entry => {
+    if (typeof entry !== 'string' || !/\.(?:mjs|cjs|js)$/.test(entry)) return true;
+    const relativeEntry = path.relative(pluginDir, path.resolve(pluginDir, entry));
+    return relativeEntry.startsWith('..') || path.isAbsolute(relativeEntry)
+      || !fs.existsSync(path.join(pluginDir, entry));
+  })) {
+    throw new Error(`Runtime-bundled plugin ${plugin.id} is missing its compiled runtime entry`);
+  }
+  // Config paths are scanned first; a stale copy would shadow the trusted one.
+  if (fs.existsSync(path.join(runtimeRoot, THIRD_PARTY_EXTENSIONS_DIR, plugin.id))) {
+    throw new Error(`Stale config-origin copy of runtime-bundled plugin ${plugin.id}; rebuild OpenClaw plugins`);
+  }
+}
 
 function normalizeAsarEntry(entry) {
   return entry.replace(/\\/g, '/');
@@ -65,5 +108,7 @@ module.exports = {
   OPENCLAW_ENTRY,
   pruneBareDistAfterGatewayPack,
   pruneGatewayAsarStage,
+  resolvePreinstalledPluginDir,
   summarizeGatewayAsarEntries,
+  verifyRuntimeBundledPlugin,
 };

--- a/src/main/libs/openclawLocalExtensions.test.ts
+++ b/src/main/libs/openclawLocalExtensions.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const environment = vi.hoisted(() => ({ appPath: '', packaged: false }));
+vi.mock('electron', () => ({
+  app: {
+    get isPackaged() { return environment.packaged; },
+    getAppPath: () => environment.appPath,
+  },
+}));
+
+import {
+  cleanupStaleThirdPartyPluginsFromBundledDir,
+  listBundledOpenClawExtensionIds,
+  listBundledOpenClawExtensionManifests,
+  resolveOpenClawExtensionPluginId,
+} from './openclawLocalExtensions';
+
+describe('runtime-bundled preinstalled extensions', () => {
+  const originalResourcesPath = Object.getOwnPropertyDescriptor(process, 'resourcesPath');
+  let root: string;
+  let runtime: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'lobsterai-extension-layout-'));
+    environment.appPath = root;
+    environment.packaged = false;
+    runtime = path.join(root, 'vendor', 'openclaw-runtime', 'current');
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ openclaw: { plugins: [
+      { id: 'discord', npm: '@openclaw/discord', runtimeBundled: true },
+      { id: 'ordinary-plugin', npm: 'ordinary-plugin' },
+    ] } }));
+    // Electron adds this property to process at runtime.
+    Object.defineProperty(process, 'resourcesPath', {
+      configurable: true,
+      get: () => path.join(root, 'resources'),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalResourcesPath) Object.defineProperty(process, 'resourcesPath', originalResourcesPath);
+    else Reflect.deleteProperty(process, 'resourcesPath');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function writeManifest(base: string, directoryId: string, pluginId = directoryId): string {
+    const dir = path.join(runtime, base, directoryId);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'openclaw.plugin.json'), JSON.stringify({ id: pluginId }));
+    return dir;
+  }
+
+  test.each([false, true])('resolves Discord for config sync (packaged=%s)', (packaged) => {
+    environment.packaged = packaged;
+    if (packaged) {
+      runtime = path.join(root, 'resources', 'cfmind');
+    }
+    const discordDir = writeManifest('dist/extensions', 'discord');
+    writeManifest('dist/extensions', 'openai');
+    writeManifest('third-party-extensions', 'ordinary-plugin', 'ordinary-channel');
+    expect(resolveOpenClawExtensionPluginId('discord')).toBe('discord');
+    expect(resolveOpenClawExtensionPluginId('ordinary-plugin')).toBe('ordinary-channel');
+    expect(listBundledOpenClawExtensionIds().sort()).toEqual(['discord', 'ordinary-plugin']);
+    expect(listBundledOpenClawExtensionManifests().find(item => item.pluginId === 'discord')?.directory)
+      .toBe(discordDir);
+  });
+
+  test('preserves shipped Discord during startup cleanup but removes stale third-party copies', () => {
+    const discord = writeManifest('dist/extensions', 'discord');
+    const legacyDiscord = writeManifest('extensions', 'discord');
+    const ordinary = writeManifest('dist/extensions', 'ordinary-plugin');
+    const core = writeManifest('dist/extensions', 'openai');
+    cleanupStaleThirdPartyPluginsFromBundledDir(runtime, ['discord', 'ordinary-plugin']);
+    expect(fs.existsSync(discord)).toBe(true);
+    expect(fs.existsSync(core)).toBe(true);
+    expect(fs.existsSync(legacyDiscord)).toBe(false);
+    expect(fs.existsSync(ordinary)).toBe(false);
+  });
+});

--- a/src/main/libs/openclawLocalExtensions.ts
+++ b/src/main/libs/openclawLocalExtensions.ts
@@ -175,25 +175,36 @@ export const listLocalOpenClawExtensionManifests = (): OpenClawExtensionManifest
   listExtensionManifests(findLocalExtensionsSourceDir(), 'local')
 );
 
-export const listBundledOpenClawExtensionIds = (): string[] => {
-  const extensionsDir = findBundledExtensionsDir();
-  if (!extensionsDir) {
-    return [];
-  }
-
+const listRuntimeBundledPreinstallIds = (): string[] => {
   try {
-    return fs.readdirSync(extensionsDir, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .filter((entry) => fs.existsSync(path.join(extensionsDir, entry.name, 'openclaw.plugin.json')))
-      .map((entry) => entry.name);
+    const pkg = JSON.parse(fs.readFileSync(path.join(app.getAppPath(), 'package.json'), 'utf8'));
+    if (!Array.isArray(pkg.openclaw?.plugins)) return [];
+    return pkg.openclaw.plugins
+      .filter((plugin: { id?: string; npm?: string; runtimeBundled?: boolean }) => (
+        plugin.runtimeBundled === true
+        && typeof plugin.id === 'string'
+        && /^[a-z0-9][a-z0-9._-]*$/i.test(plugin.id)
+        && plugin.npm === `@openclaw/${plugin.id}`
+      ))
+      .map((plugin: { id: string }) => plugin.id);
   } catch {
     return [];
   }
 };
 
-export const listBundledOpenClawExtensionManifests = (): OpenClawExtensionManifest[] => (
-  listExtensionManifests(findBundledExtensionsDir(), 'bundled')
+export const listBundledOpenClawExtensionIds = (): string[] => (
+  listBundledOpenClawExtensionManifests().map(manifest => manifest.directoryId)
 );
+
+export const listBundledOpenClawExtensionManifests = (): OpenClawExtensionManifest[] => {
+  const runtimeBundledIds = new Set(listRuntimeBundledPreinstallIds());
+  return [
+    ...listExtensionManifests(findRuntimeBundledExtensionsDir(), 'bundled')
+      .filter(manifest => runtimeBundledIds.has(manifest.directoryId)),
+    ...listExtensionManifests(findBundledExtensionsDir(), 'bundled')
+      .filter(manifest => !runtimeBundledIds.has(manifest.directoryId)),
+  ];
+};
 
 export const listAvailableOpenClawExtensionManifests = (): OpenClawExtensionManifest[] => [
   ...listBundledOpenClawExtensionManifests(),
@@ -251,14 +262,19 @@ export const cleanupStaleThirdPartyPluginsFromBundledDir = (
   runtimeRoot: string,
   thirdPartyPluginIds: readonly string[],
 ): string[] => {
+  const runtimeBundledDir = path.join(runtimeRoot, 'dist', 'extensions');
   const staleDirs = [
-    path.join(runtimeRoot, 'dist', 'extensions'),
+    runtimeBundledDir,
     path.join(runtimeRoot, 'extensions'),
   ];
   const removed: string[] = [];
+  const runtimeBundledIds = new Set(listRuntimeBundledPreinstallIds());
 
   for (const id of thirdPartyPluginIds) {
     for (const baseDir of staleDirs) {
+      // Explicitly shipped official plugins (Discord) now belong in this root.
+      // Still remove their legacy source-root copy under extensions/.
+      if (baseDir === runtimeBundledDir && runtimeBundledIds.has(id)) continue;
       const staleDir = path.join(baseDir, id);
       try {
         if (fs.statSync(staleDir).isDirectory()) {

--- a/tests/ensure-openclaw-plugins.test.ts
+++ b/tests/ensure-openclaw-plugins.test.ts
@@ -12,6 +12,7 @@ const {
   buildPluginInstallEnv,
   copyDirRecursive,
   copyInstalledPluginToCache,
+  copyPreinstalledPluginToRuntime,
   findInstalledPluginDir,
   isGitSpec,
   isLocalPathSpec,
@@ -21,6 +22,58 @@ const {
 } = require('../scripts/ensure-openclaw-plugins.cjs');
 
 describe('ensure-openclaw-plugins', () => {
+  test('ships official Discord in the trusted root and removes the old config-origin copy', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-discord-layout-'));
+    try {
+      const cache = path.join(root, 'cache');
+      const runtime = path.join(root, 'runtime');
+      const declaration = { id: 'discord', npm: '@openclaw/discord', version: '2026.8.1', runtimeBundled: true };
+      fs.mkdirSync(path.join(cache, 'dist'), { recursive: true });
+      fs.writeFileSync(path.join(cache, 'package.json'), JSON.stringify({
+        name: declaration.npm,
+        version: declaration.version,
+        openclaw: { runtimeExtensions: ['./dist/index.js'] },
+      }));
+      fs.writeFileSync(path.join(cache, 'openclaw.plugin.json'), JSON.stringify({ id: declaration.id }));
+      fs.writeFileSync(path.join(cache, 'dist', 'index.js'), 'export default {};');
+      fs.writeFileSync(path.join(cache, 'plugin-install-info.json'), '{}');
+      const oldCopy = path.join(runtime, 'third-party-extensions', declaration.id);
+      fs.mkdirSync(oldCopy, { recursive: true });
+      fs.writeFileSync(path.join(oldCopy, 'stale.js'), '');
+      const otherPlugin = path.join(runtime, 'third-party-extensions', 'other-plugin');
+      fs.mkdirSync(otherPlugin);
+      fs.writeFileSync(path.join(otherPlugin, 'index.js'), 'preserve');
+
+      const installed = copyPreinstalledPluginToRuntime(cache, runtime, declaration);
+      // A repeated cached build must also keep the native bundled layout.
+      copyPreinstalledPluginToRuntime(cache, runtime, declaration);
+
+      expect(installed).toBe(path.join(runtime, 'dist', 'extensions', declaration.id));
+      expect(fs.lstatSync(installed).isSymbolicLink()).toBe(false);
+      expect(fs.readFileSync(path.join(installed, 'dist', 'index.js'), 'utf8')).toBe('export default {};');
+      expect(fs.existsSync(oldCopy)).toBe(false);
+      expect(fs.existsSync(path.join(installed, 'plugin-install-info.json'))).toBe(false);
+      expect(fs.readFileSync(path.join(otherPlugin, 'index.js'), 'utf8')).toBe('preserve');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('keeps ordinary preinstalled plugins outside the trusted bundled root', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-plugin-layout-'));
+    try {
+      const cache = path.join(root, 'cache');
+      fs.mkdirSync(cache);
+      fs.writeFileSync(path.join(cache, 'index.js'), 'plugin');
+      const runtime = path.join(root, 'runtime');
+      const target = copyPreinstalledPluginToRuntime(cache, runtime, { id: 'other-plugin', npm: 'other-plugin' });
+      expect(target).toBe(path.join(runtime, 'third-party-extensions', 'other-plugin'));
+      expect(fs.existsSync(path.join(runtime, 'dist', 'extensions', 'other-plugin'))).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('accepts capabilities for reviewed pinned build-time plugins', () => {
     expect(buildOpenClawPluginInstallArgs('C:\\staging\\plugin.tgz')).toEqual([
       'plugins',

--- a/tests/openclawRuntimePackaging.test.ts
+++ b/tests/openclawRuntimePackaging.test.ts
@@ -1,15 +1,20 @@
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
-import { createRequire } from 'node:module';
+
 import { afterEach, expect, test } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const {
   pruneBareDistAfterGatewayPack,
   pruneGatewayAsarStage,
+  resolvePreinstalledPluginDir,
   summarizeGatewayAsarEntries,
+  verifyRuntimeBundledPlugin,
 } = require('../scripts/openclaw-runtime-packaging.cjs');
+const { openclaw } = require('../package.json');
+const { shouldKeepBundledExtension } = require('../scripts/prune-openclaw-runtime.cjs');
 
 const tempDirs: string[] = [];
 
@@ -24,6 +29,56 @@ function makeTempDir(prefix: string): string {
   tempDirs.push(dir);
   return dir;
 }
+
+test('only Discord opts into the official runtime-bundled preinstall layout', () => {
+  expect(openclaw.plugins.filter((plugin: { runtimeBundled?: boolean }) => plugin.runtimeBundled === true))
+    .toEqual([{ id: 'discord', npm: '@openclaw/discord', version: '2026.8.1', runtimeBundled: true }]);
+  for (const plugin of openclaw.plugins) {
+    if (plugin.runtimeBundled === true) expect(shouldKeepBundledExtension(plugin.id)).toBe(true);
+    expect(resolvePreinstalledPluginDir('/runtime', plugin)).toBe(path.join('/runtime',
+      plugin.runtimeBundled === true ? 'dist/extensions' : 'third-party-extensions', plugin.id));
+  }
+});
+
+test('rejects unreviewed package names and escaping directory ids for trusted preinstalls', () => {
+  expect(() => resolvePreinstalledPluginDir('/runtime', {
+    id: 'discord', npm: 'unofficial-discord', runtimeBundled: true,
+  })).toThrow('official @openclaw package');
+  expect(() => resolvePreinstalledPluginDir('/runtime', {
+    id: '../discord', npm: '@openclaw/discord', runtimeBundled: true,
+  })).toThrow('directory id');
+});
+
+test('validates the shipped Discord package and rejects a stale shadowing copy', () => {
+  const root = makeTempDir('openclaw-bundled-validation-');
+  const declaration = { id: 'discord', npm: '@openclaw/discord', version: '2026.8.1', runtimeBundled: true };
+  const pluginDir = resolvePreinstalledPluginDir(root, declaration);
+  fs.mkdirSync(path.join(pluginDir, 'dist'), { recursive: true });
+  const pkg = {
+    name: declaration.npm, version: declaration.version,
+    openclaw: { runtimeExtensions: ['./dist/index.js'] },
+  };
+  fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify(pkg));
+  fs.writeFileSync(path.join(pluginDir, 'openclaw.plugin.json'), JSON.stringify({ id: declaration.id }));
+  expect(() => verifyRuntimeBundledPlugin(root, declaration)).toThrow('compiled runtime entry');
+  fs.writeFileSync(path.join(pluginDir, 'dist', 'index.js'), '');
+  expect(() => verifyRuntimeBundledPlugin(root, declaration)).not.toThrow();
+  fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ ...pkg, version: '2026.7.1' }));
+  expect(() => verifyRuntimeBundledPlugin(root, declaration)).toThrow('pinned official package');
+  fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify(pkg));
+  fs.mkdirSync(path.join(root, 'third-party-extensions', declaration.id), { recursive: true });
+  expect(() => verifyRuntimeBundledPlugin(root, declaration)).toThrow('Stale config-origin copy');
+});
+
+test('rejects a bundled directory link pointing outside the runtime', () => {
+  const root = makeTempDir('openclaw-bundled-containment-');
+  const external = makeTempDir('openclaw-external-plugin-');
+  const declaration = { id: 'discord', npm: '@openclaw/discord', runtimeBundled: true };
+  const pluginDir = resolvePreinstalledPluginDir(root, declaration);
+  fs.mkdirSync(path.dirname(pluginDir), { recursive: true });
+  fs.symlinkSync(external, pluginDir, process.platform === 'win32' ? 'junction' : 'dir');
+  expect(() => verifyRuntimeBundledPlugin(root, declaration)).toThrow('must be inside');
+});
 
 test('summarizeGatewayAsarEntries flags bundled extensions inside gateway.asar', () => {
   const summary = summarizeGatewayAsarEntries([


### PR DESCRIPTION
## Summary

OpenClaw v2026.8.1 rejects Discord during plugin registration with `openKeyedStore is only available for trusted plugins`: the official package was shipped under `third-party-extensions` and discovered with `origin=config`. Ship the pinned official Discord package under `dist/extensions/discord` so OpenClaw recognizes its bundled origin and can initialize Discord's state stores.

## Related Issue

Follow-up to the gateway startup diagnostics in #2625.

## Changes Made

- Mark only the pinned `@openclaw/discord` package as `runtimeBundled` and remove its old config-origin copy during runtime assembly.
- Validate the official package name, pinned version, manifest ID, compiled runtime entry, directory containment, and absence of a shadowing copy before packaging.
- Update Electron's extension discovery and startup cleanup to recognize and preserve the shipped Discord plugin.
- Add regression coverage for fresh and repeated assembly, packaging validation, development/packaged discovery, and startup cleanup.

## Type of Change

- [x] Bug fix

## Testing

- [x] Targeted Vitest coverage: 134 tests passed across 5 files; the final focused checks also passed.
- [x] `npm run compile:electron` and TypeScript validation passed.
- [x] Changed-file ESLint, modified CommonJS syntax checks, and `git diff --check` passed.
- [x] Built the actual Discord runtime layout and verified its packed/extracted payload.
- [x] Isolated packaged gateway reached ready and `channels.status` returned Discord; the subsequent IM audit successfully registered and queried all 11 IM channels.

The committed changes match the previously validated source contents. Runtime probes used isolated state and no live IM credentials; real Discord login and message delivery still require QA verification.

## Checklist

- [x] Reviewed the diff and followed the repository's style guidelines.
- [x] Added comments explaining the trusted layout and stale-copy handling.
- [x] Added and updated regression tests; targeted tests pass.
- [x] Changed TypeScript files pass lint with zero warnings.

## Electron-Specific Changes

- [x] Main-process extension discovery and startup cleanup.
- [x] OpenClaw runtime assembly and Electron packaging verification.

## Additional Notes

QA packages must include a rebuilt/repacked OpenClaw runtime so the previous Discord directory is removed and the bundled copy is shipped. Other IM compatibility issues and the independent user-plugin/lock-file issues are outside this PR.

