### PR TITLE
fix(openclaw): migrate legacy workspace state before gateway startup

### DIFF
--- a/docs/openclaw-v2026.8.1-migration-audit.md
+++ b/docs/openclaw-v2026.8.1-migration-audit.md
@@ -1,0 +1,58 @@
+# OpenClaw v2026.8.1 迁移适配审查
+
+审查基线：`origin/feat/openclaw-v2026.8.1`，`e3e21e589`；上游版本 `v2026.8.1`，提交 `ea806575e6450e4d1efdfc72c19f04be982a1b9b`。审查时间：2026-09-09。
+
+结论：此次工作区报错是确定的迁移遗漏，已在本分支修复。其它数据也存在遗漏，尤其是 LobsterAI 仍直接读写旧 JSON、而 OpenClaw 已只使用 SQLite 的路径。不能把一次 `doctor --session-sqlite import` 当作整个运行时升级迁移已经完成。
+
+本次只修复工作区初始化状态和工作区证明的迁移。以下其它发现仅审查，不改变它们的数据、权限或运行行为。日志包不含完整用户 state，因此代码层面的风险不等于已经在这台 QA 机器发生。
+
+## 本次修复
+
+`openclawEngineManager` 在会话迁移后、启动网关前运行独立工作区迁移工具。新工具构建时直接使用 pinned OpenClaw 的 `detectLegacyWorkspaceState` / `migrateLegacyWorkspaceState`，不执行通用 Doctor 的 IM 配置修复，也不加载用户插件。
+
+- 使用与网关一致的 home / state / config，以及全部配置 Agent 的工作区映射。
+- 复用上游对旧 setup 文件、attestation、路径别名和中断认领文件的处理；不自行删标记绕过检查。
+- 迁入 SQLite 后重新检测遗留来源；有警告、残留、进程错误或缺失结果时，阻止进入网关就绪状态并保留可重试错误。
+- 原有工作区 Markdown 文件、IM 配置、模型配置和配置锁不在该工具的写入范围。
+- 普通启动与一键修复后的重新启动共用该步骤；没有旧状态时跳过写入。
+- 迁移工具随 `openclaw:bundle` 构建。SQL schema 按上游生产构建方式内嵌，避免依赖源码目录中的 SQL 文件。打包检查要求工具存在，不能只编译 Electron 而继续使用缺少工具的旧 runtime。
+
+隔离验证：多 Agent、两种旧 setup 路径、初始化时间保留、10 个 Markdown 文件内容保留、空配置锁保持不变、损坏 JSON 保留并可重试、迁移认领文件恢复、owned attestation 迁移、无关 sibling 文件保留、无旧状态不创建数据库。真实 Windows gateway 验证了“迁移前对话报错且模型请求为零 → 停止网关并迁移 → 同配置对话成功返回本地模拟模型回复”。运行中的网关会让迁移因维护锁而拒绝；再次执行迁移会跳过。
+
+## 优先跟进的确定问题
+
+| 项目 | LobsterAI 当前路径 | 上游变化和实际影响 | 验证程度 |
+| --- | --- | --- | --- |
+| IM 配对和已批准发送者 | `src/main/im/imPairingStore.ts` 读写 `credentials/<channel>-pairing.json`、`*-allowFrom.json`；`src/main/main.ts` 的配对 IPC 仍调用它 | `src/pairing/pairing-store.ts` / `pairing-store-sqlite.ts` 已使用 `channel_pairing_requests`、`channel_pairing_allow_entries`。旧白名单不进入运行时；新版配对申请不显示在当前配对管理界面。即使一次导入旧数据，后续继续写 JSON 仍会分叉 | 隔离复现：LobsterAI 读到旧白名单 1 条，上游读到 0 条；上游创建新申请 1 条，LobsterAI 读到 0 条。没有连接真实 IM |
+| xAI OAuth / 旧 auth profiles | `src/main/libs/xaiAuth.ts` 的状态查询、登录保存和退出登录仍基于 `agents/main/agent/auth-profiles.json` | 上游 `src/agents/auth-profiles/store.ts` 不再从这些旧 JSON 提供运行时凭据。只有旧凭据而规范存储为空时抛 `AuthProfileMigrationRequiredError`；已有规范凭据时，后写入旧 JSON 的登录变更也不会更新规范存储。退出登录和 UI 状态也需一起改到规范存储 | 使用虚拟 OAuth 数据复现了 `requires legacy credential migration`。未执行真实 OAuth 登录、刷新或退出 |
+| 执行审批存储与路径 | `src/main/libs/openclawConfigSync.ts` 的 `ensureExecApprovalDefaults()` 仍写 `<OPENCLAW_HOME>/.openclaw/exec-approvals.json` | 新版规范存储为共享 SQLite 的执行审批表；`resolveExecApprovalsPath()` 在设置 `OPENCLAW_STATE_DIR` 时检测 `<stateDir>/exec-approvals.json`。目前写入既不更新规范存储，也与上游检测路径不一致。若有效 stateDir 存在旧审批文件，运行时审批读取会被迁移检查拦截 | 隔离复现有效 stateDir 下旧审批文件触发 `ExecApprovalsMigrationRequiredError`。默认 `full/off` 恰好与新版默认值一致，所以当前过时写入不一定表现为用户故障；不能据此认定权限同步有效 |
+
+建议分别修复以上存储适配，并覆盖旧数据导入以及迁移后的持续读写。尤其是 IM 配对，不能只补一次导入而保留旧 JSON 管理界面。
+
+## 其它迁移范围和覆盖边界
+
+本表对照上游 `src/infra/state-migrations.types.ts` 的 `LegacyStateDetection`、`state-migrations.doctor.ts` 的检测/执行步骤，以及 LobsterAI 启动代码。部分名称虽然叫 `autoMigrate...`，也只由 Doctor 流程调用，不能仅凭函数名推断网关启动会执行。
+
+| 类别 | 当前覆盖或潜在遗漏 | 影响与后续检查 |
+| --- | --- | --- |
+| 旧 session index / transcript | 已有 `openclawSessionLegacyMigration.ts` 调用官方 session import。前置检测只找 state 根和 `agents/*/sessions/sessions.json` | 常规存储已覆盖；自定义 session store、只剩 transcript 的情况不能据此前置检测保证覆盖。应加升级样本验证，不把本轮工作区修复解释为解决全部历史会话异常 |
+| 已有 Agent SQLite 的媒体、参与者身份、transcript directives、旧 schema | 上游有独立的 `state-migrations.media-persistence.ts`、Agent schema maintenance 和历史 transcript 迁移。部分是停止写入者后的显式迁移 | 如果机器已经用过中间版本 SQLite，而旧 `sessions.json` 已消失，当前 session import 检测可能直接跳过。需用受支持的旧 schema 样本验证；潜在影响包括启动、媒体和会话访问被拒绝。本轮不操作未知 schema |
+| 旧 main session keys / managed worktree session 元数据 | 上游 `src/config/sessions/startup-migration.ts` 仍执行部分 SQLite 启动维护 | 有上游覆盖，和旧文件导入不同；存在自定义目录、未完成迁移 claim 时仍需看具体警告 |
+| cron JSON / JSONL | 已有 `openclawCronLegacyMigration.ts`，发现旧 cron 后用临时配置运行 Doctor 并归档 | 常规 cron 已覆盖；该临时配置只明确 gateway / cron，不包含全部 Agent 映射，也仅在有旧 cron 时执行，不能用来保证其它类别已迁移 |
+| FTS-only 记忆索引、LobsterAI 工作区文件搬迁 | 已有 `openclawMemoryIndexMigration.ts`、`openclawWorkspaceMigration.ts`、AGENTS 身份内容迁移 | 属于已有适配；这些迁移不包含本次修复的上游 setup / attestation SQLite 状态 |
+| 设备身份与 device auth | 上游存在 `state-migrations.device-identity.ts` / `device-auth.ts`；运行时存在旧文件拒绝检查，node-host 另有自己的启动迁移 | LobsterAI 主网关客户端显式 `deviceIdentity: null`，所以不能把设备旧文件推断为本次聊天的根因；其它设备、节点和 CLI 路径仍应检查 |
+| 通用 provider auth / shared auth store | Doctor 有 shared-auth-store 和旧 auth profiles 来源处理 | 不限于 xAI，保留旧 OAuth/auth JSON 的升级用户可能受影响。配置中直接提供 API key 的工作路径成功，不能证明所有 OAuth 路径成功 |
+| 插件安装索引、插件 state sidecar | LobsterAI 有 `openclawPluginInstallMigration.ts` 处理旧 `plugins.installs` 配置；上游另外有旧 install index JSON 和 plugin state sidecar 迁移 | 迁移旧配置声明、导入旧插件数据、官方插件信任来源是三件不同的事。分别检查，不能以删除旧配置字段作为全部插件迁移完成的证据 |
+| IM channel pairing、插件绑定审批、current-conversation bindings、插件自定义 Doctor state plans | 上游有独立迁移步骤和插件提供的状态迁移合约；本轮 workspace-only 工具不会执行 | IM 配对读写分叉已复现，其它绑定/插件存储需结合使用中的官方或第三方插件验证。不能无条件批量执行未知用户插件的 Doctor hook |
+| delivery / session-delivery queues、task-runs / flow-runs sidecars | 上游 Doctor 有旧队列和任务 sidecar 导入；当前 LobsterAI 未有独立、无条件对应调用 | 持有旧待投递消息或任务数据时存在恢复遗漏风险，不能只测试新会话。日志中未证实 QA 有这类旧文件 |
+| MCP OAuth、managed outgoing images、ACP replay ledger、meeting transcripts | 上游有各自的 Doctor 专属状态迁移 | 对使用过这些功能的升级用户，应验证原授权、附件、回放和转录仍可用。当前日志不足以判定是否受影响 |
+| 旧 subagent registry、rescue-pending、managed worktree registry | 上游部分操作会记录“丢弃旧瞬态状态”，并非导入全部原记录 | 不宜把“补齐所有迁移”实现成无条件通用 Doctor。应区分可保留的业务数据和上游明确废弃的瞬态状态，审查后再实施 |
+| voice wake、update-check、config-health、TUI last sessions、commitments、audit logs、debug-proxy capture、APNs、Web Push、node-host config、restart sentinel | 已列入上游迁移清单；不同 owner 的启动行为和使用范围不同 | 多项并非 LobsterAI 常规桌面对话的直接依赖。本次未在 QA 日志中证实其阻塞；后续升级样本应按功能选择，而不是声明全部已安全迁移 |
+
+## 本次修复的边界
+
+关闭 `nsp-clawguard` 后暴露出的工作区状态错误已验证可修复；Discord 插件启动/信任问题和零字节 `openclaw.json.lock` 不在本分支修改范围。工作区迁移可以在保留空配置锁时成功，但不会修复配置写入超时。
+
+自动回归只在临时目录写入状态；真实 gateway 验证使用本地模拟模型和虚拟凭据，没有访问真实模型服务或用户工作区。尚未制作发布安装包，也未在 macOS / Linux 实机运行。
+
+验证入口：构建 runtime 后，设置 `OPENCLAW_WORKSPACE_MIGRATION_RUNTIME` 指向它，再运行 `npm test -- openclawWorkspaceStateMigration`。未设置时，常规单元测试仍执行，依赖真实 runtime 的集成测试明确跳过。

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "verify:installer-patches": "node scripts/verify-installer-patches.cjs",
     "openclaw:plugins": "node scripts/ensure-openclaw-plugins.cjs",
     "openclaw:extensions:local": "node scripts/sync-local-openclaw-extensions.cjs",
-    "openclaw:bundle": "node scripts/bundle-openclaw-gateway.cjs",
+    "openclaw:bundle": "node scripts/bundle-openclaw-workspace-migration.cjs && node scripts/bundle-openclaw-gateway.cjs",
     "openclaw:precompile": "node scripts/precompile-openclaw-extensions.cjs",
     "openclaw:channel-deps": "node scripts/install-openclaw-channel-deps.cjs",
     "openclaw:prune": "node scripts/prune-openclaw-runtime.cjs",

--- a/scripts/bundle-openclaw-workspace-migration.cjs
+++ b/scripts/bundle-openclaw-workspace-migration.cjs
@@ -1,0 +1,61 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const esbuild = require('esbuild');
+
+const rootDir = path.resolve(__dirname, '..');
+const entryPath = path.join(__dirname, 'openclaw-workspace-state-migration.mjs');
+
+async function bundleOpenClawWorkspaceMigration(runtimeDir, openclawSrc) {
+  const expectedVersion = require(path.join(rootDir, 'package.json')).openclaw.version.replace(/^v/, '');
+  for (const directory of [openclawSrc, runtimeDir]) {
+    const version = JSON.parse(fs.readFileSync(path.join(directory, 'package.json'), 'utf8')).version;
+    if (version !== expectedVersion) {
+      throw new Error(`Workspace migration must use OpenClaw ${expectedVersion}; found ${version} at ${directory}`);
+    }
+  }
+  const outputPath = path.join(runtimeDir, path.basename(entryPath));
+  // Rebuild even when the gateway cache is current: this entry is maintained by
+  // LobsterAI and must match the pinned upstream migration/schema implementation.
+  await esbuild.build({
+    entryPoints: [entryPath],
+    outfile: outputPath,
+    alias: {
+      '#openclaw-workspace-migration': path.join(openclawSrc, 'src/infra/state-migrations.workspace-setup.ts'),
+    },
+    tsconfig: path.join(openclawSrc, 'tsconfig.json'),
+    bundle: true,
+    minify: true,
+    platform: 'node',
+    format: 'esm',
+    packages: 'external',
+    plugins: [{
+      name: 'openclaw-sqlite-schema',
+      setup(build) {
+        // Match OpenClaw's production build: schema modules read adjacent SQL
+        // only in source checkouts. Embed both schemas in this standalone entry.
+        build.onLoad({ filter: /openclaw-(?:state|agent)-schema\.ts$/ }, args => {
+          const schema = path.basename(args.path).includes('-agent-') ? 'AGENT' : 'STATE';
+          const sql = fs.readFileSync(args.path.replace(/\.ts$/, '.sql'), 'utf8');
+          return { contents: `export const OPENCLAW_${schema}_SCHEMA_SQL = ${JSON.stringify(sql)};`, loader: 'js' };
+        });
+      },
+    }],
+    banner: { js: "import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);" },
+    logLevel: 'warning',
+  });
+  console.log(`[OpenClaw] Built workspace migration helper (${fs.statSync(outputPath).size} bytes).`);
+  return outputPath;
+}
+
+if (require.main === module) {
+  const runtimeDir = path.resolve(process.argv[2] || path.join(rootDir, 'vendor/openclaw-runtime/current'));
+  const openclawSrc = path.resolve(process.argv[3] || process.env.OPENCLAW_SRC || path.join(rootDir, '../openclaw'));
+  bundleOpenClawWorkspaceMigration(runtimeDir, openclawSrc).catch(error => {
+    console.error('[OpenClaw] Failed to build workspace migration helper:', error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { bundleOpenClawWorkspaceMigration };

--- a/scripts/electron-builder-hooks.cjs
+++ b/scripts/electron-builder-hooks.cjs
@@ -253,6 +253,7 @@ function ensureBundledOpenClawRuntime(context) {
 
   const requiredExternalPaths = [
     path.join(runtimeRoot, 'node_modules'),
+    path.join(runtimeRoot, 'openclaw-workspace-state-migration.mjs'),
   ];
   const missingExternal = requiredExternalPaths.filter((candidate) => !existsSync(candidate));
   if (missingExternal.length > 0) {

--- a/scripts/openclaw-workspace-state-migration.mjs
+++ b/scripts/openclaw-workspace-state-migration.mjs
@@ -1,0 +1,57 @@
+// Bundled against the pinned OpenClaw source. Never run the general Doctor here:
+// its config/plugin repairs also change IM settings managed by LobsterAI.
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  detectLegacyWorkspaceState,
+  migrateLegacyWorkspaceState,
+} from '#openclaw-workspace-migration';
+import {
+  OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX,
+  OpenClawWorkspaceMigrationStatus,
+} from '../src/shared/openclawEngine/workspaceMigration.ts';
+
+let sourceCount = 0;
+let report;
+try {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  const configPath = process.env.OPENCLAW_CONFIG_PATH;
+  const homeDir = process.env.OPENCLAW_HOME;
+  if (![stateDir, configPath, homeDir].every(value => value && path.isAbsolute(value))) {
+    throw new Error('Workspace migration requires explicit absolute OpenClaw state, config and home paths.');
+  }
+  // Read the generated config without loading plugins, repairing config, or
+  // acquiring openclaw.json.lock. Workspace imports use their own state lock.
+  const cfg = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  if (!cfg || typeof cfg !== 'object' || Array.isArray(cfg)) {
+    throw new Error('Workspace migration requires an OpenClaw config object.');
+  }
+  const detectionOptions = {
+    cfg, stateDir, env: process.env, homedir: () => homeDir,
+    doctorOnlyStateMigrations: true,
+  };
+  const detected = detectLegacyWorkspaceState(detectionOptions);
+  sourceCount = detected.sources.length;
+  const result = await migrateLegacyWorkspaceState({ detected, stateDir, env: process.env });
+  // A successful process exit alone does not prove all sources were imported.
+  // Conflicts, unreadable files and an active Gateway must remain retryable.
+  const remaining = detectLegacyWorkspaceState(detectionOptions);
+  const failed = result.warnings.length > 0 || remaining.hasLegacy;
+  report = {
+    status: failed ? OpenClawWorkspaceMigrationStatus.Failed
+      : detected.hasLegacy ? OpenClawWorkspaceMigrationStatus.Migrated
+        : OpenClawWorkspaceMigrationStatus.Skipped,
+    sourceCount,
+    changes: result.changes,
+    warnings: result.warnings,
+    remainingPaths: remaining.sources.map(source => source.sourcePath),
+  };
+} catch (error) {
+  report = {
+    status: OpenClawWorkspaceMigrationStatus.Failed,
+    sourceCount, changes: [], remainingPaths: [],
+    warnings: [error instanceof Error ? error.message : String(error)],
+  };
+}
+console.log(OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX + JSON.stringify(report));
+process.exitCode = report.status === OpenClawWorkspaceMigrationStatus.Failed ? 1 : 0;

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -16,6 +16,7 @@ export type LanguageType = 'zh' | 'en';
 
 const translations: Record<LanguageType, Record<string, string>> = {
   zh: {
+    openClawWorkspaceMigrationFailed: 'AI 引擎工作区状态升级失败：{error}',
     // DeepSeek Harness (experimental)
     dshWorkbenchTitle: 'DeepSeek Harness 工作台（实验）',
     dshPlanProviderName: '套餐',
@@ -382,6 +383,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     'enterprise.updateBlocked': '版本更新由企业统一管理',
   },
   en: {
+    openClawWorkspaceMigrationFailed: 'AI engine workspace state migration failed: {error}',
     // DeepSeek Harness (experimental)
     dshWorkbenchTitle: 'DeepSeek Harness Workbench (Experimental)',
     dshPlanProviderName: 'Plan',

--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -13,6 +13,8 @@ import {
   OpenClawGatewayFailureKind,
   type OpenClawGatewayFailureSnapshot,
 } from '../../shared/openclawEngine/constants';
+import { OpenClawWorkspaceMigrationStatus } from '../../shared/openclawEngine/workspaceMigration';
+import { t } from '../i18n';
 import { ensureElectronNodeShim, getElectronNodeRuntimePath, getSkillsRoot } from './coworkUtil';
 import {
   formatGatewayLogDateKey,
@@ -31,6 +33,7 @@ import { cleanupStaleThirdPartyPluginsFromBundledDir, listLocalOpenClawExtension
 import { migrateAllFtsOnlyMemoryIndexes } from './openclawMemoryIndexMigration';
 import { migrateLegacySessionStorageWithDoctor } from './openclawSessionLegacyMigration';
 import { ensureOpenClawWorkerShims } from './openclawWorkerShims';
+import { migrateLegacyWorkspaceStateBeforeStartup } from './openclawWorkspaceStateMigration';
 import { appendPythonRuntimeToEnv } from './pythonRuntime';
 
 const gwDiagTs = (): string => {
@@ -918,6 +921,24 @@ export class OpenClawEngineManager extends EventEmitter {
         version: runtime.version,
         message: 'OpenClaw legacy sessions require migration, but the bundled CLI is missing.',
         errorCode: OpenClawEngineErrorCode.RuntimeEntryMissing,
+        canRetry: true,
+      });
+      return this.getStatus();
+    }
+
+    const workspaceMigration = await migrateLegacyWorkspaceStateBeforeStartup({
+      stateDir: this.stateDir,
+      configPath: this.configPath,
+      runtimeRoot: runtime.root,
+      electronNodeRuntimePath,
+      env,
+    });
+    if (this.shutdownRequested) return this.getStatus();
+    if (workspaceMigration.status === OpenClawWorkspaceMigrationStatus.Failed) {
+      this.setStatus({
+        phase: OpenClawEnginePhase.Error,
+        version: runtime.version,
+        message: t('openClawWorkspaceMigrationFailed', { error: workspaceMigration.error ?? '' }),
         canRetry: true,
       });
       return this.getStatus();

--- a/src/main/libs/openclawWorkspaceStateMigration.test.ts
+++ b/src/main/libs/openclawWorkspaceStateMigration.test.ts
@@ -1,0 +1,102 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  OPENCLAW_WORKSPACE_MIGRATION_ENTRY,
+  OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX,
+  type OpenClawWorkspaceMigrationReport,
+  OpenClawWorkspaceMigrationStatus,
+} from '../../shared/openclawEngine/workspaceMigration';
+import { migrateLegacyWorkspaceStateBeforeStartup } from './openclawWorkspaceStateMigration';
+
+let tempDir: string;
+const report = (overrides: Partial<OpenClawWorkspaceMigrationReport> = {}): string => (
+  OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX + JSON.stringify({
+    status: OpenClawWorkspaceMigrationStatus.Migrated,
+    sourceCount: 2, changes: ['Migrated workspace setup state to SQLite.'],
+    warnings: [], remainingPaths: [], ...overrides,
+  })
+);
+
+describe('workspace state migration before gateway startup', () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lobsterai-workspace-migration-'));
+    fs.writeFileSync(path.join(tempDir, OPENCLAW_WORKSPACE_MIGRATION_ENTRY), '');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function options() {
+    return {
+      stateDir: path.join(tempDir, 'openclaw', 'state'),
+      configPath: path.join(tempDir, 'openclaw', 'state', 'openclaw.json'),
+      runtimeRoot: tempDir,
+      electronNodeRuntimePath: '/electron/node',
+      env: { EXISTING: 'preserved', OPENCLAW_STATE_DIR: '/wrong-state', OPENCLAW_HOME: '/wrong-home' },
+    };
+  }
+
+  test('runs the focused helper with the gateway state/config and preserves other environment', async () => {
+    const runner = vi.fn(async () => ({ code: 0, stdout: `diagnostic line\n${report()}\n`, stderr: '' }));
+    const params = options();
+    expect(await migrateLegacyWorkspaceStateBeforeStartup({ ...params, runner })).toEqual({
+      status: OpenClawWorkspaceMigrationStatus.Migrated,
+    });
+    expect(runner).toHaveBeenCalledWith('/electron/node', [path.join(tempDir, OPENCLAW_WORKSPACE_MIGRATION_ENTRY)], {
+      cwd: tempDir,
+      env: {
+        EXISTING: 'preserved', OPENCLAW_HOME: path.dirname(params.stateDir),
+        OPENCLAW_STATE_DIR: params.stateDir, OPENCLAW_CONFIG_PATH: params.configPath,
+        OPENCLAW_SERVICE_REPAIR_POLICY: 'external', ELECTRON_RUN_AS_NODE: '1',
+      },
+      timeoutMs: 180_000,
+    });
+  });
+
+  test('does not log a migration on an already migrated installation', async () => {
+    const runner = vi.fn(async () => ({
+      code: 0, stdout: report({ status: OpenClawWorkspaceMigrationStatus.Skipped, sourceCount: 0, changes: [] }), stderr: '',
+    }));
+    expect(await migrateLegacyWorkspaceStateBeforeStartup({ ...options(), runner })).toEqual({
+      status: OpenClawWorkspaceMigrationStatus.Skipped,
+    });
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    { code: 0, stdout: report({ remainingPaths: ['/workspace/.openclaw/workspace-state.json'] }), stderr: '', expected: 'Unmigrated workspace state' },
+    { code: 0, stdout: report({ warnings: ['Gateway owns this state directory'] }), stderr: '', expected: 'Gateway owns this state directory' },
+    { code: 1, stdout: report({ status: OpenClawWorkspaceMigrationStatus.Failed, warnings: ['legacy workspace setup contains invalid JSON'] }), stderr: '', expected: 'invalid JSON' },
+    { code: 1, stdout: report(), stderr: '', expected: 'exit code 1' },
+    { code: 0, stdout: '', stderr: '', expected: 'verified completion' },
+    { code: 0, stdout: OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX + '{}', stderr: '', expected: 'verified completion' },
+    { code: 1, stdout: '', stderr: 'Cannot find package dependency', expected: 'Cannot find package dependency' },
+  ])('blocks unverified migration: $expected', async ({ expected, ...result }) => {
+    const runner = vi.fn(async () => result);
+    expect(await migrateLegacyWorkspaceStateBeforeStartup({ ...options(), runner })).toEqual({
+      status: OpenClawWorkspaceMigrationStatus.Failed, error: expect.stringContaining(expected),
+    });
+  });
+
+  test('fails when an old runtime lacks the helper', async () => {
+    fs.unlinkSync(path.join(tempDir, OPENCLAW_WORKSPACE_MIGRATION_ENTRY));
+    const runner = vi.fn();
+    expect(await migrateLegacyWorkspaceStateBeforeStartup({ ...options(), runner })).toEqual({
+      status: OpenClawWorkspaceMigrationStatus.Failed, error: expect.stringContaining('helper is missing'),
+    });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  test('keeps process/timeout errors retryable', async () => {
+    const runner = vi.fn(async () => { throw new Error('migration timed out'); });
+    expect(await migrateLegacyWorkspaceStateBeforeStartup({ ...options(), runner })).toEqual({
+      status: OpenClawWorkspaceMigrationStatus.Failed, error: 'migration timed out',
+    });
+  });
+});

--- a/src/main/libs/openclawWorkspaceStateMigration.ts
+++ b/src/main/libs/openclawWorkspaceStateMigration.ts
@@ -1,0 +1,100 @@
+import { execFile } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  OPENCLAW_WORKSPACE_MIGRATION_ENTRY,
+  OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX,
+  type OpenClawWorkspaceMigrationReport,
+  OpenClawWorkspaceMigrationStatus,
+} from '../../shared/openclawEngine/workspaceMigration';
+
+const WORKSPACE_MIGRATION_TIMEOUT_MS = 180_000;
+const LOG_TAIL_LIMIT = 4_000;
+
+export type WorkspaceMigrationRunner = (
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; timeoutMs: number },
+) => Promise<{ code: number | null; stdout: string; stderr: string }>;
+
+const runWorkspaceMigration: WorkspaceMigrationRunner = (command, args, options) => new Promise((resolve, reject) => {
+  execFile(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    windowsHide: true,
+    encoding: 'utf8',
+    timeout: options.timeoutMs,
+    maxBuffer: 1024 * 1024,
+  }, (error, stdout, stderr) => {
+    // execFile waits for the child to close, including after a timeout, before
+    // allowing a retry to start another SQLite writer.
+    if (error && (error.killed || typeof error.code !== 'number')) {
+      reject(error);
+    } else {
+      resolve({ code: typeof error?.code === 'number' ? error.code : 0, stdout, stderr });
+    }
+  });
+});
+
+function parseReport(stdout: string): OpenClawWorkspaceMigrationReport | null {
+  const line = stdout.split(/\r?\n/).findLast(value => value.startsWith(OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX));
+  if (!line) return null;
+  try {
+    const report = JSON.parse(line.slice(OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX.length));
+    if (!report || !Object.values(OpenClawWorkspaceMigrationStatus).includes(report.status)
+      || !Number.isSafeInteger(report.sourceCount) || report.sourceCount < 0
+      || ![report.changes, report.warnings, report.remainingPaths].every(
+        values => Array.isArray(values) && values.every(value => typeof value === 'string'),
+      )) return null;
+    return report as OpenClawWorkspaceMigrationReport;
+  } catch {
+    return null;
+  }
+}
+
+export async function migrateLegacyWorkspaceStateBeforeStartup(params: {
+  stateDir: string;
+  configPath: string;
+  runtimeRoot: string;
+  electronNodeRuntimePath: string;
+  env: NodeJS.ProcessEnv;
+  runner?: WorkspaceMigrationRunner;
+}): Promise<{ status: OpenClawWorkspaceMigrationStatus; error?: string }> {
+  const entryPath = path.join(params.runtimeRoot, OPENCLAW_WORKSPACE_MIGRATION_ENTRY);
+  try {
+    if (!fs.existsSync(entryPath)) {
+      throw new Error(`Bundled workspace migration helper is missing: ${entryPath}`);
+    }
+    const result = await (params.runner ?? runWorkspaceMigration)(params.electronNodeRuntimePath, [entryPath], {
+      cwd: params.runtimeRoot,
+      env: {
+        ...params.env,
+        OPENCLAW_HOME: path.dirname(params.stateDir),
+        OPENCLAW_STATE_DIR: params.stateDir,
+        OPENCLAW_CONFIG_PATH: params.configPath,
+        OPENCLAW_SERVICE_REPAIR_POLICY: 'external',
+        ELECTRON_RUN_AS_NODE: '1',
+      },
+      timeoutMs: WORKSPACE_MIGRATION_TIMEOUT_MS,
+    });
+    const report = parseReport(result.stdout);
+    if (result.code !== 0 || !report || report.status === OpenClawWorkspaceMigrationStatus.Failed
+      || report.warnings.length > 0 || report.remainingPaths.length > 0) {
+      const detail = report
+        ? [...report.warnings, ...report.remainingPaths.map(value => `Unmigrated workspace state: ${value}`)].join('\n')
+        : result.stderr.trim().slice(-LOG_TAIL_LIMIT);
+      throw new Error(detail || `Workspace migration did not report verified completion (exit code ${result.code}).`);
+    }
+    if (report.status === OpenClawWorkspaceMigrationStatus.Migrated) {
+      console.log(`[OpenClaw] Migrated ${report.sourceCount} legacy workspace state source(s) to SQLite.`);
+    }
+    return { status: report.status };
+  } catch (error) {
+    console.error('[OpenClaw] Workspace state migration failed before gateway startup:', error);
+    return {
+      status: OpenClawWorkspaceMigrationStatus.Failed,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/shared/openclawEngine/workspaceMigration.ts
+++ b/src/shared/openclawEngine/workspaceMigration.ts
@@ -1,0 +1,19 @@
+export const OPENCLAW_WORKSPACE_MIGRATION_ENTRY = 'openclaw-workspace-state-migration.mjs';
+export const OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX = 'LOBSTERAI_WORKSPACE_MIGRATION_RESULT ';
+
+export const OpenClawWorkspaceMigrationStatus = {
+  Skipped: 'skipped',
+  Migrated: 'migrated',
+  Failed: 'failed',
+} as const;
+
+export type OpenClawWorkspaceMigrationStatus =
+  typeof OpenClawWorkspaceMigrationStatus[keyof typeof OpenClawWorkspaceMigrationStatus];
+
+export interface OpenClawWorkspaceMigrationReport {
+  status: OpenClawWorkspaceMigrationStatus;
+  sourceCount: number;
+  changes: string[];
+  warnings: string[];
+  remainingPaths: string[];
+}

--- a/tests/openclawWorkspaceStateMigration.integration.test.ts
+++ b/tests/openclawWorkspaceStateMigration.integration.test.ts
@@ -1,0 +1,141 @@
+// Run against a built runtime, using only temporary state:
+// OPENCLAW_WORKSPACE_MIGRATION_RUNTIME=<runtime> npm test -- openclawWorkspaceStateMigration
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { promisify } from 'node:util';
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  OPENCLAW_WORKSPACE_MIGRATION_ENTRY,
+  OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX,
+  type OpenClawWorkspaceMigrationReport,
+  OpenClawWorkspaceMigrationStatus,
+} from '../src/shared/openclawEngine/workspaceMigration';
+
+const runtimeRoot = process.env.OPENCLAW_WORKSPACE_MIGRATION_RUNTIME;
+const execFileAsync = promisify(execFile);
+const seededAt = '2026-09-01T01:02:03.000Z';
+const completedAt = '2026-09-02T04:05:06.000Z';
+const content = JSON.stringify({ version: 1, bootstrapSeededAt: seededAt, onboardingCompletedAt: completedAt });
+const digest = (file: string): string => createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+let tempDir: string;
+let stateDir: string;
+let configPath: string;
+let workspaces: string[];
+
+describe.skipIf(!runtimeRoot)('bundled OpenClaw workspace migration', () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lobsterai-workspace-migration-integration-'));
+    stateDir = path.join(tempDir, 'state');
+    configPath = path.join(stateDir, 'openclaw.json');
+    workspaces = [path.join(stateDir, 'workspace-main'), path.join(tempDir, 'custom workspace')];
+    for (const workspace of workspaces) {
+      fs.mkdirSync(path.join(workspace, '.openclaw'), { recursive: true });
+      for (const filename of ['AGENTS.md', 'SOUL.md', 'USER.md', 'IDENTITY.md', 'MEMORY.md']) {
+        fs.writeFileSync(path.join(workspace, filename), `# Preserve ${filename}\nUser content.\n`);
+      }
+    }
+    fs.writeFileSync(configPath, JSON.stringify({
+      agents: { entries: { main: { default: true, workspace: workspaces[0] }, custom: { workspace: workspaces[1] } } },
+      // A full Doctor/validator would reject this: this migration must leave IM alone.
+      channels: { discord: { accounts: { fixture: { dm: { policy: 'open', allowFrom: ['*'] } } } } },
+      plugins: { load: { paths: [path.join(tempDir, 'must-not-load-plugin')] } },
+    }));
+  });
+  afterEach(() => { fs.rmSync(tempDir, { recursive: true, force: true }); });
+
+  async function migrate(): Promise<{ code: number; report: OpenClawWorkspaceMigrationReport }> {
+    const args = [path.join(runtimeRoot!, OPENCLAW_WORKSPACE_MIGRATION_ENTRY)];
+    const options = {
+      cwd: runtimeRoot, windowsHide: true, timeout: 30_000,
+      env: { ...process.env, OPENCLAW_HOME: tempDir, OPENCLAW_STATE_DIR: stateDir, OPENCLAW_CONFIG_PATH: configPath },
+    };
+    let stdout: string;
+    let stderr = '';
+    let code = 0;
+    try {
+      ({ stdout, stderr } = await execFileAsync(process.execPath, args, options));
+    } catch (error) {
+      const failure = error as Error & { code: number; stdout: string; stderr: string };
+      if (failure.code !== 1) throw error;
+      code = failure.code;
+      stdout = failure.stdout;
+      stderr = failure.stderr;
+    }
+    const line = stdout.split(/\r?\n/).find(value => value.startsWith(OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX));
+    expect(line, (stdout + stderr).slice(-3000)).toBeDefined();
+    return { code, report: JSON.parse(line!.slice(OPENCLAW_WORKSPACE_MIGRATION_RESULT_PREFIX.length)) };
+  }
+
+  test('imports both legacy setup formats for all configured workspaces and preserves files/config/empty lock', async () => {
+    const markers = [path.join(workspaces[0], '.openclaw/workspace-state.json'), path.join(workspaces[1], 'openclaw-workspace-state.json')];
+    for (const marker of markers) fs.writeFileSync(marker, content);
+    fs.writeFileSync(`${configPath}.lock`, '');
+    const lockMtime = fs.statSync(`${configPath}.lock`).mtimeMs;
+    const protectedFiles = [configPath, ...workspaces.flatMap(workspace =>
+      ['AGENTS.md', 'SOUL.md', 'USER.md', 'IDENTITY.md', 'MEMORY.md'].map(name => path.join(workspace, name)))];
+    const before = protectedFiles.map(digest);
+    const result = await migrate();
+    expect(result.code).toBe(0);
+    expect(result.report).toMatchObject({ status: OpenClawWorkspaceMigrationStatus.Migrated, sourceCount: 2, warnings: [], remainingPaths: [] });
+    expect(markers.every(marker => !fs.existsSync(marker))).toBe(true);
+    expect(protectedFiles.map(digest)).toEqual(before);
+    expect(fs.statSync(`${configPath}.lock`).size).toBe(0);
+    expect(fs.statSync(`${configPath}.lock`).mtimeMs).toBe(lockMtime);
+    const db = new DatabaseSync(path.join(stateDir, 'state/openclaw.sqlite'), { readOnly: true });
+    try {
+      const rows = db.prepare('SELECT bootstrap_seeded_at, setup_completed_at FROM workspace_setup_state').all();
+      expect(rows).toHaveLength(2);
+      expect(rows).toEqual(Array.from({ length: 2 }, () => ({ bootstrap_seeded_at: seededAt, setup_completed_at: completedAt })));
+    } finally { db.close(); }
+    expect((await migrate()).report.status).toBe(OpenClawWorkspaceMigrationStatus.Skipped);
+  });
+
+  test('preserves invalid state and retries successfully after it is repaired', async () => {
+    const marker = path.join(workspaces[0], 'openclaw-workspace-state.json');
+    fs.writeFileSync(marker, '{broken');
+    const failed = await migrate();
+    expect(failed.code).toBe(1);
+    expect(failed.report.status).toBe(OpenClawWorkspaceMigrationStatus.Failed);
+    expect(failed.report.warnings.join(' ')).toContain('invalid JSON');
+    expect(fs.readFileSync(marker, 'utf8')).toBe('{broken');
+    fs.writeFileSync(marker, content);
+    expect((await migrate()).report.status).toBe(OpenClawWorkspaceMigrationStatus.Migrated);
+  });
+
+  test('recovers an interrupted Doctor claim', async () => {
+    const marker = path.join(workspaces[1], 'openclaw-workspace-state.json.doctor-importing');
+    fs.writeFileSync(marker, content);
+    const result = await migrate();
+    expect(result.code).toBe(0);
+    expect(result.report.status).toBe(OpenClawWorkspaceMigrationStatus.Migrated);
+    expect(fs.existsSync(marker)).toBe(false);
+  });
+
+  test('imports owned attestation files and preserves unrelated sibling files', async () => {
+    const attestation = `${workspaces[0]}.attested`;
+    const unrelated = `${workspaces[1]}.attested`;
+    const generatedHash = digest(path.join(workspaces[0], 'AGENTS.md'));
+    fs.writeFileSync(attestation, `openclaw-workspace-attestation:v1\n${seededAt}\ngenerated:AGENTS.md:${generatedHash}\n`);
+    fs.writeFileSync(unrelated, 'Unrelated user file');
+    const result = await migrate();
+    expect(result.code).toBe(0);
+    expect(result.report.status).toBe(OpenClawWorkspaceMigrationStatus.Migrated);
+    expect(fs.existsSync(attestation)).toBe(false);
+    expect(fs.readFileSync(unrelated, 'utf8')).toBe('Unrelated user file');
+    const db = new DatabaseSync(path.join(stateDir, 'state/openclaw.sqlite'), { readOnly: true });
+    try {
+      expect(db.prepare('SELECT COUNT(*) AS count FROM workspace_generated_bootstrap_hashes').get()?.count).toBe(1);
+    } finally { db.close(); }
+  });
+
+  test('does not create a database when there are no legacy workspace sources', async () => {
+    expect((await migrate()).report.status).toBe(OpenClawWorkspaceMigrationStatus.Skipped);
+    expect(fs.existsSync(path.join(stateDir, 'state/openclaw.sqlite'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

修复升级到 OpenClaw v2026.8.1 后，网关已就绪但对话在准备 Agent 工作区时被 `Legacy workspace setup state requires migration` 拦截的问题。在网关启动前调用上游工作区状态迁移，将旧 setup / attestation 元数据导入 SQLite，并验证没有遗留来源后再启动网关。

## Related Issue

QA 2026-09-09 回归：关闭 `nsp-clawguard` 后网关启动成功，主 Agent 对话仍报工作区状态迁移错误。没有独立 issue 编号。

## Changes Made

- 构建独立迁移入口，直接复用 pinned OpenClaw 的检测、导入及中断恢复逻辑；使用网关的 home / state / config 和完整 Agent 工作区映射。
- 主进程在启动网关前等待迁移完成；警告、残留来源、子进程失败或缺少工具时返回可重试错误。普通启动与一键修复后的启动共用该步骤。
- 将迁移工具纳入 runtime 构建和打包检查，内嵌上游 SQL schema；新增单元、真实 runtime 集成测试及其它迁移遗漏的审查文档。

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] 11 个测试文件、100 项 Vitest 回归通过，包含工作区迁移、session / cron 迁移、网关启动恢复、runtime 打包及最新 Discord 插件适配。
- [x] Electron TypeScript 编译、全部改动 TypeScript 文件的 ESLint（零警告）、脚本语法检查和 diff 检查通过。
- [x] 真实 Windows 网关隔离验证：迁移前对话失败且没有模型请求；停止网关并迁移后，同配置对话成功返回本地模拟模型回复。运行中的网关会阻止迁移；再次执行会跳过写入。

集成测试使用临时状态目录，覆盖多 Agent、两种旧 setup 路径、attestation、中断迁移恢复、损坏数据保留与重试，以及工作区文件、配置和空配置锁保持不变。

```powershell
$env:OPENCLAW_WORKSPACE_MIGRATION_RUNTIME='<built-runtime>'
npm --ignore-scripts test -- openclawWorkspaceStateMigration openclawSessionLegacyMigration openclawCronLegacyMigration openclawEngineManager openclawRuntimePackaging openclawBundleAssets openclawLocalExtensions ensure-openclaw-plugins
npm --ignore-scripts run compile:electron
```

## Screenshots

不涉及界面布局调整。

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Non-obvious migration and packaging behavior documented in code
- [x] Corresponding documentation added
- [x] Changed-file lint passes without warnings
- [x] Regression tests added and relevant tests pass locally

## Electron-Specific Changes

- [x] Changes to main process (`src/main/`)

新增启动前迁移子进程，设置超时并等待进程结束后才允许重试；迁移失败会显示中英文错误。工作区元数据按上游合约迁入 SQLite，已有 Markdown 内容保留原位。

## Additional Notes

- 出包必须重新构建 runtime，携带 `openclaw-workspace-state-migration.mjs`。本次尚未制作完整发布安装包，也未在 macOS / Linux 实机验证。
- 本机 Windows 小文件样例中，1 / 20 / 100 个 Agent 的首次迁移分别约 3.8 / 4.8 / 6.1 秒；后续检查约 0.9～1.4 秒，包含子进程加载开销，不代表 QA 机器耗时。
- 其它 IM 配对、OAuth、执行审批等迁移适配问题记录于 `docs/openclaw-v2026.8.1-migration-audit.md`，仅作审查。通用 Doctor 的 IM / 插件配置修复以及零字节 `openclaw.json.lock` 的处理不包含在此次修复中。
