### PR TITLE
fix(openclaw): keep default model out of system prompts

### DIFF
--- a/scripts/apply-openclaw-patches.cjs
+++ b/scripts/apply-openclaw-patches.cjs
@@ -810,6 +810,26 @@ const v20260801StrongPatchValidators = {
       snippets: ['expect(promptCall?.runtimeCwd).toBe(taskRepo)'],
     },
   ],
+  'openclaw-omit-default-model-from-system-prompt.patch': [
+    {
+      file: 'src/agents/system-prompt.ts',
+      snippets: ['runtimeInfo?.model ?'],
+      forbiddenSnippets: ['default_model='],
+    },
+    {
+      file: 'src/auto-reply/reply/session-reset-prompt.ts',
+      snippets: ['Execute your Session Startup sequence now'],
+      forbiddenSnippets: ['default_model'],
+    },
+    {
+      file: 'src/agents/system-prompt-default-model.test.ts',
+      snippets: [
+        'provider requests stable when another session changes the default model',
+        'expect(payload).toEqual(originalPayload)',
+        'still reports a change to the actual running model',
+      ],
+    },
+  ],
 };
 
 const strongPatchValidators = openclawVersion === 'v2026.8.1'

--- a/scripts/patches/v2026.8.1/openclaw-omit-default-model-from-system-prompt.patch
+++ b/scripts/patches/v2026.8.1/openclaw-omit-default-model-from-system-prompt.patch
@@ -1,0 +1,173 @@
+diff --git a/src/agents/system-prompt-default-model.test.ts b/src/agents/system-prompt-default-model.test.ts
+new file mode 100644
+index 00000000000..8726b3ec47b3
+--- /dev/null
++++ b/src/agents/system-prompt-default-model.test.ts
+@@ -0,0 +1,83 @@
++import { Type } from "typebox";
++import { describe, expect, it } from "vitest";
++import { buildOpenAICompletionsParams } from "../../packages/ai/src/transports/openai-completions-params.js";
++import type { Context, Model } from "../llm/types.js";
++import { buildAgentSystemPrompt } from "./system-prompt.js";
++
++const selectedModel = {
++  id: "selected-model",
++  name: "Selected model",
++  provider: "custom",
++  api: "openai-completions",
++  baseUrl: "https://example.invalid/v1",
++  reasoning: false,
++  input: ["text"],
++  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
++  contextWindow: 128_000,
++  maxTokens: 4096,
++} satisfies Model<"openai-completions">;
++
++const context: Context = {
++  messages: [{ role: "user", content: "Stable conversation history. ".repeat(1024), timestamp: 0 }],
++  tools: [
++    {
++      name: "read",
++      description: "Read a file",
++      parameters: Type.Object({ path: Type.String() }),
++    },
++  ],
++};
++
++function buildPrompt(
++  defaultModel: string | undefined,
++  promptMode: "full" | "minimal",
++  modelId = selectedModel.id,
++) {
++  return buildAgentSystemPrompt({
++    workspaceDir: "/workspace",
++    promptMode,
++    toolNames: ["read"],
++    runtimeInfo: {
++      agentId: "main",
++      sessionKey: "agent:main:existing-session",
++      model: `${selectedModel.provider}/${modelId}`,
++      defaultModel,
++    },
++  });
++}
++
++describe("system prompt default model isolation", () => {
++  it.each(["full", "minimal"] as const)(
++    "keeps %s provider requests stable when another session changes the default model",
++    (promptMode) => {
++      const originalPrompt = buildPrompt("custom/selected-model", promptMode);
++      const originalPayload = buildOpenAICompletionsParams(
++        selectedModel,
++        { ...context, systemPrompt: originalPrompt },
++        undefined,
++      );
++
++      for (const defaultModel of ["other/short", "other/a-longer-default-model", undefined]) {
++        const systemPrompt = buildPrompt(defaultModel, promptMode);
++        const payload = buildOpenAICompletionsParams(
++          selectedModel,
++          { ...context, systemPrompt },
++          undefined,
++        );
++        expect(systemPrompt).toBe(originalPrompt);
++        expect(systemPrompt).not.toContain("default_model=");
++        expect(systemPrompt).toContain("model=custom/selected-model");
++        expect(payload).toEqual(originalPayload);
++        expect(payload.model).toBe(selectedModel.id);
++      }
++    },
++  );
++
++  it("still reports a change to the actual running model", () => {
++    const before = buildPrompt("other/default", "full");
++    const after = buildPrompt("other/default", "full", "new-selected-model");
++    expect(after).not.toBe(before);
++    expect(after).toContain("model=custom/new-selected-model");
++    expect(after).not.toContain("model=custom/selected-model");
++  });
++});
+diff --git a/src/agents/system-prompt.test.ts b/src/agents/system-prompt.test.ts
+index 30fcc796de5..45e1f3aa08f 100644
+--- a/src/agents/system-prompt.test.ts
++++ b/src/agents/system-prompt.test.ts
+@@ -2033,7 +2033,7 @@ describe("buildAgentSystemPrompt", () => {
+     expect(prompt).toContain("os=macOS (arm64)");
+     expect(prompt).toContain("node=v20");
+     expect(prompt).toContain("model=anthropic/claude");
+-    expect(prompt).toContain("default_model=anthropic/claude-opus-4-5");
++    expect(prompt).not.toContain("default_model=");
+     expect(prompt).toContain("active_node=mac-123");
+     expect(prompt).toContain("channel=telegram");
+     expect(prompt).toContain("capabilities=inlinebuttons");
+diff --git a/src/auto-reply/reply/session-reset-prompt.test.ts b/src/auto-reply/reply/session-reset-prompt.test.ts
+index 165f18be7f2..3b5e64e8112 100644
+--- a/src/auto-reply/reply/session-reset-prompt.test.ts
++++ b/src/auto-reply/reply/session-reset-prompt.test.ts
+@@ -25,6 +25,7 @@ describe("resolveBareSessionResetPromptState", () => {
+     expect(prompt).toContain("read the required files before responding to the user");
+     expect(prompt).toContain("If BOOTSTRAP.md exists in the provided Project Context");
+     expect(prompt).toContain("read it and follow its instructions first");
++    expect(prompt).not.toContain("default_model");
+     expect(prompt).not.toContain(
+       "If runtime-provided startup context is included for this first turn",
+     );
+@@ -42,6 +43,7 @@ describe("resolveBareSessionResetPromptState", () => {
+     expect(prompt).toContain("Never claim completion early");
+     expect(prompt).toContain("Your first user-visible reply must follow BOOTSTRAP.md");
+     expect(prompt).not.toContain("Then greet the user in your configured persona");
++    expect(prompt).not.toContain("default_model");
+   });
+
+   it("uses limited bootstrap wording for constrained reset runs", async () => {
+@@ -53,6 +55,7 @@ describe("resolveBareSessionResetPromptState", () => {
+     expect(prompt).toContain("no generic first greeting");
+     expect(prompt).toContain("switching to a primary interactive run with normal workspace access");
+     expect(prompt).not.toContain("Please read BOOTSTRAP.md from the workspace now");
++    expect(prompt).not.toContain("default_model");
+   });
+
+   it("appends current time line so agents know the date", async () => {
+diff --git a/src/auto-reply/reply/session-reset-prompt.ts b/src/auto-reply/reply/session-reset-prompt.ts
+index 42d0f127b98..4abb4a69ec8 100644
+--- a/src/auto-reply/reply/session-reset-prompt.ts
++++ b/src/auto-reply/reply/session-reset-prompt.ts
+@@ -13,7 +13,7 @@ import { isWorkspaceBootstrapPending } from "../../agents/workspace.js";
+ import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+ const BARE_SESSION_RESET_PROMPT_BASE =
+-  "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. If BOOTSTRAP.md exists in the provided Project Context, read it and follow its instructions first. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
++  "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. If BOOTSTRAP.md exists in the provided Project Context, read it and follow its instructions first. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. Do not mention internal steps, files, tools, or reasoning.";
+
+ const BARE_SESSION_RESET_PROMPT_BOOTSTRAP_PENDING = [
+   "A new session was started via /new or /reset while bootstrap is still pending for this workspace.",
+@@ -23,7 +23,6 @@ const BARE_SESSION_RESET_PROMPT_BOOTSTRAP_PENDING = [
+     firstReplyLine:
+       "Your first user-visible reply must follow BOOTSTRAP.md, not a generic greeting.",
+   }),
+-  "If the runtime model differs from default_model in the system prompt, mention the default model only after handling BOOTSTRAP.md.",
+   "Do not mention internal steps, files, tools, or reasoning.",
+ ].join(" ");
+
+@@ -35,7 +34,6 @@ const BARE_SESSION_RESET_PROMPT_BOOTSTRAP_LIMITED = [
+     nextStepLine:
+       "Typical next steps include switching to a primary interactive run with normal workspace access or having the user complete the canonical BOOTSTRAP.md deletion afterward.",
+   }).slice(1),
+-  "If the runtime model differs from default_model in the system prompt, mention the default model only after you have handled this limitation.",
+   "Do not mention internal steps, files, tools, or reasoning.",
+ ].join(" ");
+
+diff --git a/src/agents/system-prompt.ts b/src/agents/system-prompt.ts
+index f673d212cb9..a8cbec65390 100644
+--- a/src/agents/system-prompt.ts
++++ b/src/agents/system-prompt.ts
+@@ -1586,8 +1586,8 @@ function buildRuntimeLine(
+     runtimeInfo?.activeNode
+       ? `active_node=${sanitizeForPromptLiteral(runtimeInfo.activeNode)}`
+       : "",
++    // Shared defaults can change in other sessions and invalidate this run's history cache.
+     runtimeInfo?.model ? `model=${runtimeInfo.model}` : "",
+-    runtimeInfo?.defaultModel ? `default_model=${runtimeInfo.defaultModel}` : "",
+     runtimeInfo?.shell ? `shell=${runtimeInfo.shell}` : "",
+     runtimeChannel ? `channel=${runtimeChannel}` : "",
+     runtimeChannel

--- a/specs/refactors/openclaw-upgrade/2026-09-09-default-model-prompt-cache.md
+++ b/specs/refactors/openclaw-upgrade/2026-09-09-default-model-prompt-cache.md
@@ -1,0 +1,80 @@
+# 默认模型变更与已有会话的 system 缓存隔离
+
+## 范围
+
+针对固定版本 `v2026.8.1`，移除 Runtime system 文本中的 `default_model`，保留
+当前实际运行的 `model` 以及已有的模型身份说明。
+
+同一 agent 的默认模型可由其他会话操作改变。即使已有会话继续使用自己的模型
+override，原先每轮生成的 `default_model` 仍会改变 system，影响后续长历史的前缀复用。
+
+本次不调整 `modelSelectionScope`、sticky model 行为、agent 默认配置、session
+override、模型路由或共享记忆更新。
+
+## 实现
+
+补丁：`scripts/patches/v2026.8.1/openclaw-omit-default-model-from-system-prompt.patch`。
+
+- 在上游 `src/agents/system-prompt.ts` 的统一 Runtime 渲染处省略该字段。
+  内部 `runtimeInfo.defaultModel` 类型和配置读取保持兼容，仅改变模型接收的提示文本。
+- 删除 `src/auto-reply/reply/session-reset-prompt.ts` 三种重置提示中要求比较
+  `default_model` 的句子，避免提示词继续依赖已移除的字段。
+- 增加真实 system 构造器与 OpenAI Completions 参数构造器的回归测试：默认模型
+  改变、缺省时，完整请求保持相同；实际运行模型改变时，模型身份仍更新。
+- 在补丁应用脚本中增加强校验，确保该字段及 reset 依赖确实被移除，且实际模型
+  输出和回归测试存在。
+
+选择统一渲染处是为了覆盖所有 provider。现有 `lobsterai-model-compat` 的
+`transformSystemPrompt` 钩子只覆盖它接管的 provider，且只能处理拼接后的字符串；
+为这一字段扩展 provider 接管范围、插件启用配置和文本解析，会增加适配范围。
+
+## 验证
+
+基于 `origin/feat/openclaw-v2026.8.1` 的 `13f833829`，在独立的 OpenClaw
+`v2026.8.1` 验证 worktree 中执行，未改动开发者现有 sibling OpenClaw 工作区。
+
+- 修改前：新增测试的 full/minimal 两个请求稳定性用例失败，diff 明确指向
+  Runtime 中默认模型值变化；实际模型变更用例通过。
+- 整套版本补丁：26 个全部应用成功；新补丁反向应用检查通过。
+- 应用整套补丁后：system 默认模型回归 3 项、system prompt 133 项、embedded
+  system prompt 6 项、相关 reset 路径 4 项通过，共 146 项。
+- 上游变更文件的 Oxlint、Oxfmt 检查通过。
+- `npm run compile:electron` 通过；补丁脚本语法检查和 diff 空白检查通过。
+
+针对性测试命令，在应用本项目补丁后的 OpenClaw 源码目录执行：
+
+```sh
+node scripts/run-vitest.mjs src/agents/system-prompt-default-model.test.ts src/agents/system-prompt.test.ts src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
+node scripts/run-vitest.mjs src/auto-reply/reply/session-reset-prompt.test.ts src/auto-reply/reply/session-reset-prompt.runtime-model.test.ts -t 'includes the explicit|uses bootstrap-specific|uses limited bootstrap wording|resolves runtime model context once'
+```
+
+### Gateway 验证
+
+使用真实源码 Gateway、独立临时状态目录、loopback HTTP，以及本地模拟 OpenAI
+Completions 服务；禁用外部通道和插件，无真实供应商模型调用。
+
+1. 会话 A 指定 `fixture/selected-model`，完成一次请求。
+2. 修改默认配置为 `fixture/other-default-model`，确认 Gateway 热加载成功。
+3. 会话 B 不指定模型，模拟服务实际收到 `other-default-model`。
+4. 会话 A 再请求，实际模型仍是 `selected-model`；两次 A 请求的 system 内容完全相同，
+   没有 `default_model=`，保留 `model=fixture/selected-model`。
+5. 三次请求成功，Gateway 正常关闭。
+
+禁用插件的验证环境在热加载时有一条 prepared chat metadata 不可用警告，HTTP
+请求和上述断言均成功。未执行 Electron 图形界面回测或真实供应商缓存命中率回测。
+
+### 已确认的基线失败
+
+完整的上游 `session-reset-prompt.test.ts` 中，`appends current time line so agents
+know the date` 在当前环境期望 `9:00 AM`，实际为 `09:00`。
+
+恢复该生产模块为未经修改的固定版本代码后，同一用例仍以相同时间文本失败。
+固定版本的 `resolveCronStyleNow()` 调用 `resolveUserTimeFormat(undefined)`，没有
+采用该用例配置的 `timeFormat: "12"`。本次保留该基线问题，没有修改时间格式代码
+或放宽断言；三个修改过的 reset 提示路径均已单独验证通过。
+
+## 后续升级
+
+升级 OpenClaw 时，重新检查 Runtime 渲染和 reset 提示；若上游已经保证默认配置
+变化不会重写已有会话的 system，且不再依赖已移除字段，可移除此补丁。
+验收应比较实际 provider 请求内容，不能仅凭内部缓存边界标记或平均命中率判断。


### PR DESCRIPTION
## Summary

Switching a model in another session can update the agent's default model while an existing session keeps its selected model. OpenClaw currently renders that changing `default_model` into every system prompt, breaking the reusable conversation prefix. This patch omits that field and preserves the actual running `model`.

## Related Issue

QA cache-hit regression investigated on 2026-09-09; no linked issue.

## Changes Made

- Add a version-scoped OpenClaw v2026.8.1 patch at the shared Runtime prompt renderer, covering all providers.
- Remove the three `/new` and `/reset` instructions that compare against the omitted field.
- Add request-stability regression tests, patch validation, and a [validation report](https://github.com/netease-youdao/LobsterAI/blob/d106a1fc/specs/refactors/openclaw-upgrade/2026-09-09-default-model-prompt-cache.md).

## Type of Change

- [x] Bug fix
- [x] Performance improvement

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] Electron GUI / real-provider cache-hit testing

Validation used an isolated OpenClaw checkout at the pinned version:

- The new full/minimal request-stability tests fail before the fix and pass afterward. Changes to the actual running model still update the prompt.
- All 26 version patches apply successfully; reverse-application check passes.
- 146 focused tests pass across system prompt, provider request stability, embedded prompt, and affected reset paths.
- Oxlint and Oxfmt pass for the upstream TypeScript files; patch script syntax and staged diff checks pass.
- `npm run compile:electron` passes.
- A real source Gateway with an isolated state directory and local mock provider starts successfully. After a default-model config hot reload, an unpinned session uses the new default while the pinned session retains its model and byte-identical system content. All three HTTP requests succeed. No live provider was used.

Known baseline failure: the full upstream reset suite has one time-format assertion expecting `9:00 AM` but receiving `09:00` on this environment. The same failure was reproduced with the production reset module restored to the unmodified pin. The affected reset paths pass; this PR does not alter time formatting.

## Checklist

- [x] Followed the project's style guidelines and reviewed the diff
- [x] Documented the change and added regression coverage
- [x] Focused tests and build checks pass
- [ ] All upstream tests pass (known baseline failure described above)

## Electron-Specific Changes

The behavior changes inside the bundled OpenClaw runtime. Rebuild and sync the runtime before QA. There are no main/preload, IPC, storage-schema, or UI changes.

## Additional Notes

`agents.defaults.modelSelectionScope`, sticky model persistence, session overrides, and routing are unchanged. This removes the cache disturbance caused by rendering the shared default; it does not change how selections can update that default. Provider cache-hit rates still require QA measurement.

The plugin-disabled Gateway fixture logged an existing prepared-chat-metadata warning during reload; all HTTP and prompt assertions passed.
