### PR TITLE
fix(openclaw): make automatic skill review opt-in

### DIFF
--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -96,7 +96,8 @@ function setupDb(): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS cowork_config (
       key TEXT PRIMARY KEY,
-      value TEXT
+      value TEXT,
+      updated_at INTEGER NOT NULL DEFAULT 0
     );
   `);
 
@@ -1337,6 +1338,29 @@ test('getConfig defaults OpenClaw heartbeat to disabled when config is missing',
   const config = store.getConfig();
 
   expect(config.openClawHeartbeatEnabled).toBe(false);
+});
+
+test('defaults automatic skill review to disabled for users without the setting', () => {
+  store.setConfig({ openClawHeartbeatEnabled: true });
+
+  expect(store.getConfig().openClawSkillReviewEnabled).toBe(false);
+});
+
+test('persists skill review opt-in and opt-out independently of other settings', () => {
+  store.setConfig({ openClawSkillReviewEnabled: true });
+  store.setConfig({ openClawHeartbeatEnabled: true });
+  const reloadedStore = new CoworkStore(db);
+
+  expect(reloadedStore.getConfig()).toMatchObject({
+    openClawSkillReviewEnabled: true,
+    openClawHeartbeatEnabled: true,
+  });
+
+  reloadedStore.setConfig({ openClawSkillReviewEnabled: false });
+  expect(new CoworkStore(db).getConfig()).toMatchObject({
+    openClawSkillReviewEnabled: false,
+    openClawHeartbeatEnabled: true,
+  });
 });
 
 test('backfillEmptyAgentModels assigns the current default model to empty agents only', () => {

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -633,6 +633,7 @@ export interface CoworkConfig {
   memoryUserMemoriesMaxItems: number;
   skipMissedJobs: boolean;
   openClawHeartbeatEnabled: boolean;
+  openClawSkillReviewEnabled: boolean;
   embeddingEnabled: boolean;
   embeddingProvider: string;
   embeddingModel: string;
@@ -658,6 +659,7 @@ CoworkConfig,
   | 'memoryUserMemoriesMaxItems'
   | 'skipMissedJobs'
   | 'openClawHeartbeatEnabled'
+  | 'openClawSkillReviewEnabled'
   | 'embeddingEnabled'
   | 'embeddingProvider'
   | 'embeddingModel'
@@ -2497,6 +2499,7 @@ export class CoworkStore {
       'memoryUserMemoriesMaxItems',
       'skipMissedJobs',
       'openClawHeartbeatEnabled',
+      'openClawSkillReviewEnabled',
       'embeddingEnabled',
       'embeddingProvider',
       'embeddingModel',
@@ -2535,6 +2538,7 @@ export class CoworkStore {
       ),
       skipMissedJobs: parseBooleanConfig(cfg.get('skipMissedJobs'), true),
       openClawHeartbeatEnabled: parseBooleanConfig(cfg.get('openClawHeartbeatEnabled'), false),
+      openClawSkillReviewEnabled: parseBooleanConfig(cfg.get('openClawSkillReviewEnabled'), false),
       embeddingEnabled: parseBooleanConfig(cfg.get('embeddingEnabled'), DEFAULT_EMBEDDING_ENABLED),
       embeddingProvider: cfg.get('embeddingProvider') || DEFAULT_EMBEDDING_PROVIDER,
       embeddingModel: cfg.get('embeddingModel') || DEFAULT_EMBEDDING_MODEL,
@@ -2581,6 +2585,9 @@ export class CoworkStore {
     }
     if (config.openClawHeartbeatEnabled !== undefined) {
       this.upsertConfig('openClawHeartbeatEnabled', config.openClawHeartbeatEnabled ? '1' : '0', now);
+    }
+    if (config.openClawSkillReviewEnabled !== undefined) {
+      this.upsertConfig('openClawSkillReviewEnabled', config.openClawSkillReviewEnabled ? '1' : '0', now);
     }
     if (config.embeddingEnabled !== undefined) {
       this.upsertConfig('embeddingEnabled', config.embeddingEnabled ? '1' : '0', now);

--- a/src/main/libs/openclawConfigImpact.test.ts
+++ b/src/main/libs/openclawConfigImpact.test.ts
@@ -177,6 +177,18 @@ describe('OpenClaw config impact classification', () => {
     });
   });
 
+  test.each([true, false])('syncs skill review changes without a gateway restart (enabled: %s)', (enabled) => {
+    const result = classifyCoworkConfigChange(
+      { openClawSkillReviewEnabled: !enabled },
+      { openClawSkillReviewEnabled: enabled },
+    );
+
+    expect(result).toEqual({
+      impact: OpenClawConfigImpact.Sync,
+      reasons: [OpenClawConfigImpactReason.CoworkOpenClawConfig],
+    });
+  });
+
   test('classifies dreaming changes as restart', () => {
     const result = classifyCoworkConfigChange(
       { dreamingEnabled: false, dreamingFrequency: '0 3 * * *' },

--- a/src/main/libs/openclawConfigImpact.ts
+++ b/src/main/libs/openclawConfigImpact.ts
@@ -64,6 +64,7 @@ const COWORK_SYNC_FIELDS = new Set([
   'workingDirectory',
   'skipMissedJobs',
   'openClawHeartbeatEnabled',
+  'openClawSkillReviewEnabled',
   'embeddingEnabled',
   'embeddingProvider',
   'embeddingModel',

--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -8,6 +8,7 @@ import {
   BrowserCredentialLoginTool,
   BrowserCredentialMcpServer,
 } from '../../shared/browserCredentials/constants';
+import { OpenClawSkillReviewMode } from '../../shared/openclawEngine/constants';
 import { OpenClawProviderId, ProviderName } from '../../shared/providers';
 import { DEFAULT_DISCORD_OPENCLAW_CONFIG, DEFAULT_QQ_CONFIG, DiscordDmPolicy } from '../im/types';
 import { OpenClawAgentOwnership } from './openclawAgentModels';
@@ -261,7 +262,10 @@ describe('OpenClawConfigSync runtime config output', () => {
     const sync = await createSync();
     expect(sync.sync('first-start')).toMatchObject({ ok: true, changed: true });
     const { meta: _meta, ...config } = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-    expect(config).toEqual({ gateway: { mode: 'local' } });
+    expect(config).toEqual({
+      gateway: { mode: 'local' },
+      skills: { workshop: { autonomous: { mode: OpenClawSkillReviewMode.Off } } },
+    });
     expect(sync.sync('repeat-start')).toMatchObject({ ok: true, changed: false });
   });
 
@@ -711,6 +715,46 @@ describe('OpenClawConfigSync runtime config output', () => {
       lightContext: true,
       isolatedSession: true,
     });
+  });
+
+  test.each([true, false])('disables existing automatic reviews without opt-in (model available: %s)', async (modelAvailable) => {
+    if (!modelAvailable) mockRuntimeState.rawApiConfig.config = null;
+    fs.writeFileSync(configPath, JSON.stringify({
+      skills: { workshop: { autonomous: { mode: OpenClawSkillReviewMode.Auto } } },
+    }), 'utf8');
+    const sync = await createSync();
+
+    expect(sync.sync('skill-review-default')).toMatchObject({ ok: true, changed: true });
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.skills.workshop.autonomous.mode).toBe(OpenClawSkillReviewMode.Off);
+    expect(sync.sync('skill-review-default-repeat')).toMatchObject({ ok: true, changed: false });
+  });
+
+  test.each([true, false])('applies skill review opt-in and opt-out (model available: %s)', async (modelAvailable) => {
+    if (!modelAvailable) mockRuntimeState.rawApiConfig.config = null;
+    let enabled = true;
+    const sync = await createSync({
+      getCoworkConfig: () => ({
+        workingDirectory: tmpDir,
+        systemPrompt: '',
+        executionMode: 'local',
+        agentEngine: 'openclaw',
+        openClawSkillReviewEnabled: enabled,
+      }),
+    });
+
+    expect(sync.sync('skill-review-enabled')).toMatchObject({ ok: true, changed: true });
+    const enabledConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(enabledConfig.skills.workshop.autonomous.mode).toBe(OpenClawSkillReviewMode.Auto);
+    expect(sync.sync('skill-review-enabled-repeat')).toMatchObject({ ok: true, changed: false });
+
+    enabled = false;
+    expect(sync.sync('skill-review-disabled')).toMatchObject({ ok: true, changed: true });
+    const disabledConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(disabledConfig.skills.workshop.autonomous.mode).toBe(OpenClawSkillReviewMode.Off);
+    expect(disabledConfig.skills.entries).toEqual(enabledConfig.skills.entries);
+    expect(disabledConfig.agents).toEqual(enabledConfig.agents);
+    expect(sync.sync('skill-review-disabled-repeat')).toMatchObject({ ok: true, changed: false });
   });
 
   test('writes model provider env-proxy transport when system proxy is enabled', async () => {

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -20,7 +20,7 @@ import {
 import { COWORK_TEMP_DIR_NAME } from '../../shared/cowork/constants';
 import { CoworkErrorModelSource } from '../../shared/cowork/errorDetail';
 import { normalizeMcpServerUrlInput } from '../../shared/mcp/url';
-import { OPENCLAW_PLUGIN_INDEX_MANAGED_KEYS } from '../../shared/openclawEngine/constants';
+import { OPENCLAW_PLUGIN_INDEX_MANAGED_KEYS, OpenClawSkillReviewMode } from '../../shared/openclawEngine/constants';
 import { OpenClawTranscriptSafetyLimit } from '../../shared/openclawTranscript/constants';
 import type {
   ModelRuntimeProfile as ModelRuntimeProfileType,
@@ -2029,6 +2029,10 @@ export class OpenClawConfigSync {
   sync(reason: string): OpenClawConfigSyncResult {
     const configPath = this.engineManager.getConfigPath();
     const coworkConfig = this.getCoworkConfig();
+    // OpenClaw defaults to automatic review; require an explicit user opt-in.
+    const skillReviewMode = coworkConfig.openClawSkillReviewEnabled === true
+      ? OpenClawSkillReviewMode.Auto
+      : OpenClawSkillReviewMode.Off;
     const browserWebAccess = normalizeBrowserWebAccessConfig(this.getBrowserWebAccessConfig());
     const serverModels = getAllServerModelMetadata();
     const invalidKimiK3Transports = findInvalidKimiK3ServerTransports(serverModels);
@@ -2057,7 +2061,7 @@ export class OpenClawConfigSync {
       } else {
         // This also happens during logout or before server models finish
         // loading. Keep existing non-provider state so IM stays configured.
-        const result = this.writeMinimalConfig(configPath, reason);
+        const result = this.writeMinimalConfig(configPath, reason, skillReviewMode);
         // Still sync AGENTS.md even when API is not configured — skills/systemPrompt
         // may already be set and should be available when the user configures a model.
         const mainWorkspacePath = getMainAgentWorkspacePath(this.engineManager.getStateDir());
@@ -2486,6 +2490,9 @@ export class OpenClawConfigSync {
       tools: this.buildWebToolsConfig(browserWebAccess),
       browser: this.buildBrowserConfig(browserWebAccess),
       skills: {
+        workshop: {
+          autonomous: { mode: skillReviewMode },
+        },
         entries: {
           ...this.buildSkillEntries(),
           ...MANAGED_SKILL_ENTRY_OVERRIDES,
@@ -4072,7 +4079,11 @@ export class OpenClawConfigSync {
    * Start fresh installs without a provider, or remove unavailable providers
    * from an existing config while preserving IM and other runtime state.
    */
-  private writeMinimalConfig(configPath: string, _reason: string): OpenClawConfigSyncResult {
+  private writeMinimalConfig(
+    configPath: string,
+    _reason: string,
+    skillReviewMode: OpenClawSkillReviewMode,
+  ): OpenClawConfigSyncResult {
     const baseMinimalConfig: Record<string, unknown> = {
       gateway: {
         mode: 'local',
@@ -4113,6 +4124,20 @@ export class OpenClawConfigSync {
         // Malformed JSON — overwrite with base minimal config.
       }
     }
+
+    // Apply the review preference even before models load or after logout.
+    const skills = asConfigRecord(mergedConfig.skills);
+    const workshop = asConfigRecord(skills?.workshop);
+    mergedConfig.skills = {
+      ...skills,
+      workshop: {
+        ...workshop,
+        autonomous: {
+          ...asConfigRecord(workshop?.autonomous),
+          mode: skillReviewMode,
+        },
+      },
+    };
 
     const nextContent = `${JSON.stringify(mergedConfig, null, 2)}\n`;
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10986,7 +10986,7 @@ if (!gotTheLock) {
     };
   }
 
-  ipcMain.handle('cowork:config:set', async (_event, config: {
+  ipcMain.handle(CoworkIpcChannel.ConfigSet, async (_event, config: {
     workingDirectory?: string;
     executionMode?: 'auto' | 'local' | 'sandbox';
     agentEngine?: CoworkAgentEngine;
@@ -10997,6 +10997,7 @@ if (!gotTheLock) {
     memoryUserMemoriesMaxItems?: number;
     skipMissedJobs?: boolean;
     openClawHeartbeatEnabled?: boolean;
+    openClawSkillReviewEnabled?: boolean;
     embeddingEnabled?: boolean;
     embeddingProvider?: string;
     embeddingModel?: string;
@@ -11040,6 +11041,9 @@ if (!gotTheLock) {
       const normalizedOpenClawHeartbeatEnabled = typeof config.openClawHeartbeatEnabled === 'boolean'
         ? config.openClawHeartbeatEnabled
         : undefined;
+      const normalizedOpenClawSkillReviewEnabled = typeof config.openClawSkillReviewEnabled === 'boolean'
+        ? config.openClawSkillReviewEnabled
+        : undefined;
       const normalizedEmbedding = normalizeEmbeddingConfig(config);
       const normalizedConfig: Parameters<CoworkStore['setConfig']>[0] = {
         ...config,
@@ -11052,6 +11056,7 @@ if (!gotTheLock) {
         memoryUserMemoriesMaxItems: normalizedMemoryUserMemoriesMaxItems,
         skipMissedJobs: normalizedSkipMissedJobs,
         openClawHeartbeatEnabled: normalizedOpenClawHeartbeatEnabled,
+        openClawSkillReviewEnabled: normalizedOpenClawSkillReviewEnabled,
         ...normalizedEmbedding,
       };
       const previousConfig = getCoworkStore().getConfig();
@@ -11072,6 +11077,14 @@ if (!gotTheLock) {
       ) {
         console.log(
           `[Cowork] OpenClaw heartbeat setting changed: enabled=${nextConfig.openClawHeartbeatEnabled}, previous=${previousConfig.openClawHeartbeatEnabled}, impact=${impactDecision.impact}`,
+        );
+      }
+      if (
+        normalizedConfig.openClawSkillReviewEnabled !== undefined
+        && previousConfig.openClawSkillReviewEnabled !== nextConfig.openClawSkillReviewEnabled
+      ) {
+        console.log(
+          `[Cowork] OpenClaw skill review setting changed: enabled=${nextConfig.openClawSkillReviewEnabled}, previous=${previousConfig.openClawSkillReviewEnabled}, impact=${impactDecision.impact}`,
         );
       }
       if (impactDecision.impact !== OpenClawConfigImpact.None) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -662,6 +662,7 @@ contextBridge.exposeInMainWorld('electron', {
       memoryUserMemoriesMaxItems?: number;
       skipMissedJobs?: boolean;
       openClawHeartbeatEnabled?: boolean;
+      openClawSkillReviewEnabled?: boolean;
       embeddingEnabled?: boolean;
       embeddingProvider?: string;
       embeddingModel?: string;
@@ -669,7 +670,7 @@ contextBridge.exposeInMainWorld('electron', {
       embeddingVectorWeight?: number;
       embeddingRemoteBaseUrl?: string;
       embeddingRemoteApiKey?: string;
-    }) => ipcRenderer.invoke('cowork:config:set', config),
+    }) => ipcRenderer.invoke(CoworkIpcChannel.ConfigSet, config),
 
     // Session temp storage (.cowork-temp) maintenance
     getTempStorageUsage: () => ipcRenderer.invoke(CoworkIpcChannel.TempStorageUsage),

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1748,6 +1748,7 @@ const Settings: React.FC<SettingsProps> = ({
   const [tempCleanSelection, setTempCleanSelection] = useState<Record<string, boolean>>({});
   const [showTempCleanConfirm, setShowTempCleanConfirm] = useState<boolean>(false);
   const [openClawHeartbeatEnabled, setOpenClawHeartbeatEnabled] = useState<boolean>(coworkConfig.openClawHeartbeatEnabled ?? false);
+  const [openClawSkillReviewEnabled, setOpenClawSkillReviewEnabled] = useState<boolean>(coworkConfig.openClawSkillReviewEnabled ?? false);
   const [embeddingEnabled, setEmbeddingEnabled] = useState<boolean>(coworkConfig.embeddingEnabled ?? false);
   const [embeddingProvider, setEmbeddingProvider] = useState<string>(coworkConfig.embeddingProvider ?? 'openai');
   const [embeddingModel, setEmbeddingModel] = useState<string>(coworkConfig.embeddingModel ?? '');
@@ -1790,6 +1791,7 @@ const Settings: React.FC<SettingsProps> = ({
     setCoworkMemoryLlmJudgeEnabled(coworkConfig.memoryLlmJudgeEnabled ?? false);
     setSkipMissedJobs(coworkConfig.skipMissedJobs ?? true);
     setOpenClawHeartbeatEnabled(coworkConfig.openClawHeartbeatEnabled ?? false);
+    setOpenClawSkillReviewEnabled(coworkConfig.openClawSkillReviewEnabled ?? false);
     setEmbeddingEnabled(coworkConfig.embeddingEnabled ?? false);
     setEmbeddingProvider(coworkConfig.embeddingProvider ?? 'openai');
     setEmbeddingModel(coworkConfig.embeddingModel ?? '');
@@ -1809,6 +1811,7 @@ const Settings: React.FC<SettingsProps> = ({
     coworkConfig.openClawSessionPolicy?.keepAlive,
     coworkConfig.skipMissedJobs,
     coworkConfig.openClawHeartbeatEnabled,
+    coworkConfig.openClawSkillReviewEnabled,
     coworkConfig.embeddingEnabled,
     coworkConfig.embeddingProvider,
     coworkConfig.embeddingModel,
@@ -2832,6 +2835,7 @@ const Settings: React.FC<SettingsProps> = ({
     || coworkMemoryLlmJudgeEnabled !== coworkConfig.memoryLlmJudgeEnabled
     || skipMissedJobs !== (coworkConfig.skipMissedJobs ?? true)
     || openClawHeartbeatEnabled !== (coworkConfig.openClawHeartbeatEnabled ?? false)
+    || openClawSkillReviewEnabled !== (coworkConfig.openClawSkillReviewEnabled ?? false)
     || openClawSessionKeepAlive !== (coworkConfig.openClawSessionPolicy?.keepAlive || OpenClawSessionKeepAliveValues.ThirtyDays)
     || embeddingEnabled !== (coworkConfig.embeddingEnabled ?? false)
     || embeddingProvider !== (coworkConfig.embeddingProvider ?? 'openai')
@@ -3393,6 +3397,7 @@ const Settings: React.FC<SettingsProps> = ({
         : normalizedProviders;
       const previousSkipMissedJobs = coworkConfig.skipMissedJobs ?? true;
       const previousOpenClawHeartbeatEnabled = coworkConfig.openClawHeartbeatEnabled ?? false;
+      const previousOpenClawSkillReviewEnabled = coworkConfig.openClawSkillReviewEnabled ?? false;
       const previousAgentEngine = coworkConfig.agentEngine || 'openclaw';
       const previousOpenClawSessionKeepAlive = coworkConfig.openClawSessionPolicy?.keepAlive
         || OpenClawSessionKeepAliveValues.ThirtyDays;
@@ -3523,12 +3528,18 @@ const Settings: React.FC<SettingsProps> = ({
             `[Settings] updating OpenClaw heartbeat: enabled=${openClawHeartbeatEnabled}, previous=${previousOpenClawHeartbeatEnabled}`,
           );
         }
+        if (previousOpenClawSkillReviewEnabled !== openClawSkillReviewEnabled) {
+          console.log(
+            `[Settings] updating OpenClaw skill review: enabled=${openClawSkillReviewEnabled}, previous=${previousOpenClawSkillReviewEnabled}`,
+          );
+        }
         const updated = await coworkService.updateConfig({
           agentEngine: coworkAgentEngine,
           memoryEnabled: coworkMemoryEnabled,
           memoryLlmJudgeEnabled: coworkMemoryLlmJudgeEnabled,
           skipMissedJobs,
           openClawHeartbeatEnabled,
+          openClawSkillReviewEnabled,
           embeddingEnabled,
           embeddingProvider,
           embeddingModel,
@@ -3642,6 +3653,13 @@ const Settings: React.FC<SettingsProps> = ({
             'openClawHeartbeatEnabled',
             openClawHeartbeatEnabled,
             previousOpenClawHeartbeatEnabled,
+          );
+        }
+        if (previousOpenClawSkillReviewEnabled !== openClawSkillReviewEnabled) {
+          reportAgentEngineSettingChanged(
+            'openClawSkillReviewEnabled',
+            openClawSkillReviewEnabled,
+            previousOpenClawSkillReviewEnabled,
           );
         }
         if (previousOpenClawSessionKeepAlive !== openClawSessionKeepAlive) {
@@ -5195,6 +5213,37 @@ const Settings: React.FC<SettingsProps> = ({
                         </div>
                         <p className="mt-1.5 text-[13px] leading-5 text-secondary">
                           {i18nService.t('openClawHeartbeatEnabledDescription')}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-border bg-surface p-4">
+                    <div className="flex items-start gap-3.5">
+                      <span
+                        className={`inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl transition-colors ${
+                          openClawSkillReviewEnabled
+                            ? 'bg-primary-muted text-primary'
+                            : 'bg-surface-raised text-secondary'
+                        }`}
+                      >
+                        <ArrowPathRoundedSquareIcon className="h-5 w-5" />
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center justify-between gap-3">
+                          <h4 className="min-w-0 text-sm font-medium leading-5 text-foreground">
+                            {i18nService.t('openClawSkillReviewEnabled')}
+                          </h4>
+                          <SettingsSwitch
+                            checked={openClawSkillReviewEnabled}
+                            label={i18nService.t('openClawSkillReviewEnabled')}
+                            onClick={() => {
+                              setOpenClawSkillReviewEnabled((prev) => !prev);
+                            }}
+                          />
+                        </div>
+                        <p className="mt-1.5 text-[13px] leading-5 text-secondary">
+                          {i18nService.t('openClawSkillReviewEnabledDescription')}
                         </p>
                       </div>
                     </div>

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1238,6 +1238,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     openClawHeartbeatEnabled: '启用后台心跳',
     openClawHeartbeatEnabledDescription:
       '开启后，Agent 每小时在后台自动巡检一次你交办的持续关注事项，有进展即主动提醒；关闭后仅在你发起对话时响应，可降低空闲时的 token 消耗。',
+    openClawSkillReviewEnabled: '启用技能自动复盘',
+    openClawSkillReviewEnabledDescription:
+      '开启后，Agent 会在复杂任务结束后于后台复盘，提炼经验并创建或改进技能，供后续任务复用。复盘会额外调用模型，长对话可能产生较多 token 消耗，默认关闭。',
     openClawGatewayAddress: '网关地址',
     openClawStartupProgressLabel: '启动进度',
     openClawStatusBadgeReady: '已就绪',
@@ -5095,6 +5098,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     openClawHeartbeatEnabled: 'Enable background heartbeat',
     openClawHeartbeatEnabledDescription:
       'When on, the agent runs an hourly background sweep of the items you asked it to keep watching and reaches out the moment there is an update. When off, it responds only when you start a conversation, which lowers idle token usage.',
+    openClawSkillReviewEnabled: 'Enable automatic skill review',
+    openClawSkillReviewEnabledDescription:
+      'When on, the agent reviews complex tasks in the background after they end, turning lessons into new or improved skills for future tasks. Reviews require extra model calls and may use substantial tokens for long conversations. Off by default.',
     openClawGatewayAddress: 'Gateway address',
     openClawStartupProgressLabel: 'Startup progress',
     openClawStatusBadgeReady: 'Ready',

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -87,6 +87,7 @@ test('defaults hidden OpenClaw session policy to thirty days', () => {
   });
   expect(state.config.skipMissedJobs).toBe(true);
   expect(state.config.openClawHeartbeatEnabled).toBe(false);
+  expect(state.config.openClawSkillReviewEnabled).toBe(false);
 });
 
 test('clears account-scoped media models and selections together', () => {
@@ -186,6 +187,7 @@ test('setConfig preserves loaded OpenClaw session policy', () => {
     memoryUserMemoriesMaxItems: 12,
     skipMissedJobs: false,
     openClawHeartbeatEnabled: false,
+    openClawSkillReviewEnabled: true,
     embeddingEnabled: false,
     embeddingProvider: 'openai',
     embeddingModel: '',
@@ -204,6 +206,7 @@ test('setConfig preserves loaded OpenClaw session policy', () => {
 
   expect(state.config.openClawSessionPolicy.keepAlive).toBe('365d');
   expect(state.config.openClawHeartbeatEnabled).toBe(false);
+  expect(state.config.openClawSkillReviewEnabled).toBe(true);
 });
 
 test('updateCurrentSessionModelOverride only patches the active session', () => {

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -162,6 +162,7 @@ const initialState: CoworkState = {
     memoryUserMemoriesMaxItems: 12,
     skipMissedJobs: true,
     openClawHeartbeatEnabled: false,
+    openClawSkillReviewEnabled: false,
     embeddingEnabled: false,
     embeddingProvider: 'openai',
     embeddingModel: '',

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -190,6 +190,7 @@ export interface CoworkConfig {
   memoryUserMemoriesMaxItems: number;
   skipMissedJobs: boolean;
   openClawHeartbeatEnabled: boolean;
+  openClawSkillReviewEnabled: boolean;
   embeddingEnabled: boolean;
   embeddingProvider: string;
   embeddingModel: string;
@@ -228,6 +229,7 @@ export type CoworkConfigUpdate = Partial<Pick<
   | 'memoryUserMemoriesMaxItems'
   | 'skipMissedJobs'
   | 'openClawHeartbeatEnabled'
+  | 'openClawSkillReviewEnabled'
   | 'embeddingEnabled'
   | 'embeddingProvider'
   | 'embeddingModel'

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -275,6 +275,7 @@ interface CoworkConfig {
   memoryUserMemoriesMaxItems: number;
   skipMissedJobs: boolean;
   openClawHeartbeatEnabled: boolean;
+  openClawSkillReviewEnabled: boolean;
   embeddingEnabled: boolean;
   embeddingProvider: string;
   embeddingModel: string;
@@ -298,6 +299,7 @@ type CoworkConfigUpdate = Partial<
     | 'memoryUserMemoriesMaxItems'
     | 'skipMissedJobs'
     | 'openClawHeartbeatEnabled'
+    | 'openClawSkillReviewEnabled'
     | 'embeddingEnabled'
     | 'embeddingProvider'
     | 'embeddingModel'

--- a/src/shared/cowork/constants.ts
+++ b/src/shared/cowork/constants.ts
@@ -57,6 +57,7 @@ export const COWORK_TEMP_DIR_NAME = '.cowork-temp';
 export const COWORK_TEMP_ATTACHMENTS_DIR_NAME = 'attachments';
 
 export const CoworkIpcChannel = {
+  ConfigSet: 'cowork:config:set',
   PermissionRespond: 'cowork:permission:respond',
   GetPendingQuestions: 'cowork:question:pending',
   StreamPermissionDismiss: 'cowork:stream:permissionDismiss',

--- a/src/shared/openclawEngine/constants.ts
+++ b/src/shared/openclawEngine/constants.ts
@@ -26,6 +26,15 @@ export const OpenClawEnginePhase = {
 export type OpenClawEnginePhase =
   typeof OpenClawEnginePhase[keyof typeof OpenClawEnginePhase];
 
+/** Native Skill Workshop modes exposed by the automatic skill review setting. */
+export const OpenClawSkillReviewMode = {
+  Off: 'off',
+  Auto: 'auto',
+} as const;
+
+export type OpenClawSkillReviewMode =
+  typeof OpenClawSkillReviewMode[keyof typeof OpenClawSkillReviewMode];
+
 export const OpenClawGatewayRepairErrorCode = {
   Busy: 'busy',
   ConfigApplyPending: 'config_apply_pending',


### PR DESCRIPTION

## Summary

OpenClaw v2026.8.1 enables automatic Skill Workshop reviews by default. Reviews after long tasks can generate substantial additional model usage. Add an opt-in "Enable automatic skill review" switch under Settings → Agent Engine → Background runtime, with Chinese and English explanations of its purpose and token cost.

## Related Issue

QA regression investigation following the OpenClaw v2026.8.1 upgrade; no linked issue.

## Changes Made

- Persist `openClawSkillReviewEnabled`, defaulting to `false` for new installations and existing users without the setting.
- Map the preference to native `skills.workshop.autonomous.mode` (`off` / `auto`) in both full and minimal configuration, including before models load and after logout.
- Apply changes through the existing config IPC and hot reload path; no gateway restart or upstream runtime patch is needed.

## Type of Change

- [x] Bug fix
- [x] New feature

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [x] Manual testing performed

220 relevant tests passed across `coworkStore.test.ts`, `openclawConfigSync.runtime.test.ts`, `openclawConfigImpact.test.ts`, and `coworkSlice.test.ts`. Also passed changed-file ESLint, `npm run build`, `npm run compile:electron`, and `git diff --check`.

An isolated Electron profile verified default-off, cancel without saving, enable/save/reopen, disable/save/reopen, and Chinese/English UI rendering. Gateway logs confirmed `config hot reload applied (skills.workshop.autonomous.mode)` and `config.set acked restartScheduled=false` for both toggle directions.

## Screenshots

<img width="1276" height="798" alt="settings-zh-dark" src="https://github.com/user-attachments/assets/9d708813-1f4e-4efe-b4dc-580077cc7bb6" />

<img width="1276" height="798" alt="settings-en-dark" src="https://github.com/user-attachments/assets/dcece934-f0a0-43aa-b8e4-a6de4c0ff93b" />

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Non-obvious default and minimal-config handling is commented
- [x] User-facing explanations are provided in Chinese and English
- [x] Changed files pass lint without warnings
- [x] Regression coverage verifies defaults, persistence, and runtime configuration changes
- [x] Relevant new and existing tests pass locally

## Electron-Specific Changes

- [x] Main process: Cowork preference persistence and OpenClaw configuration sync
- [x] Preload and IPC: extend the existing config payload and use its shared channel constant
- [ ] Window management

## Additional Notes

Native `auto` mode controls both post-task experience review and weekly skill collection review; turning this setting off disables both automatic paths. It does not require waiting for the weekly timer to test the setting.

Suggested QA:
1. Upgrade an existing profile without this preference and verify the switch is off and native mode is `off`. Confirm reopening the app preserves the saved preference; canceling an edit must not persist it.
2. Enable and save, then use a normal foreground task with at least 10 model iterations in one user turn. Allow the task to finish without compaction/errors, leave the agent system idle for 1–2 minutes, and inspect the review run/usage.
3. Disable and save, repeat an equivalent task, and verify no new automatic review is started. Also test disabling during the 30-second post-task idle window.
4. In both directions, verify native mode changes and the gateway remains running. Use review-specific logs/usage rather than expecting every foreground request to have a high cache-hit rate.
