### PR TITLE
fix(openclaw): unblock legacy session migration

### DIFF
--- a/scripts/patches/v2026.8.1/openclaw-session-migration-duplicate-headers.patch
+++ b/scripts/patches/v2026.8.1/openclaw-session-migration-duplicate-headers.patch
@@ -1,0 +1,282 @@
+OpenClaw v2026.8.1: normalize duplicate legacy session headers during migration.
+
+Import and validation share first-header identity handling. Raw row indexes and
+archived JSONL bytes are preserved; non-header identity collisions remain blocking.
+Base: ea806575e6450e4d1efdfc72c19f04be982a1b9b.
+
+diff --git a/src/commands/doctor-session-sqlite-readers.ts b/src/commands/doctor-session-sqlite-readers.ts
+index ad50ea265cf..378547ac26f 100644
+--- a/src/commands/doctor-session-sqlite-readers.ts
++++ b/src/commands/doctor-session-sqlite-readers.ts
+@@ -71,10 +71,8 @@ export function countTranscriptEventsForPath(
+   }
+   let events = 0;
+   try {
+-    for (const line of iterateJsonlLinesSync(transcriptPath)) {
+-      if (!parseJsonlLine(line)) {
+-        continue;
+-      }
++    const transcript = iterateTranscriptEvents(transcriptPath, false);
++    while (!transcript.next().done) {
+       events += 1;
+     }
+     return { status: "ok", events };
+@@ -267,17 +265,31 @@ function* iterateTranscriptEvents(
+   allowMalformedPrefix: boolean,
+ ): Generator<{ event: FileEntry; originalIndex: number }> {
+   let originalIndex = 0;
++  let firstSessionHeader: Record<string, unknown> | undefined;
+   try {
+     for (const line of iterateJsonlLinesSync(transcriptPath)) {
+       const parsed = parseJsonlLine(line);
+       if (!parsed) {
+         continue;
+       }
++      // Keep raw indexes for v1 compaction links even when a repeated header is skipped.
++      const eventIndex = originalIndex++;
++      if (isRecord(parsed) && parsed.type === "session") {
++        // Legacy writers could append another header for the same session. SQLite
++        // keeps the first identity; import and validation must count it only once.
++        if (
++          typeof parsed.id === "string" &&
++          parsed.id.trim() &&
++          parsed.id === firstSessionHeader?.id
++        ) {
++          continue;
++        }
++        firstSessionHeader ??= parsed;
++      }
+       yield {
+         event: normalizeLoadedFileEntry(parsed as FileEntry),
+-        originalIndex,
++        originalIndex: eventIndex,
+       };
+-      originalIndex += 1;
+     }
+   } catch (error) {
+     if (!allowMalformedPrefix || error instanceof TranscriptImportLimitError) {
+diff --git a/src/commands/doctor-session-sqlite-duplicate-headers.test.ts b/src/commands/doctor-session-sqlite-duplicate-headers.test.ts
+new file mode 100644
+index 00000000000..00f9ed747e9
+--- /dev/null
++++ b/src/commands/doctor-session-sqlite-duplicate-headers.test.ts
+@@ -0,0 +1,219 @@
++import fs from "node:fs";
++import path from "node:path";
++import { afterEach, describe, expect, it, vi } from "vitest";
++import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
++import { importSqliteSessionRows } from "../config/sessions/session-accessor.sqlite-import.js";
++import { loadTranscriptEventsSync } from "../config/sessions/session-accessor.sqlite-read.js";
++import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
++import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
++import { runDoctorSessionSqlite } from "./doctor-session-sqlite.js";
++
++const tempDirs = useAutoCleanupTempDirTracker(afterEach);
++const sessionId = "legacy-session";
++const sessionKey = "agent:main:main";
++const header = {
++  type: "session",
++  version: 3,
++  id: sessionId,
++  timestamp: "2026-04-16T08:42:53.333Z",
++  cwd: "/application/runtime",
++};
++
++afterEach(() => {
++  closeOpenClawAgentDatabasesForTest();
++  closeOpenClawStateDatabaseForTest();
++  vi.unstubAllEnvs();
++});
++
++function message(id: string, role: string, text: string, parentId: string | null = null) {
++  return {
++    type: "message",
++    id,
++    parentId,
++    message: { role, content: [{ type: "text", text }] },
++  };
++}
++
++function createLegacyStore(events: unknown[]) {
++  const stateDir = tempDirs.make("openclaw-doctor-duplicate-headers-");
++  const sessionDir = path.join(stateDir, "agents", "main", "sessions");
++  const storePath = path.join(sessionDir, "sessions.json");
++  const transcriptPath = path.join(sessionDir, `${sessionId}.jsonl`);
++  const peerPath = path.join(sessionDir, "peer-session.jsonl");
++  const configPath = path.join(stateDir, "openclaw.json");
++  const originalTranscript = `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
++  const peerEvents = [{ ...header, id: "peer-session" }, message("peer-message", "user", "peer")];
++  fs.mkdirSync(sessionDir, { recursive: true });
++  fs.writeFileSync(configPath, "{}\n", { mode: 0o600 });
++  fs.writeFileSync(transcriptPath, originalTranscript, { mode: 0o600 });
++  fs.writeFileSync(peerPath, `${peerEvents.map((event) => JSON.stringify(event)).join("\n")}\n`, {
++    mode: 0o600,
++  });
++  fs.writeFileSync(
++    storePath,
++    JSON.stringify({
++      [sessionKey]: { sessionId, updatedAt: 1, sessionFile: transcriptPath },
++      "agent:main:peer": {
++        sessionId: "peer-session",
++        updatedAt: 1,
++        sessionFile: peerPath,
++      },
++    }),
++    { mode: 0o600 },
++  );
++  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
++  vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
++  const env = { ...process.env };
++  const scope = { agentId: "main", env, sessionId, sessionKey, storePath };
++  const options = { env, mode: "import" as const, store: storePath };
++  return { options, originalTranscript, peerEvents, peerPath, scope, storePath, transcriptPath };
++}
++
++describe("legacy session headers in SQLite migration", () => {
++  it.each(["fresh", "partial", "already imported"] as const)(
++    "archives duplicate headers and healthy peers after %s import without losing messages",
++    async (existing) => {
++      // A legacy injected reply was written before the buffered original header.
++      // The two headers share identity but intentionally differ in metadata.
++      const events = [
++        header,
++        {
++          ...message("injected", "assistant", "injected reply"),
++          message: {
++            ...message("injected", "assistant", "injected reply").message,
++            provider: "openclaw",
++            model: "gateway-injected",
++          },
++        },
++        { ...header, timestamp: "2026-04-16T08:42:50.809Z", cwd: "/original/workspace" },
++        { type: "model_change", id: "model", parentId: null, provider: "test", modelId: "test" },
++        { type: "thinking_level_change", id: "thinking", parentId: "model", thinkingLevel: "off" },
++        { type: "custom", id: "snapshot", parentId: "thinking", customType: "snapshot" },
++        message("user", "user", "question", "snapshot"),
++        { type: "custom", id: "metadata", parentId: "user", customType: "metadata" },
++        message("answer", "assistant", "answer", "metadata"),
++      ];
++      const store = createLegacyStore(events);
++      const expected = events.filter((_, index) => index !== 2);
++      let seededEvents = 0;
++      if (existing !== "fresh") {
++        const seed = existing === "partial" ? events.slice(0, 2) : events;
++        // Seed through the real importer, including the old writer's identity dedupe.
++        const seeded = await importSqliteSessionRows({
++          ...store.scope,
++          entry: { sessionId, updatedAt: 1 },
++          readTranscriptEvents: (append) => seed.forEach(append),
++        });
++        seededEvents = seeded.transcriptEvents;
++        closeOpenClawAgentDatabasesForTest();
++      }
++
++      const report = await runDoctorSessionSqlite(store.options);
++
++      expect(report.targets[0]?.issues).toEqual([]);
++      expect(report.totals).toMatchObject({
++        importedEntries: 2,
++        importedTranscriptEvents: 10 - seededEvents,
++        archivedTranscriptFiles: 2,
++        archivedLegacyStoreFiles: 1,
++      });
++      expect(loadTranscriptEventsSync(store.scope)).toEqual(expected);
++      expect(
++        loadTranscriptEventsSync({
++          ...store.scope,
++          sessionId: "peer-session",
++          sessionKey: "agent:main:peer",
++        }),
++      ).toEqual(store.peerEvents);
++      expect(fs.existsSync(store.storePath)).toBe(false);
++      expect(fs.existsSync(store.transcriptPath)).toBe(false);
++      expect(fs.existsSync(store.peerPath)).toBe(false);
++      const archivedBytes = report.targets[0]!.archivedTranscriptFiles.map((filePath) =>
++        fs.readFileSync(filePath),
++      );
++      expect(archivedBytes).toContainEqual(Buffer.from(store.originalTranscript));
++
++      const retry = await runDoctorSessionSqlite(store.options);
++      expect(retry.totals).toMatchObject({ importedTranscriptEvents: 0, issues: 0 });
++      expect(loadTranscriptEventsSync(store.scope)).toEqual(expected);
++    },
++  );
++
++  it.each(["same payload", "different payload"])(
++    "keeps non-header identity collisions blocking (%s)",
++    async (payload) => {
++      const firstMessage = message("collision", "user", "first message");
++      const collision =
++        payload === "same payload"
++          ? firstMessage
++          : message("collision", "user", "different message");
++      const store = createLegacyStore([
++        header,
++        firstMessage,
++        { ...header, cwd: "/other" },
++        collision,
++      ]);
++
++      for (const attempt of [0, 1]) {
++        const report = await runDoctorSessionSqlite(store.options);
++        expect(report.targets[0]?.issues).toContainEqual({
++          code: "sqlite_transcript_count_mismatch",
++          message: "SQLite transcript has 2 events; source has 3.",
++          sessionKey,
++        });
++        expect(report.totals).toMatchObject({
++          importedTranscriptEvents: attempt === 0 ? 4 : 0,
++          archivedTranscriptFiles: 0,
++          archivedLegacyStoreFiles: 0,
++        });
++        expect(fs.existsSync(store.storePath)).toBe(true);
++        expect(fs.existsSync(store.peerPath)).toBe(true);
++        expect(fs.readFileSync(store.transcriptPath, "utf8")).toBe(store.originalTranscript);
++      }
++    },
++  );
++
++  it("preserves session headers with a different identity", async () => {
++    const events = [
++      header,
++      { ...header, id: "other-session" },
++      message("user", "user", "question"),
++    ];
++    const store = createLegacyStore(events);
++
++    const report = await runDoctorSessionSqlite(store.options);
++
++    expect(report.targets[0]?.issues).toEqual([]);
++    expect(report.totals.importedTranscriptEvents).toBe(5);
++    expect(loadTranscriptEventsSync(store.scope)).toEqual(events);
++  });
++
++  it("preserves original v1 compaction indexes across skipped headers", async () => {
++    const legacyHeader = { ...header, version: 1 };
++    const store = createLegacyStore([
++      legacyHeader,
++      { type: "message", message: { role: "assistant", content: "injected reply" } },
++      { ...legacyHeader, cwd: "/original/workspace" },
++      { type: "message", message: { role: "user", content: "kept message" } },
++      { type: "compaction", summary: "summary", firstKeptEntryIndex: 3, tokensBefore: 42 },
++    ]);
++
++    const report = await runDoctorSessionSqlite(store.options);
++
++    expect(report.targets[0]?.issues).toEqual([]);
++    const events = loadTranscriptEventsSync(store.scope) as Array<{
++      id: string;
++      type: string;
++      parentId?: string;
++      firstKeptEntryId?: string;
++    }>;
++    expect(events).toHaveLength(4);
++    expect(events[3]).toMatchObject({
++      type: "compaction",
++      firstKeptEntryId: events[2]!.id,
++      parentId: events[2]!.id,
++    });
++    expect(events[3]).not.toHaveProperty("firstKeptEntryIndex");
++    expect(events[0]).toMatchObject({ type: "session", version: 3 });
++  });
++});

--- a/src/main/libs/openclawPatches/v20260801UpgradeDecisions.test.ts
+++ b/src/main/libs/openclawPatches/v20260801UpgradeDecisions.test.ts
@@ -27,6 +27,7 @@ const RETAINED_PATCHES = [
   'openclaw-run-failure-detail.patch',
   'openclaw-safe-error-metadata.patch',
   'openclaw-session-goal-rpc.patch',
+  'openclaw-session-migration-duplicate-headers.patch',
   'openclaw-shell-snapshot-electron-node-env.patch',
   'openclaw-skip-disabled-web-search-discovery.patch',
   'openclaw-skip-derive-prompt-segments-deadloop.patch',

--- a/src/main/libs/openclawSessionLegacyMigration.test.ts
+++ b/src/main/libs/openclawSessionLegacyMigration.test.ts
@@ -4,7 +4,10 @@ import path from 'path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
+  LEGACY_SESSION_SQLITE_IMPORT_MODE,
   type LegacySessionMigrationRunner,
+  type LegacySessionMigrationRunResult,
+  LegacySessionMigrationWarningCode,
   listLegacySessionStorePaths,
   migrateLegacySessionStorageWithDoctor,
 } from './openclawSessionLegacyMigration';
@@ -17,6 +20,33 @@ let configPath = '';
 function writeFile(filePath: string, content = '{}\n'): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, content, 'utf8');
+}
+
+function createWarningImportFixture() {
+  const legacyPath = path.join(stateDir, 'agents', 'main', 'sessions', 'sessions.json');
+  const archivePath = path.join(stateDir, 'archives', 'sessions.json.imported');
+  writeFile(legacyPath);
+  return {
+    legacyPath,
+    archivePath,
+    report: {
+      mode: LEGACY_SESSION_SQLITE_IMPORT_MODE as string,
+      totals: { issues: 2, targets: 1 },
+      migrationRun: { manifestPath: path.join(stateDir, 'session-sqlite-migration-runs', 'run.json') },
+      targets: [{
+        agentId: 'main', storePath: legacyPath, archivedLegacyStoreFiles: [archivePath],
+        issues: [
+          { code: LegacySessionMigrationWarningCode.EntryInvalid as string, message: 'Session entry is missing a valid sessionId.' },
+          { code: LegacySessionMigrationWarningCode.TranscriptMissing as string, message: 'Historical transcript is missing.' },
+        ],
+      }],
+    },
+  };
+}
+
+function archiveWarningFixture(fixture: ReturnType<typeof createWarningImportFixture>): void {
+  fs.mkdirSync(path.dirname(fixture.archivePath), { recursive: true });
+  fs.renameSync(fixture.legacyPath, fixture.archivePath);
 }
 
 describe('openclawSessionLegacyMigration', () => {
@@ -183,6 +213,111 @@ describe('openclawSessionLegacyMigration', () => {
       status: 'failed', error: expect.stringContaining('main: Transcript validation failed'),
     });
   });
+
+  test('continues after warning-only import only when every discovered store has an existing archive', async () => {
+    const fixture = createWarningImportFixture();
+    const workerPath = path.join(stateDir, 'agents', 'worker', 'sessions', 'sessions.json');
+    const workerArchive = path.join(stateDir, 'archives', 'worker-sessions.json.imported');
+    writeFile(workerPath);
+    fixture.report.targets.push({ agentId: 'worker', storePath: workerPath, archivedLegacyStoreFiles: [workerArchive], issues: [] });
+    fixture.report.totals.targets += 1;
+    const logWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logInfo = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const runner = vi.fn<LegacySessionMigrationRunner>().mockImplementation(async () => {
+      archiveWarningFixture(fixture);
+      fs.renameSync(workerPath, workerArchive);
+      return { code: 1, stdout: JSON.stringify(fixture.report), stderr: '' };
+    });
+
+    const result = await migrateLegacySessionStorageWithDoctor({
+      stateDir, configPath, runtimeRoot, electronNodeRuntimePath: process.execPath, env: {}, runner,
+    });
+
+    expect(result).toEqual({ status: 'migrated', code: 1, migratedPaths: [fixture.legacyPath, workerPath] });
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining('completed with warnings'));
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining(JSON.stringify(fixture.report.migrationRun.manifestPath)));
+    expect(fs.readFileSync(fixture.archivePath, 'utf8')).toBe('{}\n');
+  });
+
+  test('shows a blocking issue from a later target before an invalid-entry warning and logs issue counts', async () => {
+    const fixture = createWarningImportFixture();
+    const blockerCode = 'sqlite_transcript_count_mismatch';
+    const sessionKey = 'agent:worker:historical-session';
+    const logInfo = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const stdout = JSON.stringify({
+      ...fixture.report,
+      totals: { issues: 3, targets: 2 },
+      targets: [...fixture.report.targets, {
+        agentId: 'worker', storePath: path.join(stateDir, 'agents', 'worker', 'sessions', 'sessions.json'),
+        issues: [{ code: blockerCode, message: 'SQLite transcript has 8 events; source has 9.', sessionKey }],
+      }],
+    });
+    const runner = vi.fn<LegacySessionMigrationRunner>().mockResolvedValue({ code: 1, stdout, stderr: '' });
+
+    const result = await migrateLegacySessionStorageWithDoctor({
+      stateDir, configPath, runtimeRoot, electronNodeRuntimePath: process.execPath, env: {}, runner,
+    });
+
+    expect(result).toMatchObject({ status: 'failed', error: expect.stringContaining(`worker: [${blockerCode}]`) });
+    if (!('error' in result)) throw new Error('Expected migration failure');
+    expect(result.error).toContain(sessionKey);
+    expect(result.error).not.toContain('missing a valid sessionId');
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining(`"${blockerCode}":1`));
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining(JSON.stringify(fixture.report.migrationRun.manifestPath)));
+  });
+
+  const rejectedWarningImports: Array<{
+    name: string;
+    mutate: (fixture: ReturnType<typeof createWarningImportFixture>, result: LegacySessionMigrationRunResult) => void;
+  }> = [
+    { name: 'terminated process', mutate: (_fixture, result) => { result.code = null; } },
+    { name: 'unexpected exit code', mutate: (_fixture, result) => { result.code = 2; } },
+    { name: 'exception after report', mutate: (_fixture, result) => { result.stderr = 'Error: SQLite finalization failed'; } },
+    { name: 'different doctor mode', mutate: (fixture) => { fixture.report.mode = 'validate'; } },
+    { name: 'mismatched issue total', mutate: (fixture) => { fixture.report.totals.issues += 1; } },
+    { name: 'mismatched target total', mutate: (fixture) => { fixture.report.totals.targets += 1; } },
+    { name: 'unknown issue code', mutate: (fixture) => { fixture.report.targets[0].issues[0].code = 'future_blocking_issue'; } },
+    { name: 'unreported archive', mutate: (fixture) => { fixture.report.targets[0].archivedLegacyStoreFiles = []; } },
+    { name: 'missing archive file', mutate: (fixture) => { fs.unlinkSync(fixture.archivePath); } },
+    { name: 'uncovered source store', mutate: (fixture) => { fixture.report.targets[0].storePath = path.join(stateDir, 'other.json'); } },
+    { name: 'remaining source store', mutate: (fixture) => { fs.copyFileSync(fixture.archivePath, fixture.legacyPath); } },
+    { name: 'newly created source store', mutate: () => { writeFile(path.join(stateDir, 'agents', 'new', 'sessions', 'sessions.json')); } },
+  ];
+
+  test.each(rejectedWarningImports)('rejects warning-only completion with $name', async ({ mutate }) => {
+    const fixture = createWarningImportFixture();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const runner = vi.fn<LegacySessionMigrationRunner>().mockImplementation(async () => {
+      archiveWarningFixture(fixture);
+      const result: LegacySessionMigrationRunResult = { code: 1, stdout: '', stderr: '' };
+      mutate(fixture, result);
+      result.stdout = JSON.stringify(fixture.report);
+      return result;
+    });
+
+    const result = await migrateLegacySessionStorageWithDoctor({
+      stateDir, configPath, runtimeRoot, electronNodeRuntimePath: process.execPath, env: {}, runner,
+    });
+
+    expect(result.status).toBe('failed');
+  });
+
+  test.each(['', 'not JSON', '{"mode":"import","targets":null}', '{"mode":"import","targets":[]}'])(
+    'does not infer success from missing stores with an incomplete report: %s', async (stdout) => {
+      const fixture = createWarningImportFixture();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const runner = vi.fn<LegacySessionMigrationRunner>().mockImplementation(async () => {
+        archiveWarningFixture(fixture);
+        return { code: 1, stdout, stderr: '' };
+      });
+      const result = await migrateLegacySessionStorageWithDoctor({
+        stateDir, configPath, runtimeRoot, electronNodeRuntimePath: process.execPath, env: {}, runner,
+      });
+      expect(result.status).toBe('failed');
+    },
+  );
 
   test('fails closed when doctor exits successfully but leaves the legacy store', async () => {
     const legacyPath = path.join(stateDir, 'agents', 'main', 'sessions', 'sessions.json');

--- a/src/main/libs/openclawSessionLegacyMigration.ts
+++ b/src/main/libs/openclawSessionLegacyMigration.ts
@@ -2,11 +2,37 @@ import { spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { stripVTControlCharacters } from 'util';
+import { z } from 'zod';
 
 import { inspectOpenClawPath, logOpenClawConfigLockDiagnostics } from './openclawConfigDiagnostics';
 
 const LEGACY_SESSION_DOCTOR_TIMEOUT_MS = 300_000;
 const LOG_TAIL_LIMIT = 4_000;
+export const LEGACY_SESSION_SQLITE_IMPORT_MODE = 'import';
+// OpenClaw v2026.8.1 doctor-session-sqlite-types.ts. Unknown codes remain blocking.
+export const LegacySessionMigrationWarningCode = {
+  EntryInvalid: 'entry_invalid',
+  TranscriptArchiveFailed: 'transcript_archive_failed',
+  TranscriptMalformed: 'transcript_malformed',
+  TranscriptMissing: 'transcript_missing',
+  UnreferencedJsonlArchiveFailed: 'unreferenced_jsonl_archive_failed',
+} as const;
+const WARNING_ISSUE_CODES = new Set<string>(Object.values(LegacySessionMigrationWarningCode));
+const DOCTOR_EXCEPTION_LINE = /^(?:\w*Error\b|Cannot\b|Failed\b|Fatal\b|ERR_|file lock timeout|Config validation failed)/i;
+const doctorReportSchema = z.object({
+  mode: z.string().optional(),
+  totals: z.object({ issues: z.number().int().nonnegative(), targets: z.number().int().nonnegative() }).optional(),
+  migrationRun: z.object({ manifestPath: z.string() }).optional(),
+  targets: z.array(z.object({
+    agentId: z.string().optional(),
+    storePath: z.string().optional(),
+    archivedLegacyStoreFiles: z.array(z.string().min(1)).optional(),
+    issues: z.array(z.object({
+      code: z.string().optional(), message: z.string(), sessionKey: z.string().optional(),
+    })),
+  })),
+});
+type DoctorReport = z.infer<typeof doctorReportSchema>;
 
 export type LegacySessionMigrationRunResult = {
   code: number | null;
@@ -61,22 +87,50 @@ function tailLog(text: string): string {
   return text.length <= LOG_TAIL_LIMIT ? text : text.slice(-LOG_TAIL_LIMIT);
 }
 
-function summarizeDoctorFailure(stderr: string, stdout: string): string | undefined {
-  const cleanLines = (text: string) => stripVTControlCharacters(text).split(/\r?\n/)
+function parseDoctorReport(stdout: string): DoctorReport | undefined {
+  try {
+    const result = doctorReportSchema.safeParse(JSON.parse(stdout));
+    return result.success ? result.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasArchivedWarningOnlyImport(report: DoctorReport | undefined, legacyPaths: string[]): boolean {
+  if (!report || report.mode !== LEGACY_SESSION_SQLITE_IMPORT_MODE) return false;
+  const issues = report.targets.flatMap(target => target.issues);
+  if (issues.length === 0 || report.totals?.issues !== issues.length
+    || report.totals.targets !== report.targets.length
+    || issues.some(issue => !WARNING_ISSUE_CODES.has(issue.code ?? ''))) return false;
+
+  const normalizePath = (filePath: string) => {
+    const resolved = path.resolve(filePath);
+    return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+  };
+  const archivedStores = new Set(report.targets
+    .filter(target => target.storePath && target.archivedLegacyStoreFiles?.some(fileExists))
+    .map(target => normalizePath(target.storePath!)));
+  return legacyPaths.every(filePath => archivedStores.has(normalizePath(filePath)));
+}
+
+function cleanDoctorLines(text: string): string[] {
+  return stripVTControlCharacters(text).split(/\r?\n/)
     .map(line => line.trim().replace(/^[│┃|]\s*/, '').replace(/\s*[│┃|]$/, '').trim());
-  const stderrLines = cleanLines(stderr);
-  const lines = [...stderrLines, ...cleanLines(stdout)];
+}
+
+function summarizeDoctorFailure(stderr: string, stdout: string, report?: DoctorReport): string | undefined {
+  const stderrLines = cleanDoctorLines(stderr);
+  const lines = [...stderrLines, ...cleanDoctorLines(stdout)];
   // Doctor writes boxed, wrapped validation errors to stdout. Prefer those
   // and actual exceptions over stderr warnings such as snapshot rotation.
-  const exception = lines.find(line => /^(?:\w*Error\b|Cannot\b|Failed\b|Fatal\b|ERR_|file lock timeout|Config validation failed)/i.test(line));
+  const exception = lines.find(line => DOCTOR_EXCEPTION_LINE.test(line));
   if (exception) return exception;
-  try {
-    const report = JSON.parse(stdout) as { targets?: Array<{ agentId?: string; issues?: Array<{ message?: string }> }> };
-    const target = report.targets?.find(target => target.issues?.some(issue => typeof issue.message === 'string'));
-    const issue = target?.issues?.find(issue => typeof issue.message === 'string');
-    if (issue?.message) return `${target?.agentId ?? 'session'}: ${issue.message}`.slice(0, 1_000);
-  } catch {
-    // Generic doctor failures can still use boxed text instead of JSON.
+  const issues = report?.targets.flatMap(target => target.issues.map(issue => ({ ...issue, agentId: target.agentId })));
+  const issue = issues?.find(item => !WARNING_ISSUE_CODES.has(item.code ?? '')) ?? issues?.[0];
+  if (issue) {
+    const code = issue.code ? `[${issue.code}] ` : '';
+    const session = issue.sessionKey ? ` (${issue.sessionKey})` : '';
+    return `${issue.agentId ?? 'session'}: ${code}${issue.message}${session}`.slice(0, 1_000);
   }
   const issueIndex = lines.findIndex(line => /^-?\s*[\w.[\]-]+:\s*invalid config\b/i.test(line));
   if (issueIndex >= 0) {
@@ -169,7 +223,7 @@ export async function migrateLegacySessionStorageWithDoctor(params: {
   // Session import validates and archives legacy data itself. Generic
   // `doctor --fix` also rewrites IM config; in v2026.8.1 its generic QQ
   // repairs conflict with the official QQ 2.0 schema and abort migration.
-  const args = [openclawCliPath, 'doctor', '--session-sqlite', 'import', '--session-sqlite-all-agents', '--json'];
+  const args = [openclawCliPath, 'doctor', '--session-sqlite', LEGACY_SESSION_SQLITE_IMPORT_MODE, '--session-sqlite-all-agents', '--json'];
   const runner = params.runner ?? runLegacySessionMigrationProcess;
 
   console.log(
@@ -198,7 +252,23 @@ export async function migrateLegacySessionStorageWithDoctor(params: {
     });
     console.log(`[OpenClaw] Legacy session doctor exited: code=${result.code} elapsedMs=${Date.now() - startedAt}`);
 
-    if (result.code !== 0) {
+    const report = parseDoctorReport(result.stdout);
+    // A fresh scan also catches a legacy store created after the initial discovery.
+    const remainingPaths = listLegacySessionStorePaths(params.stateDir);
+    const completedWithWarnings = result.code === 1 && remainingPaths.length === 0
+      && !cleanDoctorLines(result.stderr).some(line => DOCTOR_EXCEPTION_LINE.test(line))
+      && hasArchivedWarningOnlyImport(report, legacyPaths);
+    if (report) {
+      const issueCounts: Record<string, number> = {};
+      for (const issue of report.targets.flatMap(target => target.issues)) {
+        const code = issue.code ?? 'unknown';
+        issueCounts[code] = (issueCounts[code] ?? 0) + 1;
+      }
+      console.log(`[OpenClaw] Legacy session migration report: ${JSON.stringify({
+        code: result.code, issueCounts, manifestPath: report.migrationRun?.manifestPath, remainingPaths,
+      })}`);
+    }
+    if (result.code !== 0 && !completedWithWarnings) {
       const failure = `OpenClaw legacy session migration failed with exit code ${result.code}.`;
       const details = [
         failure,
@@ -207,11 +277,10 @@ export async function migrateLegacySessionStorageWithDoctor(params: {
       ].filter(Boolean).join('\n');
       console.error(`[OpenClaw] ${details}`);
       logFailureDiagnostics();
-      const cause = summarizeDoctorFailure(result.stderr, result.stdout);
+      const cause = summarizeDoctorFailure(result.stderr, result.stdout, report);
       return { status: 'failed', code: result.code, error: cause ? `${cause}\n${failure}` : failure };
     }
 
-    const remainingPaths = legacyPaths.filter(fileExists);
     if (remainingPaths.length > 0) {
       const error = `OpenClaw doctor completed but ${remainingPaths.length} legacy session store(s) remain.`;
       console.warn(`[OpenClaw] ${error}`);
@@ -221,6 +290,9 @@ export async function migrateLegacySessionStorageWithDoctor(params: {
       return { status: 'failed', code: result.code, error };
     }
 
+    if (completedWithWarnings) {
+      console.warn('[OpenClaw] Legacy session migration completed with warnings; all legacy stores were archived.');
+    }
     console.log(
       `[OpenClaw] Legacy session doctor migration completed for ${legacyPaths.length} store(s).`,
     );


### PR DESCRIPTION
## Summary

Fix gateway startup after upgrading to OpenClaw v2026.8.1 when legacy transcripts contain repeated session headers with the same ID. SQLite retained the first header, while archive validation counted both (for example, 8 stored events versus 9 source events), blocking archival of the entire agent store on every startup.

Also recognize completed imports that return exit code 1 solely for known migration warnings, and surface blocking issues before historical invalid-entry warnings.

## Related Issue

QA-reported Mac upgrade failure; no linked issue.

## Changes Made

- Add a version-scoped OpenClaw patch so import and validation share duplicate-header handling. Preserve the first header, original v1 compaction indexes, and complete raw JSONL archives. Non-header identity collisions remain blocking.
- Validate the Doctor report and require an existing archive for every discovered legacy store, no remaining legacy stores, and only known warning codes before accepting exit code 1. Unknown issues, incomplete reports, and process failures still fail startup.
- Prioritize blocking error details and log issue counts and the migration manifest path. Add adapter and actual SQLite regression coverage, and register the patch in the pinned-version inventory.

## Type of Change

- [x] Bug fix

## Testing

- [x] LobsterAI migration, gateway manager, config sync, and patch inventory: 203 tests passed across 7 files.
- [x] New upstream SQLite migration regressions: 7 passed, covering fresh/partial/already-imported stores, healthy peers, retry, archive preservation, non-header collisions, and v1 compactions.
- [x] Electron TypeScript compilation, changed-file ESLint, upstream formatting/type-aware lint, and patch application checks passed.
- [x] Isolated full QA data migration on Windows: 1,031 sessions and 43,721 events imported; legacy index and JSONL files archived. Only 2 invalid-entry and 21 missing-transcript warnings remained, correctly accepted as completed migration.
- [x] Existing partial-import recovery needed zero new events. All 17 messages and 38 non-header events in the five affected transcripts matched; raw archives were byte-identical. Repeat migration skipped cleanly.
- [x] OpenClaw runtime build, production dependency installation, ASAR packing, and layout checks passed. Both compiled source and the isolated distribution runtime passed gateway readiness and config RPC checks using the migrated state.

The broader upstream Doctor run recorded 88 passes, 14 skips, and 3 Windows temporary-directory cleanup failures (`fs.rmSync` / `EPERM`). That run overlapped build preparation and is not reported as a full pass; the final patch's isolated 7-test run passed.

## Checklist

- [x] Followed project style and performed self-review.
- [x] Added comments for migration invariants and regression tests for the failure.
- [x] Changed-file lint and targeted tests pass.
- [x] Included only product code, tests, and the version-scoped patch; QA data and generated runtimes are excluded.

## Electron-Specific Changes

- [x] Main process gateway startup: accept proven warning-only migration completion and improve failure diagnostics.

## Additional Notes

Rebuild the OpenClaw runtime when packaging this change. Validation used copied Mac session data on a Windows host; macOS Electron device regression remains to be performed. The separate Windows workspace-attestation failure is outside this PR.
