### PR TITLE
feat(openclaw): add opt-in memory flush setting

### DIFF
--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -1363,6 +1363,31 @@ test('persists skill review opt-in and opt-out independently of other settings',
   });
 });
 
+test('defaults memory flush to disabled for users without the setting', () => {
+  store.setConfig({ openClawHeartbeatEnabled: true, openClawSkillReviewEnabled: true });
+
+  expect(store.getConfig().openClawMemoryFlushEnabled).toBe(false);
+});
+
+test('persists memory flush opt-in and opt-out independently of other maintenance settings', () => {
+  store.setConfig({ openClawMemoryFlushEnabled: true });
+  store.setConfig({ openClawHeartbeatEnabled: true, openClawSkillReviewEnabled: true });
+  const reloadedStore = new CoworkStore(db);
+
+  expect(reloadedStore.getConfig()).toMatchObject({
+    openClawMemoryFlushEnabled: true,
+    openClawHeartbeatEnabled: true,
+    openClawSkillReviewEnabled: true,
+  });
+
+  reloadedStore.setConfig({ openClawMemoryFlushEnabled: false });
+  expect(new CoworkStore(db).getConfig()).toMatchObject({
+    openClawMemoryFlushEnabled: false,
+    openClawHeartbeatEnabled: true,
+    openClawSkillReviewEnabled: true,
+  });
+});
+
 test('backfillEmptyAgentModels assigns the current default model to empty agents only', () => {
   const now = Date.now();
   db.prepare(

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -634,6 +634,7 @@ export interface CoworkConfig {
   skipMissedJobs: boolean;
   openClawHeartbeatEnabled: boolean;
   openClawSkillReviewEnabled: boolean;
+  openClawMemoryFlushEnabled: boolean;
   embeddingEnabled: boolean;
   embeddingProvider: string;
   embeddingModel: string;
@@ -660,6 +661,7 @@ CoworkConfig,
   | 'skipMissedJobs'
   | 'openClawHeartbeatEnabled'
   | 'openClawSkillReviewEnabled'
+  | 'openClawMemoryFlushEnabled'
   | 'embeddingEnabled'
   | 'embeddingProvider'
   | 'embeddingModel'
@@ -2500,6 +2502,7 @@ export class CoworkStore {
       'skipMissedJobs',
       'openClawHeartbeatEnabled',
       'openClawSkillReviewEnabled',
+      'openClawMemoryFlushEnabled',
       'embeddingEnabled',
       'embeddingProvider',
       'embeddingModel',
@@ -2539,6 +2542,7 @@ export class CoworkStore {
       skipMissedJobs: parseBooleanConfig(cfg.get('skipMissedJobs'), true),
       openClawHeartbeatEnabled: parseBooleanConfig(cfg.get('openClawHeartbeatEnabled'), false),
       openClawSkillReviewEnabled: parseBooleanConfig(cfg.get('openClawSkillReviewEnabled'), false),
+      openClawMemoryFlushEnabled: parseBooleanConfig(cfg.get('openClawMemoryFlushEnabled'), false),
       embeddingEnabled: parseBooleanConfig(cfg.get('embeddingEnabled'), DEFAULT_EMBEDDING_ENABLED),
       embeddingProvider: cfg.get('embeddingProvider') || DEFAULT_EMBEDDING_PROVIDER,
       embeddingModel: cfg.get('embeddingModel') || DEFAULT_EMBEDDING_MODEL,
@@ -2588,6 +2592,9 @@ export class CoworkStore {
     }
     if (config.openClawSkillReviewEnabled !== undefined) {
       this.upsertConfig('openClawSkillReviewEnabled', config.openClawSkillReviewEnabled ? '1' : '0', now);
+    }
+    if (config.openClawMemoryFlushEnabled !== undefined) {
+      this.upsertConfig('openClawMemoryFlushEnabled', config.openClawMemoryFlushEnabled ? '1' : '0', now);
     }
     if (config.embeddingEnabled !== undefined) {
       this.upsertConfig('embeddingEnabled', config.embeddingEnabled ? '1' : '0', now);

--- a/src/main/libs/openclawConfigImpact.test.ts
+++ b/src/main/libs/openclawConfigImpact.test.ts
@@ -177,6 +177,18 @@ describe('OpenClaw config impact classification', () => {
     });
   });
 
+  test.each([true, false])('syncs memory flush changes without a gateway restart (enabled: %s)', (enabled) => {
+    const result = classifyCoworkConfigChange(
+      { openClawMemoryFlushEnabled: !enabled },
+      { openClawMemoryFlushEnabled: enabled },
+    );
+
+    expect(result).toEqual({
+      impact: OpenClawConfigImpact.Sync,
+      reasons: [OpenClawConfigImpactReason.CoworkOpenClawConfig],
+    });
+  });
+
   test.each([true, false])('syncs skill review changes without a gateway restart (enabled: %s)', (enabled) => {
     const result = classifyCoworkConfigChange(
       { openClawSkillReviewEnabled: !enabled },

--- a/src/main/libs/openclawConfigImpact.ts
+++ b/src/main/libs/openclawConfigImpact.ts
@@ -65,6 +65,7 @@ const COWORK_SYNC_FIELDS = new Set([
   'skipMissedJobs',
   'openClawHeartbeatEnabled',
   'openClawSkillReviewEnabled',
+  'openClawMemoryFlushEnabled',
   'embeddingEnabled',
   'embeddingProvider',
   'embeddingModel',

--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -265,6 +265,7 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(config).toEqual({
       gateway: { mode: 'local' },
       skills: { workshop: { autonomous: { mode: OpenClawSkillReviewMode.Off } } },
+      agents: { defaults: { compaction: { memoryFlush: { enabled: false } } } },
     });
     expect(sync.sync('repeat-start')).toMatchObject({ ok: true, changed: false });
   });
@@ -667,6 +668,7 @@ describe('OpenClawConfigSync runtime config output', () => {
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
     expect(config.agents.defaults.compaction).toEqual({
       maxActiveTranscriptBytes: '32mb',
+      memoryFlush: { enabled: false },
     });
     expect(config.session.maintenance.rotateBytes).toBeUndefined();
   });
@@ -755,6 +757,79 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(disabledConfig.skills.entries).toEqual(enabledConfig.skills.entries);
     expect(disabledConfig.agents).toEqual(enabledConfig.agents);
     expect(sync.sync('skill-review-disabled-repeat')).toMatchObject({ ok: true, changed: false });
+  });
+
+  test.each([true, false])('disables existing memory flush without opt-in (model available: %s)', async (modelAvailable) => {
+    if (!modelAvailable) mockRuntimeState.rawApiConfig.config = null;
+    fs.writeFileSync(configPath, JSON.stringify({
+      agents: { defaults: { compaction: { memoryFlush: { enabled: true } } } },
+    }), 'utf8');
+    const sync = await createSync();
+
+    expect(sync.sync('memory-flush-default')).toMatchObject({ ok: true, changed: true });
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.agents.defaults.compaction.memoryFlush.enabled).toBe(false);
+    expect(sync.sync('memory-flush-default-repeat')).toMatchObject({ ok: true, changed: false });
+  });
+
+  test.each([true, false])('applies memory flush opt-in and opt-out independently (model available: %s)', async (modelAvailable) => {
+    if (!modelAvailable) mockRuntimeState.rawApiConfig.config = null;
+    let enabled = true;
+    const sync = await createSync({
+      getCoworkConfig: () => ({
+        workingDirectory: tmpDir,
+        systemPrompt: '',
+        executionMode: 'local',
+        agentEngine: 'openclaw',
+        openClawMemoryFlushEnabled: enabled,
+        openClawSkillReviewEnabled: true,
+        openClawHeartbeatEnabled: true,
+      }),
+    });
+
+    expect(sync.sync('memory-flush-enabled')).toMatchObject({ ok: true, changed: true });
+    const enabledConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(enabledConfig.agents.defaults.compaction.memoryFlush.enabled).toBe(true);
+    expect(sync.sync('memory-flush-enabled-repeat')).toMatchObject({ ok: true, changed: false });
+
+    enabled = false;
+    expect(sync.sync('memory-flush-disabled')).toMatchObject({ ok: true, changed: true });
+    const disabledConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(disabledConfig.agents.defaults.compaction).toEqual({
+      ...enabledConfig.agents.defaults.compaction,
+      memoryFlush: { enabled: false },
+    });
+    expect(disabledConfig.agents.defaults.heartbeat).toEqual(enabledConfig.agents.defaults.heartbeat);
+    expect(disabledConfig.memory).toEqual(enabledConfig.memory);
+    expect(disabledConfig.plugins).toEqual(enabledConfig.plugins);
+    expect(disabledConfig.skills).toEqual(enabledConfig.skills);
+    expect(disabledConfig.skills.workshop.autonomous.mode).toBe(OpenClawSkillReviewMode.Auto);
+    expect(sync.sync('memory-flush-disabled-repeat')).toMatchObject({ ok: true, changed: false });
+  });
+
+  test('preserves compaction and memory settings while disabling flush without a model', async () => {
+    mockRuntimeState.rawApiConfig.config = null;
+    const compaction = {
+      mode: 'safeguard',
+      maxActiveTranscriptBytes: '32mb',
+      reserveTokens: 20000,
+      memoryFlush: { enabled: true, softThresholdTokens: 4000, forceFlushTranscriptBytes: '2mb' },
+    };
+    const agents = { defaults: { workspace: tmpDir, compaction }, list: [{ id: 'main' }] };
+    const memory = { search: { enabled: true, provider: 'none' } };
+    fs.writeFileSync(configPath, JSON.stringify({ agents, memory }), 'utf8');
+    const sync = await createSync();
+
+    expect(sync.sync('memory-flush-no-model')).toMatchObject({ ok: true, changed: true });
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.agents).toEqual({
+      ...agents,
+      defaults: {
+        ...agents.defaults,
+        compaction: { ...compaction, memoryFlush: { ...compaction.memoryFlush, enabled: false } },
+      },
+    });
+    expect(config.memory).toEqual(memory);
   });
 
   test('writes model provider env-proxy transport when system proxy is enabled', async () => {

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -2033,6 +2033,8 @@ export class OpenClawConfigSync {
     const skillReviewMode = coworkConfig.openClawSkillReviewEnabled === true
       ? OpenClawSkillReviewMode.Auto
       : OpenClawSkillReviewMode.Off;
+    // Native memory flush is enabled by default and can issue costly background calls.
+    const memoryFlushEnabled = coworkConfig.openClawMemoryFlushEnabled === true;
     const browserWebAccess = normalizeBrowserWebAccessConfig(this.getBrowserWebAccessConfig());
     const serverModels = getAllServerModelMetadata();
     const invalidKimiK3Transports = findInvalidKimiK3ServerTransports(serverModels);
@@ -2061,7 +2063,7 @@ export class OpenClawConfigSync {
       } else {
         // This also happens during logout or before server models finish
         // loading. Keep existing non-provider state so IM stays configured.
-        const result = this.writeMinimalConfig(configPath, reason, skillReviewMode);
+        const result = this.writeMinimalConfig(configPath, reason, skillReviewMode, memoryFlushEnabled);
         // Still sync AGENTS.md even when API is not configured — skills/systemPrompt
         // may already be set and should be available when the user configures a model.
         const mainWorkspacePath = getMainAgentWorkspacePath(this.engineManager.getStateDir());
@@ -2464,6 +2466,7 @@ export class OpenClawConfigSync {
           mediaMaxMb: 30,
           compaction: {
             maxActiveTranscriptBytes: OpenClawTranscriptSafetyLimit.SoftConfigValue,
+            memoryFlush: { enabled: memoryFlushEnabled },
           },
           ...(taskWorkingDirectory ? { cwd: path.resolve(taskWorkingDirectory) } : {}),
           heartbeat: {
@@ -4083,6 +4086,7 @@ export class OpenClawConfigSync {
     configPath: string,
     _reason: string,
     skillReviewMode: OpenClawSkillReviewMode,
+    memoryFlushEnabled: boolean,
   ): OpenClawConfigSyncResult {
     const baseMinimalConfig: Record<string, unknown> = {
       gateway: {
@@ -4125,7 +4129,25 @@ export class OpenClawConfigSync {
       }
     }
 
-    // Apply the review preference even before models load or after logout.
+    // Apply maintenance preferences even before models load or after logout.
+    // Preserve the rest of compaction and memory settings when disabling only flush.
+    const agents = asConfigRecord(mergedConfig.agents);
+    const agentDefaults = asConfigRecord(agents?.defaults);
+    const compaction = asConfigRecord(agentDefaults?.compaction);
+    mergedConfig.agents = {
+      ...agents,
+      defaults: {
+        ...agentDefaults,
+        compaction: {
+          ...compaction,
+          memoryFlush: {
+            ...asConfigRecord(compaction?.memoryFlush),
+            enabled: memoryFlushEnabled,
+          },
+        },
+      },
+    };
+
     const skills = asConfigRecord(mergedConfig.skills);
     const workshop = asConfigRecord(skills?.workshop);
     mergedConfig.skills = {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10998,6 +10998,7 @@ if (!gotTheLock) {
     skipMissedJobs?: boolean;
     openClawHeartbeatEnabled?: boolean;
     openClawSkillReviewEnabled?: boolean;
+    openClawMemoryFlushEnabled?: boolean;
     embeddingEnabled?: boolean;
     embeddingProvider?: string;
     embeddingModel?: string;
@@ -11044,6 +11045,9 @@ if (!gotTheLock) {
       const normalizedOpenClawSkillReviewEnabled = typeof config.openClawSkillReviewEnabled === 'boolean'
         ? config.openClawSkillReviewEnabled
         : undefined;
+      const normalizedOpenClawMemoryFlushEnabled = typeof config.openClawMemoryFlushEnabled === 'boolean'
+        ? config.openClawMemoryFlushEnabled
+        : undefined;
       const normalizedEmbedding = normalizeEmbeddingConfig(config);
       const normalizedConfig: Parameters<CoworkStore['setConfig']>[0] = {
         ...config,
@@ -11057,6 +11061,7 @@ if (!gotTheLock) {
         skipMissedJobs: normalizedSkipMissedJobs,
         openClawHeartbeatEnabled: normalizedOpenClawHeartbeatEnabled,
         openClawSkillReviewEnabled: normalizedOpenClawSkillReviewEnabled,
+        openClawMemoryFlushEnabled: normalizedOpenClawMemoryFlushEnabled,
         ...normalizedEmbedding,
       };
       const previousConfig = getCoworkStore().getConfig();
@@ -11085,6 +11090,14 @@ if (!gotTheLock) {
       ) {
         console.log(
           `[Cowork] OpenClaw skill review setting changed: enabled=${nextConfig.openClawSkillReviewEnabled}, previous=${previousConfig.openClawSkillReviewEnabled}, impact=${impactDecision.impact}`,
+        );
+      }
+      if (
+        normalizedConfig.openClawMemoryFlushEnabled !== undefined
+        && previousConfig.openClawMemoryFlushEnabled !== nextConfig.openClawMemoryFlushEnabled
+      ) {
+        console.log(
+          `[Cowork] OpenClaw memory flush setting changed: enabled=${nextConfig.openClawMemoryFlushEnabled}, previous=${previousConfig.openClawMemoryFlushEnabled}, impact=${impactDecision.impact}`,
         );
       }
       if (impactDecision.impact !== OpenClawConfigImpact.None) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -663,6 +663,7 @@ contextBridge.exposeInMainWorld('electron', {
       skipMissedJobs?: boolean;
       openClawHeartbeatEnabled?: boolean;
       openClawSkillReviewEnabled?: boolean;
+      openClawMemoryFlushEnabled?: boolean;
       embeddingEnabled?: boolean;
       embeddingProvider?: string;
       embeddingModel?: string;

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1749,6 +1749,7 @@ const Settings: React.FC<SettingsProps> = ({
   const [showTempCleanConfirm, setShowTempCleanConfirm] = useState<boolean>(false);
   const [openClawHeartbeatEnabled, setOpenClawHeartbeatEnabled] = useState<boolean>(coworkConfig.openClawHeartbeatEnabled ?? false);
   const [openClawSkillReviewEnabled, setOpenClawSkillReviewEnabled] = useState<boolean>(coworkConfig.openClawSkillReviewEnabled ?? false);
+  const [openClawMemoryFlushEnabled, setOpenClawMemoryFlushEnabled] = useState<boolean>(coworkConfig.openClawMemoryFlushEnabled ?? false);
   const [embeddingEnabled, setEmbeddingEnabled] = useState<boolean>(coworkConfig.embeddingEnabled ?? false);
   const [embeddingProvider, setEmbeddingProvider] = useState<string>(coworkConfig.embeddingProvider ?? 'openai');
   const [embeddingModel, setEmbeddingModel] = useState<string>(coworkConfig.embeddingModel ?? '');
@@ -1792,6 +1793,7 @@ const Settings: React.FC<SettingsProps> = ({
     setSkipMissedJobs(coworkConfig.skipMissedJobs ?? true);
     setOpenClawHeartbeatEnabled(coworkConfig.openClawHeartbeatEnabled ?? false);
     setOpenClawSkillReviewEnabled(coworkConfig.openClawSkillReviewEnabled ?? false);
+    setOpenClawMemoryFlushEnabled(coworkConfig.openClawMemoryFlushEnabled ?? false);
     setEmbeddingEnabled(coworkConfig.embeddingEnabled ?? false);
     setEmbeddingProvider(coworkConfig.embeddingProvider ?? 'openai');
     setEmbeddingModel(coworkConfig.embeddingModel ?? '');
@@ -1812,6 +1814,7 @@ const Settings: React.FC<SettingsProps> = ({
     coworkConfig.skipMissedJobs,
     coworkConfig.openClawHeartbeatEnabled,
     coworkConfig.openClawSkillReviewEnabled,
+    coworkConfig.openClawMemoryFlushEnabled,
     coworkConfig.embeddingEnabled,
     coworkConfig.embeddingProvider,
     coworkConfig.embeddingModel,
@@ -2836,6 +2839,7 @@ const Settings: React.FC<SettingsProps> = ({
     || skipMissedJobs !== (coworkConfig.skipMissedJobs ?? true)
     || openClawHeartbeatEnabled !== (coworkConfig.openClawHeartbeatEnabled ?? false)
     || openClawSkillReviewEnabled !== (coworkConfig.openClawSkillReviewEnabled ?? false)
+    || openClawMemoryFlushEnabled !== (coworkConfig.openClawMemoryFlushEnabled ?? false)
     || openClawSessionKeepAlive !== (coworkConfig.openClawSessionPolicy?.keepAlive || OpenClawSessionKeepAliveValues.ThirtyDays)
     || embeddingEnabled !== (coworkConfig.embeddingEnabled ?? false)
     || embeddingProvider !== (coworkConfig.embeddingProvider ?? 'openai')
@@ -3398,6 +3402,7 @@ const Settings: React.FC<SettingsProps> = ({
       const previousSkipMissedJobs = coworkConfig.skipMissedJobs ?? true;
       const previousOpenClawHeartbeatEnabled = coworkConfig.openClawHeartbeatEnabled ?? false;
       const previousOpenClawSkillReviewEnabled = coworkConfig.openClawSkillReviewEnabled ?? false;
+      const previousOpenClawMemoryFlushEnabled = coworkConfig.openClawMemoryFlushEnabled ?? false;
       const previousAgentEngine = coworkConfig.agentEngine || 'openclaw';
       const previousOpenClawSessionKeepAlive = coworkConfig.openClawSessionPolicy?.keepAlive
         || OpenClawSessionKeepAliveValues.ThirtyDays;
@@ -3533,6 +3538,11 @@ const Settings: React.FC<SettingsProps> = ({
             `[Settings] updating OpenClaw skill review: enabled=${openClawSkillReviewEnabled}, previous=${previousOpenClawSkillReviewEnabled}`,
           );
         }
+        if (previousOpenClawMemoryFlushEnabled !== openClawMemoryFlushEnabled) {
+          console.log(
+            `[Settings] updating OpenClaw memory flush: enabled=${openClawMemoryFlushEnabled}, previous=${previousOpenClawMemoryFlushEnabled}`,
+          );
+        }
         const updated = await coworkService.updateConfig({
           agentEngine: coworkAgentEngine,
           memoryEnabled: coworkMemoryEnabled,
@@ -3540,6 +3550,7 @@ const Settings: React.FC<SettingsProps> = ({
           skipMissedJobs,
           openClawHeartbeatEnabled,
           openClawSkillReviewEnabled,
+          openClawMemoryFlushEnabled,
           embeddingEnabled,
           embeddingProvider,
           embeddingModel,
@@ -3667,6 +3678,13 @@ const Settings: React.FC<SettingsProps> = ({
             'openClawSessionKeepAlive',
             openClawSessionKeepAlive,
             previousOpenClawSessionKeepAlive,
+          );
+        }
+        if (previousOpenClawMemoryFlushEnabled !== openClawMemoryFlushEnabled) {
+          reportAgentEngineSettingChanged(
+            'openClawMemoryFlushEnabled',
+            openClawMemoryFlushEnabled,
+            previousOpenClawMemoryFlushEnabled,
           );
         }
         const memorySettingsSummary = buildMemorySettingAnalyticsSummary(
@@ -5244,6 +5262,37 @@ const Settings: React.FC<SettingsProps> = ({
                         </div>
                         <p className="mt-1.5 text-[13px] leading-5 text-secondary">
                           {i18nService.t('openClawSkillReviewEnabledDescription')}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-border bg-surface p-4">
+                    <div className="flex items-start gap-3.5">
+                      <span
+                        className={`inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl transition-colors ${
+                          openClawMemoryFlushEnabled
+                            ? 'bg-primary-muted text-primary'
+                            : 'bg-surface-raised text-secondary'
+                        }`}
+                      >
+                        <BrainIcon className="h-5 w-5" />
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center justify-between gap-3">
+                          <h4 className="min-w-0 text-sm font-medium leading-5 text-foreground">
+                            {i18nService.t('openClawMemoryFlushEnabled')}
+                          </h4>
+                          <SettingsSwitch
+                            checked={openClawMemoryFlushEnabled}
+                            label={i18nService.t('openClawMemoryFlushEnabled')}
+                            onClick={() => {
+                              setOpenClawMemoryFlushEnabled((prev) => !prev);
+                            }}
+                          />
+                        </div>
+                        <p className="mt-1.5 text-[13px] leading-5 text-secondary">
+                          {i18nService.t('openClawMemoryFlushEnabledDescription')}
                         </p>
                       </div>
                     </div>

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1241,6 +1241,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     openClawSkillReviewEnabled: '启用技能自动复盘',
     openClawSkillReviewEnabledDescription:
       '开启后，Agent 会在复杂任务结束后于后台复盘，提炼经验并创建或改进技能，供后续任务复用。复盘会额外调用模型，长对话可能产生较多 token 消耗，默认关闭。',
+    openClawMemoryFlushEnabled: '启用压缩前记忆保存',
+    openClawMemoryFlushEnabledDescription:
+      '开启后，Agent 会在长对话整理上下文前，自动提取重要信息并保存为长期记忆，供后续对话使用。保存过程会额外调用模型，长对话可能产生较多 token 消耗，默认关闭。',
     openClawGatewayAddress: '网关地址',
     openClawStartupProgressLabel: '启动进度',
     openClawStatusBadgeReady: '已就绪',
@@ -5101,6 +5104,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     openClawSkillReviewEnabled: 'Enable automatic skill review',
     openClawSkillReviewEnabledDescription:
       'When on, the agent reviews complex tasks in the background after they end, turning lessons into new or improved skills for future tasks. Reviews require extra model calls and may use substantial tokens for long conversations. Off by default.',
+    openClawMemoryFlushEnabled: 'Save memory before context compaction',
+    openClawMemoryFlushEnabledDescription:
+      'When on, the agent extracts important information from long conversations and saves it to long-term memory before context compaction for use in future conversations. Saving requires extra model calls and may use substantial tokens for long conversations. Off by default.',
     openClawGatewayAddress: 'Gateway address',
     openClawStartupProgressLabel: 'Startup progress',
     openClawStatusBadgeReady: 'Ready',

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -88,6 +88,7 @@ test('defaults hidden OpenClaw session policy to thirty days', () => {
   expect(state.config.skipMissedJobs).toBe(true);
   expect(state.config.openClawHeartbeatEnabled).toBe(false);
   expect(state.config.openClawSkillReviewEnabled).toBe(false);
+  expect(state.config.openClawMemoryFlushEnabled).toBe(false);
 });
 
 test('clears account-scoped media models and selections together', () => {
@@ -188,6 +189,7 @@ test('setConfig preserves loaded OpenClaw session policy', () => {
     skipMissedJobs: false,
     openClawHeartbeatEnabled: false,
     openClawSkillReviewEnabled: true,
+    openClawMemoryFlushEnabled: true,
     embeddingEnabled: false,
     embeddingProvider: 'openai',
     embeddingModel: '',
@@ -207,6 +209,7 @@ test('setConfig preserves loaded OpenClaw session policy', () => {
   expect(state.config.openClawSessionPolicy.keepAlive).toBe('365d');
   expect(state.config.openClawHeartbeatEnabled).toBe(false);
   expect(state.config.openClawSkillReviewEnabled).toBe(true);
+  expect(state.config.openClawMemoryFlushEnabled).toBe(true);
 });
 
 test('updateCurrentSessionModelOverride only patches the active session', () => {

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -163,6 +163,7 @@ const initialState: CoworkState = {
     skipMissedJobs: true,
     openClawHeartbeatEnabled: false,
     openClawSkillReviewEnabled: false,
+    openClawMemoryFlushEnabled: false,
     embeddingEnabled: false,
     embeddingProvider: 'openai',
     embeddingModel: '',

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -191,6 +191,7 @@ export interface CoworkConfig {
   skipMissedJobs: boolean;
   openClawHeartbeatEnabled: boolean;
   openClawSkillReviewEnabled: boolean;
+  openClawMemoryFlushEnabled: boolean;
   embeddingEnabled: boolean;
   embeddingProvider: string;
   embeddingModel: string;
@@ -230,6 +231,7 @@ export type CoworkConfigUpdate = Partial<Pick<
   | 'skipMissedJobs'
   | 'openClawHeartbeatEnabled'
   | 'openClawSkillReviewEnabled'
+  | 'openClawMemoryFlushEnabled'
   | 'embeddingEnabled'
   | 'embeddingProvider'
   | 'embeddingModel'

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -276,6 +276,7 @@ interface CoworkConfig {
   skipMissedJobs: boolean;
   openClawHeartbeatEnabled: boolean;
   openClawSkillReviewEnabled: boolean;
+  openClawMemoryFlushEnabled: boolean;
   embeddingEnabled: boolean;
   embeddingProvider: string;
   embeddingModel: string;
@@ -300,6 +301,7 @@ type CoworkConfigUpdate = Partial<
     | 'skipMissedJobs'
     | 'openClawHeartbeatEnabled'
     | 'openClawSkillReviewEnabled'
+    | 'openClawMemoryFlushEnabled'
     | 'embeddingEnabled'
     | 'embeddingProvider'
     | 'embeddingModel'


### PR DESCRIPTION
## Summary

OpenClaw 的压缩前记忆保存会额外调用模型，长对话可能产生较多 token 消耗。设置 → Agent 引擎 → 后台运行新增「启用压缩前记忆保存」开关，默认关闭，由用户主动开启；中英文说明同时介绍功能和 token 成本。

## Related Issue

参考 #2641 的设置交互与配置同步方式。

## Changes Made

- 新增独立的 `openClawMemoryFlushEnabled` 配置，持久化到 `cowork_config`；新用户及尚未存储该配置的已有用户默认关闭。
- 完整配置和未加载模型时的最小配置均显式同步 `agents.defaults.compaction.memoryFlush.enabled`，防止回落到上游默认开启。
- 沿用现有 IPC、设置保存/取消流程及网关热更新；普通上下文压缩、记忆检索、心跳和技能复盘分别保留原有控制方式。

## Type of Change

- [x] New feature
- [x] Performance improvement

## Testing

- [x] 229 项相关测试通过，覆盖存储默认值与持久化、完整/最小配置、配置影响判定和 Redux 状态。首次通过 227 项，独立运行时依赖补齐后另外 2 项原生配置校验补跑通过。
- [x] 变更文件 ESLint 零警告，`git diff --check` 通过。
- [x] `npm run build` 和 Electron TypeScript 编译通过（`npm --ignore-scripts run compile:electron`）。
- [x] 独立配置目录实测 Electron：默认关闭、取消不保存、开启/关闭保存、重新打开设置、应用重启后保持、中英文展示。
- [x] 原生 OpenClaw 2026.8.1 网关实测双向热更新，日志确认 `config hot reload applied (agents.defaults.compaction.memoryFlush.enabled)`，`restartScheduled=false`。

## Electron-Specific Changes

- [x] 主进程配置存储与同步
- [x] Preload / IPC 类型扩展（复用现有配置通道）
- [x] 保存设置后网关热更新，无需重启

## Additional Notes

开关控制后续 memory flush 是否触发，不中断已经运行中的 flush。本次未提交付费长对话模型任务；上游 flush 和 compaction 算法未修改。
