### PR TITLE
fix(renderer): restore collapsed engine failure overlay clicks

### DIFF
--- a/src/renderer/components/cowork/EngineFailureOverlay.tsx
+++ b/src/renderer/components/cowork/EngineFailureOverlay.tsx
@@ -115,7 +115,7 @@ const EngineFailureOverlay: React.FC<EngineFailureOverlayProps> = ({
   if (isDeferred) {
     return (
       <div className="pointer-events-none fixed inset-x-0 top-4 z-[90] flex justify-center px-4">
-        <div className="pointer-events-auto flex max-w-[calc(100vw-2rem)] items-center gap-1.5 rounded-full border border-red-200 bg-surface py-1 pl-3 pr-1 shadow-lg animate-fade-in-down dark:border-red-900/60">
+        <div className="non-draggable pointer-events-auto flex max-w-[calc(100vw-2rem)] items-center gap-1.5 rounded-full border border-red-200 bg-surface py-1 pl-3 pr-1 shadow-lg animate-fade-in-down dark:border-red-900/60">
           <button
             type="button"
             onClick={() => setIsDeferred(false)}


### PR DESCRIPTION
## Summary

On Windows, collapsing the engine startup failure dialog leaves its status pill overlapping the native window drag region. Mouse clicks on the restore and quick-repair buttons are swallowed. Mark the pill container as `non-draggable` so both buttons receive clicks and the dialog can reopen while the engine remains in its error state.

## Related Issue

QA report; no linked GitHub issue.

## Changes Made

- Add the existing `non-draggable` class to the collapsed pill container. Its descendants inherit the existing CSS exclusions from native window dragging, while the surrounding title bar remains draggable.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Changed-file ESLint passed with zero warnings.
- [x] `npx vitest run src/renderer/components/cowork/EngineFailureOverlay.test.ts src/renderer/components/window/WindowsAppTitleBar.test.ts` — 11 tests passed.
- [x] Hidden Electron 43.5.0 verification using the actual component and CSS: collapse, reopen, repeated reopen, mocked quick repair, and computed `no-drag` on both buttons and their children. Background drag regions remained active. The window stayed hidden and unfocused; interaction checks used DOM clicks without OS mouse or keyboard input.

The original bug was also reproduced with native mouse input on Electron 40.2.1 and 43.5.0 during investigation. Applying equivalent `no-drag` CSS restored native clicking on 43.5.0. The existing static-render tests alone do not exercise native window hit-testing.

## Screenshots (if applicable)

Not applicable: the visual layout is unchanged; this change corrects native drag hit-testing.

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Diff reviewed; one class added in one component.
- [x] No new lint warnings.
- [x] Relevant existing tests pass.

## Electron-Specific Changes

- [x] Changes to window management: renderer drag-region exclusion for the collapsed failure pill.

## Additional Notes

The missing drag exclusion dates back to the introduction of the collapsed pill in `604c4ecf4`. Reopening the dialog only updates local React state; it does not require a response from the failed gateway.
