### PR TITLE
fix(scheduled-task): apply history date filters locally

### DIFF
--- a/src/renderer/components/scheduledTasks/AllRunsHistory.tsx
+++ b/src/renderer/components/scheduledTasks/AllRunsHistory.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { ScheduledTaskDataStatus, TaskStatus } from '../../../scheduledTask/constants';
+import { createRunFilter } from '../../../scheduledTask/runFilter';
 import type { RunFilter, ScheduledTaskRunWithName } from '../../../scheduledTask/types';
 import { i18nService } from '../../services/i18n';
 import { scheduledTaskService } from '../../services/scheduledTask';
@@ -45,18 +46,6 @@ const statusConfig: Record<TaskStatus, { label: string; color: string; activeCol
   },
 };
 
-function applyClientFilter(
-  runs: ScheduledTaskRunWithName[],
-  filter: RunFilter,
-): ScheduledTaskRunWithName[] {
-  return runs.filter(run => {
-    if (filter.status && run.status !== filter.status) return false;
-    if (filter.startDate && run.startedAt < filter.startDate + 'T00:00:00') return false;
-    if (filter.endDate && run.startedAt > filter.endDate + 'T23:59:59') return false;
-    return true;
-  });
-}
-
 const EMPTY_FILTER: RunFilter = {};
 
 interface AllRunsHistoryProps {
@@ -76,7 +65,7 @@ const AllRunsHistory: React.FC<AllRunsHistoryProps> = ({ searchText = '' }) => {
   const normalizedSearch = searchText.trim().toLowerCase();
 
   const displayedRuns = useMemo(() => {
-    let runs = hasActiveFilter ? applyClientFilter(allRuns, filter) : allRuns;
+    let runs = hasActiveFilter ? allRuns.filter(createRunFilter(filter)) : allRuns;
     if (normalizedSearch) {
       runs = runs.filter(run =>
         [run.taskName, run.summary ?? '', run.error ?? '']

--- a/src/renderer/components/scheduledTasks/TaskRunHistory.tsx
+++ b/src/renderer/components/scheduledTasks/TaskRunHistory.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { TaskStatus } from '../../../scheduledTask/constants';
+import { createRunFilter } from '../../../scheduledTask/runFilter';
 import type { RunFilter, ScheduledTask, ScheduledTaskRun } from '../../../scheduledTask/types';
 import { i18nService } from '../../services/i18n';
 import { scheduledTaskService } from '../../services/scheduledTask';
@@ -62,15 +63,6 @@ const RunStatusIcon: React.FC<{ status: TaskStatus }> = ({ status }) => {
   return <MinusCircleIcon className="h-4 w-4 shrink-0 text-yellow-500" />;
 };
 
-function applyClientFilter(runs: ScheduledTaskRun[], filter: RunFilter): ScheduledTaskRun[] {
-  return runs.filter(run => {
-    if (filter.status && run.status !== filter.status) return false;
-    if (filter.startDate && run.startedAt < filter.startDate + 'T00:00:00') return false;
-    if (filter.endDate && run.startedAt > filter.endDate + 'T23:59:59') return false;
-    return true;
-  });
-}
-
 const EMPTY_FILTER: RunFilter = {};
 
 const TaskRunHistory: React.FC<TaskRunHistoryProps> = ({ task, runs }) => {
@@ -85,7 +77,7 @@ const TaskRunHistory: React.FC<TaskRunHistoryProps> = ({ task, runs }) => {
   const hasActiveFilter = Boolean(filter.startDate || filter.endDate || filter.status);
 
   const displayedRuns = useMemo(
-    () => (hasActiveFilter ? applyClientFilter(runs, filter) : runs),
+    () => (hasActiveFilter ? runs.filter(createRunFilter(filter)) : runs),
     [runs, filter, hasActiveFilter],
   );
   const taskAnalyticsParams = useMemo(

--- a/src/scheduledTask/cronJobService.runFilter.test.ts
+++ b/src/scheduledTask/cronJobService.runFilter.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { GatewayStatus, TaskStatus } from './constants';
+import { CronJobService } from './cronJobService';
+import type { RunFilter } from './types';
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+const GatewayMethod = {
+  List: 'cron.list',
+  Runs: 'cron.runs',
+} as const;
+
+interface RunEntry {
+  ts: number;
+  jobId: string;
+  runAtMs?: number;
+  status: GatewayStatus;
+  error?: string;
+  deliveryError?: string;
+}
+
+function makeEntry(startedAt: string, overrides: Partial<RunEntry> = {}): RunEntry {
+  const timestamp = new Date(startedAt).getTime();
+  return {
+    ts: timestamp + 1_000,
+    jobId: 'user-job',
+    runAtMs: timestamp,
+    status: GatewayStatus.Ok,
+    ...overrides,
+  };
+}
+
+function createService(entries: RunEntry[]) {
+  const runRequests: Array<{ limit: number; offset: number }> = [];
+  const service = new CronJobService({
+    ensureGatewayReady: async () => {},
+    getGatewayClient: () => ({
+      request: async <T>(method: string, params?: unknown) => {
+        if (method === GatewayMethod.List) return { jobs: [] } as T;
+        expect(method).toBe(GatewayMethod.Runs);
+        // The gateway rejects these unsupported date parameters before reading history.
+        expect(params).not.toHaveProperty('startMs');
+        expect(params).not.toHaveProperty('endMs');
+        const page = params as { limit: number; offset: number };
+        runRequests.push(page);
+        return { entries: entries.slice(page.offset, page.offset + page.limit) } as T;
+      },
+    }),
+  });
+  return { service, runRequests };
+}
+
+const readers = [
+  {
+    name: 'global',
+    read: (service: CronJobService, limit: number, offset: number, filter: RunFilter) =>
+      service.listAllRuns(limit, offset, filter),
+  },
+  {
+    name: 'single-task',
+    read: (service: CronJobService, limit: number, offset: number, filter: RunFilter) =>
+      service.listRuns('user-job', limit, offset, filter),
+  },
+];
+
+describe.each(readers)('$name history date filtering', ({ read }) => {
+  test.each([
+    { filter: { startDate: '2026-09-10' }, expectedIndexes: [0, 1, 2] },
+    { filter: { endDate: '2026-09-10' }, expectedIndexes: [1, 2, 3] },
+    {
+      filter: { startDate: '2026-09-10', endDate: '2026-09-10' },
+      expectedIndexes: [1, 2],
+    },
+  ])('filters local calendar days for $filter', async ({ filter, expectedIndexes }) => {
+    const entries = [
+      makeEntry('2026-09-11T00:00:00.000'),
+      makeEntry('2026-09-10T23:59:59.999'),
+      makeEntry('2026-09-10T00:00:00.000'),
+      makeEntry('2026-09-09T23:59:59.999'),
+    ];
+    const { service } = createService(entries);
+
+    const runs = await read(service, 20, 0, filter);
+
+    expect(runs.map(run => run.id)).toEqual(
+      expectedIndexes.map(index => `user-job-${entries[index].ts}`),
+    );
+  });
+
+  test('finds old runs across pages and applies offsets after date and status filtering', async () => {
+    const recentRuns = Array.from({ length: 100 }, (_, index) =>
+      makeEntry('2026-09-11T12:00:00', { ts: new Date('2026-09-11T12:01:00').getTime() - index }),
+    );
+    const firstMatch = makeEntry('2026-09-10T13:00:00');
+    const secondMatch = makeEntry('2026-09-10T12:00:00', {
+      status: GatewayStatus.Error,
+      error: 'delivery failed',
+      deliveryError: 'delivery failed',
+    });
+    const thirdMatch = makeEntry('2026-09-10T11:00:00');
+    const entries = [
+      ...recentRuns,
+      firstMatch,
+      makeEntry('2026-09-10T12:30:00', { status: GatewayStatus.Skipped }),
+      secondMatch,
+      makeEntry('2026-09-10T11:30:00', { status: GatewayStatus.Error, error: 'agent failed' }),
+      thirdMatch,
+      makeEntry('2026-09-09T23:00:00'),
+    ];
+    const { service, runRequests } = createService(entries);
+
+    const runs = await read(service, 2, 1, {
+      startDate: '2026-09-10',
+      endDate: '2026-09-10',
+      status: TaskStatus.Success,
+    });
+
+    expect(runs.map(run => run.id)).toEqual([
+      `user-job-${secondMatch.ts}`,
+      `user-job-${thirdMatch.ts}`,
+    ]);
+    expect(runRequests.map(page => page.offset)).toEqual([0, 50, 100]);
+  });
+
+  test('keeps scanning when completion order differs from start order', async () => {
+    const olderStarts = Array.from({ length: 50 }, (_, index) =>
+      makeEntry('2026-09-09T23:00:00', { ts: new Date('2026-09-11T00:00:00').getTime() - index }),
+    );
+    const target = makeEntry('2026-09-10T01:00:00');
+    const { service, runRequests } = createService([...olderStarts, target]);
+
+    const runs = await read(service, 1, 0, {
+      startDate: '2026-09-10',
+      endDate: '2026-09-10',
+    });
+
+    expect(runs.map(run => run.id)).toEqual([`user-job-${target.ts}`]);
+    expect(runRequests.map(page => page.offset)).toEqual([0, 50]);
+  });
+
+  test('exhausts history when the requested date range has no matches', async () => {
+    const entries = Array.from({ length: 100 }, (_, index) =>
+      makeEntry('2026-09-11T12:00:00', { ts: index + 1 }),
+    );
+    const { service, runRequests } = createService(entries);
+
+    expect(await read(service, 20, 0, { endDate: '2026-01-01' })).toEqual([]);
+    expect(runRequests.map(page => page.offset)).toEqual([0, 50, 100]);
+  });
+
+  test('uses the history timestamp when an entry has no start timestamp', async () => {
+    const entry = makeEntry('2026-09-10T12:00:00', { runAtMs: undefined });
+    const { service } = createService([entry]);
+
+    const runs = await read(service, 20, 0, { startDate: '2026-09-10', endDate: '2026-09-10' });
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].startedAt).toBe(new Date(entry.ts).toISOString());
+  });
+});

--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -18,6 +18,7 @@ import {
   ScheduleKind,
   TaskStatus,
 } from './constants';
+import { createRunFilter } from './runFilter';
 import type {
   RunFilter,
   Schedule,
@@ -241,11 +242,6 @@ function mapGatewayResultStatus(
   if (status === GatewayStatus.Error) return TaskStatus.Error;
   if (status === GatewayStatus.Skipped) return TaskStatus.Skipped;
   return null;
-}
-
-function matchesRunFilter(run: ScheduledTaskRun, filter?: RunFilter): boolean {
-  if (filter?.status && run.status !== filter.status) return false;
-  return true;
 }
 
 /**
@@ -781,7 +777,10 @@ export class CronJobService {
     let rawOffset = 0;
     const pageSize = getGatewayRunPageSize(visibleLimit);
     logGatewayRunPageClamp('job', visibleLimit, visibleOffset, pageSize);
+    const matchesFilter = createRunFilter(filter);
 
+    // cron.runs has no date-range parameters. Filter before counting visible
+    // offsets, and keep scanning: its completion-time order is not start order.
     while (visibleRuns.length < visibleLimit) {
       const requestLimit = getGatewayRunRequestLimit(pageSize, visibleLimit - visibleRuns.length);
       const result = await client.request<{ entries?: GatewayRunLogEntry[] }>('cron.runs', {
@@ -790,15 +789,13 @@ export class CronJobService {
         limit: requestLimit,
         offset: rawOffset,
         sortDir: 'desc',
-        ...(filter?.startDate && { startMs: new Date(filter.startDate + 'T00:00:00').getTime() }),
-        ...(filter?.endDate && { endMs: new Date(filter.endDate + 'T23:59:59').getTime() }),
       });
       const entries = Array.isArray(result.entries) ? result.entries : [];
       if (entries.length === 0) break;
 
       for (const entry of entries) {
         const run = mapGatewayRun(entry);
-        if (!matchesRunFilter(run, filter)) continue;
+        if (!matchesFilter(run)) continue;
         if (skippedVisible < visibleOffset) {
           skippedVisible += 1;
           continue;
@@ -853,7 +850,9 @@ export class CronJobService {
     let rawOffset = 0;
     const pageSize = getGatewayRunPageSize(visibleLimit);
     logGatewayRunPageClamp('all', visibleLimit, visibleOffset, pageSize);
+    const matchesFilter = createRunFilter(filter);
 
+    // As with job history, apply dates locally before visible pagination.
     while (visibleRuns.length < visibleLimit) {
       const requestLimit = getGatewayRunRequestLimit(pageSize, visibleLimit - visibleRuns.length);
       const result = await client.request<{ entries?: GatewayRunLogEntry[] }>('cron.runs', {
@@ -861,8 +860,6 @@ export class CronJobService {
         limit: requestLimit,
         offset: rawOffset,
         sortDir: 'desc',
-        ...(filter?.startDate && { startMs: new Date(filter.startDate + 'T00:00:00').getTime() }),
-        ...(filter?.endDate && { endMs: new Date(filter.endDate + 'T23:59:59').getTime() }),
       });
       const entries = Array.isArray(result.entries) ? result.entries : [];
       if (entries.length === 0) break;
@@ -870,7 +867,7 @@ export class CronJobService {
       for (const entry of entries) {
         if (internalJobIds.has(entry.jobId)) continue;
         const run = mapGatewayRun(entry);
-        if (!matchesRunFilter(run, filter)) continue;
+        if (!matchesFilter(run)) continue;
         if (skippedVisible < visibleOffset) {
           skippedVisible += 1;
           continue;

--- a/src/scheduledTask/runFilter.test.ts
+++ b/src/scheduledTask/runFilter.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { TaskStatus } from './constants';
+import { createRunFilter } from './runFilter';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('createRunFilter', () => {
+  test('preserves unfiltered and status-only behavior', () => {
+    const run = { startedAt: '', status: TaskStatus.Error };
+    expect(createRunFilter()(run)).toBe(true);
+    expect(createRunFilter({ status: TaskStatus.Error })(run)).toBe(true);
+    expect(createRunFilter({ status: TaskStatus.Success })(run)).toBe(false);
+  });
+
+  test('compares UTC run timestamps against local days, including the last millisecond', () => {
+    vi.stubEnv('TZ', 'Asia/Shanghai');
+    const matches = createRunFilter({ startDate: '2026-09-10', endDate: '2026-09-10' });
+    const run = (startedAt: string) => ({ startedAt, status: TaskStatus.Success });
+
+    expect(matches(run('2026-09-09T15:59:59.999Z'))).toBe(false);
+    expect(matches(run('2026-09-09T16:00:00.000Z'))).toBe(true);
+    expect(matches(run('2026-09-10T15:59:59.999Z'))).toBe(true);
+    expect(matches(run('2026-09-10T16:00:00.000Z'))).toBe(false);
+  });
+
+  test.each([
+    { date: '2026-03-08', start: '2026-03-08T05:00:00.000Z', end: '2026-03-09T04:00:00.000Z' },
+    { date: '2026-11-01', start: '2026-11-01T04:00:00.000Z', end: '2026-11-02T05:00:00.000Z' },
+  ])('uses local calendar boundaries across daylight saving on $date', ({ date, start, end }) => {
+    vi.stubEnv('TZ', 'America/New_York');
+    const matches = createRunFilter({ startDate: date, endDate: date });
+    const run = (startedAt: string) => ({ startedAt, status: TaskStatus.Success });
+
+    expect(matches(run(new Date(Date.parse(start) - 1).toISOString()))).toBe(false);
+    expect(matches(run(start))).toBe(true);
+    expect(matches(run(new Date(Date.parse(end) - 1).toISOString()))).toBe(true);
+    expect(matches(run(end))).toBe(false);
+  });
+
+  test('supports open date bounds while applying status filtering', () => {
+    const run = {
+      startedAt: new Date('2026-09-10T12:00:00').toISOString(),
+      status: TaskStatus.Success,
+    };
+    expect(createRunFilter({ startDate: '2026-09-10' })(run)).toBe(true);
+    expect(createRunFilter({ endDate: '2026-09-10' })(run)).toBe(true);
+    expect(createRunFilter({ startDate: '2026-09-11' })(run)).toBe(false);
+    expect(createRunFilter({ endDate: '2026-09-09' })(run)).toBe(false);
+    expect(createRunFilter({ endDate: '2026-09-10', status: TaskStatus.Error })(run)).toBe(false);
+  });
+
+  test('does not match an invalid run timestamp when filtering dates', () => {
+    expect(createRunFilter({ startDate: '2026-09-10' })({
+      startedAt: 'invalid',
+      status: TaskStatus.Success,
+    })).toBe(false);
+  });
+});

--- a/src/scheduledTask/runFilter.ts
+++ b/src/scheduledTask/runFilter.ts
@@ -1,0 +1,23 @@
+import type { RunFilter, ScheduledTaskRun } from './types';
+
+/** Shared by history pagination and the renderer's live run filtering. */
+export function createRunFilter(
+  filter: RunFilter = {},
+): (run: Pick<ScheduledTaskRun, 'startedAt' | 'status'>) => boolean {
+  const { startDate, endDate, status } = filter;
+  const startMs = startDate
+    ? new Date(`${startDate}T00:00:00`).getTime()
+    : Number.NEGATIVE_INFINITY;
+  const end = endDate ? new Date(`${endDate}T00:00:00`) : null;
+  // Use the next local midnight to include the entire end date, including
+  // milliseconds, and account for days shortened or extended by daylight saving.
+  if (end) end.setDate(end.getDate() + 1);
+  const endMs = end?.getTime() ?? Number.POSITIVE_INFINITY;
+
+  return run => {
+    if (status && run.status !== status) return false;
+    if (!startDate && !endDate) return true;
+    const startedAtMs = new Date(run.startedAt).getTime();
+    return startedAtMs >= startMs && startedAtMs < endMs;
+  };
+}


### PR DESCRIPTION
## Summary

Selecting a date in scheduled task history sends unsupported `startMs` / `endMs` parameters to OpenClaw, causing `cron.runs` to reject the request. Apply date filters locally in LobsterAI so both global and single-task history work with the existing gateway API.

## Related Issue

QA report: scheduled tasks → history → selecting a date fails with `invalid cron.runs params: at root: unexpected property 'startMs'`. No linked issue.

## Changes Made

- Remove unsupported date parameters from both history requests. Filter mapped runs by start time and application status before applying the visible page offset and limit.
- Share the filter between the main-process service and both history components. Compare timestamps against local calendar-day boundaries and include the entire end date, including milliseconds and daylight-saving transitions.
- Continue reading gateway pages until enough matching runs are collected or history is exhausted. Completion-time ordering cannot justify stopping early based on a run's start time.
- Add 20 regression cases covering both history scopes, old dates across multiple pages, filtered offsets, status mapping, empty results, missing start timestamps, and local-day boundaries.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] 70 tests passed across six targeted Vitest suites: the existing and new CronJobService suites, shared run filtering, renderer scheduled-task service, Redux slice, and scheduled-task IPC handlers.
- [x] Changed-file ESLint passed with `--report-unused-disable-directives --max-warnings 0`.
- [x] `npm --ignore-scripts run compile:electron` passed.
- [x] `npm run build` passed.
- [x] Eight requests from the updated service passed the actual OpenClaw v2026.8.1 parameter validator in an offline check.
- [x] Manual browser verification with the real history components and service, using simulated gateway data: skipped 120 recent records to find old dates, retained midnight and the end date's last millisecond, loaded more runs, combined date/status filters, and cleared filters.

Native dependency rebuild hooks were skipped for targeted tests and the standalone TypeScript compile because this worktree reuses the existing dependency directory. Full Electron/OpenClaw live integration was not run.

## Screenshots (if applicable)

No layout or styling changes; the existing date controls and history views were exercised in the isolated browser verification described above.

## Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my code.
- [x] Non-obvious date-boundary and pagination behavior is documented in code.
- [x] New and existing targeted unit tests pass locally.

## Electron-Specific Changes

- [x] Main-process history querying changes in `src/scheduledTask/cronJobService.ts`.
- The existing IPC contract, preload API, storage, and OpenClaw runtime/configuration remain unchanged. No OpenClaw patch is added.

## Additional Notes

Date selection continues to mean the run's start date. Sparse or old date ranges may require scanning many gateway pages; this is the accepted fallback for the expected small history volume.
