### PR TITLE
fix(openclaw): quarantine corrupt workspace attestations before startup

### DIFF
--- a/scripts/apply-openclaw-patches.cjs
+++ b/scripts/apply-openclaw-patches.cjs
@@ -830,6 +830,25 @@ const v20260801StrongPatchValidators = {
       ],
     },
   ],
+  'openclaw-workspace-attestation-quarantine.patch': [
+    {
+      file: 'src/infra/state-migrations.workspace-setup.ts',
+      snippets: [
+        'isRecoverableWorkspaceAttestation(params.source, snapshot)',
+        'backupCorruptWorkspaceAttestation({',
+        'remainingMessage: "legacy workspace source remains after quarantine cleanup"',
+      ],
+    },
+    {
+      file: 'src/infra/state-migrations.workspace-attestation-recovery.ts',
+      snippets: [
+        'snapshot.size === snapshot.raw.length',
+        'await sourceRoot.create(relativePath, bytes, { mode: 0o600 })',
+        'workspace attestation backup verification failed',
+        'attestation recovery requires existing workspace content',
+      ],
+    },
+  ],
 };
 
 const strongPatchValidators = openclawVersion === 'v2026.8.1'

--- a/scripts/patches/v2026.8.1/openclaw-workspace-attestation-quarantine.patch
+++ b/scripts/patches/v2026.8.1/openclaw-workspace-attestation-quarantine.patch
@@ -1,0 +1,483 @@
+OpenClaw v2026.8.1: quarantine empty and all-NUL workspace attestations before migration.
+
+Based on the source-claim recovery approach in upstream PR #134641:
+https://github.com/openclaw/openclaw/pull/134641
+Base: ea806575e6450e4d1efdfc72c19f04be982a1b9b.
+
+Extend zero-byte handling to the observed 59-byte all-NUL Windows marker.
+Require a configured hashed marker and surviving workspace content. Preserve
+the exact bytes plus metadata in workspace-attestation-quarantine before
+verified cleanup, under the existing maintenance lock and source claim.
+Other malformed/linked/unconfigured sources and receipt conflicts still block.
+No synthetic attestation, setup state, or migration receipt is imported.
+
+diff --git a/src/infra/state-migrations.workspace-attestation-recovery.test.ts b/src/infra/state-migrations.workspace-attestation-recovery.test.ts
+new file mode 100644
+index 00000000000..15f95197b9a
+--- /dev/null
++++ b/src/infra/state-migrations.workspace-attestation-recovery.test.ts
+@@ -0,0 +1,262 @@
++import fs from "node:fs";
++import path from "node:path";
++import { afterEach, describe, expect, it, vi } from "vitest";
++import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
++import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
++import { acquireGatewayLock } from "./gateway-lock.js";
++import * as recovery from "./state-migrations.workspace-attestation-recovery.js";
++import { migrateLegacyWorkspaceState } from "./state-migrations.workspace-setup.js";
++import { useWorkspaceMigrationTestFixture } from "./state-migrations.workspace-setup.test-support.js";
++
++const VALID_MARKER = "openclaw-workspace-attestation:v1\n2026-09-01T01:02:03.000Z\n";
++const CLAIM_SUFFIX = ".doctor-importing";
++
++describe("corrupt workspace attestation quarantine", () => {
++  const { setup, detect, migrate } = useWorkspaceMigrationTestFixture();
++  afterEach(() => vi.restoreAllMocks());
++
++  function fixture(bytes = Buffer.alloc(59)) {
++    const context = setup();
++    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
++    const marker = path.join(
++      context.stateDir,
++      "workspace-attestations",
++      identity.workspaceKey + ".attested",
++    );
++    const quarantine = path.join(
++      context.stateDir,
++      recovery.WORKSPACE_ATTESTATION_QUARANTINE_DIRNAME,
++    );
++    fs.mkdirSync(path.dirname(marker), { recursive: true });
++    fs.writeFileSync(marker, bytes);
++    fs.writeFileSync(
++      path.join(context.workspaceDir, "USER.md"),
++      "# Existing user\nKeep this content.\n",
++    );
++    return { ...context, marker, quarantine, bytes };
++  }
++
++  function backups(context: ReturnType<typeof fixture>) {
++    return fs.readdirSync(context.quarantine).filter((file) => file.endsWith(".attested"));
++  }
++
++  it.each([0, 59])(
++    "backs up all %i zero bytes, preserves setup, and converges on retry",
++    async (size) => {
++      const context = fixture(Buffer.alloc(size));
++      const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
++      const completedAt = "2026-09-01T01:02:03.000Z";
++      fs.writeFileSync(setupPath, JSON.stringify({ version: 1, setupCompletedAt: completedAt }));
++      const mtimeMs = fs.statSync(context.marker).mtimeMs;
++      const result = await migrate(context);
++      expect(result.warnings).toEqual([]);
++      expect(result.changes.join("\n")).toContain("backup: ");
++      expect(detect(context).hasLegacy).toBe(false);
++      const files = backups(context);
++      expect(files).toHaveLength(1);
++      expect(fs.readFileSync(path.join(context.quarantine, files[0]))).toEqual(context.bytes);
++      const metadata = JSON.parse(
++        fs.readFileSync(
++          path.join(context.quarantine, files[0].replace(".attested", ".json")),
++          "utf8",
++        ),
++      );
++      expect(metadata).toMatchObject({ sourcePath: context.marker, size, mtimeMs });
++      const state = readWorkspaceStateSnapshot(context.workspaceDir, { env: context.env });
++      expect(state.setup.setupCompletedAt).toBe(completedAt);
++      expect(state.attestation).toBeUndefined();
++      expect(fs.readFileSync(path.join(context.workspaceDir, "USER.md"), "utf8")).toContain(
++        "Keep this content.",
++      );
++      expect((await migrate(context)).changes).toEqual([]);
++      expect(backups(context)).toEqual(files);
++    },
++  );
++
++  it("resumes a claim interrupted before backup", async () => {
++    const context = fixture();
++    fs.renameSync(context.marker, context.marker + CLAIM_SUFFIX);
++    expect((await migrate(context)).warnings).toEqual([]);
++    expect(detect(context).hasLegacy).toBe(false);
++    expect(fs.readFileSync(path.join(context.quarantine, backups(context)[0]))).toEqual(
++      context.bytes,
++    );
++  });
++
++  it.each([
++    Buffer.from("bad header"),
++    Buffer.from(" "),
++    Buffer.from([0xef, 0xbb, 0xbf]),
++    Buffer.from([0xef, 0xbb, 0xbf, 0]),
++    Buffer.from(VALID_MARKER + "\0"),
++    Buffer.from([0xff]),
++    Buffer.alloc(2049),
++  ])("retains other malformed or oversized input %#", async (bytes) => {
++    const context = fixture(bytes);
++    expect((await migrate(context)).warnings.length).toBeGreaterThan(0);
++    expect(fs.readFileSync(context.marker)).toEqual(bytes);
++    expect(fs.existsSync(context.quarantine)).toBe(false);
++  });
++
++  it.each([false, true])(
++    "retains a marker when its workspace is empty or missing: %s",
++    async (missing) => {
++      const context = fixture();
++      fs.unlinkSync(path.join(context.workspaceDir, "USER.md"));
++      if (missing) {
++        fs.rmdirSync(context.workspaceDir);
++      }
++      expect((await migrate(context)).warnings.length).toBeGreaterThan(0);
++      expect(fs.readFileSync(context.marker)).toEqual(context.bytes);
++      expect(fs.existsSync(context.quarantine)).toBe(false);
++    },
++  );
++
++  it("leaves unconfigured and unrelated sibling markers intact", async () => {
++    const context = fixture();
++    const orphan = path.join(path.dirname(context.marker), "f".repeat(64) + ".attested");
++    const sibling = context.workspaceDir + ".attested";
++    fs.renameSync(context.marker, orphan);
++    fs.writeFileSync(sibling, context.bytes);
++    expect((await migrate(context)).warnings.length).toBeGreaterThan(0);
++    expect(fs.readFileSync(orphan)).toEqual(context.bytes);
++    expect(fs.readFileSync(sibling)).toEqual(context.bytes);
++    expect(fs.existsSync(context.quarantine)).toBe(false);
++  });
++
++  it("does not recover a zero-filled setup JSON source", async () => {
++    const context = fixture();
++    fs.renameSync(context.marker, path.join(context.workspaceDir, "openclaw-workspace-state.json"));
++    expect((await migrate(context)).warnings.length).toBeGreaterThan(0);
++    expect(fs.existsSync(context.quarantine)).toBe(false);
++  });
++
++  it("rejects a hardlinked marker", async () => {
++    const context = fixture();
++    const link = path.join(context.homeDir, "hardlink");
++    fs.linkSync(context.marker, link);
++    expect((await migrate(context)).warnings.length).toBeGreaterThan(0);
++    expect(fs.readFileSync(context.marker)).toEqual(context.bytes);
++    expect(fs.readFileSync(link)).toEqual(context.bytes);
++    expect(fs.existsSync(context.quarantine)).toBe(false);
++  });
++
++  it("restores a source replaced before claim and imports the replacement on retry", async () => {
++    const context = fixture();
++    const result = await migrateLegacyWorkspaceState({
++      detected: detect(context),
++      stateDir: context.stateDir,
++      env: context.env,
++      beforeClaim: () => fs.writeFileSync(context.marker, VALID_MARKER),
++    });
++    expect(result.warnings.join(" ")).toContain("changed before");
++    expect(fs.readFileSync(context.marker, "utf8")).toBe(VALID_MARKER);
++    expect(fs.existsSync(context.quarantine)).toBe(false);
++    expect((await migrate(context)).warnings).toEqual([]);
++    expect(
++      readWorkspaceStateSnapshot(context.workspaceDir, { env: context.env }).attestation,
++    ).toBeDefined();
++  });
++
++  it("restores the source after backup failure and can retry", async () => {
++    const context = fixture();
++    fs.writeFileSync(context.quarantine, "block directory creation");
++    expect((await migrate(context)).warnings.join(" ")).toContain("Failed quarantining");
++    expect(fs.readFileSync(context.marker)).toEqual(context.bytes);
++    expect(fs.existsSync(context.marker + CLAIM_SUFFIX)).toBe(false);
++    fs.unlinkSync(context.quarantine);
++    expect((await migrate(context)).warnings).toEqual([]);
++    expect(detect(context).hasLegacy).toBe(false);
++  });
++
++  it("keeps the backup and restores the source when cleanup fails", async () => {
++    const context = fixture();
++    const result = await migrateLegacyWorkspaceState({
++      detected: detect(context),
++      stateDir: context.stateDir,
++      env: context.env,
++      removeSource: () => {
++        throw new Error("injected cleanup failure");
++      },
++    });
++    expect(result.warnings.join(" ")).toContain("injected cleanup failure");
++    expect(result.warnings.join(" ")).toContain("backup: ");
++    expect(fs.readFileSync(context.marker)).toEqual(context.bytes);
++    expect(backups(context)).toHaveLength(1);
++    expect((await migrate(context)).warnings).toEqual([]);
++    expect(detect(context).hasLegacy).toBe(false);
++  });
++
++  it("preserves a claim changed while the backup is written", async () => {
++    const context = fixture();
++    const backup = recovery.backupCorruptWorkspaceAttestation;
++    vi.spyOn(recovery, "backupCorruptWorkspaceAttestation").mockImplementationOnce(
++      async (params) => {
++        const backupPath = await backup(params);
++        fs.writeFileSync(context.marker + CLAIM_SUFFIX, VALID_MARKER);
++        return backupPath;
++      },
++    );
++    expect((await migrate(context)).warnings.join(" ")).toContain("claim changed");
++    expect(fs.readFileSync(context.marker, "utf8")).toBe(VALID_MARKER);
++    expect(fs.readFileSync(path.join(context.quarantine, backups(context)[0]))).toEqual(
++      context.bytes,
++    );
++  });
++
++  it("retains both paths when a source and an interrupted claim coexist", async () => {
++    const context = fixture();
++    fs.writeFileSync(context.marker + CLAIM_SUFFIX, context.bytes);
++    expect((await migrate(context)).warnings.join(" ")).toContain("both exist");
++    expect(fs.readFileSync(context.marker)).toEqual(context.bytes);
++    expect(fs.readFileSync(context.marker + CLAIM_SUFFIX)).toEqual(context.bytes);
++    expect(fs.existsSync(context.quarantine)).toBe(false);
++  });
++
++  it("rejects a symlinked marker and a symlinked backup directory", async () => {
++    const context = fixture();
++    const target = path.join(context.homeDir, "original.attested");
++    fs.renameSync(context.marker, target);
++    fs.symlinkSync(target, context.marker);
++    expect((await migrate(context)).warnings.length).toBeGreaterThan(0);
++    expect(fs.readFileSync(target)).toEqual(context.bytes);
++    fs.unlinkSync(context.marker);
++    fs.renameSync(target, context.marker);
++    const outside = path.join(context.homeDir, "outside");
++    fs.mkdirSync(outside);
++    fs.symlinkSync(outside, context.quarantine, process.platform === "win32" ? "junction" : "dir");
++    expect((await migrate(context)).warnings.length).toBeGreaterThan(0);
++    expect(fs.readFileSync(context.marker)).toEqual(context.bytes);
++    expect(fs.readdirSync(outside)).toEqual([]);
++  });
++
++  it("restores the marker if workspace content disappears during backup", async () => {
++    const context = fixture();
++    const backup = recovery.backupCorruptWorkspaceAttestation;
++    vi.spyOn(recovery, "backupCorruptWorkspaceAttestation").mockImplementationOnce(
++      async (params) => {
++        const backupPath = await backup(params);
++        fs.unlinkSync(path.join(context.workspaceDir, "USER.md"));
++        return backupPath;
++      },
++    );
++    expect((await migrate(context)).warnings.join(" ")).toContain(
++      "requires existing workspace content",
++    );
++    expect(fs.readFileSync(context.marker)).toEqual(context.bytes);
++    expect(backups(context)).toHaveLength(1);
++  });
++
++  it("leaves the source untouched while another gateway owns the state", async () => {
++    const context = fixture();
++    const lock = await acquireGatewayLock({ env: context.env, allowInTests: true });
++    expect(lock).toBeDefined();
++    try {
++      expect((await migrate(context)).warnings.join(" ")).toContain("owns this state directory");
++      expect(fs.readFileSync(context.marker)).toEqual(context.bytes);
++      expect(fs.existsSync(context.quarantine)).toBe(false);
++    } finally {
++      await lock?.release();
++    }
++  });
++});
+diff --git a/src/infra/state-migrations.workspace-attestation-recovery.ts b/src/infra/state-migrations.workspace-attestation-recovery.ts
+new file mode 100644
+index 00000000000..14dd8bea01d
+--- /dev/null
++++ b/src/infra/state-migrations.workspace-attestation-recovery.ts
+@@ -0,0 +1,99 @@
++import { createHash, randomUUID } from "node:crypto";
++import path from "node:path";
++import { root, type Root } from "@openclaw/fs-safe";
++import { LEGACY_WORKSPACE_ATTESTATION_DIRNAME } from "../agents/workspace-legacy-state.js";
++import type { SourceSnapshot } from "./state-migrations.workspace-setup-store.js";
++import type { LegacyWorkspaceStateSource } from "./state-migrations.workspace-setup.types.js";
++
++export const WORKSPACE_ATTESTATION_QUARANTINE_DIRNAME = "workspace-attestation-quarantine";
++const WORKSPACE_CONTENT_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "IDENTITY.md", "MEMORY.md"];
++
++export function isRecoverableWorkspaceAttestation(
++  source: LegacyWorkspaceStateSource,
++  snapshot: SourceSnapshot,
++): boolean {
++  if (source.kind !== "attestation" || !source.workspaceDir || !source.workspaceAliasPath) {
++    return false;
++  }
++  const keys = [
++    source.workspaceKey,
++    createHash("sha256").update(source.workspaceAliasPath).digest("hex"),
++  ];
++  // Only configured, reserved markers with no usable bytes qualify. Checking
++  // byte length also rejects a BOM that TextDecoder would otherwise strip.
++  return (
++    keys.some(
++      (key) =>
++        source.relativePath === path.join(LEGACY_WORKSPACE_ATTESTATION_DIRNAME, key + ".attested"),
++    ) &&
++    snapshot.size === snapshot.raw.length &&
++    /^\0*$/.test(snapshot.raw)
++  );
++}
++
++export async function assertWorkspaceAttestationRecoverySafe(
++  source: LegacyWorkspaceStateSource,
++): Promise<void> {
++  if (!source.workspaceDir) {
++    throw new Error("attestation recovery requires a configured workspace");
++  }
++  const workspace = await root(source.workspaceDir, { hardlinks: "reject", symlinks: "reject" });
++  for (const filename of WORKSPACE_CONTENT_FILES) {
++    if (!(await workspace.exists(filename))) {
++      continue;
++    }
++    const opened = await workspace.open(filename);
++    try {
++      if (opened.stat.isFile() && opened.stat.size > 0) {
++        return;
++      }
++    } finally {
++      await opened[Symbol.asyncDispose]();
++    }
++  }
++  // Losing an attestation must not turn a missing/empty workspace into a fresh
++  // bootstrap. Runtime keeps its canonical setup and disappearance checks too.
++  throw new Error(
++    "attestation recovery requires existing workspace content at " + source.workspaceDir,
++  );
++}
++
++export async function backupCorruptWorkspaceAttestation(params: {
++  sourceRoot: Root;
++  source: LegacyWorkspaceStateSource;
++  snapshot: SourceSnapshot;
++}): Promise<string> {
++  const { sourceRoot, source, snapshot } = params;
++  const relativeBase = path.join(WORKSPACE_ATTESTATION_QUARANTINE_DIRNAME, randomUUID());
++  const relativePath = relativeBase + ".attested";
++  const bytes = Buffer.from(snapshot.raw, "utf8");
++  const metadata =
++    JSON.stringify(
++      {
++        version: 1,
++        sourcePath: source.sourcePath,
++        workspaceDir: source.workspaceDir,
++        workspaceKey: source.workspaceKey,
++        size: snapshot.size,
++        sha256: snapshot.sha256,
++        mtimeMs: snapshot.mtimeMs,
++        quarantinedAt: new Date().toISOString(),
++        reason: "empty-or-nul-attestation",
++      },
++      null,
++      2,
++    ) + "\n";
++  // Atomic, no-clobber writes outside discovery precede source cleanup. A failed
++  // backup or verification leaves the claim available for restore/retry.
++  await sourceRoot.create(relativePath, bytes, { mode: 0o600 });
++  await sourceRoot.create(relativeBase + ".json", metadata, { mode: 0o600 });
++  const saved = await sourceRoot.readBytes(relativePath, { maxBytes: snapshot.size });
++  if (
++    saved.length !== snapshot.size ||
++    createHash("sha256").update(saved).digest("hex") !== snapshot.sha256 ||
++    (await sourceRoot.readText(relativeBase + ".json")) !== metadata
++  ) {
++    throw new Error("workspace attestation backup verification failed");
++  }
++  return path.join(source.rootDir, relativePath);
++}
+diff --git a/src/infra/state-migrations.workspace-setup.ts b/src/infra/state-migrations.workspace-setup.ts
+index 56aa339666d..0c9fdd97888 100644
+--- a/src/infra/state-migrations.workspace-setup.ts
++++ b/src/infra/state-migrations.workspace-setup.ts
+@@ -26,6 +26,11 @@ import {
+   legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
+ } from "./state-migrations.source-snapshot.js";
+ import type { MigrationMessages } from "./state-migrations.types.js";
++import {
++  assertWorkspaceAttestationRecoverySafe,
++  backupCorruptWorkspaceAttestation,
++  isRecoverableWorkspaceAttestation,
++} from "./state-migrations.workspace-attestation-recovery.js";
+ import {
+   markLegacyMigrationSourceRemoved,
+   readReceipt,
+@@ -457,9 +462,10 @@ async function migrateOneSource(params: {
+   removeSource?: (sourcePath: string) => Promise<void> | void;
+ }): Promise<MigrationMessages> {
+   let sourceClaim: LegacyMigrationSourceClaim<SourceSnapshot>;
++  let sourceRoot: Root;
+   try {
+     assertConfiguredWorkspaceIdentity(params.source);
+-    const sourceRoot = await root(params.source.rootDir, {
++    sourceRoot = await root(params.source.rootDir, {
+       hardlinks: "reject",
+       symlinks: "reject",
+     });
+@@ -507,11 +513,15 @@ async function migrateOneSource(params: {
+   }
+
+   let snapshot: SourceSnapshot;
+-  let parsed: ParsedSource;
++  let parsed: ParsedSource | undefined;
+   let claimedByThisRun = false;
+   try {
+     snapshot = await sourceClaim.read(!hasSource);
+-    parsed = parseSource(params.source, snapshot);
++    if (isRecoverableWorkspaceAttestation(params.source, snapshot)) {
++      await assertWorkspaceAttestationRecoverySafe(params.source);
++    } else {
++      parsed = parseSource(params.source, snapshot);
++    }
+   } catch (error) {
+     return {
+       changes: [],
+@@ -541,6 +551,50 @@ async function migrateOneSource(params: {
+     }
+   }
+
++  if (!parsed) {
++    let backupPath: string | undefined;
++    try {
++      assertConfiguredWorkspaceIdentity(params.source);
++      backupPath = await backupCorruptWorkspaceAttestation({
++        sourceRoot,
++        source: params.source,
++        snapshot,
++      });
++      await assertWorkspaceAttestationRecoverySafe(params.source);
++      if (!snapshotsMatch(snapshot, await sourceClaim.read(true))) {
++        throw new Error("legacy workspace claim changed before quarantine cleanup");
++      }
++      assertConfiguredWorkspaceIdentity(params.source);
++      await sourceClaim.remove({
++        removeSource: params.removeSource,
++        remainingMessage: "legacy workspace source remains after quarantine cleanup",
++      });
++      return {
++        changes: [
++          "Quarantined corrupt workspace attestation at " +
++            params.source.sourcePath +
++            "; backup: " +
++            backupPath +
++            ".",
++        ],
++        warnings: [],
++      };
++    } catch (error) {
++      const restoreError = claimedByThisRun ? await sourceClaim.restore() : null;
++      return {
++        changes: [],
++        warnings: [
++          "Failed quarantining workspace attestation at " +
++            params.source.sourcePath +
++            ": " +
++            formatErrorMessage(error) +
++            (backupPath ? "; backup: " + backupPath : "") +
++            (restoreError ? "; restore failure: " + restoreError : ""),
++        ],
++      };
++    }
++  }
++
+   let result: ReturnType<typeof importAndRecordReceipt>;
+   try {
+     assertConfiguredWorkspaceIdentity(params.source);

--- a/specs/refactors/openclaw-upgrade/2026-09-10-workspace-attestation-quarantine.md
+++ b/specs/refactors/openclaw-upgrade/2026-09-10-workspace-attestation-quarantine.md
@@ -1,0 +1,124 @@
+# Recovering empty and all-NUL legacy workspace attestations
+
+Base: LobsterAI branch `feat/openclaw-v2026.8.1`, commit
+`b46d7422b36005f51a035de1968f0e9267222c26`; OpenClaw `v2026.8.1`,
+`ea806575e6450e4d1efdfc72c19f04be982a1b9b`.
+
+## Failure and upstream precedent
+
+A Windows upgrade failed before gateway spawn because the main workspace's
+reserved `.attested` file contained 59 NUL bytes. Its SHA-256 was
+`dda4668c44df722c5a963fbbfa1ff3a597aaeef5f2bf0ebd5bc28c88c1383f33`.
+The strict parser rejects its header; retaining the source causes every later
+migration attempt to fail. Rebuilding `openclaw.json` cannot repair this source.
+
+[Upstream issue #134445](https://github.com/openclaw/openclaw/issues/134445)
+reports the same upgrade failure with a zero-byte marker.
+[PR #134641](https://github.com/openclaw/openclaw/pull/134641), merged September 1,
+reuses the migration source claim to discard safe empty markers. It does not
+handle a nonempty, all-NUL file and does not retain a forensic backup.
+
+## Local recovery contract
+
+The version-scoped `openclaw-workspace-attestation-quarantine.patch` extends the
+same migration owner, rather than adding a second preflight cleanup owner.
+The bundled LobsterAI workspace helper already calls this migration under its
+exclusive maintenance lock. No gateway-startup success check is relaxed.
+
+A source qualifies only when:
+
+- It is a bounded, single-link regular attestation file, read through the
+  existing symlink-rejecting source root.
+- Its reserved hashed path corresponds to a configured workspace's canonical
+  path or configured alias. Orphan and workspace-sibling files do not qualify.
+- Its bytes are exactly empty or all NUL. BOMs, whitespace, partial valid
+  records, other malformed content, and sources over the upstream 2 KiB limit
+  retain the existing failure behavior.
+- The workspace exists and at least one of `AGENTS.md`, `SOUL.md`, `USER.md`,
+  `IDENTITY.md`, or `MEMORY.md` is a nonempty regular file. This deliberately
+  conservative recovery check does not replace the runtime's setup and
+  disappearance checks.
+
+The migration takes the normal `.doctor-importing` claim, checking the source
+identity and snapshot as before. It atomically creates:
+
+```text
+<source-state-root>/workspace-attestation-quarantine/<uuid>.attested
+<source-state-root>/workspace-attestation-quarantine/<uuid>.json
+```
+
+The first file preserves the exact bytes. JSON records the original source and
+workspace paths, workspace key, size, SHA-256, observed modification time, backup
+time, and reason. Both files are read back and verified before source cleanup.
+The source snapshot and workspace are checked again before removing the claim.
+No synthetic attestation, setup state, or successful SQLite import receipt is
+created for corrupt data. Other valid legacy sources still migrate normally.
+
+Backups are outside legacy discovery, are never overwritten, and have no
+automatic retention/deletion policy in this fix. A cleanup failure can leave an
+additional backup on retry. Source/claim collisions, active gateway ownership,
+existing receipt conflicts, backup failures, and changed source/workspace state
+still block startup. A newly claimed file is restored when recovery fails;
+an interrupted claim stays discoverable for retry.
+
+Migration changes, including backup locations, now appear in the main log even
+if another source prevents that run from completing. Failed recovery also
+reports its backup path when the backup completed.
+
+## Verification
+
+- The two new bundled positive cases fail on the original pinned helper:
+  zero bytes and the observed 59 NUL bytes both return exit 1 / invalid header.
+- The patched source passed the existing workspace migration and source-claim
+  tests (36 cases) plus 23 recovery cases. Coverage includes interrupted claims,
+  backup/cleanup failures, source replacement, hardlinks, symlinks, missing
+  workspace content, content disappearing during backup, and gateway ownership.
+- LobsterAI's migration wrapper, built-helper integration, and version patch-set
+  tests passed (38 cases), with the runtime integration suite explicitly enabled.
+- All 28 version-scoped patches applied successfully to an isolated pinned
+  source checkout, including the new patch's strong source validation.
+- Changed LobsterAI TypeScript files passed ESLint; `npm run compile:electron`
+  passed.
+- The patched OpenClaw files passed type-aware Oxlint. A separate whole-upstream
+  core typecheck was interrupted under local memory pressure; no full upstream
+  typecheck pass is claimed.
+- A live smoke test used the original 59-byte sample, the compiled LobsterAI
+  startup migration wrapper, and the local bundled gateway with isolated state
+  and its own loopback port. Migration returned `migrated` then `skipped`, the
+  backup matched byte-for-byte, `/startupz` returned the `started` state, and the
+  original workspace files were unchanged. The test gateway was stopped.
+  This does not claim that the QA machine or the Electron UI has been tested.
+- The local `vendor/openclaw-runtime/current` (Windows x64) helper was rebuilt
+  through the normal bundler. All 8 integration cases also passed against that
+  runtime's packaged dependencies.
+- A subsequent real QA archive, `LobsterAI-Windows-Workspace-20260910-152450-2bce5ca2.zip`,
+  passed all 845 manifest file hashes and SQLite integrity checks. Full isolated
+  copies reproduced the old helper's invalid-header failure and passed the
+  patched bundled helper through the compiled LobsterAI startup wrapper:
+  `migrated`, then `skipped`. The raw backup matched the original 59 NUL bytes.
+  All 842 workspace files and the schema/rows of all 104 SQLite tables were
+  unchanged by migration. Only configured workspace paths and the corresponding
+  reserved marker filename were relocated for isolation; the database was not
+  rewritten to construct the fixture.
+- On that migrated QA copy, the pinned OpenClaw `ensureAgentWorkspace` function
+  passed twice with bootstrap-file provisioning enabled. It preserved all 842
+  files, did not recreate `BOOTSTRAP.md`, and recorded normal setup completion
+  and a fresh attestation in SQLite. Only `workspace_setup_state` and
+  `workspace_path_aliases` changed; every other table retained its schema and
+  rows. Migration still returned `skipped` afterward. This called workspace
+  initialization directly, without starting the QA database's scheduled jobs,
+  pending deliveries, plugins, or a full gateway. Other agents' workspace and
+  session directories were outside the collector's scope.
+
+Normal runtime builds apply this patch before bundling the workspace migration
+helper. For a focused local helper rebuild using an already patched source:
+
+```powershell
+node scripts/bundle-openclaw-workspace-migration.cjs <runtime-dir> <patched-openclaw-source>
+$env:OPENCLAW_WORKSPACE_MIGRATION_RUNTIME = '<runtime-dir>'
+npm test -- openclawWorkspaceStateMigration v20260801UpgradeDecisions
+```
+
+The initial corruption event remains unknown. This change recovers the observed
+legacy input and preserves evidence; it does not attribute the damage to an
+interrupted write or repair unrelated corrupted state.

--- a/src/main/libs/openclawPatches/v20260801UpgradeDecisions.test.ts
+++ b/src/main/libs/openclawPatches/v20260801UpgradeDecisions.test.ts
@@ -35,6 +35,7 @@ const RETAINED_PATCHES = [
   'openclaw-view-image-task-cwd.patch',
   'openclaw-windows-file-path-redaction.patch',
   'openclaw-windows-process-identity.patch',
+  'openclaw-workspace-attestation-quarantine.patch',
   'zz-openclaw-task-cwd-system-prompt.patch',
 ] as const;
 

--- a/src/main/libs/openclawWorkspaceStateMigration.test.ts
+++ b/src/main/libs/openclawWorkspaceStateMigration.test.ts
@@ -69,6 +69,21 @@ describe('workspace state migration before gateway startup', () => {
     expect(console.log).not.toHaveBeenCalled();
   });
 
+  test('logs the quarantine backup when another source prevents startup', async () => {
+    const change = 'Quarantined corrupt workspace attestation; backup: /state/workspace-attestation-quarantine/copy.attested.';
+    const runner = vi.fn(async () => ({
+      code: 1,
+      stdout: report({
+        status: OpenClawWorkspaceMigrationStatus.Failed,
+        changes: [change], warnings: ['Another source is invalid'], remainingPaths: ['/state/other-source'],
+      }),
+      stderr: '',
+    }));
+    expect((await migrateLegacyWorkspaceStateBeforeStartup({ ...options(), runner })).status)
+      .toBe(OpenClawWorkspaceMigrationStatus.Failed);
+    expect(console.log).toHaveBeenCalledWith('[OpenClaw] Workspace state migration: ' + change);
+  });
+
   test.each([
     { code: 0, stdout: report({ remainingPaths: ['/workspace/.openclaw/workspace-state.json'] }), stderr: '', expected: 'Unmigrated workspace state' },
     { code: 0, stdout: report({ warnings: ['Gateway owns this state directory'] }), stderr: '', expected: 'Gateway owns this state directory' },

--- a/src/main/libs/openclawWorkspaceStateMigration.ts
+++ b/src/main/libs/openclawWorkspaceStateMigration.ts
@@ -79,6 +79,10 @@ export async function migrateLegacyWorkspaceStateBeforeStartup(params: {
       timeoutMs: WORKSPACE_MIGRATION_TIMEOUT_MS,
     });
     const report = parseReport(result.stdout);
+    // Keep backup locations visible even when another source blocks this run.
+    for (const change of report?.changes ?? []) {
+      console.log('[OpenClaw] Workspace state migration: ' + change);
+    }
     if (result.code !== 0 || !report || report.status === OpenClawWorkspaceMigrationStatus.Failed
       || report.warnings.length > 0 || report.remainingPaths.length > 0) {
       const detail = report
@@ -87,7 +91,7 @@ export async function migrateLegacyWorkspaceStateBeforeStartup(params: {
       throw new Error(detail || `Workspace migration did not report verified completion (exit code ${result.code}).`);
     }
     if (report.status === OpenClawWorkspaceMigrationStatus.Migrated) {
-      console.log(`[OpenClaw] Migrated ${report.sourceCount} legacy workspace state source(s) to SQLite.`);
+      console.log(`[OpenClaw] Processed ${report.sourceCount} legacy workspace state source(s).`);
     }
     return { status: report.status };
   } catch (error) {

--- a/tests/openclawWorkspaceStateMigration.integration.test.ts
+++ b/tests/openclawWorkspaceStateMigration.integration.test.ts
@@ -138,4 +138,49 @@ describe.skipIf(!runtimeRoot)('bundled OpenClaw workspace migration', () => {
     expect((await migrate()).report.status).toBe(OpenClawWorkspaceMigrationStatus.Skipped);
     expect(fs.existsSync(path.join(stateDir, 'state/openclaw.sqlite'))).toBe(false);
   });
+
+  test.each([0, 59])('quarantines a %i-byte zero-filled attestation without changing workspace/config', async (size) => {
+    const workspace = fs.realpathSync.native(workspaces[0]);
+    const marker = path.join(stateDir, 'workspace-attestations',
+      createHash('sha256').update(workspace).digest('hex') + '.attested');
+    fs.mkdirSync(path.dirname(marker), { recursive: true });
+    const bytes = Buffer.alloc(size);
+    fs.writeFileSync(marker, bytes);
+    const mtimeMs = fs.statSync(marker).mtimeMs;
+    const protectedFiles = [configPath, ...workspaces.flatMap(directory =>
+      ['AGENTS.md', 'SOUL.md', 'USER.md', 'IDENTITY.md', 'MEMORY.md'].map(name => path.join(directory, name)))];
+    const before = protectedFiles.map(digest);
+    const result = await migrate();
+    expect(result).toMatchObject({
+      code: 0,
+      report: { status: OpenClawWorkspaceMigrationStatus.Migrated, sourceCount: 1, warnings: [], remainingPaths: [] },
+    });
+    const quarantine = path.join(stateDir, 'workspace-attestation-quarantine');
+    const backups = fs.readdirSync(quarantine).filter(name => name.endsWith('.attested'));
+    expect(backups).toHaveLength(1);
+    const backupPath = path.join(quarantine, backups[0]);
+    expect(fs.readFileSync(backupPath)).toEqual(bytes);
+    const metadata = JSON.parse(fs.readFileSync(backupPath.replace(/\.attested$/, '.json'), 'utf8'));
+    expect(metadata).toMatchObject({ sourcePath: marker, size, mtimeMs, sha256: digest(backupPath) });
+    expect(result.report.changes.join('\n')).toContain(backupPath);
+    expect(fs.existsSync(marker)).toBe(false);
+    expect(protectedFiles.map(digest)).toEqual(before);
+    expect((await migrate()).report.status).toBe(OpenClawWorkspaceMigrationStatus.Skipped);
+    expect(fs.readdirSync(quarantine).filter(name => name.endsWith('.attested'))).toEqual(backups);
+  });
+
+  test('keeps a full-NUL attestation when the backup cannot be written', async () => {
+    const marker = path.join(stateDir, 'workspace-attestations',
+      createHash('sha256').update(fs.realpathSync.native(workspaces[0])).digest('hex') + '.attested');
+    fs.mkdirSync(path.dirname(marker), { recursive: true });
+    fs.writeFileSync(marker, Buffer.alloc(59));
+    fs.writeFileSync(path.join(stateDir, 'workspace-attestation-quarantine'), 'unrelated existing file');
+    const result = await migrate();
+    expect(result.code).toBe(1);
+    expect(result.report.status).toBe(OpenClawWorkspaceMigrationStatus.Failed);
+    expect(result.report.warnings.join('\n')).toContain('Failed quarantining');
+    expect(result.report.remainingPaths).toContain(marker);
+    expect(fs.readFileSync(marker)).toEqual(Buffer.alloc(59));
+    expect(fs.existsSync(marker + '.doctor-importing')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

After upgrading to OpenClaw v2026.8.1, an empty or all-NUL legacy workspace attestation can block every gateway startup with `legacy workspace attestation has an invalid header`. The observed Windows file contains 59 NUL bytes. This fix verifies and backs up those unusable markers before retiring them through the existing migration claim, allowing startup migration to complete.

## Related Issue

Related upstream report: https://github.com/openclaw/openclaw/issues/134445

Extends the source-claim approach in https://github.com/openclaw/openclaw/pull/134641 with all-NUL handling and a verified forensic backup.

## Changes Made

- Add a v2026.8.1 patch limited to empty/all-NUL reserved markers associated with a configured workspace that still has content. Preserve the existing lock, path, snapshot, receipt-conflict, and unsafe-source checks.
- Save exact bytes and metadata under `workspace-attestation-quarantine/`, verify both, and recheck source/workspace state before cleanup. Restore newly claimed sources on failure; retries converge without fabricating SQLite migration receipts.
- Log backup locations in the Electron main process even when another migration source fails. Add source-level and bundled-runtime coverage and document the recovery contract.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] QA original-machine / packaged Electron UI startup verification

Validation includes:

- After rebasing onto the latest target branch: all 67 tests pass across workspace migration, the reviewed patch set, gateway restart, and legacy session-store ownership; bundled workspace integration explicitly enabled.
- Changed-file ESLint and `npm run compile:electron`.
- 59 upstream workspace migration/source-claim/recovery tests, type-aware lint of the patched source files, and application of all 28 version-scoped patches to the pinned source.
- Full isolated QA archive: all 845 manifest hashes match; the old helper reproduces the failure, the fixed helper returns `migrated` then `skipped`, and the raw backup matches. Migration preserves all 842 workspace files and the schema/rows of all 104 SQLite tables.
- Normal workspace initialization on the migrated QA copy succeeds twice without recreating `BOOTSTRAP.md` or changing workspace files. Only the expected workspace setup and alias tables change.
- An isolated live gateway smoke test with the original 59-byte sample reaches `/startupz` status `started`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Recovery boundaries and failure handling documented in code
- [x] Documentation updated
- [x] Changed-file checks pass without new warnings
- [x] Regression coverage demonstrates the original failure and successful recovery
- [x] Relevant existing and new tests pass locally

## Electron-Specific Changes

- [x] Changes to main process (`src/main/`)

This runs in the bundled workspace migration helper before gateway spawn. Main-process logs expose the quarantine location. Other malformed sources and recovery failures continue to block startup. Quarantine backups are retained without an automatic deletion policy.

## Additional Notes

The original corruption mechanism remains unknown. Full upstream core typechecking was interrupted by local memory pressure; the checks above do not claim a full upstream typecheck pass. QA data was exercised through isolated migration and workspace initialization without starting its scheduled jobs or pending deliveries. The recovery contract and detailed validation are documented in `specs/refactors/openclaw-upgrade/2026-09-10-workspace-attestation-quarantine.md`.
