### PR TITLE
fix(openclaw): deduplicate IM restarts and hot reload MCP config

### DIFF
--- a/src/main/ipcHandlers/mcp/handlers.ts
+++ b/src/main/ipcHandlers/mcp/handlers.ts
@@ -47,7 +47,7 @@ function syncMcpConfig(
 ): void {
   syncOpenClawConfig({
     reason,
-    expectedImpact: OpenClawConfigImpact.Restart,
+    expectedImpact: OpenClawConfigImpact.Sync,
   }).catch(err =>
     console.error('[MCP] config sync error:', err),
   );

--- a/src/main/libs/openclawConfigImpact.test.ts
+++ b/src/main/libs/openclawConfigImpact.test.ts
@@ -234,15 +234,29 @@ describe('OpenClaw config impact classification', () => {
     });
   });
 
-  test('classifies IM fingerprint changes as restart and identical fingerprints as none', () => {
+  test('delivers IM config edits without forcing another gateway restart', () => {
     const previous = createStableConfigFingerprint({ telegram: { enabled: false } });
     const next = createStableConfigFingerprint({ telegram: { enabled: true } });
 
     expect(classifyImOpenClawConfigChange(previous, previous).impact).toBe(OpenClawConfigImpact.None);
     expect(classifyImOpenClawConfigChange(previous, next)).toEqual({
-      impact: OpenClawConfigImpact.Restart,
+      impact: OpenClawConfigImpact.Sync,
       reasons: [OpenClawConfigImpactReason.ImConfig],
     });
+  });
+
+  test('keeps IM binding saves as sync when removing an unrelated restart reason', () => {
+    const imDecision = classifyImOpenClawConfigChange(
+      createStableConfigFingerprint({ settings: { platformAgentBindings: {} } }),
+      createStableConfigFingerprint({ settings: { platformAgentBindings: { qq: 'worker' } } }),
+    );
+    const combined = mergeImpactDecision(imDecision, {
+      impact: OpenClawConfigImpact.Restart,
+      reasons: [OpenClawConfigImpactReason.AppUseSystemProxy],
+    });
+
+    expect(removeImpactDecisionReasons(combined, [OpenClawConfigImpactReason.AppUseSystemProxy]))
+      .toEqual({ impact: OpenClawConfigImpact.Sync, reasons: [OpenClawConfigImpactReason.ImConfig] });
   });
 
   test('classifies forced IM sync as restart even without fingerprint diff', () => {

--- a/src/main/libs/openclawConfigImpact.test.ts
+++ b/src/main/libs/openclawConfigImpact.test.ts
@@ -234,18 +234,18 @@ describe('OpenClaw config impact classification', () => {
     });
   });
 
-  test('delivers IM config edits without forcing another gateway restart', () => {
+  test('classifies IM fingerprint changes as restart and identical fingerprints as none', () => {
     const previous = createStableConfigFingerprint({ telegram: { enabled: false } });
     const next = createStableConfigFingerprint({ telegram: { enabled: true } });
 
     expect(classifyImOpenClawConfigChange(previous, previous).impact).toBe(OpenClawConfigImpact.None);
     expect(classifyImOpenClawConfigChange(previous, next)).toEqual({
-      impact: OpenClawConfigImpact.Sync,
+      impact: OpenClawConfigImpact.Restart,
       reasons: [OpenClawConfigImpactReason.ImConfig],
     });
   });
 
-  test('keeps IM binding saves as sync when removing an unrelated restart reason', () => {
+  test('keeps IM binding saves as restart when removing an unrelated restart reason', () => {
     const imDecision = classifyImOpenClawConfigChange(
       createStableConfigFingerprint({ settings: { platformAgentBindings: {} } }),
       createStableConfigFingerprint({ settings: { platformAgentBindings: { qq: 'worker' } } }),
@@ -256,7 +256,7 @@ describe('OpenClaw config impact classification', () => {
     });
 
     expect(removeImpactDecisionReasons(combined, [OpenClawConfigImpactReason.AppUseSystemProxy]))
-      .toEqual({ impact: OpenClawConfigImpact.Sync, reasons: [OpenClawConfigImpactReason.ImConfig] });
+      .toEqual({ impact: OpenClawConfigImpact.Restart, reasons: [OpenClawConfigImpactReason.ImConfig] });
   });
 
   test('classifies forced IM sync as restart even without fingerprint diff', () => {

--- a/src/main/libs/openclawConfigImpact.ts
+++ b/src/main/libs/openclawConfigImpact.ts
@@ -155,7 +155,6 @@ export const removeImpactDecisionReasons = (
       reason === OpenClawConfigImpactReason.AppUseSystemProxy
       || reason === OpenClawConfigImpactReason.AppProviderSecret
       || reason === OpenClawConfigImpactReason.CoworkDreamingConfig
-      || reason === OpenClawConfigImpactReason.ImConfig
       || reason === OpenClawConfigImpactReason.ImForceRestart
       || reason === OpenClawConfigImpactReason.PluginInstall
       || reason === OpenClawConfigImpactReason.PluginUninstall
@@ -294,7 +293,11 @@ export const classifyImOpenClawConfigChange = (
   if (previousFingerprint === null || previousFingerprint === nextFingerprint) {
     return noImpact();
   }
-  return decision(OpenClawConfigImpact.Restart, OpenClawConfigImpactReason.ImConfig);
+  // Ordinary IM edits only request config delivery. The sync layer still
+  // restarts for changed bindings or process secrets, while OpenClaw reloads
+  // channel config. A queued IM save must not force another restart after an
+  // earlier sync has already applied the same edit.
+  return decision(OpenClawConfigImpact.Sync, OpenClawConfigImpactReason.ImConfig);
 };
 
 export const classifyPluginConfigChange = (

--- a/src/main/libs/openclawConfigImpact.ts
+++ b/src/main/libs/openclawConfigImpact.ts
@@ -155,6 +155,7 @@ export const removeImpactDecisionReasons = (
       reason === OpenClawConfigImpactReason.AppUseSystemProxy
       || reason === OpenClawConfigImpactReason.AppProviderSecret
       || reason === OpenClawConfigImpactReason.CoworkDreamingConfig
+      || reason === OpenClawConfigImpactReason.ImConfig
       || reason === OpenClawConfigImpactReason.ImForceRestart
       || reason === OpenClawConfigImpactReason.PluginInstall
       || reason === OpenClawConfigImpactReason.PluginUninstall
@@ -293,11 +294,7 @@ export const classifyImOpenClawConfigChange = (
   if (previousFingerprint === null || previousFingerprint === nextFingerprint) {
     return noImpact();
   }
-  // Ordinary IM edits only request config delivery. The sync layer still
-  // restarts for changed bindings or process secrets, while OpenClaw reloads
-  // channel config. A queued IM save must not force another restart after an
-  // earlier sync has already applied the same edit.
-  return decision(OpenClawConfigImpact.Sync, OpenClawConfigImpactReason.ImConfig);
+  return decision(OpenClawConfigImpact.Restart, OpenClawConfigImpactReason.ImConfig);
 };
 
 export const classifyPluginConfigChange = (

--- a/src/main/libs/openclawConfigSync.runtime.test.ts
+++ b/src/main/libs/openclawConfigSync.runtime.test.ts
@@ -2747,6 +2747,12 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(result.ok).toBe(true);
     expect(result.bindingsChanged).toBe(true);
 
+    // Agent saving can queue this after bootstrap-updated already consumed
+    // the binding edit. Only the first sync should request a binding restart.
+    const imSave = sync.sync('im-config-change');
+    expect(imSave).toMatchObject({ ok: true, changed: false });
+    expect(imSave.bindingsChanged).toBeUndefined();
+
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
     expect(config.channels['dingtalk-connector']).not.toHaveProperty('_agentBinding');
     expect(config.channels).not.toHaveProperty('dingtalk');
@@ -3408,23 +3414,42 @@ describe('OpenClawConfigSync runtime config output', () => {
     expect(leaveInAppConfig.mcp).toBeUndefined();
   });
 
-  test('marks MCP server config changes as restart impact', async () => {
-    const { OpenClawConfigImpact } = await import('./openclawConfigImpact');
-    const sync = await createSync({
-      getResolvedMcpServers: () => [{
-        name: 'Tavily',
-        transportType: 'stdio',
-        command: 'node',
-        args: ['server.js'],
-        env: { TAVILY_API_KEY: '${LOBSTER_TAVILY_API_KEY}' },
-      }],
-    });
+  test('adds, updates, and removes MCP servers without requesting a gateway restart', async () => {
+    let servers: import('./openclawConfigSync').ResolvedMcpServer[] = [];
+    const sync = await createSync({ getResolvedMcpServers: () => servers });
+    expect(sync.sync('baseline').ok).toBe(true);
 
-    const result = sync.sync('mcp-server-toggled');
+    const server = {
+      name: 'Tavily',
+      transportType: 'stdio' as const,
+      command: 'node',
+      args: ['server.js'],
+      env: { TAVILY_API_KEY: 'first-key' },
+    };
+    for (const nextServers of [
+      [server],
+      [{ ...server, args: ['installed-server.js'], env: { TAVILY_API_KEY: 'updated-key' } }],
+      [],
+    ]) {
+      servers = nextServers;
+      const result = sync.sync('mcp-server-updated');
 
-    expect(result.ok).toBe(true);
-    expect(result.changedTopLevelKeys).toContain('mcp');
-    expect(result.restartImpact).toBe(OpenClawConfigImpact.Restart);
+      expect(result).toMatchObject({ ok: true, changed: true });
+      expect(result.changedTopLevelKeys).toContain('mcp');
+      expect(result.restartImpact).toBeUndefined();
+      expect(result.bindingsChanged).toBeUndefined();
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      if (servers.length > 0) {
+        expect(config.mcp.servers.Tavily).toMatchObject({
+          command: servers[0].command,
+          args: servers[0].args,
+          env: servers[0].env,
+        });
+      } else {
+        expect(config.mcp?.servers?.Tavily).toBeUndefined();
+      }
+      expect(sync.sync('mcp-launch-ready:Tavily')).toMatchObject({ ok: true, changed: false });
+    }
   });
 
   test('writes all remote MCP headers to openclaw config', async () => {

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -3327,7 +3327,9 @@ export class OpenClawConfigSync {
       configPath,
       ...(bindingsChanged ? { bindingsChanged } : {}),
       ...(changedTopLevelKeys.length > 0 ? { changedTopLevelKeys } : {}),
-      ...(changedTopLevelKeys.includes('mcp') || modelCompatRestartRequired
+      // Native MCP config reload disposes affected runtimes; server edits do
+      // not require respawning the gateway. Keep model compatibility restarts.
+      ...(modelCompatRestartRequired
         ? { restartImpact: OpenClawConfigImpact.Restart }
         : {}),
       ...(agentsMdWarning ? { agentsMdWarning } : {}),

--- a/src/main/libs/openclawImConfigRestart.test.ts
+++ b/src/main/libs/openclawImConfigRestart.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { OpenClawEnginePhase } from '../../shared/openclawEngine/constants';
+import { OpenClawImConfigRestartTracker } from './openclawImConfigRestart';
+
+function createHarness() {
+  const state = { fingerprint: 'im-a', gatewayGeneration: 1 as number | undefined };
+  const tracker = new OpenClawImConfigRestartTracker({
+    getImConfigFingerprint: () => state.fingerprint,
+    getGatewayGeneration: () => state.gatewayGeneration,
+  });
+  const restart = vi.fn(async () => {
+    state.gatewayGeneration = (state.gatewayGeneration ?? 0) + 1;
+    return { phase: OpenClawEnginePhase.Running };
+  });
+  return { state, tracker, restart };
+}
+
+describe('IM config restart deduplication', () => {
+  test('retains the restart demand when config was only written or hot delivered', () => {
+    const { state, tracker } = createHarness();
+    tracker.captureConfig();
+    // No config diff is not evidence that a gateway restart loaded it.
+    expect(tracker.isRestartSatisfied(state.fingerprint, false)).toBe(false);
+    tracker.captureConfig();
+    expect(tracker.isRestartSatisfied(state.fingerprint, false)).toBe(false);
+  });
+
+  test('satisfies a queued IM save only after the preceding bootstrap restart completes', async () => {
+    const { state, tracker, restart } = createHarness();
+    let finishRestart!: () => void;
+    const restarting = new Promise<void>(resolve => { finishRestart = resolve; });
+    const bootstrap = tracker.restartGateway(tracker.captureConfig(), async () => {
+      await restarting;
+      return restart();
+    });
+    const requestedFingerprint = state.fingerprint;
+    const queuedImSave = bootstrap.then(() => {
+      tracker.captureConfig();
+      return tracker.isRestartSatisfied(requestedFingerprint, false);
+    });
+
+    expect(tracker.isRestartSatisfied(requestedFingerprint, false)).toBe(false);
+    finishRestart();
+    expect(await queuedImSave).toBe(true);
+    expect(restart).toHaveBeenCalledOnce();
+  });
+
+  test('retains explicit force restarts and newly rendered config changes', async () => {
+    const { state, tracker, restart } = createHarness();
+    await tracker.restartGateway(tracker.captureConfig(), restart);
+
+    expect(tracker.isRestartSatisfied(state.fingerprint, false)).toBe(true);
+    // Explicit login/force requests deliberately carry no deduplication fingerprint.
+    expect(tracker.isRestartSatisfied(undefined, false)).toBe(false);
+    expect(tracker.isRestartSatisfied(state.fingerprint, true)).toBe(false);
+  });
+
+  test('does not mark IM edits made while awaiting restart as loaded', async () => {
+    const { state, tracker, restart } = createHarness();
+    const renderedFingerprint = tracker.captureConfig();
+    await tracker.restartGateway(renderedFingerprint, async () => {
+      state.fingerprint = 'im-b';
+      return restart();
+    });
+
+    tracker.captureConfig();
+    expect(tracker.isRestartSatisfied(state.fingerprint, false)).toBe(false);
+    await tracker.restartGateway(tracker.captureConfig(), restart);
+    expect(tracker.isRestartSatisfied(state.fingerprint, false)).toBe(true);
+    expect(restart).toHaveBeenCalledTimes(2);
+  });
+
+  test('invalidates an old receipt when another IM config is synced, including a later revert', async () => {
+    const { state, tracker, restart } = createHarness();
+    await tracker.restartGateway(tracker.captureConfig(), restart);
+    state.fingerprint = 'im-b';
+    tracker.captureConfig();
+    state.fingerprint = 'im-a';
+    tracker.captureConfig();
+
+    expect(tracker.isRestartSatisfied(state.fingerprint, false)).toBe(false);
+  });
+
+  test.each([OpenClawEnginePhase.Error, OpenClawEnginePhase.Starting, OpenClawEnginePhase.Ready])(
+    'does not count a restart ending in %s as successful',
+    async phase => {
+      const { state, tracker } = createHarness();
+      await tracker.restartGateway(tracker.captureConfig(), async () => {
+        state.gatewayGeneration = 2;
+        return { phase };
+      });
+      expect(tracker.isRestartSatisfied(state.fingerprint, false)).toBe(false);
+    },
+  );
+
+  test('discards the previous receipt when a subsequent restart fails', async () => {
+    const { state, tracker, restart } = createHarness();
+    await tracker.restartGateway(tracker.captureConfig(), restart);
+    await expect(tracker.restartGateway(tracker.captureConfig(), async () => {
+      throw new Error('gateway failed to start');
+    })).rejects.toThrow('gateway failed to start');
+    expect(tracker.isRestartSatisfied(state.fingerprint, false)).toBe(false);
+  });
+
+  test('does not reuse a receipt from another gateway process generation', async () => {
+    const { state, tracker, restart } = createHarness();
+    await tracker.restartGateway(tracker.captureConfig(), restart);
+    state.gatewayGeneration = 3;
+    expect(tracker.isRestartSatisfied(state.fingerprint, false)).toBe(false);
+  });
+
+  test.each([1, undefined])('requires a confirmed new gateway generation, received %s', async generation => {
+    const { state, tracker } = createHarness();
+    await tracker.restartGateway(tracker.captureConfig(), async () => {
+      state.gatewayGeneration = generation;
+      return { phase: OpenClawEnginePhase.Running };
+    });
+    expect(tracker.isRestartSatisfied(state.fingerprint, false)).toBe(false);
+  });
+
+  test('retains restart behavior if the IM config cannot be captured', async () => {
+    let gatewayGeneration = 1;
+    const tracker = new OpenClawImConfigRestartTracker({
+      getImConfigFingerprint: () => { throw new Error('IM store unavailable'); },
+      getGatewayGeneration: () => gatewayGeneration,
+    });
+    const fingerprint = tracker.captureConfig();
+    expect(fingerprint).toBeNull();
+    await tracker.restartGateway(fingerprint, async () => {
+      gatewayGeneration += 1;
+      return { phase: OpenClawEnginePhase.Running };
+    });
+    expect(tracker.isRestartSatisfied('im-a', false)).toBe(false);
+  });
+});

--- a/src/main/libs/openclawImConfigRestart.ts
+++ b/src/main/libs/openclawImConfigRestart.ts
@@ -1,0 +1,63 @@
+import { OpenClawEnginePhase } from '../../shared/openclawEngine/constants';
+
+type ImRestartReceipt = {
+  fingerprint: string;
+  gatewayGeneration: number;
+};
+
+/** Tracks IM config loaded by a completed supervisor restart, never by hot delivery. */
+export class OpenClawImConfigRestartTracker {
+  private syncedFingerprint: string | null = null;
+  private receipt: ImRestartReceipt | null = null;
+
+  constructor(private readonly deps: {
+    getImConfigFingerprint: () => string;
+    getGatewayGeneration: () => number | undefined;
+  }) {}
+
+  /** Call immediately before synchronous config rendering, after async preparation. */
+  captureConfig(): string | null {
+    let fingerprint: string | null = null;
+    try {
+      fingerprint = this.deps.getImConfigFingerprint();
+    } catch {
+      // Missing IM state must retain the existing restart behavior.
+    }
+    if (fingerprint !== this.syncedFingerprint || fingerprint === null) {
+      this.receipt = null;
+    }
+    this.syncedFingerprint = fingerprint;
+    return fingerprint;
+  }
+
+  isRestartSatisfied(requestFingerprint: string | undefined, configChanged: boolean): boolean {
+    return !configChanged
+      && requestFingerprint !== undefined
+      && this.receipt !== null
+      && this.receipt.fingerprint === requestFingerprint
+      && this.receipt.fingerprint === this.syncedFingerprint
+      && this.receipt.gatewayGeneration === this.deps.getGatewayGeneration();
+  }
+
+  async restartGateway<T extends { phase: OpenClawEnginePhase }>(
+    fingerprint: string | null,
+    restart: () => Promise<T>,
+  ): Promise<T> {
+    this.receipt = null;
+    const previousGeneration = this.deps.getGatewayGeneration();
+    const status = await restart();
+    const gatewayGeneration = this.deps.getGatewayGeneration();
+    if (
+      status.phase === OpenClawEnginePhase.Running
+      && fingerprint !== null
+      && fingerprint === this.syncedFingerprint
+      && previousGeneration !== undefined
+      && gatewayGeneration !== undefined
+      && gatewayGeneration > previousGeneration
+    ) {
+      // Use the snapshot rendered before restart, not IM edits made while awaiting it.
+      this.receipt = { fingerprint, gatewayGeneration };
+    }
+    return status;
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -463,6 +463,7 @@ import {
   backupOpenClawConfig,
   getOpenClawGatewayRepairBusyError,
 } from './libs/openclawGatewayRepair';
+import { OpenClawImConfigRestartTracker } from './libs/openclawImConfigRestart';
 import {
   getCoworkParentSessionId,
   resolveCoworkSessionIdByOpenClawSessionKey,
@@ -2685,6 +2686,8 @@ type SyncOpenClawConfigOptions = {
   reason: string;
   restartGatewayIfRunning?: boolean;
   expectedImpact?: OpenClawConfigImpact;
+  /** Only ordinary IM saves can reuse a completed restart of this exact config. */
+  imConfigRestartFingerprint?: string;
 };
 
 type SyncOpenClawConfigResult = {
@@ -2705,6 +2708,10 @@ let openClawConfigApplyQueue: Promise<void> = Promise.resolve();
 let openClawConfigApplyState: GatewayConfigApplyState | null = null;
 let openClawConfigApplyGeneration = 0;
 let deferredRestartReason: string | null = null;
+const imConfigRestartTracker = new OpenClawImConfigRestartTracker({
+  getImConfigFingerprint: () => createStableConfigFingerprint(getIMGatewayManager().getConfig()),
+  getGatewayGeneration: () => getOpenClawEngineManager().getGatewayConnectionInfo().generation,
+});
 
 const buildConfigApplyPendingStatus = (message: string): OpenClawEngineStatus => {
   const current = getOpenClawEngineManager().getStatus();
@@ -2884,6 +2891,7 @@ const _syncOpenClawConfigImpl = async (
     getMcpRuntime().clearResolvedServersCache();
   }
 
+  const imConfigFingerprint = imConfigRestartTracker.captureConfig();
   const syncResult = configSync.sync(options.reason);
   console.log(
     `${D()} sync() ok=${syncResult.ok} changed=${syncResult.changed} bindingsChanged=${!!syncResult.bindingsChanged} restartImpact=${syncResult.restartImpact ?? OpenClawConfigImpact.None}`,
@@ -2966,12 +2974,20 @@ const _syncOpenClawConfigImpl = async (
     && options.expectedImpact === OpenClawConfigImpact.Restart;
   const syncRestartImpact =
     syncResult.restartImpact === OpenClawConfigImpact.Restart;
+  const imRestartSatisfied = imConfigRestartTracker.isRestartSatisfied(
+    options.imConfigRestartFingerprint,
+    effectiveConfigChanged,
+  );
   const needsHardRestart =
     secretEnvVarsChanged ||
     syncResult.bindingsChanged === true ||
     syncRestartImpact ||
     expectedRestartImpact ||
-    options.restartGatewayIfRunning === true;
+    (options.restartGatewayIfRunning === true && !imRestartSatisfied);
+
+  if (imRestartSatisfied && !needsHardRestart) {
+    console.log('[OpenClawConfigSync] IM config already loaded by a completed gateway restart; skipping duplicate restart.');
+  }
 
   console.log(
     `${D()} needsHardRestart=${needsHardRestart} (envChanged=${secretEnvVarsChanged} bindingsChanged=${!!syncResult.bindingsChanged} configChanged=${effectiveConfigChanged} restartImpact=${syncResult.restartImpact ?? OpenClawConfigImpact.None} expectedRestart=${expectedRestartImpact} restartFlag=${!!options.restartGatewayIfRunning})`,
@@ -3077,7 +3093,10 @@ const _syncOpenClawConfigImpl = async (
     openClawRuntimeAdapter.disconnectGatewayClient();
   }
 
-  const restarted = await manager.restartGateway(`config-sync:${options.reason}`);
+  const restarted = await imConfigRestartTracker.restartGateway(
+    imConfigFingerprint,
+    () => manager.restartGateway(`config-sync:${options.reason}`),
+  );
   if (restarted.phase !== 'running') {
     return {
       success: false,
@@ -11190,7 +11209,8 @@ if (!gotTheLock) {
   let imConfigSyncTimer: ReturnType<typeof setTimeout> | null = null;
   let imConfigSyncRunning = false;
   let imConfigSyncPending = false;
-  let imConfigSyncRestartGatewayIfRunning = false;
+  // Explicit restart demands (including out-of-config login state) cannot be deduplicated.
+  let imConfigSyncForceRestart = false;
   let lastSyncedImOpenClawConfigFingerprint: string | null = null;
   const IM_CONFIG_SYNC_DEBOUNCE_MS = 600;
   type IMConfigSyncOptions = {
@@ -11220,12 +11240,15 @@ if (!gotTheLock) {
 
   const doImConfigSync = async (): Promise<IMConfigSyncResult> => {
     imConfigSyncRunning = true;
-    const restartGatewayIfRunning = imConfigSyncRestartGatewayIfRunning;
-    imConfigSyncRestartGatewayIfRunning = false;
+    const forceRestart = imConfigSyncForceRestart;
+    imConfigSyncForceRestart = false;
     try {
       const syncResult = await syncOpenClawConfig({
         reason: 'im-config-change',
-        restartGatewayIfRunning,
+        restartGatewayIfRunning: true,
+        ...(forceRestart ? {} : {
+          imConfigRestartFingerprint: getCurrentImOpenClawConfigFingerprint(),
+        }),
       });
       if (!syncResult.success) {
         throw new Error(syncResult.error || 'OpenClaw config sync failed.');
@@ -11251,7 +11274,7 @@ if (!gotTheLock) {
     } finally {
       imConfigSyncRunning = false;
       if (imConfigSyncPending) {
-        const restartPendingGatewayIfRunning = imConfigSyncRestartGatewayIfRunning;
+        const restartPendingGatewayIfRunning = imConfigSyncForceRestart;
         imConfigSyncPending = false;
         scheduleImConfigSync({
           restartGatewayIfRunning: restartPendingGatewayIfRunning,
@@ -11262,7 +11285,7 @@ if (!gotTheLock) {
 
   const scheduleImConfigSync = (options: IMConfigSyncOptions = {}) => {
     if (options.restartGatewayIfRunning) {
-      imConfigSyncRestartGatewayIfRunning = true;
+      imConfigSyncForceRestart = true;
     }
     if (imConfigSyncRunning) {
       // A sync is already in progress; mark pending so it re-runs after completion.
@@ -11278,7 +11301,7 @@ if (!gotTheLock) {
 
   const runImConfigSyncNow = async (options: IMConfigSyncOptions = {}): Promise<IMConfigSyncResult> => {
     if (options.restartGatewayIfRunning) {
-      imConfigSyncRestartGatewayIfRunning = true;
+      imConfigSyncForceRestart = true;
     }
     if (imConfigSyncTimer) {
       clearTimeout(imConfigSyncTimer);
@@ -11309,9 +11332,7 @@ if (!gotTheLock) {
 
     if (options.syncGateway) {
       scheduleImConfigSync({
-        restartGatewayIfRunning:
-          options.restartGatewayIfRunning === true
-          || impactDecision.impact === OpenClawConfigImpact.Restart,
+        restartGatewayIfRunning: options.restartGatewayIfRunning === true,
       });
     }
   };
@@ -11362,7 +11383,7 @@ if (!gotTheLock) {
         return { success: true, skipped: true };
       }
       const syncResult = await runImConfigSyncNow({
-        restartGatewayIfRunning: impactDecision.impact === OpenClawConfigImpact.Restart,
+        restartGatewayIfRunning: imConfigRestartOnNextSettingsSave,
       });
       if (!syncResult.success) {
         return { success: false, error: syncResult.error };

--- a/src/main/mcp/mcpRuntime.ts
+++ b/src/main/mcp/mcpRuntime.ts
@@ -72,7 +72,7 @@ export class McpRuntime {
         reason => {
           this.deps.syncOpenClawConfig({
             reason,
-            expectedImpact: OpenClawConfigImpact.Restart,
+            expectedImpact: OpenClawConfigImpact.Sync,
           }).catch(err =>
             console.error('[MCP] config sync error after launch resolution:', err),
           );


### PR DESCRIPTION
## Summary

Agent 编辑 IM 开关后，前一轮 bootstrap 配置同步可能已重启 gateway 并加载变更，排队执行的 IM 保存仍会再次强制重启。MCP 配置更新和安装完成也被标记为必须重启 gateway。

本 PR 保留 IM 原有的重启策略，仅去掉已经完成的重复重启；MCP 配置改用 OpenClaw 原生热重载。

## Related Issue

QA 反馈：Agent 编辑 IM 开关时 gateway 重启两次，安装 MCP 时有时也出现多次重启。暂无关联 Issue。

## Changes Made

- IM 配置保存仍要求重启。只有配置未再次变化、同一份 IM 配置已由一次成功的 supervisor 重启加载，且 gateway 进程 generation 匹配时，才跳过排队请求中的重复重启。
- 在同步配置前记录 IM 快照；仅写文件或热更新、重启未完成或失败、重启期间产生新配置、进程 generation 改变，都不能作为跳过重启的依据。显式强制重启及进程凭证变化仍保留原行为。
- MCP 新增、修改、启停、删除及安装解析完成使用配置热投递，由 OpenClaw 刷新 MCP 运行时。沿用现有 config.set 确认、哈希冲突重试和失败兜底机制。

## Type of Change

- [x] Bug fix

## Testing

- [x] Tested locally：5 组定向 Vitest 测试，171 项全部通过，覆盖 IM 去重、配置分类/生成/投递及 gateway 重启管理。
- [x] Added new tests：完成/失败/未完成的重启、配置变化与回退、显式强制重启、进程 generation 变化及无法读取 IM 配置。
- [x] Updated existing tests：保留 IM Restart 分类，验证 MCP 配置变化无需 gateway 重启。
- [x] 使用隔离桩执行实际 main 配置队列及 IM 保存处理函数：7 个场景通过，包括 bootstrap + 排队 IM 保存仅一次重启、普通 IM 编辑仍重启、前一次仅热更新仍须重启、显式登录重启、新配置、凭证变化及 MCP 热投递。
- [x] 隔离 OpenClaw v2026.8.1 + 本地 MCP/模型桩：新增、修改环境变量、停用、重新启用、移除及工具调用通过，gateway PID 和 WebSocket 连接保持不变。
- [x] Electron TypeScript 编译与改动文件 ESLint 通过。

## Screenshots (if applicable)

不适用。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Relevant new and existing tests pass locally

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [x] IM/MCP IPC handler 的配置应用与重启调度行为调整

## Additional Notes

真实 IM 账号的开关、绑定、策略保存及消息路由仍需 QA 回归。本 PR 范围限于 IM 重启去重和 MCP 热重载。
