### PR TITLE
fix(openclaw): recover memory sidecar archive collisions

### DIFF
--- a/scripts/apply-openclaw-patches.cjs
+++ b/scripts/apply-openclaw-patches.cjs
@@ -830,6 +830,30 @@ const v20260801StrongPatchValidators = {
       ],
     },
   ],
+  'openclaw-memory-sidecar-archive-generations.patch': [
+    {
+      file: 'extensions/memory-core/src/migration/doctor-memory-sidecar.ts',
+      snippets: [
+        'archiveRoot = await root(path.dirname(params.source.legacyPath)',
+        'archiveSuffix = generation === 1 ? ".migrated" : `.migrated.${generation}`',
+        'await fs.lstat(`${params.source.legacyPath}${suffix}${archiveSuffix}`)',
+        'await archiveRoot.move(path.basename(sourcePath), path.basename(archivedPath))',
+        'path.basename(entry.archivedPath),',
+        'path.basename(entry.sourcePath),',
+      ],
+      forbiddenSnippets: [
+        'Left migrated Memory Core legacy memory index sidecar in place because',
+      ],
+    },
+    {
+      file: 'extensions/memory-core/doctor-contract-api.test.ts',
+      snippets: [
+        'archives a conflicting sidecar despite an existing archive and converges on retry',
+        'preserves the SQLite journal family across archive and retry',
+        'does not overwrite an archive created after generation selection',
+      ],
+    },
+  ],
   'openclaw-workspace-attestation-quarantine.patch': [
     {
       file: 'src/infra/state-migrations.workspace-setup.ts',

--- a/scripts/patches/v2026.8.1/openclaw-memory-sidecar-archive-generations.patch
+++ b/scripts/patches/v2026.8.1/openclaw-memory-sidecar-archive-generations.patch
@@ -1,0 +1,311 @@
+OpenClaw v2026.8.1: retain older memory-index archives without blocking startup.
+
+Base: ea806575e6450e4d1efdfc72c19f04be982a1b9b.
+
+The memory-core migration already resolves derived-index conflicts by keeping
+canonical per-agent SQLite rows. An existing main.sqlite.migrated nevertheless
+leaves the legacy sidecar active and emits a warning, which startup preflight
+treats as fatal on every retry.
+
+Follow the numbered .migrated.2 convention of archiveLegacyStateSource, but
+choose one free generation for the entire SQLite family (database/WAL/SHM/journal).
+Preserve all earlier archives, use no-clobber moves and rollback, and retain
+normal blocking behavior on import or filesystem failures. This belongs in the
+plugin migration owner, not in LobsterAI's config repair or startup helper.
+
+diff --git a/extensions/memory-core/doctor-contract-api.test.ts b/extensions/memory-core/doctor-contract-api.test.ts
+index 42502c822d1..2accfedb9a4 100644
+--- a/extensions/memory-core/doctor-contract-api.test.ts
++++ b/extensions/memory-core/doctor-contract-api.test.ts
+@@ -2102,4 +2102,205 @@ describe("memory-core doctor dreaming migration", () => {
+   });
+
++  it("archives a conflicting sidecar despite an existing archive and converges on retry", async () => {
++    const stateDir = path.join(rootDir, "state");
++    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
++    const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
++    await writeLegacyMemorySidecar(legacyPath);
++    await createCanonicalMemoryIndex(agentPath, "canonical memory remains authoritative");
++    const originalBytes = await fs.readFile(legacyPath);
++    const oldArchive = Buffer.from("an earlier migration backup; preserve it");
++    await fs.writeFile(`${legacyPath}.migrated`, oldArchive);
++    const canonicalRows = readMemoryRows(agentPath);
++
++    const migration = legacyMemoryIndexMigration();
++    const result = await migration.migrateLegacyState(migrationParams());
++
++    expect(result.warnings).toEqual([]);
++    expect(result.changes).toContain(
++      `Archived Memory Core legacy memory index sidecar -> ${legacyPath}.migrated.2`,
++    );
++    expect(readMemoryRows(agentPath)).toEqual(canonicalRows);
++    await expect(fs.readFile(`${legacyPath}.migrated`)).resolves.toEqual(oldArchive);
++    await expect(fs.readFile(`${legacyPath}.migrated.2`)).resolves.toEqual(originalBytes);
++    await expect(fs.access(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
++    expect(await migration.detectLegacyState(migrationParams())).toBeNull();
++    expect(await migration.migrateLegacyState(migrationParams())).toEqual({
++      changes: [],
++      warnings: [],
++    });
++  });
++
++  it.each(["", "-wal", "-shm", "-journal"])(
++    "selects one unused archive generation when %s has an older backup",
++    async (suffix) => {
++      const legacyPath = path.join(rootDir, "state", "memory", "main.sqlite");
++      await writeLegacyMemorySidecar(legacyPath);
++      const originalBytes = await fs.readFile(legacyPath);
++      await fs.writeFile(`${legacyPath}.migrated`, "first archive");
++      const occupied = `${legacyPath}${suffix}.migrated.2`;
++      await fs.writeFile(occupied, "second archive companion");
++
++      const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
++
++      expect(result.warnings).toEqual([]);
++      expect(result.changes).toContain(
++        `Archived Memory Core legacy memory index sidecar -> ${legacyPath}.migrated.3`,
++      );
++      await expect(fs.readFile(`${legacyPath}.migrated.3`)).resolves.toEqual(originalBytes);
++      await expect(fs.readFile(`${legacyPath}.migrated`, "utf8")).resolves.toBe("first archive");
++      await expect(fs.readFile(occupied, "utf8")).resolves.toBe("second archive companion");
++      expect(await legacyMemoryIndexMigration().detectLegacyState(migrationParams())).toBeNull();
++    },
++  );
++
++  it("preserves an identical older backup while importing the current sidecar", async () => {
++    const legacyPath = path.join(rootDir, "state", "memory", "main.sqlite");
++    await writeLegacyMemorySidecar(legacyPath);
++    const bytes = await fs.readFile(legacyPath);
++    await fs.writeFile(`${legacyPath}.migrated`, bytes);
++
++    const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
++
++    expect(result.warnings).toEqual([]);
++    await expect(fs.readFile(`${legacyPath}.migrated`)).resolves.toEqual(bytes);
++    await expect(fs.readFile(`${legacyPath}.migrated.2`)).resolves.toEqual(bytes);
++    expect(await legacyMemoryIndexMigration().detectLegacyState(migrationParams())).toBeNull();
++  });
++
++  it("preserves a directory occupying an archive name", async () => {
++    const legacyPath = path.join(rootDir, "state", "memory", "main.sqlite");
++    await writeLegacyMemorySidecar(legacyPath);
++    await fs.mkdir(`${legacyPath}.migrated`);
++
++    const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
++
++    expect(result.warnings).toEqual([]);
++    expect((await fs.lstat(`${legacyPath}.migrated`)).isDirectory()).toBe(true);
++    await expect(fs.access(`${legacyPath}.migrated.2`)).resolves.toBeUndefined();
++  });
++
++  it("retains the sidecar when archive inspection fails and succeeds on retry", async () => {
++    const legacyPath = path.join(rootDir, "state", "memory", "main.sqlite");
++    await writeLegacyMemorySidecar(legacyPath);
++    const bytes = await fs.readFile(legacyPath);
++    const realLstat = fs.lstat;
++    const probe = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
++      if (String(args[0]) === `${legacyPath}.migrated`) {
++        throw Object.assign(new Error("injected archive inspection failure"), { code: "EACCES" });
++      }
++      return realLstat(...args);
++    });
++
++    const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
++    probe.mockRestore();
++
++    expect(result.warnings.join(" ")).toContain("injected archive inspection failure");
++    await expect(fs.readFile(legacyPath)).resolves.toEqual(bytes);
++    expect(
++      (await legacyMemoryIndexMigration().migrateLegacyState(migrationParams())).warnings,
++    ).toEqual([]);
++    expect(await legacyMemoryIndexMigration().detectLegacyState(migrationParams())).toBeNull();
++  });
++
++  it("does not overwrite an archive created after generation selection", async () => {
++    const legacyPath = path.join(rootDir, "state", "memory", "main.sqlite");
++    await writeLegacyMemorySidecar(legacyPath);
++    const bytes = await fs.readFile(legacyPath);
++    await fs.writeFile(`${legacyPath}.migrated`, "first archive");
++    const realLstat = fs.lstat;
++    let checked = 0;
++    const probe = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
++      try {
++        return await realLstat(...args);
++      } catch (err) {
++        if (String(args[0]).startsWith(legacyPath) && String(args[0]).endsWith(".migrated.2")) {
++          checked++;
++          if (checked === 4) {
++            await fs.writeFile(`${legacyPath}.migrated.2`, "concurrent archive");
++          }
++        }
++        throw err;
++      }
++    });
++
++    const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
++    probe.mockRestore();
++
++    expect(result.warnings.join(" ")).toContain("Failed archiving");
++    await expect(fs.readFile(legacyPath)).resolves.toEqual(bytes);
++    await expect(fs.readFile(`${legacyPath}.migrated.2`, "utf8")).resolves.toBe(
++      "concurrent archive",
++    );
++    expect(
++      (await legacyMemoryIndexMigration().migrateLegacyState(migrationParams())).warnings,
++    ).toEqual([]);
++    await expect(fs.readFile(`${legacyPath}.migrated.3`)).resolves.toEqual(bytes);
++  });
++
++  it.each([false, true])(
++    "preserves the SQLite journal family across archive and retry (race=%s)",
++    async (race) => {
++      const legacyPath = path.join(rootDir, "state", "memory", "main.sqlite");
++      await writeLegacyMemorySidecar(legacyPath);
++      const db = new DatabaseSync(legacyPath);
++      try {
++        db.exec(
++          "PRAGMA journal_mode=PERSIST; UPDATE chunks SET text = 'persistent journal fixture'",
++        );
++      } finally {
++        db.close();
++      }
++      const bytes = await fs.readFile(legacyPath);
++      const journal = await fs.readFile(`${legacyPath}-journal`);
++      expect(journal.length).toBeGreaterThan(0);
++      await fs.writeFile(`${legacyPath}.migrated`, "first archive");
++      const realLstat = fs.lstat;
++      let checked = 0;
++      const probe = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
++        try {
++          return await realLstat(...args);
++        } catch (err) {
++          if (
++            race &&
++            String(args[0]).startsWith(legacyPath) &&
++            String(args[0]).endsWith(".migrated.2")
++          ) {
++            checked++;
++            if (checked === 4) {
++              await fs.writeFile(`${legacyPath}-journal.migrated.2`, "concurrent journal archive");
++            }
++          }
++          throw err;
++        }
++      });
++      const migration = legacyMemoryIndexMigration();
++      const result = await migration.migrateLegacyState(migrationParams());
++      probe.mockRestore();
++
++      if (race) {
++        expect(result.warnings.join(" ")).toContain("Failed archiving");
++        // The main database was moved before the journal collision. It must
++        // be restored alongside the journal, without replacing the contender.
++        await expect(fs.readFile(legacyPath)).resolves.toEqual(bytes);
++        await expect(fs.readFile(`${legacyPath}-journal`)).resolves.toEqual(journal);
++        await expect(fs.access(`${legacyPath}.migrated.2`)).rejects.toMatchObject({
++          code: "ENOENT",
++        });
++        await expect(fs.readFile(`${legacyPath}-journal.migrated.2`, "utf8")).resolves.toBe(
++          "concurrent journal archive",
++        );
++        expect((await migration.migrateLegacyState(migrationParams())).warnings).toEqual([]);
++      } else {
++        expect(result.warnings).toEqual([]);
++      }
++      const suffix = race ? ".migrated.3" : ".migrated.2";
++      await expect(fs.readFile(`${legacyPath}${suffix}`)).resolves.toEqual(bytes);
++      await expect(fs.readFile(`${legacyPath}-journal${suffix}`)).resolves.toEqual(journal);
++      await expect(fs.readFile(`${legacyPath}.migrated`, "utf8")).resolves.toBe("first archive");
++      await expect(fs.access(`${legacyPath}-journal`)).rejects.toMatchObject({ code: "ENOENT" });
++      expect(await migration.detectLegacyState(migrationParams())).toBeNull();
++    },
++  );
++
+   it("archives conflicting custom derived indexes without creating a retry copy", async () => {
+     const stateDir = path.join(rootDir, "state");
+diff --git a/extensions/memory-core/src/migration/doctor-memory-sidecar.ts b/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
+index e5a35125913..2d99ac5e360 100644
+--- a/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
++++ b/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
+@@ -3,4 +3,5 @@ import type { Dirent } from "node:fs";
+ import fs from "node:fs/promises";
+ import path from "node:path";
++import { root, type Root } from "@openclaw/fs-safe";
+ import { reclaimDefinitelyStaleFileLock } from "openclaw/plugin-sdk/file-lock";
+ import { resolveUserPath } from "openclaw/plugin-sdk/memory-core-host-engine-fs";
+@@ -208,15 +209,36 @@ async function archiveLegacyMemorySidecar(params: {
+     return;
+   }
+-  const existingArchives = (
+-    await Promise.all(
+-      existingSources.map(async (sourcePath) => {
+-        const archivedPath = `${sourcePath}.migrated`;
+-        return (await legacyStateFileExists(archivedPath)) ? archivedPath : null;
+-      }),
+-    )
+-  ).filter((filePath): filePath is string => filePath !== null);
+-  if (existingArchives.length > 0) {
++  let archiveRoot: Root;
++  let archiveSuffix = ".migrated";
++  try {
++    archiveRoot = await root(path.dirname(params.source.legacyPath), {
++      hardlinks: "reject",
++      symlinks: "reject",
++    });
++    // Import/canonical conflict resolution has already completed. Keep earlier
++    // backups and select one free generation for the entire SQLite family,
++    // including companions absent from this source, so generations cannot mix.
++    for (let generation = 1; ; generation++) {
++      archiveSuffix = generation === 1 ? ".migrated" : `.migrated.${generation}`;
++      const occupied = await Promise.all(
++        LEGACY_MEMORY_SIDECAR_SUFFIXES.map(async (suffix) => {
++          try {
++            await fs.lstat(`${params.source.legacyPath}${suffix}${archiveSuffix}`);
++            return true;
++          } catch (err) {
++            if ((err as NodeJS.ErrnoException).code === "ENOENT") {
++              return false;
++            }
++            throw err;
++          }
++        }),
++      );
++      if (!occupied.some(Boolean)) {
++        break;
++      }
++    }
++  } catch (err) {
+     params.warnings.push(
+-      `Left migrated Memory Core legacy memory index sidecar in place because ${existingArchives[0]} already exists`,
++      `Failed preparing Memory Core legacy memory index archive for ${params.source.legacyPath}: ${String(err)}`,
+     );
+     return;
+@@ -224,7 +246,9 @@ async function archiveLegacyMemorySidecar(params: {
+   const renamed: Array<{ sourcePath: string; archivedPath: string }> = [];
+   for (const sourcePath of existingSources) {
+-    const archivedPath = `${sourcePath}.migrated`;
++    const archivedPath = `${sourcePath}${archiveSuffix}`;
+     try {
+-      await fs.rename(sourcePath, archivedPath);
++      // move defaults to no-clobber, including a destination created after the
++      // generation check. Rollback uses the same rule to preserve new sources.
++      await archiveRoot.move(path.basename(sourcePath), path.basename(archivedPath));
+       renamed.push({ sourcePath, archivedPath });
+     } catch (err) {
+@@ -235,5 +259,8 @@ async function archiveLegacyMemorySidecar(params: {
+             !(await legacyStateFileExists(entry.sourcePath))
+           ) {
+-            await fs.rename(entry.archivedPath, entry.sourcePath);
++            await archiveRoot.move(
++              path.basename(entry.archivedPath),
++              path.basename(entry.sourcePath),
++            );
+           }
+         } catch (rollbackErr) {
+@@ -250,5 +277,5 @@ async function archiveLegacyMemorySidecar(params: {
+   }
+   params.changes.push(
+-    `Archived Memory Core legacy memory index sidecar -> ${params.source.legacyPath}.migrated`,
++    `Archived Memory Core legacy memory index sidecar -> ${params.source.legacyPath}${archiveSuffix}`,
+   );
+ }

--- a/specs/refactors/openclaw-upgrade/2026-09-11-memory-sidecar-archive-generations.md
+++ b/specs/refactors/openclaw-upgrade/2026-09-11-memory-sidecar-archive-generations.md
@@ -1,0 +1,115 @@
+# Memory sidecar archive collisions during gateway startup
+
+Base: LobsterAI `feat/openclaw-v2026.8.1`,
+`92d9eca81c6cdb8b2568e9ea6f599466cec15048`; OpenClaw `v2026.8.1`,
+`ea806575e6450e4d1efdfc72c19f04be982a1b9b`.
+
+## Evidence and cause
+
+The Windows diagnostic archive `lobsterai-logs-20260910-190511.zip` shows two
+separate migration stages:
+
+- At 19:01:43 (UTC+8), `main-2026-09-10.log:97146` records successful quarantine
+  of the corrupt workspace attestation. The next line confirms workspace setup
+  migration to SQLite. The earlier attestation fix worked.
+- At 19:01:58, `gateway-2026-09-10.log:35398` reports that the legacy Memory Core
+  sidecar cannot be retired because `openclaw/state/memory/main.sqlite.migrated`
+  already exists. The migration has already resolved derived-index conflicts by
+  keeping the canonical per-agent SQLite rows.
+- `gateway-2026-09-10.log:35420` reports that startup migrations did not complete
+  cleanly. Every subsequent attempt rediscovers the retained legacy source and
+  fails again. The five-attempt/model-configuration UI message hides this cause.
+
+This is an archive-name collision, not evidence that the memory database is
+corrupt. The supplied logs do not establish why the legacy file and its earlier
+archive coexist. The previous workspace diagnostic ZIP did not collect the
+legacy memory directory or per-agent database, so this regression uses synthetic
+SQLite fixtures matching the observed state; it is not a replay of those QA DBs.
+
+The owner is `extensions/memory-core/src/migration/doctor-memory-sidecar.ts`.
+Its fixed `.migrated` target causes a recoverable archive collision to produce a
+warning. Gateway startup deliberately treats migration warnings as fatal.
+Rebuilding `openclaw.json` does not remove this persisted-state collision.
+
+## Recovery contract
+
+`openclaw-memory-sidecar-archive-generations.patch` changes the upstream plugin
+owner. It retains the existing import policy, including canonical-row precedence
+for conflicting derived indexes and blocking warnings for unresolved imports.
+There is no separate cleanup in LobsterAI's state helper or config repair path.
+
+The generic upstream `archiveLegacyStateSource` already supports numbered
+archives. Memory sidecars need a single generation for the entire SQLite family:
+
+```text
+main.sqlite.migrated.2
+main.sqlite-wal.migrated.2
+main.sqlite-shm.migrated.2
+main.sqlite-journal.migrated.2
+```
+
+The first generation still uses `.migrated`. If any of the four candidate paths
+exists, the migration selects the first entirely free generation, even when a
+particular companion is absent from the current source. `lstat` also recognizes
+occupied directory/symlink names. Unexpected inspection errors are blocking.
+
+Earlier backups are never compared, overwritten or deleted. All present source
+files move through `@openclaw/fs-safe` with its default no-overwrite policy,
+including destinations created after selection. If a later companion cannot
+move, already moved files are rolled back without overwriting a newly created
+source. Archive/rollback failures retain warnings and stop startup. This keeps
+the existing best-effort rollback semantics; it is not an atomic multi-file
+transaction or a new guarantee about process/power loss during archival.
+
+The success log includes the actual archive path. After a completed archive,
+legacy discovery finds no source, so another startup creates no extra backup.
+Both imported and previously backed-up data remain available for inspection.
+
+## Verification
+
+- The new public migration regression fails on the pinned unpatched owner with
+  the same archive-exists warning as QA, then passes with the fix.
+- Added cases cover canonical conflicts, import without a canonical index,
+  identical backups, all four family-member name collisions, multiple archive
+  generations, an occupied directory, inspection failure/retry, concurrent
+  destination creation, and a real SQLite persistent journal with rollback.
+- After applying the complete patch set, all 52 selected memory/index/archive
+  contract tests passed, including the 11 added cases. Command, from the pinned
+  source checkout:
+
+  ```text
+  node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/doctor-contract-api.test.ts --maxWorkers=1 -t "sidecar|index|archive|canonical|SQLite journal"
+  ```
+
+- All 29 version patches apply to an isolated pinned OpenClaw checkout and pass
+  the build script's strong source validation.
+- LobsterAI patch and startup-wrapper tests passed: 85 tests, with 20 gated
+  tests skipped (the runtime integration suite was not enabled in this command).
+  Changed-file ESLint, type-aware Oxlint for the two patched upstream files,
+  `npm run compile:electron`, and `git diff --check` passed.
+- A temporary Windows runtime rebuilds the Memory Core doctor entry from the
+  patched source against the pinned packaged SDK. A live gateway fixture with
+  conflicting canonical rows and an existing valid SQLite archive reproduces
+  the original fatal warning. The patched gateway serves `/startupz` and
+  `config.get` on the first start and restart, without creating another archive.
+  Byte hashes of both archives, canonical memory rows and the generated
+  configuration are checked. Temporary gateways use private state,
+  disabled schedules/channels/browser, and their own loopback ports.
+- The full upstream doctor-contract test run before adding the journal cases
+  had 66 passes, 2 skips and one timeout in the unchanged oversized host-event
+  log import test (120-second limit). No full-suite pass is claimed.
+
+The source patch is shipped through the normal runtime build. The development
+runtime under `vendor/openclaw-runtime/current` is not modified by the isolated
+smoke test. This does not claim an installer rebuild, Electron UI test, or a
+successful run on the QA computer.
+
+If the upgraded QA build still fails, collect both directories while LobsterAI
+is closed, including SQLite companion files and existing archives:
+
+```text
+%APPDATA%\LobsterAI\openclaw\state\memory\
+%APPDATA%\LobsterAI\openclaw\state\agents\main\agent\
+```
+
+These are also needed to investigate the original file reappearance separately.

--- a/src/main/libs/openclawPatches/v20260801UpgradeDecisions.test.ts
+++ b/src/main/libs/openclawPatches/v20260801UpgradeDecisions.test.ts
@@ -18,6 +18,7 @@ const RETAINED_PATCHES = [
   'openclaw-im-bound-agent-run-cwd.patch',
   'openclaw-lancedb-optional-transformers.patch',
   'openclaw-lobsterai-model-compat-api.patch',
+  'openclaw-memory-sidecar-archive-generations.patch',
   'openclaw-omit-default-model-from-system-prompt.patch',
   'openclaw-openai-compatible-cache-control.patch',
   'openclaw-plugin-archive-windows-timeout.patch',


### PR DESCRIPTION
## Summary

Gateway startup on OpenClaw v2026.8.1 fails repeatedly when a legacy memory index coexists with an earlier `.migrated` backup. The migration has already imported the index or kept authoritative per-agent rows, but the archive-name collision leaves the source active and produces a fatal startup warning.

Preserve the earlier backup and archive the current SQLite family under the first unused `.migrated.2`, `.migrated.3`, etc. generation so startup can complete.

## Related Issue

Related startup migration fixes: #2647 and #2649.

## Changes Made

- Patch the upstream memory-core migration owner with one archive generation for the database, WAL, SHM and journal. Use no-overwrite moves and rollback; retain blocking warnings for import and filesystem failures.
- Register the version-scoped patch and strong source checks. Add 11 upstream regression cases covering collisions, data preservation, concurrent destinations, inspection failure and journal rollback/retry.
- Document the incident evidence, recovery contract and validation limits.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Testing

- [x] Tested locally and added regression coverage.
- 52 selected upstream memory/index/archive contract tests passed, including the 11 new cases.
- `npm test -- openclawPatches openclawStartupStateMigration --maxWorkers=1`: 85 passed, 20 gated tests skipped.
- All 29 version patches applied to an isolated pinned source checkout with strong validation. Final patch reverse-apply validation passed.
- Changed-file ESLint, upstream type-aware Oxlint, `npm run compile:electron`, and staged diff checks passed.
- Live isolated Windows gateway: baseline reproduced the fatal archive collision; patched first start and restart served `/startupz` and `config.get`. Both archive byte hashes, canonical memory rows and configuration were preserved; restart created no extra archive.

The broader upstream doctor-contract run had 66 passes, 2 skips and one timeout in the unchanged oversized host-event log import test (120-second limit). A complete upstream suite pass is not claimed.

## Checklist

- [x] Code follows the project style and has been reviewed.
- [x] Recovery behavior is documented and regression-tested.
- [x] Relevant regression tests and lint checks pass.

## Electron-Specific Changes

Bundled OpenClaw runtime/storage behavior changes during gateway startup: an occupied archive name can now be recovered without overwriting existing backups. The patch must be included in the next runtime build.

## Additional Notes

Gateway validation used synthetic SQLite fixtures matching the log evidence. The QA memory databases were not included in the earlier workspace archive, so the original reason for the legacy file reappearing remains unverified. The installer and development runtime were not rebuilt; QA validation requires a package with the rebuilt runtime.
