### PR TITLE
fix(openclaw): prevent stale desktop sessions from resuming

### DIFF
--- a/scripts/apply-openclaw-patches.cjs
+++ b/scripts/apply-openclaw-patches.cjs
@@ -413,6 +413,33 @@ const legacyStrongPatchValidators = {
 };
 
 const v20260801StrongPatchValidators = {
+  'openclaw-lobsterai-startup-recovery.patch': [
+    {
+      file: 'src/agents/main-session-recovery/main-session-restart-recovery-marking.ts',
+      snippets: ['const LOBSTERAI_SESSION_PREFIX = "lobsterai:"'],
+      orderedSnippets: [
+        'export async function markStartupOrphanedMainSessionsForRecovery',
+        'entry.abortedLastRun === true',
+        'hasCurrentProcessOwner({',
+        'if (isMainRestartRecoveryAggregateTerminalOnly(entry))',
+        'return { action: "retire_terminal" }',
+        'parseAgentSessionKey(sessionKey)?.rest ?? sessionKey.trim()',
+        'sessionNamespace.startsWith(LOBSTERAI_SESSION_PREFIX)',
+        'sessionNamespace.slice(LOBSTERAI_SESSION_PREFIX.length).trim()',
+        'return undefined',
+        'return { action: "mark" }',
+      ],
+    },
+    {
+      file: 'src/agents/main-session-recovery/main-session-restart-recovery.test.ts',
+      snippets: [
+        'does not revive unmarked $age running session $sessionKey',
+        'preserves explicit recovery of $sessionKey across consecutive gateway restarts',
+        'retires terminal-only managed recovery residue before skipping new orphan marks',
+        'keeps upstream orphan recovery for unrelated namespace %s',
+      ],
+    },
+  ],
   'openclaw-aborted-tool-loop-breaker.patch': [
     {
       file: 'src/agents/embedded-agent-runner/replay-history.ts',

--- a/scripts/patches/v2026.8.1/openclaw-lobsterai-startup-recovery.patch
+++ b/scripts/patches/v2026.8.1/openclaw-lobsterai-startup-recovery.patch
@@ -1,0 +1,232 @@
+OpenClaw v2026.8.1: require explicit restart markers for LobsterAI desktop sessions.
+
+Base: ea806575e6450e4d1efdfc72c19f04be982a1b9b.
+
+The new startup orphan scan treats every persisted running root session without
+an active owner as interrupted. LobsterAI desktop sessions can retain that status
+long after a task ended, so upgrading can revive historical tasks and tools.
+
+Skip NEW orphan marks for the LobsterAI desktop namespace (agent:<id>:lobsterai:*
+and legacy lobsterai:*). Reuse the runtime session-key parser, preserve terminal
+residue retirement, and leave explicit shutdown marking and recovery dispatch
+unchanged. Both early gateway startup and the scheduled recovery scan use this
+same marking function. IM, cron, subagent, and ACP policies remain upstream-owned.
+
+This is intentionally narrower than rolling back all restart recovery to v2026.6.1.
+An unmarked hard crash is not inferred from desktop running state; existing
+abortedLastRun markers, including ones previously written by the faulty scan,
+are not cleaned up. No age threshold, config setting, or UI state change is added.
+
+Regression proof (from the OpenClaw source checkout):
+  node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery.test.ts -t "LobsterAI startup recovery" --reporter=dot
+The tests exercise the real SQLite marking/recovery boundary and mock only the
+agent dispatch. Closing fixture databases before removal also permits Windows runs.
+
+Retire this product patch when upstream provides an equivalent recovery boundary
+or LobsterAI desktop state has a reliable interruption provenance contract.
+
+diff --git a/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts b/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
+index 32b34f423bc..ea2fef8c02e 100644
+--- a/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
++++ b/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
+@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
+ import type { RestartRecoveryCandidate } from "../../gateway/chat-abort.js";
+ import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
+ import { listAgentRunsForSession } from "../../infra/agent-run-registry.js";
++import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
+ import {
+   collectActiveSessionWorkAdmissions,
+   isSessionWorkAdmissionTargetActive,
+@@ -32,6 +33,8 @@ import {
+   resolveRestartRecoveryStorePaths,
+ } from "./main-session-restart-recovery-shared.js";
+
++const LOBSTERAI_SESSION_PREFIX = "lobsterai:";
++
+ async function markRecoveryStore(params: {
+   storePath: string;
+   statuses?: Array<NonNullable<SessionEntry["status"]>>;
+@@ -249,9 +252,20 @@ export async function markStartupOrphanedMainSessionsForRecovery(params: {
+         ) {
+           return undefined;
+         }
+-        return isMainRestartRecoveryAggregateTerminalOnly(entry)
+-          ? { action: "retire_terminal" }
+-          : { action: "mark" };
++        if (isMainRestartRecoveryAggregateTerminalOnly(entry)) {
++          return { action: "retire_terminal" };
++        }
++        // LobsterAI desktop rows may retain historical running state. Only an explicit
++        // restart interruption marker may authorize their recovery; the shutdown marker
++        // and recovery of already-marked rows remain unchanged.
++        const sessionNamespace = parseAgentSessionKey(sessionKey)?.rest ?? sessionKey.trim();
++        if (
++          sessionNamespace.startsWith(LOBSTERAI_SESSION_PREFIX) &&
++          sessionNamespace.slice(LOBSTERAI_SESSION_PREFIX.length).trim()
++        ) {
++          return undefined;
++        }
++        return { action: "mark" };
+       },
+     });
+     result.marked += storeResult.marked;
+diff --git a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+index fa067c96a40..0f5a7bce96c 100644
+--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
++++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+@@ -207,6 +207,8 @@ beforeEach(async () => {
+
+ afterEach(async () => {
+   resetGatewayWorkAdmission();
++  closeOpenClawAgentDatabasesForTest();
++  closeOpenClawStateDatabaseForTest();
+   await fs.rm(tmpDir, { recursive: true, force: true });
+ });
+
+@@ -2967,6 +2969,146 @@ describe("main-session-restart-recovery", () => {
+     expect(store["agent:main:main"]?.abortedLastRun).toBe(false);
+   });
+
++  describe("LobsterAI startup recovery", () => {
++    const managedSessions = [
++      { agentId: "main", sessionKey: "agent:main:lobsterai:desktop" },
++      { agentId: "writer", sessionKey: "agent:writer:lobsterai:desktop" },
++      { agentId: "main", sessionKey: "lobsterai:legacy" },
++      { agentId: "main", sessionKey: "agent:main:lobsterai:desktop:fork" },
++    ];
++
++    it.each(
++      managedSessions.flatMap((session) => [
++        { ...session, age: "historical", ageMs: 100 * 24 * 60 * 60 * 1_000 },
++        { ...session, age: "recent", ageMs: 10_000 },
++      ]),
++    )(
++      "does not revive unmarked $age running session $sessionKey",
++      async ({ agentId, sessionKey, ageMs }) => {
++        const sessionsDir = await makeSessionsDir(agentId);
++        const storePath = path.join(sessionsDir, "sessions.json");
++        const cutoff = Date.now();
++        await writeStore(sessionsDir, {
++          [sessionKey]: runningSessionEntry("desktop-session", { updatedAt: cutoff - ageMs }),
++        });
++        await writeTranscript(sessionsDir, "desktop-session", [
++          makeUserMessage("continue the old task"),
++          makeToolResultMessage(),
++        ]);
++        const before = readStore(storePath);
++
++        await expect(
++          markStartupOrphanedMainSessionsForRecovery({ stateDir: tmpDir, updatedBeforeMs: cutoff }),
++        ).resolves.toEqual({ marked: 0, skipped: 0 });
++        await expectRecovery({ started: 0, settled: 0, failed: 0, skipped: 0 });
++
++        expect(callGateway).not.toHaveBeenCalled();
++        expect(readStore(storePath)).toEqual(before);
++      },
++    );
++
++    it.each(managedSessions)(
++      "preserves explicit recovery of $sessionKey across consecutive gateway restarts",
++      async ({ agentId, sessionKey }) => {
++        const sessionsDir = await makeSessionsDir(agentId);
++        const storePath = path.join(sessionsDir, "sessions.json");
++        // SQLite canonicalizes legacy desktop keys when persisting the session.
++        const storedSessionKey = sessionKey.startsWith("agent:")
++          ? sessionKey
++          : `agent:${agentId}:${sessionKey}`;
++        await writeStore(sessionsDir, {
++          [sessionKey]: runningSessionEntry("desktop-session", { updatedAt: 100 }),
++        });
++        await writeTranscript(sessionsDir, "desktop-session", [
++          makeUserMessage("finish the interrupted task"),
++          { role: "assistant", content: [{ type: "toolCall", id: "exec-1", name: "exec" }] },
++        ]);
++        let activeRun = activeRestartRun(storedSessionKey, "desktop-session");
++
++        for (let restart = 0; restart < 2; restart++) {
++          await expect(
++            markRestartAbortedMainSessions({ stateDir: tmpDir, activeRuns: [activeRun] }),
++          ).resolves.toEqual({ marked: 1, skipped: 0 });
++          const interrupted = readStore(storePath)[storedSessionKey];
++          expect(interrupted?.abortedLastRun).toBe(true);
++          expect(interrupted?.restartRecoveryRuns).toContainEqual({
++            runId: activeRun.runId,
++            lifecycleGeneration: activeRun.lifecycleGeneration,
++          });
++
++          rotateAgentEventLifecycleGeneration();
++          await expect(
++            markStartupOrphanedMainSessionsForRecovery({ stateDir: tmpDir }),
++          ).resolves.toEqual({ marked: 0, skipped: 0 });
++          expect(readStore(storePath)[storedSessionKey]).toEqual(interrupted);
++          await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
++
++          expect(callGateway).toHaveBeenCalledTimes(restart + 1);
++          const request = vi.mocked(callGateway).mock.calls[restart]?.[0];
++          expect(request).toMatchObject({
++            method: "agent",
++            params: { sessionKey: storedSessionKey, forceRestartSafeTools: true },
++          });
++          const resumed = readStore(storePath)[storedSessionKey];
++          expect(resumed).toMatchObject({ abortedLastRun: false, status: "running" });
++          expect(resumed?.lifecycleRunId).toEqual(expect.any(String));
++          expect(resumed?.lifecycleRunId).toBe(
++            expectRecord(request?.params, "recovery dispatch params").idempotencyKey,
++          );
++          expect(resumed?.restartRecoveryRuns).toContainEqual({
++            runId: resumed?.lifecycleRunId,
++            lifecycleGeneration: getAgentEventLifecycleGeneration(),
++          });
++          activeRun = activeRestartRun(storedSessionKey, "desktop-session", {
++            runId: resumed?.lifecycleRunId,
++          });
++        }
++      },
++    );
++
++    it("retires terminal-only managed recovery residue before skipping new orphan marks", async () => {
++      const sessionsDir = await makeSessionsDir();
++      const sessionKey = "agent:main:lobsterai:desktop";
++      await writeStore(sessionsDir, {
++        [sessionKey]: runningSessionEntry("desktop-session", {
++          abortedLastRun: false,
++          mainRestartRecovery: { cycleId: "settled-cycle", revision: 1, chargedAttempts: 0 },
++          restartRecoveryRuns: [{ runId: "settled-run", lifecycleGeneration: "prior-process" }],
++          restartRecoveryTerminalRunIds: ["settled-run"],
++        }),
++      });
++
++      await expect(
++        markStartupOrphanedMainSessionsForRecovery({ stateDir: tmpDir }),
++      ).resolves.toEqual({ marked: 0, skipped: 1 });
++      const entry = readStore(path.join(sessionsDir, "sessions.json"))[sessionKey];
++      expect(entry?.abortedLastRun).toBe(false);
++      expect(entry?.mainRestartRecovery).toBeUndefined();
++      expect(entry?.restartRecoveryRuns).toBeUndefined();
++      await expectRecovery({ started: 0, settled: 0, failed: 0, skipped: 0 });
++      expect(callGateway).not.toHaveBeenCalled();
++    });
++
++    it.each(["agent:main:telegram:direct:lobsterai:peer", "agent:main:lobsterai-other:desktop"])(
++      "keeps upstream orphan recovery for unrelated namespace %s",
++      async (sessionKey) => {
++        const sessionsDir = await makeSessionsDir();
++        await writeStore(sessionsDir, { [sessionKey]: runningSessionEntry("other-session") });
++        await writeTranscript(sessionsDir, "other-session", [
++          makeUserMessage(),
++          makeToolResultMessage(),
++        ]);
++
++        await expect(
++          markStartupOrphanedMainSessionsForRecovery({ stateDir: tmpDir }),
++        ).resolves.toEqual({ marked: 1, skipped: 0 });
++        await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
++        expect(callGateway).toHaveBeenCalledOnce();
++        expect(gatewayParams().sessionKey).toBe(sessionKey);
++      },
++    );
++  });
++
+   it("marks startup-orphaned running main sessions before recovery", async () => {
+     const sessionsDir = await makeSessionsDir();
+     const cutoff = Date.now();

--- a/src/main/libs/openclawPatches/v20260801UpgradeDecisions.test.ts
+++ b/src/main/libs/openclawPatches/v20260801UpgradeDecisions.test.ts
@@ -18,6 +18,7 @@ const RETAINED_PATCHES = [
   'openclaw-im-bound-agent-run-cwd.patch',
   'openclaw-lancedb-optional-transformers.patch',
   'openclaw-lobsterai-model-compat-api.patch',
+  'openclaw-lobsterai-startup-recovery.patch',
   'openclaw-memory-sidecar-archive-generations.patch',
   'openclaw-omit-default-model-from-system-prompt.patch',
   'openclaw-openai-compatible-cache-control.patch',


### PR DESCRIPTION
## Summary

OpenClaw v2026.8.1's startup orphan scan can treat historical LobsterAI desktop sessions with stale `running` status as interrupted and automatically rerun them. Require an existing interruption marker for desktop-session recovery while preserving explicit gateway shutdown marking and recovery of interrupted active tasks.

## Related Issue

QA report: historical desktop conversations unexpectedly resume after the OpenClaw upgrade. No linked issue.

## Changes Made

- Add a version-scoped patch that skips new startup orphan marks for `agent:<agentId>:lobsterai:<sessionId>` and legacy `lobsterai:<sessionId>` keys, after terminal-only residue cleanup. Both gateway startup scan paths use this function.
- Preserve explicit interruption marking, consecutive restart recovery, restart-safe tool restrictions, and upstream IM/cron/subagent/ACP policies.
- Register the patch with ordered source validation and the reviewed patch inventory. Add 15 regression cases using real SQLite storage and close fixture database handles before Windows cleanup.

## Type of Change

- [x] Bug fix

## Testing

- [x] Reproduced the bug before the fix: 8 unmarked-session cases failed; all 15 focused cases pass after the fix.
- [x] OpenClaw complete restart recovery suite: 197 tests passed.
- [x] LobsterAI upgrade decisions, gateway restart, and config sync suites: 168 tests passed.
- [x] `npm run compile:electron`, changed-file ESLint, upstream formatting and scoped type-aware oxlint passed.
- [x] All 30 patches applied with strong validation on a clean v2026.8.1 source copy. Final patch forward/reverse checks pass and produce the same tested source.
- [ ] Rebuilt runtime and desktop manual acceptance testing.

## Checklist

- [x] Changes follow the project style and were reviewed.
- [x] Regression coverage proves the stale-session fix and preserves explicit restart recovery.
- [x] Patch rationale and recovery boundaries are documented in the patch header.

## Electron-Specific Changes

Changes the bundled OpenClaw gateway's startup recovery policy. No IPC, preload, or window contract changes.

## Additional Notes

- This policy uses interruption provenance, not an age threshold. An unmarked hard crash is no longer inferred solely from desktop `running` state.
- Existing `abortedLastRun` markers are preserved, including any already written by the faulty startup scan; cleanup of contaminated state is outside this change.
- The upstream comprehensive `check:changed` gate is blocked by existing `SAFETY` assertion-comment violations in other patches (memory probe, completion parameters, replay history, transport fetch, and server chat). Checks on the touched files passed.